### PR TITLE
Simple Payments: Update front-end messages style

### DIFF
--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -69,32 +69,53 @@ input[type="number"].jetpack-simple-payments-items-number {
 }
 
 .jetpack-simple-payments-purchase-message {
+	background-color: rgba(255, 255, 255, 0.7);
+	border: 2px solid #fff;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
 	display: none;
-	padding: 0.5em 1em;
 	margin-bottom: 1.5em;
+	min-height: 48px;
+	padding: 1em;
+	position: relative;
 }
 
-/* Higher specificity in order to set the text color */
-body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p {
-	color: #fff;
-	margin: 0 0 0.5em;
-	padding: 0;
-}
-
-body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p:last-child {
-	margin: 0;
+.jetpack-simple-payments-purchase-message:before {
+	font-family: dashicons !important;
+	font-size: 48px !important;
+	line-height: 1 !important;
+	position: absolute;
+	speak: none;
+	top: 50%;
+	left: 0;
+	transform: translateY(-50%);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 .jetpack-simple-payments-purchase-message.show {
 	display: block;
 }
 
-.jetpack-simple-payments-purchase-message.success {
-	background-color: #4ab866;
+.jetpack-simple-payments-purchase-message.success:before {
+	color: #4ab866;
+	content: "\f147";
 }
 
-.jetpack-simple-payments-purchase-message.error {
-	background-color: #d94f4f;
+.jetpack-simple-payments-purchase-message.error:before {
+	color: #d94f4f;
+	content: "\f335";
+}
+
+/* Higher specificity in order to reset */
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p {
+	color: #222;
+	margin: 0 0 0.5em;
+	padding: 0 0 0 40px;
+}
+
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p:last-child {
+	margin: 0;
 }
 
 @media screen and (min-width: 400px) {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -104,7 +104,7 @@ class Jetpack_Simple_Payments {
 			wp_enqueue_script( 'paypal-express-checkout' );
 		}
 		if ( ! wp_style_is( 'simple-payments', 'enqueued' ) ) {
-			wp_enqueue_style( 'simple-payments', plugins_url( 'simple-payments.css', __FILE__ ) );
+			wp_enqueue_style( 'simple-payments', plugins_url( 'simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 		}
 
 		wp_add_inline_script( 'paypal-express-checkout', sprintf(

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -133,13 +133,13 @@ class Jetpack_Simple_Payments {
 		}
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
-	<div class='${css_prefix}-purchase-message' id='{$data['dom_id']}-message-container'></div>
 	<div class='${css_prefix}-product'>
 		{$image}
 		<div class='${css_prefix}-details'>
 			<div class='${css_prefix}-title'><p>{$data['title']}</p></div>
 			<div class='${css_prefix}-description'><p>{$data['description']}</p></div>
 			<div class='${css_prefix}-price'><p>{$data['price']}</p></div>
+			<div class='${css_prefix}-purchase-message' id='{$data['dom_id']}-message-container'></div>
 			<div class='${css_prefix}-purchase-box'>
 				{$items}
 				<div class='${css_prefix}-button' id='{$data['dom_id']}_button'></div>


### PR DESCRIPTION
This PR intends to improve front-end message style so it doesn't stand out too much with some theme styles. Instead of the block colours it uses Dashicons and a semi-transparent white background.

Also, it moves the message closer to the button because if there is a long description the message can be out of viewport especially on small screens.

**Before:**
<img width="687" alt="screen shot 2017-09-22 at 18 25 46" src="https://user-images.githubusercontent.com/908665/30768780-47f21cf2-a005-11e7-8814-82d148b5ff97.png">

<img width="643" alt="screen shot 2017-09-22 at 16 52 31" src="https://user-images.githubusercontent.com/908665/30768783-4c489e98-a005-11e7-949f-998457ffb6f2.png">

**After:**
<img width="633" alt="screen shot 2017-09-23 at 02 34 49" src="https://user-images.githubusercontent.com/908665/30769031-1049bb08-a009-11e7-90b4-b27840755727.png">

<img width="390" alt="screen shot 2017-09-23 at 02 36 35" src="https://user-images.githubusercontent.com/908665/30769042-272aa062-a009-11e7-9f27-75e62bb9bb43.png">

<img width="351" alt="screen shot 2017-09-23 at 02 35 20" src="https://user-images.githubusercontent.com/908665/30769033-18375ef6-a009-11e7-81ae-22b35a9c05b7.png">

_with a whitebackground_
<img width="422" alt="screen shot 2017-09-23 at 02 37 57" src="https://user-images.githubusercontent.com/908665/30769036-1e5fc76e-a009-11e7-831e-bdb7cf5a62b1.png">

_with an imagery background_
<img width="418" alt="screen shot 2017-09-23 at 02 40 10" src="https://user-images.githubusercontent.com/908665/30769039-2252d514-a009-11e7-90a4-f4ee0aa178b0.png">





