### PR TITLE
REST API: Correct Highlander comment avatars.

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1069,7 +1069,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$first_name  = '';
 			$last_name   = '';
 			$URL         = $author->comment_author_url;
-			$avatar_URL  = $this->api->get_avatar_url( $email );
+			$avatar_URL  = $this->api->get_avatar_url( $author );
 			$profile_URL = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;


### PR DESCRIPTION
A previous change in #7707 could lead to incorrect avatars being displayed on Highlander comments made through Facebook. This fix restores the `get_avatar_url()` param to its previous `$author` value.

WPCom: D7075 (which is #7707 plus this correction)