### PR TITLE
REST API: Allow post authors to moderate their own comments.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -191,7 +191,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			return new WP_Error( 'unauthorized', 'User cannot create comments', 403 );
 		}
 
-		if ( ! ( comments_open( $post->ID ) || current_user_can( 'moderate_comments' ) ) ) {
+		if ( ! comments_open( $post->ID ) && ! current_user_can( 'edit_post', $post->ID ) ) {
 			return new WP_Error( 'unauthorized', 'Comments on this post are closed', 403 );
 		}
 
@@ -292,10 +292,6 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 		}
 
 		$comment_status = wp_get_comment_status( $comment->comment_ID );
-		if ( $comment_status !== $update['comment_status'] && !current_user_can( 'moderate_comments' ) ) {
-			return new WP_Error( 'unauthorized', 'User cannot moderate comments', 403 );
-		}
-
 		if ( isset( $update['comment_status'] ) ) {
 			switch ( $update['comment_status'] ) {
 				case 'approved' :


### PR DESCRIPTION
Allow post authors to moderate their own comments, as they can in wp-admin.

Currrently, the API requires the `moderate_comments` cap to, uh, moderate comments, and [this cap is only possessed by admins and editors](https://codex.wordpress.org/Roles_and_Capabilities), not authors nor contributors (meaning authors and contributors cannot moderate comments on their own posts with the API). However, this is not what's used by wp-admin; the meta cap of `edit_comment` ("can the current user edit this particular comment") [is used instead](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/class-wp-comments-list-table.php#L501) to display the actions that allow moderation. This PR brings the API inline with wp-admin.

See: https://github.com/Automattic/wp-calypso/issues/17687

WPCom diff: D7553-code

**Testing**
* Apply this PR to your JP sandbox.
* Log in as an author on your sandbox. Make sure you have at least one post, and an unapproved comment by another user on that post.
* Using the developer console, POST to `https://public-api.wordpress.com/rest/v1.1/sites/:site/comments/:comment_id/?status=approved`, and be sure you get back positive confirmation.