### PR TITLE
Top Posts: display the default title when it is set to false.

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -64,6 +64,9 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->defaults() );
 
+		if ( false === $instance['title'] ) {
+			$instance['title'] = $this->default_title;
+		}
 		$title = stripslashes( $instance['title'] );
 
 		$count = isset( $instance['count'] ) ? (int) $instance['count'] : 10;


### PR DESCRIPTION
Fixes #7402

When you want to see the default title in the widget, let's display it.

#### Testing instructions:

* Add a Top Posts Widget to your sidebar.
* Set a custom title for that widget, ensure it gets saved and displayed on the site and in the widget setting screen.
* Now change that title to "Top Posts & Pages"
* When saving your changes, make sure the title doesn't disappear from the widget settings.

#### Proposed changelog entry for your changes:
* Top Posts Widgets: display the default title when it is set to false.