### PR TITLE
Gutenblock: Jetpack Subscription Form

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -767,6 +767,9 @@ class Jetpack_Subscriptions {
 			'Success Message Text:' => __( 'Success Message Text:', 'jetpack' ),
 			'Show total number of subscribers?' => __( 'Show total number of subscribers?', 'jetpack' ),
 		) );
+
+		wp_register_style( 'jetpack-subscriptions', plugins_url( 'subscriptions/subscriptions.css', __FILE__ ) );
+		wp_enqueue_style( 'jetpack-subscriptions' );
 	}
 }
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -81,6 +81,17 @@ class Jetpack_Subscriptions {
 		// Gutenberg!
 		add_action( 'init', array( __CLASS__, 'register_block_type' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
+
+		// Add REST API route to get the total number of subscribers.
+		add_action( 'rest_api_init', array( $this, 'rest_api_get_subscriber_count' ) );
+	}
+
+	function rest_api_get_subscriber_count() {
+		register_rest_route( 'jetpack', '/get_subscriber_count', array(
+			'methods' => 'GET',
+			'callback' => array( 'Jetpack_Subscriptions_Widget', 'fetch_subscriber_count' ),
+		) );
+
 	}
 
 	/**
@@ -973,7 +984,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		return $current_subs_array;
 	}
 
-	function fetch_subscriber_count() {
+	public static function fetch_subscriber_count() {
 		$subs_count = get_transient( 'wpcom_subscribers_total' );
 
 		if ( FALSE === $subs_count || 'failed' == $subs_count['status'] ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -77,6 +77,10 @@ class Jetpack_Subscriptions {
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
 
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
+
+		// Gutenberg!
+		add_action( 'init', array( __CLASS__, 'register_block_type' ) );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 	}
 
 	/**
@@ -729,10 +733,44 @@ class Jetpack_Subscriptions {
 		}
 	}
 
+	public static function register_block_type() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+		register_block_type( 'jetpack/subscription-form', array(
+			'render_callback' => 'jetpack_do_subscription_form',
+		) );
+	}
+
+	public static function enqueue_block_editor_assets() {
+		wp_register_script(
+			'jetpack-block-subscription-form',
+			plugins_url( 'subscriptions/block.js', __FILE__ ),
+			array( 'wp-blocks', 'wp-element' )
+		);
+		wp_enqueue_script( 'jetpack-block-subscription-form' );
+		wp_localize_script( 'jetpack-block-subscription-form', 'jpSubBlockI18n', array(
+			'Subscription Form' => __( 'Subscription Form', 'jetpack' ),
+			'Subscribe to Blog via Email' => __( 'Subscribe to Blog via Email', 'jetpack' ),
+			'Enter your email address to subscribe to this blog and receive notifications of new posts by email.'
+				=> __( 'Enter your email address to subscribe to this blog and receive notifications of new posts by email.', 'jetpack' ),
+			'Email Address' => __( 'Email Address', 'jetpack' ),
+			'Subscribe' => __( 'Subscribe', 'jetpack' ),
+			"Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
+				=> __( "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing.", 'jetpack' ),
+			'Join %s other subscribers' => __( 'Join %s other subscribers', 'jetpack' ),
+			'Widget title:' => __( 'Widget title:', 'jetpack' ),
+			'Subscription Form settings' => __( 'Subscription Form settings', 'jetpack' ),
+			'Optional text to display to your readers:' => __( 'Optional text to display to your readers:', 'jetpack' ),
+			'Subscribe Placeholder:' => __( 'Subscribe Placeholder:', 'jetpack' ),
+			'Subscribe Button:' => __( 'Subscribe Button:', 'jetpack' ),
+			'Success Message Text:' => __( 'Success Message Text:', 'jetpack' ),
+			'Show total number of subscribers?' => __( 'Show total number of subscribers?', 'jetpack' ),
+		) );
+	}
 }
 
 Jetpack_Subscriptions::init();
-
 
 /***
  * Blog Subscription Widget

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -738,7 +738,7 @@ class Jetpack_Subscriptions {
 			return;
 		}
 		register_block_type( 'jetpack/subscription-form', array(
-			'render_callback' => 'jetpack_do_subscription_form',
+			'render_callback' => 'jetpack_do_subscription_form'
 		) );
 	}
 
@@ -1092,6 +1092,13 @@ function jetpack_do_subscription_form( $instance ) {
 		$instance = array();
 	}
 	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) ? false : true;
+
+	if (
+		array_key_exists( 'subscribe_text', $instance ) &&
+		is_array( $instance['subscribe_text'] )
+	) {
+		$instance['subscribe_text'] = $instance['subscribe_text'][0];
+	}
 
 	$instance = shortcode_atts(
 		Jetpack_Subscriptions_Widget::defaults(),

--- a/modules/subscriptions/block.css
+++ b/modules/subscriptions/block.css
@@ -1,0 +1,1 @@
+/* Write front-end styles */

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -1,229 +1,132 @@
-( function( wp, i18n ) {
-	wp.blocks.registerBlockType( 'jetpack/subscription-form', {
-		title : i18n['Subscription Form'],
-		icon : 'email-alt',
-		category : 'common',
-		attributes : {
-			title : {
-				type : 'string',
-				default : i18n['Subscribe to Blog via Email']
+'use strict';
+
+(function (wp, i18n) {
+	wp.blocks.registerBlockType('jetpack/subscription-form', {
+		title: i18n['Subscription Form'],
+		icon: 'email-alt',
+		category: 'common',
+		attributes: {
+			title: {
+				type: 'string',
+				default: i18n['Subscribe to Blog via Email']
 			},
-			subscribe_text : {
-				type : 'string',
-				default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
+			subscribe_text: {
+				type: 'string',
+				default: i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
 			},
-			subscribe_placeholder : {
-				type : 'string',
-				default : i18n['Email Address']
+			subscribe_placeholder: {
+				type: 'string',
+				default: i18n['Email Address']
 			},
-			subscribe_button : {
-				type : 'string',
-				default : i18n['Subscribe']
+			subscribe_button: {
+				type: 'string',
+				default: i18n['Subscribe']
 			},
-			success_message : {
-				type : 'string',
-				default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+			success_message: {
+				type: 'string',
+				default: i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
 			},
-			show_subscribers_total : {
-				type : 'bool',
-				default : true
+			show_subscribers_total: {
+				type: 'bool',
+				default: true
 			}
 		},
 
-		edit : function( props ) {
+		edit: function edit(props) {
 			var el = wp.element.createElement;
-			function handleTitleChange( value ) {
+			function handleTitleChange(value) {
 				props.setAttributes({
-					title : value
+					title: value
 				});
 			}
-			function handleSubscribeTextChange( value ) {
+			function handleSubscribeTextChange(value) {
 				props.setAttributes({
-					subscribe_text : value
+					subscribe_text: value
 				});
 			}
-			function handleSubscribePlaceholderChange( value ) {
+			function handleSubscribePlaceholderChange(value) {
 				props.setAttributes({
-					subscribe_placeholder : value
+					subscribe_placeholder: value
 				});
 			}
-			function handleSubscribeButtonChange( value ) {
+			function handleSubscribeButtonChange(value) {
 				props.setAttributes({
-					subscribe_button : value
+					subscribe_button: value
 				});
 			}
-			function handleSuccessMessageChange( value ) {
+			function handleSuccessMessageChange(value) {
 				props.setAttributes({
-					success_message : value
+					success_message: value
 				});
 			}
-			function handleShowSubscribersTotalChange( value ) {
+			function handleShowSubscribersTotalChange(value) {
 				props.setAttributes({
-					show_subscribers_change : !! value
+					show_subscribers_change: !!value
 				});
 			}
 
-			return [
-				el(
-					'div',
-					{ key : 'jetpack/subscription-form/preview' },
-					[
-						!! props.attributes.title && el(
-							'h2',
-							{
-								key : 'jetpack/subscription-form/title/preview',
-								className : 'widgettitle'
-							},
-							props.attributes.title
-						),
-						el(
-							'form',
-							{ key : 'jetpack/subscription-form/preview' },
-							el(
-								'fieldset',
-								{ disabled : true },
-								[
-									!! props.attributes.subscribe_text && el(
-										'div',
-										{
-											key : 'jetpack/subscription-form/subscribe_text/preview',
-											id : 'subscribe-text'
-										},
-										el(
-											'p',
-											null,
-											props.attributes.subscribe_text
-										)
-									),
-									!! props.attributes.show_subscribers_total && el(
-										'p',
-										{ key : 'jetpack/subscription-form/show_subscribers_total/preview' },
-										( i18n['Join %s other subscribers'] ).replace( '%s', '___' )
-									),
-									el(
-										'p',
-										{
-											key : 'jetpack/subscription-form/email-field-wrapper',
-											id : 'subscribe-email'
-										},
-										[
-											el(
-												'label',
-												{
-													key : 'jetpack/subscription-form/subscribe_placeholder/label',
-													id : 'jetpack-subscribe-label'
-												},
-												props.attributes.subscribe_placeholder
-											),
-											el(
-												'input',
-												{
-													key : 'jetpack/subscription-form/subscribe-placeholder/preview',
-													type : 'email',
-													required : 'required',
-													className : 'required',
-													placeholder : props.attributes.subscribe_placeholder,
-													style : { display : 'block' }
-												}
-											)
-										]
-									),
-									el(
-										'p',
-										{
-											key : 'jetpack/subscription-form/subscribe-submit-wrapper',
-											id : 'subscribe-submit'
-										},
-										el(
-											'input',
-											{
-												key : 'jetpack/subscription-form/subscribe_button/preview',
-												type : 'submit',
-												value : props.attributes.subscribe_button
-											}
-										)
-									)
-								]
-							)
-						)
-					]
-				),
-
-				!! props.focus && el(
-					wp.blocks.InspectorControls,
-					{ key : 'inspector' },
-					[
-						el(
-							wp.blocks.BlockDescription,
-							{ key : 'jetpack/subscription-form/description' },
-							el(
-								'p',
-								null,
-								i18n['Subscription Form settings']
-							)
-						),
-						el(
-							wp.blocks.InspectorControls.TextControl,
-							{
-								key : 'jetpack/subscription-form/title/edit',
-								label : i18n['Widget title:'],
-								value : props.attributes.title,
-								onChange : handleTitleChange
-							}
-						),
-						el(
-							wp.blocks.InspectorControls.TextareaControl,
-							{
-								key : 'jetpack/subscription-form/subscribe_text/edit',
-								label : i18n['Optional text to display to your readers:'],
-								value : props.attributes.subscribe_text,
-								onChange : handleSubscribeTextChange
-							}
-						),
-						el(
-							wp.blocks.InspectorControls.TextControl,
-							{
-								key : 'jetpack/subscription-form/subscribe_placeholder/edit',
-								label : i18n['Subscribe Placeholder:'],
-								value : props.attributes.subscribe_placeholder,
-								onChange : handleSubscribePlaceholderChange
-							}
-						),
-						el(
-							wp.blocks.InspectorControls.TextControl,
-							{
-								key : 'jetpack/subscription-form/subscribe_button/edit',
-								label : i18n['Subscribe Button:'],
-								value : props.attributes.subscribe_button,
-								onChange : handleSubscribeButtonChange
-							}
-						),
-						el(
-							wp.blocks.InspectorControls.TextareaControl,
-							{
-								key : 'jetpack/subscription-form/success_message/edit',
-								label : i18n['Success Message Text:'],
-								value : props.attributes.success_message,
-								onChange : handleSuccessMessageChange
-							}
-						),
-						el(
-							wp.blocks.InspectorControls.CheckboxControl,
-							{
-								key : 'jetpack/subscription-form/show_subscribers_total/edit',
-								label : i18n['Show total number of subscribers?'],
-								checked : props.attributes.show_subscribers_total,
-								onChange : handleShowSubscribersTotalChange
-							}
-						)
-					]
-				)
-			];
+			return [el('div', { key: 'jetpack/subscription-form/preview' }, [!!props.attributes.title && el('h2', {
+				key: 'jetpack/subscription-form/title/preview',
+				className: 'widgettitle'
+			}, props.attributes.title), el('form', { key: 'jetpack/subscription-form/preview' }, el('fieldset', { disabled: true }, [!!props.attributes.subscribe_text && el('div', {
+				key: 'jetpack/subscription-form/subscribe_text/preview',
+				id: 'subscribe-text'
+			}, el('p', null, props.attributes.subscribe_text)), !!props.attributes.show_subscribers_total && el('p', { key: 'jetpack/subscription-form/show_subscribers_total/preview' }, i18n['Join %s other subscribers'].replace('%s', '___')), el('p', {
+				key: 'jetpack/subscription-form/email-field-wrapper',
+				id: 'subscribe-email'
+			}, [el('label', {
+				key: 'jetpack/subscription-form/subscribe_placeholder/label',
+				id: 'jetpack-subscribe-label'
+			}, props.attributes.subscribe_placeholder), el('input', {
+				key: 'jetpack/subscription-form/subscribe-placeholder/preview',
+				type: 'email',
+				required: 'required',
+				className: 'required',
+				placeholder: props.attributes.subscribe_placeholder,
+				style: { display: 'block' }
+			})]), el('p', {
+				key: 'jetpack/subscription-form/subscribe-submit-wrapper',
+				id: 'subscribe-submit'
+			}, el('input', {
+				key: 'jetpack/subscription-form/subscribe_button/preview',
+				type: 'submit',
+				value: props.attributes.subscribe_button
+			}))]))]), !!props.focus && el(wp.blocks.InspectorControls, { key: 'inspector' }, [el(wp.blocks.BlockDescription, { key: 'jetpack/subscription-form/description' }, el('p', null, i18n['Subscription Form settings'])), el(wp.blocks.InspectorControls.TextControl, {
+				key: 'jetpack/subscription-form/title/edit',
+				label: i18n['Widget title:'],
+				value: props.attributes.title,
+				onChange: handleTitleChange
+			}), el(wp.blocks.InspectorControls.TextareaControl, {
+				key: 'jetpack/subscription-form/subscribe_text/edit',
+				label: i18n['Optional text to display to your readers:'],
+				value: props.attributes.subscribe_text,
+				onChange: handleSubscribeTextChange
+			}), el(wp.blocks.InspectorControls.TextControl, {
+				key: 'jetpack/subscription-form/subscribe_placeholder/edit',
+				label: i18n['Subscribe Placeholder:'],
+				value: props.attributes.subscribe_placeholder,
+				onChange: handleSubscribePlaceholderChange
+			}), el(wp.blocks.InspectorControls.TextControl, {
+				key: 'jetpack/subscription-form/subscribe_button/edit',
+				label: i18n['Subscribe Button:'],
+				value: props.attributes.subscribe_button,
+				onChange: handleSubscribeButtonChange
+			}), el(wp.blocks.InspectorControls.TextareaControl, {
+				key: 'jetpack/subscription-form/success_message/edit',
+				label: i18n['Success Message Text:'],
+				value: props.attributes.success_message,
+				onChange: handleSuccessMessageChange
+			}), el(wp.blocks.InspectorControls.CheckboxControl, {
+				key: 'jetpack/subscription-form/show_subscribers_total/edit',
+				label: i18n['Show total number of subscribers?'],
+				checked: props.attributes.show_subscribers_total,
+				onChange: handleShowSubscribersTotalChange
+			})])];
 		},
 
-		save : function() {
+		save: function save() {
 			return null;
 		}
 
-	} );
-} )( window.wp, jpSubBlockI18n );
+	});
+})(window.wp, jpSubBlockI18n);

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -1,0 +1,229 @@
+( function( wp, i18n ) {
+	wp.blocks.registerBlockType( 'jetpack/subscription-form', {
+		title : i18n['Subscription Form'],
+		icon : 'email-alt',
+		category : 'common',
+		attributes : {
+			title : {
+				type : 'string',
+				default : i18n['Subscribe to Blog via Email']
+			},
+			subscribe_text : {
+				type : 'string',
+				default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
+			},
+			subscribe_placeholder : {
+				type : 'string',
+				default : i18n['Email Address']
+			},
+			subscribe_button : {
+				type : 'string',
+				default : i18n['Subscribe']
+			},
+			success_message : {
+				type : 'string',
+				default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+			},
+			show_subscribers_total : {
+				type : 'bool',
+				default : true
+			}
+		},
+
+		edit : function( props ) {
+			var el = wp.element.createElement;
+			function handleTitleChange( value ) {
+				props.setAttributes({
+					title : value
+				});
+			}
+			function handleSubscribeTextChange( value ) {
+				props.setAttributes({
+					subscribe_text : value
+				});
+			}
+			function handleSubscribePlaceholderChange( value ) {
+				props.setAttributes({
+					subscribe_placeholder : value
+				});
+			}
+			function handleSubscribeButtonChange( value ) {
+				props.setAttributes({
+					subscribe_button : value
+				});
+			}
+			function handleSuccessMessageChange( value ) {
+				props.setAttributes({
+					success_message : value
+				});
+			}
+			function handleShowSubscribersTotalChange( value ) {
+				props.setAttributes({
+					show_subscribers_change : !! value
+				});
+			}
+
+			return [
+				el(
+					'div',
+					{ key : 'jetpack/subscription-form/preview' },
+					[
+						!! props.attributes.title && el(
+							'h2',
+							{
+								key : 'jetpack/subscription-form/title/preview',
+								className : 'widgettitle'
+							},
+							props.attributes.title
+						),
+						el(
+							'form',
+							{ key : 'jetpack/subscription-form/preview' },
+							el(
+								'fieldset',
+								{ disabled : true },
+								[
+									!! props.attributes.subscribe_text && el(
+										'div',
+										{
+											key : 'jetpack/subscription-form/subscribe_text/preview',
+											id : 'subscribe-text'
+										},
+										el(
+											'p',
+											null,
+											props.attributes.subscribe_text
+										)
+									),
+									!! props.attributes.show_subscribers_total && el(
+										'p',
+										{ key : 'jetpack/subscription-form/show_subscribers_total/preview' },
+										( i18n['Join %s other subscribers'] ).replace( '%s', '___' )
+									),
+									el(
+										'p',
+										{
+											key : 'jetpack/subscription-form/email-field-wrapper',
+											id : 'subscribe-email'
+										},
+										[
+											el(
+												'label',
+												{
+													key : 'jetpack/subscription-form/subscribe_placeholder/label',
+													id : 'jetpack-subscribe-label'
+												},
+												props.attributes.subscribe_placeholder
+											),
+											el(
+												'input',
+												{
+													key : 'jetpack/subscription-form/subscribe-placeholder/preview',
+													type : 'email',
+													required : 'required',
+													className : 'required',
+													placeholder : props.attributes.subscribe_placeholder,
+													style : { display : 'block' }
+												}
+											)
+										]
+									),
+									el(
+										'p',
+										{
+											key : 'jetpack/subscription-form/subscribe-submit-wrapper',
+											id : 'subscribe-submit'
+										},
+										el(
+											'input',
+											{
+												key : 'jetpack/subscription-form/subscribe_button/preview',
+												type : 'submit',
+												value : props.attributes.subscribe_button
+											}
+										)
+									)
+								]
+							)
+						)
+					]
+				),
+
+				!! props.focus && el(
+					wp.blocks.InspectorControls,
+					{ key : 'inspector' },
+					[
+						el(
+							wp.blocks.BlockDescription,
+							{ key : 'jetpack/subscription-form/description' },
+							el(
+								'p',
+								null,
+								i18n['Subscription Form settings']
+							)
+						),
+						el(
+							wp.blocks.InspectorControls.TextControl,
+							{
+								key : 'jetpack/subscription-form/title/edit',
+								label : i18n['Widget title:'],
+								value : props.attributes.title,
+								onChange : handleTitleChange
+							}
+						),
+						el(
+							wp.blocks.InspectorControls.TextareaControl,
+							{
+								key : 'jetpack/subscription-form/subscribe_text/edit',
+								label : i18n['Optional text to display to your readers:'],
+								value : props.attributes.subscribe_text,
+								onChange : handleSubscribeTextChange
+							}
+						),
+						el(
+							wp.blocks.InspectorControls.TextControl,
+							{
+								key : 'jetpack/subscription-form/subscribe_placeholder/edit',
+								label : i18n['Subscribe Placeholder:'],
+								value : props.attributes.subscribe_placeholder,
+								onChange : handleSubscribePlaceholderChange
+							}
+						),
+						el(
+							wp.blocks.InspectorControls.TextControl,
+							{
+								key : 'jetpack/subscription-form/subscribe_button/edit',
+								label : i18n['Subscribe Button:'],
+								value : props.attributes.subscribe_button,
+								onChange : handleSubscribeButtonChange
+							}
+						),
+						el(
+							wp.blocks.InspectorControls.TextareaControl,
+							{
+								key : 'jetpack/subscription-form/success_message/edit',
+								label : i18n['Success Message Text:'],
+								value : props.attributes.success_message,
+								onChange : handleSuccessMessageChange
+							}
+						),
+						el(
+							wp.blocks.InspectorControls.CheckboxControl,
+							{
+								key : 'jetpack/subscription-form/show_subscribers_total/edit',
+								label : i18n['Show total number of subscribers?'],
+								checked : props.attributes.show_subscribers_total,
+								onChange : handleShowSubscribersTotalChange
+							}
+						)
+					]
+				)
+			];
+		},
+
+		save : function() {
+			return null;
+		}
+
+	} );
+} )( window.wp, jpSubBlockI18n );

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -45,7 +45,8 @@ registerBlockType('jetpack/subscription-form', {
 		// `jetpack_do_subscription_form` shortcode.
 		show_subscribers_total: {
 			type: 'bool',
-			default: true
+			// Keep this in sync with server defaults
+			default: false
 		},
 		subscribersCount: {
 			type: 'number',

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -119,7 +119,7 @@ registerBlockType('jetpack/subscription-form', {
 						i18n['Join %s other subscribers'].replace('%s', subscribersCount)
 					),
 					wp.element.createElement(
-						'p',
+						'div',
 						{ id: 'subscribe-email' },
 						wp.element.createElement(
 							'label',
@@ -136,7 +136,7 @@ registerBlockType('jetpack/subscription-form', {
 						})
 					),
 					wp.element.createElement(
-						'p',
+						'div',
 						{ id: 'subscribe-submit' },
 						wp.element.createElement('input', { type: 'submit', value: subscribe_button, disabled: true })
 					)

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -8,7 +8,7 @@
 		attributes: {
 			title: {
 				type: 'string',
-				default: i18n['Subscribe to Blog via Email']
+				default: 'Subscribe to this site'
 			},
 			subscribe_text: {
 				type: 'string',
@@ -44,11 +44,6 @@
 					subscribe_text: value
 				});
 			}
-			function handleSubscribePlaceholderChange(value) {
-				props.setAttributes({
-					subscribe_placeholder: value
-				});
-			}
 			function handleSubscribeButtonChange(value) {
 				props.setAttributes({
 					subscribe_button: value
@@ -65,18 +60,26 @@
 				});
 			}
 
-			return [el('div', { key: 'jetpack/subscription-form/preview' }, [!!props.attributes.title && el('h2', {
+			return [el('div', {
+				key: 'jetpack/subscription-form/preview',
+				className: 'subscription-form'
+			}, [!!props.attributes.title && el('h2', {
 				key: 'jetpack/subscription-form/title/preview',
-				className: 'widgettitle'
+				className: 'subscription-form__title'
 			}, props.attributes.title), el('form', { key: 'jetpack/subscription-form/preview' }, el('fieldset', { disabled: true }, [!!props.attributes.subscribe_text && el('div', {
 				key: 'jetpack/subscription-form/subscribe_text/preview',
-				id: 'subscribe-text'
-			}, el('p', null, props.attributes.subscribe_text)), !!props.attributes.show_subscribers_total && el('p', { key: 'jetpack/subscription-form/show_subscribers_total/preview' }, i18n['Join %s other subscribers'].replace('%s', '___')), el('p', {
+				id: 'subscribe-text',
+				className: 'subscription-form__text'
+			}, el('p', null, props.attributes.subscribe_text)), !!props.attributes.show_subscribers_total && el('p', {
+				key: 'jetpack/subscription-form/show_subscribers_total/preview',
+				className: 'subscription-form__subscribers'
+			}, i18n['Join %s other subscribers'].replace('%s', '___')), el('p', {
 				key: 'jetpack/subscription-form/email-field-wrapper',
 				id: 'subscribe-email'
 			}, [el('label', {
 				key: 'jetpack/subscription-form/subscribe_placeholder/label',
-				id: 'jetpack-subscribe-label'
+				id: 'jetpack-subscribe-label',
+				className: 'subscription-form__email-label'
 			}, props.attributes.subscribe_placeholder), el('input', {
 				key: 'jetpack/subscription-form/subscribe-placeholder/preview',
 				type: 'email',
@@ -91,9 +94,9 @@
 				key: 'jetpack/subscription-form/subscribe_button/preview',
 				type: 'submit',
 				value: props.attributes.subscribe_button
-			}))]))]), !!props.focus && el(wp.blocks.InspectorControls, { key: 'inspector' }, [el(wp.blocks.BlockDescription, { key: 'jetpack/subscription-form/description' }, el('p', null, i18n['Subscription Form settings'])), el(wp.blocks.InspectorControls.TextControl, {
+			}))]))]), !!props.focus && el(wp.blocks.InspectorControls, { key: 'inspector' }, [el(wp.blocks.BlockDescription, { key: 'jetpack/subscription-form/description' }, el('h3', null, i18n['Subscription Form settings'])), el(wp.blocks.InspectorControls.TextControl, {
 				key: 'jetpack/subscription-form/title/edit',
-				label: i18n['Widget title:'],
+				label: 'Title',
 				value: props.attributes.title,
 				onChange: handleTitleChange
 			}), el(wp.blocks.InspectorControls.TextareaControl, {
@@ -102,13 +105,8 @@
 				value: props.attributes.subscribe_text,
 				onChange: handleSubscribeTextChange
 			}), el(wp.blocks.InspectorControls.TextControl, {
-				key: 'jetpack/subscription-form/subscribe_placeholder/edit',
-				label: i18n['Subscribe Placeholder:'],
-				value: props.attributes.subscribe_placeholder,
-				onChange: handleSubscribePlaceholderChange
-			}), el(wp.blocks.InspectorControls.TextControl, {
 				key: 'jetpack/subscription-form/subscribe_button/edit',
-				label: i18n['Subscribe Button:'],
+				label: 'Subscribe button',
 				value: props.attributes.subscribe_button,
 				onChange: handleSubscribeButtonChange
 			}), el(wp.blocks.InspectorControls.TextareaControl, {

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -138,7 +138,11 @@ registerBlockType('jetpack/subscription-form', {
 					wp.element.createElement(
 						'div',
 						{ id: 'subscribe-submit' },
-						wp.element.createElement('input', { type: 'submit', value: subscribe_button, disabled: true })
+						wp.element.createElement(
+							'span',
+							{ className: 'button' },
+							subscribe_button
+						)
 					)
 				)
 			)

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -1,130 +1,214 @@
 'use strict';
 
-(function (wp, i18n) {
-	wp.blocks.registerBlockType('jetpack/subscription-form', {
-		title: i18n['Subscription Form'],
-		icon: 'email-alt',
-		category: 'common',
-		attributes: {
-			title: {
-				type: 'string',
-				default: 'Subscribe to this site'
-			},
-			subscribe_text: {
-				type: 'string',
-				default: i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
-			},
-			subscribe_placeholder: {
-				type: 'string',
-				default: i18n['Email Address']
-			},
-			subscribe_button: {
-				type: 'string',
-				default: i18n['Subscribe']
-			},
-			success_message: {
-				type: 'string',
-				default: i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
-			},
-			show_subscribers_total: {
-				type: 'bool',
-				default: true
-			}
+var _wp$blocks = wp.blocks,
+    registerBlockType = _wp$blocks.registerBlockType,
+    InspectorControls = _wp$blocks.InspectorControls,
+    BlockDescription = _wp$blocks.BlockDescription,
+    source = _wp$blocks.source;
+var createElement = wp.element.createElement;
+var text = source.text;
+
+
+var i18n = jpSubBlockI18n;
+
+registerBlockType('jetpack/subscription-form', {
+	title: i18n['Subscription Form'],
+	icon: 'email-alt',
+	category: 'common',
+	attributes: {
+		title: {
+			type: 'string',
+			source: text('.subscription-form__title'),
+			default: 'Subscribe to this site'
 		},
-
-		edit: function edit(props) {
-			var el = wp.element.createElement;
-			function handleTitleChange(value) {
-				props.setAttributes({
-					title: value
-				});
-			}
-			function handleSubscribeTextChange(value) {
-				props.setAttributes({
-					subscribe_text: value
-				});
-			}
-			function handleSubscribeButtonChange(value) {
-				props.setAttributes({
-					subscribe_button: value
-				});
-			}
-			function handleSuccessMessageChange(value) {
-				props.setAttributes({
-					success_message: value
-				});
-			}
-			function handleShowSubscribersTotalChange(value) {
-				props.setAttributes({
-					show_subscribers_change: !!value
-				});
-			}
-
-			return [el('div', {
-				key: 'jetpack/subscription-form/preview',
-				className: 'subscription-form'
-			}, [!!props.attributes.title && el('h2', {
-				key: 'jetpack/subscription-form/title/preview',
-				className: 'subscription-form__title'
-			}, props.attributes.title), el('form', { key: 'jetpack/subscription-form/preview' }, el('fieldset', { disabled: true }, [!!props.attributes.subscribe_text && el('div', {
-				key: 'jetpack/subscription-form/subscribe_text/preview',
-				id: 'subscribe-text',
-				className: 'subscription-form__text'
-			}, el('p', null, props.attributes.subscribe_text)), !!props.attributes.show_subscribers_total && el('p', {
-				key: 'jetpack/subscription-form/show_subscribers_total/preview',
-				className: 'subscription-form__subscribers'
-			}, i18n['Join %s other subscribers'].replace('%s', '___')), el('p', {
-				key: 'jetpack/subscription-form/email-field-wrapper',
-				id: 'subscribe-email'
-			}, [el('label', {
-				key: 'jetpack/subscription-form/subscribe_placeholder/label',
-				id: 'jetpack-subscribe-label',
-				className: 'subscription-form__email-label'
-			}, props.attributes.subscribe_placeholder), el('input', {
-				key: 'jetpack/subscription-form/subscribe-placeholder/preview',
-				type: 'email',
-				required: 'required',
-				className: 'required',
-				placeholder: props.attributes.subscribe_placeholder,
-				style: { display: 'block' }
-			})]), el('p', {
-				key: 'jetpack/subscription-form/subscribe-submit-wrapper',
-				id: 'subscribe-submit'
-			}, el('input', {
-				key: 'jetpack/subscription-form/subscribe_button/preview',
-				type: 'submit',
-				value: props.attributes.subscribe_button
-			}))]))]), !!props.focus && el(wp.blocks.InspectorControls, { key: 'inspector' }, [el(wp.blocks.BlockDescription, { key: 'jetpack/subscription-form/description' }, el('h3', null, i18n['Subscription Form settings'])), el(wp.blocks.InspectorControls.TextControl, {
-				key: 'jetpack/subscription-form/title/edit',
-				label: 'Title',
-				value: props.attributes.title,
-				onChange: handleTitleChange
-			}), el(wp.blocks.InspectorControls.TextareaControl, {
-				key: 'jetpack/subscription-form/subscribe_text/edit',
-				label: i18n['Optional text to display to your readers:'],
-				value: props.attributes.subscribe_text,
-				onChange: handleSubscribeTextChange
-			}), el(wp.blocks.InspectorControls.TextControl, {
-				key: 'jetpack/subscription-form/subscribe_button/edit',
-				label: 'Subscribe button',
-				value: props.attributes.subscribe_button,
-				onChange: handleSubscribeButtonChange
-			}), el(wp.blocks.InspectorControls.TextareaControl, {
-				key: 'jetpack/subscription-form/success_message/edit',
-				label: i18n['Success Message Text:'],
-				value: props.attributes.success_message,
-				onChange: handleSuccessMessageChange
-			}), el(wp.blocks.InspectorControls.CheckboxControl, {
-				key: 'jetpack/subscription-form/show_subscribers_total/edit',
-				label: i18n['Show total number of subscribers?'],
-				checked: props.attributes.show_subscribers_total,
-				onChange: handleShowSubscribersTotalChange
-			})])];
+		subscribe_text: {
+			type: 'string',
+			source: text('.subscription-form__text'),
+			default: i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
 		},
+		subscribe_button: {
+			type: 'string',
+			default: i18n['Subscribe']
+		},
+		success_message: {
+			type: 'string',
+			default: i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+		},
+		show_subscribers_total: {
+			type: 'bool',
+			default: true
+		}
+	},
 
-		save: function save() {
-			return null;
+	edit: function edit(_ref) {
+		var attributes = _ref.attributes,
+		    setAttributes = _ref.setAttributes,
+		    focus = _ref.focus;
+
+		function handleTitleChange(value) {
+			setAttributes({
+				title: value
+			});
+		}
+		function handleSubscribeTextChange(value) {
+			setAttributes({
+				subscribe_text: value
+			});
+		}
+		function handleSubscribeButtonChange(value) {
+			setAttributes({
+				subscribe_button: value
+			});
+		}
+		function handleSuccessMessageChange(value) {
+			setAttributes({
+				success_message: value
+			});
+		}
+		function handleShowSubscribersTotalChange(value) {
+			setAttributes({
+				show_subscribers_change: !!value
+			});
 		}
 
-	});
-})(window.wp, jpSubBlockI18n);
+		var title = attributes.title,
+		    subscribe_text = attributes.subscribe_text,
+		    show_subscribers_total = attributes.show_subscribers_total,
+		    subscribe_button = attributes.subscribe_button;
+
+
+		return [wp.element.createElement(
+			'div',
+			{ key: 'subscription-form', className: 'subscription-form' },
+			!!title && wp.element.createElement(
+				'h2',
+				{ className: 'subscription-form__title' },
+				title
+			),
+			wp.element.createElement(
+				'form',
+				null,
+				wp.element.createElement(
+					'fieldset',
+					{ disabled: true },
+					!!subscribe_text && wp.element.createElement(
+						'div',
+						{ id: 'subscribe-text', className: 'subscription-form__text' },
+						wp.element.createElement(
+							'p',
+							null,
+							subscribe_text
+						)
+					),
+					!!show_subscribers_total && wp.element.createElement(
+						'p',
+						{ className: 'subscription-form__subscribers' },
+						i18n['Join %s other subscribers'].replace('%s', '___')
+					),
+					wp.element.createElement(
+						'p',
+						{ id: 'subscribe-email' },
+						wp.element.createElement(
+							'label',
+							{
+								id: 'jetpack-subscribe-label',
+								className: 'subscription-form__email-label'
+							},
+							i18n['Email Address']
+						),
+						wp.element.createElement('input', {
+							type: 'email',
+							className: 'required',
+							placeholder: i18n['Email Address'],
+							style: { display: 'block' },
+							required: true
+						})
+					),
+					wp.element.createElement(
+						'p',
+						{ id: 'subscribe-submit' },
+						wp.element.createElement('input', { type: 'submit', value: subscribe_button })
+					)
+				)
+			)
+		), !!focus && wp.element.createElement(
+			InspectorControls,
+			{ key: 'inspector' },
+			wp.element.createElement(
+				BlockDescription,
+				null,
+				wp.element.createElement(
+					'h3',
+					null,
+					i18n['Subscription Form settings']
+				)
+			)
+		)];
+	},
+
+	save: function save(_ref2) {
+		var attributes = _ref2.attributes;
+		var title = attributes.title,
+		    subscribe_text = attributes.subscribe_text,
+		    show_subscribers_total = attributes.show_subscribers_total,
+		    subscribe_button = attributes.subscribe_button;
+
+
+		return wp.element.createElement(
+			'div',
+			{ className: 'subscription-form' },
+			!!title && wp.element.createElement(
+				'h2',
+				{ className: 'subscription-form__title' },
+				title
+			),
+			wp.element.createElement(
+				'form',
+				null,
+				wp.element.createElement(
+					'fieldset',
+					{ disabled: true },
+					!!subscribe_text && wp.element.createElement(
+						'div',
+						{ id: 'subscribe-text', className: 'subscription-form__text' },
+						wp.element.createElement(
+							'p',
+							null,
+							subscribe_text
+						)
+					),
+					!!show_subscribers_total && wp.element.createElement(
+						'p',
+						{ className: 'subscription-form__subscribers' },
+						i18n['Join %s other subscribers'].replace('%s', '___')
+					),
+					wp.element.createElement(
+						'p',
+						{ id: 'subscribe-email' },
+						wp.element.createElement(
+							'label',
+							{
+								id: 'jetpack-subscribe-label',
+								className: 'subscription-form__email-label'
+							},
+							i18n['Email Address']
+						),
+						wp.element.createElement('input', {
+							type: 'email',
+							className: 'required',
+							placeholder: i18n['Email Address'],
+							style: { display: 'block' },
+							required: true
+						})
+					),
+					wp.element.createElement(
+						'p',
+						{ id: 'subscribe-submit' },
+						wp.element.createElement('input', { type: 'submit', value: subscribe_button })
+					)
+				)
+			)
+		);
+	}
+
+});

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -46,6 +46,10 @@ registerBlockType('jetpack/subscription-form', {
 		show_subscribers_total: {
 			type: 'bool',
 			default: true
+		},
+		subscribersCount: {
+			type: 'number',
+			default: -1
 		}
 	},
 
@@ -58,12 +62,25 @@ registerBlockType('jetpack/subscription-form', {
 		    subscribe_text = attributes.subscribe_text,
 		    show_subscribers_total = attributes.show_subscribers_total,
 		    subscribe_button = attributes.subscribe_button,
-		    success_message = attributes.success_message;
+		    success_message = attributes.success_message,
+		    subscribersCount = attributes.subscribersCount;
 
 
 		var toggleshow_subscribers_total = function toggleshow_subscribers_total() {
 			return setAttributes({ show_subscribers_total: !show_subscribers_total });
 		};
+
+		var getSubscriberCount = function getSubscriberCount() {
+			var restRootUrl = wp.api.utils.getRootUrl();
+
+			return jQuery.getJSON(restRootUrl + 'wp-json/jetpack/get_subscriber_count');
+		};
+
+		if (subscribersCount === -1) {
+			getSubscriberCount().then(function (data) {
+				return setAttributes({ subscribersCount: data['value'] });
+			});
+		}
 
 		return [wp.element.createElement(
 			'div',
@@ -88,20 +105,17 @@ registerBlockType('jetpack/subscription-form', {
 					!!subscribe_text && wp.element.createElement(
 						'div',
 						{ id: 'subscribe-text', className: 'subscription-form__text' },
-						wp.element.createElement(Editable, {
-							tagName: 'p',
+						wp.element.createElement('textarea', {
 							value: subscribe_text,
-							onChange: function onChange(value) {
-								return setAttributes({ subscribe_text: value });
-							},
-							focus: focus,
-							onFocus: setFocus
+							onChange: function onChange(e) {
+								return setAttributes({ subscribe_text: e.target.value });
+							}
 						})
 					),
-					!!show_subscribers_total && wp.element.createElement(
+					!!show_subscribers_total && subscribersCount > 0 && wp.element.createElement(
 						'p',
 						{ className: 'subscription-form__subscribers' },
-						i18n['Join %s other subscribers'].replace('%s', '___')
+						i18n['Join %s other subscribers'].replace('%s', subscribersCount)
 					),
 					wp.element.createElement(
 						'p',

--- a/modules/subscriptions/block.js
+++ b/modules/subscriptions/block.js
@@ -1,12 +1,15 @@
 'use strict';
 
+/** @format */
 var _wp$blocks = wp.blocks,
     registerBlockType = _wp$blocks.registerBlockType,
     InspectorControls = _wp$blocks.InspectorControls,
     BlockDescription = _wp$blocks.BlockDescription,
-    source = _wp$blocks.source;
+    Editable = _wp$blocks.Editable,
+    _wp$blocks$InspectorC = _wp$blocks.InspectorControls,
+    CheckboxControl = _wp$blocks$InspectorC.CheckboxControl,
+    TextControl = _wp$blocks$InspectorC.TextControl;
 var createElement = wp.element.createElement;
-var text = source.text;
 
 
 var i18n = jpSubBlockI18n;
@@ -18,22 +21,28 @@ registerBlockType('jetpack/subscription-form', {
 	attributes: {
 		title: {
 			type: 'string',
-			source: text('.subscription-form__title'),
 			default: 'Subscribe to this site'
 		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
 		subscribe_text: {
 			type: 'string',
-			source: text('.subscription-form__text'),
 			default: i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
 		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
 		subscribe_button: {
 			type: 'string',
 			default: i18n['Subscribe']
 		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
 		success_message: {
 			type: 'string',
-			default: i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+			default: i18n["Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."]
 		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
 		show_subscribers_total: {
 			type: 'bool',
 			default: true
@@ -43,39 +52,18 @@ registerBlockType('jetpack/subscription-form', {
 	edit: function edit(_ref) {
 		var attributes = _ref.attributes,
 		    setAttributes = _ref.setAttributes,
-		    focus = _ref.focus;
-
-		function handleTitleChange(value) {
-			setAttributes({
-				title: value
-			});
-		}
-		function handleSubscribeTextChange(value) {
-			setAttributes({
-				subscribe_text: value
-			});
-		}
-		function handleSubscribeButtonChange(value) {
-			setAttributes({
-				subscribe_button: value
-			});
-		}
-		function handleSuccessMessageChange(value) {
-			setAttributes({
-				success_message: value
-			});
-		}
-		function handleShowSubscribersTotalChange(value) {
-			setAttributes({
-				show_subscribers_change: !!value
-			});
-		}
-
+		    focus = _ref.focus,
+		    setFocus = _ref.setFocus;
 		var title = attributes.title,
 		    subscribe_text = attributes.subscribe_text,
 		    show_subscribers_total = attributes.show_subscribers_total,
-		    subscribe_button = attributes.subscribe_button;
+		    subscribe_button = attributes.subscribe_button,
+		    success_message = attributes.success_message;
 
+
+		var toggleshow_subscribers_total = function toggleshow_subscribers_total() {
+			return setAttributes({ show_subscribers_total: !show_subscribers_total });
+		};
 
 		return [wp.element.createElement(
 			'div',
@@ -83,22 +71,32 @@ registerBlockType('jetpack/subscription-form', {
 			!!title && wp.element.createElement(
 				'h2',
 				{ className: 'subscription-form__title' },
-				title
+				wp.element.createElement('input', {
+					type: 'text',
+					value: title,
+					onChange: function onChange(e) {
+						return setAttributes({ title: e.target.value });
+					}
+				})
 			),
 			wp.element.createElement(
 				'form',
 				null,
 				wp.element.createElement(
 					'fieldset',
-					{ disabled: true },
+					null,
 					!!subscribe_text && wp.element.createElement(
 						'div',
 						{ id: 'subscribe-text', className: 'subscription-form__text' },
-						wp.element.createElement(
-							'p',
-							null,
-							subscribe_text
-						)
+						wp.element.createElement(Editable, {
+							tagName: 'p',
+							value: subscribe_text,
+							onChange: function onChange(value) {
+								return setAttributes({ subscribe_text: value });
+							},
+							focus: focus,
+							onFocus: setFocus
+						})
 					),
 					!!show_subscribers_total && wp.element.createElement(
 						'p',
@@ -110,10 +108,7 @@ registerBlockType('jetpack/subscription-form', {
 						{ id: 'subscribe-email' },
 						wp.element.createElement(
 							'label',
-							{
-								id: 'jetpack-subscribe-label',
-								className: 'subscription-form__email-label'
-							},
+							{ id: 'jetpack-subscribe-label', className: 'subscription-form__email-label' },
 							i18n['Email Address']
 						),
 						wp.element.createElement('input', {
@@ -121,13 +116,14 @@ registerBlockType('jetpack/subscription-form', {
 							className: 'required',
 							placeholder: i18n['Email Address'],
 							style: { display: 'block' },
-							required: true
+							required: true,
+							disabled: true
 						})
 					),
 					wp.element.createElement(
 						'p',
 						{ id: 'subscribe-submit' },
-						wp.element.createElement('input', { type: 'submit', value: subscribe_button })
+						wp.element.createElement('input', { type: 'submit', value: subscribe_button, disabled: true })
 					)
 				)
 			)
@@ -142,73 +138,30 @@ registerBlockType('jetpack/subscription-form', {
 					null,
 					i18n['Subscription Form settings']
 				)
-			)
+			),
+			wp.element.createElement(CheckboxControl, {
+				label: i18n['Show total number of subscribers?'],
+				checked: show_subscribers_total,
+				onChange: toggleshow_subscribers_total
+			}),
+			wp.element.createElement(TextControl, {
+				label: i18n['Subscribe Button:'],
+				value: subscribe_button,
+				onChange: function onChange(value) {
+					return setAttributes({ subscribe_button: value });
+				}
+			}),
+			wp.element.createElement(TextControl, {
+				label: i18n['Success Message Text:'],
+				value: success_message,
+				onChange: function onChange(value) {
+					return setAttributes({ success_message: value });
+				}
+			})
 		)];
 	},
 
-	save: function save(_ref2) {
-		var attributes = _ref2.attributes;
-		var title = attributes.title,
-		    subscribe_text = attributes.subscribe_text,
-		    show_subscribers_total = attributes.show_subscribers_total,
-		    subscribe_button = attributes.subscribe_button;
-
-
-		return wp.element.createElement(
-			'div',
-			{ className: 'subscription-form' },
-			!!title && wp.element.createElement(
-				'h2',
-				{ className: 'subscription-form__title' },
-				title
-			),
-			wp.element.createElement(
-				'form',
-				null,
-				wp.element.createElement(
-					'fieldset',
-					{ disabled: true },
-					!!subscribe_text && wp.element.createElement(
-						'div',
-						{ id: 'subscribe-text', className: 'subscription-form__text' },
-						wp.element.createElement(
-							'p',
-							null,
-							subscribe_text
-						)
-					),
-					!!show_subscribers_total && wp.element.createElement(
-						'p',
-						{ className: 'subscription-form__subscribers' },
-						i18n['Join %s other subscribers'].replace('%s', '___')
-					),
-					wp.element.createElement(
-						'p',
-						{ id: 'subscribe-email' },
-						wp.element.createElement(
-							'label',
-							{
-								id: 'jetpack-subscribe-label',
-								className: 'subscription-form__email-label'
-							},
-							i18n['Email Address']
-						),
-						wp.element.createElement('input', {
-							type: 'email',
-							className: 'required',
-							placeholder: i18n['Email Address'],
-							style: { display: 'block' },
-							required: true
-						})
-					),
-					wp.element.createElement(
-						'p',
-						{ id: 'subscribe-submit' },
-						wp.element.createElement('input', { type: 'submit', value: subscribe_button })
-					)
-				)
-			)
-		);
+	save: function save() {
+		return null;
 	}
-
 });

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -1,0 +1,229 @@
+( function( wp, i18n ) {
+	wp.blocks.registerBlockType( 'jetpack/subscription-form', {
+		title : i18n['Subscription Form'],
+		icon : 'email-alt',
+		category : 'common',
+		attributes : {
+			title : {
+				type : 'string',
+				default : i18n['Subscribe to Blog via Email']
+			},
+			subscribe_text : {
+				type : 'string',
+				default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
+			},
+			subscribe_placeholder : {
+				type : 'string',
+				default : i18n['Email Address']
+			},
+			subscribe_button : {
+				type : 'string',
+				default : i18n['Subscribe']
+			},
+			success_message : {
+				type : 'string',
+				default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+			},
+			show_subscribers_total : {
+				type : 'bool',
+				default : true
+			}
+		},
+
+		edit : function( props ) {
+			var el = wp.element.createElement;
+			function handleTitleChange( value ) {
+				props.setAttributes({
+					title : value
+				});
+			}
+			function handleSubscribeTextChange( value ) {
+				props.setAttributes({
+					subscribe_text : value
+				});
+			}
+			function handleSubscribePlaceholderChange( value ) {
+				props.setAttributes({
+					subscribe_placeholder : value
+				});
+			}
+			function handleSubscribeButtonChange( value ) {
+				props.setAttributes({
+					subscribe_button : value
+				});
+			}
+			function handleSuccessMessageChange( value ) {
+				props.setAttributes({
+					success_message : value
+				});
+			}
+			function handleShowSubscribersTotalChange( value ) {
+				props.setAttributes({
+					show_subscribers_change : !! value
+				});
+			}
+
+			return [
+				el(
+					'div',
+					{ key : 'jetpack/subscription-form/preview' },
+					[
+						!! props.attributes.title && el(
+							'h2',
+							{
+								key : 'jetpack/subscription-form/title/preview',
+								className : 'widgettitle'
+							},
+							props.attributes.title
+						),
+						el(
+							'form',
+							{ key : 'jetpack/subscription-form/preview' },
+							el(
+								'fieldset',
+								{ disabled : true },
+								[
+									!! props.attributes.subscribe_text && el(
+										'div',
+										{
+											key : 'jetpack/subscription-form/subscribe_text/preview',
+											id : 'subscribe-text'
+										},
+										el(
+											'p',
+											null,
+											props.attributes.subscribe_text
+										)
+									),
+									!! props.attributes.show_subscribers_total && el(
+										'p',
+										{ key : 'jetpack/subscription-form/show_subscribers_total/preview' },
+										( i18n['Join %s other subscribers'] ).replace( '%s', '___' )
+						),
+						el(
+							'p',
+							{
+								key : 'jetpack/subscription-form/email-field-wrapper',
+								id : 'subscribe-email'
+							},
+							[
+								el(
+									'label',
+									{
+										key : 'jetpack/subscription-form/subscribe_placeholder/label',
+										id : 'jetpack-subscribe-label'
+									},
+									props.attributes.subscribe_placeholder
+								),
+								el(
+									'input',
+									{
+										key : 'jetpack/subscription-form/subscribe-placeholder/preview',
+										type : 'email',
+										required : 'required',
+										className : 'required',
+										placeholder : props.attributes.subscribe_placeholder,
+										style : { display : 'block' }
+									}
+								)
+							]
+						),
+						el(
+							'p',
+							{
+								key : 'jetpack/subscription-form/subscribe-submit-wrapper',
+								id : 'subscribe-submit'
+							},
+							el(
+								'input',
+								{
+									key : 'jetpack/subscription-form/subscribe_button/preview',
+									type : 'submit',
+									value : props.attributes.subscribe_button
+								}
+							)
+						)
+					]
+				)
+		)
+		]
+		),
+
+			!! props.focus && el(
+				wp.blocks.InspectorControls,
+				{ key : 'inspector' },
+				[
+					el(
+						wp.blocks.BlockDescription,
+						{ key : 'jetpack/subscription-form/description' },
+						el(
+							'p',
+							null,
+							i18n['Subscription Form settings']
+			)
+		),
+			el(
+				wp.blocks.InspectorControls.TextControl,
+				{
+					key : 'jetpack/subscription-form/title/edit',
+					label : i18n['Widget title:'],
+				value : props.attributes.title,
+				onChange : handleTitleChange
+		}
+		),
+			el(
+				wp.blocks.InspectorControls.TextareaControl,
+				{
+					key : 'jetpack/subscription-form/subscribe_text/edit',
+					label : i18n['Optional text to display to your readers:'],
+					value : props.attributes.subscribe_text,
+					onChange : handleSubscribeTextChange
+				}
+			),
+				el(
+					wp.blocks.InspectorControls.TextControl,
+					{
+						key : 'jetpack/subscription-form/subscribe_placeholder/edit',
+						label : i18n['Subscribe Placeholder:'],
+				value : props.attributes.subscribe_placeholder,
+				onChange : handleSubscribePlaceholderChange
+		}
+		),
+			el(
+				wp.blocks.InspectorControls.TextControl,
+				{
+					key : 'jetpack/subscription-form/subscribe_button/edit',
+					label : i18n['Subscribe Button:'],
+				value : props.attributes.subscribe_button,
+				onChange : handleSubscribeButtonChange
+		}
+		),
+			el(
+				wp.blocks.InspectorControls.TextareaControl,
+				{
+					key : 'jetpack/subscription-form/success_message/edit',
+					label : i18n['Success Message Text:'],
+					value : props.attributes.success_message,
+					onChange : handleSuccessMessageChange
+				}
+			),
+				el(
+					wp.blocks.InspectorControls.CheckboxControl,
+					{
+						key : 'jetpack/subscription-form/show_subscribers_total/edit',
+						label : i18n['Show total number of subscribers?'],
+						checked : props.attributes.show_subscribers_total,
+						onChange : handleShowSubscribersTotalChange
+					}
+				)
+		]
+		)
+		];
+		},
+
+		save : function() {
+			return null;
+		}
+
+	} );
+} )( window.wp, jpSubBlockI18n );

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -6,7 +6,7 @@
 		attributes : {
 			title : {
 				type : 'string',
-				default : i18n['Subscribe to Blog via Email']
+				default : 'Subscribe to this site'
 			},
 			subscribe_text : {
 				type : 'string',
@@ -42,11 +42,6 @@
 					subscribe_text : value
 				});
 			}
-			function handleSubscribePlaceholderChange( value ) {
-				props.setAttributes({
-					subscribe_placeholder : value
-				});
-			}
 			function handleSubscribeButtonChange( value ) {
 				props.setAttributes({
 					subscribe_button : value
@@ -66,13 +61,16 @@
 			return [
 				el(
 					'div',
-					{ key : 'jetpack/subscription-form/preview' },
+					{
+						key : 'jetpack/subscription-form/preview',
+						className : 'subscription-form'
+					},
 					[
 						!! props.attributes.title && el(
 							'h2',
 							{
 								key : 'jetpack/subscription-form/title/preview',
-								className : 'widgettitle'
+								className : 'subscription-form__title'
 							},
 							props.attributes.title
 						),
@@ -87,7 +85,8 @@
 										'div',
 										{
 											key : 'jetpack/subscription-form/subscribe_text/preview',
-											id : 'subscribe-text'
+											id : 'subscribe-text',
+											className : 'subscription-form__text'
 										},
 										el(
 											'p',
@@ -97,7 +96,10 @@
 									),
 									!! props.attributes.show_subscribers_total && el(
 										'p',
-										{ key : 'jetpack/subscription-form/show_subscribers_total/preview' },
+										{
+											key : 'jetpack/subscription-form/show_subscribers_total/preview',
+											className : 'subscription-form__subscribers'
+										},
 										( i18n['Join %s other subscribers'] ).replace( '%s', '___' )
 						),
 						el(
@@ -111,7 +113,8 @@
 									'label',
 									{
 										key : 'jetpack/subscription-form/subscribe_placeholder/label',
-										id : 'jetpack-subscribe-label'
+										id : 'jetpack-subscribe-label',
+										className : 'subscription-form__email-label'
 									},
 									props.attributes.subscribe_placeholder
 								),
@@ -157,7 +160,7 @@
 						wp.blocks.BlockDescription,
 						{ key : 'jetpack/subscription-form/description' },
 						el(
-							'p',
+							'h3',
 							null,
 							i18n['Subscription Form settings']
 			)
@@ -166,7 +169,7 @@
 				wp.blocks.InspectorControls.TextControl,
 				{
 					key : 'jetpack/subscription-form/title/edit',
-					label : i18n['Widget title:'],
+					label : 'Title',
 				value : props.attributes.title,
 				onChange : handleTitleChange
 		}
@@ -180,25 +183,16 @@
 					onChange : handleSubscribeTextChange
 				}
 			),
-				el(
-					wp.blocks.InspectorControls.TextControl,
-					{
-						key : 'jetpack/subscription-form/subscribe_placeholder/edit',
-						label : i18n['Subscribe Placeholder:'],
-				value : props.attributes.subscribe_placeholder,
-				onChange : handleSubscribePlaceholderChange
-		}
-		),
 			el(
 				wp.blocks.InspectorControls.TextControl,
 				{
 					key : 'jetpack/subscription-form/subscribe_button/edit',
-					label : i18n['Subscribe Button:'],
+					label : 'Subscribe button',
 				value : props.attributes.subscribe_button,
 				onChange : handleSubscribeButtonChange
-		}
-		),
-			el(
+			}
+			),
+ 				el(
 				wp.blocks.InspectorControls.TextareaControl,
 				{
 					key : 'jetpack/subscription-form/success_message/edit',

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -117,7 +117,9 @@ registerBlockType( 'jetpack/subscription-form', {
 							/>
 						</div>
 						<div id="subscribe-submit">
-							<input type="submit" value={ subscribe_button } disabled />
+							<span className="button">
+								{ subscribe_button }
+							</span>
 						</div>
 					</fieldset>
 				</form>

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -49,6 +49,10 @@ registerBlockType( 'jetpack/subscription-form', {
 			type: 'bool',
 			default: true,
 		},
+		subscribersCount: {
+			type: 'number',
+			default: -1,
+		},
 	},
 
 	edit: function( { attributes, setAttributes, focus, setFocus } ) {
@@ -58,10 +62,21 @@ registerBlockType( 'jetpack/subscription-form', {
 			show_subscribers_total,
 			subscribe_button,
 			success_message,
+			subscribersCount,
 		} = attributes;
 
 		const toggleshow_subscribers_total = () =>
 			setAttributes( { show_subscribers_total: ! show_subscribers_total } );
+
+		const getSubscriberCount = () => {
+			const restRootUrl = wp.api.utils.getRootUrl();
+
+			return jQuery.getJSON( `${ restRootUrl }wp-json/jetpack/get_subscriber_count` );
+		};
+
+		if ( subscribersCount === -1 ) {
+			getSubscriberCount().then( data => setAttributes( { subscribersCount: data[ 'value' ] } ) );
+		}
 
 		return [
 			<div key="subscription-form" className="subscription-form">
@@ -77,17 +92,15 @@ registerBlockType( 'jetpack/subscription-form', {
 					<fieldset>
 						{ !! subscribe_text &&
 							<div id="subscribe-text" className="subscription-form__text">
-								<Editable
-									tagName="p"
+								<textarea
 									value={ subscribe_text }
-									onChange={ value => setAttributes( { subscribe_text: value } ) }
-									focus={ focus }
-									onFocus={ setFocus }
+									onChange={ e => setAttributes( { subscribe_text: e.target.value } ) }
 								/>
 							</div> }
 						{ !! show_subscribers_total &&
+							subscribersCount > 0 &&
 							<p className="subscription-form__subscribers">
-								{ i18n[ 'Join %s other subscribers' ].replace( '%s', '___' ) }
+								{ i18n[ 'Join %s other subscribers' ].replace( '%s', subscribersCount ) }
 							</p> }
 						<p id="subscribe-email">
 							<label id="jetpack-subscribe-label" className="subscription-form__email-label">

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -103,7 +103,7 @@ registerBlockType( 'jetpack/subscription-form', {
 							<p className="subscription-form__subscribers">
 								{ i18n[ 'Join %s other subscribers' ].replace( '%s', subscribersCount ) }
 							</p> }
-						<p id="subscribe-email">
+						<div id="subscribe-email">
 							<label id="jetpack-subscribe-label" className="subscription-form__email-label">
 								{ i18n[ 'Email Address' ] }
 							</label>
@@ -115,10 +115,10 @@ registerBlockType( 'jetpack/subscription-form', {
 								required
 								disabled
 							/>
-						</p>
-						<p id="subscribe-submit">
+						</div>
+						<div id="subscribe-submit">
 							<input type="submit" value={ subscribe_button } disabled />
-						</p>
+						</div>
 					</fieldset>
 				</form>
 			</div>,

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -47,7 +47,8 @@ registerBlockType( 'jetpack/subscription-form', {
 		// `jetpack_do_subscription_form` shortcode.
 		show_subscribers_total: {
 			type: 'bool',
-			default: true,
+			// Keep this in sync with server defaults
+			default: false,
 		},
 		subscribersCount: {
 			type: 'number',

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -1,170 +1,140 @@
-const { registerBlockType, InspectorControls, BlockDescription, source } = wp.blocks;
+/** @format */
+const {
+	registerBlockType,
+	InspectorControls,
+	BlockDescription,
+	Editable,
+	InspectorControls: { CheckboxControl, TextControl },
+} = wp.blocks;
 const { createElement } = wp.element;
-const { text } = source;
 
 const i18n = jpSubBlockI18n;
 
 registerBlockType( 'jetpack/subscription-form', {
-	title : i18n['Subscription Form'],
-	icon : 'email-alt',
-	category : 'common',
-	attributes : {
-		title : {
-			type : 'string',
-			source: text( '.subscription-form__title' ),
-			default : 'Subscribe to this site'
+	title: i18n[ 'Subscription Form' ],
+	icon: 'email-alt',
+	category: 'common',
+	attributes: {
+		title: {
+			type: 'string',
+			default: 'Subscribe to this site',
 		},
-		subscribe_text : {
-			type : 'string',
-			source: text( '.subscription-form__text' ),
-			default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		subscribe_text: {
+			type: 'string',
+			default:
+				i18n[
+					'Enter your email address to subscribe to this blog and receive notifications of new posts by email.'
+				],
 		},
-		subscribe_button : {
-			type : 'string',
-			default : i18n['Subscribe']
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		subscribe_button: {
+			type: 'string',
+			default: i18n[ 'Subscribe' ],
 		},
-		success_message : {
-			type : 'string',
-			default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		success_message: {
+			type: 'string',
+			default:
+				i18n[
+					"Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
+				],
 		},
-		show_subscribers_total : {
-			type : 'bool',
-			default : true
-		}
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		show_subscribers_total: {
+			type: 'bool',
+			default: true,
+		},
 	},
 
-	edit : function( { attributes, setAttributes, focus } ) {
-		function handleTitleChange( value ) {
-			setAttributes({
-				title : value
-			});
-		}
-		function handleSubscribeTextChange( value ) {
-			setAttributes({
-				subscribe_text : value
-			});
-		}
-		function handleSubscribeButtonChange( value ) {
-			setAttributes({
-				subscribe_button : value
-			});
-		}
-		function handleSuccessMessageChange( value ) {
-			setAttributes({
-				success_message : value
-			});
-		}
-		function handleShowSubscribersTotalChange( value ) {
-			setAttributes({
-				show_subscribers_change : !! value
-			});
-		}
-
+	edit: function( { attributes, setAttributes, focus, setFocus } ) {
 		const {
 			title,
 			subscribe_text,
 			show_subscribers_total,
 			subscribe_button,
+			success_message,
 		} = attributes;
+
+		const toggleshow_subscribers_total = () =>
+			setAttributes( { show_subscribers_total: ! show_subscribers_total } );
 
 		return [
 			<div key="subscription-form" className="subscription-form">
 				{ !! title &&
-					<h2 className="subscription-form__title">{ title }</h2>
-				}
+					<h2 className="subscription-form__title">
+						<input
+							type="text"
+							value={ title }
+							onChange={ e => setAttributes( { title: e.target.value } ) }
+						/>
+					</h2> }
 				<form>
-					<fieldset disabled>
+					<fieldset>
 						{ !! subscribe_text &&
 							<div id="subscribe-text" className="subscription-form__text">
-								<p>{subscribe_text}</p>
-							</div>
-						}
+								<Editable
+									tagName="p"
+									value={ subscribe_text }
+									onChange={ value => setAttributes( { subscribe_text: value } ) }
+									focus={ focus }
+									onFocus={ setFocus }
+								/>
+							</div> }
 						{ !! show_subscribers_total &&
 							<p className="subscription-form__subscribers">
-								{ i18n['Join %s other subscribers'].replace( '%s', '___' ) }
-							</p>
-						}
+								{ i18n[ 'Join %s other subscribers' ].replace( '%s', '___' ) }
+							</p> }
 						<p id="subscribe-email">
-							<label
-								id="jetpack-subscribe-label"
-								className="subscription-form__email-label"
-							>
-								{ i18n['Email Address'] }
+							<label id="jetpack-subscribe-label" className="subscription-form__email-label">
+								{ i18n[ 'Email Address' ] }
 							</label>
 							<input
 								type="email"
 								className="required"
-								placeholder={ i18n['Email Address'] }
+								placeholder={ i18n[ 'Email Address' ] }
 								style={ { display: 'block' } }
 								required
+								disabled
 							/>
 						</p>
 						<p id="subscribe-submit">
-							<input type="submit" value={ subscribe_button } />
+							<input type="submit" value={ subscribe_button } disabled />
 						</p>
 					</fieldset>
 				</form>
 			</div>,
-			!! focus && (
+			!! focus &&
 				<InspectorControls key="inspector">
 					<BlockDescription>
 						<h3>
-							{ i18n['Subscription Form settings'] }
+							{ i18n[ 'Subscription Form settings' ] }
 						</h3>
 					</BlockDescription>
-				</InspectorControls>
-
-			)
+					<CheckboxControl
+						label={ i18n[ 'Show total number of subscribers?' ] }
+						checked={ show_subscribers_total }
+						onChange={ toggleshow_subscribers_total }
+					/>
+					<TextControl
+						label={ i18n[ 'Subscribe Button:' ] }
+						value={ subscribe_button }
+						onChange={ value => setAttributes( { subscribe_button: value } ) }
+					/>
+					<TextControl
+						label={ i18n[ 'Success Message Text:' ] }
+						value={ success_message }
+						onChange={ value => setAttributes( { success_message: value } ) }
+					/>
+				</InspectorControls>,
 		];
 	},
 
-	save : function( { attributes } ) {
-		const {
-			title,
-			subscribe_text,
-			show_subscribers_total,
-			subscribe_button,
-		} = attributes;
-
-		return (
-			<div className="subscription-form">
-				{ !! title &&
-				<h2 className="subscription-form__title">{ title }</h2>
-				}
-				<form>
-					<fieldset disabled>
-						{ !! subscribe_text &&
-						<div id="subscribe-text" className="subscription-form__text">
-							<p>{subscribe_text}</p>
-						</div>
-						}
-						{ !! show_subscribers_total &&
-						<p className="subscription-form__subscribers">
-							{ i18n['Join %s other subscribers'].replace( '%s', '___' ) }
-						</p>
-						}
-						<p id="subscribe-email">
-							<label
-								id="jetpack-subscribe-label"
-								className="subscription-form__email-label"
-							>
-								{ i18n['Email Address'] }
-							</label>
-							<input
-								type="email"
-								className="required"
-								placeholder={ i18n['Email Address'] }
-								style={ { display: 'block' } }
-								required
-							/>
-						</p>
-						<p id="subscribe-submit">
-							<input type="submit" value={ subscribe_button } />
-						</p>
-					</fieldset>
-				</form>
-			</div>
-		);
-	}
-
+	save: function() {
+		return null;
+	},
 } );

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -1,223 +1,170 @@
-( function( wp, i18n ) {
-	wp.blocks.registerBlockType( 'jetpack/subscription-form', {
-		title : i18n['Subscription Form'],
-		icon : 'email-alt',
-		category : 'common',
-		attributes : {
-			title : {
-				type : 'string',
-				default : 'Subscribe to this site'
-			},
-			subscribe_text : {
-				type : 'string',
-				default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
-			},
-			subscribe_placeholder : {
-				type : 'string',
-				default : i18n['Email Address']
-			},
-			subscribe_button : {
-				type : 'string',
-				default : i18n['Subscribe']
-			},
-			success_message : {
-				type : 'string',
-				default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
-			},
-			show_subscribers_total : {
-				type : 'bool',
-				default : true
-			}
+const { registerBlockType, InspectorControls, BlockDescription, source } = wp.blocks;
+const { createElement } = wp.element;
+const { text } = source;
+
+const i18n = jpSubBlockI18n;
+
+registerBlockType( 'jetpack/subscription-form', {
+	title : i18n['Subscription Form'],
+	icon : 'email-alt',
+	category : 'common',
+	attributes : {
+		title : {
+			type : 'string',
+			source: text( '.subscription-form__title' ),
+			default : 'Subscribe to this site'
 		},
+		subscribe_text : {
+			type : 'string',
+			source: text( '.subscription-form__text' ),
+			default : i18n['Enter your email address to subscribe to this blog and receive notifications of new posts by email.']
+		},
+		subscribe_button : {
+			type : 'string',
+			default : i18n['Subscribe']
+		},
+		success_message : {
+			type : 'string',
+			default : i18n['Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.']
+		},
+		show_subscribers_total : {
+			type : 'bool',
+			default : true
+		}
+	},
 
-		edit : function( props ) {
-			var el = wp.element.createElement;
-			function handleTitleChange( value ) {
-				props.setAttributes({
-					title : value
-				});
-			}
-			function handleSubscribeTextChange( value ) {
-				props.setAttributes({
-					subscribe_text : value
-				});
-			}
-			function handleSubscribeButtonChange( value ) {
-				props.setAttributes({
-					subscribe_button : value
-				});
-			}
-			function handleSuccessMessageChange( value ) {
-				props.setAttributes({
-					success_message : value
-				});
-			}
-			function handleShowSubscribersTotalChange( value ) {
-				props.setAttributes({
-					show_subscribers_change : !! value
-				});
-			}
+	edit : function( { attributes, setAttributes, focus } ) {
+		function handleTitleChange( value ) {
+			setAttributes({
+				title : value
+			});
+		}
+		function handleSubscribeTextChange( value ) {
+			setAttributes({
+				subscribe_text : value
+			});
+		}
+		function handleSubscribeButtonChange( value ) {
+			setAttributes({
+				subscribe_button : value
+			});
+		}
+		function handleSuccessMessageChange( value ) {
+			setAttributes({
+				success_message : value
+			});
+		}
+		function handleShowSubscribersTotalChange( value ) {
+			setAttributes({
+				show_subscribers_change : !! value
+			});
+		}
 
-			return [
-				el(
-					'div',
-					{
-						key : 'jetpack/subscription-form/preview',
-						className : 'subscription-form'
-					},
-					[
-						!! props.attributes.title && el(
-							'h2',
-							{
-								key : 'jetpack/subscription-form/title/preview',
-								className : 'subscription-form__title'
-							},
-							props.attributes.title
-						),
-						el(
-							'form',
-							{ key : 'jetpack/subscription-form/preview' },
-							el(
-								'fieldset',
-								{ disabled : true },
-								[
-									!! props.attributes.subscribe_text && el(
-										'div',
-										{
-											key : 'jetpack/subscription-form/subscribe_text/preview',
-											id : 'subscribe-text',
-											className : 'subscription-form__text'
-										},
-										el(
-											'p',
-											null,
-											props.attributes.subscribe_text
-										)
-									),
-									!! props.attributes.show_subscribers_total && el(
-										'p',
-										{
-											key : 'jetpack/subscription-form/show_subscribers_total/preview',
-											className : 'subscription-form__subscribers'
-										},
-										( i18n['Join %s other subscribers'] ).replace( '%s', '___' )
-						),
-						el(
-							'p',
-							{
-								key : 'jetpack/subscription-form/email-field-wrapper',
-								id : 'subscribe-email'
-							},
-							[
-								el(
-									'label',
-									{
-										key : 'jetpack/subscription-form/subscribe_placeholder/label',
-										id : 'jetpack-subscribe-label',
-										className : 'subscription-form__email-label'
-									},
-									props.attributes.subscribe_placeholder
-								),
-								el(
-									'input',
-									{
-										key : 'jetpack/subscription-form/subscribe-placeholder/preview',
-										type : 'email',
-										required : 'required',
-										className : 'required',
-										placeholder : props.attributes.subscribe_placeholder,
-										style : { display : 'block' }
-									}
-								)
-							]
-						),
-						el(
-							'p',
-							{
-								key : 'jetpack/subscription-form/subscribe-submit-wrapper',
-								id : 'subscribe-submit'
-							},
-							el(
-								'input',
-								{
-									key : 'jetpack/subscription-form/subscribe_button/preview',
-									type : 'submit',
-									value : props.attributes.subscribe_button
-								}
-							)
-						)
-					]
-				)
-		)
-		]
-		),
+		const {
+			title,
+			subscribe_text,
+			show_subscribers_total,
+			subscribe_button,
+		} = attributes;
 
-			!! props.focus && el(
-				wp.blocks.InspectorControls,
-				{ key : 'inspector' },
-				[
-					el(
-						wp.blocks.BlockDescription,
-						{ key : 'jetpack/subscription-form/description' },
-						el(
-							'h3',
-							null,
-							i18n['Subscription Form settings']
+		return [
+			<div key="subscription-form" className="subscription-form">
+				{ !! title &&
+					<h2 className="subscription-form__title">{ title }</h2>
+				}
+				<form>
+					<fieldset disabled>
+						{ !! subscribe_text &&
+							<div id="subscribe-text" className="subscription-form__text">
+								<p>{subscribe_text}</p>
+							</div>
+						}
+						{ !! show_subscribers_total &&
+							<p className="subscription-form__subscribers">
+								{ i18n['Join %s other subscribers'].replace( '%s', '___' ) }
+							</p>
+						}
+						<p id="subscribe-email">
+							<label
+								id="jetpack-subscribe-label"
+								className="subscription-form__email-label"
+							>
+								{ i18n['Email Address'] }
+							</label>
+							<input
+								type="email"
+								className="required"
+								placeholder={ i18n['Email Address'] }
+								style={ { display: 'block' } }
+								required
+							/>
+						</p>
+						<p id="subscribe-submit">
+							<input type="submit" value={ subscribe_button } />
+						</p>
+					</fieldset>
+				</form>
+			</div>,
+			!! focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<h3>
+							{ i18n['Subscription Form settings'] }
+						</h3>
+					</BlockDescription>
+				</InspectorControls>
+
 			)
-		),
-			el(
-				wp.blocks.InspectorControls.TextControl,
-				{
-					key : 'jetpack/subscription-form/title/edit',
-					label : 'Title',
-				value : props.attributes.title,
-				onChange : handleTitleChange
-		}
-		),
-			el(
-				wp.blocks.InspectorControls.TextareaControl,
-				{
-					key : 'jetpack/subscription-form/subscribe_text/edit',
-					label : i18n['Optional text to display to your readers:'],
-					value : props.attributes.subscribe_text,
-					onChange : handleSubscribeTextChange
-				}
-			),
-			el(
-				wp.blocks.InspectorControls.TextControl,
-				{
-					key : 'jetpack/subscription-form/subscribe_button/edit',
-					label : 'Subscribe button',
-				value : props.attributes.subscribe_button,
-				onChange : handleSubscribeButtonChange
-			}
-			),
- 				el(
-				wp.blocks.InspectorControls.TextareaControl,
-				{
-					key : 'jetpack/subscription-form/success_message/edit',
-					label : i18n['Success Message Text:'],
-					value : props.attributes.success_message,
-					onChange : handleSuccessMessageChange
-				}
-			),
-				el(
-					wp.blocks.InspectorControls.CheckboxControl,
-					{
-						key : 'jetpack/subscription-form/show_subscribers_total/edit',
-						label : i18n['Show total number of subscribers?'],
-						checked : props.attributes.show_subscribers_total,
-						onChange : handleShowSubscribersTotalChange
-					}
-				)
-		]
-		)
 		];
-		},
+	},
 
-		save : function() {
-			return null;
-		}
+	save : function( { attributes } ) {
+		const {
+			title,
+			subscribe_text,
+			show_subscribers_total,
+			subscribe_button,
+		} = attributes;
 
-	} );
-} )( window.wp, jpSubBlockI18n );
+		return (
+			<div className="subscription-form">
+				{ !! title &&
+				<h2 className="subscription-form__title">{ title }</h2>
+				}
+				<form>
+					<fieldset disabled>
+						{ !! subscribe_text &&
+						<div id="subscribe-text" className="subscription-form__text">
+							<p>{subscribe_text}</p>
+						</div>
+						}
+						{ !! show_subscribers_total &&
+						<p className="subscription-form__subscribers">
+							{ i18n['Join %s other subscribers'].replace( '%s', '___' ) }
+						</p>
+						}
+						<p id="subscribe-email">
+							<label
+								id="jetpack-subscribe-label"
+								className="subscription-form__email-label"
+							>
+								{ i18n['Email Address'] }
+							</label>
+							<input
+								type="email"
+								className="required"
+								placeholder={ i18n['Email Address'] }
+								style={ { display: 'block' } }
+								required
+							/>
+						</p>
+						<p id="subscribe-submit">
+							<input type="submit" value={ subscribe_button } />
+						</p>
+					</fieldset>
+				</form>
+			</div>
+		);
+	}
+
+} );

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -6,8 +6,17 @@
 }
 
 .subscription-form__title {
-	font-size: 16px;
+	margin: 0;
+}
+
+.subscription-form__title.subscription-form__title input {
 	margin: 0 0 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	box-shadow: none;
+	font-size: 20px;
+	font-weight: 600;
 }
 
 .subscription-form__text p {

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -9,12 +9,16 @@
 	margin: 0;
 }
 
-.subscription-form__title.subscription-form__title input {
+.subscription-form__title.subscription-form__title input,
+.subscription-form__text.subscription-form__text textarea  {
+	width: 100%;
 	margin: 0 0 0;
-	padding: 0;
-	border: 0;
 	outline: 0;
 	box-shadow: none;
+	margin-bottom: 16px;
+}
+
+.subscription-form__title.subscription-form__title input {
 	font-size: 20px;
 	font-weight: 600;
 }

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -1,7 +1,33 @@
-#subscribe-email input {
-	width: 95%;
+.subscription-form {
+	margin: 0 0 0;
+	padding: 20px;
+	border: 4px solid black;
+	background: rgba( 255, 255, 255, .9 );
 }
 
-.comment-subscription-form .subscribe-label {
-	display: inline !important;
+.subscription-form__title {
+	font-size: 16px;
+	margin: 0 0 0;
+}
+
+.subscription-form__text p {
+	font-size: 14px;
+}
+
+p.subscription-form__subscribers {
+	font-size: 12px;
+	color: #555d66;
+}
+
+.subscription-form__email-label {
+	font-size: 14px;
+	font-weight: 600;
+}
+
+#subscribe-email input {
+	width: 100%;
+}
+
+#subscribe-submit {
+	margin: 0;
 }

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -35,6 +35,7 @@ p.subscription-form__subscribers {
 .subscription-form__email-label {
 	font-size: 14px;
 	font-weight: 600;
+	margin-left: 2px;
 }
 
 #subscribe-email input {
@@ -42,5 +43,5 @@ p.subscription-form__subscribers {
 }
 
 #subscribe-submit {
-	margin: 0;
+	margin: 16px 0 0;
 }


### PR DESCRIPTION
Initial once through for creating a Gutenberg Block based on the Jetpack Subscription Form.

The js should probably get yanked to its own file and done in es6, but this works for now and saves an additional file to sync and transpile.

CheckboxControl doesn't seem to update.  I may be missing something there.

Apart from that, seems to work.