### PR TITLE
Remove incorrect RTL filepath in Contact Form module's editor css

### DIFF
--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -83,7 +83,7 @@ class Grunion_Editor_View {
 			)
 		) );
 
-		add_editor_style( plugins_url( 'css/editor-style.css', __FILE__ ) );
+		add_editor_style( plugin_dir_url( __FILE__ ) . '/css/editor-style.css' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7608 

`plugins_url()` is being filtered by [`maybe_min_asset()`](https://github.com/Automattic/jetpack/blob/f4cd94c378cd49349625f768849240e7ab237605/class.jetpack.php#L5961) to use a minified file path if a minified file exists.

This causes an issue when passed to `add_editor_style()`, which according to the [codex](https://developer.wordpress.org/reference/functions/add_editor_style/) "automatically adds another stylesheet with -rtl prefix, e.g. editor-style-rtl.css."

This results in a url pattern like editor-style.min-rtl.css, where the `-rtl` string is appended to the min extension, rather than the root filename.

#### Changes proposed in this Pull Request:

* Switch from `plugins_url()`, which is filtered, to `plugin_dir_url()`, which is unfiltered

#### Testing instructions:

* You can see the stylesheets passed to TinyMCE by adding `var_dump( get_editor_stylesheets() );` on line 87 of `grunion-editor-view.php`.
* You can see the stylesheets TinyMCE has loaded in by opening a single post and typing `tinymce.editors[0].contentCSS` into the console.
* #7608 has instructions for reproducing the resulting issue this PR aims to resolve.

#### Notes:

* This will result in an unminified version of `/wp-content/plugins/jetpack/modules/contact-form/css/editor-style.css` being passed to TinyMCE, but will also allow the correct RTL file to load.
* If keeping the files in TinyMCE minified is a priority, then we could add a filter for [`mce_css`](https://developer.wordpress.org/reference/hooks/mce_css/) that runs the logic in [`maybe_min_asset()`](https://github.com/Automattic/jetpack/blob/f4cd94c378cd49349625f768849240e7ab237605/class.jetpack.php#L5961).