### PR TITLE
is_object check on $user variable in grofiles_hovercards_data

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -235,7 +235,7 @@ function grofiles_hovercards_data_html( $author ) {
 	$data = grofiles_hovercards_data( $author );
 	if ( is_numeric( $author ) ) {
 		$user = get_userdata( $author );
-		$hash = md5( $user->user_email );
+		$hash = is_object( $user ) ? md5($user->user_email) : md5( $author );
 	} else {
 		$hash = md5( $author );
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

Began receiving this error in our logs:
PHP Notice:  Trying to get property of non-object in /var/www/vhosts/trimhealthymember.com/wp-content/plugins/jetpack/modules/gravatar-hovercards.php on line 238

Have not determined the underlying cause of why the $user variable is not being returned as an object but put a check in there. The issue is that this doesn't likely cause the problem yet since the hash returned will be from a numeric version of that variable (not the e-mail) but thought I would at least start this by exposing it.

#### Testing instructions:

Monitored server log.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
