### PR TITLE
Admin Page: Replace call to own REST API with internal call for getting module list

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,8 +1,5 @@
 <?php
 include_once( 'class.jetpack-admin-page.php' );
-// Load API endpoint base classes and endpoints for getting the module list fed into the JS Admin Page
-require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
-require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 
 // Builds the landing page and its menu
 class Jetpack_React_Page extends Jetpack_Admin_Page {
@@ -220,6 +217,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			);
 		}
 
+		// Load API endpoint base classes and endpoints for getting the module list fed into the JS Admin Page
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 		$moduleListEndpoint = new Jetpack_Core_API_Module_List_Endpoint();
 		$modules = $moduleListEndpoint->get_modules();
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,5 +1,8 @@
 <?php
 include_once( 'class.jetpack-admin-page.php' );
+// Load API endpoint base classes and endpoints for getting the module list fed into the JS Admin Page
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 
 // Builds the landing page and its menu
 class Jetpack_React_Page extends Jetpack_Admin_Page {
@@ -217,8 +220,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			);
 		}
 
-		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/module/all' ) );
-		$modules = $response->get_data();
+		$moduleListEndpoint = new Jetpack_Core_API_Module_List_Endpoint();
+		$modules = $moduleListEndpoint->get_modules();
 
 		// Preparing translated fields for JSON encoding by transforming all HTML entities to
 		// respective characters.


### PR DESCRIPTION
Addresses #7952.

#### Changes proposed in this Pull Request:

* Replaces usage of `rest_do_request` for a call to `Jetpack_Core_API_Module_List_Endpoint:get_modules()`.

#### Testing instructions:

1. Checkout this branch.
1. Load the admin page.
1. Expect the admin page to load properly If this PR introduced any problem, the Admin Page wouldn't load
