### PR TITLE
Fix search plan support

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -95,9 +95,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<# if ( item.configurable ) { #>
 							<span class='configure'>{{{ item.configurable }}}</span>
 						<# } #>
-						<# if ( item.activated && 'vaultpress' !== item.module && item.available && 'videopress' !== item.module ) { #>
+						<# if ( item.activated && 'vaultpress' !== item.module && 'search' !== item.module && item.available && 'videopress' !== item.module ) { #>
 							<span class='delete'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php _e( 'Deactivate', 'jetpack' ); ?></a></span>
-						<# } else if ( item.available && 'videopress' !== item.module ) { #>
+						<# } else if ( item.available && 'videopress' !== item.module && 'search' !== item.module ) { #>
 							<span class='activate'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php _e( 'Activate', 'jetpack' ); ?></a></span>
 						<# } #>
 						</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1433,6 +1433,7 @@ class Jetpack {
 				'seo-tools',
 				'google-analytics',
 				'wordads',
+				'search',
 			);
 			$plan['class'] = 'business';
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -64,7 +64,7 @@ class Jetpack_Search {
 	 * @module search
 	 */
 	public function setup() {
-		if ( ! Jetpack::is_active() ) {
+		if ( ! Jetpack::is_active() || ! Jetpack::active_plan_supports( 'search' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
A bunch of free plans appear to have enabled the search module somehow. It won't work for them, since the API checks plan status, but it would help to also check plan support for search when initializing the plugin.