### PR TITLE
Record discovery terms

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -477,6 +477,16 @@ class Jetpack_Network {
 			'timeout' => $timeout,
 		);
 
+		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source', false );
+		
+		if ( $activation_source_name ) {
+			$args['_as'] = urlencode( $activation_source_name );
+		}
+
+		if ( $activation_source_keyword ) {
+			$args['_ak'] = urlencode( $activation_source_keyword );
+		}
+
 		// Attempt to retrieve shadow blog details
 		$response = Jetpack_Client::_wp_remote_request(
 			Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'subsiteregister' ) ), $args, true

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2914,25 +2914,25 @@ p {
 		$source_query = null;
 
 		if ( $plugins_path === $referer['path'] ) {
-			$source_type = 'plugins-list';
+			$source_type = 'list';
 		} elseif ( $plugins_install_path === $referer['path'] ) {
 			$tab = isset( $query_parts['tab'] ) ? $query_parts['tab'] : 'featured';
 			switch( $tab ) {
 				case 'popular':
-					$source_type = 'plugin-install-popular';
+					$source_type = 'popular';
 					break;
 				case 'recommended':
-					$source_type = 'plugin-install-recommended';
+					$source_type = 'recommended';
 					break;
 				case 'favorites':
-					$source_type = 'plugin-install-favorites';
+					$source_type = 'favorites';
 					break;
 				case 'search':
-					$source_type = 'plugin-install-search-' . ( isset( $query_parts['type'] ) ? $query_parts['type'] : 'term' );
+					$source_type = 'search-' . ( isset( $query_parts['type'] ) ? $query_parts['type'] : 'term' );
 					$source_query = isset( $query_parts['s'] ) ? $query_parts['s'] : null;
 					break;
 				default:
-					$source_type = 'plugin-install-featured';
+					$source_type = 'featured';
 			}
 		} else {
 			$source_type = 'unknown';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2897,8 +2897,11 @@ p {
 
 		$referer = parse_url( $referer_url );
 		
+		$source_type = 'unknown';
+		$source_query = null;
+
 		if ( ! is_array( $referer ) ) {
-			return array( 'unknown', null );
+			return array( $source_type, $source_query );
 		}
 
 		$plugins_path = parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
@@ -2909,9 +2912,6 @@ p {
 		} else {
 			$query_parts = array();
 		}
-
-		$source_type = false;
-		$source_query = null;
 
 		if ( $plugins_path === $referer['path'] ) {
 			$source_type = 'list';
@@ -2934,8 +2934,6 @@ p {
 				default:
 					$source_type = 'featured';
 			}
-		} else {
-			$source_type = 'unknown';
 		}
 
 		return array( $source_type, $source_query );
@@ -4387,15 +4385,7 @@ p {
 				)
 			);
 
-			list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
-
-			if ( $activation_source_name ) {
-				$args['_as'] = urlencode( $activation_source_name );
-			}
-
-			if ( $activation_source_keyword ) {
-				$args['_ak'] = urlencode( $activation_source_keyword );
-			}
+			$this->apply_activation_source_to_args( $args );
 
 			$url = add_query_arg( $args, Jetpack::api_url( 'authorize' ) );
 		}
@@ -4410,6 +4400,18 @@ p {
 		}
 
 		return $raw ? $url : esc_url( $url );
+	}
+
+	private function apply_activation_source_to_args( &$args ) {
+		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
+		
+		if ( $activation_source_name ) {
+			$args['_as'] = urlencode( $activation_source_name );
+		}
+
+		if ( $activation_source_keyword ) {
+			$args['_ak'] = urlencode( $activation_source_keyword );
+		}
 	}
 
 	function build_reconnect_url( $raw = false ) {
@@ -4948,15 +4950,7 @@ p {
 			'timeout' => $timeout,
 		);
 
-		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source', false );
-		
-		if ( $activation_source_name ) {
-			$args['_as'] = urlencode( $activation_source_name );
-		}
-
-		if ( $activation_source_keyword ) {
-			$args['_ak'] = urlencode( $activation_source_keyword );
-		}
+		$this->apply_activation_source_to_args( $args );
 
 		$response = Jetpack_Client::_wp_remote_request( Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'register' ) ), $args, true );
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -24,8 +24,6 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = getenv( 'WP_DEVELOP_DIR' );
 } else if ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
 	$test_root = '../../../../tests/phpunit';
-} else if ( file_exists( '/vagrant/www/wordpress-develop/public_html/tests/phpunit/includes/bootstrap.php' ) ) {
-	$test_root = '/vagrant/www/wordpress-develop/public_html/tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -24,6 +24,8 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = getenv( 'WP_DEVELOP_DIR' );
 } else if ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
 	$test_root = '../../../../tests/phpunit';
+} else if ( file_exists( '/vagrant/www/wordpress-develop/public_html/tests/phpunit/includes/bootstrap.php' ) ) {
+	$test_root = '/vagrant/www/wordpress-develop/public_html/tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -676,14 +676,14 @@ EXPECTED;
 		$plugins_url = admin_url( 'plugins.php' );
 		$plugin_install_url = admin_url( 'plugin-install.php' );
 
-		$this->assertEquals( array( 'plugins-list', null ), Jetpack::get_activation_source( $plugins_url . '?plugin_status=all&paged=1&s' ) );
-		$this->assertEquals( array( 'plugin-install-featured', null ), Jetpack::get_activation_source( $plugin_install_url ) );
-		$this->assertEquals( array( 'plugin-install-popular', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=popular' ) );
-		$this->assertEquals( array( 'plugin-install-recommended', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=recommended' ) );
-		$this->assertEquals( array( 'plugin-install-favorites', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=favorites' ) );
-		$this->assertEquals( array( 'plugin-install-search-term', 'jetpack' ), Jetpack::get_activation_source( $plugin_install_url . '?s=jetpack&tab=search&type=term' ) );
-		$this->assertEquals( array( 'plugin-install-search-author', 'foo' ), Jetpack::get_activation_source( $plugin_install_url . '?s=foo&tab=search&type=author' ) );
-		$this->assertEquals( array( 'plugin-install-search-tag', 'social' ), Jetpack::get_activation_source( $plugin_install_url . '?s=social&tab=search&type=tag' ) );
+		$this->assertEquals( array( 'list', null ), Jetpack::get_activation_source( $plugins_url . '?plugin_status=all&paged=1&s' ) );
+		$this->assertEquals( array( 'featured', null ), Jetpack::get_activation_source( $plugin_install_url ) );
+		$this->assertEquals( array( 'popular', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=popular' ) );
+		$this->assertEquals( array( 'recommended', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=recommended' ) );
+		$this->assertEquals( array( 'favorites', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=favorites' ) );
+		$this->assertEquals( array( 'search-term', 'jetpack' ), Jetpack::get_activation_source( $plugin_install_url . '?s=jetpack&tab=search&type=term' ) );
+		$this->assertEquals( array( 'search-author', 'foo' ), Jetpack::get_activation_source( $plugin_install_url . '?s=foo&tab=search&type=author' ) );
+		$this->assertEquals( array( 'search-tag', 'social' ), Jetpack::get_activation_source( $plugin_install_url . '?s=social&tab=search&type=tag' ) );
 	}
 
 	static function __cyrillic_salt( $password ) {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -664,6 +664,28 @@ EXPECTED;
 		$this->assertArrayHasKey( 'verify_secrets_expired', $expired->errors );
 	}
 
+	/**
+	 * Parse the referer on plugin activation and record the activation source
+	 * - featured plugins page
+	 * - popular plugins page
+	 * - search (with query)
+	 * - plugins list
+	 * - other
+	 */
+	function test_get_activation_source() {
+		$plugins_url = admin_url( 'plugins.php' );
+		$plugin_install_url = admin_url( 'plugin-install.php' );
+
+		$this->assertEquals( array( 'plugins-list', null ), Jetpack::get_activation_source( $plugins_url . '?plugin_status=all&paged=1&s' ) );
+		$this->assertEquals( array( 'plugin-install-featured', null ), Jetpack::get_activation_source( $plugin_install_url ) );
+		$this->assertEquals( array( 'plugin-install-popular', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=popular' ) );
+		$this->assertEquals( array( 'plugin-install-recommended', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=recommended' ) );
+		$this->assertEquals( array( 'plugin-install-favorites', null ), Jetpack::get_activation_source( $plugin_install_url . '?tab=favorites' ) );
+		$this->assertEquals( array( 'plugin-install-search-term', 'jetpack' ), Jetpack::get_activation_source( $plugin_install_url . '?s=jetpack&tab=search&type=term' ) );
+		$this->assertEquals( array( 'plugin-install-search-author', 'foo' ), Jetpack::get_activation_source( $plugin_install_url . '?s=foo&tab=search&type=author' ) );
+		$this->assertEquals( array( 'plugin-install-search-tag', 'social' ), Jetpack::get_activation_source( $plugin_install_url . '?s=social&tab=search&type=tag' ) );
+	}
+
 	static function __cyrillic_salt( $password ) {
 		return 'ленка' . $password . 'пенка';
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -675,6 +675,7 @@ EXPECTED;
 	function test_get_activation_source() {
 		$plugins_url = admin_url( 'plugins.php' );
 		$plugin_install_url = admin_url( 'plugin-install.php' );
+		$unknown_url = admin_url( 'unknown.php' );
 
 		$this->assertEquals( array( 'list', null ), Jetpack::get_activation_source( $plugins_url . '?plugin_status=all&paged=1&s' ) );
 		$this->assertEquals( array( 'featured', null ), Jetpack::get_activation_source( $plugin_install_url ) );
@@ -684,6 +685,7 @@ EXPECTED;
 		$this->assertEquals( array( 'search-term', 'jetpack' ), Jetpack::get_activation_source( $plugin_install_url . '?s=jetpack&tab=search&type=term' ) );
 		$this->assertEquals( array( 'search-author', 'foo' ), Jetpack::get_activation_source( $plugin_install_url . '?s=foo&tab=search&type=author' ) );
 		$this->assertEquals( array( 'search-tag', 'social' ), Jetpack::get_activation_source( $plugin_install_url . '?s=social&tab=search&type=tag' ) );
+		$this->assertEquals( array( 'unknown', null ), Jetpack::get_activation_source( $unknown_url ) );
 	}
 
 	static function __cyrillic_salt( $password ) {


### PR DESCRIPTION
In order to understand how our users are discovering and activating Jetpack, this change parses the referer or WP_CLI environment and extracts out useful stuff to know, then includes it with the register and authorize URLs.

The plugin activation source is split into two parts: the source name, and any keywords associated with it (or null).

Currently detected activation sources:
- wp-cli
- list
- featured
- popular
- recommended
- favorites
- search-term (plus query)
- search-author (plus query)
- search-tag (plus query)

