### PR TITLE
Widgets: Add schema.org markup to the contact info widget

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -93,6 +93,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			 */
 			do_action( 'jetpack_contact_info_widget_start' );
 
+			echo '<div itemscope itemtype="http://schema.org/LocalBusiness">';
+
 			if ( '' != $instance['address'] ) {
 
 				$showmap = $instance['showmap'];
@@ -112,15 +114,15 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 				$map_link = $this->build_map_link( $instance['address'] );
 
-				echo '<div class="confit-address"><a href="' . esc_url( $map_link ) . '" target="_blank">' . str_replace( "\n", "<br/>", esc_html( $instance['address'] ) ) . "</a></div>";
+				echo '<div class="confit-address" itemscope itemtype="http://schema.org/PostalAddress" itemprop="address"><a href="' . esc_url( $map_link ) . '" target="_blank">' . str_replace( "\n", "<br/>", esc_html( $instance['address'] ) ) . "</a></div>";
 			}
 
 			if ( '' != $instance['phone'] ) {
 				if ( wp_is_mobile() ) {
-					echo '<div class="confit-phone"><a href="' . esc_url( 'tel:' . $instance['phone'] ) . '">' . esc_html( $instance['phone'] ) . "</a></div>";
+					echo '<div class="confit-phone"><span itemprop="telephone"><a href="' . esc_url( 'tel:' . $instance['phone'] ) . '">' . esc_html( $instance['phone'] ) . "</a></span></div>";
 				}
 				else {
-					echo '<div class="confit-phone">' . esc_html( $instance['phone'] ) . '</div>';
+					echo '<div class="confit-phone"><span itemprop="telephone">' . esc_html( $instance['phone'] ) . '</span></div>';
 				}
 			}
 
@@ -132,8 +134,10 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			}
 
 			if ( '' != $instance['hours'] ) {
-				echo '<div class="confit-hours">' . str_replace( "\n", "<br/>", esc_html( $instance['hours'] ) ) . "</div>";
+				echo '<div class="confit-hours" itemprop="openingHours">' . str_replace( "\n", "<br/>", esc_html( $instance['hours'] ) ) . "</div>";
 			}
+
+			echo '</div>';
 
 			/**
 			 * Fires at the end of Contact Info widget.


### PR DESCRIPTION
This should help with SEO, as Google uses this to more easily discover
metadata about businesses.

More info on the schema from Google: https://developers.google.com/search/docs/data-types/local-businesses

This patch is based on `D7261-code` by @scruffian - I'm just porting it to Jetpack.

#### Changes proposed in this Pull Request:

* Adding `LocalBusiness` Schema Markup markup to the Contact Info widget.

#### Testing instructions:

* Use Google's testing tool, https://search.google.com/structured-data/testing-tool/u/0/, to verify that the fields have been properly discovered.

This is how it looks like using the default values of the contact info widget:
<img width="630" alt="screen shot 2017-09-25 at 14 28 27" src="https://user-images.githubusercontent.com/3392497/30808305-ddb4e432-a1fd-11e7-97c3-afd603cc84d2.png">

#### Known issues
It seems that due to the limitations of the contact info widget (the address is just one big textarea), we can't precisely define/declare all the parts of a postal address - so it's not properly found.
The `name` and `image` fields are also not present - but those are not part of the contact info widget and are also missing from the original patch, so I wanted first to port this change to Jetpack and then perhaps improve it further (and then port _those_ changes to WordPress.com ;)).