### PR TITLE
Improve/core update sync

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -118,6 +118,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		// ignore `last_checked`
 		unset( $a_value['last_checked'] );
 		unset( $a_value['checked'] );
+		unset( $a_value['version_checked'] );
+		unset( $a_value['updates'] );
 		if ( empty( $a_value ) ) {
 			return false;
 		}

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -114,12 +114,14 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function get_update_checksum( $value ) {
 		// Create an new array so we don't modify the object passed in.
 		$a_value = (array) $value;
-
 		// ignore `last_checked`
 		unset( $a_value['last_checked'] );
 		unset( $a_value['checked'] );
 		unset( $a_value['version_checked'] );
-		unset( $a_value['updates'] );
+		if ( empty( $a_value['updates'] ) ) {
+			unset( $a_value['updates'] );
+		}
+
 		if ( empty( $a_value ) ) {
 			return false;
 		}

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -47,10 +47,20 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}
 
+		$this->sender->do_sync();
+		delete_site_transient( 'update_core' );
+		$this->server_event_storage->reset();
+
 		_maybe_update_core();
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertTrue( is_int( $updates->last_checked ) );
+		
+		// Since the transient gets updates twice and we only care about the
+		// last update we only want to see 1 sync event.
+		$events = $this->server_event_storage->get_all_events( 'jetpack_update_core_change' );
+		$this->assertEquals( count( $events ) , 1 );
+
 	}
 
 	public function test_sync_wp_version() {


### PR DESCRIPTION
Currently when we sync core that there is core updates. We sync 2 events we should only sync one. 

#### Changes proposed in this Pull Request:
* Only sync 1 core update event.   

#### Testing instructions:
* Update the $wp_version in wp-includes/version.php to be something less then the current version. Notice on the .com side that one 1 event gets synced. 

Do the tests pass? 

#### How it all works:
When we check via the _maybe_update_core() function we set the transient twice which creates 2 events in the process. 
The first time there not much data and then the second time we fill the transient with the data that we got from the API. 
We only really care when the data is set so we want to ignore changes that don’t populate the transient with the data from the API. 
the checksum of the change makes sure that we don’t send the same data twice. 