### PR TITLE
SEO tools suite loading even if the site is not active and not in development mode.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1654,10 +1654,15 @@ class Jetpack {
 	 * Loads the currently active modules.
 	 */
 	public static function load_modules() {
-		if ( ! self::is_active() && !self::is_development_mode() ) {
-			if ( ! is_multisite() || ! get_site_option( 'jetpack_protect_active' ) ) {
-				return;
-			}
+		if (
+			! self::is_active()
+			&& ! self::is_development_mode()
+			&& (
+				! is_multisite()
+				|| ! get_site_option( 'jetpack_protect_active' )
+			)
+		) {
+			return;
 		}
 
 		$version = Jetpack_Options::get_option( 'version' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1734,8 +1734,7 @@ class Jetpack {
 		do_action( 'jetpack_modules_loaded' );
 
 		// Load module-specific code that is needed even when a module isn't active. Loaded here because code contained therein may need actions such as setup_theme.
-		if ( Jetpack::is_active() || Jetpack::is_development_mode() )
-			require_once( JETPACK__PLUGIN_DIR . 'modules/module-extras.php' );
+		require_once( JETPACK__PLUGIN_DIR . 'modules/module-extras.php' );
 	}
 
 	/**

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -40,7 +40,7 @@ if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
  * Filter extra tools (not modules) to include.
  *
  * @since 2.4.0
- * @since 5.4.0 can be used when Jetpack is not connected to WordPress.com and not in development mode.
+ * @since 5.4.0 can be used in multisite when Jetpack is not connected to WordPress.com and not in development mode.
  *
  * @param array $tools Array of extra tools to include.
  */

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -27,10 +27,20 @@ $tools = array(
 	'verification-tools/verification-tools-utils.php',
 );
 
+// Not every tool needs to be included if Jetpack is inactive and not in development mode
+if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+	$tools = array(
+		'seo-tools/jetpack-seo-utils.php',
+		'seo-tools/jetpack-seo-titles.php',
+		'seo-tools/jetpack-seo-posts.php',
+	);
+}
+
 /**
  * Filter extra tools (not modules) to include.
  *
  * @since 2.4.0
+ * @since 5.4.0 can be used when Jetpack is not connected to WordPress.com and not in development mode.
  *
  * @param array $tools Array of extra tools to include.
  */


### PR DESCRIPTION
This is required because with some recent changes in the code SEO tool class constants are required by the code even when Jetpack is not active, for example in multisite environment.

Fixes #7898.
