### PR TITLE
Sync: Sync `get_editable_roles`

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -191,6 +191,7 @@ class Jetpack_Sync_Defaults {
 		'hosting_provider'                 => array( 'Jetpack_Sync_Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
+		'get_editable_roles'               => 'get_editable_roles',
 	);
 
 	public static function get_callable_whitelist() {

--- a/sync/class.jetpack-sync-users.php
+++ b/sync/class.jetpack-sync-users.php
@@ -27,8 +27,8 @@ class Jetpack_Sync_Users {
 	}
 
 	static function get_role( $user_id ) {
-		if ( isset( $user_roles[ $user_id ] ) ) {
-			return $user_roles[ $user_id ];
+		if ( isset( self::$user_roles[ $user_id ] ) ) {
+			return self::$user_roles[ $user_id ];
 		}
 
 		$current_user_id = get_current_user_id();

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -79,6 +79,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'locale'                           => get_locale(),
 			'site_icon_url'                    => Jetpack_Sync_Functions::site_icon_url(),
 			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
+			'get_editable_roles'               => get_editable_roles(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {


### PR DESCRIPTION
In order to allow invitations for custom roles we need to sync the list of roles to WPCOM.

See: https://github.com/Automattic/jetpack/issues/7812