### PR TITLE
Instrument token request

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -33,7 +33,6 @@ class Jetpack_Client_Server {
 			 * @param int Jetpack Blog ID.
 			 */
 			do_action( 'jetpack_client_authorized', Jetpack_Options::get_option( 'id' ) );
-			JetpackTracking::record_user_event( 'jpc_client_authorize_success' );
 		}
 
 		if ( wp_validate_redirect( $redirect ) ) {
@@ -43,6 +42,8 @@ class Jetpack_Client_Server {
 			// Exit happens below in $this->do_exit()
 			wp_safe_redirect( Jetpack::admin_url() );
 		}
+
+		JetpackTracking::record_user_event( 'jpc_client_authorize_success' );
 
 		$this->do_exit();
 	}
@@ -200,12 +201,17 @@ class Jetpack_Client_Server {
 				'redirect' => $redirect ? urlencode( $redirect ) : false,
 			), menu_page_url( 'jetpack', false ) );
 
+		// inject identity for analytics
+		$tracks_identity = jetpack_tracks_get_identity( get_current_user_id() );
+
 		$body = array(
 			'client_id' => Jetpack_Options::get_option( 'id' ),
 			'client_secret' => $client_secret->secret,
 			'grant_type' => 'authorization_code',
 			'code' => $data['code'],
 			'redirect_uri' => $redirect_uri,
+			'_ui' => $tracks_identity['_ui'],
+			'_ut' => $tracks_identity['_ut'],
 		);
 
 		$args = array(


### PR DESCRIPTION
Fixes an issue where instrumentation was losing events because WPCOM didn't have a Jetpack anon ID for token requests.

This PR also moves the client authorize success event to the end of the authorization response to allow for other failures.