### PR TITLE
REST API: Reduce duplication in the comments tree endpoint response.

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -56,6 +56,9 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-sharing-buttons-endpoi
 // v1.1
 // **********
 
+// Comments
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php' );
+
 // Media
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-delete-media-v1-1-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-media-v1-1-endpoint.php' );

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -2,6 +2,8 @@
 
 new WPCOM_JSON_API_Get_Comments_Tree_Endpoint( array(
 	'description' => 'Get a comments tree for site.',
+	'max_version' => '1',
+	'new_version' => '1.1',
 	'group'       => 'comments-tree',
 	'stat'        => 'comments-tree:1',
 

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -56,9 +56,9 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 		$trackbacks = array();
 		$pingbacks = array();
 		foreach ( $db_comment_rows as $row ) {
-			$comment_id = (int) $row[0];
-			$comment_post_id = (int) $row[1];
-			$comment_parent_id = (int) $row[2];
+			$comment_id = intval( $row[0] );
+			$comment_post_id = intval( $row[1] );
+			$comment_parent_id = intval( $row[2] );
 			switch ( $row[3] ) {
 				case 'trackback':
 					$trackbacks[] = array( $comment_id, $comment_post_id );

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -61,10 +61,10 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 			$comment_parent_id = intval( $row[2] );
 			switch ( $row[3] ) {
 				case 'trackback':
-					$trackbacks[] = array( $comment_id, $comment_post_id );
+					$trackbacks[ $comment_post_id ][] = $comment_id;
 					break;
 				case 'pingback':
-					$pingbacks[] = array( $comment_id, $comment_post_id );
+					$pingbacks[ $comment_post_id ][] = $comment_id;
 					break;
 				default:
 					if ( 0 === $comment_parent_id ) {

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
@@ -61,6 +61,9 @@ class WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint extends WPCOM_JSON_API_Get_
 			$comment_id = intval( $row[0] );
 			$comment_post_id = intval( $row[1] );
 			$comment_parent_id = intval( $row[2] );
+			if ( ! isset( $comments[ $comment_post_id ] ) ) {
+				$comments[ $comment_post_id ] = array( array(), array() );
+			}
 			switch ( $row[3] ) {
 				case 'trackback':
 					$trackbacks[ $comment_post_id ][] = $comment_id;

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
@@ -17,14 +17,14 @@ new WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint ( array(
 	),
 	'response_format' => array(
 		'comments_count' => '(int) Total number of comments on the site',
-		'comments_tree' => '(array) Array of arrays representing the comments tree for given site (max 50000)',
+		'comments_tree' => '(array) Array of post IDs representing the comments tree for given site (max 50000)',
 		'trackbacks_count' => '(int) Total number of trackbacks on the site',
-		'trackbacks_tree' => '(array) Array of arrays representing the trackbacks tree for given site (max 50000)',
+		'trackbacks_tree' => '(array) Array of post IDs representing the trackbacks tree for given site (max 50000)',
 		'pingbacks_count' => '(int) Total number of pingbacks on the site',
-		'pingbacks_tree' => '(array) Array of arrays representing the pingbacks tree for given site (max 50000)',
+		'pingbacks_tree' => '(array) Array of post IDs representing the pingbacks tree for given site (max 50000)',
 	),
 
-	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments-tree?status=approved'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/comments-tree?status=approved'
 ) );
 
 class WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint extends WPCOM_JSON_API_Get_Comments_Tree_Endpoint {

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
@@ -1,0 +1,89 @@
+<?php
+
+new WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint ( array(
+	'description' => 'Get a comments tree for site.',
+	'min_version' => '1.1',
+	'max_version' => '1.1',
+	'group'       => 'comments-tree',
+	'stat'        => 'comments-tree:1',
+
+	'method'      => 'GET',
+	'path'        =>  '/sites/%s/comments-tree',
+	'path_labels' => array(
+		'$site'   => '(int|string) Site ID or domain',
+	),
+	'query_parameters' => array(
+		'status' => '(string) Filter returned comments based on this value (allowed values: all, approved, pending, trash, spam).'
+	),
+	'response_format' => array(
+		'comments_count' => '(int) Total number of comments on the site',
+		'comments_tree' => '(array) Array of arrays representing the comments tree for given site (max 50000)',
+		'trackbacks_count' => '(int) Total number of trackbacks on the site',
+		'trackbacks_tree' => '(array) Array of arrays representing the trackbacks tree for given site (max 50000)',
+		'pingbacks_count' => '(int) Total number of pingbacks on the site',
+		'pingbacks_tree' => '(array) Array of arrays representing the pingbacks tree for given site (max 50000)',
+	),
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments-tree?status=approved'
+) );
+
+class WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint extends WPCOM_JSON_API_Get_Comments_Tree_Endpoint {
+	/**
+	 * Retrieves a list of comment data for a given site.
+	 *
+	 * @param string $status Filter by status: all, approved, pending, spam or trash.
+	 * @param int $start_at first comment to search from going back in time
+	 *
+	 * @return array
+	 */
+	function get_site_tree( $status, $start_at = PHP_INT_MAX ) {
+		global $wpdb;
+		$max_comment_count = 50000;
+		$db_status = $this->get_comment_db_status( $status );
+
+		$db_comment_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT comment_ID, comment_post_ID, comment_parent, comment_type " .
+				"FROM $wpdb->comments AS comments " .
+				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
+				"WHERE comment_ID <= %d AND ( %s = 'all' OR comment_approved = %s ) " .
+				"ORDER BY comment_ID DESC " .
+				"LIMIT %d",
+				(int) $start_at, $db_status, $db_status, $max_comment_count
+			),
+			ARRAY_N
+		);
+
+		$comments = array();
+		$trackbacks = array();
+		$pingbacks = array();
+		foreach ( $db_comment_rows as $row ) {
+			$comment_id = intval( $row[0] );
+			$comment_post_id = intval( $row[1] );
+			$comment_parent_id = intval( $row[2] );
+			switch ( $row[3] ) {
+				case 'trackback':
+					$trackbacks[ $comment_post_id ][] = $comment_id;
+					break;
+				case 'pingback':
+					$pingbacks[ $comment_post_id ][] = $comment_id;
+					break;
+				default:
+					if ( 0 === $comment_parent_id ) {
+						$comments[ $comment_post_id ][0][] = $comment_id;
+					} else {
+						$comments[ $comment_post_id ][1][] = array( $comment_id, $comment_parent_id );
+					}
+			}
+		}
+
+		return array(
+			'comments_count' => $this->get_site_tree_total_count( $status, 'comment' ),
+			'comments_tree' => $comments,
+			'trackbacks_count' => $this->get_site_tree_total_count( $status, 'trackback' ),
+			'trackbacks_tree' => $trackbacks,
+			'pingbacks_count' => $this->get_site_tree_total_count( $status, 'pingback' ),
+			'pingbacks_tree' => $pingbacks,
+		);
+	}
+}


### PR DESCRIPTION
This PR seeks to remove much of the duplication in the comments tree endpoint response to make it as light as possible (greatly benefitting sites with thousands of comments, such as `en.blog.wordpress.com` and `wptavern.com`). Because we're changing the shape of the response, we're versioning these changes to v1.1.

Rather than the current flat list duplicating post IDs and parent IDs of `0`, each post ID is now its own key, with an array of parent-less (top-level) comment IDs (at `[0]`) and an array of comments with parent IDs. eg. `[ comment_id, comment_parent_id ]`, at `[1]`). Because pingbacks and trackbacks never have comment parents, they simply have the one array of comment IDs on a comment post ID key. The shape now looks like this:

```
{
    comments_count: 1234,
    comments_tree: {
        "comment_post_id": [
            0: [ comment_id, comment_id, ... ],
            1: [
                [ comment_id, comment_parent_id ],
                [ comment_id, comment_parent_id ],
                ...
            ]
        ]
    },
    trackbacks_count: 0,
    trackbacks_tree: {
        "comment_post_id": [ comment_id, comment_id, ... ],
        ...
    },
    pingbacks_count: 0,
    pingbacks_tree: {
        "comment_post_id": [ comment_id, comment_id, ... ],
        ...
    }
}
```

The WP.com changes are in D7470-code.

**Testing**
* Load this PR and hit both the original v1 and new v1.1 versions of the endpoint: `https://public-api.wordpress.com/rest/v1/sites/(JP testing site)/comments-tree` and `https://public-api.wordpress.com/rest/v1.1/sites/(JP testing site)/comments-tree`.
* Compare response sizes of this diff vs. production on various sites. Savings should get bigger with the more comments a site has.
* The v1.1 response should look like the above, while the v1 original response will be all flat:
```
{
    comments_count: 1234,
    comments_tree: [
            0: [ comment_id, comment_post_id, comment_parent_id ],
            1: [ comment_id, comment_post_id, comment_parent_id ],
            ...
    ],
    trackbacks_count: 1234,
    trackbacks_tree: [
        0: [ comment_id, comment_post_id, comment_parent_id ],
        ...
    ],
    pingbacks_count: 1234,
    pingbacks_tree: [
        0: [ comment_id, comment_post_id, comment_parent_id ],
        ...
    ]
}
```