### PR TITLE
Jetpack Signature: Fix spelling of 'invalid_scheme' in class.jetpack.signature.php

### DIFF
--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -25,7 +25,7 @@ class Jetpack_Signature {
 		if ( isset( $override['scheme'] ) ) {
 			$scheme = $override['scheme'];
 			if ( !in_array( $scheme, array( 'http', 'https' ) ) ) {
-				return new Jetpack_Error( 'invalid_sheme', 'Invalid URL scheme' );
+				return new Jetpack_Error( 'invalid_scheme', 'Invalid URL scheme' );
 			}
 		} else {
 			if ( is_ssl() ) {


### PR DESCRIPTION
Fixes a typo in an unused aspect of the code :P

#### Changes proposed in this Pull Request:

* Changes `sheme` for `scheme` in an error code.

#### Testing instructions:

* Couldn't find any references in .com code, Jetpack code, or anywhere else. So regular check with your own eyes is fine.

