### PR TITLE
Mailchimp: save a shortcode when pasting a form code in the widget

### DIFF
--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -2,11 +2,13 @@
 
 if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 
+	if ( ! class_exists( 'MailChimp_Subscriber_Popup' ) ) {
+		include_once JETPACK__PLUGIN_DIR . 'modules/shortcodes/mailchimp.php';
+	}
+
 	//register MailChimp Subscriber Popup widget
 	function jetpack_mailchimp_subscriber_popup_widget_init() {
-		if ( class_exists( 'MailChimp_Subscriber_Popup' ) ) {
-			register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
-		}
+		register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
 	}
 
 	add_action( 'widgets_init', 'jetpack_mailchimp_subscriber_popup_widget_init' );
@@ -69,7 +71,7 @@ if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 		 */
 		function update( $new_instance, $old_instance ) {
 			$instance         = array();
-			$instance['code'] = wp_kses_post( stripslashes( $new_instance['code'] ) );
+			$instance['code'] = MailChimp_Subscriber_Popup::reversal( $new_instance['code'] );
 
 			return $instance;
 		}


### PR DESCRIPTION
**Important: this PR is set to be merged into the `fix/mailchimp-shortcode-7945` branch, since the widget is broken right now and this PR couldn't be tested without the changes included in #7989**

Fixes #7960
Fixes #7990

- The widget now calls the shortcode file even when the shortcodes are not active, so you do not need to activate the shortcode module for this to work.
- On save, the widget uses the reversal function provided in the shortcode to save a valid shortcode.
- That shortcode is then displayed in the widget, as before.

#### Testing instructions:

1. Start activating both the widget and the shortcode module.
2. Add “MailChimp Subscriber Popup (Jetpack)” widget in a widget area.
3. Copy code from mail chimp into the code area, as explained in the documentation:
https://en.support.wordpress.com/mailchimp/
4. Save & watch the script get transformed into a shortcode.
5. The form should appear on your site.

Repeat those steps when the Shortcodes module is deactivated; nothing should change.

#### Proposed changelog entry for your changes:
* Mailchimp: do not require the use of the shortcodes feature to use the Mailchimp widget.
* Mailchimp: fix issue where Mailchimp form code could not be added to the Mailchimp widget.