### PR TITLE
Grav Hover: Ensure user object is present before using

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -239,7 +239,7 @@ function grofiles_hovercards_data_html( $author ) {
 		if ( $user ) {
 			$hash = md5( $user->user_email );
 		}
-	} else {
+	} elseif ( is_email( $author ) ) {
 		$hash = md5( $author );
 	}
 	

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -229,7 +229,7 @@ function grofiles_extra_data() {
 /**
  * Echoes the data from grofiles_hovercards_data() as HTML elements.
  *
- * @param int|string $author User ID or email address
+ * @param int|string|WP_User $author User ID, email address, or a WP_User object
  */
 function grofiles_hovercards_data_html( $author ) {
 	$data = grofiles_hovercards_data( $author );
@@ -241,6 +241,8 @@ function grofiles_hovercards_data_html( $author ) {
 		}
 	} elseif ( is_email( $author ) ) {
 		$hash = md5( $author );
+	} elseif ( is_a( $author, 'WP_User' ) {
+		$hash = md5( $author->user_email );
 	}
 	
 	if ( ! $hash ) {

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -229,6 +229,8 @@ function grofiles_extra_data() {
 /**
  * Echoes the data from grofiles_hovercards_data() as HTML elements.
  *
+ * @since 5.5.0 Add support for a passed WP_User object
+ *
  * @param int|string|WP_User $author User ID, email address, or a WP_User object
  */
 function grofiles_hovercards_data_html( $author ) {
@@ -241,7 +243,7 @@ function grofiles_hovercards_data_html( $author ) {
 		}
 	} elseif ( is_email( $author ) ) {
 		$hash = md5( $author );
-	} elseif ( is_a( $author, 'WP_User' ) {
+	} elseif ( is_a( $author, 'WP_User' ) ) {
 		$hash = md5( $author->user_email );
 	}
 	

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -233,11 +233,18 @@ function grofiles_extra_data() {
  */
 function grofiles_hovercards_data_html( $author ) {
 	$data = grofiles_hovercards_data( $author );
+	$hash = '';
 	if ( is_numeric( $author ) ) {
 		$user = get_userdata( $author );
-		$hash = md5( $user->user_email );
+		if ( $user ) {
+			$hash = md5( $user->user_email );
+		}
 	} else {
 		$hash = md5( $author );
+	}
+	
+	if ( ! $hash ) {
+		return;
 	}
 ?>
 	<div class="grofile-hash-map-<?php echo $hash; ?>">


### PR DESCRIPTION
Fixes `PHP Notice:  Trying to get property of non-object in ...jetpack/modules/gravatar-hovercards.php on line 238`

Ensure that the $user object is not false before using and return out early if we don't have a hash.

cc: @donnchawp 