### PR TITLE
Simple Payments: a few updates

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -140,6 +140,7 @@ var PaypalExpressCheckout = {
 
 			style: {
 				label: 'pay',
+				fundingicons: true,
 				shape: 'rect',
 				color: 'silver'
 			},

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -14,7 +14,7 @@ class Jetpack_Simple_Payments {
 	static $css_classname_prefix = 'jetpack-simple-payments';
 
 	// Increase this number each time there's a change in CSS or JS to bust cache.
-	static $version = '0.23';
+	static $version = '0.25';
 
 	// Classic singleton pattern:
 	private static $instance;

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -77,7 +77,7 @@ class Jetpack_Simple_Payments {
 		if ( ! $product || is_wp_error( $product ) ) {
 			return;
 		}
-		if ( $product->post_type !== self::$post_type_product ) {
+		if ( $product->post_type !== self::$post_type_product || $product->post_status === 'trash' ) {
 			return;
 		}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -77,7 +77,7 @@ class Jetpack_Simple_Payments {
 		if ( ! $product || is_wp_error( $product ) ) {
 			return;
 		}
-		if ( $product->post_type !== self::$post_type_product || $product->post_status === 'trash' ) {
+		if ( $product->post_type !== self::$post_type_product || 'trash' === $product->post_status ) {
 			return;
 		}
 


### PR DESCRIPTION
Another round of Simple Payments updates:

- don't show trashed payment buttons;
- change the style of the "Pay now" PayPal button

## Testing

Create a payment button. Do you see the icons of accepted credit cards beneath the "Pay with" btn?

Now, edit the status of the button "post" to be `trash`. Is the payment button hidden from the post on the front-end?