### PR TITLE
Sync: add in an empty file to replace deprecated file.

### DIFF
--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Deprecated. No longer needed.
+ *
+ * @package Jetpack
+ */


### PR DESCRIPTION
This file was removed in #7974.
However, in some situations (cache, ...), the file can still be called, or not deleted properly.
This should help.

Related:
- 8c3790d8cb1463a687a250b6b3d687c03a0365ca
- e9cb5f0e468abba56a00ed706606dadb6b7a8cf2
