### PR TITLE
Reduced the sitemaps generator batch size.

### DIFF
--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -46,7 +46,7 @@ if ( ! defined( 'JP_NEWS_SITEMAP_MAX_ITEMS' ) ) {
  * @since 4.8.0
  */
 if ( ! defined( 'JP_SITEMAP_BATCH_SIZE' ) ) {
-	define( 'JP_SITEMAP_BATCH_SIZE', 1000 );
+	define( 'JP_SITEMAP_BATCH_SIZE', 50 );
 }
 
 /**


### PR DESCRIPTION
This reduction will make sure that Sitemaps do not consume too much memory on generation.

Fixes a problem where the cron script would run out of memory trying to load 1000 posts.

#### Changes proposed in this Pull Request:
* Fixed memory consumption problem during Sitemaps generation.

#### Testing instructions:
* Get a site with more than 1000 posts with a significant amount of content.
* Optionally lower PHP memory limits.
* Try to rebuild the sitemaps by adding the following code to your functions file:
```
add_action( 'wp_loaded', function() {
	$sitemap_builder = new Jetpack_Sitemap_Builder();
	$sitemap_builder->update_sitemap();
} );
```
* See that the process runs out of memory.
* Roll this PR on, see that it runs OK.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
