### PR TITLE
VideoPress: build an RTL version of the editor CSS files

### DIFF
--- a/tools/builder/admin-css.js
+++ b/tools/builder/admin-css.js
@@ -32,6 +32,8 @@ const admincss = [
 	'modules/protect/protect-dashboard-widget.css',
 	'modules/sharedaddy/admin-sharing.css',
 	'modules/videopress/videopress-admin.css',
+	'modules/videopress/css/editor.css',
+	'modules/videopress/css/videopress-editor-style.css',
 	'modules/widget-visibility/widget-conditions/widget-conditions.css',
 	'modules/widgets/gallery/css/admin.css',
 	'modules/sso/jetpack-sso-login.css' // Displayed when logging into the site.
@@ -69,4 +71,3 @@ gulp.task( 'admincss:rtl', function() {
 			util.log( 'Admin modules RTL CSS finished.' );
 		} );
 } );
-


### PR DESCRIPTION
Fixes #7464

#### Testing instructions:

1. Activate VideoPress
2. Go to Users > My profile and switch your interface language to Hebrew.
3. Go to Posts > Add New
4. Make sure the visual editor is active. 
5. You should not see the following error in your editor anymore:

```
Failed to load content css: .../wp-content/plugins/jetpack/modules/videopress/css/videopress-editor-style-rtl.css
```

![screenshot 2017-10-12 at 15 12 32](https://user-images.githubusercontent.com/426388/31497781-57c55364-af60-11e7-8beb-437715289371.png)

You should also see the RTL file when looking at your network tab.

![screenshot 2017-10-12 at 15 25 54](https://user-images.githubusercontent.com/426388/31498286-d56bc2b6-af61-11e7-9b85-af1a0846cbf9.png)

**Note: this requires rebuilding the plugin to create the files.**

#### Proposed changelog entry for your changes:
* VideoPress: avoid missing file warning in the editor when using an RTL language.