### PR TITLE
Only enable Search Filters widget with filter

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -11,6 +11,18 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			return;
 		}
 
+		/**
+		 * Enables or disables the search filters widget. Disabled by default for Jetpack sites.
+		 * Enable if your site's security strategy allows aggregation.
+		 *
+		 * @since 5.5
+		 *
+		 * @param bool whether to enable search filters widget
+		 */
+		if ( ! apply_filters( 'jetpack_search_enable_filters_widget', false ) ) {
+			return;
+		}
+
 		parent::__construct(
 			'jetpack-search-filters',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */


### PR DESCRIPTION
Fixes 1064-gh-jpop-issues

#### Changes proposed in this Pull Request:

* Only enable Jetpack Search filters widget with a filter `jetpack_search_enable_filters_widget`. This is because by default Jetpack Search does not allow aggregations (but Jetpack VIP does).

#### Testing instructions:

* Try to add `Search Filters (Jetpack)` widget - it should not be available
* `add_filter( 'jetpack_search_enable_filters_widget', '__return_true' )` somewhere
* Search Filters widget should now be available (but won't be visible without some filters configured and a suitable ES security strategy)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
