### PR TITLE
Added a hook on comment subscription.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -666,7 +666,7 @@ class Jetpack_Subscriptions {
 		if ( isset( $_REQUEST['subscribe_blog'] ) )
 			$post_ids[] = 0;
 
-		Jetpack_Subscriptions::subscribe(
+		$result = Jetpack_Subscriptions::subscribe(
 									$comment->comment_author_email,
 									$post_ids,
 									true,
@@ -677,6 +677,18 @@ class Jetpack_Subscriptions {
 										'server_data'    => $_SERVER,
 									)
 		);
+
+		/**
+		 * Fires on each comment subscription form submission.
+		 *
+		 * @module subscriptions
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param NULL|WP_Error $result Result of form submission: NULL on success, WP_Error otherwise.
+		 * @param Array $post_ids An array of post IDs that the user subscribed to, 0 means blog subscription.
+		 */
+		do_action( 'jetpack_subscriptions_comment_form_submission', $result, $post_ids );
 	}
 
 	/**


### PR DESCRIPTION
This will allow other plugins to track whenever a user has subscribed to new comments on the post via a comment form.

#### Changes proposed in this Pull Request:
* Added a new hook called `jetpack_subscriptions_comment_form_submission`

#### Testing instructions:
* Add a testing hook event to your WordPress installation, like this:
```
add_action( 'jetpack_subscriptions_comment_form_submission', function( $result, $post_ids ) {
	error_log( $result );
	error_log( print_r( $post_ids, true ) );
}, 10, 2 );
```
* When you subscribe to comments to a post make sure you see nothing output by the first statement, and the array containing the post ID by the second statement.
* When you also tick the subscribe to blog checkbox, you should see a zero entry in the array

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added a filter to track comment subscription activations.