### PR TITLE
REST API: Match permissions for viewing comments to those of wp-admin.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -74,9 +74,9 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		case 'display' :
 			if ( 'approved' !== $status ) {
 				$current_user_id = get_current_user_id();
-				$user_can_read_coment = false;
+				$user_can_read_comment = false;
 				if ( $current_user_id && $comment->user_id && $current_user_id == $comment->user_id ) {
-					$user_can_read_coment = true;
+					$user_can_read_comment = true;
 				} elseif (
 					$comment->comment_author_email && $comment->comment_author
 				&&
@@ -88,12 +88,12 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 				&&
 					$this->api->token_details['user']['display_name'] === $comment->comment_author
 				) {
-					$user_can_read_coment = true;
+					$user_can_read_comment = true;
 				} else {
-					$user_can_read_coment = current_user_can( 'edit_comment', $comment->comment_ID );
+					$user_can_read_comment = current_user_can( 'edit_posts' );
 				}
 
-				if ( !$user_can_read_coment ) {
+				if ( !$user_can_read_comment ) {
 					return new WP_Error( 'unauthorized', 'User cannot read unapproved comment', 403 );
 				}
 			}

--- a/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -173,7 +173,7 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 			}
 			break;
 		default :
-			if ( !current_user_can( 'moderate_comments' ) ) {
+			if ( ! current_user_can( 'edit_posts' ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot read non-approved comments', 403 );
 			}
 			if ( 'unapproved' === $args['status'] ) {


### PR DESCRIPTION
In wp-admin, contributors and authors can see others' unapproved comments, as `edit-comments.php` just [does a check](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/edit-comments.php#L11) for the `edit_posts` cap (which [both contributors and authors possess](https://codex.wordpress.org/Roles_and_Capabilities#Capabilities)). By using `moderate_comments` in our API (which wp-admin doesn't use at all), we're blocking authors and contributors from seeing the same info they can see in wp-admin. This PR brings the API inline with wp-admin. Some spelling errors ("coment") were also corrected.

Note that while they can see others' comments, they cannot see the comment author's email nor IP address; these will be `false` in the API response.

See: https://github.com/Automattic/wp-calypso/issues/17687

WPCom diff: D7548-code

**Testing**
* Apply this PR to your JP sandbox.
* Log in as an author on your sandbox. Make sure you have at least one post, and a comment by another user on that post.
* Using the developer console, go to `https://public-api.wordpress.com/rest/v1.1/sites/:site/comments`, and be sure you can see all comments, and no "User cannot read unapproved comment" error.