### PR TITLE
Shortcodes: remove aws domain from Mailchimp shortcode.

### DIFF
--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -6,7 +6,7 @@
  * [mailchimp_subscriber_popup baseUrl="mc.us11.list-manage.com" uuid="1ca7856462585a934b8674c71" lid="2d24f1898b"]
  *
  * Embed code example:
- * <script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"1ca7856462585a934b8674c71","lid":"2d24f1898b"}) })</script>
+ * <script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"1ca7856462585a934b8674c71","lid":"2d24f1898b"}) })</script>
  *
  */
 
@@ -46,9 +46,9 @@ class MailChimp_Subscriber_Popup {
 	 */
 	static $reversal_regexes = array(
 		/* raw examplejs */
-		'/<script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">require\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s',
+		'/<script type="text\/javascript" src="(https?:)?\/\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">require\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s',
 		/* visual editor */
-		'/&lt;script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"&gt;&lt;\/script&gt;&lt;script type="text\/javascript"&gt;require\(\["mojo\/signup-forms\/Loader"]\, function\(L\) { L\.start\({([^}]*?)}\) }\)&lt;\/script&gt;/s',
+		'/&lt;script type="text\/javascript" src="(https?:)?\/\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"&gt;&lt;\/script&gt;&lt;script type="text\/javascript"&gt;require\(\["mojo\/signup-forms\/Loader"]\, function\(L\) { L\.start\({([^}]*?)}\) }\)&lt;\/script&gt;/s',
 	);
 
 	/**
@@ -199,6 +199,6 @@ class MailChimp_Subscriber_Popup {
 
 		$displayed_once = true;
 
-		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); } );</script>' . "\n\n";
+		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); } );</script>' . "\n\n";
 	}
 }

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -2,11 +2,13 @@
 
 if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 
+	if ( ! class_exists( 'MailChimp_Subscriber_Popup' ) ) {
+		include_once JETPACK__PLUGIN_DIR . 'modules/shortcodes/mailchimp.php';
+	}
+
 	//register MailChimp Subscriber Popup widget
 	function jetpack_mailchimp_subscriber_popup_widget_init() {
-		if ( class_exists( 'MailChimp_Subscriber_Popup' ) ) {
-			register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
-		}
+		register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
 	}
 
 	add_action( 'widgets_init', 'jetpack_mailchimp_subscriber_popup_widget_init' );
@@ -69,7 +71,7 @@ if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 		 */
 		function update( $new_instance, $old_instance ) {
 			$instance         = array();
-			$instance['code'] = wp_kses_post( stripslashes( $new_instance['code'] ) );
+			$instance['code'] = MailChimp_Subscriber_Popup::reversal( $new_instance['code'] );
 
 			return $instance;
 		}

--- a/tests/php/modules/shortcodes/test_class.mailchimp.php
+++ b/tests/php/modules/shortcodes/test_class.mailchimp.php
@@ -37,6 +37,6 @@ class WP_Test_Jetpack_Shortcodes_MailChimp extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( '<script type="text/javascript" data-dojo-config="usePlainJson: true, isDebug: false">jQuery.getScript( "//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"' . $uuid . '","lid":"' . $lid . '"}) }); } );</script>', $shortcode_content );
+		$this->assertContains( '<script type="text/javascript" data-dojo-config="usePlainJson: true, isDebug: false">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"' . $uuid . '","lid":"' . $lid . '"}) }); } );</script>', $shortcode_content );
 	}
 }


### PR DESCRIPTION
Fixes #7945

To test, create a Maichimp form as explained here:
https://en.support.wordpress.com/mailchimp/

Then try to embed it into one of your posts or pages, when logged in as an editor. You should see the form transform into a shortcode on save. Make sure
the form is displayed properly on the site.

#### Proposed changelog entry for your changes:
* Maichimp: make sure subscription forms can still be embedded in posts and pages.