### PR TITLE
Moved the Milestone widget i18n and calculation out of client side code.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -48,6 +48,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		// Load API endpoints
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php';
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php';
 
 		self::$user_permissions_error_msg = esc_html__(
 			'You do not have the correct user permissions to perform this action.
@@ -64,6 +65,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$module_data_endpoint = new Jetpack_Core_API_Module_Data_Endpoint();
 		$module_toggle_endpoint = new Jetpack_Core_API_Module_Toggle_Endpoint( new Jetpack_IXR_Client() );
 		$site_endpoint = new Jetpack_Core_API_Site_Endpoint();
+		$widget_endpoint = new Jetpack_Core_API_Widget_Endpoint();
 
 		register_rest_route( 'jetpack/v4', '/jitm', array(
 			'methods'  => WP_REST_Server::READABLE,
@@ -331,6 +333,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::get_plugin',
 			'permission_callback' => __CLASS__ . '::activate_plugins_permission_check',
+		) );
+
+		// Widgets: get information about a widget that supports it.
+		register_rest_route( 'jetpack/v4', '/widgets/(?P<id>[0-9a-z\-_]+)', array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => array( $widget_endpoint, 'process' ),
+			'permission_callback' => array( $widget_endpoint, 'can_request' ),
 		) );
 	}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Widget information getter endpoint.
+ *
+ */
+class Jetpack_Core_API_Widget_Endpoint {
+
+	/**
+	 * @since 5.5.0
+	 *
+	 * @param WP_REST_Request $request {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $id Widget id.
+	 * }
+	 *
+	 * @return WP_REST_Response|WP_Error A REST response if the request was served successfully, otherwise an error.
+	 */
+	public function process( $request ) {
+		$widgets = get_option( 'sidebars_widgets', array() );
+
+		$widget_base = _get_widget_id_base( $request['id'] );
+		$widget_id = (int) substr( $request['id'], strlen( $widget_base ) + 1 );
+
+		$instances = get_option( 'widget_' . $widget_base, array() );
+
+		$instance = $instances[ $widget_id ];
+
+		$widget = new Milestone_Widget();
+
+		return $widget->get_widget_data( $instance );
+	}
+
+	/**
+	 * Check that the current user has permissions to manage Jetpack modules.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return bool
+	 */
+	public function can_request() {
+		return true;
+	}
+}

--- a/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
@@ -17,22 +17,30 @@ class Jetpack_Core_API_Widget_Endpoint {
 	 * @return WP_REST_Response|WP_Error A REST response if the request was served successfully, otherwise an error.
 	 */
 	public function process( $request ) {
-		$widgets = get_option( 'sidebars_widgets', array() );
-
 		$widget_base = _get_widget_id_base( $request['id'] );
 		$widget_id = (int) substr( $request['id'], strlen( $widget_base ) + 1 );
 
-		$instances = get_option( 'widget_' . $widget_base, array() );
+		switch( $widget_base ) {
+			case 'milestone_widget':
+				$instances = get_option( 'widget_milestone_widget', array() );
 
-		$instance = $instances[ $widget_id ];
+				if ( isset( $instances[ $widget_id ] ) ) {
+					$instance = $instances[ $widget_id ];
+					$widget = new Milestone_Widget();
+					return $widget->get_widget_data( $instance );
+				}
+		}
 
-		$widget = new Milestone_Widget();
-
-		return $widget->get_widget_data( $instance );
+		return new WP_Error(
+			'not_found',
+			esc_html__( 'The requested widget was not found.', 'jetpack' ),
+			array( 'status' => 404 )
+		);
 	}
 
 	/**
-	 * Check that the current user has permissions to manage Jetpack modules.
+	 * Check that the current user has permissions to view widget information.
+	 * For the currently supported widget there are no permissions required.
 	 *
 	 * @since 4.3.0
 	 *

--- a/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
@@ -24,7 +24,11 @@ class Jetpack_Core_API_Widget_Endpoint {
 			case 'milestone_widget':
 				$instances = get_option( 'widget_milestone_widget', array() );
 
-				if ( isset( $instances[ $widget_id ] ) ) {
+				if (
+					class_exists( 'Milestone_Widget' )
+					&& is_active_widget( false, $widget_base . '-' . $widget_id, $widget_base )
+					&& isset( $instances[ $widget_id ] )
+				) {
 					$instance = $instances[ $widget_id ];
 					$widget = new Milestone_Widget();
 					return $widget->get_widget_data( $instance );

--- a/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php
@@ -46,7 +46,7 @@ class Jetpack_Core_API_Widget_Endpoint {
 	 * Check that the current user has permissions to view widget information.
 	 * For the currently supported widget there are no permissions required.
 	 *
-	 * @since 4.3.0
+	 * @since 5.5.0
 	 *
 	 * @return bool
 	 */

--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -12,7 +12,7 @@ var Milestone = ( function( $ ) {
 			$.ajax( {
 				url: MilestoneConfig.api_root + 'jetpack/v4/widgets/' + id,
 				success: function( result ) {
-					$widget.find( '.milestone-message' ).html( result.message );
+					$widget.find( '.milestone-countdown' ).replaceWith( result.message );
 					refresh = result.refresh * 1000;
 
 					if ( ! refresh ) {

--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -2,171 +2,37 @@
 
 var Milestone = ( function( $ ) {
 	var Milestone = function ( args ) {
-		var num,
-			labels = MilestoneConfig.labels;
-
-		this.id = args.id;
-		this.diff = args.diff;
-		this.message = args.message;
-		this.unit = args.unit;
-		this.type = args.type;
-		this.widget = $( '#' + this.id );
-		this.widgetContent = this.widget.find( '.milestone-content' );
-		this.secondsPerMonth = 2628000;
-		this.secondsPerDay = 86400;
-		this.secondsPerHour = 3600;
-		this.secondsPerMinute = 60;
-
-		this.getYears = function() {
-			num = ( this.diff / 60 / 60 / 24 / 365 ).toFixed( 1 );
-
-			if ( 0 === num.charAt( num.length - 1 ) ) {
-				num = Math.floor( num );
-			}
-
-			return num;
-		};
-
-		this.getYearsLabel = function() {
-			return labels.years;
-		};
-
-		this.getMonths = function() {
-			return Math.floor( this.diff / 60 / 60 / 24 / 30 );
-		};
-
-		this.getMonthsLabel = function() {
-			return ( 1 === this.number ) ? labels.month : labels.months;
-		};
-
-		this.getDays = function() {
-			return Math.floor( this.diff / 60 / 60 / 24 ) + 1;
-		};
-
-		this.getDaysLabel = function() {
-			return ( 1 === this.number ) ? labels.day : labels.days;
-		};
-
-		this.getHours = function() {
-			return Math.floor( this.diff / 60 / 60 );
-		};
-
-		this.getHoursLabel = function() {
-			return ( 1 === this.number ) ? labels.hour : labels.hours;
-		};
-
-		this.getMinutes = function() {
-			return Math.floor( this.diff / 60 ) + 1;
-		};
-
-		this.getMinutesLabel = function() {
-			return ( 1 === this.number ) ? labels.minute : labels.minutes;
-		};
-
-		this.getSeconds = function() {
-			return this.diff;
-		};
-
-		this.getSecondsLabel = function() {
-			return ( 1 === this.number ) ? labels.second : labels.seconds;
-		};
+		var $widget = $( '#' + args.id ),
+			id = args.id,
+			refresh = args.refresh * 1000;
 
 		this.timer = function() {
-			if ( 'until' === this.type ) {
-				this.diff = this.diff - 1;
-			} else {
-				this.diff = this.diff + 1;
-			}
+			var instance = this;
 
-			switch ( this.unit ) {
-				case 'months':
-					if ( this.diff >= this.secondsPerMonth ) { // more than 1 month - show in months
-						this.number = this.getMonths();
-						this.label = this.getMonthsLabel();
-					} else if ( this.diff >= this.secondsPerDay - 1 ) { // less than 1 month - show in days
-						this.number = this.getDays();
-						this.label = this.getDaysLabel();
-					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
-						this.number = this.getHours();
-						this.label = this.getHoursLabel();
-					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
-						this.number = this.getMinutes();
-						this.label = this.getMinutesLabel();
-					} else { // less than 1 minute - show in seconds
-						this.number = this.getSeconds();
-						this.label = this.getSecondsLabel();
+			$.ajax( {
+				url: MilestoneConfig.api_root + 'jetpack/v4/widgets/' + id,
+				success: function( result ) {
+					$widget.find( '.milestone-message' ).html( result.message );
+					refresh = result.refresh * 1000;
+
+					if ( ! refresh ) {
+						return;
 					}
 
-					break;
-				case 'days':
-					if ( this.diff >= this.secondsPerDay - 1 ) { // more than 1 day - show in days
-						this.number = this.getDays();
-						this.label = this.getDaysLabel();
-					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
-						this.number = this.getHours();
-						this.label = this.getHoursLabel();
-					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
-						this.number = this.getMinutes();
-						this.label = this.getMinutesLabel();
-					} else { // less than 1 minute - show in seconds
-						this.number = this.getSeconds();
-						this.label = this.getSecondsLabel();
-					}
-
-					break;
-				case 'hours':
-					if ( this.diff >= this.secondsPerHour - 1 ) { // more than 1 hour - show in hours
-						this.number = this.getHours();
-						this.label = this.getHoursLabel();
-					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
-						this.number = this.getMinutes();
-						this.label = this.getMinutesLabel();
-					} else { // less than 1 minute - show in seconds
-						this.number = this.getSeconds();
-						this.label = this.getSecondsLabel();
-					}
-
-					break;
-				default:
-					if ( this.diff >= 63113852 ) { // more than 2 years - show in years, one decimal point
-						this.number = this.getYears();
-						this.label = this.getYearsLabel();
-					} else if ( this.diff >= 7775999 ) { // fewer than 2 years - show in months
-						this.number = this.getMonths();
-						this.label = this.getMonthsLabel();
-					} else if ( this.diff >= this.secondsPerDay - 1 ) { // fewer than 3 months - show in days
-						this.number = this.getDays();
-						this.label = this.getDaysLabel();
-					} else if ( this.diff >= this.secondsPerHour - 1 ) { // less than 1 day - show in hours
-						this.number = this.getHours();
-						this.label = this.getHoursLabel();
-					} else if ( this.diff >= this.secondsPerMinute - 1 ) { // less than 1 hour - show in minutes
-						this.number = this.getMinutes();
-						this.label = this.getMinutesLabel();
-					} else { // less than 1 minute - show in seconds
-						this.number = this.getSeconds();
-						this.label = this.getSecondsLabel();
-					}
-			}
-
-			this.widget.find( '.difference' ).html( this.number );
-			this.widget.find( '.label' ).html( this.label );
-
-			// Milestone has been reached.
-			if ( 1 > this.diff ) {
-				// Message is not applicable when counting up to future date.
-				if ( this.type === 'since' ) {
-					this.widget.find( '.milestone-countdown' ).remove();
-				} else {
-					this.widget.find( '.milestone-countdown' ).replaceWith( '<div class="milestone-message">' + this.message + '</div>' );
+					setTimeout(
+						function() {
+							instance.timer();
+						},
+						refresh
+					);
 				}
-			} else {
-				var instance = this;
-				setTimeout( function() { instance.timer(); }, 1000 );
-			}
+			} );
+
 		};
 
-		this.timer();
+		if ( refresh > 0 ) {
+			this.timer();
+		}
 	};
 	return function ( args ) {
 		return new Milestone( args );

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -396,17 +396,44 @@ class Milestone_Widget extends WP_Widget {
 	protected function get_unit( $seconds, $maximum_unit = 'automatic' ) {
 		$unit = '';
 
-		if ( $seconds >= 63113852 ) { // more than 2 years - show in years, one decimal point
+		if ( $seconds >= YEAR_IN_SECONDS * 2 ) {
+			// more than 2 years - show in years, one decimal point
 			$unit = 'years';
-		} else if ( $seconds >= 7775999 ) { // fewer than 2 years - show in months
+
+		} else if ( $seconds >= YEAR_IN_SECONDS ) {
+			if ( 'years' === $maximum_unit ) {
+				$unit = 'years';
+			} else {
+				// automatic mode - showing months even if it's between one and two years
+				$unit = 'months';
+			}
+
+		} else if ( $seconds >= MONTH_IN_SECONDS * 3 ) {
+			// fewer than 2 years - show in months
 			$unit = 'months';
-		} else if ( $seconds >= DAY_IN_SECONDS - 1 ) { // fewer than 3 months - show in days
+
+		} else if ( $seconds >= MONTH_IN_SECONDS ) {
+			if ( 'months' === $maximum_unit ) {
+				$unit = 'months';
+			} else {
+				// automatic mode - showing days even if it's between one and three months
+				$unit = 'days';
+			}
+
+		} else if ( $seconds >= DAY_IN_SECONDS - 1 ) {
+			// fewer than a month - show in days
 			$unit = 'days';
-		} else if ( $seconds >= HOUR_IN_SECONDS - 1 ) { // less than 1 day - show in hours
+
+		} else if ( $seconds >= HOUR_IN_SECONDS - 1 ) {
+			// less than 1 day - show in hours
 			$unit = 'hours';
-		} else if ( $seconds >= MINUTE_IN_SECONDS - 1 ) { // less than 1 hour - show in minutes
+
+		} else if ( $seconds >= MINUTE_IN_SECONDS - 1 ) {
+			// less than 1 hour - show in minutes
 			$unit = 'minutes';
-		} else { // less than 1 minute - show in seconds
+
+		} else {
+			// less than 1 minute - show in seconds
 			$unit = 'seconds';
 		}
 
@@ -432,7 +459,9 @@ class Milestone_Widget extends WP_Widget {
 	protected function get_interval_in_units( $seconds, $units ) {
 		switch ( $units ) {
 			case 'years':
-				return (int) ( $seconds / 60 / 60 / 24 / 365 );
+				$years = $seconds / YEAR_IN_SECONDS;
+				$decimals = abs( round( $years, 1 ) - round( $years ) ) > 0 ? 1 : 0;
+				return number_format_i18n( $years, $decimals );
 			case 'months':
 				return (int) ( $seconds / 60 / 60 / 24 / 30 );
 			case 'days':
@@ -526,10 +555,11 @@ class Milestone_Widget extends WP_Widget {
 		$instance = $this->sanitize_instance( $instance );
 
 		$units = array(
-			'automatic' => __( 'Automatic', 'jetpack' ),
-			'months' => __( 'Months', 'jetpack' ),
-			'days' => __( 'Days', 'jetpack' ),
-			'hours' => __( 'Hours', 'jetpack' ),
+			'automatic' => _x( 'Automatic', 'Milestone widget: mode in which the date unit is determined automatically', 'jetpack' ),
+			'years' => _x( 'Years', 'Milestone widget: mode in which the date unit is set to years', 'jetpack' ),
+			'months' => _x( 'Months', 'Milestone widget: mode in which the date unit is set to months', 'jetpack' ),
+			'days' => _x( 'Days', 'Milestone widget: mode in which the date unit is set to days', 'jetpack' ),
+			'hours' => _x( 'Hours', 'Milestone widget: mode in which the date unit is set to hours', 'jetpack' ),
 		);
 		?>
 

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -246,8 +246,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'years':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">year ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">years ago.</span>',
+								'<span class="difference">%s</span> <span class="label">year ago.</span>',
+								'<span class="difference">%s</span> <span class="label">years ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -257,8 +257,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'months':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">month ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">months ago.</span>',
+								'<span class="difference">%s</span> <span class="label">month ago.</span>',
+								'<span class="difference">%s</span> <span class="label">months ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -268,8 +268,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'days':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">day ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">days ago.</span>',
+								'<span class="difference">%s</span> <span class="label">day ago.</span>',
+								'<span class="difference">%s</span> <span class="label">days ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -279,8 +279,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'hours':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">hour ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">hours ago.</span>',
+								'<span class="difference">%s</span> <span class="label">hour ago.</span>',
+								'<span class="difference">%s</span> <span class="label">hours ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -290,8 +290,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'minutes':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">minute ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">minutes ago.</span>',
+								'<span class="difference">%s</span> <span class="label">minute ago.</span>',
+								'<span class="difference">%s</span> <span class="label">minutes ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -301,8 +301,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'seconds':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">second ago.</span>',
-								'<span class="difference">%1$s</span> <span class="label">seconds ago.</span>',
+								'<span class="difference">%s</span> <span class="label">second ago.</span>',
+								'<span class="difference">%s</span> <span class="label">seconds ago.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -315,8 +315,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'years':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">year to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">years to go.</span>',
+								'<span class="difference">%s</span> <span class="label">year to go.</span>',
+								'<span class="difference">%s</span> <span class="label">years to go.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -326,8 +326,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'months':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">month to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">months to go.</span>',
+								'<span class="difference">%s</span> <span class="label">month to go.</span>',
+								'<span class="difference">%s</span> <span class="label">months to go.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -337,8 +337,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'days':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">day to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">days to go.</span>',
+								'<span class="difference">%s</span> <span class="label">day to go.</span>',
+								'<span class="difference">%s</span> <span class="label">days to go.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -348,8 +348,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'hours':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">hour to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">hours to go.</span>',
+								'<span class="difference">%s</span> <span class="label">hour to go.</span>',
+								'<span class="difference">%s</span> <span class="label">hours to go.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -359,8 +359,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'minutes':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">minute to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">minutes to go.</span>',
+								'<span class="difference">%s</span> <span class="label">minute to go.</span>',
+								'<span class="difference">%s</span> <span class="label">minutes to go.</span>',
 								$interval,
 								'jetpack'
 							),
@@ -370,8 +370,8 @@ class Milestone_Widget extends WP_Widget {
 					case 'seconds':
 						$data['message'] = sprintf(
 							_n(
-								'<span class="difference">%1$s</span> <span class="label">second to go.</span>',
-								'<span class="difference">%1$s</span> <span class="label">seconds to go.</span>',
+								'<span class="difference">%s</span> <span class="label">second to go.</span>',
+								'<span class="difference">%s</span> <span class="label">seconds to go.</span>',
 								$interval,
 								'jetpack'
 							),

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -192,7 +192,7 @@ class Milestone_Widget extends WP_Widget {
 		echo '<span class="date">' . esc_html( date_i18n( get_option( 'date_format' ), $data['milestone'] ) ) . '</span>';
 		echo '</div>';
 
-		echo '<div class="milestone-message">' . $data['message'] . '</div>';
+		echo $data['message'];
 
 		echo '</div><!--milestone-content-->';
 
@@ -234,7 +234,7 @@ class Milestone_Widget extends WP_Widget {
 		$data['milestone'] = $milestone;
 
 		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
-			$data['message'] = $instance['message'];
+			$data['message'] = '<div class="milestone-message">' . $instance['message'] . '</div>';
 			$data['refresh'] = 0; // No need to refresh, the milestone has been reached
 		} else {
 			$interval_text = $this->get_interval_in_units( $diff, $data['unit'] );
@@ -380,6 +380,7 @@ class Milestone_Widget extends WP_Widget {
 					break;
 				}
 			}
+			$data['message'] = '<div class="milestone-countdown">' . $data['message'] . '</div>';
 		}
 
 		return $data;

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -171,6 +171,7 @@ class Milestone_Widget extends WP_Widget {
 	function widget( $args, $instance ) {
 		echo $args['before_widget'];
 
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . $title . $args['after_title'];

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -16,9 +16,21 @@ add_action( 'widgets_init', 'jetpack_register_widget_milestone' );
 class Milestone_Widget extends WP_Widget {
 	private static $dir       = null;
 	private static $url       = null;
-	private static $labels    = null;
 	private static $defaults  = null;
 	private static $config_js = null;
+
+	/**
+	 * Available time units sorted in descending order.
+	 * @var Array
+	 */
+	protected $available_units = array(
+		'years',
+		'months',
+		'days',
+		'hours',
+		'minutes',
+		'seconds'
+	);
 
 	function __construct() {
 		$widget = array(
@@ -35,20 +47,6 @@ class Milestone_Widget extends WP_Widget {
 
 		self::$dir = trailingslashit( dirname( __FILE__ ) );
 		self::$url = plugin_dir_url( __FILE__ );
-		self::$labels = array(
-			'year'    => __( 'year', 'jetpack' ),
-			'years'   => __( 'years', 'jetpack' ),
-			'month'   => __( 'month', 'jetpack' ),
-			'months'  => __( 'months', 'jetpack' ),
-			'day'     => __( 'day', 'jetpack' ),
-			'days'    => __( 'days', 'jetpack' ),
-			'hour'    => __( 'hour', 'jetpack' ),
-			'hours'   => __( 'hours', 'jetpack' ),
-			'minute'  => __( 'minute', 'jetpack' ),
-			'minutes' => __( 'minutes', 'jetpack' ),
-			'second'  => __( 'second', 'jetpack' ),
-			'seconds' => __( 'seconds', 'jetpack' ),
-		);
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
@@ -163,14 +161,49 @@ class Milestone_Widget extends WP_Widget {
 			wp_dequeue_script( 'milestone' );
 			return;
 		}
-		self::$config_js['labels'] = self::$labels;
+		self::$config_js['api_root'] = esc_url_raw( rest_url() );
 		wp_localize_script( 'milestone', 'MilestoneConfig', self::$config_js );
 	}
 
-    /**
-     * Widget
-     */
-    function widget( $args, $instance ) {
+	/**
+	 * Widget
+	 */
+	function widget( $args, $instance ) {
+		echo $args['before_widget'];
+
+		$title = apply_filters( 'widget_title', $instance['title'] );
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
+
+		$data = $this->get_widget_data( $instance );
+
+		self::$config_js['instances'][] = array(
+			'id'      => $args['widget_id'],
+			'message' => $data['message'],
+			'refresh' => $data['refresh']
+		);
+
+		echo '<div class="milestone-content">';
+
+		echo '<div class="milestone-header">';
+		echo '<strong class="event">' . esc_html( $instance['event'] ) . '</strong>';
+		echo '<span class="date">' . esc_html( date_i18n( get_option( 'date_format' ), $data['milestone'] ) ) . '</span>';
+		echo '</div>';
+
+		echo '<div class="milestone-message">' . $data['message'] . '</div>';
+
+		echo '</div><!--milestone-content-->';
+
+		echo $args['after_widget'];
+
+		/** This action is documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'milestone' );
+	}
+
+	function get_widget_data( $instance ) {
+		$data = array();
+
 		$instance = $this->sanitize_instance( $instance );
 
 		$milestone = mktime( $instance['hour'], $instance['min'], 0, $instance['month'], $instance['day'], $instance['year'] );
@@ -183,59 +216,240 @@ class Milestone_Widget extends WP_Widget {
 			$diff = (int) floor( $milestone - $now );
 		}
 
-		echo $args['before_widget'];
+		$data['diff'] = $diff;
+		$data['unit'] = $this->get_unit( $diff, $instance['unit'] );
 
-		$title = apply_filters( 'widget_title', $instance['title'] );
-		if ( ! empty( $title ) ) {
-			echo $args['before_title'] . $title . $args['after_title'];
-		}
+		// Setting the refresh counter to equal the number of seconds it takes to flip a unit
+		$refresh_intervals = array(
+			0, // should be YEAR_IN_SECONDS, but doing setTimeout for a year doesn't seem to be logical
+			0, // same goes for MONTH_IN_SECONDS,
+			DAY_IN_SECONDS,
+			HOUR_IN_SECONDS,
+			MINUTE_IN_SECONDS,
+			1
+		);
 
-		echo '<div class="milestone-content">';
-
-		echo '<div class="milestone-header">';
-		echo '<strong class="event">' . esc_html( $instance['event'] ) . '</strong>';
-		echo '<span class="date">' . esc_html( date_i18n( __( 'F jS, Y', 'jetpack' ), $milestone ) ) . '</span>';
-		echo '</div>';
+		$data['refresh'] = $refresh_intervals[ array_search( $data['unit'], $this->available_units ) ];
+		$data['milestone'] = $milestone;
 
 		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
-			echo '<div class="milestone-message">' . $instance['message'] . '</div>';
+			$data['message'] = $instance['message'];
+			$data['refresh'] = 0; // No need to refresh, the milestone has been reached
 		} else {
+			$interval_text = $this->get_interval_in_units( $diff, $data['unit'] );
+			$interval = intval( $interval_text );
+
 			if ( 'since' === $type ) {
-				$text = __( 'ago.', 'jetpack' );
+
+				switch ( $data['unit'] ) {
+					case 'years':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">year ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">years ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'months':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">month ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">months ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'days':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">day ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">days ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'hours':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">hour ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">hours ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'minutes':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">minute ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">minutes ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'seconds':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">second ago.</span>',
+								'<span class="difference">%1$s</span> <span class="label">seconds ago.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+				}
 			} else {
-				$text = __( 'to go.', 'jetpack' );
+				switch ( $this->get_unit( $diff, $instance['unit'] ) ) {
+					case 'years':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">year to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">years to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'months':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">month to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">months to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'days':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">day to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">days to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'hours':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">hour to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">hours to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'minutes':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">minute to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">minutes to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+					case 'seconds':
+						$data['message'] = sprintf(
+							_n(
+								'<span class="difference">%1$s</span> <span class="label">second to go.</span>',
+								'<span class="difference">%1$s</span> <span class="label">seconds to go.</span>',
+								$interval,
+								'jetpack'
+							),
+							$interval_text
+						);
+					break;
+				}
 			}
-
-			/* Countdown to the milestone. */
-			echo '<div class="milestone-countdown">' . sprintf( __( '%1$s %2$s %3$s', 'jetpack' ),
-				'<span class="difference"></span>',
-				'<span class="label"></span>',
-				$text
-			) . '</div>';
-
-			self::$config_js['instances'][] = array(
-				'id'      => $args['widget_id'],
-				'diff'    => $diff,
-				'message' => $instance['message'],
-				'unit'    => $instance['unit'],
-				'type'    => $instance['type'],
-			);
 		}
 
-		echo '</div><!--milestone-content-->';
+		return $data;
+	}
 
-		echo $args['after_widget'];
+	/**
+	 * Return the largest possible time unit that the difference will be displayed in.
+	 *
+	 * @param Integer $seconds the interval in seconds
+	 * @param String $maximum_unit the maximum unit that will be used. Optional.
+	 * @return String $calculated_unit
+	 */
+	protected function get_unit( $seconds, $maximum_unit = 'automatic' ) {
+		$unit = '';
 
-	    /** This action is documented in modules/widgets/gravatar-profile.php */
-	    do_action( 'jetpack_stats_extra', 'widget_view', 'milestone' );
-    }
+		if ( $seconds >= 63113852 ) { // more than 2 years - show in years, one decimal point
+			$unit = 'years';
+		} else if ( $seconds >= 7775999 ) { // fewer than 2 years - show in months
+			$unit = 'months';
+		} else if ( $seconds >= DAY_IN_SECONDS - 1 ) { // fewer than 3 months - show in days
+			$unit = 'days';
+		} else if ( $seconds >= HOUR_IN_SECONDS - 1 ) { // less than 1 day - show in hours
+			$unit = 'hours';
+		} else if ( $seconds >= MINUTE_IN_SECONDS - 1 ) { // less than 1 hour - show in minutes
+			$unit = 'minutes';
+		} else { // less than 1 minute - show in seconds
+			$unit = 'seconds';
+		}
 
-    /**
-     * Update
-     */
-    function update( $new_instance, $old_instance ) {
+		$maximum_unit_index = array_search( $maximum_unit, $this->available_units );
+		$unit_index = array_search( $unit, $this->available_units );
+
+		if (
+			false === $maximum_unit_index // the maximum unit parameter is automatic
+			|| $unit_index > $maximum_unit_index // there is not enough seconds for even one maximum time unit
+		) {
+			return $unit;
+		}
+		return $maximum_unit;
+	}
+
+	/**
+	 * Returns a time difference value in specified units.
+	 *
+	 * @param Integer $seconds
+	 * @param String $units
+	 * @return Integer|String $time_in_units
+	 */
+	protected function get_interval_in_units( $seconds, $units ) {
+		switch ( $units ) {
+			case 'years':
+				return (int) ( $seconds / 60 / 60 / 24 / 365 );
+			case 'months':
+				return (int) ( $seconds / 60 / 60 / 24 / 30 );
+			case 'days':
+				return (int) ( $seconds / 60 / 60 / 24 + 1 );
+			case 'hours':
+				return (int) ( $seconds / 60 / 60 );
+			case 'minutes':
+				return (int) ( $seconds / 60 + 1 );
+			default:
+				return $seconds;
+		}
+	}
+
+	/**
+	 * Update
+	 */
+	function update( $new_instance, $old_instance ) {
 		return $this->sanitize_instance( $new_instance );
-    }
+	}
 
 	/*
 	 * Make sure that a number is within a certain range.
@@ -303,10 +517,10 @@ class Milestone_Widget extends WP_Widget {
 		return $clean;
 	}
 
-    /**
-     * Form
-     */
-    function form( $instance ) {
+	/**
+	 * Form
+	 */
+	function form( $instance ) {
 		$instance = $this->sanitize_instance( $instance );
 
 		$units = array(

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -899,10 +899,10 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 					'type' => 'until',
 					'message' => 'The big day is here.',
 					'year' => date( 'Y' ) + 10,
-					'month' => '10',
+					'month' => date( 'm' ),
 					'hour' => '0',
 					'min' => '00',
-					'day' => '6'
+					'day' => date( 'd' )
 				)
 			)
 		);
@@ -917,6 +917,34 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			),
 			$response
 		);
+	}
+
+	/**
+	 * Test fetching a widget that does not exist.
+	 *
+	 * @since 5.5.0
+	 */
+	public function test_fetch_nonexistent_widget_data() {
+		jetpack_register_widget_milestone();
+
+		$response = $this->create_and_get_request( 'widgets/some_other_slug-133', array(), 'GET' );
+
+		// Fails because user is not authenticated
+		$this->assertResponseStatus( 404, $response );
+	}
+
+	/**
+	 * Test fetching a nonexistent instance of an existing widget.
+	 *
+	 * @since 5.5.0
+	 */
+	public function test_fetch_nonexistent_widget_instance_data() {
+		jetpack_register_widget_milestone();
+
+		$response = $this->create_and_get_request( 'widgets/milestone_widget-333', array(), 'GET' );
+
+		// Fails because user is not authenticated
+		$this->assertResponseStatus( 404, $response );
 	}
 
 } // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -925,7 +925,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'widgets/milestone_widget-3', array(), 'GET' );
 
-		// Fails because user is not authenticated
+		// Should return the widget data
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData(
 			array(
@@ -934,6 +934,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			$response
 		);
 
+		// Cleaning up the sidebars
 		$sidebars = wp_get_sidebars_widgets();
 		foreach( $sidebars as $key => $sidebar ) {
 			$sidebars[ $key ] = array_diff( $sidebar, array( 'milestone_widget-3' ) );
@@ -952,7 +953,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'widgets/some_other_slug-133', array(), 'GET' );
 
-		// Fails because user is not authenticated
+		// Fails because there is no such widget
 		$this->assertResponseStatus( 404, $response );
 
 		unregister_widget( 'Milestone_Widget' );
@@ -968,7 +969,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'widgets/milestone_widget-333', array(), 'GET' );
 
-		// Fails because user is not authenticated
+		// Fails because there is no such widget instance
 		$this->assertResponseStatus( 404, $response );
 
 		unregister_widget( 'Milestone_Widget' );
@@ -996,7 +997,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'widgets/milestone_widget-3', array(), 'GET' );
 
-		// Fails because user is not authenticated
+		// Fails because the widget is inactive
 		$this->assertResponseStatus( 404, $response );
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -4,6 +4,8 @@
  *
  * @since 4.4.0
  */
+require_once( dirname( __FILE__ ) . '/../../../../modules/widgets/milestone.php' );
+
 class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 	/**
@@ -877,6 +879,44 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Test deactivation of Jumpstart
 		$response = $this->create_and_get_request( 'jumpstart', array( 'active' => false ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * Test fetching milestone widget data.
+	 *
+	 * @since 5.5.0
+	 */
+	public function test_fetch_milestone_widget_data() {
+		jetpack_register_widget_milestone();
+
+		update_option(
+			'widget_milestone_widget',
+			array(
+				3 => array(
+					'title' => 'Ouou',
+					'event' => 'The Biog Day',
+					'unit' => 'years',
+					'type' => 'until',
+					'message' => 'The big day is here.',
+					'year' => date( 'Y' ) + 10,
+					'month' => '10',
+					'hour' => '0',
+					'min' => '00',
+					'day' => '6'
+				)
+			)
+		);
+
+		$response = $this->create_and_get_request( 'widgets/milestone_widget-3', array(), 'GET' );
+
+		// Fails because user is not authenticated
+		$this->assertResponseStatus( 200, $response );
+		$this->assertResponseData(
+			array(
+				'message' => '<span class="difference">10</span> <span class="label">years to go.</span>'
+			),
+			$response
+		);
 	}
 
 } // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -929,7 +929,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData(
 			array(
-				'message' => '<span class="difference">10</span> <span class="label">years to go.</span>'
+				'message' => '<div class="milestone-countdown"><span class="difference">10</span> <span class="label">years to go.</span></div>'
 			),
 			$response
 		);

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -891,23 +891,22 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		global $_wp_sidebars_widgets, $wp_registered_widgets;
 
-		update_option(
-			'widget_milestone_widget',
-			array(
-				3 => array(
-					'title' => 'Ouou',
-					'event' => 'The Biog Day',
-					'unit' => 'years',
-					'type' => 'until',
-					'message' => 'The big day is here.',
-					'year' => date( 'Y' ) + 10,
-					'month' => date( 'm' ),
-					'hour' => '0',
-					'min' => '00',
-					'day' => date( 'd' )
-				)
+		$widget_instances = array(
+			3 => array(
+				'title' => 'Ouou',
+				'event' => 'The Biog Day',
+				'unit' => 'years',
+				'type' => 'until',
+				'message' => 'The big day is here.',
+				'year' => date( 'Y' ) + 10,
+				'month' => date( 'm' ),
+				'hour' => '0',
+				'min' => '00',
+				'day' => date( 'd' )
 			)
 		);
+
+		update_option( 'widget_milestone_widget', $widget_instances );
 
 		$sidebars = wp_get_sidebars_widgets();
 		foreach( $sidebars as $key => $sidebar ) {
@@ -930,6 +929,24 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseData(
 			array(
 				'message' => '<div class="milestone-countdown"><span class="difference">10</span> <span class="label">years to go.</span></div>'
+			),
+			$response
+		);
+
+		$widget_instances[3] = array_merge(
+			$widget_instances[3],
+			array(
+				'year' => date( 'Y' ) + 1,
+				'unit' => 'months',
+			)
+		);
+		update_option( 'widget_milestone_widget', $widget_instances );
+		$response = $this->create_and_get_request( 'widgets/milestone_widget-3', array(), 'GET' );
+
+		$this->assertResponseStatus( 200, $response );
+		$this->assertResponseData(
+			array(
+				'message' => '<div class="milestone-countdown"><span class="difference">12</span> <span class="label">months to go.</span></div>'
 			),
 			$response
 		);


### PR DESCRIPTION
Fixes #7940, replaces #7942.

#### Changes proposed in this Pull Request:
* Adds a new unit test for the widget data getter.
* Moves i18n out of client side code to fully utilize gettext powers.
* Moves calculation out of the client side code, making server side data the only source of truth.
* Relies on REST API refreshes to show messages.

#### Testing instructions:
* Test various widget configurations: time units, until and since modes.
* Make sure unit tests pass.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed the Milestone widget in different translations.