### PR TITLE
General: Connection: Only force register on build_connect_url max one time

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -147,6 +147,7 @@ class Jetpack_Client_Server {
 
 		// Since this is a fresh connection, be sure to clear out IDC options
 		Jetpack_IDC::clear_all_idc_options();
+		Jetpack_Options::delete_raw_option( 'jetpack_last_connect_url_check' );
 
 		// Start nonce cleaner
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -687,10 +687,10 @@ class Jetpack {
 			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
 			wp_send_json_success();
 		}
-		
+
 		wp_die();
 	}
-	
+
 	function jetpack_admin_ajax_tracks_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {
@@ -3836,7 +3836,7 @@ p {
 				JetpackTracking::record_user_event( 'jpc_register_success', array(
 					'from' => $from
 				) );
-				
+
 				wp_redirect( $this->build_connect_url( true, $redirect, $from ) );
 				exit;
 			case 'activate' :
@@ -4253,15 +4253,21 @@ p {
 			}
 		} else {
 
-			// Checking existing token
-			$response = Jetpack_Client::wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d', $site_id ) .'?force=wpcom',
-				'1.1'
-			);
+			// Let's check the existing blog token to see if we need to re-register. We only check once per minute
+			// because otherwise this logic can get us in to a loop.
+			$last_connect_url_check = intval( Jetpack_Options::get_raw_option( 'jetpack_last_connect_url_check' ) );
+			if ( ! $last_connect_url_check || ( time() - $last_connect_url_check ) > MINUTE_IN_SECONDS ) {
+				Jetpack_Options::update_raw_option( 'jetpack_last_connect_url_check', time() );
 
-			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				// Generating a register URL instead to refresh the existing token
-				return $this->build_connect_url( $raw, $redirect, $from, true );
+				$response = Jetpack_Client::wpcom_json_api_request_as_blog(
+					sprintf( '/sites/%d', $site_id ) .'?force=wpcom',
+					'1.1'
+				);
+
+				if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					// Generating a register URL instead to refresh the existing token
+					return $this->build_connect_url( $raw, $redirect, $from, true );
+				}
 			}
 
 			if ( defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) && include_once JETPACK__GLOTPRESS_LOCALES_PATH ) {
@@ -4300,7 +4306,7 @@ p {
 			$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
 
 			$tracks_identity = jetpack_tracks_get_identity( get_current_user_id() );
-			
+
 			$args = urlencode_deep(
 				array(
 					'response_type' => 'code',


### PR DESCRIPTION
Today, while testing Jetpack Onboarding, with latest `master` for Jetpack, I cleared out the connection on my site with:

- `wp option delete jetpack_options`
- `wp option delete jetpack_private_options`

Then, when I tried to reconnect, I got an `ERR_TOO_MANY_REDIRECTS` error in Chrome. Upon debugging, it looks like `build_connect_url` got into some loop where it kept trying to register. Here's some debug.

```
[04-Sep-2017 21:04:54 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url

[04-Sep-2017 21:04:54 UTC] {"register":true,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:54 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url, Jetpack->build_connect_url

[04-Sep-2017 21:04:55 UTC] {"register":false,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:55 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url

[04-Sep-2017 21:04:55 UTC] {"register":true,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:55 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url, Jetpack->build_connect_url

[04-Sep-2017 21:04:56 UTC] {"register":false,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:56 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url

[04-Sep-2017 21:04:56 UTC] {"register":true,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:56 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url, Jetpack->build_connect_url

[04-Sep-2017 21:04:57 UTC] {"register":false,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:57 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url

[04-Sep-2017 21:04:57 UTC] {"register":true,"token":"*****************","site_id":14310116}
[04-Sep-2017 21:04:57 UTC] do_action('load-toplevel_page_jetpack'), WP_Hook->do_action, WP_Hook->apply_filters, Jetpack_Admin_Page->admin_page_load, Jetpack->admin_page_load, Jetpack->build_
connect_url, Jetpack->build_connect_url
```

Note how the calls are back-to-back and `build_connect_url` is calling itself. This is actually Jetpack redirecting back to itself. I was able to isolate the issue back to #6964.

### How to reproduce

It's not foolproof, but I was often able to reproduce by connecting, and then running the WP CLI calls to delete local Jetpack options.

### How to test

Get your site in a state where you get the redirect, then apply this patch. 