### PR TITLE
Sync: make sure that the admin_init hook gets called before getting the links

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -131,10 +131,6 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	}
 
 	protected function get_plugins() {
-		// Do the admin_init action in order to capture plugin action links.
-		// See get_plugin_action_links()
-		/** This action is documented in wp-admin/admin.php */
-		do_action( 'admin_init' );
 		$plugins = array();
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
 		$installed_plugins = apply_filters( 'all_plugins', get_plugins() );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -290,7 +290,7 @@ class Jetpack_Sync_Functions {
 			return is_null( $plugin_file_singular ) ? $action_links : $action_links[ $plugin_file_singular ];
 		}
 		if ( ! did_action( 'admin_init' ) ) {
-			do_action( 'admin_init' );
+			return new WP_Error('wrong-context', __( 'You need to call do_action(\'admin_init\') before running this function.', 'jetpack' ) );
 		}
 		$plugins_action_links = array();
 		$plugins = is_null( $plugin_file_singular ) ? array_keys( self::get_plugins() ) : array( $plugin_file_singular );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -280,66 +280,18 @@ class Jetpack_Sync_Functions {
 	 * @return array of plugin action links (key: link name value: url)
 	 */
 	public static function get_plugins_action_links( $plugin_file_singular = null ) {
-
-		// Some sites may have DOM disabled in PHP
+		// Some sites may have DOM disabled in PHP fail early
 		if ( ! class_exists( 'DOMDocument' ) ) {
 			return array();
 		}
-		$plugins_action_links = get_transient( 'jetpack_plugin_api_action_links', array() );
+		$plugins_action_links = get_option( 'jetpack_plugin_api_action_links', array() );
 		if ( ! empty( $plugins_action_links ) ) {
-			return self::_get_plugins_action_links( $plugins_action_links, $plugin_file_singular );
-		}
-		if ( ! did_action( 'admin_init' ) ) {
-			return ( is_null( $plugin_file_singular ) ?
-				new WP_Error( 'wrong-context', __( 'You need to call do_action(\'admin_init\') before running this function.', 'jetpack' ) ) :
-				array()
-			); // this gets called in the api context...
-		}
-		$plugins = array_keys( self::get_plugins() );
-		foreach ( $plugins as $plugin_file ) {
-
-			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( 'plugin_action_links', array(), $plugin_file, null, 'all' );
-			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
-			$formatted_action_links = null;
-			if ( ! empty( $action_links ) && count( $action_links ) > 0 ) {
-				$dom_doc = new DOMDocument;
-				foreach ( $action_links as $action_link ) {
-					$dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
-					$link_elements = $dom_doc->getElementsByTagName( 'a' );
-					if ( $link_elements->length == 0 ) {
-						continue;
-					}
-
-					$link_element = $link_elements->item( 0 );
-					if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
-						$link_url = trim( $link_element->getAttribute( 'href' ) );
-
-						// Add the full admin path to the url if the plugin did not provide it
-						$link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
-						if ( empty( $link_url_scheme ) ) {
-							$link_url = admin_url( $link_url );
-						}
-
-						$formatted_action_links[ $link_element->nodeValue ] = $link_url;
-					}
-				}
+			if ( is_null( $plugin_file_singular ) ) {
+				return $plugins_action_links;
 			}
-			if ( $formatted_action_links ) {
-				$plugins_action_links[ $plugin_file ] = $formatted_action_links;
-			}
+			return ( isset( $plugins_action_links[ $plugin_file_singular ] ) ? $plugins_action_links[ $plugin_file_singular ] : array() );
 		}
-		set_transient( 'jetpack_plugin_api_action_links', $plugins_action_links, DAY_IN_SECONDS );
-		return self::_get_plugins_action_links( $plugins_action_links, $plugin_file_singular );
-	}
-
-	private static function _get_plugins_action_links( $action_links, $plugin_file = null ) {
-		if ( is_null( $plugin_file ) ) {
-			return $action_links;
-		} else {
-			return ( isset( $action_links[ $plugin_file ] ) ? $action_links[ $plugin_file ] : array() );
-		}
+		return array();
 	}
 
 	public static function wp_version() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -290,7 +290,7 @@ class Jetpack_Sync_Functions {
 			return is_null( $plugin_file_singular ) ? $action_links : $action_links[ $plugin_file_singular ];
 		}
 		if ( ! did_action( 'admin_init' ) ) {
-			return new WP_Error('wrong-context', __( 'You need to call do_action(\'admin_init\') before running this function.', 'jetpack' ) );
+			return new WP_Error( 'wrong-context', __( 'You need to call do_action(\'admin_init\') before running this function.', 'jetpack' ) );
 		}
 		$plugins_action_links = array();
 		$plugins = is_null( $plugin_file_singular ) ? array_keys( self::get_plugins() ) : array( $plugin_file_singular );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -289,6 +289,9 @@ class Jetpack_Sync_Functions {
 		if ( ! empty( $action_links ) ) {
 			return is_null( $plugin_file_singular ) ? $action_links : $action_links[ $plugin_file_singular ];
 		}
+		if ( ! did_action( 'admin_init' ) ) {
+			do_action( 'admin_init' );
+		}
 		$plugins_action_links = array();
 		$plugins = is_null( $plugin_file_singular ) ? array_keys( self::get_plugins() ) : array( $plugin_file_singular );
 		foreach( $plugins as $plugin_file ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -127,7 +127,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		}
 
 		// Is the transient lock in place?
-		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh' );
+		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh', false );
 		if ( ! empty( $plugins_lock ) ) {
 			return;
 		}
@@ -166,7 +166,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 		}
 		// Cache things for a long time
-		set_transient( 'jetpack_plugin_api_action_links_refresh', true, DAY_IN_SECONDS );
+		set_transient( 'jetpack_plugin_api_action_links_refresh', time(), DAY_IN_SECONDS );
 		update_option( 'jetpack_plugin_api_action_links', $plugins_action_links );
 	}
 

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -129,7 +129,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 		// Is the transient lock in place?
-		if ( ! empty( get_transient( 'jetpack_plugin_api_action_links_refresh' ) ) ) {
+		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh' );
+		if ( ! empty( $plugins_lock ) ) {
 			return;
 		}
 		$plugins = array_keys( Jetpack_Sync_Functions::get_plugins() );

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
-		add_action( 'admin_footer', array( $this, 'set_plugin_action_links' ) );
+		add_action( 'admin_init', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
 
 		// For some options, we should always send the change right away!
 		$always_send_updates_to_these_options = array(
@@ -118,16 +118,14 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function unlock_plugin_action_link_and_callables() {
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_transient( 'jetpack_plugin_api_action_links' );
+		delete_transient( 'jetpack_plugin_api_action_links_refresh' );
 	}
 
 	public function set_plugin_action_links() {
 		if ( ! class_exists( 'DOMDocument' ) ) {
 			return;
 		}
-		if ( ! did_action( 'admin_init' ) ) {
-			return;
-		}
+
 		// Is the transient lock in place?
 		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh' );
 		if ( ! empty( $plugins_lock ) ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -81,13 +81,17 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			array_keys( $this->get_callable_whitelist() ),
 			array_map( array( $this, 'get_callable' ), array_values( $this->get_callable_whitelist() ) )
 		);
+		$callables = array_filter( $callables, array( $this, 'remove_callables_with_errors' ) );
 		wp_set_current_user( $current_user_id );
-
 		return $callables;
 	}
 
 	private function get_callable( $callable ) {
 		return call_user_func( $callable );
+	}
+
+	public function remove_callables_with_errors( $callable_value ) {
+		return ! is_wp_error( $callable_value );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -641,9 +641,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 }
 
-function jetpack_foo_is_callable_error() {
-	return new WP_Error( 'wrong-context' );
-}
 /* Example Test Taxonomy */
 class ABC_FOO_TEST_Taxonomy_Example {
 	function __construct() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -561,7 +561,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$helper_jetpack->array_override = array( '<a href="settings.php">settings</a>', '<a href="https://jetpack.com/support">support</a>' );
 		add_filter( 'plugin_action_links_jetpack/jetpack.php', array( $helper_jetpack, 'filter_override_array' ), 10 );
 
-		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
+		$callables_module = new Jetpack_Sync_Module_Callables(); // Do the admin init here so that we calculate the plugin links
+		$callables_module->set_plugin_action_links();
 		// Let's see if the original values get synced
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -571,7 +572,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				'fun' => admin_url( 'fun.php' )
 			),
 			'jetpack/jetpack.php' => array(
-				'Jetpack' => admin_url( 'admin.php?page=jetpack' ),
 				'settings' => admin_url( 'settings.php' ),
 				'support' => 'https://jetpack.com/support'
 			)
@@ -580,7 +580,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
 		$this->resetCallableAndConstantTimeouts();
-		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
+		$callables_module->set_plugin_action_links();
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -589,7 +589,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		activate_plugin('hello.php', '', false, true );
 		$this->resetCallableAndConstantTimeouts();
-		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
+		$callables_module->set_plugin_action_links();
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -636,15 +636,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		}
 
 	}
-
-	function test_callables_that_return_an_error_dont_get_synced() {
-		$this->callable_module->set_callable_whitelist( array( 'jetpack_error_foo' => 'jetpack_foo_is_callable_error' ) );
-
-		$this->sender->do_sync();
-
-		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_error_foo' );
-		$this->assertNull( $synced_value );
-	}
 }
 
 function jetpack_foo_is_callable_error() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -561,6 +561,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$helper_jetpack->array_override = array( '<a href="settings.php">settings</a>', '<a href="https://jetpack.com/support">support</a>' );
 		add_filter( 'plugin_action_links_jetpack/jetpack.php', array( $helper_jetpack, 'filter_override_array' ), 10 );
 
+		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
 		// Let's see if the original values get synced
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -570,15 +571,16 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				'fun' => admin_url( 'fun.php' )
 			),
 			'jetpack/jetpack.php' => array(
+				'Jetpack' => admin_url( 'admin.php?page=jetpack' ),
 				'settings' => admin_url( 'settings.php' ),
 				'support' => 'https://jetpack.com/support'
 			)
 		);
-
-  		$this->assertEquals( $plugins_action_links, $expected_array );
+  		$this->assertEquals( $expected_array, $plugins_action_links );
 
 		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
 		$this->resetCallableAndConstantTimeouts();
+		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -587,6 +589,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		activate_plugin('hello.php', '', false, true );
 		$this->resetCallableAndConstantTimeouts();
+		do_action( 'admin_init' ); // Do the admin init here so that we calculate the plugin links
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -637,8 +637,19 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 	}
 
+	function test_callables_that_return_an_error_dont_get_synced() {
+		$this->callable_module->set_callable_whitelist( array( 'jetpack_error_foo' => 'jetpack_foo_is_callable_error' ) );
+
+		$this->sender->do_sync();
+
+		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_error_foo' );
+		$this->assertNull( $synced_value );
+	}
 }
 
+function jetpack_foo_is_callable_error() {
+	return new WP_Error( 'wrong-context' );
+}
 /* Example Test Taxonomy */
 class ABC_FOO_TEST_Taxonomy_Example {
 	function __construct() {


### PR DESCRIPTION
Make sure that the admin_init action gets called at least ones. So that we get the right plugin_action hooks.
Make sure that the plugins did `jetpack_plugin_api_action_links` gets called in the right conntext.

I am not sure if this is the best way to go but it fixes the issue. 

#### Testing instructions:
* Make sure to send the data. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
