### PR TITLE
JITM: Fix docblock for default argument value

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -22,8 +22,9 @@ class Jetpack_JITM {
 		 * Filter to turn off all just in time messages
 		 *
 		 * @since 3.7.0
+		 * @since 5.4.0 Correct docblock to reflect default arg value
 		 *
-		 * @param bool true Whether to show just in time messages.
+		 * @param bool false Whether to show just in time messages.
 		 */
 		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 			return false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -675,7 +675,7 @@ class Jetpack {
 		 *
 		 * @since 5.4.0
 		 *
-		 * @param bool true Whether to cache just in time messages
+		 * @param bool false Whether to cache just in time messages
 		 */
 		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', false ) ) {
 			return $params;


### PR DESCRIPTION
In reviewing #7833, I realized that the docblocks were incorrect for a couple of JITM filters. While the default state for JITMs is to be on, that is only because we filter in the `Jetpack` class and return true on a priority of 9. The filters for JITMs are provided a false value which means if we didn't hook on in the `Jetpack` class they would return false.

The docblocks now reflect the default args correctly.