### PR TITLE
Fix -rtl suffix for gulp task

### DIFF
--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -51,8 +51,11 @@ const concat_list = [
  * This list will need to have files added as we move to the add_style RTL approach.
  */
 const separate_list = [
+	'modules/carousel/jetpack-carousel.css',
+	'modules/contact-form/css/grunion.css',
 	'modules/shortcodes/css/recipes.css',
 	'modules/shortcodes/css/recipes-print.css',
+	'modules/tiled-gallery/tiled-gallery/tiled-gallery.css',
 ];
 
 const pathModifier = function( file, contents ) {

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -53,6 +53,7 @@ const concat_list = [
 const separate_list = [
 	'modules/carousel/jetpack-carousel.css',
 	'modules/contact-form/css/grunion.css',
+	'modules/related-posts/related-posts.css',
 	'modules/shortcodes/css/recipes.css',
 	'modules/shortcodes/css/recipes-print.css',
 	'modules/tiled-gallery/tiled-gallery/tiled-gallery.css',

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -85,7 +85,7 @@ gulp.task( 'frontendcss', [ 'frontendcss:separate' ], function() {
 		) )
 		.pipe( gulp.dest( 'css' ) )
 		.pipe( rtlcss() )
-		.pipe( rename( { suffix: '.rtl' } ) )
+		.pipe( rename( { suffix: '-rtl' } ) )
 		.pipe( gulp.dest( 'css/' ) )
 		.on( 'end', function() {
 			util.log( 'Front end modules CSS finished.' );


### PR DESCRIPTION
Changes in #7767 led to the `gulp frontendcss` task building to a file `jetpack.rtl.css`, where we need `jetpack-rtl.css`.  This will fix it! 

to test: 
- run `gulp frontendcss` task 
- make sure the correct files get updated.  