### PR TITLE
Masterbar: add Tracks instrumentation

### DIFF
--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -1,25 +1,36 @@
 /* global jpTracksAJAX, jQuery */
 
 (function( $, jpTracksAJAX ) {
+	window.jpTracksAJAX = window.jpTracksAJAX || {};
+
+	window.jpTracksAJAX.record_ajax_event = function ( eventName, eventType, eventProp ) {
+		var data = {
+			tracksNonce: jpTracksAJAX.jpTracksAJAX_nonce,
+			action: 'jetpack_tracks',
+			tracksEventType: eventType,
+			tracksEventName: eventName,
+			tracksEventProp: eventProp || false
+		};
+
+		return $.ajax( {
+			type: 'POST',
+			url: jpTracksAJAX.ajaxurl,
+			data: data
+		} );
+	};
 
 	$( document ).ready( function () {
 		$( 'body' ).on( 'click', '.jptracks a, a.jptracks', function( event ) {
-
 			// We know that the jptracks element is either this, or its ancestor
 			var $jptracks = $( this ).closest( '.jptracks' );
 
-			var data = {
-				tracksNonce: jpTracksAJAX.jpTracksAJAX_nonce,
-				action: 'jetpack_tracks',
-				tracksEventType: 'click',
-				tracksEventName: $jptracks.attr( 'data-jptracks-name' ),
-				tracksEventProp: $jptracks.attr( 'data-jptracks-prop' ) || false
-			};
-
 			// We need an event name at least
-			if ( undefined === data.tracksEventName ) {
+			var eventName = $jptracks.attr( 'data-jptracks-name' );
+			if ( undefined === eventName ) {
 				return;
 			}
+
+			var eventProp = $jptracks.attr( 'data-jptracks-prop' ) || false;
 
 			var url    = $( this ).attr( 'href' );
 			var target = $( this ).get( 0 ).target;
@@ -29,11 +40,7 @@
 
 			event.preventDefault();
 
-			$.ajax( {
-				type: 'POST',
-				url: jpTracksAJAX.ajaxurl,
-				data: data
-			} ).always( function() {
+			window.jpTracksAJAX.record_ajax_event( eventName, 'click', eventProp ).always( function() {
 				// Continue on to whatever url they were trying to get to.
 				if ( url ) {
 					if ( newTabWindow ) {
@@ -43,7 +50,7 @@
 					window.location = url;
 				}
 			} );
-		});
-	});
+		} );
+	} );
 
-})( jQuery, jpTracksAJAX );
+} )( jQuery, jpTracksAJAX );

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -81,7 +81,7 @@ class JetpackTracking {
 	* @return mixed|void
 	*/
 	static function get_tracks_authorized_redirect_targets() {
-		$jetpack_tracks_authorized_redirect_targets = [];
+		$jetpack_tracks_authorized_redirect_targets = array();
 	/**
 		* Array of authorized redirect targets.
 		*
@@ -99,7 +99,7 @@ class JetpackTracking {
 	* @return mixed|void
 	*/
 	static function get_tracks_authorized_event_names() {
-		$jetpack_tracks_authorized_event_names = [];
+		$jetpack_tracks_authorized_event_names = array();
 	/**
 		* Array of authorized event names.
 		*

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -7,7 +7,7 @@ require_once( dirname( __FILE__ ) . '/_inc/lib/tracks/client.php' );
 
 class JetpackTracking {
 	static $product_name = 'jetpack';
-	static $track_redirects = [];
+	static $track_and_bounce_query_vars = array( 'jetpack_tracks_and_bounce_id', 'jetpack_tracks_and_bounce_event', 'jetpack_tracks_and_bounce_nonce' );
 
 	static function track_jetpack_usage() {
 		if ( ! Jetpack::is_active() ) {
@@ -23,21 +23,11 @@ class JetpackTracking {
 		add_action( 'wp_login_failed',           array( __CLASS__, 'track_failed_login_attempts' ) );
 	}
 
-	static function enqueue_tracks_scripts() {
-		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
-		wp_localize_script( 'jptracks', 'jpTracksAJAX', array(
-			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-			'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
-		) );
+	static function add_track_and_bounce_query_vars( $query_vars ) {
+		return array_merge( $query_vars, self::$track_and_bounce_query_vars );
 	}
 
-	public function add_query_vars( $query_vars ) {
-		$query_vars[] = 'tracks_and_bounce';
-		$query_vars[] = 'tracks_and_bounce_nonce';
-		return $query_vars;
-	}
-
-	public function allow_wpcom_domain( $domains ) {
+	static function allow_wpcom_domain( $domains ) {
 		if ( empty( $domains ) ) {
 			$domains = array();
 		}
@@ -45,12 +35,24 @@ class JetpackTracking {
 		return array_unique( $domains );
 	}
 
-	public function parse_request( $query ) {
-		if ( ! array_key_exists( 'tracks_and_bounce', $query->query_vars ) ) {
+	static function parse_track_and_bounce_request( $query ) {
+		if ( count( array_intersect_key( array_flip( self::$track_and_bounce_query_vars ), $query->query_vars ) ) !== count( self::$track_and_bounce_query_vars ) ) {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $query->query_vars[ 'tracks_and_bounce_nonce' ], 'jp-tracks-masterbar-nonce' ) ) {
+		$track_id = $query->query_vars[ 'jetpack_tracks_and_bounce_id' ];
+		$jetpack_tracks_authorized_redirect_targets = self::get_tracks_authorized_redirect_targets();
+		if ( ! array_key_exists( $track_id, $jetpack_tracks_authorized_redirect_targets ) ) {
+			return;
+		}
+
+		$event_name = $query->query_vars[ 'jetpack_tracks_and_bounce_event' ];
+		$jetpack_tracks_authorized_event_names = self::get_tracks_authorized_event_names();
+		if ( ! in_array( $event_name, $jetpack_tracks_authorized_event_names ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( $query->query_vars[ 'jetpack_tracks_and_bounce_nonce' ], 'jp-masterbar-tracks-nonce' ) ) {
 			// no nonce, wrong link or missing tracking information, push back to settings page
 			wp_safe_redirect(
 				add_query_arg(
@@ -61,26 +63,59 @@ class JetpackTracking {
 			die();
 		}
 
-		$trackId = $query->query_vars[ 'tracks_and_bounce' ];
-		if ( ! array_key_exists( $trackId, self::$track_redirects ) ) {
-			return;
-		}
-
-		$track_target = self::$track_redirects[ $trackId ];
-
-		self::record_user_event(
-			'track_and_bounce',
-			array(
-				'source' => $trackId,
-				'target' => $track_target
-			)
+		$redirect_target = $jetpack_tracks_authorized_redirect_targets[ $track_id ];
+		$tracks_data = array(
+			'source' => $track_id,
+			'target' => $redirect_target
 		);
-		wp_safe_redirect( $track_target );
+
+		JetpackTracking::record_user_event( $event_name, $tracks_data );
+		wp_safe_redirect( $redirect_target );
 		die();
 	}
 
-	static function add_redirect( $events ) {
-		self::$track_redirects = array_merge( self::$track_redirects, $events );
+	/**
+	* Gets an array of authorized redirect targets.
+	*
+	* @since 5.5
+	* @return mixed|void
+	*/
+	static function get_tracks_authorized_redirect_targets() {
+		$jetpack_tracks_authorized_redirect_targets = [];
+	/**
+		* Array of authorized redirect targets.
+		*
+		* @since 5.5
+		*
+		* @param array $jetpack_tracks_authorized_redirect_targets.
+		*/
+		return apply_filters( 'jetpack_tracks_authorized_redirect_targets', $jetpack_tracks_authorized_redirect_targets );
+	}
+
+	/**
+	* Gets an array of authorized event names.
+	*
+	* @since 5.5
+	* @return mixed|void
+	*/
+	static function get_tracks_authorized_event_names() {
+		$jetpack_tracks_authorized_event_names = [];
+	/**
+		* Array of authorized event names.
+		*
+		* @since 5.5
+		*
+		* @param array $jetpack_tracks_authorized_event_names.
+		*/
+		return apply_filters( 'jetpack_tracks_authorized_event_names', $jetpack_tracks_authorized_event_names );
+	}
+
+	static function enqueue_tracks_scripts() {
+		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
+		wp_localize_script( 'jptracks', 'jpTracksAJAX', array(
+			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+			'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
+		) );
 	}
 
 	/* User has linked their account */

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -715,7 +715,11 @@ class Jetpack {
 
 		$tracks_data = array();
 		if ( 'click' === $_REQUEST['tracksEventType'] && isset( $_REQUEST['tracksEventProp'] ) ) {
-			$tracks_data = array( 'clicked' => $_REQUEST['tracksEventProp'] );
+			if ( is_array( $_REQUEST['tracksEventProp'] ) ) {
+				$tracks_data = $_REQUEST['tracksEventProp'];
+			} else {
+				$tracks_data = array( 'clicked' => $_REQUEST['tracksEventProp'] );
+			}
 		}
 
 		JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], $tracks_data );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -21,52 +21,7 @@ class A8C_WPCOM_Masterbar {
 	private $primary_site_slug;
 	private $user_text_direction;
 	private $user_site_count;
-
-	private $links_tracks_events = array(
-		"wp-admin-bar-switch-site"                => array( "masterbar_switch_site_link_click", "/sites" ),
-		"wp-admin-bar-blog-info"                  => array( "masterbar_blog_info_link_click", "{blog_url}" ),
-		"wp-admin-bar-site-view"                  => array( "masterbar_view_site_link_click", "{blog_url}" ),
-		"wp-admin-bar-blog-stats"                 => array( "masterbar_blog_stats_link_click", "/stats/{blog_url}" ),
-		"wp-admin-bar-plan"                       => array( "masterbar_plan_link_click", "/stats/{blog_url}" ),
-		"wp-admin-bar-plan-secondary"             => array( "masterbar_plan_badge_link_click", "/plan/{blog_url}" ),
-		//my sites - manage
-		"wp-admin-bar-new-page"                   => array( "masterbar_new_page_link_click", "/pages/{blog_url}" ),
-		"wp-admin-bar-new-page-secondary"         => array( "masterbar_add_page_link_click", "/page/{blog_url}" ),
-		"wp-admin-bar-new-post"                   => array( "masterbar_new_post_link_click", "/posts/{blog_url}" ),
-		"wp-admin-bar-new-post-secondary"         => array( "masterbar_add_new_post_link_click", "/post/{blog_url}" ),
-		"wp-admin-bar-comments"                   => array( "masterbar_comments_link_click", "/comments/{blog_url}" ),
-		//my sites - personalize
-		"wp-admin-bar-themes"                     => array( "masterbar_themes_link_click", "/design/{blog_url}" ),
-		"wp-admin-bar-themes-secondary"           => array( "masterbar_themes_customize_button_click", "/design/{blog_url}" ),
-		//my sites - configure
-		"wp-admin-bar-sharing"                    => array( "masterbar_configure_sharing_link_click", "/sharing/{blog_url}" ),
-		"wp-admin-bar-users-toolbar"              => array( "masterbar_configure_people_link_click", "/people/team/{blog_url}" ),
-		"wp-admin-bar-users-toolbar-secondary"    => array( "masterbar_configure_people_add_button_click", "/wp-admin/user-new.php" ),
-		"wp-admin-bar-plugins"                    => array( "masterbar_configure_plugins_link_click", "/plugins/{blog_url}" ),
-		"wp-admin-bar-plugins-secondary"          => array( "masterbar_configure_plugins_add_button_click", "/plugins/browse/{blog_url}" ),
-		"wp-admin-bar-blog-settings"              => array( "masterbar_settings_link_click", "/settings/general/{blog_url}" ),
-
-		//reader
-		"wp-admin-bar-following"                  => array( "masterbar_followed_sites_link_click", "" ),
-		"wp-admin-bar-following-secondary"        => array( "masterbar_followed_sites_manage_button_click", "/following/edit" ),
-		"wp-admin-bar-discover-discover"          => array( "masterbar_reader_discover_link_click", "/discover" ),
-		"wp-admin-bar-discover-search"            => array( "masterbar_reader_search_link_click", "/read/search" ),
-		"wp-admin-bar-discover-recommended-blogs" => array( "masterbar_reader_recommendations_link_click", "/recommendations" ),
-		"wp-admin-bar-my-activity-my-likes"       => array( "masterbar_reader_my_links_link_click", "/activities/likes" ),
-
-		//account
-		"wp-admin-bar-user-info"                  => array( "masterbar_user_name_link_click", "" ),
-		// account - profile
-		"wp-admin-bar-my-profile"                 => array( "masterbar_profile_my_profile_link_click", "/me" ),
-		"wp-admin-bar-account-settings"           => array( "masterbar_profile_account_settings_link_click", "/me/account" ),
-		"wp-admin-bar-billing"                    => array( "masterbar_profile_manage_purchases_link_click", "/me/purchases" ),
-		"wp-admin-bar-security"                   => array( "masterbar_profile_security_link_click", "/me/security" ),
-		"wp-admin-bar-notifications"              => array( "masterbar_profile_notifications_link_click", "/me/notifications" ),
-		//account - special
-		"wp-admin-bar-get-apps"                   => array( "masterbar_get_apps_link_click", "/me/get-apps" ),
-		"wp-admin-bar-next-steps"                 => array( "masterbar_next_steps_link_click", "/me/next" ),
-		"wp-admin-bar-help"                       => array( "masterbar_help_link_click", "" ),
-	);
+	private $tracks_events;
 
 	function __construct() {
 		$this->locale  = $this->get_locale();
@@ -91,6 +46,8 @@ class A8C_WPCOM_Masterbar {
 
 		// Used to build menu links that point directly to Calypso.
 		$this->primary_site_slug = Jetpack::build_raw_urls( get_home_url() );
+
+		$this->initialize_tracks_events( $this->primary_site_slug );
 
 		// Used for display purposes and for building WP Admin links.
 		$this->primary_site_url = str_replace( '::', '/', $this->primary_site_slug );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -58,6 +58,7 @@ class A8C_WPCOM_Masterbar {
 		add_action( 'init', array( $this, 'tracks_and_redirect_add_route' ) );
 		add_filter( 'query_vars', array( $this, 'tracks_and_redirect_add_query_vars' ) );
 		add_action( 'parse_request', array( $this, 'tracks_and_redirect_parse_request' ) );
+		add_filter( 'allowed_redirect_hosts', array( $this, 'tracks_and_redirect_allow_wpcom_domain' ) );
 
 		if ( $this->is_rtl() ) {
 			// Extend core WP_Admin_Bar class in order to add rtl styles

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -55,11 +55,6 @@ class A8C_WPCOM_Masterbar {
 		// We need to use user's setting here, instead of relying on current blog's text direction
 		$this->user_text_direction = $this->user_data['text_direction'];
 
-		add_action( 'init', array( $this, 'tracks_and_redirect_add_route' ) );
-		add_filter( 'query_vars', array( $this, 'tracks_and_redirect_add_query_vars' ) );
-		add_action( 'parse_request', array( $this, 'tracks_and_redirect_parse_request' ) );
-		add_filter( 'allowed_redirect_hosts', array( $this, 'tracks_and_redirect_allow_wpcom_domain' ) );
-
 		if ( $this->is_rtl() ) {
 			// Extend core WP_Admin_Bar class in order to add rtl styles
 			add_filter( 'wp_admin_bar_class', array( $this, 'get_rtl_admin_bar_class' ) );
@@ -80,6 +75,53 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
+	}
+
+	private function initialize_tracks_events( $site_slug ) {
+		JetpackTracking::add_redirect( array (
+			//my sites - top level items
+			'wp-admin-bar-switch-site'                => 'https://wordpress.com/sites',
+			'wp-admin-bar-blog-info'                  => 'https://wordpress.com/' . $site_slug,
+			'wp-admin-bar-site-view'                  => 'https://wordpress.com/' . $site_slug,
+			'wp-admin-bar-blog-stats'                 => 'https://wordpress.com/stats/' . $site_slug,
+			'wp-admin-bar-plan'                       => 'https://wordpress.com/stats/' . $site_slug,
+			'wp-admin-bar-plan-secondary'             => 'https://wordpress.com/plan/' . $site_slug,
+			//my sites - manage
+			'wp-admin-bar-new-page'                   => 'https://wordpress.com/pages/' . $site_slug,
+			'wp-admin-bar-new-page-secondary'         => 'https://wordpress.com/page/' . $site_slug,
+			'wp-admin-bar-new-post'                   => 'https://wordpress.com/posts/' . $site_slug,
+			'wp-admin-bar-new-post-secondary'         => 'https://wordpress.com/post/' . $site_slug,
+			'wp-admin-bar-comments'                   => 'https://wordpress.com/comments/' . $site_slug,
+			//my sites - personalize
+			'wp-admin-bar-themes'                     => 'https://wordpress.com/design/' . $site_slug,
+			'wp-admin-bar-themes-secondary'           => 'https://wordpress.com/design/' . $site_slug,
+			//my sites - configure
+			'wp-admin-bar-sharing'                    => 'https://wordpress.com/sharing/' . $site_slug,
+			'wp-admin-bar-users-toolbar'              => 'https://wordpress.com/people/team/' . $site_slug,
+			'wp-admin-bar-users-toolbar-secondary'    => 'https://wordpress.com/people/new/' . $site_slug,
+			'wp-admin-bar-plugins'                    => 'https://wordpress.com/plugins/' . $site_slug,
+			'wp-admin-bar-plugins-secondary'          => 'https://wordpress.com/plugins/browse/' . $site_slug,
+			'wp-admin-bar-blog-settings'              => 'https://wordpress.com/settings/general/' . $site_slug,
+			//reader
+			'wp-admin-bar-following'                  => 'https://wordpress.com',
+			'wp-admin-bar-following-secondary'        => 'https://wordpress.com/following/edit',
+			'wp-admin-bar-discover-discover'          => 'https://wordpress.com/discover',
+			'wp-admin-bar-discover-search'            => 'https://wordpress.com/read/search',
+			'wp-admin-bar-discover-recommended-blogs' => 'https://wordpress.com/recommendations',
+			'wp-admin-bar-my-activity-my-likes'       => 'https://wordpress.com/activities/likes',
+			//account
+			'wp-admin-bar-user-info'                  => 'https://wordpress.com',
+			// account - profile
+			'wp-admin-bar-my-profile'                 => 'https://wordpress.com/me',
+			'wp-admin-bar-account-settings'           => 'https://wordpress.com/me/account',
+			'wp-admin-bar-billing'                    => 'https://wordpress.com/me/purchases',
+			'wp-admin-bar-security'                   => 'https://wordpress.com/me/security',
+			'wp-admin-bar-notifications'              => 'https://wordpress.com/me/notifications',
+			//account - special
+			'wp-admin-bar-get-apps'                   => 'https://wordpress.com/me/get-apps',
+			'wp-admin-bar-next-steps'                 => 'https://wordpress.com/me/next',
+			'wp-admin-bar-help'                       => 'https://jetpack.com/support/',
+		) );
 	}
 
 	public function maybe_logout_user_from_wpcom() {
@@ -138,9 +180,6 @@ class A8C_WPCOM_Masterbar {
 		) );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
-
-		// so tracks events can be fired from the frontend.
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 	}
 
 	function wpcom_static_url( $file ) {

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -124,15 +124,15 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
-		wp_localize_script( 'a8c_wpcom_masterbar_overrides', 'jetpackTracks', array(
-			'siteId' => Jetpack_Options::get_option( 'id' ),
-			'siteUrl' => get_option( 'siteurl' ),
+		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK_VERSION );
+		wp_localize_script( 'a8c_wpcom_masterbar_tracks_events', 'jetpackTracks', array(
+			'user_id' => Jetpack::get_connected_user_data( get_current_user_id() )['ID'],
 		) );
 
+		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
+
 		// so tracks events can be fired from the frontend.
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array( 'a8c_wpcom_masterbar_overrides' ), gmdate( 'YW' ), true );
-		wp_enqueue_script( 'jp-tracks-functions', plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ), array( 'a8c_wpcom_masterbar_overrides' ), JETPACK__VERSION, false );
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 	}
 
 	function wpcom_static_url( $file ) {

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -125,6 +125,14 @@ class A8C_WPCOM_Masterbar {
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
+		wp_localize_script( 'a8c_wpcom_masterbar_overrides', 'jetpackTracks', array(
+			'siteId' => Jetpack_Options::get_option( 'id' ),
+			'siteUrl' => get_option( 'siteurl' ),
+		) );
+
+		// so tracks events can be fired from the frontend.
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array( 'a8c_wpcom_masterbar_overrides' ), gmdate( 'YW' ), true );
+		wp_enqueue_script( 'jp-tracks-functions', plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ), array( 'a8c_wpcom_masterbar_overrides' ), JETPACK__VERSION, false );
 	}
 
 	function wpcom_static_url( $file ) {

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -47,8 +47,6 @@ class A8C_WPCOM_Masterbar {
 		// Used to build menu links that point directly to Calypso.
 		$this->primary_site_slug = Jetpack::build_raw_urls( get_home_url() );
 
-		$this->initialize_tracks_events( $this->primary_site_slug );
-
 		// Used for display purposes and for building WP Admin links.
 		$this->primary_site_url = str_replace( '::', '/', $this->primary_site_slug );
 
@@ -60,6 +58,9 @@ class A8C_WPCOM_Masterbar {
 			add_filter( 'wp_admin_bar_class', array( $this, 'get_rtl_admin_bar_class' ) );
 		}
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
+
+		add_filter( 'jetpack_tracks_authorized_event_names', array( $this, 'add_tracks_authorized_event_names' ) );
+		add_filter( 'jetpack_tracks_authorized_redirect_targets', array( $this, 'add_tracks_authorized_redirect_targets' ) );
 
 		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
 
@@ -77,50 +78,55 @@ class A8C_WPCOM_Masterbar {
 		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
 	}
 
-	private function initialize_tracks_events( $site_slug ) {
-		JetpackTracking::add_redirect( array (
+	function add_tracks_authorized_event_names( $tracks_authorized_event_names ) {
+		$tracks_authorized_event_names[] = 'masterbar_link_click';
+		return $tracks_authorized_event_names;
+	}
+
+	function add_tracks_authorized_redirect_targets( $track_authorized_targets ) {
+		return array_merge( $track_authorized_targets, array (
 			//my sites - top level items
-			'wp-admin-bar-switch-site'                => 'https://wordpress.com/sites',
-			'wp-admin-bar-blog-info'                  => 'https://wordpress.com/' . $site_slug,
-			'wp-admin-bar-site-view'                  => 'https://wordpress.com/' . $site_slug,
-			'wp-admin-bar-blog-stats'                 => 'https://wordpress.com/stats/' . $site_slug,
-			'wp-admin-bar-plan'                       => 'https://wordpress.com/stats/' . $site_slug,
-			'wp-admin-bar-plan-secondary'             => 'https://wordpress.com/plan/' . $site_slug,
+			'wp-admin-bar-switch-site'                  => 'https://wordpress.com/sites',
+			'wp-admin-bar-blog-info'                    => 'https://wordpress.com/' . $this->primary_site_slug,
+			'wp-admin-bar-site-view'                    => 'https://wordpress.com/' . $this->primary_site_slug,
+			'wp-admin-bar-blog-stats'                   => 'https://wordpress.com/stats/' . $this->primary_site_slug,
+			'wp-admin-bar-plan'                         => 'https://wordpress.com/stats/' . $this->primary_site_slug,
+			'wp-admin-bar-plan-badge'                   => 'https://wordpress.com/plan/' . $this->primary_site_slug,
 			//my sites - manage
-			'wp-admin-bar-new-page'                   => 'https://wordpress.com/pages/' . $site_slug,
-			'wp-admin-bar-new-page-secondary'         => 'https://wordpress.com/page/' . $site_slug,
-			'wp-admin-bar-new-post'                   => 'https://wordpress.com/posts/' . $site_slug,
-			'wp-admin-bar-new-post-secondary'         => 'https://wordpress.com/post/' . $site_slug,
-			'wp-admin-bar-comments'                   => 'https://wordpress.com/comments/' . $site_slug,
+			'wp-admin-bar-edit-page'                    => 'https://wordpress.com/pages/' . $this->primary_site_slug,
+			'wp-admin-bar-new-page'                     => 'https://wordpress.com/page/' . $this->primary_site_slug,
+			'wp-admin-bar-edit-post'                    => 'https://wordpress.com/posts/' . $this->primary_site_slug,
+			'wp-admin-bar-new-post'                     => 'https://wordpress.com/post/' . $this->primary_site_slug,
+			'wp-admin-bar-comments'                     => 'https://wordpress.com/comments/' . $this->primary_site_slug,
 			//my sites - personalize
-			'wp-admin-bar-themes'                     => 'https://wordpress.com/design/' . $site_slug,
-			'wp-admin-bar-themes-secondary'           => 'https://wordpress.com/design/' . $site_slug,
+			'wp-admin-bar-themes'                       => 'https://wordpress.com/design/' . $this->primary_site_slug,
+			'wp-admin-bar-cmz'                          => 'https://wordpress.com/design/' . $this->primary_site_slug,
 			//my sites - configure
-			'wp-admin-bar-sharing'                    => 'https://wordpress.com/sharing/' . $site_slug,
-			'wp-admin-bar-users-toolbar'              => 'https://wordpress.com/people/team/' . $site_slug,
-			'wp-admin-bar-users-toolbar-secondary'    => 'https://wordpress.com/people/new/' . $site_slug,
-			'wp-admin-bar-plugins'                    => 'https://wordpress.com/plugins/' . $site_slug,
-			'wp-admin-bar-plugins-secondary'          => 'https://wordpress.com/plugins/browse/' . $site_slug,
-			'wp-admin-bar-blog-settings'              => 'https://wordpress.com/settings/general/' . $site_slug,
+			'wp-admin-bar-sharing'                      => 'https://wordpress.com/sharing/' . $this->primary_site_slug,
+			'wp-admin-bar-people'                       => 'https://wordpress.com/people/team/' . $this->primary_site_slug,
+			'wp-admin-bar-people-add'                   => 'https://wordpress.com/people/new/' . $this->primary_site_slug,
+			'wp-admin-bar-plugins'                      => 'https://wordpress.com/plugins/' . $this->primary_site_slug,
+			'wp-admin-bar-plugins-add'                  => 'https://wordpress.com/plugins/browse/' . $this->primary_site_slug,
+			'wp-admin-bar-blog-settings'                => 'https://wordpress.com/settings/general/' . $this->primary_site_slug,
 			//reader
-			'wp-admin-bar-following'                  => 'https://wordpress.com',
-			'wp-admin-bar-following-secondary'        => 'https://wordpress.com/following/edit',
-			'wp-admin-bar-discover-discover'          => 'https://wordpress.com/discover',
-			'wp-admin-bar-discover-search'            => 'https://wordpress.com/read/search',
-			'wp-admin-bar-discover-recommended-blogs' => 'https://wordpress.com/recommendations',
-			'wp-admin-bar-my-activity-my-likes'       => 'https://wordpress.com/activities/likes',
+			'wp-admin-bar-followed-sites'               => 'https://wordpress.com',
+			'wp-admin-bar-reader-followed-sites-manage' => 'https://wordpress.com/following/edit',
+			'wp-admin-bar-discover-discover'            => 'https://wordpress.com/discover',
+			'wp-admin-bar-discover-search'              => 'https://wordpress.com/read/search',
+			'wp-admin-bar-discover-recommended-blogs'   => 'https://wordpress.com/recommendations',
+			'wp-admin-bar-my-activity-my-likes'         => 'https://wordpress.com/activities/likes',
 			//account
-			'wp-admin-bar-user-info'                  => 'https://wordpress.com',
+			'wp-admin-bar-user-info'                    => 'https://wordpress.com',
 			// account - profile
-			'wp-admin-bar-my-profile'                 => 'https://wordpress.com/me',
-			'wp-admin-bar-account-settings'           => 'https://wordpress.com/me/account',
-			'wp-admin-bar-billing'                    => 'https://wordpress.com/me/purchases',
-			'wp-admin-bar-security'                   => 'https://wordpress.com/me/security',
-			'wp-admin-bar-notifications'              => 'https://wordpress.com/me/notifications',
+			'wp-admin-bar-my-profile'                   => 'https://wordpress.com/me',
+			'wp-admin-bar-account-settings'             => 'https://wordpress.com/me/account',
+			'wp-admin-bar-billing'                      => 'https://wordpress.com/me/purchases',
+			'wp-admin-bar-security'                     => 'https://wordpress.com/me/security',
+			'wp-admin-bar-notifications'                => 'https://wordpress.com/me/notifications',
 			//account - special
-			'wp-admin-bar-get-apps'                   => 'https://wordpress.com/me/get-apps',
-			'wp-admin-bar-next-steps'                 => 'https://wordpress.com/me/next',
-			'wp-admin-bar-help'                       => 'https://jetpack.com/support/',
+			'wp-admin-bar-get-apps'                     => 'https://wordpress.com/me/get-apps',
+			'wp-admin-bar-next-steps'                   => 'https://wordpress.com/me/next',
+			'wp-admin-bar-help'                         => 'https://jetpack.com/support/',
 		) );
 	}
 
@@ -176,7 +182,8 @@ class A8C_WPCOM_Masterbar {
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK__VERSION );
 		wp_localize_script( 'a8c_wpcom_masterbar_tracks_events', 'jetpackTracks', array(
-			'tracks_nonce' => wp_create_nonce( 'jp-tracks-masterbar-nonce' ),
+			'tracks_nonce' => wp_create_nonce( 'jp-masterbar-tracks-nonce' ),
+			'event_name'   => 'masterbar_link_click'
 		) );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
@@ -265,7 +272,7 @@ class A8C_WPCOM_Masterbar {
 				           '</span>' .
 				           '</div>' .
 				           '</div>',
-				'class' => 'menupop',
+				'class' => 'menupop mb-trackable',
 			),
 			'parent' => 'top-secondary',
 		) );
@@ -277,6 +284,9 @@ class A8C_WPCOM_Masterbar {
 			'id'    => 'newdash',
 			'title' => esc_html__( 'Reader', 'jetpack' ),
 			'href'  => '#',
+			'meta'  => array(
+				'class' => 'mb-trackable',
+			)
 		) );
 
 		$wp_admin_bar->add_menu( array(
@@ -399,7 +409,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		$avatar = get_avatar( $this->user_email, 32, 'mm', '', array( 'force_display' => true ) );
-		$class  = empty( $avatar ) ? '' : 'with-avatar';
+		$class  = empty( $avatar ) ? 'mb-trackable' : 'with-avatar mb-trackable';
 
 		// Add the 'Me' menu
 		$wp_admin_bar->add_menu( array(
@@ -589,7 +599,7 @@ class A8C_WPCOM_Masterbar {
 			'title' => _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' ),
 			'href'  => '#',
 			'meta'  => array(
-				'class' => 'my-sites',
+				'class' => 'my-sites mb-trackable',
 			),
 		) );
 
@@ -766,7 +776,7 @@ class A8C_WPCOM_Masterbar {
 			'id'     => 'new-post',
 			'title'  => $posts_title,
 			'meta'   => array(
-				'class' => 'inline-action',
+				'class' => 'inline-action mb-trackable',
 			),
 		) );
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -22,6 +22,52 @@ class A8C_WPCOM_Masterbar {
 	private $user_text_direction;
 	private $user_site_count;
 
+	private $links_tracks_events = array(
+		"wp-admin-bar-switch-site"                => array( "masterbar_switch_site_link_click", "/sites" ),
+		"wp-admin-bar-blog-info"                  => array( "masterbar_blog_info_link_click", "{blog_url}" ),
+		"wp-admin-bar-site-view"                  => array( "masterbar_view_site_link_click", "{blog_url}" ),
+		"wp-admin-bar-blog-stats"                 => array( "masterbar_blog_stats_link_click", "/stats/{blog_url}" ),
+		"wp-admin-bar-plan"                       => array( "masterbar_plan_link_click", "/stats/{blog_url}" ),
+		"wp-admin-bar-plan-secondary"             => array( "masterbar_plan_badge_link_click", "/plan/{blog_url}" ),
+		//my sites - manage
+		"wp-admin-bar-new-page"                   => array( "masterbar_new_page_link_click", "/pages/{blog_url}" ),
+		"wp-admin-bar-new-page-secondary"         => array( "masterbar_add_page_link_click", "/page/{blog_url}" ),
+		"wp-admin-bar-new-post"                   => array( "masterbar_new_post_link_click", "/posts/{blog_url}" ),
+		"wp-admin-bar-new-post-secondary"         => array( "masterbar_add_new_post_link_click", "/post/{blog_url}" ),
+		"wp-admin-bar-comments"                   => array( "masterbar_comments_link_click", "/comments/{blog_url}" ),
+		//my sites - personalize
+		"wp-admin-bar-themes"                     => array( "masterbar_themes_link_click", "/design/{blog_url}" ),
+		"wp-admin-bar-themes-secondary"           => array( "masterbar_themes_customize_button_click", "/design/{blog_url}" ),
+		//my sites - configure
+		"wp-admin-bar-sharing"                    => array( "masterbar_configure_sharing_link_click", "/sharing/{blog_url}" ),
+		"wp-admin-bar-users-toolbar"              => array( "masterbar_configure_people_link_click", "/people/team/{blog_url}" ),
+		"wp-admin-bar-users-toolbar-secondary"    => array( "masterbar_configure_people_add_button_click", "/wp-admin/user-new.php" ),
+		"wp-admin-bar-plugins"                    => array( "masterbar_configure_plugins_link_click", "/plugins/{blog_url}" ),
+		"wp-admin-bar-plugins-secondary"          => array( "masterbar_configure_plugins_add_button_click", "/plugins/browse/{blog_url}" ),
+		"wp-admin-bar-blog-settings"              => array( "masterbar_settings_link_click", "/settings/general/{blog_url}" ),
+
+		//reader
+		"wp-admin-bar-following"                  => array( "masterbar_followed_sites_link_click", "" ),
+		"wp-admin-bar-following-secondary"        => array( "masterbar_followed_sites_manage_button_click", "/following/edit" ),
+		"wp-admin-bar-discover-discover"          => array( "masterbar_reader_discover_link_click", "/discover" ),
+		"wp-admin-bar-discover-search"            => array( "masterbar_reader_search_link_click", "/read/search" ),
+		"wp-admin-bar-discover-recommended-blogs" => array( "masterbar_reader_recommendations_link_click", "/recommendations" ),
+		"wp-admin-bar-my-activity-my-likes"       => array( "masterbar_reader_my_links_link_click", "/activities/likes" ),
+
+		//account
+		"wp-admin-bar-user-info"                  => array( "masterbar_user_name_link_click", "" ),
+		// account - profile
+		"wp-admin-bar-my-profile"                 => array( "masterbar_profile_my_profile_link_click", "/me" ),
+		"wp-admin-bar-account-settings"           => array( "masterbar_profile_account_settings_link_click", "/me/account" ),
+		"wp-admin-bar-billing"                    => array( "masterbar_profile_manage_purchases_link_click", "/me/purchases" ),
+		"wp-admin-bar-security"                   => array( "masterbar_profile_security_link_click", "/me/security" ),
+		"wp-admin-bar-notifications"              => array( "masterbar_profile_notifications_link_click", "/me/notifications" ),
+		//account - special
+		"wp-admin-bar-get-apps"                   => array( "masterbar_get_apps_link_click", "/me/get-apps" ),
+		"wp-admin-bar-next-steps"                 => array( "masterbar_next_steps_link_click", "/me/next" ),
+		"wp-admin-bar-help"                       => array( "masterbar_help_link_click", "" ),
+	);
+
 	function __construct() {
 		$this->locale  = $this->get_locale();
 		$this->user_id = get_current_user_id();
@@ -51,6 +97,10 @@ class A8C_WPCOM_Masterbar {
 
 		// We need to use user's setting here, instead of relying on current blog's text direction
 		$this->user_text_direction = $this->user_data['text_direction'];
+
+		add_action( 'init', array( $this, 'tracks_and_redirect_add_route' ) );
+		add_filter( 'query_vars', array( $this, 'tracks_and_redirect_add_query_vars' ) );
+		add_action( 'parse_request', array( $this, 'tracks_and_redirect_parse_request' ) );
 
 		if ( $this->is_rtl() ) {
 			// Extend core WP_Admin_Bar class in order to add rtl styles
@@ -124,9 +174,9 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK_VERSION );
+		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK__VERSION );
 		wp_localize_script( 'a8c_wpcom_masterbar_tracks_events', 'jetpackTracks', array(
-			'user_id' => Jetpack::get_connected_user_data( get_current_user_id() )['ID'],
+			'tracks_nonce' => wp_create_nonce( 'jp-tracks-masterbar-nonce' ),
 		) );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -59,9 +59,6 @@ class A8C_WPCOM_Masterbar {
 		}
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
-		add_filter( 'jetpack_tracks_authorized_event_names', array( $this, 'add_tracks_authorized_event_names' ) );
-		add_filter( 'jetpack_tracks_authorized_redirect_targets', array( $this, 'add_tracks_authorized_redirect_targets' ) );
-
 		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_styles_and_scripts' ) );
@@ -76,58 +73,6 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
-	}
-
-	function add_tracks_authorized_event_names( $tracks_authorized_event_names ) {
-		$tracks_authorized_event_names[] = 'masterbar_link_click';
-		return $tracks_authorized_event_names;
-	}
-
-	function add_tracks_authorized_redirect_targets( $track_authorized_targets ) {
-		return array_merge( $track_authorized_targets, array (
-			//my sites - top level items
-			'wp-admin-bar-switch-site'                  => 'https://wordpress.com/sites',
-			'wp-admin-bar-blog-info'                    => 'https://wordpress.com/' . $this->primary_site_slug,
-			'wp-admin-bar-site-view'                    => 'https://wordpress.com/' . $this->primary_site_slug,
-			'wp-admin-bar-blog-stats'                   => 'https://wordpress.com/stats/' . $this->primary_site_slug,
-			'wp-admin-bar-plan'                         => 'https://wordpress.com/stats/' . $this->primary_site_slug,
-			'wp-admin-bar-plan-badge'                   => 'https://wordpress.com/plan/' . $this->primary_site_slug,
-			//my sites - manage
-			'wp-admin-bar-edit-page'                    => 'https://wordpress.com/pages/' . $this->primary_site_slug,
-			'wp-admin-bar-new-page'                     => 'https://wordpress.com/page/' . $this->primary_site_slug,
-			'wp-admin-bar-edit-post'                    => 'https://wordpress.com/posts/' . $this->primary_site_slug,
-			'wp-admin-bar-new-post'                     => 'https://wordpress.com/post/' . $this->primary_site_slug,
-			'wp-admin-bar-comments'                     => 'https://wordpress.com/comments/' . $this->primary_site_slug,
-			//my sites - personalize
-			'wp-admin-bar-themes'                       => 'https://wordpress.com/design/' . $this->primary_site_slug,
-			'wp-admin-bar-cmz'                          => 'https://wordpress.com/design/' . $this->primary_site_slug,
-			//my sites - configure
-			'wp-admin-bar-sharing'                      => 'https://wordpress.com/sharing/' . $this->primary_site_slug,
-			'wp-admin-bar-people'                       => 'https://wordpress.com/people/team/' . $this->primary_site_slug,
-			'wp-admin-bar-people-add'                   => 'https://wordpress.com/people/new/' . $this->primary_site_slug,
-			'wp-admin-bar-plugins'                      => 'https://wordpress.com/plugins/' . $this->primary_site_slug,
-			'wp-admin-bar-plugins-add'                  => 'https://wordpress.com/plugins/browse/' . $this->primary_site_slug,
-			'wp-admin-bar-blog-settings'                => 'https://wordpress.com/settings/general/' . $this->primary_site_slug,
-			//reader
-			'wp-admin-bar-followed-sites'               => 'https://wordpress.com',
-			'wp-admin-bar-reader-followed-sites-manage' => 'https://wordpress.com/following/edit',
-			'wp-admin-bar-discover-discover'            => 'https://wordpress.com/discover',
-			'wp-admin-bar-discover-search'              => 'https://wordpress.com/read/search',
-			'wp-admin-bar-discover-recommended-blogs'   => 'https://wordpress.com/recommendations',
-			'wp-admin-bar-my-activity-my-likes'         => 'https://wordpress.com/activities/likes',
-			//account
-			'wp-admin-bar-user-info'                    => 'https://wordpress.com',
-			// account - profile
-			'wp-admin-bar-my-profile'                   => 'https://wordpress.com/me',
-			'wp-admin-bar-account-settings'             => 'https://wordpress.com/me/account',
-			'wp-admin-bar-billing'                      => 'https://wordpress.com/me/purchases',
-			'wp-admin-bar-security'                     => 'https://wordpress.com/me/security',
-			'wp-admin-bar-notifications'                => 'https://wordpress.com/me/notifications',
-			//account - special
-			'wp-admin-bar-get-apps'                     => 'https://wordpress.com/me/get-apps',
-			'wp-admin-bar-next-steps'                   => 'https://wordpress.com/me/next',
-			'wp-admin-bar-help'                         => 'https://jetpack.com/support/',
-		) );
 	}
 
 	public function maybe_logout_user_from_wpcom() {
@@ -181,10 +126,6 @@ class A8C_WPCOM_Masterbar {
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK__VERSION );
-		wp_localize_script( 'a8c_wpcom_masterbar_tracks_events', 'jetpackTracks', array(
-			'tracks_nonce' => wp_create_nonce( 'jp-masterbar-tracks-nonce' ),
-			'event_name'   => 'masterbar_link_click'
-		) );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
 	}
@@ -578,6 +519,9 @@ class A8C_WPCOM_Masterbar {
 			'id' => 'ab-new-post',
 			'href' => $blog_post_page,
 			'title' => '<span>' . esc_html__( 'Write', 'jetpack' ) . '</span>',
+			'meta'  => array(
+				'class' => 'mb-trackable',
+			)
 		) );
 	}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -21,7 +21,6 @@ class A8C_WPCOM_Masterbar {
 	private $primary_site_slug;
 	private $user_text_direction;
 	private $user_site_count;
-	private $tracks_events;
 
 	function __construct() {
 		$this->locale  = $this->get_locale();

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -11,23 +11,49 @@
 		'wp-admin-bar-notes'       : 'jetpack_masterbar_notifications_link_click'
 	};
 
-	var linksWhitelist = [
+	var linksToTrack = [
 		//my sites - top items
-		'wp-admin-bar-switch-site', 'wp-admin-bar-blog-info', 'wp-admin-bar-site-view', 'wp-admin-bar-blog-stats', 'wp-admin-bar-plan', 'wp-admin-bar-plan-secondary',
+		'wp-admin-bar-switch-site',
+		'wp-admin-bar-blog-info',
+		'wp-admin-bar-site-view',
+		'wp-admin-bar-blog-stats',
+		'wp-admin-bar-plan',
+		'wp-admin-bar-plan-secondary',
 		//my sites - manage
-		'wp-admin-bar-new-page', 'wp-admin-bar-new-page-secondary', 'wp-admin-bar-new-post', 'wp-admin-bar-new-post-secondary', 'wp-admin-bar-comments',
+		'wp-admin-bar-new-page',
+		'wp-admin-bar-new-page-secondary',
+		'wp-admin-bar-new-post',
+		'wp-admin-bar-new-post-secondary',
+		'wp-admin-bar-comments',
 		//my sites - personalize
-		'wp-admin-bar-themes', 'wp-admin-bar-themes-secondary',
+		'wp-admin-bar-themes',
+		'wp-admin-bar-themes-secondary',
 		//my sites - configure
-		'wp-admin-bar-sharing', 'wp-admin-bar-users-toolbar', 'wp-admin-bar-users-toolbar-secondary', 'wp-admin-bar-plugins', 'wp-admin-bar-plugins-secondary', 'wp-admin-bar-blog-settings',
+		'wp-admin-bar-sharing',
+		'wp-admin-bar-users-toolbar',
+		'wp-admin-bar-users-toolbar-secondary',
+		'wp-admin-bar-plugins',
+		'wp-admin-bar-plugins-secondary',
+		'wp-admin-bar-blog-settings',
 		//reader
-		'wp-admin-bar-following', 'wp-admin-bar-following-secondary', 'wp-admin-bar-discover-discover', 'wp-admin-bar-discover-search', 'wp-admin-bar-discover-recommended-blogs', 'wp-admin-bar-my-activity-my-likes',
+		'wp-admin-bar-following',
+		'wp-admin-bar-following-secondary',
+		'wp-admin-bar-discover-discover',
+		'wp-admin-bar-discover-search',
+		'wp-admin-bar-discover-recommended-blogs',
+		'wp-admin-bar-my-activity-my-likes',
 		//account
 		'wp-admin-bar-user-info',
 		// account - profile
-		'wp-admin-bar-my-profile', 'wp-admin-bar-account-settings', 'wp-admin-bar-billing', 'wp-admin-bar-security', 'wp-admin-bar-notifications',
+		'wp-admin-bar-my-profile',
+		'wp-admin-bar-account-settings',
+		'wp-admin-bar-billing',
+		'wp-admin-bar-security',
+		'wp-admin-bar-notifications',
 		//account - special
-		'wp-admin-bar-get-apps', 'wp-admin-bar-next-steps', 'wp-admin-bar-help'
+		'wp-admin-bar-get-apps',
+		'wp-admin-bar-next-steps',
+		'wp-admin-bar-help'
 	];
 
 	var notesTracksEvents = {
@@ -66,7 +92,7 @@
 
 			var parentId = $parent.attr( 'ID' );
 			var trackId = $target.hasClass( 'ab-secondary' ) ? parentId + '-secondary' : parentId;
-			var eventName = linksTracksEvents[ trackId ] || linksWhitelist.indexOf( trackId ) || null;
+			var eventName = linksTracksEvents[ trackId ] || linksToTrack.indexOf( trackId ) || null;
 			if ( ! eventName ) {
 				return;
 			}
@@ -76,7 +102,7 @@
 				window._tkq.push( [ 'recordEvent', eventName ] );
 			} else {
 				e.preventDefault();
-				window.location = 'jetpack-track-and-bounce.php?' + $.param( {
+				window.location = 'index.php?' + $.param( {
 					tracks_and_bounce: trackId,
 					tracks_and_bounce_nonce: nonce
 				} );

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -2,92 +2,29 @@
 (function( $, jetpackTracks ) {
 	window._tkq = window._tkq || [];
 
-	var linksTracksEvents = {
-		//top level items
-		'wp-admin-bar-blog'        : 'jetpack_masterbar_my_sites_link_click',
-		'wp-admin-bar-newdash'     : 'jetpack_masterbar_reader_link_click',
-		'wp-admin-bar-ab-new-post' : 'jetpack_masterbar_write_button_click',
-		'wp-admin-bar-my-account'  : 'jetpack_masterbar_my_account_link_click',
-		'wp-admin-bar-notes'       : 'jetpack_masterbar_notifications_link_click'
-	};
-
-	var linksToTrack = [
-		//my sites - top items
-		'wp-admin-bar-switch-site',
-		'wp-admin-bar-blog-info',
-		'wp-admin-bar-site-view',
-		'wp-admin-bar-blog-stats',
-		'wp-admin-bar-plan',
-		'wp-admin-bar-plan-secondary',
-		//my sites - manage
-		'wp-admin-bar-new-page',
-		'wp-admin-bar-new-page-secondary',
-		'wp-admin-bar-new-post',
-		'wp-admin-bar-new-post-secondary',
-		'wp-admin-bar-comments',
-		//my sites - personalize
-		'wp-admin-bar-themes',
-		'wp-admin-bar-themes-secondary',
-		//my sites - configure
-		'wp-admin-bar-sharing',
-		'wp-admin-bar-users-toolbar',
-		'wp-admin-bar-users-toolbar-secondary',
-		'wp-admin-bar-plugins',
-		'wp-admin-bar-plugins-secondary',
-		'wp-admin-bar-blog-settings',
-		//reader
-		'wp-admin-bar-following',
-		'wp-admin-bar-following-secondary',
-		'wp-admin-bar-discover-discover',
-		'wp-admin-bar-discover-search',
-		'wp-admin-bar-discover-recommended-blogs',
-		'wp-admin-bar-my-activity-my-likes',
-		//account
-		'wp-admin-bar-user-info',
-		// account - profile
-		'wp-admin-bar-my-profile',
-		'wp-admin-bar-account-settings',
-		'wp-admin-bar-billing',
-		'wp-admin-bar-security',
-		'wp-admin-bar-notifications',
-		//account - special
-		'wp-admin-bar-get-apps',
-		'wp-admin-bar-next-steps',
-		'wp-admin-bar-help'
-	];
-
 	var notesTracksEvents = {
-		openSite: {
-			name: 'jetpack_masterbar_notifications_open_site',
-			properties: function( data ) {
-				return {
-					site_id: data.siteId,
-					post_id: data.postId
-				};
-			}
+		openSite: function( data ) {
+			return {
+				site_id: data.siteId
+			};
 		},
-		openPost: {
-			name: 'jetpack_masterbar_notifications_open_post',
-			properties: function( data ) {
-				return {
-					site_id: data.siteId,
-					post_id: data.postId
-				};
-			}
+		openPost: function( data ) {
+			return {
+				site_id: data.siteId,
+				post_id: data.postId
+			};
 		},
-		openComment: {
-			name: 'jetpack_masterbar_notifications_open_comment',
-			properties: function( data ) {
-				return {
-					site_id: data.siteId,
-					post_id: data.postId,
-					comment_id: data.commentId
-				};
-			}
+		openComment: function( data ) {
+			return {
+				site_id: data.siteId,
+				post_id: data.postId,
+				comment_id: data.commentId
+			};
 		}
 	};
 
 	var nonce = jetpackTracks.tracks_nonce;
+	var eventName = jetpackTracks.event_name;
 
 	function parseJson( s, defaultValue ) {
 		try {
@@ -98,7 +35,7 @@
 	}
 
 	$( document ).ready( function() {
-		$( '.ab-item, .ab-secondary' ).on( 'click touchstart', function( e ) {
+		$( '.mb-trackable a' ).on( 'click touchstart', function( e ) {
 			var $target = $( e.target ),
 					$parent = $target.closest( 'li' );
 
@@ -106,21 +43,19 @@
 				return;
 			}
 
-			var parentId = $parent.attr( 'ID' );
-			var trackId = $target.hasClass( 'ab-secondary' ) ? parentId + '-secondary' : parentId;
-			var eventName = linksTracksEvents[ trackId ] || linksToTrack.indexOf( trackId ) || null;
-			if ( ! eventName ) {
-				return;
-			}
-
 			if( $parent.hasClass( 'menupop' ) ) {
 				//top level items that open a panel
-				window._tkq.push( [ 'recordEvent', eventName ] );
+				window._tkq.push( [ 'recordEvent', 'jetpack_' + eventName, {
+					source: 'masterbar',
+					item: $parent.attr( 'ID' ),
+					target: $target.attr( 'href' )
+				} ] );
 			} else {
 				e.preventDefault();
-				window.location = 'index.php?' + $.param( {
-					tracks_and_bounce: trackId,
-					tracks_and_bounce_nonce: nonce
+				window.location = 'jetpack-track-and-bounce.php?' + $.param( {
+					jetpack_tracks_and_bounce_id: $target.attr( 'ID' ) || $parent.attr( 'ID' ),
+					jetpack_tracks_and_bounce_event: eventName,
+					jetpack_tracks_and_bounce_nonce: nonce
 				} );
 			}
 		} );
@@ -143,7 +78,7 @@
 			return;
 		}
 
-		window._tkq.push( [ 'recordEvent', eventData.name, eventData.properties( data ) ] );
+		window._tkq.push( [ 'recordEvent', 'jetpack_masterbar_link_click', eventData( data ) ] );
 	} );
 
 	window.jetpackTracks = null;

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,0 +1,73 @@
+(function() {
+	window.wpcom_masterbar = window.wpcom_masterbar || {};
+
+	window.wpcom_masterbar.linksTracksEvents = {
+		//top level items
+		'wp-admin-bar-blog'                       : 'jetpack_masterbar_my_sites_link_click',
+		'wp-admin-bar-newdash'                    : 'jetpack_masterbar_reader_link_click',
+		'wp-admin-bar-ab-new-post'                : 'jetpack_masterbar_write_button_click',
+		'wp-admin-bar-my-account'                 : 'jetpack_masterbar_my_account_link_click',
+		'wp-admin-bar-notes'                      : 'jetpack_masterbar_notifications_link_click',
+		//my sites - top items
+		'wp-admin-bar-switch-site'                : 'jetpack_masterbar_switch_site_link_click',
+		'wp-admin-bar-blog-info'                  : 'jetpack_masterbar_blog_info_link_click',
+		'wp-admin-bar-site-view'                  : 'jetpack_masterbar_view_site_link_click',
+		'wp-admin-bar-blog-stats'                 : 'jetpack_masterbar_blog_stats_link_click',
+		'wp-admin-bar-plan'                       : 'jetpack_masterbar_plan_link_click',
+		'wp-admin-bar-plan-secondary'             : 'jetpack_masterbar_plan_badge_link_click',
+		//my sites - manage
+		'wp-admin-bar-new-page'                   : 'jetpack_masterbar_new_page_link_click',
+		'wp-admin-bar-new-page-secondary'         : 'jetpack_masterbar_add_page_link_click',
+		'wp-admin-bar-new-post'                   : 'jetpack_masterbar_new_post_link_click',
+		'wp-admin-bar-new-post-secondary'         : 'jetpack_masterbar_add_new_post_link_click',
+		'wp-admin-bar-comments'                   : 'jetpack_masterbar_comments_link_click',
+		//my sites - personalize
+		'wp-admin-bar-themes'                     : 'jetpack_masterbar_themes_link_click',
+		'wp-admin-bar-themes-secondary'           : 'jetpack_masterbar_themes_customize_button_click',
+		//my sites - configure
+		'wp-admin-bar-sharing'                    : 'jetpack_masterbar_configure_sharing_link_click',
+		'wp-admin-bar-users-toolbar'              : 'jetpack_masterbar_configure_people_link_click',
+		'wp-admin-bar-users-toolbar-secondary'    : 'jetpack_masterbar_configure_people_add_button_click',
+		'wp-admin-bar-plugins'                    : 'jetpack_masterbar_configure_plugins_link_click',
+		'wp-admin-bar-plugins-secondary'          : 'jetpack_masterbar_configure_plugins_add_button_click',
+		'wp-admin-bar-blog-settings'              : 'jetpack_masterbar_settings_link_click',
+
+		//reader
+		'wp-admin-bar-following'                  : 'jetpack_masterbar_followed_sites_link_click',
+		'wp-admin-bar-following-secondary'        : 'jetpack_masterbar_followed_sites_manage_button_click',
+		'wp-admin-bar-discover-discover'          : 'jetpack_masterbar_reader_discover_link_click',
+		'wp-admin-bar-discover-search'            : 'jetpack_masterbar_reader_search_link_click',
+		'wp-admin-bar-discover-recommended-blogs' : 'jetpack_masterbar_reader_recommendations_link_click',
+		'wp-admin-bar-my-activity-my-likes'       : 'jetpack_masterbar_reader_my_links_link_click',
+
+		//account
+		'wp-admin-bar-user-info'                  : 'jetpack_masterbar_user_name_link_click',
+		// account - profile
+		'wp-admin-bar-my-profile'                 : 'jetpack_masterbar_profile_my_profile_link_click',
+		'wp-admin-bar-account-settings'           : 'jetpack_masterbar_profile_account_settings_link_click',
+		'wp-admin-bar-billing'                    : 'jetpack_masterbar_profile_manage_purchases_link_click',
+		'wp-admin-bar-security'                   : 'jetpack_masterbar_profile_security_link_click',
+		'wp-admin-bar-notifications'              : 'jetpack_masterbar_profile_notifications_link_click',
+		//account - special
+		'wp-admin-bar-get-apps'                   : 'jetpack_masterbar_get_apps_link_click',
+		'wp-admin-bar-next-steps'                 : 'jetpack_masterbar_next_steps_link_click',
+		'wp-admin-bar-help'                       : 'jetpack_masterbar_help_link_click',
+	};
+
+	window.wpcom_masterbar.notesTracksEvents = {
+		openSite: {
+			name: 'jetpack_masterbar_notifications_open_site',
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId } }
+		},
+		openPost: {
+			name: 'jetpack_masterbar_notifications_open_post',
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId } }
+		},
+		openComment: {
+			name: 'jetpack_masterbar_notifications_open_comment',
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId, comment_id: data.commentId } }
+		},
+	};
+
+	window.wpcom_masterbar.user_id = jetpackTracks.user_id;
+})( jetpackTracks );

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,3 +1,4 @@
+/*globals JSON, jetpackTracks */
 (function( $, jetpackTracks ) {
 	window._tkq = window._tkq || [];
 
@@ -7,7 +8,7 @@
 		'wp-admin-bar-newdash'     : 'jetpack_masterbar_reader_link_click',
 		'wp-admin-bar-ab-new-post' : 'jetpack_masterbar_write_button_click',
 		'wp-admin-bar-my-account'  : 'jetpack_masterbar_my_account_link_click',
-		'wp-admin-bar-notes'       : 'jetpack_masterbar_notifications_link_click',
+		'wp-admin-bar-notes'       : 'jetpack_masterbar_notifications_link_click'
 	};
 
 	var linksWhitelist = [
@@ -26,22 +27,22 @@
 		// account - profile
 		'wp-admin-bar-my-profile', 'wp-admin-bar-account-settings', 'wp-admin-bar-billing', 'wp-admin-bar-security', 'wp-admin-bar-notifications',
 		//account - special
-		'wp-admin-bar-get-apps', 'wp-admin-bar-next-steps', 'wp-admin-bar-help',
+		'wp-admin-bar-get-apps', 'wp-admin-bar-next-steps', 'wp-admin-bar-help'
 	];
 
 	var notesTracksEvents = {
 		openSite: {
 			name: 'jetpack_masterbar_notifications_open_site',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId } }
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId }; }
 		},
 		openPost: {
 			name: 'jetpack_masterbar_notifications_open_post',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId } }
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId }; }
 		},
 		openComment: {
 			name: 'jetpack_masterbar_notifications_open_comment',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId, comment_id: data.commentId } }
-		},
+			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId, comment_id: data.commentId }; }
+		}
 	};
 
 	var nonce = jetpackTracks.tracks_nonce;
@@ -77,7 +78,7 @@
 				e.preventDefault();
 				window.location = 'jetpack-track-and-bounce.php?' + $.param( {
 					tracks_and_bounce: trackId,
-					tracks_and_bounce_nonce: nonce,
+					tracks_and_bounce_nonce: nonce
 				} );
 			}
 		} );
@@ -90,7 +91,7 @@
 			return;
 		}
 
-		var data = ( 'string' == typeof event.data ) ? parseJson( event.data, {} ) : event.data;
+		var data = ( 'string' === typeof event.data ) ? parseJson( event.data, {} ) : event.data;
 		if ( 'notesIframeMessage' !== data.type ) {
 			return;
 		}

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -59,15 +59,31 @@
 	var notesTracksEvents = {
 		openSite: {
 			name: 'jetpack_masterbar_notifications_open_site',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId }; }
+			properties: function( data ) {
+				return {
+					site_id: data.siteId,
+					post_id: data.postId
+				};
+			}
 		},
 		openPost: {
 			name: 'jetpack_masterbar_notifications_open_post',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId }; }
+			properties: function( data ) {
+				return {
+					site_id: data.siteId,
+					post_id: data.postId
+				};
+			}
 		},
 		openComment: {
 			name: 'jetpack_masterbar_notifications_open_comment',
-			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId, comment_id: data.commentId }; }
+			properties: function( data ) {
+				return {
+					site_id: data.siteId,
+					post_id: data.postId,
+					comment_id: data.commentId
+				};
+			}
 		}
 	};
 

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -5,17 +5,20 @@
 	var notesTracksEvents = {
 		openSite: function( data ) {
 			return {
+				source: 'masterbar_notifications_panel',
 				site_id: data.siteId
 			};
 		},
 		openPost: function( data ) {
 			return {
+				source: 'masterbar_notifications_panel',
 				site_id: data.siteId,
 				post_id: data.postId
 			};
 		},
 		openComment: function( data ) {
 			return {
+				source: 'masterbar_notifications_panel',
 				site_id: data.siteId,
 				post_id: data.postId,
 				comment_id: data.commentId
@@ -78,7 +81,7 @@
 			return;
 		}
 
-		window._tkq.push( [ 'recordEvent', 'jetpack_masterbar_link_click', eventData( data ) ] );
+		window._tkq.push( [ 'recordEvent', 'jetpack_' + eventName, eventData( data ) ] );
 	} );
 
 	window.jetpackTracks = null;

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -81,7 +81,7 @@
 		}
 	}
 
-	$( document ).ready( function(){
+	$( document ).ready( function() {
 		$( '.ab-item, .ab-secondary' ).on( 'click touchstart', function( e ) {
 			var $target = $( e.target ),
 					$parent = $target.closest( 'li' );

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,60 +1,35 @@
-(function() {
-	window.wpcom_masterbar = window.wpcom_masterbar || {};
+(function( $, jetpackTracks ) {
+	window._tkq = window._tkq || [];
 
-	window.wpcom_masterbar.linksTracksEvents = {
+	var linksTracksEvents = {
 		//top level items
-		'wp-admin-bar-blog'                       : 'jetpack_masterbar_my_sites_link_click',
-		'wp-admin-bar-newdash'                    : 'jetpack_masterbar_reader_link_click',
-		'wp-admin-bar-ab-new-post'                : 'jetpack_masterbar_write_button_click',
-		'wp-admin-bar-my-account'                 : 'jetpack_masterbar_my_account_link_click',
-		'wp-admin-bar-notes'                      : 'jetpack_masterbar_notifications_link_click',
-		//my sites - top items
-		'wp-admin-bar-switch-site'                : 'jetpack_masterbar_switch_site_link_click',
-		'wp-admin-bar-blog-info'                  : 'jetpack_masterbar_blog_info_link_click',
-		'wp-admin-bar-site-view'                  : 'jetpack_masterbar_view_site_link_click',
-		'wp-admin-bar-blog-stats'                 : 'jetpack_masterbar_blog_stats_link_click',
-		'wp-admin-bar-plan'                       : 'jetpack_masterbar_plan_link_click',
-		'wp-admin-bar-plan-secondary'             : 'jetpack_masterbar_plan_badge_link_click',
-		//my sites - manage
-		'wp-admin-bar-new-page'                   : 'jetpack_masterbar_new_page_link_click',
-		'wp-admin-bar-new-page-secondary'         : 'jetpack_masterbar_add_page_link_click',
-		'wp-admin-bar-new-post'                   : 'jetpack_masterbar_new_post_link_click',
-		'wp-admin-bar-new-post-secondary'         : 'jetpack_masterbar_add_new_post_link_click',
-		'wp-admin-bar-comments'                   : 'jetpack_masterbar_comments_link_click',
-		//my sites - personalize
-		'wp-admin-bar-themes'                     : 'jetpack_masterbar_themes_link_click',
-		'wp-admin-bar-themes-secondary'           : 'jetpack_masterbar_themes_customize_button_click',
-		//my sites - configure
-		'wp-admin-bar-sharing'                    : 'jetpack_masterbar_configure_sharing_link_click',
-		'wp-admin-bar-users-toolbar'              : 'jetpack_masterbar_configure_people_link_click',
-		'wp-admin-bar-users-toolbar-secondary'    : 'jetpack_masterbar_configure_people_add_button_click',
-		'wp-admin-bar-plugins'                    : 'jetpack_masterbar_configure_plugins_link_click',
-		'wp-admin-bar-plugins-secondary'          : 'jetpack_masterbar_configure_plugins_add_button_click',
-		'wp-admin-bar-blog-settings'              : 'jetpack_masterbar_settings_link_click',
-
-		//reader
-		'wp-admin-bar-following'                  : 'jetpack_masterbar_followed_sites_link_click',
-		'wp-admin-bar-following-secondary'        : 'jetpack_masterbar_followed_sites_manage_button_click',
-		'wp-admin-bar-discover-discover'          : 'jetpack_masterbar_reader_discover_link_click',
-		'wp-admin-bar-discover-search'            : 'jetpack_masterbar_reader_search_link_click',
-		'wp-admin-bar-discover-recommended-blogs' : 'jetpack_masterbar_reader_recommendations_link_click',
-		'wp-admin-bar-my-activity-my-likes'       : 'jetpack_masterbar_reader_my_links_link_click',
-
-		//account
-		'wp-admin-bar-user-info'                  : 'jetpack_masterbar_user_name_link_click',
-		// account - profile
-		'wp-admin-bar-my-profile'                 : 'jetpack_masterbar_profile_my_profile_link_click',
-		'wp-admin-bar-account-settings'           : 'jetpack_masterbar_profile_account_settings_link_click',
-		'wp-admin-bar-billing'                    : 'jetpack_masterbar_profile_manage_purchases_link_click',
-		'wp-admin-bar-security'                   : 'jetpack_masterbar_profile_security_link_click',
-		'wp-admin-bar-notifications'              : 'jetpack_masterbar_profile_notifications_link_click',
-		//account - special
-		'wp-admin-bar-get-apps'                   : 'jetpack_masterbar_get_apps_link_click',
-		'wp-admin-bar-next-steps'                 : 'jetpack_masterbar_next_steps_link_click',
-		'wp-admin-bar-help'                       : 'jetpack_masterbar_help_link_click',
+		'wp-admin-bar-blog'        : 'jetpack_masterbar_my_sites_link_click',
+		'wp-admin-bar-newdash'     : 'jetpack_masterbar_reader_link_click',
+		'wp-admin-bar-ab-new-post' : 'jetpack_masterbar_write_button_click',
+		'wp-admin-bar-my-account'  : 'jetpack_masterbar_my_account_link_click',
+		'wp-admin-bar-notes'       : 'jetpack_masterbar_notifications_link_click',
 	};
 
-	window.wpcom_masterbar.notesTracksEvents = {
+	var linksWhitelist = [
+		//my sites - top items
+		'wp-admin-bar-switch-site', 'wp-admin-bar-blog-info', 'wp-admin-bar-site-view', 'wp-admin-bar-blog-stats', 'wp-admin-bar-plan', 'wp-admin-bar-plan-secondary',
+		//my sites - manage
+		'wp-admin-bar-new-page', 'wp-admin-bar-new-page-secondary', 'wp-admin-bar-new-post', 'wp-admin-bar-new-post-secondary', 'wp-admin-bar-comments',
+		//my sites - personalize
+		'wp-admin-bar-themes', 'wp-admin-bar-themes-secondary',
+		//my sites - configure
+		'wp-admin-bar-sharing', 'wp-admin-bar-users-toolbar', 'wp-admin-bar-users-toolbar-secondary', 'wp-admin-bar-plugins', 'wp-admin-bar-plugins-secondary', 'wp-admin-bar-blog-settings',
+		//reader
+		'wp-admin-bar-following', 'wp-admin-bar-following-secondary', 'wp-admin-bar-discover-discover', 'wp-admin-bar-discover-search', 'wp-admin-bar-discover-recommended-blogs', 'wp-admin-bar-my-activity-my-likes',
+		//account
+		'wp-admin-bar-user-info',
+		// account - profile
+		'wp-admin-bar-my-profile', 'wp-admin-bar-account-settings', 'wp-admin-bar-billing', 'wp-admin-bar-security', 'wp-admin-bar-notifications',
+		//account - special
+		'wp-admin-bar-get-apps', 'wp-admin-bar-next-steps', 'wp-admin-bar-help',
+	];
+
+	var notesTracksEvents = {
 		openSite: {
 			name: 'jetpack_masterbar_notifications_open_site',
 			properties: function( data ) { return { site_id: data.siteId, post_id: data.postId } }
@@ -69,5 +44,65 @@
 		},
 	};
 
-	window.wpcom_masterbar.user_id = jetpackTracks.user_id;
-})( jetpackTracks );
+	var nonce = jetpackTracks.tracks_nonce;
+
+	function parseJson( s, defaultValue ) {
+		try {
+			return JSON.parse( s );
+		} catch ( e ) {
+			return defaultValue;
+		}
+	}
+
+	$( document ).ready( function(){
+		$( '.ab-item, .ab-secondary' ).on( 'click touchstart', function( e ) {
+			var $target = $( e.target ),
+					$parent = $target.closest( 'li' );
+
+			if( ! $parent ) {
+				return;
+			}
+
+			var parentId = $parent.attr( 'ID' );
+			var trackId = $target.hasClass( 'ab-secondary' ) ? parentId + '-secondary' : parentId;
+			var eventName = linksTracksEvents[ trackId ] || linksWhitelist.indexOf( trackId ) || null;
+			if ( ! eventName ) {
+				return;
+			}
+
+			if( $parent.hasClass( 'menupop' ) ) {
+				//top level items that open a panel
+				window._tkq.push( [ 'recordEvent', eventName ] );
+			} else {
+				e.preventDefault();
+				window.location = 'jetpack-track-and-bounce.php?' + $.param( {
+					tracks_and_bounce: trackId,
+					tracks_and_bounce_nonce: nonce,
+				} );
+			}
+		} );
+	} );
+
+	// listen for postMessage events from the notifications iframe
+	$( window ).on( 'message', function( e ) {
+		var event = ! e.data && e.originalEvent.data ? e.originalEvent : event;
+		if ( event.origin !== 'https://widgets.wp.com' ) {
+			return;
+		}
+
+		var data = ( 'string' == typeof event.data ) ? parseJson( event.data, {} ) : event.data;
+		if ( 'notesIframeMessage' !== data.type ) {
+			return;
+		}
+
+		var eventData = notesTracksEvents[ data.action ];
+		if ( ! eventData ) {
+			return;
+		}
+
+		window._tkq.push( [ 'recordEvent', eventData.name, eventData.properties( data ) ] );
+	} );
+
+	window.jetpackTracks = null;
+
+})( jQuery, jetpackTracks );

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,4 +1,4 @@
-/*globals JSON, jetpackTracks */
+/*globals JSON */
 (function( $ ) {
 	var notesTracksEvents = {
 		openSite: function( data ) {

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -43,13 +43,13 @@
 			var $target = $( e.target ),
 					$parent = $target.closest( 'li' );
 
-			if( ! $parent ) {
+			if ( ! $parent ) {
 				return;
 			}
 
 			var trackingId = $target.attr( 'ID' ) || $parent.attr( 'ID' );
 
-			if( $parent.hasClass( 'menupop' ) ) {
+			if ( $parent.hasClass( 'menupop' ) ) {
 				window.jpTracksAJAX.record_ajax_event( eventName, 'click', trackingId );
 			} else {
 				e.preventDefault();


### PR DESCRIPTION
Fixes #7738
~~Depends on D7169-code~~

#### Changes proposed in this Pull Request:

~~Enqueues tracks scripts when the WordPress.com masterbar is loaded, to make them available to the javascript overrides.~~

Makes the Masterbar and the Notifications Panel interactions trackable by making the record event function global on `tracks-ajax.js` and adding event handling to the Masterbar plugin.

#### Testing instructions:

* ~~Sandbox `s0.wp.com`.~~
* ~~Apply D7169-code on your sandbox.~~
* ~~Using a http debugger, click on any menu item (this does not work on top level items). An entry for the corresponding event with the domain `pixel.wp.com` should appear.~~

* Run a WordPress instance with this branch
* Enable WordPress.com Masterbar
* Using an http debugger, any activity on the masterbar, or opening a site, post or comment on the notifications panel should trigger an `admin-ajax.php` request with the `jetpack_tracks` action.
