### PR TITLE
Milestone Widget - Add "Time Unit" setting and ability to count up to a milestone

### DIFF
--- a/modules/widgets/milestone/admin.js
+++ b/modules/widgets/milestone/admin.js
@@ -1,0 +1,25 @@
+( function( $ ) {
+	// We could either be in wp-admin/widgets.php or the customizer.
+	var $container = $( '#customize-controls' );
+
+	if ( ! $container.length ) {
+		$container = $( '#wpbody' );
+	}
+
+	$container.on( 'change', '.milestone-type', function() {
+		var $messageWrapper = $( this ).parent().find( '.milestone-message-wrapper' );
+
+		$( this ).find( 'input[type="radio"]:checked' ).val() === 'since' ? $messageWrapper.hide() : $messageWrapper.show();
+	} );
+
+	function triggerChange() {
+		$container.find( '.milestone-type' ).trigger( 'change' );
+	}
+
+	// Used when adding widget via customizer or saving settings.
+	$( document ).on( 'widget-added widget-updated', function() {
+		triggerChange();
+	} );
+
+	triggerChange();
+} )( jQuery );

--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -8,34 +8,140 @@ var Milestone = ( function( $ ) {
 		this.id = args.id;
 		this.diff = args.diff;
 		this.message = args.message;
+		this.unit = args.unit;
 		this.widget = $( '#' + this.id );
 		this.widgetContent = this.widget.find( '.milestone-content' );
+		this.secondsPerMonth = 2628000;
+		this.secondsPerDay = 86400;
+		this.secondsPerHour = 3600;
+		this.secondsPerMinute = 60;
+
+		this.getYears = function() {
+			num = ( this.diff / 60 / 60 / 24 / 365 ).toFixed( 1 );
+
+			if ( 0 === num.charAt( num.length - 1 ) ) {
+				num = Math.floor( num );
+			}
+
+			return num;
+		};
+
+		this.getYearsLabel = function() {
+			return labels.years;
+		};
+
+		this.getMonths = function() {
+			return Math.floor( this.diff / 60 / 60 / 24 / 30 );
+		};
+
+		this.getMonthsLabel = function() {
+			return ( 1 === this.number ) ? labels.month : labels.months;
+		};
+
+		this.getDays = function() {
+			return Math.floor( this.diff / 60 / 60 / 24 ) + 1;
+		};
+
+		this.getDaysLabel = function() {
+			return ( 1 === this.number ) ? labels.day : labels.days;
+		};
+
+		this.getHours = function() {
+			return Math.floor( this.diff / 60 / 60 );
+		};
+
+		this.getHoursLabel = function() {
+			return ( 1 === this.number ) ? labels.hour : labels.hours;
+		};
+
+		this.getMinutes = function() {
+			return Math.floor( this.diff / 60 ) + 1;
+		};
+
+		this.getMinutesLabel = function() {
+			return ( 1 === this.number ) ? labels.minute : labels.minutes;
+		};
+
+		this.getSeconds = function() {
+			return this.diff;
+		};
+
+		this.getSecondsLabel = function() {
+			return ( 1 === this.number ) ? labels.second : labels.seconds;
+		};
 
 		this.timer = function() {
 			this.diff = this.diff - 1;
 
-			if ( 63113852 < this.diff ) { // more than 2 years - show in years, one decimal point
-				num = ( this.diff / 60 / 60 / 24 / 365 ).toFixed( 1 );
-				if ( 0 === num.charAt( num.length - 1 ) ) {
-					num = Math.floor( num );
-				}
-				this.number = num;
-				this.label = labels.years;
-			} else if ( 7775999 < this.diff ) { // fewer than 2 years - show in months
-				this.number = Math.floor( this.diff / 60 / 60 / 24 / 30 );
-				this.label = ( 1 === this.number ) ? labels.month : labels.months;
-			} else if ( 86399 < this.diff ) { // fewer than 3 months - show in days
-				this.number = Math.floor( this.diff / 60 / 60 / 24 ) + 1;
-				this.label = ( 1 === this.number ) ? labels.day : labels.days;
-			} else if ( 3599 < this.diff ) { // less than 1 day - show in hours
-				this.number = Math.floor( this.diff / 60 / 60 );
-				this.label = ( 1 === this.number ) ? labels.hour : labels.hours;
-			} else if ( 59 < this.diff ) { // less than 1 hour - show in minutes
-				this.number = Math.floor( this.diff / 60 ) + 1;
-				this.label = ( 1 === this.number ) ? labels.minute : labels.minutes;
-			} else { // less than 1 minute - show in seconds
-				this.number = this.diff;
-				this.label = ( 1 === this.number ) ? labels.second : labels.seconds;
+			switch ( this.unit ) {
+				case 'months':
+					if ( this.diff >= this.secondsPerMonth ) { // more than 1 month - show in months
+						this.number = this.getMonths();
+						this.label = this.getMonthsLabel();
+					} else if ( this.diff >= this.secondsPerDay - 1 ) { // less than 1 month - show in days
+						this.number = this.getDays();
+						this.label = this.getDaysLabel();
+					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
+						this.number = this.getHours();
+						this.label = this.getHoursLabel();
+					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
+						this.number = this.getMinutes();
+						this.label = this.getMinutesLabel();
+					} else { // less than 1 minute - show in seconds
+						this.number = this.getSeconds();
+						this.label = this.getSecondsLabel();
+					}
+
+					break;
+				case 'days':
+					if ( this.diff >= this.secondsPerDay - 1 ) { // more than 1 day - show in days
+						this.number = this.getDays();
+						this.label = this.getDaysLabel();
+					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
+						this.number = this.getHours();
+						this.label = this.getHoursLabel();
+					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
+						this.number = this.getMinutes();
+						this.label = this.getMinutesLabel();
+					} else { // less than 1 minute - show in seconds
+						this.number = this.getSeconds();
+						this.label = this.getSecondsLabel();
+					}
+
+					break;
+				case 'hours':
+					if ( this.diff >= this.secondsPerHour - 1 ) { // more than 1 hour - show in hours
+						this.number = this.getHours();
+						this.label = this.getHoursLabel();
+					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
+						this.number = this.getMinutes();
+						this.label = this.getMinutesLabel();
+					} else { // less than 1 minute - show in seconds
+						this.number = this.getSeconds();
+						this.label = this.getSecondsLabel();
+					}
+
+					break;
+				default:
+					if ( this.diff >= 63113852 ) { // more than 2 years - show in years, one decimal point
+						this.number = this.getYears();
+						this.label = this.getYearsLabel();
+					} else if ( this.diff >= 7775999 ) { // fewer than 2 years - show in months
+						this.number = this.getMonths();
+						this.label = this.getMonthsLabel();
+					} else if ( this.diff >= this.secondsPerDay - 1 ) { // fewer than 3 months - show in days
+						this.number = this.getDays();
+						this.label = this.getDaysLabel();
+					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
+						this.number = this.getHours();
+						this.label = this.getHoursLabel();
+					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
+						this.number = this.getMinutes();
+						this.label = this.getMinutesLabel();
+					} else { // less than 1 minute - show in seconds
+						this.number = this.getSeconds();
+						this.label = this.getSecondsLabel();
+					}
 			}
 
 			this.widget.find( '.difference' ).html( this.number );

--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -9,6 +9,7 @@ var Milestone = ( function( $ ) {
 		this.diff = args.diff;
 		this.message = args.message;
 		this.unit = args.unit;
+		this.type = args.type;
 		this.widget = $( '#' + this.id );
 		this.widgetContent = this.widget.find( '.milestone-content' );
 		this.secondsPerMonth = 2628000;
@@ -71,7 +72,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.timer = function() {
-			this.diff = this.diff - 1;
+			if ( 'until' === this.type ) {
+				this.diff = this.diff - 1;
+			} else {
+				this.diff = this.diff + 1;
+			}
 
 			switch ( this.unit ) {
 				case 'months':
@@ -147,8 +152,14 @@ var Milestone = ( function( $ ) {
 			this.widget.find( '.difference' ).html( this.number );
 			this.widget.find( '.label' ).html( this.label );
 
+			// Milestone has been reached.
 			if ( 1 > this.diff ) {
-				this.widget.find( '.milestone-countdown' ).replaceWith( '<div class="milestone-message">' + this.message + '</div>' );
+				// Message is not applicable when counting up to future date.
+				if ( this.type === 'since' ) {
+					this.widget.find( '.milestone-countdown' ).remove();
+				} else {
+					this.widget.find( '.milestone-countdown' ).replaceWith( '<div class="milestone-message">' + this.message + '</div>' );
+				}
 			} else {
 				var instance = this;
 				setTimeout( function() { instance.timer(); }, 1000 );

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -324,7 +324,7 @@ class Milestone_Widget extends WP_Widget {
         </p>
 
         <p>
-        	<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Event', 'jetpack' ); ?></label>
+        	<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
         	<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'event' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
         </p>
 
@@ -401,7 +401,7 @@ class Milestone_Widget extends WP_Widget {
 		</ul>
 
 		<p class="milestone-message-wrapper">
-			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Message', 'jetpack' ); ?></label>
+			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Milestone Reached Message', 'jetpack' ); ?></label>
 			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
 		</p>
 	</div>

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -175,30 +175,7 @@ class Milestone_Widget extends WP_Widget {
 		$milestone = mktime( $instance['hour'], $instance['min'], 0, $instance['month'], $instance['day'], $instance['year'] );
 		$now  = (int) current_time( 'timestamp' );
 		$diff = (int) floor( $milestone - $now );
-
 		$unit = $instance['unit'];
-		$number = 0;
-		$label  = '';
-
-		if ( 63113852 < $diff ) { // more than 2 years - show in years, one decimal point
-			$number = round( $diff / 60 / 60 / 24 / 365, 1 );
-			$label  = self::$labels['years'];
-		} else if ( 7775999 < $diff ) { // fewer than 2 years - show in months
-			$number = floor( $diff / 60 / 60 / 24 / 30 );
-			$label  = ( 1 == $number ) ? self::$labels['month'] : self::$labels['months'];
-		} else if ( 86399 < $diff ) { // fewer than 3 months - show in days
-			$number = floor( $diff / 60 / 60 / 24 ) + 1;
-			$label  = ( 1 == $number ) ? self::$labels['day'] : self::$labels['days'];
-		} else if ( 3599 < $diff ) { // less than 1 day - show in hours
-			$number = floor( $diff / 60 / 60 );
-			$label  = ( 1 == $number ) ? self::$labels['hour'] : self::$labels['hours'];
-		} else if ( 59 < $diff ) { // less than 1 hour - show in minutes
-			$number = floor( $diff / 60 ) + 1;
-			$label = ( 1 == $number ) ? self::$labels['minute'] : self::$labels['minutes'];
-		} else { // less than 1 minute - show in seconds
-			$number = $diff;
-			$label = ( 1 == $number ) ? self::$labels['second'] : self::$labels['seconds'] ;
-		}
 
 		echo $args['before_widget'];
 
@@ -220,8 +197,8 @@ class Milestone_Widget extends WP_Widget {
 		} else {
 			/* Countdown to the milestone. */
 			echo '<div class="milestone-countdown">' . sprintf( __( '%1$s %2$s to go.', 'jetpack' ),
-				'<span class="difference">' . esc_html( $number ) . '</span>',
-				'<span class="label">' . esc_html( $label ) . '</span>'
+				'<span class="difference"></span>',
+				'<span class="label"></span>'
 			) . '</div>';
 
 			self::$config_js['instances'][] = array(

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -258,6 +258,7 @@ class Milestone_Widget extends WP_Widget {
 			'title'   => '',
 			'event'   => __( 'The Big Day', 'jetpack' ),
 			'unit'    => 'automatic',
+			'type'    => 'until',
 			'message' => __( 'The big day is here.', 'jetpack' ),
 			'day'     => date( 'd', $now ),
 			'month'   => date( 'm', $now ),
@@ -276,6 +277,7 @@ class Milestone_Widget extends WP_Widget {
 			'title'   => trim( strip_tags( stripslashes( $dirty['title'] ) ) ),
 			'event'   => trim( strip_tags( stripslashes( $dirty['event'] ) ) ),
 			'unit'    => $dirty['unit'],
+			'type'    => $dirty['type'],
 			'message' => wp_kses( $dirty['message'], $allowed_tags ),
 			'year'    => $this->sanitize_range( $dirty['year'],  1901, 2037 ),
 			'month'   => $this->sanitize_range( $dirty['month'], 1, 12 ),
@@ -359,7 +361,33 @@ class Milestone_Widget extends WP_Widget {
 			?></select>
 		</fieldset>
 
-		<p>
+		<ul class="milestone-type">
+			<li>
+				<label>
+					<input
+						<?php checked( $instance['type'], 'until' ); ?>
+						name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
+						type="radio"
+						value="until"
+					/>
+					<?php esc_html_e( 'Until your milestone', 'jetpack' ); ?>
+				</label>
+			</li>
+
+			<li>
+				<label>
+					<input
+						<?php checked( $instance['type'], 'since' ); ?>
+						name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
+						type="radio"
+						value="since"
+					/>
+					<?php esc_html_e( 'Since your milestone', 'jetpack' ); ?>
+				</label>
+			</li>
+		</ul>
+
+		<p class="milestone-message-wrapper">
 			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Message', 'jetpack' ); ?></label>
 			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
 		</p>

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -175,8 +175,13 @@ class Milestone_Widget extends WP_Widget {
 
 		$milestone = mktime( $instance['hour'], $instance['min'], 0, $instance['month'], $instance['day'], $instance['year'] );
 		$now  = (int) current_time( 'timestamp' );
-		$diff = (int) floor( $milestone - $now );
-		$unit = $instance['unit'];
+		$type = $instance['type'];
+
+		if ( 'since' === $type ) {
+			$diff = (int) floor( $now - $milestone );
+		} else {
+			$diff = (int) floor( $milestone - $now );
+		}
 
 		echo $args['before_widget'];
 
@@ -192,14 +197,20 @@ class Milestone_Widget extends WP_Widget {
 		echo '<span class="date">' . esc_html( date_i18n( __( 'F jS, Y', 'jetpack' ), $milestone ) ) . '</span>';
 		echo '</div>';
 
-		if ( 1 > $diff ) {
-			/* Milestone has past. */
+		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
 			echo '<div class="milestone-message">' . $instance['message'] . '</div>';
 		} else {
+			if ( 'since' === $type ) {
+				$text = __( 'ago.', 'jetpack' );
+			} else {
+				$text = __( 'to go.', 'jetpack' );
+			}
+
 			/* Countdown to the milestone. */
-			echo '<div class="milestone-countdown">' . sprintf( __( '%1$s %2$s to go.', 'jetpack' ),
+			echo '<div class="milestone-countdown">' . sprintf( __( '%1$s %2$s %3$s', 'jetpack' ),
 				'<span class="difference"></span>',
-				'<span class="label"></span>'
+				'<span class="label"></span>',
+				$text
 			) . '</div>';
 
 			self::$config_js['instances'][] = array(
@@ -207,6 +218,7 @@ class Milestone_Widget extends WP_Widget {
 				'diff'    => $diff,
 				'message' => $instance['message'],
 				'unit'    => $instance['unit'],
+				'type'    => $instance['type'],
 			);
 		}
 

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -62,6 +62,7 @@ class Milestone_Widget extends WP_Widget {
 	public static function enqueue_admin( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
 			wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
+			wp_enqueue_script( 'milestone-admin-js', self::$url . 'admin.js', array( 'jquery' ), '20170915', true );
 		}
 	}
 

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -176,6 +176,7 @@ class Milestone_Widget extends WP_Widget {
 		$now  = (int) current_time( 'timestamp' );
 		$diff = (int) floor( $milestone - $now );
 
+		$unit = $instance['unit'];
 		$number = 0;
 		$label  = '';
 
@@ -227,6 +228,7 @@ class Milestone_Widget extends WP_Widget {
 				'id'      => $args['widget_id'],
 				'diff'    => $diff,
 				'message' => $instance['message'],
+				'unit'    => $instance['unit'],
 			);
 		}
 
@@ -278,6 +280,7 @@ class Milestone_Widget extends WP_Widget {
 		$dirty = wp_parse_args( $dirty, array(
 			'title'   => '',
 			'event'   => __( 'The Big Day', 'jetpack' ),
+			'unit'    => 'automatic',
 			'message' => __( 'The big day is here.', 'jetpack' ),
 			'day'     => date( 'd', $now ),
 			'month'   => date( 'm', $now ),
@@ -295,6 +298,7 @@ class Milestone_Widget extends WP_Widget {
 		$clean = array(
 			'title'   => trim( strip_tags( stripslashes( $dirty['title'] ) ) ),
 			'event'   => trim( strip_tags( stripslashes( $dirty['event'] ) ) ),
+			'unit'    => $dirty['unit'],
 			'message' => wp_kses( $dirty['message'], $allowed_tags ),
 			'year'    => $this->sanitize_range( $dirty['year'],  1901, 2037 ),
 			'month'   => $this->sanitize_range( $dirty['month'], 1, 12 ),
@@ -312,7 +316,14 @@ class Milestone_Widget extends WP_Widget {
      */
     function form( $instance ) {
 		$instance = $this->sanitize_instance( $instance );
-        ?>
+
+		$units = array(
+			'automatic' => __( 'Automatic', 'jetpack' ),
+			'months' => __( 'Months', 'jetpack' ),
+			'days' => __( 'Days', 'jetpack' ),
+			'hours' => __( 'Hours', 'jetpack' ),
+		);
+		?>
 
 	<div class="milestone-widget">
         <p>
@@ -355,6 +366,20 @@ class Milestone_Widget extends WP_Widget {
 			<span class="time-separator">:</span>
 
 			<input id="<?php echo $this->get_field_id( 'min' ); ?>" class="minutes" name="<?php echo $this->get_field_name( 'min' ); ?>" type="text" value="<?php echo esc_attr( $instance['min'] ); ?>">
+		</fieldset>
+
+		<fieldset class="jp-ms-data-unit">
+			<legend><?php esc_html_e( 'Time Unit', 'jetpack' ); ?></legend>
+
+			<label for="<?php echo $this->get_field_id( 'unit' ); ?>" class="assistive-text">
+				<?php _e( 'Time Unit', 'jetpack' ); ?>
+			</label>
+			<select id="<?php echo $this->get_field_id( 'unit' ); ?>" class="unit" name="<?php echo $this->get_field_name( 'unit' ); ?>">
+			<?php
+				foreach ( $units as $key => $unit ) {
+					echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $instance['unit'], false ) . '>' . $unit . '</option>';
+				}
+			?></select>
 		</fieldset>
 
 		<p>

--- a/modules/widgets/milestone/style-admin.css
+++ b/modules/widgets/milestone/style-admin.css
@@ -30,7 +30,8 @@
 	width: 4.5em;
 }
 
-.jp-ms-data-time .assistive-text {
+.jp-ms-data-time .assistive-text,
+.jp-ms-data-unit .assistive-text {
 	position: absolute !important;
 	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
 	clip: rect(1px, 1px, 1px, 1px);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR adds a new _Time Unit_ setting and enables counting up to a milestone in addition to counting down.

![milestone-widget](https://user-images.githubusercontent.com/1190420/30696044-41b4b704-9ea8-11e7-8aa0-3156d2caf7fe.jpg)

## Time Unit

The options are:

* Automatic (default)
* Months
* Days
* Hours

The _Time Unit_ setting implements the following logic on the front-end:

_Automatic (how it currently works)_
* More than 2 years - show in years to one decimal point
* Fewer than 2 years - show in months
* Fewer than 3 months - show in days
* Less than 1 day - show in hours
* Less than 1 hour - show in minutes
* Less than 1 minute - show in seconds

_Months_
* More than 1 month - show in months
* Less than 1 month - show in days
* Less than 1 day - show in hours
* Less than 1 hour - show in minutes
* Less than 1 minute - show in seconds

_Days_
* More than 1 day - show in days
* Less than 1 day - show in hours
* Less than 1 hour - show in minutes
* Less than 1 minute - show in seconds

_Hours_
* More than 1 hour - show in hours
* Less than 1 hour - show in minutes
* Less than 1 minute - show in seconds

#### Testing instructions:

* Add the milestone widget to a site.
* Select an option from the _Time Unit_ setting.
* Ensure the option is saved.
* Check that the units are displayed correctly on the front-end as per the rules defined above.
* Repeat for each of the _Time Unit_ settings.

## Until your milestone / Since your milestone

_Until your milestone_ counts down to a particular date. This is how the widget currently works and is the default option.

_Since your milestone_ counts up from a particular date.

#### Testing instructions:

* Check the _Since your milestone_ radio button. The _Milestone Reached Message_ field should disappear.
* Ensure that _Date_ is set to a date in the past.
* Verify that the widget shows the text "ago" instead of "to go", and that the correct units and amount of time are displayed:
![widget-count-up-past-date](https://user-images.githubusercontent.com/1190420/30696405-88b67d80-9ea9-11e7-8624-ac6abf53da2e.jpg)
* Change the _Date_ setting to a future date.
* Verify that the widget only shows the header area:
![widget-count-up-future-date](https://user-images.githubusercontent.com/1190420/30696379-73e8b094-9ea9-11e7-9af7-09286c1cfc66.jpg)