### PR TITLE
Fix kickstarter shortcode unit test

### DIFF
--- a/tests/php/modules/shortcodes/test_class.kickstarter.php
+++ b/tests/php/modules/shortcodes/test_class.kickstarter.php
@@ -49,6 +49,6 @@ class WP_Test_Jetpack_Shortcodes_Kickstarter extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( '<a href="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world">', $shortcode_content );
+		$this->assertContains( '<a href="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world?ref=video">', $shortcode_content );
 	}
 }


### PR DESCRIPTION
It has been failing with this... I guess the URL changed.  

```
1) WP_Test_Jetpack_Shortcodes_Kickstarter::test_shortcodes_kickstarter_image
Failed asserting that '<iframe src="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world/widget/video.html" height="281.25" width="500" frameborder="0" scrolling="no"></iframe>' contains "<a href="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world">".
/tmp/wordpress-master/src/wp-content/plugins/jetpack/tests/php/modules/shortcodes/test_class.kickstarter.php:52
```

Do the tests pass?

