### PR TITLE
WPML / Top Posts Widget: avoid Fatal Error when post doesn't exist

### DIFF
--- a/3rd-party/wpml.php
+++ b/3rd-party/wpml.php
@@ -28,9 +28,11 @@ function wpml_jetpack_widget_get_top_posts( $posts, $post_ids, $count ) {
 
 	foreach ( $posts as $k => $post ) {
 		$lang_information = wpml_get_language_information( $post['post_id'] );
-		$post_language    = substr( $lang_information['locale'], 0, 2 );
-		if ( $post_language !== $sitepress->get_current_language() ) {
-			unset( $posts[ $k ] );
+		if ( ! is_wp_error( $lang_information ) ) {
+			$post_language = substr( $lang_information['locale'], 0, 2 );
+			if ( $post_language !== $sitepress->get_current_language() ) {
+				unset( $posts[ $k ] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #7931

`wpml_get_language_information` can return either an array of language infomation about a specific post ID,
or a `WP_Error` if no ID is provided or if no post exists with the provided ID.

The `wpml_jetpack_widget_get_top_posts` now accounts for that second possibility,
and will not attempt to remove a post if WPML cannot find info about it.

#### Proposed changelog entry for your changes:
* Avoid Fatal Errors when the Top Posts Widget is used on a site using WPML, and when a popular post cannot be found by WPML.