### PR TITLE
Squelch warning in wp-cli protect whitelist on new install

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -415,7 +415,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			case 'whitelist':
 				$whitelist         = array();
 				$new_ip            = $args[1];
-				$current_whitelist = get_site_option( 'jetpack_protect_whitelist' );
+				$current_whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
 
 				// Build array of IPs that are already whitelisted.
 				// Re-build manually instead of using jetpack_protect_format_whitelist() so we can easily get


### PR DESCRIPTION
When Jetpack Protect is first installed, the option
`jetpack_protect_whitelist` does not exist, which means the whitelist
command tries to iterate over FALSE, so you get warnings:

```
PHP Warning:  Invalid argument supplied for foreach() in
/path/to/wp-content/plugins/jetpack/class.jetpack-cli.php on line 381
Warning: Invalid argument supplied for foreach() in
/path/to/wp-content/plugins/jetpack/class.jetpack-cli.php on line 381
Success: 4.2.2.2 has been whitelisted.
```

Squelch these messages to tidy things up for novice users.

#### Changes proposed in this Pull Request:

* Silence PHP warnings when whitelist option is empty.

#### Testing instructions:

* On clean installation, `wp jetpack protect whitelist list` should emit no warnings.

Note that `whitelist clear` does not erase the whitelist option, so no warnings there.
