### PR TITLE
Simple Payments: Remove border from product image on front-end

### DIFF
--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -19,10 +19,9 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
 }
 
 .jetpack-simple-payments-image {
-	border: 1px solid rgba(0, 0, 0, 0.1);
 	box-sizing: border-box;
 	min-width: 70px;
-	padding-top: calc(100% - 2px);
+	padding-top: 100%;
 	position: relative;
 }
 


### PR DESCRIPTION
This PR intends to remove the border from the product image on the front-end. This has come up as an internal feedback.

Before:
<img width="615" alt="screen shot 2017-09-07 at 16 02 13" src="https://user-images.githubusercontent.com/908665/30170169-47c07ff6-93e6-11e7-96ab-3ead80d51c1b.png">

After:
<img width="612" alt="screen shot 2017-09-07 at 16 03 04" src="https://user-images.githubusercontent.com/908665/30170186-50ca3bf0-93e6-11e7-9650-9d02fb3842b2.png">

