### PR TITLE
Contact Form: remove min-width on jquery datepicker styles

### DIFF
--- a/modules/contact-form/css/jquery-ui-datepicker.css
+++ b/modules/contact-form/css/jquery-ui-datepicker.css
@@ -9,7 +9,6 @@
 	border-top: none;
 	-webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
-	min-width: 17em;
 	width: auto;
 }
 


### PR DESCRIPTION
I noticed that the min-width on the jquery datepicker was causing some display issues. This PR removes the min-width, fixing the problem. Test cross-browser, and appears to fix the problem across the board.

Before:
<img width="371" alt="screen shot 2017-10-10 at 4 53 25 pm" src="https://user-images.githubusercontent.com/2522431/31410063-dc6fb798-addb-11e7-84e8-8fdab9de028b.png">

After:
<img width="343" alt="screen shot 2017-10-10 at 4 53 37 pm" src="https://user-images.githubusercontent.com/2522431/31410072-e1774008-addb-11e7-9d8d-5640eafc69d3.png">
