### PR TITLE
Milestone Widget - Fix translations

### DIFF
--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -17,6 +17,10 @@ var Milestone = ( function( $ ) {
 		this.secondsPerHour = 3600;
 		this.secondsPerMinute = 60;
 
+		this.isCountingDown = function() {
+			return ! this.type || 'until' === this.type;
+		};
+
 		this.getYears = function() {
 			num = ( this.diff / 60 / 60 / 24 / 365 ).toFixed( 1 );
 
@@ -28,7 +32,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getYearsLabel = function() {
-			return labels.years;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.yearToGo : labels.yearsToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.yearAgo : labels.yearsAgo;
 		};
 
 		this.getMonths = function() {
@@ -36,7 +44,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getMonthsLabel = function() {
-			return ( 1 === this.number ) ? labels.month : labels.months;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.monthToGo : labels.monthsToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.monthAgo : labels.monthsAgo;
 		};
 
 		this.getDays = function() {
@@ -44,7 +56,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getDaysLabel = function() {
-			return ( 1 === this.number ) ? labels.day : labels.days;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.dayToGo : labels.daysToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.dayAgo : labels.daysAgo;
 		};
 
 		this.getHours = function() {
@@ -52,7 +68,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getHoursLabel = function() {
-			return ( 1 === this.number ) ? labels.hour : labels.hours;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.hourToGo : labels.hoursToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.hourAgo : labels.hoursAgo;
 		};
 
 		this.getMinutes = function() {
@@ -60,7 +80,11 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getMinutesLabel = function() {
-			return ( 1 === this.number ) ? labels.minute : labels.minutes;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.minuteToGo : labels.minutesToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.minuteAgo : labels.minutesAgo;
 		};
 
 		this.getSeconds = function() {
@@ -68,11 +92,15 @@ var Milestone = ( function( $ ) {
 		};
 
 		this.getSecondsLabel = function() {
-			return ( 1 === this.number ) ? labels.second : labels.seconds;
+			if ( this.isCountingDown() ) {
+				return ( 1 === this.number ) ? labels.secondToGo : labels.secondsToGo;
+			}
+
+			return ( 1 === this.number ) ? labels.secondAgo : labels.secondsAgo;
 		};
 
 		this.timer = function() {
-			if ( 'until' === this.type ) {
+			if ( this.isCountingDown() ) {
 				this.diff = this.diff - 1;
 			} else {
 				this.diff = this.diff + 1;
@@ -154,8 +182,8 @@ var Milestone = ( function( $ ) {
 
 			// Milestone has been reached.
 			if ( 1 > this.diff ) {
-				// Message is not applicable when counting up to future date.
-				if ( this.type === 'since' ) {
+				// Message is only applicable when counting down.
+				if ( ! this.isCountingDown() ) {
 					this.widget.find( '.milestone-countdown' ).remove();
 				} else {
 					this.widget.find( '.milestone-countdown' ).replaceWith( '<div class="milestone-message">' + this.message + '</div>' );

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -36,18 +36,30 @@ class Milestone_Widget extends WP_Widget {
 		self::$dir = trailingslashit( dirname( __FILE__ ) );
 		self::$url = plugin_dir_url( __FILE__ );
 		self::$labels = array(
-			'year'    => __( 'year', 'jetpack' ),
-			'years'   => __( 'years', 'jetpack' ),
-			'month'   => __( 'month', 'jetpack' ),
-			'months'  => __( 'months', 'jetpack' ),
-			'day'     => __( 'day', 'jetpack' ),
-			'days'    => __( 'days', 'jetpack' ),
-			'hour'    => __( 'hour', 'jetpack' ),
-			'hours'   => __( 'hours', 'jetpack' ),
-			'minute'  => __( 'minute', 'jetpack' ),
-			'minutes' => __( 'minutes', 'jetpack' ),
-			'second'  => __( 'second', 'jetpack' ),
-			'seconds' => __( 'seconds', 'jetpack' ),
+			'yearToGo'    => __( 'year to go.', 'jetpack' ),
+			'yearsToGo'   => __( 'years to go.', 'jetpack' ),
+			'monthToGo'   => __( 'month to go.', 'jetpack' ),
+			'monthsToGo'  => __( 'months to go.', 'jetpack' ),
+			'dayToGo'     => __( 'day to go.', 'jetpack' ),
+			'daysToGo'    => __( 'days to go.', 'jetpack' ),
+			'hourToGo'    => __( 'hour to go.', 'jetpack' ),
+			'hoursToGo'   => __( 'hours to go.', 'jetpack' ),
+			'minuteToGo'  => __( 'minute to go.', 'jetpack' ),
+			'minutesToGo' => __( 'minutes to go.', 'jetpack' ),
+			'secondToGo'  => __( 'second to go.', 'jetpack' ),
+			'secondsToGo' => __( 'seconds to go.', 'jetpack' ),
+			'yearAgo'    => __( 'year ago.', 'jetpack' ),
+			'yearsAgo'   => __( 'years ago.', 'jetpack' ),
+			'monthAgo'   => __( 'month ago.', 'jetpack' ),
+			'monthsAgo'  => __( 'months ago.', 'jetpack' ),
+			'dayAgo'     => __( 'day ago.', 'jetpack' ),
+			'daysAgo'    => __( 'days ago.', 'jetpack' ),
+			'hourAgo'    => __( 'hour ago.', 'jetpack' ),
+			'hoursAgo'   => __( 'hours ago.', 'jetpack' ),
+			'minuteAgo'  => __( 'minute ago.', 'jetpack' ),
+			'minutesAgo' => __( 'minutes ago.', 'jetpack' ),
+			'secondAgo'  => __( 'second ago.', 'jetpack' ),
+			'secondsAgo' => __( 'seconds ago.', 'jetpack' ),
 		);
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
@@ -200,20 +212,11 @@ class Milestone_Widget extends WP_Widget {
 		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
 			echo '<div class="milestone-message">' . $instance['message'] . '</div>';
 		} else {
-			if ( 'since' === $type ) {
-				/* translators: text that the widget displays when counting up from a milestone (e.g. 5 days ago.) */
-				$text = __( 'ago.', 'jetpack' );
-			} else {
-				/* translators: text that the widget displays when counting down to a milestone (e.g. 5 days to go.) */
-				$text = __( 'to go.', 'jetpack' );
-			}
-
 			/* Countdown to the milestone. */
-			echo '<div class="milestone-countdown">' . sprintf( __( '%1$s %2$s %3$s', 'jetpack' ),
-				'<span class="difference"></span>',
-				'<span class="label"></span>',
-				$text
-			) . '</div>';
+			echo '<div class="milestone-countdown">' .
+				'<span class="difference"></span>' .
+				'<span class="label"></span>' .
+				'</div>';
 
 			self::$config_js['instances'][] = array(
 				'id'      => $args['widget_id'],

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -201,8 +201,10 @@ class Milestone_Widget extends WP_Widget {
 			echo '<div class="milestone-message">' . $instance['message'] . '</div>';
 		} else {
 			if ( 'since' === $type ) {
+				/* translators: text that the widget displays when counting up from a milestone (e.g. 5 days ago.) */
 				$text = __( 'ago.', 'jetpack' );
 			} else {
+				/* translators: text that the widget displays when counting down to a milestone (e.g. 5 days to go.) */
 				$text = __( 'to go.', 'jetpack' );
 			}
 


### PR DESCRIPTION
Fixes #7940.

#### Changes proposed in this Pull Request:

Create separate string translations for all possible variations of the widget text that could display on the front-end of the site. These get passed to the JS, which handles dynamically updating this text based on the amount of time left until the milestone is reached, or the amount of time that has passed since the milestone was reached.