### PR TITLE
Onboarding: create the token as a network option.

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1079,7 +1079,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 */
 	public function can_request( $request ) {
 		$req_params = $request->get_params();
-		if ( isset( $req_params['onboarding'] ) && isset( $req_params['onboarding']['token'] ) && isset( $req_params['rest_route'] ) ) {
+		if ( ! empty( $req_params['onboarding']['token'] ) && isset( $req_params['rest_route'] ) ) {
 			return Jetpack::validate_onboarding_token_action( $req_params['onboarding']['token'], $req_params['rest_route'] );
 		}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -52,7 +52,7 @@ class Jetpack_Options {
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
-				'onboarding',            // (string) Auth token to be used in the onboarding connection flow
+				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 			);
 
 		case 'private' :
@@ -64,6 +64,7 @@ class Jetpack_Options {
 
 		case 'network' :
 			return array(
+				'onboarding',                   // (string) Auth token to be used in the onboarding connection flow
 				'file_data'                     // (array) List of absolute paths to all Jetpack modules
 			);
 		}
@@ -87,7 +88,6 @@ class Jetpack_Options {
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
-			'onboarding',                   // (bool)   Whether to onboard the connection.
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5252,8 +5252,14 @@ p {
 			) {
 				$jpUser = get_user_by( 'email', $jpo->onboarding->jpUser );
 				if ( is_a( $jpUser, 'WP_User' ) ) {
-					$token_type = 'user';
-					$token->external_user_id = $jpUser->ID;
+					wp_set_current_user( $jpUser->ID );
+					$user_can = is_multisite()
+						? current_user_can_for_blog( get_current_blog_id(), 'manage_options' )
+						: current_user_can( 'manage_options' );
+					if ( $user_can ) {
+						$token_type = 'user';
+						$token->external_user_id = $jpUser->ID;
+					}
 				}
 			}
 		}

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -654,6 +654,21 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test onboarding token and make sure it's a network option.
+	 *
+	 * @since 5.4.0
+	 */
+	public function test_check_onboarding_token() {
+		$this->assertFalse( Jetpack_Options::get_option( 'onboarding' ) );
+
+		Jetpack::create_onboarding_token();
+
+		$this->assertTrue( Jetpack_Options::is_valid( array( 'onboarding' ) ) );
+		$this->assertTrue( ctype_alnum( Jetpack_Options::get_option( 'onboarding' ) ) );
+		$this->assertTrue( in_array( 'onboarding', Jetpack_Options::get_option_names( 'network' ) ) );
+	}
+
+	/**
 	 * Test connection url build when there's a blog token or id.
 	 *
 	 * @since 4.4.0


### PR DESCRIPTION
While this token is now a created a network Jetpack option and will be valid for all sites in the network, it doesn't pose a threat because the `user_email` must match a user added to the site and the new checking introduced will ensure this and also the WP REST API endpoints will provide the proper validation for that. The onboarding token is just one part of the validation to ensure that the request comes from a trusted site but the new checking and the REST validation will check that the user has the permissions to execute the desired operation.

#### Changes proposed in this Pull Request:

* create Jetpack_Option `onboarding` as a `network` option so it can be read from a child site in a multisite
* introduces one new test for onboarding option
* fixes issue after connection when saving anything to `jetpack/v4/settings` like Google Analytics ID - Fixes #7897

#### Testing instructions:

1. in your wpcom sandbox, apply D7342
2. locally, build and run https://github.com/Automattic/wp-calypso/pull/17443 to test saving when site isn't connected and user isn't logged in wpcom
3. use this branch `update/network-onboarding` in your sandboxorg
4. in your sandboxorg, do `wp eval "Jetpack::create_onboarding_token();"` to generate the token that will validate unauthorized requests performed during onboarding
5. ensure your sandboxorg will use your local Calypso development environment by editing `class.jetpack.php` and uncomment `//$url = add_query_arg( 'calypso_env', 'development', $url );`
6. go to the WP Admin of your sandboxorg, to the Jetpack settings, connect it and you should be sent to the `/start/jetpack-onboarding` flow.
7. test only the first step of the onboarding flow, saving a Site Title and Site Description. Make sure they're saved back to the Jetpack site.
