### PR TITLE
jetpack raw option: Add a way to bypass it

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -333,11 +333,11 @@ class Jetpack_Options {
 	 * Deletes an option via $wpdb query.
 	 *
 	 * @param string $name Option name.
-	 * 
+	 *
 	 * @return bool Is the option deleted?
 	 */
 	static function delete_raw_option( $name ) {
-		if ( self::by_pass_raw_option( $name ) ) {
+		if ( self::bypass_raw_option( $name ) ) {
 			return delete_option( $name );
 		}
 		global $wpdb;
@@ -355,7 +355,7 @@ class Jetpack_Options {
 	 * @return bool Is the option updated?
 	 */
 	static function update_raw_option( $name, $value, $autoload = false ) {
-		if ( self::by_pass_raw_option( $name ) ) {
+		if ( self::bypass_raw_option( $name ) ) {
 			return update_option( $name, $value, $autoload );
 		}
 		global $wpdb;
@@ -394,7 +394,7 @@ class Jetpack_Options {
 	 * @return mixed Option value, or null if option is not found and default is not specified.
 	 */
 	static function get_raw_option( $name, $default = null ) {
-		if ( self::by_pass_raw_option( $name ) ) {
+		if ( self::bypass_raw_option( $name ) ) {
 			return get_option( $name, $default );
 		}
 
@@ -415,26 +415,25 @@ class Jetpack_Options {
 	}
 
 	/**
-	 * This function lets us by pass certain options to be gotten via the raw sql calls.
-	 * Instead we should use the regular wp calls.
+	 * This function checks for a constant that, if present, will disable direct DB queries Jetpack uses to manage certain options and force Jetpack to always use Options API instead.
+	 * Options can be selectively managed via a blacklist by filtering option names via the jetpack_disabled_raw_option filter.
+	 *
 	 * @param $name Option name
 	 *
 	 * @return bool
 	 */
-	static function by_pass_raw_option( $name ) {
+	static function bypass_raw_option( $name ) {
 
-		if ( Jetpack_Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTION' ) ) {
+		if ( Jetpack_Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
 			return true;
 		}
 		/**
-		 * Allows us to disable the some raw options.
+		 * Allows to disable particular raw options.
 		 * @since 5.5.0
 		 *
-		 *
-		 * @param array $disabled_raw_options has the key set of the option that you want to disable
+		 * @param array $disabled_raw_options An array of option names that you can selectively blacklist from being managed via direct database queries.
 		 */
-		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_option', array() );
-		return isset( $disabled_raw_options[$name] );
+		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_options', array() );
+		return isset( $disabled_raw_options[ $name ] );
 	}
-
 }

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -337,6 +337,9 @@ class Jetpack_Options {
 	 * @return bool Is the option deleted?
 	 */
 	static function delete_raw_option( $name ) {
+		if ( self::by_pass_raw_option( $name ) ) {
+			return delete_option( $name );
+		}
 		global $wpdb;
 		$result = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name = %s", $name ) );
 		return $result;
@@ -352,6 +355,9 @@ class Jetpack_Options {
 	 * @return bool Is the option updated?
 	 */
 	static function update_raw_option( $name, $value, $autoload = false ) {
+		if ( self::by_pass_raw_option( $name ) ) {
+			return update_option( $name, $value, $autoload );
+		}
 		global $wpdb;
 		$autoload_value = $autoload ? 'yes' : 'no';
 
@@ -388,6 +394,10 @@ class Jetpack_Options {
 	 * @return mixed Option value, or null if option is not found and default is not specified.
 	 */
 	static function get_raw_option( $name, $default = null ) {
+		if ( self::by_pass_raw_option( $name ) ) {
+			return get_option( $name, $default );
+		}
+
 		global $wpdb;
 		$value = $wpdb->get_var(
 			$wpdb->prepare(
@@ -402,6 +412,29 @@ class Jetpack_Options {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * This function lets us by pass certain options to be gotten via the raw sql calls.
+	 * Instead we should use the regular wp calls.
+	 * @param $name Option name
+	 *
+	 * @return bool
+	 */
+	static function by_pass_raw_option( $name ) {
+
+		if ( Jetpack_Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTION' ) ) {
+			return true;
+		}
+		/**
+		 * Allows us to disable the some raw options.
+		 * @since 5.5.0
+		 *
+		 *
+		 * @param array $disabled_raw_options has the key set of the option that you want to disable
+		 */
+		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_option', array() );
+		return isset( $disabled_raw_options[$name] );
 	}
 
 }

--- a/tests/php/test_class.jetpack-options.php
+++ b/tests/php/test_class.jetpack-options.php
@@ -17,7 +17,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 		}
 		return $value;
 	}
-	
+
 	function test_delete_non_compact_option_returns_true_when_successfully_deleted() {
 		Jetpack_Options::update_option( 'migrate_for_idc', true );
 
@@ -32,7 +32,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 		// Did Jetpack_Options::delete_option() properly return true?
 		$this->assertTrue( $deleted );
 	}
-	
+
 	function test_raw_option_update_will_bypass_wp_cache_and_filters() {
 		$option_name = 'test_option';
 		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
@@ -48,7 +48,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
 
 	function test_raw_option_with_constant_does_not_by_pass_wp_cache_filters() {
-		Jetpack_Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTION', true);
+		Jetpack_Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true);
 		$option_name = 'test_option_with_constant';
 		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
@@ -60,11 +60,11 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
 		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
-		Jetpack_Constants::clear_single_constant( 'JETPACK_DISABLE_RAW_OPTION' );
+		Jetpack_Constants::clear_single_constant( 'JETPACK_DISABLE_RAW_OPTIONS' );
 	}
 
 	function test_raw_option_with_filter_does_not_by_pass_wp_cache_filters() {
-		add_filter( 'jetpack_disabled_raw_option', array( $this, 'set_disable_raw_option' ) );
+		add_filter( 'jetpack_disabled_raw_options', array( $this, 'set_disable_raw_option' ) );
 		$option_name = 'test_option_with_filter';
 		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
@@ -76,7 +76,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
 		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
-		remove_filter( 'jetpack_disabled_raw_option', array( $this, 'set_disable_raw_option' ) );
+		remove_filter( 'jetpack_disabled_raw_options', array( $this, 'set_disable_raw_option' ) );
 	}
 
 	function set_disable_raw_option( $options ) {

--- a/tests/php/test_class.jetpack-options.php
+++ b/tests/php/test_class.jetpack-options.php
@@ -34,15 +34,54 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 	}
 	
 	function test_raw_option_update_will_bypass_wp_cache_and_filters() {
+		$option_name = 'test_option';
 		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
-		add_filter( 'option_test_option', array( $this, 'get_test_option_from_cache' ) );
+		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
 
 		update_option( 'test_option', 'cached_value' );
-		Jetpack_Options::update_raw_option( 'test_option', 'updated_value' );
-		$this->assertEquals( 'cached_value', get_option( 'test_option') );
+		Jetpack_Options::update_raw_option( $option_name, 'updated_value' );
+		$this->assertEquals( 'cached_value', get_option( $option_name ) );
 
 		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
-		remove_filter( 'option_test_option', array( $this, 'get_test_option_from_cache' ) );
+		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
+	}
+
+
+	function test_raw_option_with_constant_does_not_by_pass_wp_cache_filters() {
+		Jetpack_Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTION', true);
+		$option_name = 'test_option_with_constant';
+		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
+		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
+
+		update_option( 'test_option', 'cached_value' );
+		Jetpack_Options::update_raw_option( $option_name, 'updated_value' );
+		$this->assertEquals( 'updated_value', get_option( $option_name ) );
+		$this->assertEquals( 'updated_value', Jetpack_Options::get_raw_option( $option_name ) );
+
+		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
+		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
+		Jetpack_Constants::clear_single_constant( 'JETPACK_DISABLE_RAW_OPTION' );
+	}
+
+	function test_raw_option_with_filter_does_not_by_pass_wp_cache_filters() {
+		add_filter( 'jetpack_disabled_raw_option', array( $this, 'set_disable_raw_option' ) );
+		$option_name = 'test_option_with_filter';
+		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
+		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
+
+		update_option( 'test_option', 'cached_value' );
+		Jetpack_Options::update_raw_option( $option_name, 'updated_value' );
+		$this->assertEquals( 'updated_value', get_option( $option_name ) );
+		$this->assertEquals( 'updated_value', Jetpack_Options::get_raw_option( $option_name ) );
+
+		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
+		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
+		remove_filter( 'jetpack_disabled_raw_option', array( $this, 'set_disable_raw_option' ) );
+	}
+
+	function set_disable_raw_option( $options ) {
+		$options['test_option_with_filter'] = true;
+		return $options;
 	}
 
 	function test_raw_option_get_will_bypass_wp_cache_and_filters() {


### PR DESCRIPTION
In some cases it might be better if we bypassed that option to get the raw info.

#### Changes proposed in this Pull Request:
* Allows other devs to define constants and filters that lets them define which options should be allows to be set directly. 

#### Testing instructions:
* Do the tests pass? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
