### PR TITLE
JPO: allow to delete the onboarding token

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1817,7 +1817,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 						'businessZipCode'  => '',
 					),
 					'homepageFormat'   => 'news',
-					'addContactForm'   => false
+					'addContactForm'   => false,
+					'end'              => false,
 				),
 				'validate_callback' => __CLASS__ . '::validate_onboarding',
 				'jp_group'          => 'settings',

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -939,6 +939,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * @return string Result of onboarding processing and, if there is one, an error message.
 	 */
 	private function _process_onboarding( $data ) {
+		if ( isset( $data['end'] ) && $data['end'] ) {
+			return Jetpack::invalidate_onboarding_token()
+				? ''
+				: esc_html__( "The onboarding token couldn't be deleted.", 'jetpack' );
+		}
+
 		$error = array();
 
 		if ( ! empty( $data['siteTitle'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* allow to delete the onboarding token

#### Testing instructions:

1. in your wpcom sandbox, apply D7342
2. locally, build and run https://github.com/Automattic/wp-calypso/pull/18413
3. use this branch `update/network-onboarding` in your sandboxorg
4. in your sandboxorg, do `wp eval "Jetpack::create_onboarding_token();"` to generate the token that will validate unauthorized requests performed during onboarding
5. test that you have an onboarding token
    `wp jetpack options get onboarding`
5. ensure your sandboxorg will use your local Calypso development environment by editing `class.jetpack.php` and uncomment `//$url = add_query_arg( 'calypso_env', 'development', $url );`
6. go to the WP Admin of your sandboxorg, to the Jetpack settings, connect it and you should be sent to the `/start/jetpack-onboarding` flow.
7. go through the onboarding flow, after connecting, check again with
    `wp jetpack options get onboarding`
    and you shouldn't have the onboarding token
