### PR TITLE
Initialize JITMs later; add tests

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -344,6 +344,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$jitm = Jetpack_JITM::init();
 
+		if ( ! $jitm ) {
+			return array();
+		}
+
 		return $jitm->get_messages( $request['message_path'], urldecode_deep( $request['query'] ) );
 	}
 
@@ -351,6 +355,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
 
 		$jitm = Jetpack_JITM::init();
+
+		if ( ! $jitm ) {
+			return array();
+		}
 
 		return $jitm->dismiss( $request['id'], $request['feature_class'] );
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -365,7 +365,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$jitm = Jetpack_JITM::init();
 
 		if ( ! $jitm ) {
-			return array();
+			return true;
 		}
 
 		return $jitm->dismiss( $request['id'], $request['feature_class'] );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -335,9 +335,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Asks for a jitm, unless they've been disabled, in which case it returns an empty array
+	 *
 	 * @param $request WP_REST_Request
 	 *
-	 * @return array
+	 * @return array An array of jitms
 	 */
 	public static function get_jitm_message( $request ) {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
@@ -351,6 +353,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return $jitm->get_messages( $request['message_path'], urldecode_deep( $request['query'] ) );
 	}
 
+	/**
+	 * Dismisses a jitm
+	 * @param $request WP_REST_Request The request
+	 *
+	 * @return bool Always True
+	 */
 	public static function delete_jitm_message( $request ) {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -28,7 +28,7 @@ class Jetpack_JITM {
 		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 			return false;
 		}
-		
+
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_JITM;
 		}
@@ -51,8 +51,7 @@ class Jetpack_JITM {
 	 *
 	 * @return string The Jetpack emblem
 	 */
-	function get_emblem()
-	{
+	function get_emblem() {
 		return '<div class="jp-emblem">' . Jetpack::get_jp_emblem() . '</div>';
 	}
 
@@ -66,7 +65,12 @@ class Jetpack_JITM {
 	 * @param object $screen
 	 */
 	function prepare_jitms( $screen ) {
-		if ( ! in_array( $screen->id, array( 'toplevel_page_jetpack', 'jetpack_page_stats', 'jetpack_page_akismet-key-config', 'admin_page_jetpack_modules' )  ) ) {
+		if ( ! in_array( $screen->id, array(
+			'toplevel_page_jetpack',
+			'jetpack_page_stats',
+			'jetpack_page_akismet-key-config',
+			'admin_page_jetpack_modules'
+		) ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
 			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
@@ -92,7 +96,7 @@ class Jetpack_JITM {
 				$content->message = esc_html__( 'New free service: Show USPS shipping rates on your store! Added bonus: print shipping labels without leaving WooCommerce.', 'jetpack' );
 				break;
 			case 'CA':
-				 $content->message = esc_html__( 'New free service: Show Canada Post shipping rates on your store!', 'jetpack' );
+				$content->message = esc_html__( 'New free service: Show Canada Post shipping rates on your store!', 'jetpack' );
 				break;
 			default:
 				$content->message = '';
@@ -171,8 +175,8 @@ class Jetpack_JITM {
 		wp_enqueue_style( 'jetpack-jitm-css' );
 
 		wp_enqueue_script( 'jetpack-jitm-new', plugins_url( '_inc/jetpack-jitm.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, true );
-		wp_localize_script('jetpack-jitm-new', 'jitm_config', array(
-				'api_root' => esc_url_raw( rest_url() ),
+		wp_localize_script( 'jetpack-jitm-new', 'jitm_config', array(
+			'api_root' => esc_url_raw( rest_url() ),
 		) );
 	}
 
@@ -238,13 +242,13 @@ class Jetpack_JITM {
 
 		// build our jitm request
 		$path = add_query_arg( array(
-			'external_user_id'     => urlencode_deep( $user->ID ),
-			'user_roles'           => urlencode_deep( implode( ',', $user->roles ) ),
-			'query_string'         => urlencode_deep( $query ),
+			'external_user_id' => urlencode_deep( $user->ID ),
+			'user_roles'       => urlencode_deep( implode( ',', $user->roles ) ),
+			'query_string'     => urlencode_deep( $query ),
 		), sprintf( '/sites/%d/jitm/%s', $site_id, $message_path ) );
 
 		// attempt to get from cache
-		$envelopes  = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
+		$envelopes = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
 
 		// if something is in the cache and it was put in the cache after the last sync we care about, use it
 		$last_sync = (int) get_transient( 'jetpack_last_plugin_sync' );
@@ -302,7 +306,7 @@ class Jetpack_JITM {
 			$envelope->jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => $envelope->id ) );
 
 			if ( $envelope->CTA->hook ) {
-				$envelope->url = apply_filters( 'jitm_' . $envelope->CTA->hook, $envelope->url ) ;
+				$envelope->url = apply_filters( 'jitm_' . $envelope->CTA->hook, $envelope->url );
 				unset( $envelope->CTA->hook );
 			}
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -253,13 +253,7 @@ class Jetpack_JITM {
 		// if something is in the cache and it was put in the cache after the last sync we care about, use it
 		$use_cache = false;
 
-		/**
-		 * Filter to turn off jitm caching
-		 *
-		 * @since 5.4.0
-		 *
-		 * @param bool true Whether to cache just in time messages
-		 */
+		/** This filter is documented in class.jetpack.php */
 		if ( apply_filters( 'jetpack_just_in_time_msg_cache', false ) ) {
 			$use_cache = true;
 		}

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -18,6 +18,17 @@ class Jetpack_JITM {
 	 * @return Jetpack_JITM
 	 */
 	static function init() {
+		/**
+		 * Filter to turn off all just in time messages
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param bool true Whether to show just in time messages.
+		 */
+		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
+			return false;
+		}
+		
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_JITM;
 		}
@@ -69,7 +80,7 @@ class Jetpack_JITM {
 	 *
 	 * @return array The new message
 	 */
-	static function jitm_woocommerce_services_msg( $content ) {
+	function jitm_woocommerce_services_msg( $content ) {
 		if ( ! function_exists( 'wc_get_base_location' ) ) {
 			return $content;
 		}
@@ -97,7 +108,7 @@ class Jetpack_JITM {
 	 *
 	 * @return string The new CTA
 	 */
-	static function jitm_jetpack_woo_services_install( $CTA ) {
+	function jitm_jetpack_woo_services_install( $CTA ) {
 		return wp_nonce_url( add_query_arg( array(
 			'wc-services-action' => 'install'
 		), admin_url( 'admin.php?page=wc-settings' ) ), 'wc-services-install' );
@@ -110,7 +121,7 @@ class Jetpack_JITM {
 	 *
 	 * @return string The new CTA
 	 */
-	static function jitm_jetpack_woo_services_activate( $CTA ) {
+	function jitm_jetpack_woo_services_activate( $CTA ) {
 		return wp_nonce_url( add_query_arg( array(
 			'wc-services-action' => 'activate'
 		), admin_url( 'admin.php?page=wc-settings' ) ), 'wc-services-install' );
@@ -205,7 +216,7 @@ class Jetpack_JITM {
 	 *
 	 * @return array The JITM's to show, or an empty array if there is nothing to show
 	 */
-	static function get_messages( $message_path, $query ) {
+	function get_messages( $message_path, $query ) {
 		// custom filters go here
 		add_filter( 'jitm_woocommerce_services_msg', array( 'Jetpack_JITM', 'jitm_woocommerce_services_msg' ) );
 		add_filter( 'jitm_jetpack_woo_services_install', array( 'Jetpack_JITM', 'jitm_jetpack_woo_services_install' ) );
@@ -333,15 +344,5 @@ class Jetpack_JITM {
 		return $envelopes;
 	}
 }
-if (
-	/**
-	 * Filter to turn off all just in time messages
-	 *
-	 * @since 3.7.0
-	 *
-	 * @param bool true Whether to show just in time messages.
-	 */
-	apply_filters( 'jetpack_just_in_time_msgs', false )
-) {
-	Jetpack_JITM::init();
-}
+
+add_action( 'init', array( 'Jetpack_JITM', 'init' ) );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -15,7 +15,7 @@ class Jetpack_JITM {
 	/**
 	 * Initializes the class, or returns the singleton
 	 *
-	 * @return Jetpack_JITM
+	 * @return Jetpack_JITM | false
 	 */
 	static function init() {
 		/**
@@ -155,8 +155,8 @@ class Jetpack_JITM {
 	}
 
 	/**
-	* Function to enqueue jitm css and js
-	*/
+	 * Function to enqueue jitm css and js
+	 */
 	function jitm_enqueue_files() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_style(

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -84,7 +84,7 @@ class Jetpack_JITM {
 	 *
 	 * @return array The new message
 	 */
-	function jitm_woocommerce_services_msg( $content ) {
+	static function jitm_woocommerce_services_msg( $content ) {
 		if ( ! function_exists( 'wc_get_base_location' ) ) {
 			return $content;
 		}
@@ -112,7 +112,7 @@ class Jetpack_JITM {
 	 *
 	 * @return string The new CTA
 	 */
-	function jitm_jetpack_woo_services_install( $CTA ) {
+	static function jitm_jetpack_woo_services_install( $CTA ) {
 		return wp_nonce_url( add_query_arg( array(
 			'wc-services-action' => 'install'
 		), admin_url( 'admin.php?page=wc-settings' ) ), 'wc-services-install' );
@@ -125,7 +125,7 @@ class Jetpack_JITM {
 	 *
 	 * @return string The new CTA
 	 */
-	function jitm_jetpack_woo_services_activate( $CTA ) {
+	static function jitm_jetpack_woo_services_activate( $CTA ) {
 		return wp_nonce_url( add_query_arg( array(
 			'wc-services-action' => 'activate'
 		), admin_url( 'admin.php?page=wc-settings' ) ), 'wc-services-install' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -612,6 +612,7 @@ class Jetpack {
 
 		// A filter to control all just in time messages
 		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
+		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
 		// If enabled, point edit post and page links to Calypso instead of WP-Admin.
 		// We should make sure to only do this for front end links.
@@ -669,6 +670,17 @@ class Jetpack {
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {
+		/**
+		 * Filter to turn off jitm caching
+		 *
+		 * @since 5.4.0
+		 *
+		 * @param bool true Whether to cache just in time messages
+		 */
+		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', false ) ) {
+			return $params;
+		}
+
 		if ( is_array( $params ) && isset( $params[0] ) ) {
 			$option = $params[0];
 			if ( 'active_plugins' === $option ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -687,10 +687,10 @@ class Jetpack {
 			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
 			wp_send_json_success();
 		}
-		
+
 		wp_die();
 	}
-	
+
 	function jetpack_admin_ajax_tracks_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {
@@ -2896,7 +2896,7 @@ p {
 		}
 
 		$referer = parse_url( $referer_url );
-		
+
 		$source_type = 'unknown';
 		$source_query = null;
 
@@ -2906,7 +2906,7 @@ p {
 
 		$plugins_path = parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
 		$plugins_install_path = parse_url( admin_url( 'plugin-install.php' ), PHP_URL_PATH );// /wp-admin/plugin-install.php
-		
+
 		if ( isset( $referer['query'] ) ) {
 			parse_str( $referer['query'], $query_parts );
 		} else {
@@ -3889,7 +3889,7 @@ p {
 				JetpackTracking::record_user_event( 'jpc_register_success', array(
 					'from' => $from
 				) );
-				
+
 				wp_redirect( $this->build_connect_url( true, $redirect, $from ) );
 				exit;
 			case 'activate' :
@@ -4353,7 +4353,7 @@ p {
 			$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
 
 			$tracks_identity = jetpack_tracks_get_identity( get_current_user_id() );
-			
+
 			$args = urlencode_deep(
 				array(
 					'response_type' => 'code',
@@ -4404,7 +4404,7 @@ p {
 
 	public static function apply_activation_source_to_args( &$args ) {
 		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
-		
+
 		if ( $activation_source_name ) {
 			$args['_as'] = urlencode( $activation_source_name );
 		}

--- a/tests/php/test_class.jetpack-jitm.php
+++ b/tests/php/test_class.jetpack-jitm.php
@@ -4,11 +4,11 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
 
 class WP_Test_Jetpack_JITM extends WP_UnitTestCase {
 	function test_jitm_disabled_by_filter() {
-        add_filter( 'jetpack_just_in_time_msgs', '__return_false', 50 );
+		add_filter( 'jetpack_just_in_time_msgs', '__return_false', 50 );
 		$this->assertFalse( Jetpack_JITM::init() );
-    }
-    
-    function test_jitm_enabled_by_default() {
-		$this->assertTrue( !! Jetpack_JITM::init() );
+	}
+
+	function test_jitm_enabled_by_default() {
+		$this->assertTrue( ! ! Jetpack_JITM::init() );
 	}
 }

--- a/tests/php/test_class.jetpack-jitm.php
+++ b/tests/php/test_class.jetpack-jitm.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
+
+class WP_Test_Jetpack_JITM extends WP_UnitTestCase {
+	function test_jitm_disabled_by_filter() {
+        add_filter( 'jetpack_just_in_time_msgs', '__return_false', 50 );
+		$this->assertFalse( Jetpack_JITM::init() );
+    }
+    
+    function test_jitm_enabled_by_default() {
+		$this->assertTrue( !! Jetpack_JITM::init() );
+	}
+}


### PR DESCRIPTION
JITMs are initialized as soon as the JITM file is loaded, which is before `init` and before `Jetpack::init()`, which makes it hard to intercept; separately, we call Jetpack_JITM::init() in our APIs, which when invoked directly doesn't respect the `jetpack_just_in_time_msgs` filter.

This also adds cache control, related to the issue mentioned in the conversation: p1506030617000439-slack-jpop-jedi-council

This PR fixes both those issues and adds the beginning of JITM tests.

cc @withinboredom 