### PR TITLE
Admin Page: Replace call to own REST API with internal call for getting site data

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -194,17 +194,12 @@ abstract class Jetpack_Admin_Page {
 
 		self::$plan_checked = true;
 		$previous = get_option( 'jetpack_active_plan', '' );
-		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/site' ) );
-
-		if ( ! is_object( $response ) || $response->is_error() ) {
-
+		$current = Jetpack_Core_Json_Api_Endpoints::site_data();
+		if ( ! $current || is_wp_error( $current ) ) {
 			// If we can't get information about the current plan we don't do anything
 			self::$plan_checked = true;
 			return;
 		}
-
-		$current = $response->get_data();
-		$current = json_decode( $current['data'] );
 
 		$to_deactivate = array();
 		if ( isset( $current->plan->product_slug ) ) {


### PR DESCRIPTION
Fixes #7952.

#### Changes proposed in this Pull Request:

* Introduces `Jetpack_Core_Json_Api_Endpoints::site_data()` which fetches the site data from wpcom
* Refactors `Jetpack_Core_Json_Api_Endpoints::get_site_data()` to use `self::site_data()`
* Replaces usage of `rest_do_request` for a call to `Jetpack_Core_Json_Api_Endpoints::site_data()` in `class.jetpack-admin-page.php`.

#### Testing instructions:

1. Checkout this branch.
1. Load the admin page.
1. Expect the admin page to load properly If this PR introduced any problem, the Admin Page wouldn't load
