### PR TITLE
Look up user for verify and authorize method instrumentation

### DIFF
--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -58,9 +58,11 @@ class JetpackTracking {
 		self::record_user_event( 'module_deactivated', array( 'module' => $module ) );
 	}
 
-	static function record_user_event( $event_type, $data= array() ) {
+	static function record_user_event( $event_type, $data= array(), $user = null ) {
 
-		$user = wp_get_current_user();
+		if ( ! $user ) {
+			$user = wp_get_current_user();
+		}
 		$site_url = get_option( 'siteurl' );
 
 		$data['_via_ua']  = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -84,7 +84,8 @@ class Jetpack_XMLRPC_Server {
 	}
 
 	function remote_authorize( $request ) {
-		JetpackTracking::record_user_event( 'jpc_remote_authorize_begin' );
+		$user = get_user_by( 'id', $request['state'] );
+		JetpackTracking::record_user_event( 'jpc_remote_authorize_begin', array(), $user );
 
 		foreach( array( 'secret', 'state', 'redirect_uri', 'code' ) as $required ) {
 			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {
@@ -92,7 +93,7 @@ class Jetpack_XMLRPC_Server {
 			}
 		}
 
-		if ( ! get_user_by( 'id', $request['state'] ) ) {
+		if ( ! $user ) {
 			return $this->error( new Jetpack_Error( 'user_unknown', 'User not found.', 404 ), 'jpc_remote_authorize_fail' );
 		}
 
@@ -123,17 +124,17 @@ class Jetpack_XMLRPC_Server {
 		return $response;
 	}
 
-	private function tracks_record_error( $name, $error ) {
+	private function tracks_record_error( $name, $error, $user = null ) {
 		if ( is_wp_error( $error ) ) {
 			JetpackTracking::record_user_event( $name, array(
 				'error_code' => $error->get_error_code(),
 				'error_message' => $error->get_error_message()
-			) );
+			), $user );
 		} elseif( is_a( $error, 'IXR_Error' ) ) {
 			JetpackTracking::record_user_event( $name, array(
 				'error_code' => $error->code,
 				'error_message' => $error->message
-			) );
+			), $user );
 		}
 
 		return $error;
@@ -172,44 +173,45 @@ class Jetpack_XMLRPC_Server {
 		$action = $params[0];
 		$verify_secret = $params[1];
 		$state = isset( $params[2] ) ? $params[2] : '';
-		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_begin' );
+		$user = get_user_by( 'id', $state );
+		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_begin', array(), $user );
 		$tracks_failure_event_name = 'jpc_verify_' . $action . '_fail';
 
 		if ( empty( $verify_secret ) ) {
-			return $this->error( new Jetpack_Error( 'verify_secret_1_missing', sprintf( 'The required "%s" parameter is missing.', 'secret_1' ), 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'verify_secret_1_missing', sprintf( 'The required "%s" parameter is missing.', 'secret_1' ), 400 ), $tracks_failure_event_name, $user );
 		} else if ( ! is_string( $verify_secret ) ) {
-			return $this->error( new Jetpack_Error( 'verify_secret_1_malformed', sprintf( 'The required "%s" parameter is malformed.', 'secret_1' ), 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'verify_secret_1_malformed', sprintf( 'The required "%s" parameter is malformed.', 'secret_1' ), 400 ), $tracks_failure_event_name, $user );
 		} else if ( empty( $state ) ) {
-			return $this->error( new Jetpack_Error( 'state_missing', sprintf( 'The required "%s" parameter is missing.', 'state' ), 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'state_missing', sprintf( 'The required "%s" parameter is missing.', 'state' ), 400 ), $tracks_failure_event_name, $user );
 		} else if ( ! ctype_digit( $state ) ) {
-			return $this->error( new Jetpack_Error( 'state_malformed', sprintf( 'The required "%s" parameter is malformed.', 'state' ), 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'state_malformed', sprintf( 'The required "%s" parameter is malformed.', 'state' ), 400 ), $tracks_failure_event_name, $user );
 		}
 
 		$secrets = Jetpack::get_secrets( $action, $state );
 
 		if ( ! $secrets ) {
 			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_missing', 'Verification secrets not found', 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'verify_secrets_missing', 'Verification secrets not found', 400 ), $tracks_failure_event_name, $user );
 		}
 
 		if ( is_wp_error( $secrets ) ) {
 			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( $secrets->get_error_code(), $secrets->get_error_message(), 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( $secrets->get_error_code(), $secrets->get_error_message(), 400 ), $tracks_failure_event_name, $user );
 		}
 
 		if ( empty( $secrets['secret_1'] ) || empty( $secrets['secret_2'] ) || empty( $secrets['exp'] ) ) {
 			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_incomplete', 'Verification secrets are incomplete', 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'verify_secrets_incomplete', 'Verification secrets are incomplete', 400 ), $tracks_failure_event_name, $user );
 		}
 
 		if ( ! hash_equals( $verify_secret, $secrets['secret_1'] ) ) {
 			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_mismatch', 'Secret mismatch', 400 ), $tracks_failure_event_name );
+			return $this->error( new Jetpack_Error( 'verify_secrets_mismatch', 'Secret mismatch', 400 ), $tracks_failure_event_name, $user );
 		}
 
 		Jetpack::delete_secrets( $action, $state );
 
-		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_success' );
+		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_success', array(), $user );
 		
 		return $secrets['secret_2'];
 	}
@@ -242,10 +244,10 @@ class Jetpack_XMLRPC_Server {
 	 *
 	 * @return bool|IXR_Error
 	 */
-	function error( $error = null, $tracks_event_name = null ) {
+	function error( $error = null, $tracks_event_name = null, $user = null ) {
 		// record using Tracks
 		if ( null !== $tracks_event_name ) {
-			$this->tracks_record_error( $tracks_event_name, $error );
+			$this->tracks_record_error( $tracks_event_name, $error, $user );
 		}
 
 		if ( !is_null( $error ) ) {


### PR DESCRIPTION
Fixes an issue where we weren't properly identifying events triggered during authorization. This PR uses the `state` passed with authorize and verify events to look up the user who is connecting the site.

cc @withinboredom 