### PR TITLE
JSON API: GET site endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -211,7 +211,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 	private function has_blog_access( $token_details, $blog_id ) {
-		if ( is_user_member_of_blog( get_current_user_id(), $blog_id ) ) {
+		if ( is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 			return true;
 		}
 

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -210,7 +210,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		return $this->render_response_keys( $response_keys );
 	}
 
-	private function has_blog_access( $token_details, $blog_id ) {
+	private function has_blog_access( $token_details, $wpcom_blog_id ) {
 		if ( is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 			return true;
 		}
@@ -223,7 +223,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if (
 			'jetpack' === $token_details['auth'] &&
 			'blog' === $token_details['access'] &&
-			$blog_id === $token_details['blog_id']
+			$wpcom_blog_id === $token_details['blog_id']
 		) {
 			return true;
 		}


### PR DESCRIPTION
When we check that user is a member of blog, let's use current_blog_id() rather than remote blog id.

For more information and context
See corresponding JPOP issue.
And: 686842-zen 

