### PR TITLE
Don't set cookie on API requests, it's useless

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -158,10 +158,9 @@ class Jetpack_Tracks_Client {
 				$anon_id = 'jetpack:' . base64_encode( $binary );
 
 				if ( ! headers_sent()
-				&&
-					! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
-				&&
-					! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
+					&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+					&& ! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+				) {
 					setcookie( 'tk_ai', $anon_id );
 				}
 			}

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -157,7 +157,11 @@ class Jetpack_Tracks_Client {
 
 				$anon_id = 'jetpack:' . base64_encode( $binary );
 
-				if ( ! headers_sent() ) {
+				if ( ! headers_sent()
+				&&
+					! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+				&&
+					! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 					setcookie( 'tk_ai', $anon_id );
 				}
 			}


### PR DESCRIPTION
I was seeing lots of `SetCookie`s in API response headers (many identical) because we were setting the anon ID cookie multiple times in the scope of a single request.

This patch just doesn't set the cookie for clients that clearly don't care about them.