### PR TITLE
Track remote authorize IXR errors

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -104,7 +104,7 @@ class Jetpack_XMLRPC_Server {
 		$verified = $this->verify_action( array( 'authorize', $request['secret'], $request['state'] ) );
 
 		if ( is_a( $verified, 'IXR_Error' ) ) {
-			return $verified;
+			return $this->error( $verified, 'jpc_remote_authorize_fail' );
 		}
 
 		wp_set_current_user( $request['state'] );


### PR DESCRIPTION
Our remote_authorize errors weren't adding up, and I realised that we had verify errors not being captured before being returned.