### PR TITLE
General: solve undefined variable in Dashboard widget when site is disconnected

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6736,13 +6736,12 @@ p {
 	public function wp_dashboard_setup() {
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
-			$widget_title = __( 'Site Stats', 'jetpack' );
 		}
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
 			wp_add_dashboard_widget(
 				'jetpack_summary_widget',
-				$widget_title,
+				esc_html__( 'Site Stats', 'jetpack' ),
 				array( __CLASS__, 'dashboard_widget' )
 			);
 			wp_enqueue_style( 'jetpack-dashboard-widget', plugins_url( 'css/dashboard-widget.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );


### PR DESCRIPTION
Fixes this issue
```
Undefined variable: widget_title in /wp-content/plugins/jetpack/class.jetpack.php on line 6745
```

#### Changes proposed in this Pull Request:

* dismiss variable assignment so avoid an undefined variable when Jetpack is not connected but jetpack_dashboard_widget has an action

#### Testing instructions:

* check dashboard with a disconnected site with and without this PR. WP_DEBUG must be set to true

