### PR TITLE
Testimonial CPT: Confirm get_current_screen exists

### DIFF
--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -311,11 +311,10 @@ class Nova_Restaurant {
 	 * Change ‘Enter Title Here’ text for the Menu Item.
 	 */
 	function change_default_title( $title ) {
-		$screen = get_current_screen();
-
-		if ( self::MENU_ITEM_POST_TYPE == $screen->post_type )
+		if ( self::MENU_ITEM_POST_TYPE == get_post_type() ) {
 			/* translators: this is about a food menu */
 			$title = esc_html__( "Enter the menu item's name here", 'jetpack' );
+		}
 
 		return $title;
 	}

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -368,13 +368,9 @@ class Jetpack_Testimonial {
 	 * Change ‘Enter Title Here’ text for the Testimonial.
 	 */
 	function change_default_title( $title ) {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return $title;
-		}
-		$screen = get_current_screen();
-
-		if ( self::CUSTOM_POST_TYPE == $screen->post_type )
+		if ( self::CUSTOM_POST_TYPE == get_post_type() ) {
 			$title = esc_html__( "Enter the customer's name here", 'jetpack' );
+		}
 
 		return $title;
 	}

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -368,6 +368,9 @@ class Jetpack_Testimonial {
 	 * Change ‘Enter Title Here’ text for the Testimonial.
 	 */
 	function change_default_title( $title ) {
+		if ( ! function_exists( 'get_current_screen' ) {
+			return $title;
+		}
 		$screen = get_current_screen();
 
 		if ( self::CUSTOM_POST_TYPE == $screen->post_type )

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -368,7 +368,7 @@ class Jetpack_Testimonial {
 	 * Change ‘Enter Title Here’ text for the Testimonial.
 	 */
 	function change_default_title( $title ) {
-		if ( ! function_exists( 'get_current_screen' ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
 			return $title;
 		}
 		$screen = get_current_screen();


### PR DESCRIPTION
In front end editing situations, `get_current_screen` may not be available. If it isn't, return the title without modification.

Fixes #7955

#### Testing instructions:

* Using the Front End Editor feature plugin, confirm no fatals when the testimonial CPT is active.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Compatibility fix when using Testimonials and a front-end editing plugin