### PR TITLE
Google Analytics: Fatal Error: Test for WooCommerce before attempting to use it

### DIFF
--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -201,6 +201,10 @@ class Jetpack_Google_Analytics {
 	public function jetpack_wga_classic_track_purchases( $custom_vars ) {
 		global $wp;
 
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return $custom_vars;
+		}
+
 		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
 		$o = get_option( 'jetpack_wga' );
 		$ec_track_purchases = isset( $o[ 'ec_track_purchases' ] ) ? $o[ 'ec_track_purchases' ] : false;
@@ -291,6 +295,10 @@ class Jetpack_Google_Analytics {
 	 * on single views (.single_add_to_cart_button) and list views (.add_to_cart_button)
 	 */
 	public function jetpack_wga_classic_track_add_to_cart() {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
 		$tracking_id = $this->_get_tracking_code();
 		if ( empty( $tracking_id ) ) {
 			return;


### PR DESCRIPTION
Fixes #7913

**Found in 5.4-beta3 - This is a fix for 5.4**

#### Changes proposed in this Pull Request:

* Tests for WooCommerce before attempting to use it.

#### Testing instructions:

* Force ecommerce tracking on, e.g.

```
function allendav_force_wga_settings() {
	update_option( 'jetpack_wga', array(
		'code' => 'UA-13130172-7', // UA-13130172-7
		'anonymize_ip' => 1,
		'ec_track_purchases' => 1,
		'ec_track_add_to_cart' => 1
	) );
}

add_action( 'init', 'allendav_force_wga_settings' );
```
* Disable WooCommerce
* Go to any front side page
* Ensure no errors appear
* Enable WooCommerce
* Visit a product page
* Ensure tracking code like this appears in the page source

```
jQuery( function( $ ) {
  $( '.single_add_to_cart_button' ).click( function() {
    _gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#709']);
  } );
} );
```

* Complete ordering the product
* On the "order received" page, ensure tracking code similar to the following is present

```
var _gaq = _gaq || [];
  _gaq.push(['_setAccount', 'UA-13130172-7']);
  _gaq.push(['_trackPageview']);
  _gaq.push(['_gat._anonymizeIp']);
  _gaq.push( ["_addTrans","1379","Allendav Sandbox Test Site","100.00","0","0","Snohomish","WA","US"] );
  _gaq.push( ["_addItem","1379","709","A Shippable Tax-Free Product","","100","1"] );
  _gaq.push(['_trackTrans']);

 ```
