### PR TITLE
SEO Tools: don't output any tags when another SEO plugin is active.

### DIFF
--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -18,7 +18,10 @@ class Jetpack_SEO {
 		 *
 		 * @param bool true Should Jetpack's SEO Meta Tags be enabled. Defaults to true.
 		 */
-		if ( apply_filters( 'jetpack_seo_meta_tags_enabled', true ) ) {
+		if (
+			apply_filters( 'jetpack_seo_meta_tags_enabled', true )
+			&& Jetpack_SEO_Utils::is_enabled_jetpack_seo()
+		) {
 			add_action( 'wp_head', array( $this, 'meta_tags' ) );
 
 			// Add support for editing page excerpts in pages, regardless of theme support.


### PR DESCRIPTION
Fixes #7962

#### Testing instructions:

* Follow the steps in the original issue; make sure no duplicate meta description tag is added.

#### Proposed changelog entry for your changes:
- SEO Tools: do not output any custom meta tags if another SEO plugin is already active.