### PR TITLE
Google Analytics: Add support for new settings to endpoints (Differential Revision: D7273-code)

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -111,3 +111,10 @@ $json_jetpack_endpoints_dir = dirname( __FILE__ ) . '/json-endpoints/jetpack/';
 
 // This files instantiates the endpoints
 require_once( $json_jetpack_endpoints_dir . 'json-api-jetpack-endpoints.php' );
+
+// **********
+// v1.3
+// **********
+
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-v1-3-endpoint.php' );
+

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -504,6 +504,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$wga = get_option( $option_name, array() );
 					$wga['code'] = $value['code']; // maintain compatibility with wp-google-analytics
 
+					// Allow newer versions of this endpoint to filter in additional fields
+					$wga = apply_filters( 'site_settings_update_wga', $wga, $value );
+
 					if ( update_option( $option_name, $wga ) ) {
 						$updated[ $key ] = $value;
 					}

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -504,7 +504,14 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$wga = get_option( $option_name, array() );
 					$wga['code'] = $value['code']; // maintain compatibility with wp-google-analytics
 
-					// Allow newer versions of this endpoint to filter in additional fields
+					/**
+					 * Allow newer versions of this endpoint to filter in additional fields for Google Analytics
+					 *
+					 * @since 5.4.0
+					 *
+					 * @param array $wga Associative array of existing Google Analytics settings.
+					 * @param array $value Associative array of new Google Analytics settings passed to the endpoint.
+					 */
 					$wga = apply_filters( 'site_settings_update_wga', $wga, $value );
 
 					if ( update_option( $option_name, $wga ) ) {

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -89,8 +89,8 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
 		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
 		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
-		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
-		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
+		'advanced_seo_front_page_description'  => '(string) The SEO meta description for the site.', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
+		'advanced_seo_title_formats'           => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
 		'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -89,8 +89,8 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
 		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
 		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
-		'advanced_seo_front_page_description'  => '(string) The SEO meta description for the site.', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
-		'advanced_seo_title_formats'           => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
+		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
+		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
 		'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -96,8 +96,8 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
 		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
 		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
-		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
-		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
+		'advanced_seo_front_page_description'  => '(string) The SEO meta description for the site.', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
+		'advanced_seo_title_formats'           => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
 		'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',
@@ -115,10 +115,10 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 
 class WPCOM_JSON_API_Site_Settings_V1_3_Endpoint extends WPCOM_JSON_API_Site_Settings_V1_2_Endpoint {
 	public static $wga_defaults = array(
-		'code'					=> '',
-		'anonymize_ip'			=> false,
-		'ec_track_purchases'	=> false,
-		'ec_track_add_to_cart'	=> false
+		'code'                 => '',
+		'anonymize_ip'         => false,
+		'ec_track_purchases'   => false,
+		'ec_track_add_to_cart' => false
 	);
 
 	function callback( $path = '', $blog_id = 0 ) {

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -96,8 +96,8 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
 		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
 		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
-		'advanced_seo_front_page_description'  => '(string) The SEO meta description for the site.', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
-		'advanced_seo_title_formats'           => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
+		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
+		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
 		'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ * @autounit api-v1 site-settings
+ */
+
+new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
+	'description' => 'Get detailed settings information about a site.',
+	'group'       => '__do_not_document',
+	'stat'        => 'sites:X',
+	'min_version'   => '1.3',
+	'method'      => 'GET',
+	'path'        => '/sites/%s/settings',
+	'path_labels' => array(
+		'$site' => '(int|string) Site ID or domain',
+	),
+
+	'query_parameters' => array(
+		'context' => false,
+	),
+
+	'response_format' => WPCOM_JSON_API_Site_Settings_Endpoint::$site_format,
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.3/sites/en.blog.wordpress.com/settings?pretty=1',
+) );
+
+new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
+	'description' => 'Update settings for a site.',
+	'group'       => '__do_not_document',
+	'stat'        => 'sites:X',
+	'min_version'   => '1.3',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/settings',
+	'path_labels' => array(
+		'$site' => '(int|string) Site ID or domain',
+	),
+
+	'request_format'  => array(
+		'blogname'                             => '(string) Blog name',
+		'blogdescription'                      => '(string) Blog description',
+		'default_pingback_flag'                => '(bool) Notify blogs linked from article?',
+		'default_ping_status'                  => '(bool) Allow link notifications from other blogs?',
+		'default_comment_status'               => '(bool) Allow comments on new articles?',
+		'blog_public'                          => '(string) Site visibility; -1: private, 0: discourage search engines, 1: allow search engines',
+		'jetpack_sync_non_public_post_stati'   => '(bool) allow sync of post and pages with non-public posts stati',
+		'jetpack_relatedposts_enabled'         => '(bool) Enable related posts?',
+		'jetpack_relatedposts_show_headline'   => '(bool) Show headline in related posts?',
+		'jetpack_relatedposts_show_thumbnails' => '(bool) Show thumbnails in related posts?',
+		'jetpack_protect_whitelist'            => '(array) List of IP addresses to whitelist',
+		'infinite_scroll'                      => '(bool) Support infinite scroll of posts?',
+		'default_category'                     => '(int) Default post category',
+		'default_post_format'                  => '(string) Default post format',
+		'require_name_email'                   => '(bool) Require comment authors to fill out name and email?',
+		'comment_registration'                 => '(bool) Require users to be registered and logged in to comment?',
+		'close_comments_for_old_posts'         => '(bool) Automatically close comments on old posts?',
+		'close_comments_days_old'              => '(int) Age at which to close comments',
+		'thread_comments'                      => '(bool) Enable threaded comments?',
+		'thread_comments_depth'                => '(int) Depth to thread comments',
+		'page_comments'                        => '(bool) Break comments into pages?',
+		'comments_per_page'                    => '(int) Number of comments to display per page',
+		'default_comments_page'                => '(string) newest|oldest Which page of comments to display first',
+		'comment_order'                        => '(string) asc|desc Order to display comments within page',
+		'comments_notify'                      => '(bool) Email me when someone comments?',
+		'moderation_notify'                    => '(bool) Email me when a comment is helf for moderation?',
+		'social_notifications_like'            => '(bool) Email me when someone likes my post?',
+		'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
+		'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
+		'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
+		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?',
+		'comment_max_links'                    => '(int) Moderate comments that contain X or more links',
+		'moderation_keys'                      => '(string) Words or phrases that trigger comment moderation, one per line',
+		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line',
+		'lang_id'                              => '(int) ID for language blog is written in',
+		'locale'                               => '(string) locale code for language blog is written in',
+		'wga'                                  => '(array) Google Analytics Settings',
+		'disabled_likes'                       => '(bool) Are likes globally disabled (they can still be turned on per post)?',
+		'disabled_reblogs'                     => '(bool) Are reblogs disabled on posts?',
+		'jetpack_comment_likes_enabled'        => '(bool) Are comment likes enabled for all comments?',
+		'sharing_button_style'                 => '(string) Style to use for sharing buttons (icon-text, icon, text, or official)',
+		'sharing_label'                        => '(string) Label to use for sharing buttons, e.g. "Share this:"',
+		'sharing_show'                         => '(string|array:string) Post type or array of types where sharing buttons are to be displayed',
+		'sharing_open_links'                   => '(string) Link target for sharing buttons (same or new)',
+		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
+		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
+		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                          => '(bool) Enable snowfall on front end of site?',
+		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
+		'gmt_offset'                           => '(int) Site offset from UTC in hours',
+		'date_format'                          => '(string) PHP Date-compatible date format',
+		'time_format'                          => '(string) PHP Date-compatible time format',
+		'start_of_week'                        => '(int) Starting day of week (0 = Sunday, 6 = Saturday)',
+		'jetpack_testimonial'                  => '(bool) Whether testimonial custom post type is enabled for the site',
+		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
+		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
+		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
+		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
+		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
+		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
+		'amp_is_enabled'                       => '(bool) Whether AMP is enabled for this site',
+		'podcasting_archive'                   => '(string) The post category, if any, used for publishing podcasts',
+		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
+		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
+		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
+	),
+
+	'response_format' => array(
+		'updated' => '(array)'
+	),
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/settings?pretty=1',
+) );
+
+class WPCOM_JSON_API_Site_Settings_V1_3_Endpoint extends WPCOM_JSON_API_Site_Settings_V1_2_Endpoint {
+	public static $wga_defaults = array(
+		'code'					=> '',
+		'anonymize_ip'			=> false,
+		'ec_track_purchases'	=> false,
+		'ec_track_add_to_cart'	=> false
+	);
+
+	function callback( $path = '', $blog_id = 0 ) {
+		add_filter( 'site_settings_endpoint_get', array( $this, 'filter_site_settings_endpoint_get' ) );
+		add_filter( 'site_settings_update_wga', array( $this, 'filter_update_google_analytics' ), 10, 2 );
+		return parent::callback( $path, $blog_id );
+	}
+
+	/**
+	 * Filter the parent's response to include the fields
+	 * added to 1.3 (and their defaults)
+	 */
+	public function filter_site_settings_endpoint_get( $settings ) {
+		$option_name = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'wga' : 'jetpack_wga';
+		$option = get_option( $option_name, array() );
+		$settings[ 'wga' ] = wp_parse_args( $option, self::$wga_defaults );
+		return $settings;
+	}
+
+	/**
+	 * Filter the parent's response to consume our new fields
+	 */
+	public function filter_update_google_analytics( $wga, $new_values ) {
+		$wga_keys = array_keys( self::$wga_defaults );
+		foreach ( $wga_keys as $wga_key ) {
+			// Skip code since the parent class has handled it
+			if ( 'code' === $wga_key ) {
+				continue;
+			}
+			// All our new keys are booleans, so let's coerce each key's value
+			// before updating the value in settings
+			if ( array_key_exists( $wga_key, $new_values ) ) {
+				$wga[ $wga_key ] = WPCOM_JSON_API::is_truthy( $new_values[ $wga_key ] );
+			}
+		}
+		return $wga;
+	}
+}


### PR DESCRIPTION
This commit syncs r162791-wpcom.

Fixes #

Related: https://github.com/Automattic/jetpack/pull/7817

#### Changes proposed in this Pull Request:

* This changeset rolls the /site/siteID/settings GET and POST endpoints to v1.3 and adds anonymize_ip, ec_track_purchases and ec_track_add_to_cart flags to the wga (Google Analytics) setting.

#### Testing instructions:

* Install this branch on a site and then:

```
Fire up postman
Set your headers to
Content-Type: application/json
Authorization: BEARER (steal a token from a developer REST API console request)
Origin: https://developer.wordpress.com
(you'll need to use Postman Interceptor to pull that off)

Direct a v1.3 GET request at /site/{siteID}/settings ( e.g. /sites/#######/settings )
( i.e. public-api.wordpress.com/rest/v1.3/sites/########/settings )
Ensure you get a wga key in the response and that it has the following sub-keys
code, anonymize_ip, ec_track_purchases, and ec_track_add_to_cart

Direct a v1.3 POST request to /site/{siteID}/settings ( e.g. /sites/#######/settings )
Set the body to something like

{
  "wga": {
	"code": "UA-12345678-4",
	"ec_track_add_to_cart": 1
   }
}
Note: For v1 compatibility, all requests must include the code field. All other fields are optional

Try a few combinations to ensure it works well.
```

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

* Add new fields to the settings endpoints to allow turning Google Analytics anonymize_ip on/off and add basic eCommerce event tracking when WooCommerce is present.