### PR TITLE
DOMDocument: suppress errors with libxml

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -186,8 +186,8 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		return null;
 	}
 
-	 protected function get_plugin_action_links( $plugin_file ) {
+	protected function get_plugin_action_links( $plugin_file ) {
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-functions.php';
 		return Jetpack_Sync_Functions::get_plugins_action_links( $plugin_file );
-	 }
+	}
 }

--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -167,7 +167,12 @@ class Publicize_Util {
 
 		$string = mb_convert_encoding( $string, 'HTML-ENTITIES', 'UTF-8' );
 		$dom = new DOMDocument( '1.0', 'UTF-8' );
-		@$dom->loadHTML( "<html><body>$string</body></html>" ); // suppress parser warning
+
+		// The @ is not enough to suppress errors when dealing with libxml,
+		// we have to tell it directly how we want to handle errors.
+		libxml_use_internal_errors( true );
+		@$dom->loadHTML( "<html><body>$string</body></html>" );
+		libxml_use_internal_errors( false );
 
 		// Strip comment nodes, if any
 		$comment_nodes = self::get_comment_nodes( $dom->documentElement );

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -101,7 +101,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		do_action( 'jetpack_full_sync_callables', true );
 
 		// The number of actions enqueued, and next module state (true == done)
-		return array( 1, true ); 
+		return array( 1, true );
 	}
 
 	public function estimate_full_sync_actions( $config ) {
@@ -141,7 +141,12 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			if ( ! empty( $action_links ) && count( $action_links ) > 0 ) {
 				$dom_doc = new DOMDocument;
 				foreach ( $action_links as $action_link ) {
+					// The @ is not enough to suppress errors when dealing with libxml,
+					// we have to tell it directly how we want to handle errors.
+					libxml_use_internal_errors( true );
 					$dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
+					libxml_use_internal_errors( false );
+
 					$link_elements = $dom_doc->getElementsByTagName( 'a' );
 					if ( $link_elements->length == 0 ) {
 						continue;
@@ -182,7 +187,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 		return ! $this->still_valid_checksum( $callable_checksums, $name, $checksum );
 	}
-	
+
 	public function maybe_sync_callables() {
 		if ( ! is_admin() || Jetpack_Sync_Settings::is_doing_cron() ) {
 			return;


### PR DESCRIPTION
Reported here:
https://wordpress.org/support/topic/problems-with-the-plugin-9/

Avoids errors like this one:
```
PHP Warning: DOMDocument::loadHTML(): htmlParseEntityRef: expecting ‘;’ in Entity, line: 1 in /wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php on line 214
```

We also do it here already:
https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/class.filter-embedded-html-objects.php#L251-L255