### PR TITLE
Google Analytics: Add support for IP anonymization and basic ecommerce tracking

### DIFF
--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -134,6 +134,13 @@ class Jetpack_Google_Analytics {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
 		}
 
+		/**
+		 * Allow for additional elements to be added to the classic Google Analytics queue (_gaq) array
+		 *
+		 * @since 5.4.0
+		 *
+		 * @param array $custom_vars Array of classic Google Analytics queue elements
+		 */
 		$custom_vars = apply_filters( 'jetpack_wga_classic_custom_vars', $custom_vars );
 
 		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -35,7 +35,10 @@ class Jetpack_Google_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
+		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
+		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
 		add_action( 'wp_footer', array( $this, 'insert_code' ) );
+		add_filter( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
 	}
 
 	/**
@@ -115,7 +118,7 @@ class Jetpack_Google_Analytics {
 		$track = array();
 		if ( is_404() ) {
 			// This is a 404 and we are supposed to track them.
-			$custom_vars[] = "_gaq.push( [ '_trackEvent', '404', document.location.href, document.referrer ] );";
+			$custom_vars[] = "_gaq.push(['_trackEvent', '404', document.location.href, document.referrer]);";
 		} elseif ( is_search() ) {
 			// Set track for searches, if it's a search, and we are supposed to.
 			$track['data'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ); // Input var okay.
@@ -131,17 +134,20 @@ class Jetpack_Google_Analytics {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
 		}
 
-		$async_code = "<!-- Jetpack Google Analytics -->
-		<script type='text/javascript'>
-							var _gaq = _gaq || [];
-							%custom_vars%
+		$custom_vars = apply_filters( 'jetpack_wga_classic_custom_vars', $custom_vars );
 
-							(function() {
-								var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-								ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-								var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-							})();
-						</script>";
+		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
+		$async_code = "<!-- Jetpack Google Analytics -->
+			<script type='text/javascript'>
+				var _gaq = _gaq || [];
+				%custom_vars%
+
+				(function() {
+					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+				})();
+			</script>";
 
 		$custom_vars_string = implode( "\r\n", $custom_vars );
 		$async_code = str_replace( '%custom_vars%', $custom_vars_string, $async_code );
@@ -162,6 +168,136 @@ class Jetpack_Google_Analytics {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Used to filter in the anonymize IP snippet to the custom vars array for classic analytics
+	 * Ref https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizelp
+	 * @param array custom vars to be filtered
+	 * @return array possibly updated custom vars
+	 */
+	public function jetpack_wga_classic_anonymize_ip( $custom_vars ) {
+		$o = get_option( 'jetpack_wga' );
+		$anonymize_ip = isset( $o[ 'anonymize_ip' ] ) ? $o[ 'anonymize_ip' ] : false;
+		if ( $anonymize_ip ) {
+			array_push( $custom_vars, "_gaq.push(['_gat._anonymizeIp']);" );
+		}
+
+		return $custom_vars;
+	}
+
+	/**
+	 * Used to filter in the order details to the custom vars array for classic analytics
+	 * @param array custom vars to be filtered
+	 * @return array possibly updated custom vars
+	 */
+	public function jetpack_wga_classic_track_purchases( $custom_vars ) {
+		global $wp;
+
+		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
+		$o = get_option( 'jetpack_wga' );
+		$ec_track_purchases = isset( $o[ 'ec_track_purchases' ] ) ? $o[ 'ec_track_purchases' ] : false;
+		$minimum_woocommerce_active = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.0', '>=' );
+		if ( $ec_track_purchases && $minimum_woocommerce_active && is_order_received_page() ) {
+			$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
+			if ( 0 < $order_id && 1 != get_post_meta( $order_id, '_ga_tracked', true ) ) {
+				$order = new WC_Order( $order_id );
+
+				// [ '_add_Trans', '123', 'Site Title', '21.00', '1.00', '5.00', 'Snohomish', 'WA', 'USA' ]
+				$code = "_gaq.push(['_addTrans',
+					'" . esc_js( $order->get_order_number() ) . "',			// order ID
+					'" . esc_js( get_bloginfo( 'name' ) ) . "',					// store name
+					'" . esc_js( $order->get_total() ) . "',						// total
+					'" . esc_js( $order->get_total_tax() ) . "',				// tax
+					'" . esc_js( $order->get_total_shipping() ) . "',		// shipping
+					'" . esc_js( $order->get_billing_city() ) . "',			// city
+					'" . esc_js( $order->get_billing_state() ) . "',		// state or province
+					'" . esc_js( $order->get_billing_country() ) . "'		// country
+				]);";
+				array_push( $custom_vars, $code );
+
+				// Order items
+				if ( $order->get_items() ) {
+					foreach ( $order->get_items() as $item ) {
+						$product = $order->get_product_from_item( $item );
+
+						$code = "_gaq.push(['_addItem',";
+						$code .= "'" . esc_js( $order->get_order_number() ) . "',";
+						$code .= "'" . esc_js( $product->get_sku() ? $product->get_sku() : $product->get_id() ) . "',";
+						$code .= "'" . esc_js( $item['name'] ) . "',";
+						$code .= "'" . esc_js( self::get_product_categories_concatenated( $product ) ) . "',";
+						$code .= "'" . esc_js( $order->get_item_total( $item ) ) . "',";
+						$code .= "'" . esc_js( $item['qty'] ) . "'";
+						$code .= "]);";
+						array_push( $custom_vars, $code );
+					}
+				} // get_items
+
+				// Mark the order as tracked
+				update_post_meta( $order_id, '_ga_tracked', 1 );
+				array_push( $custom_vars, "_gaq.push(['_trackTrans']);" );
+			} // order not yet tracked
+		} // is order received page
+
+		return $custom_vars;
+	}
+
+	/**
+	 * Gets product categories or varation attributes as a formatted concatenated string
+	 * @param WC_Product
+	 * @return string
+	 */
+	public function get_product_categories_concatenated( $product ) {
+		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : '';
+		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
+			$line = wc_get_formatted_variation( $variation_data, true );
+		} else {
+			$out = array();
+			$categories = get_the_terms( $product->get_id(), 'product_cat' );
+			if ( $categories ) {
+				foreach ( $categories as $category ) {
+					$out[] = $category->name;
+				}
+			}
+			$line = join( "/", $out );
+		}
+		return $line;
+	}
+
+	/**
+	 * Used to add footer javascript to track user clicking on add-to-cart buttons
+	 * on single views (.single_add_to_cart_button) and list views (.add_to_cart_button)
+	 */
+	public function jetpack_wga_classic_track_add_to_cart() {
+		$tracking_id = $this->_get_tracking_code();
+		if ( empty( $tracking_id ) ) {
+			return;
+		}
+
+		$o = get_option( 'jetpack_wga' );
+		$ec_track_add_to_cart = isset( $o[ 'ec_track_add_to_cart' ] ) ? $o[ 'ec_track_add_to_cart' ] : false;
+		if ( $ec_track_add_to_cart ) {
+			if ( is_product() ) { // product page
+				global $product;
+				$product_sku_or_id = $product->get_sku() ? $product->get_sku() : "#" + $product->get_id();
+				wc_enqueue_js(
+					"jQuery( function( $ ) {
+						$( '.single_add_to_cart_button' ).click( function() {
+							_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
+						} );
+					} );"
+				);
+			} else if ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
+				wc_enqueue_js(
+					"jQuery( function( $ ) {
+						$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
+							var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );
+							_gaq.push(['_trackEvent', 'Products', 'Add to Cart', label]);
+						} );
+					} );"
+				);
+			}
+		}
 	}
 }
 

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -204,32 +204,47 @@ class Jetpack_Google_Analytics {
 				$order = new WC_Order( $order_id );
 
 				// [ '_add_Trans', '123', 'Site Title', '21.00', '1.00', '5.00', 'Snohomish', 'WA', 'USA' ]
-				$code = "_gaq.push(['_addTrans',
-					'" . esc_js( $order->get_order_number() ) . "',			// order ID
-					'" . esc_js( get_bloginfo( 'name' ) ) . "',					// store name
-					'" . esc_js( $order->get_total() ) . "',						// total
-					'" . esc_js( $order->get_total_tax() ) . "',				// tax
-					'" . esc_js( $order->get_total_shipping() ) . "',		// shipping
-					'" . esc_js( $order->get_billing_city() ) . "',			// city
-					'" . esc_js( $order->get_billing_state() ) . "',		// state or province
-					'" . esc_js( $order->get_billing_country() ) . "'		// country
-				]);";
-				array_push( $custom_vars, $code );
+				array_push(
+					$custom_vars,
+					sprintf(
+						'_gaq.push( %s );', json_encode(
+							array(
+								'_addTrans',
+								(string) $order->get_order_number(),
+								get_bloginfo( 'name' ),
+								(string) $order->get_total(),
+								(string) $order->get_total_tax(),
+								(string) $order->get_total_shipping(),
+								(string) $order->get_billing_city(),
+								(string) $order->get_billing_state(),
+								(string) $order->get_billing_country()
+							)
+						)
+					)
+				);
 
 				// Order items
 				if ( $order->get_items() ) {
 					foreach ( $order->get_items() as $item ) {
 						$product = $order->get_product_from_item( $item );
+						$product_sku_or_id = $product->get_sku() ? $product->get_sku() : $product->get_id();
 
-						$code = "_gaq.push(['_addItem',";
-						$code .= "'" . esc_js( $order->get_order_number() ) . "',";
-						$code .= "'" . esc_js( $product->get_sku() ? $product->get_sku() : $product->get_id() ) . "',";
-						$code .= "'" . esc_js( $item['name'] ) . "',";
-						$code .= "'" . esc_js( self::get_product_categories_concatenated( $product ) ) . "',";
-						$code .= "'" . esc_js( $order->get_item_total( $item ) ) . "',";
-						$code .= "'" . esc_js( $item['qty'] ) . "'";
-						$code .= "]);";
-						array_push( $custom_vars, $code );
+						array_push(
+							$custom_vars,
+							sprintf(
+								'_gaq.push( %s );', json_encode(
+									array(
+										'_addItem',
+										(string) $order->get_order_number(),
+										(string) $product_sku_or_id,
+										$item['name'],
+										self::get_product_categories_concatenated( $product ),
+										(string) $order->get_item_total( $item ),
+										(string) $item['qty']
+									)
+								)
+							)
+						);
 					}
 				} // get_items
 

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -38,7 +38,7 @@ class Jetpack_Google_Analytics {
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
 		add_action( 'wp_footer', array( $this, 'insert_code' ) );
-		add_filter( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
+		add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7777 #7778 

Related: https://github.com/Automattic/jetpack/pull/7869

WORK IN PROGRESS

#### Changes proposed in this Pull Request:

* The present Google Analytics module in Jetpack only looks for the tracking code (the UA code) in settings.
* We are adding three other fields to the jetpack_wga option  (and, as a separate PR, to the endpoint that sets that option)
* The three other fields are

1. anonymize_ip - allows IP anonymization. It defaults to off.
2. ec_track_purchases - syncs WooCommerce order amounts and items to Google Analytics as orders are received. Defaults to off.
3. ec_track_add_to_cart - notifies Google Analytics (as an event) when customers add items to their carts. Defaults to off.

* In addition to the endpoint, there will be a wp-calypso PR to allow the user to control these new settings.  For now, for testing this PR, you'll need to manipulate the option "manually."

#### Testing instructions:

* Sign up for a Google Analytics tracking code for your test site, e.g. UA-12345678-1 
* Install, activate and connect Jetpack
* Install and activate WooCommerce
* Create a product with no SKU and at least two categories
* Create another product with a SKU and at least two categories
* Replace the modules/google-analytics/wp-google-analytics.php file with the file from this branch
* "Manually" set (e.g. just do something like hack Hello Dolly) the jetpack_wga option to

```
array(
	'code' => '',
	'anonymize_ip' => 0,
	'ec_track_purchases' => 0,
	'ec_track_add_to_cart' => 0
);
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is never referenced and 2) no jQuery is present to hook .single_add_to_cart_button or .add_to_cart_button
elements.

* "Manually" set the jetpack_wga option to

```
array(
	'code' => 'UA-12345678-1',
	'anonymize_ip' => 0,
	'ec_track_purchases' => 0,
	'ec_track_add_to_cart' => 0
);
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is present but that no jQuery is present to hook .single_add_to_cart_button or .add_to_cart_button elements.

* "Manually" set the jetpack_wga option to

```
array(
	'code' => 'UA-12345678-1',
	'anonymize_ip' => 1,
	'ec_track_purchases' => 0,
	'ec_track_add_to_cart' => 0
);
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is present and that the _anonymizeIp element is present

* "Manually" set the jetpack_wga option to

```
array(
	'code' => 'UA-12345678-1',
	'anonymize_ip' => 0,
	'ec_track_purchases' => 1,
	'ec_track_add_to_cart' => 0
);
```

* In your Google Analytics Dashboard, go to Admin for your site (it looks like a gear in the lower left corner)
* Under View select Ecommerce Settings
* Enable Ecommerce if you haven't already. DO NOT ENABLE ENHANCED ECOMMERCE AT THIS TIME.

* Back on your test site, Complete the purchase of any item using a gateway like Check Payment.
* Return to your Google Analytics Dashboard and go to Conversions and then Ecommerce
* Set the date range to today
* Make sure you see the sale and that the details are correct

* "Manually" set the jetpack_wga option to

```
array(
	'code' => 'UA-12345678-1',
	'anonymize_ip' => 0,
	'ec_track_purchases' => 1,
	'ec_track_add_to_cart' => 1
);
```

* Visit each product page, adding the product to your cart.
* In your Google Analytics Dashboard, go to Real-time and then Events
* Make sure you see the addition of the SKU less and the SKU product and that the details are correct

#### Proposed changelog entry for your changes:

* Google Analytics: Add support for IP anonymization and basic WooCommerce tracking
