### PR TITLE
Sync: Pass capabilities though a filter.

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -361,6 +361,78 @@ class Jetpack_Sync_Defaults {
 		return false;
 	}
 
+	static $default_capabilities_whitelist = array(
+		'switch_themes',
+		'edit_themes',
+		'edit_theme_options',
+		'install_themes',
+		'activate_plugins',
+		'edit_plugins',
+		'install_plugins',
+		'edit_users',
+		'edit_files',
+		'manage_options',
+		'moderate_comments',
+		'manage_categories',
+		'manage_links',
+		'upload_files',
+		'import',
+		'unfiltered_html',
+		'edit_posts',
+		'edit_others_posts',
+		'edit_published_posts',
+		'publish_posts',
+		'edit_pages',
+		'read',
+		'publish_pages',
+		'edit_others_pages',
+		'edit_published_pages',
+		'delete_pages',
+		'delete_others_pages',
+		'delete_published_pages',
+		'delete_posts',
+		'delete_others_posts',
+		'delete_published_posts',
+		'delete_private_posts',
+		'edit_private_posts',
+		'read_private_posts',
+		'delete_private_pages',
+		'edit_private_pages',
+		'read_private_pages',
+		'delete_users',
+		'create_users',
+		'unfiltered_upload',
+		'edit_dashboard',
+		'customize',
+		'delete_site',
+		'update_plugins',
+		'delete_plugins',
+		'update_themes',
+		'update_core',
+		'list_users',
+		'remove_users',
+		'add_users',
+		'promote_users',
+		'delete_themes',
+		'export',
+		'edit_comment',
+		'upload_plugins',
+		'upload_themes',
+	);
+
+	public static function get_capabilities_whitelist() {
+		/**
+		 * Filter the list of capabilities that we care about
+		 *
+		 * @module sync
+		 *
+		 * @since 5.5
+		 *
+		 * @param array The default list of capabilities.
+		 */
+		return apply_filters( 'jetpack_sync_capabilities_whitelist', self::$default_capabilities_whitelist );
+	}
+
 	static function get_max_sync_execution_time() {
 		$max_exec_time = intval( ini_get( 'max_execution_time' ) );
 		if ( 0 === $max_exec_time ) {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -426,7 +426,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 5.5
+		 * @since 5.5.0
 		 *
 		 * @param array The default list of capabilities.
 		 */

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -71,9 +71,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function sanitize_user_and_expand( $user ) {
-		$user = $this->sanitize_user( $user );
-
-		return $this->add_to_user( $user );
+		$user = $this->add_to_user( $user );
+		return $this->sanitize_user( $user );
 	}
 
 	public function sanitize_user( $user ) {
@@ -84,6 +83,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			unset( $user->data->user_pass );
 		}
 
+		$user->allcaps = $this->get_real_user_capabilities( $user );
 		return $user;
 	}
 
@@ -99,6 +99,16 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		}
 
 		return $user;
+	}
+
+	public function get_real_user_capabilities( $user) {
+		$user_capabilities = array();
+		foreach( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
+			if ( $user_has_capabilities = user_can( $user , $capability ) ) {
+				$user_capabilities[ $capability ] = true;
+			}
+		}
+		return $user_capabilities;
 	}
 
 	public function expand_user( $args ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -101,7 +101,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		return $user;
 	}
 
-	public function get_real_user_capabilities( $user) {
+	public function get_real_user_capabilities( $user ) {
 		$user_capabilities = array();
 		foreach( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
 			if ( $user_has_capabilities = user_can( $user , $capability ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -25,6 +25,8 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		// The regular user object doesn't have allowed_mime_types
 		unset( $server_user->data->allowed_mime_types );
 
+		unset( $user->allcaps['subscriber'] );
+		unset( $user->allcaps['level_0'] );
 		$this->assertEqualsObject( $user, $server_user );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );


### PR DESCRIPTION
This makes sure that we are returning a whitelist of capabilities that the user has.

#### Changes proposed in this Pull Request:
* Whitelist the capabilities so that we only sync the ones we care about and also pass them thought the filter. Since plugins have the ability to change capabilities.

#### Testing instructions:
* Do the tests pass?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
