### PR TITLE
Simple Payments: do not render trashed products

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -77,7 +77,7 @@ class Jetpack_Simple_Payments {
 		if ( ! $product || is_wp_error( $product ) ) {
 			return;
 		}
-		if ( $product->post_type !== self::$post_type_product ) {
+		if ( $product->post_type !== self::$post_type_product || $product->post_status === 'trash' ) {
 			return;
 		}
 


### PR DESCRIPTION
If a Simple Payments product is trashed, it is still displayed on a post/page. This PR fixes that by filtering posts with the `trash` status.

WP.com counterpart D6739-code

## Testing

Create a post with a Simple Payment button. Go to wp-admin of your site, open `wp_posts` table and change the status of the Simple Payments button "post" row from `published` to `trash`. The button should not show when navigating to the front-end of the post anymore.