### PR TITLE
Admin Page: Introduce constants for support URLs

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -14,6 +14,7 @@ import {
 	isNoticeDismissed as _isNoticeDismissed,
 	dismissJetpackNotice
 } from 'state/jetpack-notices';
+import { JETPACK_CONTACT_SUPPORT } from 'constants';
 
 const FeedbackDashRequest = React.createClass( {
 	displayName: 'FeedbackDashRequest',
@@ -31,7 +32,7 @@ const FeedbackDashRequest = React.createClass( {
 					text={ __( 'What would you like to see on your Jetpack Dashboard?' ) }
 				>
 					<NoticeAction
-						href="https://jetpack.com/contact-support/"
+						href={ JETPACK_CONTACT_SUPPORT }
 					>
 						{ __( 'Let us know!' ) }
 					</NoticeAction>

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -18,6 +18,7 @@ import DismissableNotices from './dismissable';
 import { getConnectUrl as _getConnectUrl } from 'state/connection';
 import QueryConnectUrl from 'components/data/query-connect-url';
 import JetpackBanner from 'components/jetpack-banner';
+import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants';
 
 export const DevVersionNotice = React.createClass( {
 	displayName: 'DevVersionNotice',
@@ -30,7 +31,7 @@ export const DevVersionNotice = React.createClass( {
 					text={ __( 'You are currently running a development version of Jetpack.' ) }
 				>
 					<NoticeAction
-						href="https://jetpack.com/contact-support/beta-group/"
+						href={ JETPACK_CONTACT_BETA_SUPPORT }
 					>
 						{ __( 'Submit Beta feedback' ) }
 					</NoticeAction>

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -25,6 +25,7 @@ import {
 } from 'state/site';
 import { getSiteConnectionStatus } from 'state/connection';
 import JetpackBanner from 'components/jetpack-banner';
+import { JETPACK_CONTACT_SUPPORT } from 'constants';
 
 const SupportCard = React.createClass( {
 	displayName: 'SupportCard',
@@ -94,7 +95,7 @@ const SupportCard = React.createClass( {
 								onClick={ this.trackAskQuestionClick }
 								href={ this.props.isAtomicSite
 									? 'https://wordpress.com/help/contact/'
-									: 'https://jetpack.com/contact-support/'
+									: JETPACK_CONTACT_SUPPORT
 								}
 							>
 								{ __( 'Ask a question' ) }

--- a/_inc/client/constants.js
+++ b/_inc/client/constants.js
@@ -1,1 +1,3 @@
 export const imagePath = window.Initial_State.pluginBaseUrl + '/images/';
+export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support?rel=support';
+export const JETPACK_CONTACT_BETA_SUPPORT = 'https://jetpack.com/contact-support/beta-group';

--- a/_inc/client/constants.js
+++ b/_inc/client/constants.js
@@ -1,3 +1,3 @@
 export const imagePath = window.Initial_State.pluginBaseUrl + '/images/';
-export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support?rel=support';
+export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support';
 export const JETPACK_CONTACT_BETA_SUPPORT = 'https://jetpack.com/contact-support/beta-group';


### PR DESCRIPTION
Introduces `JETPACK_CONTACT_SUPPORT` and `JETPACK_CONTACT_BETA_SUPPORT` in `_inc/client/constants`;

#### Changes proposed in this Pull Request:

* Updates files using that URL to use the constants instead.


#### Testing instructions:

* Visit the dashboard, check that the *Ask a question* button's URL takes to `https://jetpack.com/contact-support`


