### PR TITLE
General: Update uninstall script to delete many more options

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -241,7 +241,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'options':
-				$options_to_reset = Jetpack::get_jetpack_options_for_reset();
+				$options_to_reset = Jetpack_Options::get_options_for_reset();
 
 				// Reset the Jetpack options
 				_e( "Resetting Jetpack Options...\n", "jetpack" );
@@ -522,7 +522,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 */
 	public function options( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'list';
-		$safe_to_modify = Jetpack::get_jetpack_options_for_reset();
+		$safe_to_modify = Jetpack_Options::get_options_for_reset();
 
 		// Jumpstart is special
 		array_push( $safe_to_modify, 'jumpstart' );
@@ -943,7 +943,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$redirect_uri = admin_url();
 		}
 
-		$request_body = array( 
+		$request_body = array(
 			'jp_version'    => JETPACK__VERSION,
 			'redirect_uri'  => $redirect_uri
 		);
@@ -1013,8 +1013,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( is_wp_error( $result ) ) {
 			$this->partner_provision_error( $result );
-		} 
-		
+		}
+
 		$response_code = wp_remote_retrieve_response_code( $result );
 		$body_json     = json_decode( wp_remote_retrieve_body( $result ) );
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -528,6 +528,10 @@ class Jetpack_Options {
 			'jetpack_connection_banner_ab',
 			'jetpack_active_plan',
 			'jetpack_activation_source',
+			'jetpack_sso_match_by_email',
+			'jetpack_sso_require_two_step',
+			'jetpack_sso_remove_login_form',
+			'jetpack_last_connect_url_check',
 		);
 	}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -388,6 +388,8 @@ class Jetpack_Options {
 	/**
 	 * Gets an option via $wpdb query.
 	 *
+	 * @since 5.4.0
+	 *
 	 * @param string $name Option name.
 	 * @param mixed $default Default option value if option is not found.
 	 *
@@ -435,5 +437,141 @@ class Jetpack_Options {
 		 */
 		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_options', array() );
 		return isset( $disabled_raw_options[ $name ] );
+	}
+	
+	/**
+	 * Gets all known options that are used by Jetpack and managed by Jetpack_Options.
+	 *
+	 * @since 5.4.0
+	 *
+	 * @param boolean $strip_unsafe_options If true, and by default, will strip out options necessary for the connection to WordPress.com.
+	 * @return array An array of all options managed via the Jetpack_Options class.
+	 */
+	static function get_all_jetpack_options( $strip_unsafe_options = true ) {
+		$jetpack_options            = self::get_option_names();
+		$jetpack_options_non_compat = self::get_option_names( 'non_compact' );
+		$jetpack_options_private    = self::get_option_names( 'private' );
+
+		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat, $jetpack_options_private );
+
+		if ( $strip_unsafe_options ) {
+			// Flag some Jetpack options as unsafe
+			$unsafe_options = array(
+				'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
+				'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
+				'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
+				'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+
+				// non_compact
+				'activated',
+
+				// private
+				'register',
+				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
+				'user_token',                  // (string) The User Token of this site. (deprecated)
+				'user_tokens'
+			);
+
+			// Remove the unsafe Jetpack options
+			foreach ( $unsafe_options as $unsafe_option ) {
+				if ( false !== ( $key = array_search( $unsafe_option, $all_jp_options ) ) ) {
+					unset( $all_jp_options[ $key ] );
+				}
+			}
+		}
+
+		return $all_jp_options;
+	}
+
+	/**
+	 * Get all options that are not managed by the Jetpack_Options class that are used by Jetpack.
+	 *
+	 * @since 5.4.0
+	 *
+	 * @return array
+	 */
+	static function get_all_wp_options() {
+		// A manual build of the wp options
+		return array(
+			'sharing-options',
+			'disabled_likes',
+			'disabled_reblogs',
+			'jetpack_comments_likes_enabled',
+			'wp_mobile_excerpt',
+			'wp_mobile_featured_images',
+			'wp_mobile_app_promos',
+			'stats_options',
+			'stats_dashboard_widget',
+			'safecss_preview_rev',
+			'safecss_rev',
+			'safecss_revision_migrated',
+			'nova_menu_order',
+			'jetpack_portfolio',
+			'jetpack_portfolio_posts_per_page',
+			'jetpack_testimonial',
+			'jetpack_testimonial_posts_per_page',
+			'wp_mobile_custom_css',
+			'sharedaddy_disable_resources',
+			'sharing-options',
+			'sharing-services',
+			'site_icon_temp_data',
+			'featured-content',
+			'site_logo',
+			'jetpack_dismissed_notices',
+			'jetpack-twitter-cards-site-tag',
+			'jetpack-sitemap-state',
+			'jetpack_sitemap_post_types',
+			'jetpack_sitemap_location',
+			'jetpack_protect_key',
+			'jetpack_protect_blocked_attempts',
+			'jetpack_protect_activating',
+			'jetpack_connection_banner_ab',
+			'jetpack_active_plan',
+			'jetpack_activation_source',
+		);
+	}
+
+	/**
+	 * Gets all options that can be safely reset by CLI.
+	 *
+	 * @since 5.4.0
+	 *
+	 * @return array array Associative array containing jp_options which are managed by the Jetpack_Options class and wp_options which are not.
+	 */
+	static function get_options_for_reset() {
+		$all_jp_options = self::get_all_jetpack_options();
+
+		$wp_options = self::get_all_wp_options();
+
+		$options = array(
+			'jp_options' => $all_jp_options,
+			'wp_options' => $wp_options
+		);
+
+		return $options;
+	}
+
+	/**
+	 * Delete all known options
+	 *
+	 * @since 5.4.0
+	 *
+	 * @return void
+	 */
+	static function delete_all_known_options() {
+		// Delete all compact options
+		foreach ( (array) self::$grouped_options as $option_name ) {
+			delete_option( $option_name );
+		}
+
+		// Delete all non-compact Jetpack options
+		foreach ( (array) self::get_option_names( 'non-compact' ) as $option_name ) {
+			Jetpack_Options::delete_option( $option_name );
+		}
+
+		// Delete all options that can be reset via CLI, that aren't Jetpack options
+		foreach ( (array) self::get_all_wp_options() as $option_name ) {
+			delete_option( $option_name );
+		}
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6605,74 +6605,12 @@ p {
 	 *
 	 * It is used in class.jetpack-cli.php to reset options
 	 *
+	 * @since 5.4.0 Logic moved to Jetpack_Options class. Method left in Jetpack class for backwards compat.
+	 *
 	 * @return array of options to delete.
 	 */
 	public static function get_jetpack_options_for_reset() {
-		$jetpack_options            = Jetpack_Options::get_option_names();
-		$jetpack_options_non_compat = Jetpack_Options::get_option_names( 'non_compact' );
-		$jetpack_options_private    = Jetpack_Options::get_option_names( 'private' );
-
-		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat, $jetpack_options_private );
-
-		// A manual build of the wp options
-		$wp_options = array(
-			'sharing-options',
-			'disabled_likes',
-			'disabled_reblogs',
-			'jetpack_comments_likes_enabled',
-			'wp_mobile_excerpt',
-			'wp_mobile_featured_images',
-			'wp_mobile_app_promos',
-			'stats_options',
-			'stats_dashboard_widget',
-			'safecss_preview_rev',
-			'safecss_rev',
-			'safecss_revision_migrated',
-			'nova_menu_order',
-			'jetpack_portfolio',
-			'jetpack_portfolio_posts_per_page',
-			'jetpack_testimonial',
-			'jetpack_testimonial_posts_per_page',
-			'wp_mobile_custom_css',
-			'sharedaddy_disable_resources',
-			'sharing-options',
-			'sharing-services',
-			'site_icon_temp_data',
-			'featured-content',
-			'site_logo',
-			'jetpack_dismissed_notices',
-		);
-
-		// Flag some Jetpack options as unsafe
-		$unsafe_options = array(
-			'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
-			'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
-			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
-			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
-
-			// non_compact
-			'activated',
-
-			// private
-			'register',
-			'blog_token',                  // (string) The Client Secret/Blog Token of this site.
-			'user_token',                  // (string) The User Token of this site. (deprecated)
-			'user_tokens'
-		);
-
-		// Remove the unsafe Jetpack options
-		foreach ( $unsafe_options as $unsafe_option ) {
-			if ( false !== ( $key = array_search( $unsafe_option, $all_jp_options ) ) ) {
-				unset( $all_jp_options[ $key ] );
-			}
-		}
-
-		$options = array(
-			'jp_options' => $all_jp_options,
-			'wp_options' => $wp_options
-		);
-
-		return $options;
+		return Jetpack_Options::get_options_for_reset();
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -65,7 +65,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 			$module_config = isset( $module_configs[ $module_name ] ) ? $module_configs[ $module_name ] : false;
-			
+
 			if ( ! $module_config ) {
 				continue;
 			}
@@ -113,7 +113,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// if full sync queue is full, don't enqueue more items
 		$max_queue_size_full_sync = Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
 		$full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
-		
+
 		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();
 
 		if ( $available_queue_slots <= 0 ) {
@@ -134,11 +134,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$module_name = $module->name();
 
 			// skip module if not configured for this sync or module is done
-			if ( ! isset( $configs[ $module_name ] ) 
+			if ( ! isset( $configs[ $module_name ] )
 				|| // no module config
-					! $configs[ $module_name ] 
+					! $configs[ $module_name ]
 				|| // no enqueue status
-					! $enqueue_status[ $module_name ] 
+					! $enqueue_status[ $module_name ]
 				|| // finished enqueuing this module
 					true === $enqueue_status[ $module_name ][ 2 ] ) {
 				continue;
@@ -160,7 +160,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				return;
 			}
 		}
-		
+
 		$this->set_enqueue_status( $enqueue_status );
 
 		// setting autoload to true means that it's faster to check whether we should continue enqueuing
@@ -201,7 +201,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 			if ( $items_sent > 0 ) {
 				$this->update_status_option( $status_option_name, $items_sent );
-			}	
+			}
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_end'] ) ) {
@@ -254,7 +254,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			if ( $queued ) {
 				$status[ 'queue' ][ $name ] = $queued;
 			}
-			
+
 			if ( $sent = $this->get_status_option( "{$name}_sent" ) ) {
 				$status[ 'sent' ][ $name ] = $sent;
 			}
@@ -271,6 +271,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		Jetpack_Options::delete_raw_option( "{$prefix}_send_started" );
 		Jetpack_Options::delete_raw_option( "{$prefix}_finished" );
 
+		$this->delete_enqueue_status();
+
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent" );
 		}
@@ -278,6 +280,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	public function reset_data() {
 		$this->clear_status();
+		$this->delete_config();
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		$listener = Jetpack_Sync_Listener::get_instance();
 		$listener->get_full_sync_queue()->reset();
@@ -297,6 +300,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		Jetpack_Options::update_raw_option( 'jetpack_sync_full_enqueue_status', $new_status );
 	}
 
+	private function delete_enqueue_status() {
+		return Jetpack_Options::delete_raw_option( 'jetpack_sync_full_enqueue_status' );
+	}
+
 	private function get_enqueue_status() {
 		return Jetpack_Options::get_raw_option( 'jetpack_sync_full_enqueue_status' );
 	}
@@ -304,7 +311,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	private function set_config( $config ) {
 		Jetpack_Options::update_raw_option( 'jetpack_sync_full_config', $config );
 	}
-	
+
+	private function delete_config() {
+		return Jetpack_Options::delete_raw_option( 'jetpack_sync_full_config' );
+	}
+
 	private function get_config() {
 		return Jetpack_Options::get_raw_option( 'jetpack_sync_full_config' );
 	}
@@ -318,7 +329,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// below we used "insert ignore" to at least suppress the resulting error
 		$updated_num = $wpdb->query(
 			$wpdb->prepare(
-				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s",
 				$serialized_value,
 				$name
 			)
@@ -327,7 +338,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )",
 					$name,
 					$serialized_value
 				)
@@ -338,9 +349,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function read_option( $name, $default = null ) {
 		global $wpdb;
-		$value = $wpdb->get_var( 
+		$value = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", 
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
 				$name
 			)
 		);

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -69,7 +69,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_sync_core_update_network', $wp_db_version, $old_wp_db_version, $wp_version );
 	}
-	
+
 	public function update_core( $new_wp_version ) {
 		global $pagenow;
 
@@ -208,5 +208,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			$theme_data['name'] = $theme->name;
 		}
 		return $args;
+	}
+
+	public function reset_data() {
+		delete_option( self::UPDATES_CHECKSUM_OPTION_NAME );
 	}
 }

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -103,7 +103,7 @@ class Jetpack_Sync_Sender {
 		Jetpack_Sync_Settings::set_is_syncing( false );
 
 		$exceeded_sync_wait_threshold = ( microtime( true ) - $start_time ) > (double) $this->get_sync_wait_threshold();
-		
+
 		if ( is_wp_error( $sync_result ) ) {
 			if ( 'unclosed_buffer' === $sync_result->get_error_code() ) {
 				$this->set_next_sync_time( time() + self::QUEUE_LOCKED_SYNC_DELAY, $queue->id );
@@ -210,7 +210,7 @@ class Jetpack_Sync_Sender {
 		Jetpack_Sync_Settings::set_is_sending( true );
 		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id, $checkout_duration, $preprocess_duration );
 		Jetpack_Sync_Settings::set_is_sending( false );
-		
+
 		if ( ! $processed_item_ids || is_wp_error( $processed_item_ids ) ) {
 			$checked_in_item_ids = $queue->checkin( $buffer );
 			if ( is_wp_error( $checked_in_item_ids ) ) {
@@ -348,8 +348,8 @@ class Jetpack_Sync_Sender {
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module->reset_data();
 		}
-		
-		foreach ( array( 'sync', 'full_sync' ) as $queue_name ) {
+
+		foreach ( array( 'sync', 'full_sync', 'full-sync-enqueue' ) as $queue_name ) {
 			delete_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name );
 		}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,21 +12,18 @@ if (
 }
 
 define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack-options.php';
 
-// Delete all compact options
-delete_option( 'jetpack_options'        );
-
-// Delete all non-compact options
-delete_option( 'jetpack_register'       );
-delete_option( 'jetpack_activated'      );
-delete_option( 'jetpack_active_modules' );
-delete_option( 'jetpack_do_activate'    );
+Jetpack_Options::delete_all_known_options();
 
 // Delete all legacy options
 delete_option( 'jetpack_was_activated'  );
 delete_option( 'jetpack_auto_installed' );
+delete_option( 'jetpack_register'       );
 delete_transient( 'jetpack_register'    );
 
+// Delete sync options
+//
 // Do not initialize any listeners.
 // Since all the files will be deleted.
 // No need to try to sync anything.


### PR DESCRIPTION
After talking to @annezazu, I realized that the uninstall script doesn't do a great job of cleanup.

It looks like the file was created in November 2011, and since then was only updated for sync stuff. But we've done other things since then, such as adding `jetpack_private_options` and keeping more non-compact options that are not in non-compact options. 

This PR should get us closer to a comprehensive uninstall, and can perhaps be used in abstracting out a reset button to completely reset Jetpack without deleting/reinstalling.

To test:

- Checkout PR
- Start fresh by connecting to Jetpack
- Deactivate and Uninstall Jetpack
- Check that all `jetpack_` options are deleted, except for some sync options perhaps. We can clean those up in a follow-up PR