### PR TITLE
Update inline comments to match what Core supports, and explain type checks

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -437,7 +437,7 @@ class Jetpack_Photon {
 			 *
 			 * 	 @type $image Image URL.
 			 * 	 @type $attachment_id Attachment ID of the image.
-			 * 	 @type $size Image size. Can be a string (name of the image size, e.g. full) or an integer.
+			 * 	 @type $size Image size. Can be a string (name of the image size, e.g. full) or an array of width and height.
 			 * }
 			 */
 			false === apply_filters( 'jetpack_photon_admin_allow_image_downsize', false, compact( 'image', 'attachment_id', 'size' ) )
@@ -458,7 +458,7 @@ class Jetpack_Photon {
 		 *
 		 * 	 @type $image Image URL.
 		 * 	 @type $attachment_id Attachment ID of the image.
-		 * 	 @type $size Image size. Can be a string (name of the image size, e.g. full) or an integer.
+		 * 	 @type $size Image size. Can be a string (name of the image size, e.g. full) or an array of width and height.
 		 * }
 		 */
 		if ( apply_filters( 'jetpack_photon_override_image_downsize', false, compact( 'image', 'attachment_id', 'size' ) ) ) {
@@ -478,7 +478,9 @@ class Jetpack_Photon {
 
 			$intermediate = true; // For the fourth array item returned by the image_downsize filter.
 
-			// If an image is requested with a size known to WordPress, use that size's settings with Photon
+			// If an image is requested with a size known to WordPress, use that size's settings with Photon.
+			// WP states that `add_image_size()` should use a string for the name, but doesn't enforce that.
+			// Due to differences in how Core and Photon check for the registered image size, we check both types.
 			if ( ( is_string( $size ) || is_int( $size ) ) && array_key_exists( $size, self::image_sizes() ) ) {
 				$image_args = self::image_sizes();
 				$image_args = $image_args[ $size ];


### PR DESCRIPTION
`add_image_size()` states that it accepts a string as the image name, but it does not enforce this. Due to how Core interacts with named image sizes (through `empty()` checks against a global), an integer-named size will work.

Photon has inadvertedly supported this, and at the risk of breaking existing usage, its type-check reasoning should be noted. The `is_int()` check originated in https://plugins.trac.wordpress.org/changeset/627256 as an incorrect fix for what was ultimately resolved by https://plugins.trac.wordpress.org/changeset/641399. At this point, if it was removed, integer-named images would fail; while this is technically an incorrect use, Core should enforce that rather than Photon breaking usages that have worked for the last five years.

Fixes #7746

#### Changes proposed in this Pull Request:

* Update inline documentation

#### Testing instructions:

* N/A, no functional change