### PR TITLE
API: Document bulk deletion response_format and allow posts_ids to be…

### DIFF
--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -12,7 +12,11 @@ new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
 		'$site'    => '(int|string) Site ID or domain',
 	),
 	'request_format' => array(
-		'post_ids' => '(array) An array of Post IDs to delete or trash.',
+		'post_ids' => '(array|string) An array, or comma-separated list, of Post IDs to delete or trash.',
+	),
+
+	'response_format' => array(
+		'results' => '(object) An object containing results, '
 	),
 
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/posts/delete',
@@ -39,7 +43,17 @@ class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 		$input = $this->input();
 
-		$post_ids = (array) $input['post_ids'];
+		if ( is_array( $input['post_ids'] ) ) {
+			$post_ids = (array) $input['post_ids'];
+		} else if ( ! empty( $input['post_ids'] ) ) {
+			$post_ids = explode( ',', $input['post_ids'] );
+		} else {
+			$post_ids = array();
+		}
+
+		if ( count( $post_ids ) < 1 ) {
+			return new WP_Error( 'empty_post_ids', 'The request must include post_ids' );
+		}
 
 		$result = array(
 			'results' => array(),


### PR DESCRIPTION
… specified as comma-separated

Summary:
This Diff updates the bulk deletion endpoint to address some of the feedback from #7624.

It adds a documented `response_format`,  returns a `WP_Error` when `post_ids` is empty, and also allows for `post_ids` to be either an array or comma-separated list to ease testing via the console.

Differential Revision: D7450-code

This commit syncs r163313-wpcom.

#### Testing instructions:

* Apply the diff, sandbox and make requests using the api console or some other tool against your sandboxed api.

