### PR TITLE
Fixes #7849: don't show jitms in development mode

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -40,7 +40,7 @@ class Jetpack_JITM {
 	 * Jetpack_JITM constructor.
 	 */
 	private function __construct() {
-		if ( ! Jetpack::is_active() ) {
+		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() ) {
 			return;
 		}
 		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );


### PR DESCRIPTION
Fixes #7849

#### Changes proposed in this Pull Request:

* Don't show Just in Time Messages in development mode

#### Testing instructions:

* With a fresh, free plan site
* And Jetpack in dev mode, while connected
* Visit comments screen, should see no jitms
* Turn off dev mode and go back to comments screen
* should see jitms

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Don't show Just In Time Messages while in dev mode