### PR TITLE
Don't generate sitemap on activate, wait a minute

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -64,7 +64,7 @@ class Jetpack_Client_Server {
 			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
 
 			//track unique connection
-			$jetpack = $this->get_jetpack();;
+			$jetpack = $this->get_jetpack();
 
 			$jetpack->stat( 'connections', 'unique-connection' );
 			$jetpack->do_stats( 'server_side' );

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -42,5 +42,5 @@ function jetpack_sitemap_on_activate() {
 	$sitemap_builder = new Jetpack_Sitemap_Builder();
 	add_action( 'jetpack_sitemap_generate_on_activate', array( $sitemap_builder, 'update_sitemap' ) );
 
-	wp_schedule_single_event( time(), 'jetpack_sitemap_generate_on_activate' );
+	wp_schedule_single_event( time() + 60, 'jetpack_sitemap_generate_on_activate' );
 }


### PR DESCRIPTION
Generating sitemaps can take quite a while. Currently we generate them immediately when we connect Jetpack, which can cause the requests to time out, right when we need responses to be most reliable.

This change triggers the sitemap build one minute after connect.