### PR TITLE
Add dispatch and actionTypes properties to the global window object so we can use it from the browser console when developing

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { Route, Router, useRouterHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { createHashHistory } from 'history'
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import accessibleFocus from 'lib/accessible-focus';
 import store from 'state/redux-store';
 import i18n from 'i18n-calypso';
 import Main from 'main';
+import * as actionTypes from 'state/action-types';
 
 // Initialize the accessibile focus to allow styling specifically for keyboard navigation
 accessibleFocus();
@@ -44,6 +46,14 @@ i18n.setLocale( Initial_State.locale );
 const hashHistory = useRouterHistory( createHashHistory )( { queryKey: false } );
 
 const history = syncHistoryWithStore( hashHistory, store );
+
+// Add dispatch and actionTypes to the window object so we can use it from the browser's console
+if ( 'undefined' !== typeof window && process.env.NODE_ENV === 'development' ) {
+	assign( window, {
+		actionTypes: actionTypes,
+		dispatch: store.dispatch,
+	} );
+}
 
 render();
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Adds the Redux `store.dispatch` method to `window` if `process.env.NODE_ENV === 'development'`. 
* Adds the Redux action types  to `window.actionTypes` if `process.env.NODE_ENV === 'development'`. 

#### Testing instructions:

1. Run `yarn build` to build the development version of Jetpack's UI.
1. Confirm that you can dispatch actions from the browser's console. Like `dispatch()`.
1. Confirm that `window.actionTypes` is defined and it holds all of the action types defined in `_inc/client/state/action-types.js`.
1. Run `yarn build-production` to build the development version of Jetpack's UI.
1. Confirm that neither `window.dispatch` or `window.actionTypes` is defined.

#### Proposed changelog entry for your changes:

Added utility functions to the browser's console allowing easier debugging of the Redux state while in development mode.
