### PR TITLE
updating card spacing method for ie11 compatibility

### DIFF
--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -47,8 +47,8 @@
 			margin-top: 2px;
 		}
 		& + span {
-			margin-top: 2px;
-			display: inline-block;
+			padding-top: 2px;
+			display: block;
 		}
 	}
 


### PR DESCRIPTION
Fixes #7134

#### Changes proposed in this Pull Request:

* Update the display property to resolve IE11 display issues, and switch from margin to padding to retain the spacing intended in the [original commit](https://github.com/Automattic/jetpack/commit/134a1f0dd586c60ae4989cc33328a5a39bc0fd3f#diff-25fe11b65ebc031d13de1c4b6d5b9d56R48).

#### Testing instructions:

* Using browserstack to emulate IE11, visit the module settings page of a jetpack site (`/wp-admin/admin.php?page=jetpack#/settings`). Without this patch, all card content should be pushed to the left (as seen in #7134).