### PR TITLE
Add full support for Contact Form Date Field

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -1,14 +1,80 @@
-.contact-form .clear-form { clear: both; }
-.contact-form input[type='text'], .contact-form input[type='email'], .contact-form input[type='date'] { width: 300px; max-width: 98%; margin-bottom: 13px; }
-.contact-form select { margin-bottom: 13px; }
-.contact-form textarea { height: 200px; width: 80%; float: none; margin-bottom: 13px; }
-.contact-form input[type='radio'], .contact-form input[type='checkbox'] { float: none; margin-bottom: 13px; }
-.contact-form label { margin-bottom: 3px; float: none; font-weight: bold; display: block; }
-.contact-form label.checkbox, .contact-form label.radio { margin-bottom: 3px; float: none; font-weight: bold; display: inline-block; }
-.contact-form label span { color: #AAA; margin-left: 4px; font-weight: normal; }
-.contact-form-submission { margin-bottom: 4em; padding: 1.5em 1em; }
-.contact-form-submission p { margin: 0 auto; }
-.form-errors .form-error-message { color: red; }
-.textwidget .contact-form input[type='text'], .textwidget .contact-form input[type='email'], .textwidget .contact-form input[type='date'], .textwidget .contact-form textarea { width: 250px; max-width: 100%; box-sizing: border-box; }
-#jetpack-check-feedback-spam { margin: 1px 8px 0px 0px; }
-.jetpack-check-feedback-spam-spinner { display: inline-block; margin-top: 7px; }
+.contact-form .clear-form {
+	clear: both;
+}
+
+.contact-form input[type='text'],
+.contact-form input[type='email'],
+.contact-form input[type='date'] {
+	width: 300px;
+	max-width: 98%;
+	margin-bottom: 13px;
+}
+
+.contact-form select {
+	margin-bottom: 13px;
+}
+
+.contact-form textarea {
+	height: 200px;
+	width: 80%;
+	float: none;
+	margin-bottom: 13px;
+}
+
+.contact-form input[type='radio'],
+.contact-form input[type='checkbox'] {
+	float: none;
+	margin-bottom: 13px;
+}
+
+.contact-form label {
+	margin-bottom: 3px;
+	float: none;
+	font-weight: bold;
+	display: block;
+}
+
+.contact-form label.checkbox,
+.contact-form label.radio {
+	margin-bottom: 3px;
+	float: none;
+	font-weight: bold;
+	display: inline-block;
+}
+
+.contact-form label span {
+	color: #AAA;
+	margin-left: 4px;
+	font-weight: normal;
+}
+
+.contact-form-submission {
+	margin-bottom: 4em;
+	padding: 1.5em 1em;
+}
+
+.contact-form-submission p {
+	margin: 0 auto;
+}
+
+.form-errors .form-error-message {
+	color: red;
+}
+
+.textwidget .contact-form input[type='text'],
+.textwidget .contact-form input[type='email'],
+.textwidget .contact-form input[type='date'],
+.textwidget .contact-form textarea {
+	width: 250px;
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+#jetpack-check-feedback-spam {
+	margin: 1px 8px 0px 0px;
+}
+
+.jetpack-check-feedback-spam-spinner {
+	display: inline-block;
+	margin-top: 7px;
+}

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -1,5 +1,5 @@
 .contact-form .clear-form { clear: both; }
-.contact-form input[type='text'], .contact-form input[type='email'] { width: 300px; max-width: 98%; margin-bottom: 13px; }
+.contact-form input[type='text'], .contact-form input[type='email'], .contact-form input[type='date'] { width: 300px; max-width: 98%; margin-bottom: 13px; }
 .contact-form select { margin-bottom: 13px; }
 .contact-form textarea { height: 200px; width: 80%; float: none; margin-bottom: 13px; }
 .contact-form input[type='radio'], .contact-form input[type='checkbox'] { float: none; margin-bottom: 13px; }
@@ -9,6 +9,6 @@
 .contact-form-submission { margin-bottom: 4em; padding: 1.5em 1em; }
 .contact-form-submission p { margin: 0 auto; }
 .form-errors .form-error-message { color: red; }
-.textwidget .contact-form input[type='text'], .textwidget .contact-form input[type='email'], .textwidget .contact-form textarea { width: 250px; max-width: 100%; box-sizing: border-box; }
+.textwidget .contact-form input[type='text'], .textwidget .contact-form input[type='email'], .textwidget .contact-form input[type='date'], .textwidget .contact-form textarea { width: 250px; max-width: 100%; box-sizing: border-box; }
 #jetpack-check-feedback-spam { margin: 1px 8px 0px 0px; }
 .jetpack-check-feedback-spam-spinner { display: inline-block; margin-top: 7px; }

--- a/modules/contact-form/css/jquery-ui-datepicker.css
+++ b/modules/contact-form/css/jquery-ui-datepicker.css
@@ -1,0 +1,160 @@
+.ui-datepicker {
+    padding: 0;
+    margin: 0;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    border-radius: 0;
+    background-color: #fff;
+    border: 1px solid #dfdfdf;
+    border-top: none;
+    -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
+    min-width: 17em;
+    width: auto;
+}
+
+.ui-datepicker * {
+    padding: 0;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    border-radius: 0;
+}
+
+.ui-datepicker table {
+    font-size: 13px;
+    margin: 0;
+    border: none;
+    border-collapse: collapse;
+}
+
+.ui-datepicker .ui-widget-header,
+.ui-datepicker .ui-datepicker-header {
+    background-image: none;
+    border: none;
+    font-weight: normal;
+}
+
+.ui-datepicker .ui-datepicker-header .ui-state-hover {
+    background: transparent;
+    border-color: transparent;
+    cursor: pointer;
+}
+
+.ui-datepicker .ui-datepicker-title {
+    margin: 0;
+    padding: 10px 0;
+    font-size: 14px;
+    line-height: 14px;
+    text-align: center;
+}
+
+.ui-datepicker .ui-datepicker-prev,
+.ui-datepicker .ui-datepicker-next {
+    position: relative;
+    top: 0;
+    height: 34px;
+    width: 34px;
+}
+
+.ui-datepicker .ui-state-hover.ui-datepicker-prev,
+.ui-datepicker .ui-state-hover.ui-datepicker-next {
+    border: none;
+}
+
+.ui-datepicker .ui-datepicker-prev,
+.ui-datepicker .ui-datepicker-prev-hover {
+    left: 0;
+}
+
+.ui-datepicker .ui-datepicker-next,
+.ui-datepicker .ui-datepicker-next-hover {
+    right: 0;
+}
+
+.ui-datepicker .ui-datepicker-next span,
+.ui-datepicker .ui-datepicker-prev span {
+    display: none;
+}
+
+.ui-datepicker .ui-datepicker-prev {
+    float: left;
+}
+
+.ui-datepicker .ui-datepicker-next {
+    float: right;
+}
+
+.ui-datepicker .ui-datepicker-prev:before,
+.ui-datepicker .ui-datepicker-next:before {
+    font: normal 20px/34px 'dashicons';
+    padding-left: 7px;
+    speak: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    width: 34px;
+    height: 34px;
+}
+
+.ui-datepicker .ui-datepicker-prev:before {
+    content: '\f341';
+}
+
+.ui-datepicker .ui-datepicker-next:before {
+    content: '\f345';
+}
+
+.ui-datepicker .ui-datepicker-prev-hover:before,
+.ui-datepicker .ui-datepicker-next-hover:before {
+    opacity: 0.7;
+}
+
+.ui-datepicker select.ui-datepicker-month,
+.ui-datepicker select.ui-datepicker-year {
+    width: 33%;
+}
+
+.ui-datepicker thead {
+    font-weight: 600;
+}
+
+.ui-datepicker th {
+    padding: 10px;
+}
+
+.ui-datepicker td {
+    padding: 0;
+    border: 1px solid #f4f4f4;
+}
+
+.ui-datepicker td.ui-datepicker-other-month {
+    border: transparent;
+}
+
+.ui-datepicker td.ui-datepicker-week-end {
+    background-color: #f4f4f4;
+    border: 1px solid #f4f4f4;
+}
+
+.ui-datepicker td.ui-datepicker-today {
+    background-color: #f0f0c0;
+}
+
+.ui-datepicker td.ui-datepicker-current-day {
+    background: #bbdd88;
+}
+
+.ui-datepicker td .ui-state-default {
+    background: transparent;
+    border: none;
+    text-align: center;
+    text-decoration: none;
+    width: auto;
+    display: block;
+    padding: 5px 10px;
+    font-weight: normal;
+    color: #444;
+}
+
+.ui-datepicker td.ui-state-disabled .ui-state-default {
+    opacity: 0.5;
+}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2675,6 +2675,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t</div>\n";
 
 				wp_enqueue_script( 'grunion-frontend', plugins_url( 'js/grunion-frontend.js', __FILE__ ), array( 'jquery', 'jquery-ui-datepicker' ) );
+				wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( 'css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
 			break;
 			default : // text field
 				// note that any unknown types will produce a text input, so we can use arbitrary type names to handle

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -201,6 +201,7 @@ class Grunion_Editor_View {
 			'checkbox-multiple' => __( 'Checkbox with Multiple Items', 'jetpack' ),
 			'select'            => __( 'Drop down', 'jetpack' ),
 			'radio'             => __( 'Radio', 'jetpack' ),
+			'date'              => __( 'Date', 'jetpack' ),
 		);
 		?>
 		<div class="grunion-type-options">

--- a/modules/contact-form/js/grunion-frontend.js
+++ b/modules/contact-form/js/grunion-frontend.js
@@ -1,6 +1,6 @@
 jQuery( function ( $ ) {
 	var datefield = $( '.contact-form input[type="date"]' );
 	if ( 'function' === typeof $.fn.datepicker && 'text' === datefield[0].type ) {
-		datefield.datepicker( { dateFormat : 'yy-mm-dd' } );
+		datefield.datepicker( { dateFormat : 'yyyy-mm-dd' } );
 	}
 } );

--- a/modules/contact-form/js/grunion-frontend.js
+++ b/modules/contact-form/js/grunion-frontend.js
@@ -1,5 +1,6 @@
 jQuery( function ( $ ) {
-	if ( 'function' === typeof $.fn.datepicker ) {
-		$( '.contact-form input[type="date"]' ).datepicker( { dateFormat : 'yy-mm-dd' } );
+	var datefield = $( '.contact-form input[type="date"]' );
+	if ( 'function' === typeof $.fn.datepicker && 'text' === datefield[0].type ) {
+		datefield.datepicker( { dateFormat : 'yy-mm-dd' } );
 	}
 } );


### PR DESCRIPTION
Date field support was started in https://github.com/Automattic/jetpack/commit/40e7bbe8de7f42a528ed2854bd49e738dcb2b4d0. This PR aims to complete the feature and address some of the issues raised in #269 and #3578.

#### Changes proposed in this Pull Request:

* Detect [browser support](https://caniuse.com/#search=input%20date) for `<input type="date">` elements, and conditionally setup jQuery datepicker only if native date field browser support is not available. This solves the issue reported in #269 where both the jQuery datepicker and native browser datepicker appear simultaneously.
* Add styles for jQuery datepicker (none existed previously). These were borrowed from @JJJ's [open source style library](https://github.com/stuttter/wp-datepicker-styling/blob/master/datepicker.css)  🎉, and are meant to be minimal.
* Add date field as an available field option in the visual editor.
* Update styles for date fields to match existing styles for other field types.

#### Testing instructions:

* Try creating a form containing a date field using the visual editor.
* Visit the front end using a modern browser, and try interacting with the date field. Make sure that the styling appears as you would expect. Here you should see the native browser implementation of the date field controls, including a dropdown picker (activated by an arrow inside the right edge of the input).
* You can use browserstack to emulate Windows 8 + IE10 to test the display for browsers that do not recognize `<input type="date">` elements. This should display the styled jQuery datepicker.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Now you can add a Date field to any Contact Form using the visual editor.