### PR TITLE
WP-Admin: Redirect Plugins and Users to Calypso

### DIFF
--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -28,8 +28,8 @@ class Calypso_Redirects {
 
 		// replace each menu item one by one with its redirect
 		add_submenu_page( 'users.php', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
-		add_submenu_page( 'users.php', __( 'Invite New' ), __( 'Invite New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
-		add_submenu_page( 'users.php', __( 'My Profile' ), __( 'My Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_submenu_page( 'users.php', __( 'Add New' ), __( 'Add New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
+		add_submenu_page( 'users.php', __( 'Your Profile' ), __( 'Your Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
 	}
 
 	private function register_user_redirect_handlers() {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -15,6 +15,8 @@ class Calypso_Redirects {
 		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
 		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
 		add_action( 'load-users_page_calypso-users-settings', array( $this, 'users_settings_redirect' ) );
+
+		add_action( 'load-toplevel_page_calypso-plugins', array( $this, 'plugins_redirect' ) );
 	}
 
 	private function register_user_redirects() {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -14,7 +14,7 @@ class Jetpack_Calypso_Redirects {
 
 		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_calypso_domain' ), 10, 1 );
 
-		add_action( 'load-toplevel_page_calypso-plugins', array( $this, 'plugins_redirect' ) );
+		add_action( 'load-toplevel_page_calypso_plugins', array( $this, 'plugins_redirect' ) );
 
 		if ( current_user_can( 'list_users' ) ) {
 			$this->register_user_redirect_handlers();
@@ -27,15 +27,15 @@ class Jetpack_Calypso_Redirects {
 		remove_submenu_page( 'users.php', 'profile.php' );
 
 		// replace each menu item one by one with its redirect
-		add_submenu_page( 'users.php', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
-		add_submenu_page( 'users.php', __( 'Add New' ), __( 'Add New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
-		add_submenu_page( 'users.php', __( 'Your Profile' ), __( 'Your Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_submenu_page( 'users.php', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso_users', array( $this, 'users_redirect' ) );
+		add_submenu_page( 'users.php', __( 'Add New' ), __( 'Add New' ), 'promote_users', 'calypso_users_new', array( $this, 'users_new_redirect' ) );
+		add_submenu_page( 'users.php', __( 'Your Profile' ), __( 'Your Profile' ), 'read', 'calypso_users_profile', array( $this, 'users_profile_redirect' ) );
 	}
 
 	private function register_user_redirect_handlers() {
-		add_action( 'load-users_page_calypso-users', array( $this, 'users_redirect' ) );
-		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
-		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_action( 'load-users_page_calypso_users', array( $this, 'users_redirect' ) );
+		add_action( 'load-users_page_calypso_users_new', array( $this, 'users_new_redirect' ) );
+		add_action( 'load-users_page_calypso_users_profile', array( $this, 'users_profile_redirect' ) );
 	}
 
 	private function register_track_event( $event ) {
@@ -98,7 +98,7 @@ class Jetpack_Calypso_Redirects {
 
 	public function menu_redirects() {
 		remove_menu_page( 'plugins.php' );
-		add_menu_page( __( 'Plugins' ), __( 'Plugins' ), 'manage_options', 'calypso-plugins', array( $this, 'plugins_redirect' ), 'dashicons-admin-plugins', 65 );
+		add_menu_page( __( 'Plugins' ), __( 'Plugins' ), 'manage_options', 'calypso_plugins', array( $this, 'plugins_redirect' ), 'dashicons-admin-plugins', 65 );
 
 		if ( current_user_can( 'list_users' ) ) {
 			$this->register_user_redirects();

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -52,7 +52,7 @@ class Jetpack_Calypso_Redirects {
 	}
 
 	public function enqueue_scripts() {
-		wp_enqueue_style( 'calypso-redirects-css', plugins_url( 'calypso-redirects/calypso-redirects.css' , __FILE__ ), array(), '20170922-1' );
+		wp_enqueue_style( 'calypso-redirects-css', plugins_url( 'calypso-redirects/calypso-redirects.css' , __FILE__ ), array(), JETPACK__VERSION );
 
 		// support rtl languages
 		wp_style_add_data( 'calypso-redirects-css', 'rtl', 'replace' );

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -89,6 +89,7 @@ class Calypso_Redirects {
 	}
 
 	public function menu_redirects() {
+		remove_menu_page( 'plugins.php' );
 		add_menu_page( __( 'Plugins' ), __( 'Plugins' ), 'manage_options', 'calypso-plugins', array( $this, 'plugins_redirect' ), 'dashicons-admin-plugins', 65 );
 
 		$this->register_user_redirects();

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'Calypso_Redirects' ) ) :
 class Calypso_Redirects {
 
 	public function __construct() {
-		if ( ! is_admin() ) {
+		if ( ! get_option( 'jetpack_calypso_redirects_active' ) || ! is_admin() ) {
 			return;
 		}
 

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -9,20 +9,23 @@ class Calypso_Redirects {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_calypso_domain' ), 10, 1 );
+
+		// register redirect handlers
+		add_action( 'load-users_page_calypso-users', array( $this, 'users_redirect' ) );
+		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
+		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_action( 'load-users_page_calypso-users-settings', array( $this, 'users_settings_redirect' ) );
 	}
 
 	private function register_user_redirects() {
-		remove_menu_page( 'users.php' );
-
-		// if the users page is loaded let's track and redirect
-		add_action( 'load-users.php', array( $this, 'load_users_redirect' ) );
+		remove_submenu_page( 'users.php', 'users.php' );
+		remove_submenu_page( 'users.php', 'user-new.php' );
+		remove_submenu_page( 'users.php', 'profile.php' );
 
 		// replace each menu item one by one with its redirect
-		add_menu_page( __( 'Users' ),  __( 'Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ), 'dashicons-admin-users', 70 );
-
-		add_submenu_page( 'calypso-users', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
-		add_submenu_page( 'calypso-users', __( 'Invite New' ), __( 'Invite New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
-		add_submenu_page( 'calypso-users', __( 'My Profile' ), __( 'My Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_submenu_page( 'users.php', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
+		add_submenu_page( 'users.php', __( 'Invite New' ), __( 'Invite New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
+		add_submenu_page( 'users.php', __( 'My Profile' ), __( 'My Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
 	}
 
 	private function register_track_event( $event ) {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -5,6 +5,10 @@ if ( ! class_exists( 'Calypso_Redirects' ) ) :
 class Calypso_Redirects {
 
 	public function __construct() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		add_action( 'admin_menu', array( $this, 'menu_redirects' ), 30 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -1,8 +1,8 @@
 <?php
 
-if ( ! class_exists( 'Calypso_Redirects' ) ) :
+if ( ! class_exists( 'Jetpack_Calypso_Redirects' ) ) :
 
-class Calypso_Redirects {
+class Jetpack_Calypso_Redirects {
 
 	public function __construct() {
 		if ( ! get_option( 'jetpack_calypso_redirects_active' ) || ! is_admin() ) {
@@ -108,6 +108,6 @@ class Calypso_Redirects {
 
 }
 
-new Calypso_Redirects();
+new Jetpack_Calypso_Redirects();
 
 endif; // end class exists check

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -7,6 +7,8 @@ class Calypso_Redirects {
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'menu_redirects' ), 30 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_calypso_domain' ), 10, 1 );
 	}
 
 	private function register_user_redirects() {
@@ -27,6 +29,12 @@ class Calypso_Redirects {
 		// record in tracks
 		jetpack_require_lib( 'tracks/client' );
 		jetpack_tracks_record_event( wp_get_current_user(), $event );
+	}
+
+	public function allow_calypso_domain( $domains ) {
+		$domains[] = 'wordpress.com';
+
+		return $domains;
 	}
 
 	public function enqueue_scripts() {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'Calypso_Redirects' ) ) :
 class Calypso_Redirects {
 
 	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'menu_redirects' ) );
+		add_action( 'admin_menu', array( $this, 'menu_redirects' ), 30 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -14,13 +14,9 @@ class Calypso_Redirects {
 
 		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_calypso_domain' ), 10, 1 );
 
-		// register redirect handlers
-		add_action( 'load-users_page_calypso-users', array( $this, 'users_redirect' ) );
-		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
-		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
-		add_action( 'load-users_page_calypso-users-settings', array( $this, 'users_settings_redirect' ) );
-
 		add_action( 'load-toplevel_page_calypso-plugins', array( $this, 'plugins_redirect' ) );
+
+			$this->register_user_redirect_handlers();
 	}
 
 	private function register_user_redirects() {
@@ -32,6 +28,13 @@ class Calypso_Redirects {
 		add_submenu_page( 'users.php', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
 		add_submenu_page( 'users.php', __( 'Invite New' ), __( 'Invite New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
 		add_submenu_page( 'users.php', __( 'My Profile' ), __( 'My Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+	}
+
+	private function register_user_redirect_handlers() {
+		add_action( 'load-users_page_calypso-users', array( $this, 'users_redirect' ) );
+		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
+		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+		add_action( 'load-users_page_calypso-users-settings', array( $this, 'users_settings_redirect' ) );
 	}
 
 	private function register_track_event( $event ) {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -16,7 +16,9 @@ class Calypso_Redirects {
 
 		add_action( 'load-toplevel_page_calypso-plugins', array( $this, 'plugins_redirect' ) );
 
+		if ( current_user_can( 'list_users' ) ) {
 			$this->register_user_redirect_handlers();
+		}
 	}
 
 	private function register_user_redirects() {
@@ -99,7 +101,9 @@ class Calypso_Redirects {
 		remove_menu_page( 'plugins.php' );
 		add_menu_page( __( 'Plugins' ), __( 'Plugins' ), 'manage_options', 'calypso-plugins', array( $this, 'plugins_redirect' ), 'dashicons-admin-plugins', 65 );
 
-		$this->register_user_redirects();
+		if ( current_user_can( 'list_users' ) ) {
+			$this->register_user_redirects();
+		}
 	}
 
 }

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -36,7 +36,6 @@ class Jetpack_Calypso_Redirects {
 		add_action( 'load-users_page_calypso-users', array( $this, 'users_redirect' ) );
 		add_action( 'load-users_page_calypso-users-new', array( $this, 'users_new_redirect' ) );
 		add_action( 'load-users_page_calypso-users-profile', array( $this, 'users_profile_redirect' ) );
-		add_action( 'load-users_page_calypso-users-settings', array( $this, 'users_settings_redirect' ) );
 	}
 
 	private function register_track_event( $event ) {

--- a/modules/calypso-redirects.php
+++ b/modules/calypso-redirects.php
@@ -1,0 +1,88 @@
+<?php
+
+if ( ! class_exists( 'Calypso_Redirects' ) ) :
+
+class Calypso_Redirects {
+
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'menu_redirects' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	private function register_user_redirects() {
+		remove_menu_page( 'users.php' );
+
+		// if the users page is loaded let's track and redirect
+		add_action( 'load-users.php', array( $this, 'load_users_redirect' ) );
+
+		// replace each menu item one by one with its redirect
+		add_menu_page( __( 'Users' ),  __( 'Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ), 'dashicons-admin-users', 70 );
+
+		add_submenu_page( 'calypso-users', __( 'All Users' ), __( 'All Users' ), 'list_users', 'calypso-users', array( $this, 'users_redirect' ) );
+		add_submenu_page( 'calypso-users', __( 'Invite New' ), __( 'Invite New' ), 'promote_users', 'calypso-users-new', array( $this, 'users_new_redirect' ) );
+		add_submenu_page( 'calypso-users', __( 'My Profile' ), __( 'My Profile' ), 'read', 'calypso-users-profile', array( $this, 'users_profile_redirect' ) );
+	}
+
+	private function register_track_event( $event ) {
+		// record in tracks
+		jetpack_require_lib( 'tracks/client' );
+		jetpack_tracks_record_event( wp_get_current_user(), $event );
+	}
+
+	public function enqueue_scripts() {
+		wp_enqueue_style( 'calypso-redirects-css', plugins_url( 'calypso-redirects/calypso-redirects.css' , __FILE__ ), array(), '20170922-1' );
+
+		// support rtl languages
+		wp_style_add_data( 'calypso-redirects-css', 'rtl', 'replace' );
+	}
+
+	public function plugins_redirect() {
+		$this->register_track_event( 'jetpack_admin_calypso_plugins_redirect' );
+
+		$site_slug = Jetpack::build_raw_urls( get_home_url() );
+		wp_safe_redirect( 'https://wordpress.com/plugins/' . $site_slug );
+		exit;
+	}
+
+	public function load_users_redirect() {
+		$this->register_track_event( 'jetpack_admin_calypso_load_users_php_redirect' );
+
+		$site_slug = Jetpack::build_raw_urls( get_home_url() );
+		wp_safe_redirect( 'https://wordpress.com/people/team/' . $site_slug );
+		exit;
+	}
+
+	public function users_redirect() {
+		$this->register_track_event( 'jetpack_admin_calypso_users_redirect' );
+
+		$site_slug = Jetpack::build_raw_urls( get_home_url() );
+		wp_safe_redirect( 'https://wordpress.com/people/team/' . $site_slug );
+		exit;
+	}
+
+	public function users_new_redirect() {
+		$this->register_track_event( 'jetpack_admin_calypso_users_add_new_redirect' );
+
+		$site_slug = Jetpack::build_raw_urls( get_home_url() );
+		wp_safe_redirect( 'https://wordpress.com/people/new/' . $site_slug );
+		exit;
+	}
+
+	public function users_profile_redirect() {
+		$this->register_track_event( 'jetpack_admin_calypso_users_profile_redirect' );
+
+		wp_safe_redirect( 'https://wordpress.com/me' );
+		exit;
+	}
+
+	public function menu_redirects() {
+		add_menu_page( __( 'Plugins' ), __( 'Plugins' ), 'manage_options', 'calypso-plugins', array( $this, 'plugins_redirect' ), 'dashicons-admin-plugins', 65 );
+
+		$this->register_user_redirects();
+	}
+
+}
+
+new Calypso_Redirects();
+
+endif; // end class exists check

--- a/modules/calypso-redirects/calypso-redirects.css
+++ b/modules/calypso-redirects/calypso-redirects.css
@@ -1,0 +1,43 @@
+/* All Menu Indicators */
+a[href$="calypso-plugins"] .wp-menu-name::after,
+a[href$="calypso-users"] .wp-menu-name::after,
+.wp-submenu a[href$="calypso-users"]::after,
+.wp-submenu a[href$="calypso-all-users"]::after,
+.wp-submenu a[href$="calypso-users-new"]::after,
+.wp-submenu a[href$="calypso-users-profile"]::after {
+	float: right;
+
+	/* styles from existing dashicons */
+	content: '\f504';
+	font-family: 'dashicons';
+	font-size: 20px;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+/* Top level menu indicators */
+a[href$="calypso-plugins"] .wp-menu-name::after,
+a[href$="calypso-users"] .wp-menu-name::after {
+	color: rgba(240,245,250,.6); /* match the existing menu icons */
+	padding: 0 1em 0 0;
+}
+
+/* submenu indicators */
+.wp-submenu a[href$="calypso-users"]::after,
+.wp-submenu a[href$="calypso-all-users"]::after,
+.wp-submenu a[href$="calypso-users-new"]::after,
+.wp-submenu a[href$="calypso-users-profile"]::after {
+	line-height: 0.7;
+	padding: 0.1em 0;
+}
+
+.menu-top:hover .wp-menu-name::after {
+	color: inherit;
+}
+
+@media screen and (max-width: 782px) {
+	/* do not show external indicators when the link is the trigger for expanding a submenu */
+	.wp-has-submenu .wp-menu-name::after{
+		display: none;
+	}
+}

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -25,6 +25,7 @@ $tools = array(
 	'seo-tools/jetpack-seo-posts.php',
 	'simple-payments/simple-payments.php',
 	'verification-tools/verification-tools-utils.php',
+	'calypso-redirects.php'
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode


### PR DESCRIPTION
Fixes Automattic/wp-calypso#17573

#### Changes
Assuming that the `jetpack_calypso_redirects_active` is turned on, this will replace the User Admin menu links with redirects to the relevant Calypso sections.  Modified menu options will be clearly marked with an external indicator. 

![jetpackcalypsoredirectsandindicators](https://user-images.githubusercontent.com/2500689/31422979-616fcab2-ae06-11e7-825a-4b48f8778790.png)

#### Testing instructions

1. Use a Jetpack connected test site
2. The `jetpack_calypso_redirects_active` option does not exist yet, to test you can comment the [`return` here](https://github.com/Automattic/jetpack/compare/master...jeremysawesome:add/17573_calypso_user_redirects?expand=1#diff-eedeeb177a26d631dfafde980cdab4fdR9)
3. Plugins should display an external indicator. The result of clicking on it should register a track event and redirect the user to the Calypso Plugins management page.
4. Each item in the Users menu should display an external indicator. Clicking on any Users menu item should result in a registered track even as well as a redirect to the associated Calypso page.