### PR TITLE
Master Bar: update Plugins sidebar nav

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -906,9 +906,9 @@ class A8C_WPCOM_Masterbar {
 					'label' => esc_html__( 'Plugins', 'jetpack' ),
 				),
 				array(
-					'url'   => 'https://wordpress.com/plugins/browse/' . esc_attr( $this->primary_site_slug ),
+					'url'   => 'https://wordpress.com/plugins/manage/' . esc_attr( $this->primary_site_slug ),
 					'id'    => 'wp-admin-bar-plugins-add',
-					'label' => esc_html_x( 'Add', 'Label for the button on the Masterbar to add a new plugin', 'jetpack' ),
+					'label' => esc_html_x( 'Manage', 'Label for the button on the Masterbar to manage plugins', 'jetpack' ),
 				)
 			);
 


### PR DESCRIPTION
As part of our Plugins Page Enhancements project we updated the sidebar plugins nav item in Calypso. For Jetpack and Business sites we replaced the "Add" option with a "Manage" option.

This updates the the Master bar to reflect these changes

**Testing**
- Visit the frontend of a Jetpack site
- Open the the sidebar menu from the master bar
- The plugins nav item should display "Manage" and link to https://wordpress.com/plugins/manage/site-slug