### PR TITLE
Admin Page: Show better error messages when we can't parse JSON from API responses

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -228,7 +228,7 @@ function JetpackRestApiClient( root, nonce ) {
 	}
 
 	function postRequest( route, params, body ) {
-		return fetch( route, assign( {}, params, body ) );
+		return fetch( route, assign( {}, params, body ) ).catch( catchNetworkErrors );
 	}
 
 	function statsDataUrl( range ) {
@@ -249,6 +249,7 @@ const restApi = new JetpackRestApiClient();
 export default restApi;
 
 function checkStatus( response ) {
+	// Regular success responses
 	if ( response.status >= 200 && response.status < 300 ) {
 		return response;
 	}
@@ -265,4 +266,12 @@ function parseJsonResponse( response ) {
 
 function catchJsonParseError( e ) {
 	throw new Error( `Couldn't understand Jetpack's REST API response (${ e.name })` );
+}
+
+// Catches TypeError coming from the Fetch API implementation
+function catchNetworkErrors( e ) {
+	//Either one of:
+	// * A preflight error like a redirection to an external site (which results in a CORS)
+	// * A preflight error like ERR_TOO_MANY_REDIRECTS
+	throw new Error( `Could not reach Jetpack's REST API. Check the browser's console for more details` );
 }

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -20,11 +20,11 @@ function createCustomError( name ) {
 	return CustomError;
 }
 
-const JsonParseError = createCustomError( 'JsonParseError' );
-const JsonParseAfterRedirectError = createCustomError( 'JsonParseAfterRedirectError' );
-const Api404Error = createCustomError( 'Api404Error' );
-const Api404AfterRedirectError = createCustomError( 'Api404AfterRedirectError' );
-const FetchNetworkError = createCustomError( 'FetchNetworkError' );
+export const JsonParseError = createCustomError( 'JsonParseError' );
+export const JsonParseAfterRedirectError = createCustomError( 'JsonParseAfterRedirectError' );
+export const Api404Error = createCustomError( 'Api404Error' );
+export const Api404AfterRedirectError = createCustomError( 'Api404AfterRedirectError' );
+export const FetchNetworkError = createCustomError( 'FetchNetworkError' );
 
 function JetpackRestApiClient( root, nonce ) {
 	let apiRoot = root,

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -48,26 +48,26 @@ function JetpackRestApiClient( root, nonce ) {
 		},
 
 		fetchSiteConnectionStatus: () => getRequest( `${ apiRoot }jetpack/v4/connection`, getParams )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchUserConnectionData: () => getRequest( `${ apiRoot }jetpack/v4/connection/data`, getParams )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		disconnectSite: () => postRequest( `${ apiRoot }jetpack/v4/connection`, postParams, {
 			body: JSON.stringify( { isActive: false } )
 		} )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchConnectUrl: () => getRequest( `${ apiRoot }jetpack/v4/connection/url`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		unlinkUser: () => postRequest( `${ apiRoot }jetpack/v4/connection/user`, postParams, {
 			body: JSON.stringify( { linked: false } )
 		} )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		jumpStart: ( action ) => {
 			let active;
@@ -81,16 +81,16 @@ function JetpackRestApiClient( root, nonce ) {
 				body: JSON.stringify( { active } )
 			} )
 				.then( checkStatus )
-				.then( response => response.json() );
+				.then( parseJsonResponse );
 		},
 
 		fetchModules: () => getRequest( `${ apiRoot }jetpack/v4/module/all`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchModule: ( slug ) => getRequest( `${ apiRoot }jetpack/v4/module/${ slug }`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		activateModule: ( slug ) => postRequest(
 			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
@@ -100,7 +100,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		deactivateModule: ( slug ) => postRequest(
 			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
@@ -118,7 +118,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		updateSettings: ( newOptionValues ) => postRequest(
 			`${ apiRoot }jetpack/v4/settings`,
@@ -128,11 +128,11 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		getProtectCount: () => getRequest( `${ apiRoot }jetpack/v4/module/protect/data`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		resetOptions: ( options ) => postRequest(
 			`${ apiRoot }jetpack/v4/options/${ options }`,
@@ -142,19 +142,19 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		getVaultPressData: () => getRequest( `${ apiRoot }jetpack/v4/module/vaultpress/data`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		getAkismetData: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/data`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		checkAkismetKey: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/key/check`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		checkAkismetKeyTyped: apiKey => postRequest(
 			`${ apiRoot }jetpack/v4/module/akismet/key/check`,
@@ -164,34 +164,34 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchStatsData: ( range ) => getRequest( statsDataUrl( range ), getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		getPluginUpdates: () => getRequest( `${ apiRoot }jetpack/v4/updates/plugins`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchSettings: () => getRequest( `${ apiRoot }jetpack/v4/settings`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		updateSetting: ( updatedSetting ) => postRequest( `${ apiRoot }jetpack/v4/settings`, postParams, {
 			body: JSON.stringify( updatedSetting )
 		} )
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchSiteData: () => getRequest( `${ apiRoot }jetpack/v4/site`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() )
+			.then( parseJsonResponse )
 			.then( body => JSON.parse( body.data ) ),
 
 		fetchSiteFeatures: () => getRequest( `${ apiRoot }jetpack/v4/site/features`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() )
+			.then( parseJsonResponse )
 			.then( body => JSON.parse( body.data ) ),
 
 		dismissJetpackNotice: ( notice ) => postRequest(
@@ -202,11 +202,11 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		)
 			.then( checkStatus )
-			.then( response => response.json() ),
+			.then( parseJsonResponse ),
 
 		fetchPluginsData: () => getRequest( `${ apiRoot }jetpack/v4/plugins`, getParams )
 			.then( checkStatus )
-			.then( response => response.json() )
+			.then( parseJsonResponse )
 	};
 
 	function addCacheBuster( route ) {
@@ -257,4 +257,12 @@ function checkStatus( response ) {
 		error.response = json;
 		throw error;
 	} );
+}
+
+function parseJsonResponse( response ) {
+	return response.json().catch( catchJsonParseError );
+}
+
+function catchJsonParseError( e ) {
+	throw new Error( `Couldn't understand Jetpack's REST API response (${ e.name })` );
 }

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -87,7 +87,7 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 		let messages = {
 				progress: __( 'Updating settings…' ),
 				success: __( 'Updated settings.' ),
-				error: error => __( 'Error updating settings. %(error)s', { args: { error: error } } )
+				error: error => __( 'Error updating settings. (%(error)s)', { args: { error: error.name || error } } )
 			},
 			updatedOptionsSuccess = () => newOptionValues;
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Updates message to be shown when JSON cannot be parsed from a REST API response.


#### Testing instructions:

* Checkout this branch and build. Or test it using Jetpack Beta for this PR.
* Play with manually generated errors by using this snippet in line `331` of `_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php`
  ```
            echo '/';
            //http_response_code(404);
            //header('Location: /');
            //header('Location: /nonexistantpath');
            exit;
  ```
* By uncommenting the first one, you'll get a JsonParseError. (Resembling something broken in the user's WP installation but unrelated to Jetpack
* By uncommenting the second one, you'll get a JsonApi404Error. (Resembling something weird in WP's config that doesn't let us reach the REST api.
* By uncommenting the third one, you'll get a redirection to the home. So the page will exist, but it's not where we need to end with a REST API query. 
* By uncommenting the 4th one, you'll get redirected to a 404. This resembles bad hosting config maybe coming from .htaccess or a reverse proxy. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Introduces custom JS errors in `rest-api/index.js`
* Updates the updateSettings action to show `error.name` instead of `error.
* Adds better handling of errors thrown in fetch api promises

#### Screenshots.:

**When we can't parse the response from the API**

![image](https://user-images.githubusercontent.com/746152/31283416-eeb08624-aa8b-11e7-8295-0062523720c4.png)


**When we can't parse the response from the API after detecting a redirect**

![image](https://user-images.githubusercontent.com/746152/31283430-fb5fb8ae-aa8b-11e7-9e17-820e48aaa1da.png)

**When we get a 404 from calling an API endpoint**

![image](https://user-images.githubusercontent.com/746152/31283452-0d869fc0-aa8c-11e7-90c4-98855927c122.png)


**When we get a 404 from calling an API endpoint after detecting a redirect**

![image](https://user-images.githubusercontent.com/746152/31283476-22246534-aa8c-11e7-9f7d-9a192ba222ed.png)


