### PR TITLE
Remove PHP 5.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.
 
-# Test WP trunk/master and two latest versions on minimum (5.2).
+# Test WP trunk/master and two latest versions on minimum (5.3).
 # Test WP latest two versions (4.5, 4.3) on most popular (5.5, 5.6).
 # Test WP latest stable (4.5) on other supported PHP (5.3, 5.4).
 # Test WP trunk/master on edge platforms (7.0, PHP nightly).
@@ -33,8 +33,6 @@ matrix:
   - env: WP_TRAVISCI="yarn lint"
   - env: WP_TRAVISCI="yarn test-client"
   - env: WP_TRAVISCI="yarn test-gui"
-  - php: "5.2"
-    dist: precise
   - php: "5.3"
     dist: precise
   - php: "5.5"

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
 === Jetpack by WordPress.com ===
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jacobshere, jblz, jeherve, jenhooks, jenia, jgs, jkudish, jmdodd, Joen, johnjamesjacoby, jshreve, koke, kraftbj, lamdayap, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, michael-arestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
+Requires PHP: 5.3
 Stable tag: 5.2.1
 Requires at least: 4.7
 Tested up to: 4.8


### PR DESCRIPTION
Travis tests for PHP 5.2 have stopped working again due to a missing download file.

We might as well take this opportunity to stop testing on PHP 5.2 and recommend that people upgrade since this version of PHP is insecure and extremely outdated.

This also sets the minimum PHP version in readme.txt as per the [WordPress Plugin guidelines](https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/).