### PR TITLE
Jetpack REST API: Update endpoint docs

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -43,45 +43,6 @@ WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/)
 
 `GET /wp-json/jetpack/v4`
 
-### Jetpack connection
-
-Operations related to Jetpack's connection to WordPress.com
-
-#### GET /wp-json/jetpack/v4/connection
-
-Fetch Jetpack's current connection status.
-
-#### GET /wp-json/jetpack/v4/connection/url
-
-Fetch a fresh WordPress.com URL for connecting the Jetpack installation.
-
-#### GET /wp-json/jetpack/v4/connection/data
-
-Fetch the data of the current's user WordPress.com account.
-
-#### POST /wp-json/jetpack/v4/connection
-
-Disconnect the Jetpack installation from WordPress.com servers.
-
-Accepts a JSON object in the body like:
-
-```
-{
-	"isActive": false
-}
-```
-
-#### POST /wp-json/jetpack/v4/connection/user
-
-Unlink current user from the related WordPress.com account.
-
-Accepts a JSON object in the body like:
-
-```
-{
-	"linked": false
-}
-```
 ### Jetpack settings
 
 We call settings to any option that a module provides.
@@ -135,6 +96,45 @@ Accepts a JSON object in the body like:
 {
 	"carousel_display_exif": false,
 	"carousel": true
+}
+```
+### Jetpack connection
+
+Operations related to Jetpack's connection to WordPress.com
+
+#### GET /wp-json/jetpack/v4/connection
+
+Fetch Jetpack's current connection status.
+
+#### GET /wp-json/jetpack/v4/connection/url
+
+Fetch a fresh WordPress.com URL for connecting the Jetpack installation.
+
+#### GET /wp-json/jetpack/v4/connection/data
+
+Fetch the data of the current's user WordPress.com account.
+
+#### POST /wp-json/jetpack/v4/connection
+
+Disconnect the Jetpack installation from WordPress.com servers.
+
+Accepts a JSON object in the body like:
+
+```
+{
+	"isActive": false
+}
+```
+
+#### POST /wp-json/jetpack/v4/connection/user
+
+Unlink current user from the related WordPress.com account.
+
+Accepts a JSON object in the body like:
+
+```
+{
+	"linked": false
 }
 ```
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -542,12 +542,244 @@ Get number of updated available for currently installed WordPress plugins.
 
 ### Akismet related operations
 
-#### GET /wp-json/jetpack/v4/akismet/stats/get
+#### GET /wp-json/jetpack/v4/module/akismet/data
 
 Get stats from Akismet filtered spam.
+
+**Example response**
+
+```
+{
+    "6-months": {
+        "spam": 0,
+        "ham": 0,
+        "missed_spam": 0,
+        "false_positives": 0,
+        "accuracy": 0,
+        "breakdown": {
+            "2017-03": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-03-01"
+            },
+            "2017-04": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-04-01"
+            },
+            "2017-05": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-05-01"
+            },
+            "2017-06": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-06-01"
+            },
+            "2017-07": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-07-01"
+            },
+            "2017-08": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-08-01"
+            },
+            "2017-09": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-09-01"
+            }
+        },
+        "time_saved": 0
+    },
+    "all": {
+        "spam": 0,
+        "ham": 0,
+        "missed_spam": 0,
+        "false_positives": 0,
+        "accuracy": 0,
+        "breakdown": {
+            "2011": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2011-01-01"
+            },
+            "2012": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2012-01-01"
+            },
+            "2013": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2013-01-01"
+            },
+            "2014": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2014-01-01"
+            },
+            "2015": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2015-01-01"
+            },
+            "2016": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2016-01-01"
+            },
+            "2017": {
+                "spam": 0,
+                "ham": 0,
+                "missed_spam": 0,
+                "false_positives": 0,
+                "da": "2017-01-01"
+            }
+        },
+        "time_saved": 0
+    }
+}
+```
 
 ### VaultPress options
 
 #### GET /wp-json/jetpack/v4/module/vaultpress/data
 
-get date of last backup or status and information about actions for user to take.
+Get date of last backup or status and information about actions for user to take.
+
+**Example response**
+```
+{
+    "code": "success",
+    "message": "Your site was successfully backed-up 28 mins ago.",
+    "data": {
+        "features": {
+            "backups": true,
+            "security": true
+        },
+        "settings": {
+            "has_filesystem_connection": true
+        },
+        "errors": {},
+        "site_id": 86437,
+        "active": true,
+        "ticker": {
+            "message": "Processing db changes from ping"
+        },
+        "backups": {
+            "full_backup_status": "100% complete",
+            "stats": {
+                "users": 0,
+                "comments": 0,
+                "attachments": "61",
+                "custom_css": "2",
+                "jp_img_sitemap": "2",
+                "jp_sitemap": "2",
+                "jp_sitemap_master": "2",
+                "nav_menu_item": "1",
+                "pages": "3",
+                "posts": "39",
+                "revisions": "319",
+                "categories": "4",
+                "nav_menu": "1",
+                "post_format": "3",
+                "post_tags": "16",
+                "published_posts": "22",
+                "post_types": {
+                    "attachment": "61",
+                    "custom_css": "2",
+                    "jp_img_sitemap": "2",
+                    "jp_sitemap": "2",
+                    "jp_sitemap_master": "2",
+                    "nav_menu_item": "1",
+                    "page": "3",
+                    "post": "39",
+                    "revision": "319"
+                },
+                "uploads": "274",
+                "themes": "12",
+                "plugins": "9",
+                "total_snapshots": "2592",
+                "oldest_snapshot": 85499292
+            },
+            "last_backup": 892388,
+            "has_full_backup": true
+        },
+        "security": {
+            "notice_count": 0
+        },
+        "activity": {
+            "1933": {
+                "when": 1506428487,
+                "message": "Completed a full sync of the wp_comments table"
+            },
+            "1934": {
+                "when": 1506428495,
+                "message": "Completed a full sync of the wp_links table"
+            },
+            "1935": {
+                "when": 1506428505,
+                "message": "Completed a full sync of the wp_options table"
+            },
+            "1936": {
+                "when": 1506428513,
+                "message": "Completed a full sync of the wp_postmeta table"
+            },
+            "1937": {
+                "when": 1506428528,
+                "message": "Completed a full sync of the wp_posts table"
+            },
+            "1938": {
+                "when": 1506428536,
+                "message": "Completed a full sync of the wp_commentmeta table"
+            },
+            "1939": {
+                "when": 1506428544,
+                "message": "Completed a full sync of the wp_users table"
+            },
+            "1940": {
+                "when": 1506428552,
+                "message": "Completed a full sync of the wp_usermeta table"
+            },
+            "1941": {
+                "when": 1506428560,
+                "message": "Completed a full sync of the wp_termmeta table"
+            },
+            "1942": {
+                "when": 1506428566,
+                "message": "VaultPress has just fully synchronized with your site"
+            }
+        }
+    }
+}
+```

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -319,6 +319,45 @@ Get services that this site is verified with.
 
 ### Site's plugins related operations
 
+#### GET /wp-json/jetpack/v4/plugins
+
+Get a list of the currently installed plugins on the site.
+
+**Example response**
+
+```
+{
+    "hello.php": {
+        "Name": "Hello Dolly",
+        "PluginURI": "http://wordpress.org/plugins/hello-dolly/",
+        "Version": "1.6",
+        "Description": "This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.",
+        "Author": "Matt Mullenweg",
+        "AuthorURI": "http://ma.tt/",
+        "TextDomain": "",
+        "DomainPath": "",
+        "Network": false,
+        "Title": "Hello Dolly",
+        "AuthorName": "Matt Mullenweg",
+        "active": false
+    },
+    "jetpack/jetpack.php": {
+        "Name": "Jetpack by WordPress.com",
+        "PluginURI": "https://jetpack.com",
+        "Version": "5.3",
+        "Description": "Get everything you need to <strong>design, secure, and grow your WordPress site</strong>. Jetpack gives you free themes, image tools, related content, and site security, all in one convenient bundle.",
+        "Author": "Automattic",
+        "AuthorURI": "https://jetpack.com",
+        "TextDomain": "jetpack",
+        "DomainPath": "/languages/",
+        "Network": false,
+        "Title": "Jetpack by WordPress.com",
+        "AuthorName": "Automattic",
+        "active": true
+    }
+}
+```
+
 #### GET /wp-json/jetpack/v4/updates/plugins
 
 Get number of updated available for currently installed WordPress plugins.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -248,9 +248,49 @@ POSTing with `linked` as `false` will disconect the site. Sending `linked: true`
 
 ### Jetpack modules
 
-#### GET /wp-json/jetpack/v4/module
+#### GET /wp-json/jetpack/v4/module/all
 
 Get a list of all Jetpacks modules, its description, other properties and the module's options
+
+**Note**. The response has a big paylod in the body. Use it carefully.
+
+**Example response**
+
+The response is huge. Try it on your browser's console for discovery. Here's a cut down version of it:
+
+```
+{
+	"protect": {
+	        "name": "Protect",
+		"description": "Block suspicious-looking sign in activity",
+		"jumpstart_desc": "",
+		"sort": 1,
+		"recommendation_order": 4,
+		"introduced": "3.4",
+		"changed": "",
+		"deactivate": true,
+		"free": true,
+		"requires_connection": true,
+		"auto_activate": "Yes",
+		"module_tags": [
+		    "Recommended"
+		],
+		"feature": [
+			"Security"
+		],
+		"additional_search_queries": "security, secure, protection, botnet, brute force, protect, login",
+		"module": "protect",
+		"activated": true,
+		"options": { ... },
+		...
+	}
+	"wordads": { ... },
+	"stats": { ... },
+	"manage": { ... },
+	...
+
+}
+```
 
 #### GET /wp-json/jetpack/v4/module/:module-slug
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -461,9 +461,17 @@ The string value in `data` is a stringified JSON object with data coming from th
 
 ### Protect module related operations
 
-##### GET /wp-json/jetpack/v4/module/protect/count/get
+##### GET /wp-json/jetpack/v4/module/protect/data
 
 Get count of blocked attacks by Protect.
+
+**Example response**
+
+**Note**: The response is not an object but a plain string with the number of blocked login attempts.
+
+```
+"3"
+```
 
 ### Monitor module related operations
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -506,9 +506,7 @@ Get count of blocked attacks by Protect.
 "3"
 ```
 
-### Monitor module related operations
-
-### Site's plugins related operations
+### Plugins related endpoints
 
 #### GET /wp-json/jetpack/v4/plugins
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -29,12 +29,6 @@ The root URL for the the API is found on the same page as:
 window.Initial_State.WP_API_root;
 ```
 
-## Discovery
-
-WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/) for the endpoints registered by Jetpack.
-
-`GET /wp-json/jetpack/v4`
-
 ## API Reference
 
 All endpoints return and accept JSON. Make sure you add the proper `content-type` header to your PUT/POST requests sending JSON objects.
@@ -42,6 +36,12 @@ All endpoints return and accept JSON. Make sure you add the proper `content-type
 ```
 'Content-type': 'application/json'
 ```
+
+### Discovery endpoint
+
+WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/) for the endpoints registered by Jetpack.
+
+`GET /wp-json/jetpack/v4`
 
 ### Jetpack connection
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -121,6 +121,8 @@ Accepts a JSON object in the body like:
 
 Activate several modules at a time by their slug
 
+**Note**: Try to not rely hard on this endpoint. Activation and deactivation of modules is also possible via the settings endpoint. And it may come in handy to use the settings endpoint instead as you can turn on a module and update settings related to that module at the same time in a single request.
+
 **Body parameters**
 
 * `modules`: {Array} An array of strings of identifiers of the modules to activate
@@ -134,6 +136,8 @@ Activate several modules at a time by their slug
 #### POST /wp-json/jetpack/v4/module/:module-slug
 
 Update an option's value for a module
+
+**Note**: Try to not rely hard on this endpoint. We started giving the name **settings** to the modules options and you can update them via the settings endpoint now.
 
 **URL parameters**
 
@@ -150,24 +154,59 @@ Accepts a JSON object in the body like:
 }
 ```
 
-### Jetpack miscellaneous settings
+### Jetpack settings
+
+We call settings to any option that a module provides.
+This endpoint returns a JSON object with multiple key and current values for them.
+When POSTing to this endpoint, you need to send a JSON object in the body with the new values for each key.
+
+As an extra, you can enable or disable modules with this endpoint too. You can pass a module slug as key and set it to `true` or `false` for updating its activation state.
 
 ### GET /wp-json/jetpack/v4/settings
 
-Fetch a list of Jetpack settings not related to a particular module.
+Fetch a list of Jetpack settings.
 
-### POST /wp-json/jetpack/v4/settings/update
+**Example response**
 
-Update a setting value
+```
+{
+	"onpublish":false,
+	"onupdate":false,
+	"Bias Language":false,
+	"Cliches":false,
+	"Complex Expression":false,
+	"Diacritical Marks":false,
+	"Double Negative":false,
+	"Hidden Verbs":true,
+	"Jargon Language":false,
+	"Passive voice":false,
+	"Phrases to Avoid":false,
+	"Redundant Expression":true,
+	"guess_lang":false,
+	"ignored_phrases":"billy,asdf,lola,y,l,asd,jsd",
+	"after-the-deadline":true,
+	"carousel_background_color":"white",
+	"carousel_display_exif":true
+}
+```
+
+### POST /wp-json/jetpack/v4/settings
+
+Update multiple settings at once.
 
 **Body parameters**
 
-* Accepts a simple object with the key of the setting to update and the new value.
+* Accepts a simple object with the key/values of the settings to update.
+If one of the keys you send matches a module slug and the value for it is `true`, the module we be activated. Setting it to `false` will deactivate the module.
+
+This endpoint is quite permissive, so you will be able to try to update settings for a module that is not yet active.
+You can also try to activate a module an set any of its options on the same request.
 
 Accepts a JSON object in the body like:
 ```
 {
-	"setting-key": "new-setting-value"
+	"carousel_display_exif": false,
+	"carousel": true
 }
 ```
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -473,10 +473,6 @@ Dismiss a Jetpack notice by Id.
 	* `"feedback_dash_request"`
 	* `"welcome"`.
 
-** HTTP Status codes**
-
-* `404` - When `:notice` is not valid or absent
-
 ### Site information
 
 Operations related to information about the site.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -153,6 +153,14 @@ Fetch Jetpack's current connection status.
 
 Fetch a fresh WordPress.com URL for connecting the Jetpack installation.
 
+**Note:** The response is not a JSON object, but a string enclosed in double quotes.
+
+**Example response**
+
+```
+"https:\/\/jetpack.wordpress.com\/jetpack.authorize\/1\/?response_type=code&client_id=107314117&redirect_uri=https%3A%2F%2Fmysite.mydomain.com%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack%26action%3Dauthorize%26_wpnonce%63Db10f339f8%26redirect%3Dhttps%253A%252F%252Fmysite.mydomain.com%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack&state=1&scope=administrator%3A6493e88f3b4130d138e051a48f3b417c5cf503a&user_email=siteowner%40company.com&user_login=mysite&is_active=1&jp_version=5.3&auth_type=calypso&secret=2ejv2bbhwE44GedSjwud7233TN2lGXkxh&locale=en&blogname=mysite+Sandbox&site_url=https%3A%2F%2Fmysite.mydomain.com&home_url=https%3A%2F%2Fmysite.mydomain.com&site_icon=https%3A%2F%2Fi2.wp.com%2Fmysite.mydomain.com%2Fwp-content%2Fuploads%2F2016%2F04%2Fcropped-jetpack-logo.png%3Ffit%3D512%252C512%26ssl%3D1&site_lang=en_US&_ui=7178474&_ut=wpcom%3Auser_id"
+```
+
 #### GET /wp-json/jetpack/v4/connection/data
 
 Fetch the data of the current's user WordPress.com account.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -149,6 +149,21 @@ Operations related to Jetpack's connection to WordPress.com
 
 Fetch Jetpack's current connection status.
 
+**Example Response**
+
+```
+{
+	"isActive": true,
+	"isStaging": false,
+	"devMode": {
+		"isActive":false,
+		"constant":false,
+		"url":false,
+		"filter":false
+	}
+}
+```
+
 #### GET /wp-json/jetpack/v4/connection/url
 
 Fetch a fresh WordPress.com URL for connecting the Jetpack installation.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -423,9 +423,6 @@ Reset  Jetpack module options or Jetpack modules activation state to default val
 
 	**This endpoint does not take Body parameters**
 
-### Site information
-
-Operations related to information about the site.
 
 ### Jetpack notices
 
@@ -442,6 +439,10 @@ Dismiss a Jetpack notice by Id.
 ** HTTP Status codes**
 
 * `404` - When `:notice` is not valid or absent
+
+### Site information
+
+Operations related to information about the site.
 
 #### GET /wp-json/jetpack/v4/site
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -358,10 +358,6 @@ Accepts a JSON object in the body like:
 }
 ```
 
-**URL parameters**
-
-* `module-slug`: {String} The identifier of the module on which to act.
-
 **Body parameters**
 
 * `active`: {Boolean} Send false to deactivate the module.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,6 +1,6 @@
 # Jetpack HTTP API
 
-Jetpack's HTTP API is built as an [extension to the WP-API](http://v2.wp-api.org/extending/adding/). Thus, you may find additional information on approaching the API in the [WP API Docs](http://v2.wp-api.org/).
+Jetpack's HTTP API is built as an [extension to the WordPress core REST API](https://developer.wordpress.org/rest-api/extending-the-rest-api/). Thus, you may find additional information on approaching the API in the [REST API Handbook](https://developer.wordpress.org/rest-api/).
 
 * [How to use](#how-to-use)
 * [API Authentication and authorization](#api-request-authorization-via-nonces)
@@ -47,7 +47,7 @@ fetch( '/wp-json/jetpack/v4/settings', {
 ```
 ## API Authentication and authorization
 
-The API requests rely on [cookie-based authentication and a specific nonce](http://v2.wp-api.org/guide/authentication/#cookie-authentication)
+The API requests rely on [cookie-based authentication and a specific nonce](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/#cookie-authentication)
 for requests to be authorized.
 
 ### API Request Authorization via nonces
@@ -82,7 +82,7 @@ All endpoints return and accept JSON. Make sure you add the proper `content-type
 
 ### Discovery endpoint
 
-WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/) for the endpoints registered by Jetpack.
+Core REST API-compatible [capabilities document](https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/) for the endpoints registered by Jetpack.
 
 `GET /wp-json/jetpack/v4`
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -229,6 +229,8 @@ Accepts a JSON object in the body like:
 }
 ```
 
+POSTing with `isActive` as `false` will disconect the site. Sending `isActive: true` has no effect.
+
 #### POST /wp-json/jetpack/v4/connection/user
 
 Unlink current user from the related WordPress.com account.
@@ -240,6 +242,9 @@ Accepts a JSON object in the body like:
 	"linked": false
 }
 ```
+
+POSTing with `linked` as `false` will disconect the site. Sending `linked: true` has no effect.
+
 
 ### Jetpack modules
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -10,11 +10,11 @@ Jetpack's HTTP API is built as an [extension to the WP-API](http://v2.wp-api.org
 
 All of the extensions that Jetpack adds to the core's REST API infrastructure demand authentication and, of course knowledge of the endpoints (you can find about them under [API Reference](#api-reference)).
 
-### Requesting with jQuery from the browser console.
+### Requesting with jQuery from the browser's console.
 
 If you go to the Jetpack wp-admin page (/wp-admin/admin.php?page=jetpack) on you WordPress site, you can open the console there and write an AJAX request using `jQuery.ajax`. This comes in handy when testing as every request demands a nonce generated for the REST API specifically. More details about this nonce in [API Authentication and authorization](#api-request-authorization-via-nonces).
 
-Example GET request to the settings endpoint
+**Example GET request**
 ```
 jQuery.ajax( {
     url: '/wp-json/jetpack/v4/settings/',
@@ -31,6 +31,20 @@ jQuery.ajax( {
 } );
 ```
 
+### Requesting with the fetch API from the browser's console.
+
+**Example GET request**
+```
+fetch( '/wp-json/jetpack/v4/settings', {
+	credentials: 'same-origin',
+	headers: {
+		'X-WP-Nonce': Initial_State.WP_API_nonce,
+		'Content-type': 'application/json' }
+} )
+	.then( response => response.json() )
+	.then( response => console.log( response) )
+	.catch( error => console.log( error.responseText ) );
+```
 ## API Authentication and authorization
 
 The API requests rely on [cookie-based authentication and a specific nonce](http://v2.wp-api.org/guide/authentication/#cookie-authentication)

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -289,7 +289,7 @@ POSTing with `linked` as `false` will disconect the site. Sending `linked: true`
 
 Get a list of all Jetpacks modules, its description, other properties and the module's options
 
-**Note**. The response has a big paylod in the body. Use it carefully.
+**Note**. The response has a big payload in the body. Use it carefully.
 
 **Example response**
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -82,78 +82,6 @@ Accepts a JSON object in the body like:
 	"linked": false
 }
 ```
-
-### Jetpack modules
-
-#### GET /wp-json/jetpack/v4/module
-
-Get a list of all Jetpacks modules, its description, other properties and the module's options
-
-#### GET /wp-json/jetpack/v4/module/:module-slug
-
-Get a single module description and properties by its slug.
-
-**URL parameters**
-
-* `module-slug`: {String} The identifier of the module to get info about.
-
-#### POST /wp-json/jetpack/v4/module/:module-slug/active
-
-Activate or deactivate a module by its slug
-
-Accepts a JSON object in the body like:
-```
-{
-	"active": true
-}
-```
-
-**URL parameters**
-
-* `module-slug`: {String} The identifier of the module on which to act.
-
-**Body parameters**
-
-* `active`: {Boolean} Send false to deactivate the module.
-
-
-#### POST /wp-json/jetpack/v4/module/activate
-
-Activate several modules at a time by their slug
-
-**Note**: Try to not rely hard on this endpoint. Activation and deactivation of modules is also possible via the settings endpoint. And it may come in handy to use the settings endpoint instead as you can turn on a module and update settings related to that module at the same time in a single request.
-
-**Body parameters**
-
-* `modules`: {Array} An array of strings of identifiers of the modules to activate
-
-```
-{
-	"modules": [ "protect", "monitor", "likes" ]
-}
-```
-
-#### POST /wp-json/jetpack/v4/module/:module-slug
-
-Update an option's value for a module
-
-**Note**: Try to not rely hard on this endpoint. We started giving the name **settings** to the modules options and you can update them via the settings endpoint now.
-
-**URL parameters**
-
-* `module-slug`: {String} The identifier of the module on which to act.
-
-**Body parameters**
-
-* Accepts a simple object with the key of the option to update and the new value.
-
-Accepts a JSON object in the body like:
-```
-{
-	"option-key": "new-option-value"
-}
-```
-
 ### Jetpack settings
 
 We call settings to any option that a module provides.
@@ -207,6 +135,76 @@ Accepts a JSON object in the body like:
 {
 	"carousel_display_exif": false,
 	"carousel": true
+}
+```
+
+### Jetpack modules
+
+#### GET /wp-json/jetpack/v4/module
+
+Get a list of all Jetpacks modules, its description, other properties and the module's options
+
+#### GET /wp-json/jetpack/v4/module/:module-slug
+
+Get a single module description and properties by its slug.
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module to get info about.
+
+#### POST /wp-json/jetpack/v4/module/:module-slug/active
+
+Activate or deactivate a module by its slug
+
+Accepts a JSON object in the body like:
+```
+{
+	"active": true
+}
+```
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module on which to act.
+
+**Body parameters**
+
+* `active`: {Boolean} Send false to deactivate the module.
+
+#### POST /wp-json/jetpack/v4/module/activate
+
+Activate several modules at a time by their slug
+
+**Note**: Try to not rely hard on this endpoint. Activation and deactivation of modules is also possible via the settings endpoint. And it may come in handy to use the settings endpoint instead as you can turn on a module and update settings related to that module at the same time in a single request.
+
+**Body parameters**
+
+* `modules`: {Array} An array of strings of identifiers of the modules to activate
+
+```
+{
+	"modules": [ "protect", "monitor", "likes" ]
+}
+```
+
+#### POST /wp-json/jetpack/v4/module/:module-slug
+
+Update an option's value for a module
+
+**Note**: Try to not rely hard on this endpoint. We started giving the name **settings** to the modules options and you can update them via the settings endpoint now.
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module on which to act.
+
+**Body parameters**
+
+* Accepts a simple object with the key of the option to update and the new value.
+
+Accepts a JSON object in the body like:
+```
+{
+	"option-key": "new-option-value"
 }
 ```
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -305,7 +305,18 @@ Dismiss a Jetpack notice by Id.
 
 #### GET /wp-json/jetpack/v4/site
 
-Get current site data
+Get current site data.
+The string value in `data` is a stringified JSON object with data coming from the WordPress.com API about the site.
+
+**Example response**
+
+```
+{
+    "code": "success",
+    "message": "Site data correctly received.",
+    "data": "{}"
+}
+```
 
 ### Protect module related operations
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -296,9 +296,56 @@ The response is huge. Try it on your browser's console for discovery. Here's a c
 
 Get a single module description and properties by its slug.
 
-**URL parameters**
+**Example response** for `/module/likes`
 
-* `module-slug`: {String} The identifier of the module to get info about.
+```
+{
+    "name": "Likes",
+    "description": "Give visitors an easy way to show they appreciate your content.",
+    "jumpstart_desc": "Give visitors an easy way to show they appreciate your content.",
+    "sort": 23,
+    "recommendation_order": 20,
+    "introduced": "2.2",
+    "changed": "",
+    "deactivate": true,
+    "free": true,
+    "requires_connection": true,
+    "auto_activate": "No",
+    "module_tags": [
+        "Social"
+    ],
+    "feature": [
+        "Engagement",
+        "Jumpstart"
+    ],
+    "additional_search_queries": "like, likes, wordpress.com",
+    "options": {
+        "wpl_default": {
+            "description": "WordPress.com Likes are",
+            "type": "string",
+            "default": "on",
+            "enum": [
+                "on",
+                "off"
+            ],
+            "enum_labels": {
+                "on": "On for all posts",
+                "off": "Turned on per post"
+            },
+            "jp_group": "likes",
+            "current_value": "on"
+        },
+        "social_notifications_like": {
+            "description": "Send email notification when someone likes a post",
+            "type": "boolean",
+            "default": 1,
+            "jp_group": "likes",
+            "current_value": true
+        }
+    },
+    "short_description": "Give visitors an easy way to show they appreciate your content."
+}
+```
 
 #### POST /wp-json/jetpack/v4/module/:module-slug/active
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -540,7 +540,7 @@ Get number of updated available for currently installed WordPress plugins.
 }
 ```
 
-### Akismet related operations
+### Akismet data
 
 #### GET /wp-json/jetpack/v4/module/akismet/data
 
@@ -671,7 +671,7 @@ Get stats from Akismet filtered spam.
 }
 ```
 
-### VaultPress options
+### VaultPress data
 
 #### GET /wp-json/jetpack/v4/module/vaultpress/data
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -131,7 +131,7 @@ When POSTing to this endpoint, you need to send a JSON object in the body with t
 
 As an extra, you can enable or disable modules with this endpoint too. You can pass a module slug as key and set it to `true` or `false` for updating its activation state.
 
-### GET /wp-json/jetpack/v4/settings
+#### GET /wp-json/jetpack/v4/settings
 
 Fetch a list of Jetpack settings.
 
@@ -159,7 +159,7 @@ Fetch a list of Jetpack settings.
 }
 ```
 
-### POST /wp-json/jetpack/v4/settings
+#### POST /wp-json/jetpack/v4/settings
 
 Update multiple settings at once.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -31,6 +31,27 @@ jQuery.ajax( {
 } );
 ```
 
+**Example POST request**
+
+```
+jQuery.ajax( {
+    url: '/wp-json/jetpack/v4/settings/',
+    method: 'post',
+    beforeSend: function ( xhr ) {
+        xhr.setRequestHeader( 'X-WP-Nonce', Initial_State.WP_API_nonce );
+    },
+    data: JSON.stringify( {
+        'carousel_display_exif': false
+    } ),
+    contentType: "application/json",
+    dataType: "json"
+} ).done( function ( response ) {
+    console.log( response );
+} ).error( function ( error ) {
+    console.log( error.responseText );
+} );
+```
+
 ### Requesting with the fetch API from the browser's console.
 
 **Example GET request**
@@ -45,6 +66,22 @@ fetch( '/wp-json/jetpack/v4/settings', {
 	.then( response => console.log( response) )
 	.catch( error => console.log( error.responseText ) );
 ```
+
+**Example POST request**
+
+```
+fetch( '/wp-json/jetpack/v4/settings', {
+	method: 'post',
+	body: JSON.stringify( { masterbar: true } ),
+	headers: {
+		'X-WP-Nonce': Initial_State.WP_API_nonce,
+		'Content-type': 'application/json' }
+} )
+	.then( response => response.json() )
+	.then( response => console.log( response) )
+	.catch( error => console.log( error.responseText ) );
+```
+
 ## API Authentication and authorization
 
 The API requests rely on [cookie-based authentication and a specific nonce](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/#cookie-authentication)

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -520,6 +520,26 @@ Get a list of the currently installed plugins on the site.
 
 Get number of updated available for currently installed WordPress plugins.
 
+**Example response** when all plugins are up to date
+
+```
+{
+	"code": "success",
+	"message": "All plugins are up-to-date. Keep up the good work!",
+	"count":0
+}
+```
+
+**Example response** when some plugins need to be updated
+
+```
+{
+	"code": "updates-available",
+	"message": "2 plugins need updating.",
+	"count": 2
+}
+```
+
 ### Akismet related operations
 
 #### GET /wp-json/jetpack/v4/akismet/stats/get

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -475,10 +475,6 @@ Get count of blocked attacks by Protect.
 
 ### Monitor module related operations
 
-#### GET /wp-json/jetpack/v4/module/monitor/downtime/last
-
-Get from the Monitor module, the last time the site was down.
-
 ### Verification Tools module related operations
 
 #### GET /wp-json/jetpack/v4/module/verification-tools/services

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -475,12 +475,6 @@ Get count of blocked attacks by Protect.
 
 ### Monitor module related operations
 
-### Verification Tools module related operations
-
-#### GET /wp-json/jetpack/v4/module/verification-tools/services
-
-Get services that this site is verified with.
-
 ### Site's plugins related operations
 
 #### GET /wp-json/jetpack/v4/plugins

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -2,6 +2,35 @@
 
 Jetpack's HTTP API is built as an [extension to the WP-API](http://v2.wp-api.org/extending/adding/). Thus, you may find additional information on approaching the API in the [WP API Docs](http://v2.wp-api.org/).
 
+* [How to use](#how-to-use)
+* [API Authentication and authorization](#api-request-authorization-via-nonces)
+* [API Reference](#api-reference)
+
+## How to use
+
+All of the extensions that Jetpack adds to the core's REST API infrastructure demand authentication and, of course knowledge of the endpoints (you can find about them under [API Reference](#api-reference)).
+
+### Requesting with jQuery from the browser console.
+
+If you go to the Jetpack wp-admin page (/wp-admin/admin.php?page=jetpack) on you WordPress site, you can open the console there and write an AJAX request using `jQuery.ajax`. This comes in handy when testing as every request demands a nonce generated for the REST API specifically. More details about this nonce in [API Authentication and authorization](#api-request-authorization-via-nonces).
+
+Example GET request to the settings endpoint
+```
+jQuery.ajax( {
+    url: '/wp-json/jetpack/v4/settings/',
+    method: 'get',
+    beforeSend: function ( xhr ) {
+        xhr.setRequestHeader( 'X-WP-Nonce', Initial_State.WP_API_nonce );
+    },
+    contentType: "application/json",
+    dataType: "json"
+} ).done( function ( response ) {
+    console.log( response );
+} ).error( function ( error ) {
+    console.log( error.responseText );
+} );
+```
+
 ## API Authentication and authorization
 
 The API requests rely on [cookie-based authentication and a specific nonce](http://v2.wp-api.org/guide/authentication/#cookie-authentication)

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -180,6 +180,43 @@ Fetch a fresh WordPress.com URL for connecting the Jetpack installation.
 
 Fetch the data of the current's user WordPress.com account.
 
+**Example response**
+
+```
+{
+    "currentUser": {
+        "isConnected": true,
+        "isMaster": true,
+        "username": "admin",
+        "wpcomUser": {
+            "ID": 9123841,
+            "login": "wondell",
+            "email": "wondell@gmail.com",
+            "display_name": "Wondell",
+            "text_direction": "ltr",
+            "site_count": 12,
+            "jetpack_connect": "",
+            "avatar": "http://2.gravatar.com/avatar/5e1a8fhjdj284c3dec35c2?s=64&d=mm&r=g"
+        },
+        "gravatar": "<img alt='' src='http://2.gravatar.com/avatar/5e1a8fhjdj284c3dec35c2?s=40&#038;d=mm&#038;r=g' srcset='http://2.gravatar.com/avatar/5e1a8fhjdj284c3dec35c2?s=80&amp;d=mm&amp;r=g 2x' class='avatar avatar-40 photo' height='40' width='40' />",
+        "permissions": {
+            "admin_page": true,
+            "connect": true,
+            "disconnect": true,
+            "manage_modules": true,
+            "network_admin": false,
+            "network_sites_page": false,
+            "edit_posts": true,
+            "publish_posts": true,
+            "manage_options": true,
+            "view_stats": true,
+            "manage_plugins": true
+        }
+    }
+}
+```
+
+
 #### POST /wp-json/jetpack/v4/connection
 
 Disconnect the Jetpack installation from WordPress.com servers.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -125,11 +125,12 @@ Core REST API-compatible [capabilities document](https://developer.wordpress.org
 
 ### Jetpack settings
 
-We call settings to any option that a module provides.
+**Jetpack settings** are all of the options provided by Jetpack modules. That is, any configurable aspect of the features provided by Jetpack.
+In addition, this endpoint, allows you to enable or disable modules too. You can pass a module slug as key and set it to `true` or `false` for activating or deactivating the module.
+
 This endpoint returns a JSON object with multiple key and current values for them.
 When POSTing to this endpoint, you need to send a JSON object in the body with the new values for each key.
 
-As an extra, you can enable or disable modules with this endpoint too. You can pass a module slug as key and set it to `true` or `false` for updating its activation state.
 
 #### GET /wp-json/jetpack/v4/settings
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates `docs/rest-api.md` to be up to date to latest endpoints behavior.

* Improves `/settings` endpoint documentation
* Clarifies that the modules endpoint are not super useful anymore.

#### Testing instructions:

* Check how the document in this branch looks like: [rest-api.md](https://github.com/Automattic/jetpack/blob/update/improve-api-docs-again/docs/rest-api.md)

#### Proposed changelog entry for your changes:

Improved documentation for Jetpack REST API endpoints.