### PR TITLE
Update Contact Form website field to use HTML5 url field

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -3,7 +3,8 @@
 }
 
 .contact-form input[type='text'],
-.contact-form input[type='email'] {
+.contact-form input[type='email'],
+.contact-form input[type='url'] {
 	width: 300px;
 	max-width: 98%;
 	margin-bottom: 13px;
@@ -62,6 +63,7 @@
 
 .textwidget .contact-form input[type='text'],
 .textwidget .contact-form input[type='email'],
+.textwidget .contact-form input[type='url'],
 .textwidget .contact-form textarea {
 	width: 250px;
 	max-width: 100%;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2621,6 +2621,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label telephone" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
 				$r .= "\t\t<input type='tel' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . "/>\n";
 			break;
+			case 'url' :
+				$r .= "\n<div>\n";
+				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label url" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
+				$r .= "\t\t<input type='url' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
+				$r .= "\t</div>\n";
+			break;
 			case 'textarea' :
 				$r .= "\n<div>\n";
 				$r .= "\t\t<label for='contact-form-comment-" . esc_attr( $field_id ) . "' class='grunion-field-label textarea" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -182,6 +182,13 @@ class Grunion_Editor_View {
 	</div>
 </script>
 
+<script type="text/html" id="tmpl-grunion-field-url">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label {{ data.type }}'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<input type='url' name='{{ data.id }}' id='{{ data.id }}' value='{{ data.value }}' class='{{ data.class }}' placeholder='{{ data.placeholder }}' />
+	</div>
+</script>
+
 
 <script type="text/html" id="tmpl-grunion-field-edit">
 	<div class="card is-compact grunion-field-edit grunion-field-{{ data.type }}" aria-label="<?php esc_attr_e( 'Form Field', 'jetpack' ); ?>">

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -19,7 +19,7 @@
 			date                : wp.template( 'grunion-field-date' ),
 			text                : wp.template( 'grunion-field-text' ),
 			name                : wp.template( 'grunion-field-text' ),
-			url                 : wp.template( 'grunion-field-text' )
+			url                 : wp.template( 'grunion-field-url' )
 		},
 		edit_template  : wp.template( 'grunion-field-edit' ),
 		editor_inline  : wp.template( 'grunion-editor-inline' ),


### PR DESCRIPTION
Fixes #7062 

#### Changes proposed in this Pull Request:

* Setup a condition for fields marked `url` type to use HTML5 URL fields (which include native validation).
* Update field styles to apply to url fields also.

#### Testing instructions:

* Enable the Contact Form module and create a form containing a Website field.
* On the front end, add a non-url in the Website field (such as `xfbdgbd`), and try submitting the form.
* The url field should display a validation message requiring you to enter a valid url.

#### Additonal Notes:
* I considered adding additional validation in the [`validate()` function](https://github.com/rclations/jetpack/blob/68df77386ba152b279c2cc0c6fc8050ad461da64/modules/contact-form/grunion-contact-form.php#L2498-L2504) using [FILTER_VALIDATE_URL](http://php.net/manual/en/filter.filters.validate.php), but saw that it only validates ASCII URLs, and that international non-ASCII URLs won't pass.