### PR TITLE
Verification Tools: avoid errors in PHP 5.3+

### DIFF
--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -6,7 +6,7 @@
  */
 
 function jetpack_verification_validate( $verification_services_codes ) {
-	foreach ( $verification_services_codes as $key => &$code ) {
+	foreach ( $verification_services_codes as $key => $code ) {
 		// Parse html meta tags if present
 		if ( stripos( $code, 'meta' ) )
 			$code = jetpack_verification_get_code( $code );

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -5,7 +5,7 @@
  * This file will be included in module-extras.php.
  */
 
-function jetpack_verification_validate( $verification_services_codes ) {
+function jetpack_verification_validate( &$verification_services_codes ) {
 	foreach ( $verification_services_codes as $key => $code ) {
 		// Parse html meta tags if present
 		if ( stripos( $code, 'meta' ) )
@@ -27,6 +27,8 @@ function jetpack_verification_validate( $verification_services_codes ) {
 		 * @param string $code Verification service code provided in field in the Tools menu.
 		 */
 		do_action( 'jetpack_site_verification_validate', $key, $code );
+
+		$verification_services_codes[ $key ] = $code;
 	}
 	return $verification_services_codes;
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -68,6 +68,9 @@
 		<testsuite name="contact-form">
 			<directory prefix="test_" suffix=".php">tests/php/modules/contact-form</directory>
 		</testsuite>
+		<testsuite name="verification-tools">
+			<directory prefix="test_" suffix=".php">tests/php/modules/verification-tools</directory>
+		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
 		</testsuite>

--- a/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
+++ b/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
@@ -1,0 +1,30 @@
+<?php
+require dirname( __FILE__ ) . '/../../../../modules/verification-tools/verification-tools-utils.php';
+
+class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
+
+	/**
+	 * @author zinigor
+	 * @covers jetpack_verification_validate
+	 * @since 5.5.0
+	 */
+	public function test_jetpack_verification_validate_processes_and_returns_codes() {
+		$codes = array(
+			'         untrimmed code      ',
+			'some code that is going to be longer than 100 chars in order to test the trimming'
+			. ' some code that isgoing to be longer than 100 chars in order to test the trimming'
+			. ' some code that isgoing to be longer than 100 chars in order to test the trimming',
+			'some regular string with nothing special in it'
+		);
+
+		$processed_codes = jetpack_verification_validate( $codes );
+
+		foreach( array_merge( $codes, $processed_codes ) as $code ) {
+			$this->assertEquals(
+				substr( esc_attr( trim( $code ) ), 0, 100 ),
+				$code,
+				'the code should be processed'
+			);
+		}
+	}
+}


### PR DESCRIPTION
In [this forum thread](https://wordpress.org/support/topic/error-when-saving-multisite-site-settings/), the user reported the following error:

```
Warning: Invalid argument supplied for foreach() in ../wp-content/plugins/jetpack/modules/verification-tools/verification-tools-utils.php on line 9

Warning: Cannot modify header information – headers already sent by (output started at ../wp-content/plugins/jetpack/modules/verification-tools/verification-tools-utils.php:9) in ../wp-includes/pluggable.php on line 1210
```

> I have multisite install and when I try to save site settings in the network admin I get this error message

#### Proposed changelog entry for your changes:
* Verification Tools: avoid notices when saving changes on a Multisite network admin page.