### PR TITLE
Upcoming events Widget: Fix for #7993 Undefined variable: timezone_offset_interval

### DIFF
--- a/_inc/lib/icalendar-reader.php
+++ b/_inc/lib/icalendar-reader.php
@@ -93,6 +93,7 @@ class iCalendarReader {
 		$timezone_name = get_option( 'timezone_string' );
 		if ( $timezone_name ) {
 			$timezone = new DateTimeZone( $timezone_name );
+			$timezone_offset_interval = false;
 		} else {
 			// If the timezone isn't set then the GMT offset must be set.
 			// generate a DateInterval object from the timezone offset


### PR DESCRIPTION
`if ( $timezone_offset_interval )` produces an Undefined variable when it is not set prior.

Fixes #7993

#### Testing instructions:

* See description of #7993
