### PR TITLE
Simple Payments: add CCs icons to Pay with btn

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -140,6 +140,7 @@ var PaypalExpressCheckout = {
 
 			style: {
 				label: 'pay',
+				fundingicons: true,
 				shape: 'rect',
 				color: 'silver'
 			},

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -14,7 +14,7 @@ class Jetpack_Simple_Payments {
 	static $css_classname_prefix = 'jetpack-simple-payments';
 
 	// Increase this number each time there's a change in CSS or JS to bust cache.
-	static $version = '0.23';
+	static $version = '0.25';
 
 	// Classic singleton pattern:
 	private static $instance;


### PR DESCRIPTION
Implementing @iamtakashi 's idea to add icons of accepted credit cards under the PayPal "Pay with" button:

![image](https://user-images.githubusercontent.com/4988512/30820271-b712dbe4-a221-11e7-9f95-0b8fcf7768ee.png)

## Testing

Create a Simple Payments button. See if the CC icons show up.