### PR TITLE
Contact Form: avoid duplicate / when loading editor style.

### DIFF
--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -83,7 +83,7 @@ class Grunion_Editor_View {
 			)
 		) );
 
-		add_editor_style( plugin_dir_url( __FILE__ ) . '/css/editor-style.css' );
+		add_editor_style( plugin_dir_url( __FILE__ ) . 'css/editor-style.css' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes 1130-gh-jpop-issues

#### Testing instructions:

1. Activate the Contact form module.
2. Go to Posts > Add New with the Network tab opened in your browser's dev tools.
3. Make sure you're looking at the visual post editor.
4. The `modules/contact-form//css/editor-style.css` resource should load without an extra `/`.

#### Proposed changelog entry for your changes:
- Contact Form: avoid duplicate slash when loading editor style.