### PR TITLE
API: Introduce a bulk post restoration endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -71,6 +71,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-autosave-v1-1-endp
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-autosave-post-v1-1-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-post-counts-v1-1-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-bulk-delete-post-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-bulk-restore-post-endpoint.php' );
 
 // Custom Menus
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-menus-v1-1-endpoint.php' );

--- a/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -1,0 +1,68 @@
+<?php
+
+new WPCOM_JSON_API_Bulk_Restore_Post_Endpoint( array(
+	'description' => 'Restore multiple posts.',
+	'group'       => 'posts',
+	'stat'        => 'posts:1:bulk-restore',
+	'min_version' => '1.1',
+	'max_version' => '1.1',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/posts/restore',
+	'path_labels' => array(
+		'$site'    => '(int|string) Site ID or domain',
+	),
+	'request_format' => array(
+		'post_ids' => '(array|string) An array, or comma-separated list, of Post IDs to restore.',
+	),
+
+	'response_format' => array(
+		'results' => '(object) An object containing results, '
+	),
+
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/posts/restore',
+
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+
+		'body' => array(
+			'post_ids' => array( 881, 882 ),
+		),
+
+	)
+) );
+
+class WPCOM_JSON_API_Bulk_Restore_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
+	// /sites/%s/posts/restore
+	function callback( $path = '', $blog_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$input = $this->input();
+
+		if ( is_array( $input['post_ids'] ) ) {
+			$post_ids = (array) $input['post_ids'];
+		} else if ( ! empty( $input['post_ids'] ) ) {
+			$post_ids = explode( ',', $input['post_ids'] );
+		} else {
+			$post_ids = array();
+		}
+
+		if ( count( $post_ids ) < 1 ) {
+			return new WP_Error( 'empty_post_ids', 'The request must include post_ids' );
+		}
+
+		$result = array(
+			'results' => array(),
+		);
+
+		foreach( $post_ids as $post_id ) {
+			$result['results'][ $post_id ] = $this->restore_post( $path, $blog_id, $post_id );
+		}
+
+		return $result;
+	}
+}


### PR DESCRIPTION
Summary:
This diff introduces a new bulk post restoration endpoint. The endpoint will be used in the future to enable bulk restoration of posts via Calypso. The endpoint follows the behavior of the current single-post restoration endpoint.

This PR is similar to #7926 except for restoration as opposed to deletion.

Differential Revision: D7573-code

This commit syncs r163624-wpcom.
This commit syncs r163625-wpcom.



#### Testing instructions:

* Checkout branch.
* Use the developer console on developer.wordpress.com to make requests against your Jetpack site.
* Verify that the bulk restore endpoint at `/sites/$site/posts/restore` works the same as the single post restore endpoint at `/sites/$site/posts/$post_id/restore`, except that it takes an comma-separated list of `post_ids` as a request parameter as opposed the post_id in the path.