### PR TITLE
[WIP] Add Jetpack CSS support for Code Editor control in core patch

### DIFF
--- a/modules/custom-css/class-jetpack-css-editor-customize-control.php
+++ b/modules/custom-css/class-jetpack-css-editor-customize-control.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Customize API: Jetpack_CSS_Editor_Customize_Control class
+ *
+ * @package Jetpack
+ * @subpackage Custom CSS
+ */
+
+/**
+ * Jetpack Customize CSS Editor Control class.
+ *
+ * @see WP_Customize_Control
+ */
+class Jetpack_CSS_Editor_Customize_Control extends WP_Customize_Code_Editor_Control {
+
+	/**
+	 * Customize control type.
+	 *
+	 * @var string
+	 */
+	public $type = 'jetpackCss';
+
+	// @todo Add json() method which includes the exporting of jetpack_css_settings.
+}

--- a/modules/custom-css/custom-css/js/core-customizer-css.js
+++ b/modules/custom-css/custom-css/js/core-customizer-css.js
@@ -1,5 +1,7 @@
 (function( wp, $, api ){
-	api.controlConstructor.jetpackCss = api.Control.extend({
+	var BaseControl = api.CodeEditorControl || api.Control;
+
+	api.controlConstructor.jetpackCss = BaseControl.extend({
 		modes: {
 			'default': 'text/css',
 			'less': 'text/x-less',
@@ -11,7 +13,15 @@
 		 * @return {null}
 		 */
 		ready: function() {
-			this.opts = window._jp_css_settings;
+			api.bind( 'ready', _.bind( this.addLabels, this ) );
+
+			this.opts = window._jp_css_settings; // @todo When api.CodeEditorControl, this could be grabbed from this.params.jetpack_css_settings
+
+			if ( this.extended( api.CodeEditorControl ) ) {
+				api.CodeEditorControl.prototype.ready.call( this );
+				return null;
+			}
+
 			// add our textarea
 			this.$input = $( '<textarea />', {
 				name: this.setting.id,
@@ -33,8 +43,6 @@
 			} else {
 				this.$input.removeClass( 'hidden' );
 			}
-
-			api.bind( 'ready', _.bind( this.addLabels, this ) );
 		},
 		/**
 		 * Set up our CodeMirror instance


### PR DESCRIPTION
I wanted to give you a jump start on updating Custom CSS in Jetpack with the new code editor APIs in 4.9-alpha. This is just an initial integration which fixes the JS error that was caused by Jetpack and core conflicting. I'm sure there is additional integration work needed, specifically in the realm of switching between CSS, LESS, and SCSS. But I hope this is helpful for you to get started and also to evaluate the proposed core changes in Trac [#41897](https://core.trac.wordpress.org/ticket/41897) which makes the Custom CSS control in the Customizer actually extensible (please apply that core patch or checkout the [branch](https://github.com/xwp/wordpress-develop/pull/257) to test). Any findings from the Jetpack integration here will inform what changes need to be made in that core patch.

So I hand this over to the Jetpack team to amend as needed.

Depends on https://github.com/xwp/wordpress-develop/pull/257 which resolves https://core.trac.wordpress.org/ticket/41897

Fixes #7776.