### PR TITLE
Sync: Start syncing Plugin Actions

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -190,48 +190,8 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		return null;
 	}
 
-	/**
-	 * Get custom action link tags that the plugin is using
-	 * Ref: https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
-	 * @return array of plugin action links (key: link name value: url)
-	 */
 	 protected function get_plugin_action_links( $plugin_file ) {
-		 $formatted_action_links = array();
-
-		 // Some sites may have DOM disabled in PHP
-		 if ( ! class_exists( 'DOMDocument' ) ) {
-			 return $formatted_action_links;
-		 }
-
-		 $action_links = array();
-		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-		 $action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
-		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-		 $action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
-		 if ( count( $action_links ) > 0 ) {
-			 $dom_doc = new DOMDocument;
-			 foreach( $action_links as $action_link ) {
-				 $dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
-				 $link_elements = $dom_doc->getElementsByTagName( 'a' );
-				 if ( $link_elements->length == 0 ) {
-					 continue;
-				 }
-
-				 $link_element = $link_elements->item( 0 );
-				 if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
-					 $link_url = trim( $link_element->getAttribute( 'href' ) );
-
-					 // Add the full admin path to the url if the plugin did not provide it
-					 $link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
-					 if ( empty( $link_url_scheme ) ) {
-						 $link_url = admin_url( $link_url );
-					 }
-
-					 $formatted_action_links[ $link_element->nodeValue ] = $link_url;
-				 }
-			 }
-		 }
-
-		 return $formatted_action_links;
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-functions.php';
+		return Jetpack_Sync_Functions::get_plugins_action_links( $plugin_file );
 	 }
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -187,6 +187,7 @@ class Jetpack_Sync_Defaults {
 		'sso_bypass_default_login_form'    => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 		'wp_version'                       => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
+		'get_plugins_action_links'		   => array( 'Jetpack_Sync_functions', 'get_plugins_action_links' ),
 		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
 		'hosting_provider'                 => array( 'Jetpack_Sync_Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -285,6 +285,11 @@ class Jetpack_Sync_Functions {
 			return array();
 		}
 
+		$action_links = get_transient( 'jetpack_plugin_api_action_links', false );
+		if ( ! empty( $action_links ) ) {
+			return is_null( $plugin_file_singular ) ? $action_links : $action_links[ $plugin_file_singular ];
+		}
+		$plugins_action_links = array();
 		$plugins = is_null( $plugin_file_singular ) ? array_keys( self::get_plugins() ) : array( $plugin_file_singular );
 		foreach( $plugins as $plugin_file ) {
 			$action_links = array();
@@ -318,12 +323,14 @@ class Jetpack_Sync_Functions {
 			}
 			$plugins_action_links[ $plugin_file ] = $formatted_action_links;
 		}
-		return is_null( $plugin_file_singular ) ? $plugins_action_links : $plugins_action_links[ $plugin_file ];
+
+		set_transient( 'jetpack_plugin_api_action_links', $plugins_action_links, DAY_IN_SECONDS );
+
+		return is_null( $plugin_file_singular ) ? $plugins_action_links : $plugins_action_links[ $plugin_file_singular ];
 	}
 
 	public static function wp_version() {
 		global $wp_version;
-
 		return $wp_version;
 	}
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -274,6 +274,53 @@ class Jetpack_Sync_Functions {
 		return apply_filters( 'all_plugins', get_plugins() );
 	}
 
+	/**
+	 * Get custom action link tags that the plugin is using
+	 * Ref: https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
+	 * @return array of plugin action links (key: link name value: url)
+	 */
+	public static function get_plugins_action_links( $plugin_file_singular = null ) {
+		// Some sites may have DOM disabled in PHP
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			return array();
+		}
+
+		$plugins = is_null( $plugin_file_singular ) ? array_keys( self::get_plugins() ) : array( $plugin_file_singular );
+		foreach( $plugins as $plugin_file ) {
+			$action_links = array();
+			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
+			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
+			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
+			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
+			$formatted_action_links = null;
+			if ( count( $action_links ) > 0 ) {
+				$dom_doc = new DOMDocument;
+				foreach ( $action_links as $action_link ) {
+					$dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
+					$link_elements = $dom_doc->getElementsByTagName( 'a' );
+					if ( $link_elements->length == 0 ) {
+						continue;
+					}
+
+					$link_element = $link_elements->item( 0 );
+					if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
+						$link_url = trim( $link_element->getAttribute( 'href' ) );
+
+						// Add the full admin path to the url if the plugin did not provide it
+						$link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
+						if ( empty( $link_url_scheme ) ) {
+							$link_url = admin_url( $link_url );
+						}
+
+						$formatted_action_links[$link_element->nodeValue] = $link_url;
+					}
+				}
+			}
+			$plugins_action_links[ $plugin_file ] = $formatted_action_links;
+		}
+		return is_null( $plugin_file_singular ) ? $plugins_action_links : $plugins_action_links[ $plugin_file ];
+	}
+
 	public static function wp_version() {
 		global $wp_version;
 

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -40,7 +40,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 		// get_plugins and wp_version
 		// gets fired when new code gets installed, updates etc.
-		add_action( 'upgrader_process_complete', array( $this, 'unlock_sync_callable' ) );
+		add_action( 'upgrader_process_complete', array( $this, 'unlock_plugin_action_link_and_callables' ) );
+		add_action( 'update_option_active_plugins', array( $this, 'unlock_plugin_action_link_and_callables' ) );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -113,6 +114,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function unlock_sync_callable() {
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+	}
+
+	public function unlock_plugin_action_link_and_callables() {
+		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( 'jetpack_plugin_api_action_links' );
 	}
 
 	public function should_send_callable( $callable_checksums, $name, $checksum ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -577,7 +577,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
   		$this->assertEquals( $plugins_action_links, $expected_array );
 
-
 		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
 		$this->resetCallableAndConstantTimeouts();
 		$this->sender->do_sync();
@@ -591,9 +590,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
-		// Nothing should have changed since we cache the results.
+		// Links should have changes now since we activated the plugin.
+		$expected_array['hello.php'] = array( 'not fun' => admin_url( 'not-fun.php' ) );
 		$this->assertEquals( $plugins_action_links, $expected_array );
-
 	}
 
 	function __return_filtered_url() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -576,6 +576,24 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		);
 
   		$this->assertEquals( $plugins_action_links, $expected_array );
+
+
+		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
+		$this->resetCallableAndConstantTimeouts();
+		$this->sender->do_sync();
+
+		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
+		// Nothing should have changed since we cache the results.
+		$this->assertEquals( $plugins_action_links, $expected_array );
+
+		activate_plugin('hello.php', '', false, true );
+		$this->resetCallableAndConstantTimeouts();
+		$this->sender->do_sync();
+
+		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
+		// Nothing should have changed since we cache the results.
+		$this->assertEquals( $plugins_action_links, $expected_array );
+
 	}
 
 	function __return_filtered_url() {


### PR DESCRIPTION
We want to display plugins from the .com side api endpoint. 
And we are missing info regarding the plugin action links. This PR starts syncing the new action links. 



#### Changes proposed in this Pull Request:
* 

#### Testing instructions:

* Do the tests pass? 
* test the get plugin api endpiong /sites/SITE_ID/plugin 
Do you see the actions links for jetpack ?
* Activate a plugin like Woo do you see the action links being synced on the .com side?



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
