### PR TITLE
Api/update plugins filter for 4.9

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -176,15 +176,23 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	}
 
 	protected function activate() {
+		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
+			if ( ! $this->single_plugin_current_user_can( 'activate_plugin', $plugin ) ) {
+				$this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
+				$has_errors                  = true;
+				$permission_error            = true;
+				continue;
+			}
+
 			if ( ( ! $this->network_wide && Jetpack::is_plugin_active( $plugin ) ) || is_plugin_active_for_network( $plugin ) ) {
-				$this->log[ $plugin ]['error'] = __( 'The Plugin is already active.', 'jetpack' );
+				$this->log[$plugin]['error'] = __( 'The Plugin is already active.', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
 
 			if ( ! $this->network_wide && is_network_only_plugin( $plugin ) && is_multisite() ) {
-				$this->log[ $plugin ]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
+				$this->log[$plugin]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
@@ -192,7 +200,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$result = activate_plugin( $plugin, '', $this->network_wide );
 
 			if ( is_wp_error( $result ) ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages();
+				$this->log[$plugin]['error'] = $result->get_error_messages();
 				$has_errors                  = true;
 				continue;
 			}
@@ -203,23 +211,43 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			if ( ! $success ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages;
+				$this->log[$plugin]['error'] = $result->get_error_messages;
 				$has_errors                  = true;
 				continue;
 			}
 			$this->log[ $plugin ][] = __( 'Plugin activated.', 'jetpack' );
 		}
-		if ( ! $this->bulk && isset( $has_errors ) ) {
-			$plugin = $this->plugins[0];
 
-			return new WP_Error( 'activation_error', $this->log[$plugin]['error'] );
+		if ( ! $this->bulk && isset( $has_errors )  ) {
+			$plugin = $this->plugins[0];
+			if ( $permission_error ) {
+				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 404 );
+			}
+			return new WP_Error( 'activation_error', $this->log[ $plugin ]['error'] );
 		}
 	}
 
+	protected function single_plugin_current_user_can( $capability, $plugin ) {
+		global $wp_version;
+		if ( version_compare( $wp_version, '4.9-beta2' ) >= 0 ) {
+			return current_user_can( $capability, $plugin );
+		}
+		// Assume that the user has the capability...
+		return true;
+
+	}
+
 	protected function deactivate() {
+		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
 			if ( ! Jetpack::is_plugin_active( $plugin ) ) {
 				$error = $this->log[ $plugin ]['error'] = __( 'The Plugin is already deactivated.', 'jetpack' );
+				continue;
+			}
+
+			if ( ! $this->single_plugin_current_user_can('deactivate_plugin', $plugin ) ) {
+				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.' );
+				$permission_error = true;
 				continue;
 			}
 
@@ -237,6 +265,9 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$this->log[ $plugin ][] = __( 'Plugin deactivated.', 'jetpack' );
 		}
 		if ( ! $this->bulk && isset( $error ) ) {
+			if ( $permission_error ) {
+				return new WP_Error( 'unauthorized_error', $error, 403 );
+			}
 			return new WP_Error( 'deactivation_error', $error );
 		}
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -136,7 +136,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			if ( $args['active'] ) {
 				return $this->activate();
 			} else {
-				return $this->deactivate();
+				if( $this->current_user_can( 'deactivate_plugins' ) ) {
+					return $this->deactivate();
+				} else {
+					return new WP_Error( 'unauthorized_error', __( 'Plugin deactivation is not allowed', 'jetpack' ), '403' );
+				}
 			}
 		}
 
@@ -178,6 +182,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	protected function activate() {
 		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
+
 			if ( ! $this->single_plugin_current_user_can( 'activate_plugin', $plugin ) ) {
 				$this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
 				$has_errors                  = true;
@@ -227,10 +232,13 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		}
 	}
 
-	protected function single_plugin_current_user_can( $capability, $plugin ) {
+	protected function current_user_can( $capability, $plugin = null ) {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.9-beta2' ) >= 0 ) {
-			return current_user_can( $capability, $plugin );
+			if ( $plugin ) {
+				return current_user_can( $capability, $plugin );
+			}
+			return current_user_can( $capability );
 		}
 		// Assume that the user has the capability...
 		return true;
@@ -245,8 +253,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
-			if ( ! $this->single_plugin_current_user_can('deactivate_plugin', $plugin ) ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.' );
+			if ( ! $this->current_user_can('deactivate_plugin', $plugin ) ) {
+				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
 				$permission_error = true;
 				continue;
 			}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -186,20 +186,20 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		foreach ( $this->plugins as $plugin ) {
 
 			if ( ! $this->current_user_can( 'activate_plugin', $plugin ) ) {
-				$this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
+				$this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
 				$has_errors                  = true;
 				$permission_error            = true;
 				continue;
 			}
 
 			if ( ( ! $this->network_wide && Jetpack::is_plugin_active( $plugin ) ) || is_plugin_active_for_network( $plugin ) ) {
-				$this->log[$plugin]['error'] = __( 'The Plugin is already active.', 'jetpack' );
+				$this->log[ $plugin ]['error'] = __( 'The Plugin is already active.', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
 
 			if ( ! $this->network_wide && is_network_only_plugin( $plugin ) && is_multisite() ) {
-				$this->log[$plugin]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
+				$this->log[ $plugin ]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
@@ -207,7 +207,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$result = activate_plugin( $plugin, '', $this->network_wide );
 
 			if ( is_wp_error( $result ) ) {
-				$this->log[$plugin]['error'] = $result->get_error_messages();
+				$this->log[ $plugin ]['error'] = $result->get_error_messages();
 				$has_errors                  = true;
 				continue;
 			}
@@ -218,7 +218,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			if ( ! $success ) {
-				$this->log[$plugin]['error'] = $result->get_error_messages;
+				$this->log[ $plugin ]['error'] = $result->get_error_messages;
 				$has_errors                  = true;
 				continue;
 			}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -92,12 +92,24 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plugins_Modify_Endpoint {
 
 	protected function activate() {
+		$permission_error = false;
+		$has_errors = false;
 		foreach ( $this->plugins as $plugin ) {
+
+			if ( ! $this->current_user_can( 'activate_plugin', $plugin ) ) {
+				$this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
+				$has_errors                  = true;
+				$permission_error            = true;
+				continue;
+			}
+
 			if ( ( ! $this->network_wide && Jetpack::is_plugin_active( $plugin ) ) || is_plugin_active_for_network( $plugin ) ) {
 				continue;
 			}
 
 			if ( ! $this->network_wide && is_network_only_plugin( $plugin ) && is_multisite() ) {
+				$this->log[$plugin]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
+				$has_errors                  = true;
 				continue;
 			}
 
@@ -123,14 +135,23 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 		}
 		if ( ! $this->bulk && isset( $has_errors ) ) {
 			$plugin = $this->plugins[0];
-
+			if ( $permission_error ) {
+				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );
+			}
 			return new WP_Error( 'activation_error', $this->log[$plugin]['error'] );
 		}
 	}
 
 
 	protected function deactivate() {
+		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
+			if ( ! $this->current_user_can('deactivate_plugin', $plugin ) ) {
+				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
+				$permission_error = true;
+				continue;
+			}
+
 			if ( ! Jetpack::is_plugin_active( $plugin ) ) {
 				continue;
 			}
@@ -149,6 +170,9 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			$this->log[ $plugin ][] = __( 'Plugin deactivated.', 'jetpack' );
 		}
 		if ( ! $this->bulk && isset( $error ) ) {
+			if ( $permission_error ) {
+				return new WP_Error( 'unauthorized_error', $error, 403 );
+			}
 			return new WP_Error( 'deactivation_error', $error );
 		}
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -133,7 +133,8 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			}
 			$this->log[ $plugin ][] = __( 'Plugin activated.', 'jetpack' );
 		}
-		if ( ! $this->bulk && isset( $has_errors ) ) {
+
+		if ( ! $this->bulk && $has_errors ) {
 			$plugin = $this->plugins[0];
 			if ( $permission_error ) {
 				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );


### PR DESCRIPTION
In WP 4.9 Core is introducing new capabilities for managing plugins 
See https://make.wordpress.org/core/2017/10/15/improvements-for-roles-and-capabilities-in-4-9/

The current API endpoints should respect them. 
This PR adds checks for the new capabilities if the site is running the latest beta of WP 4.9.

#### Changes proposed in this Pull Request:
* Check that if the user is running WP 4.9 or greater they are not able to activate plugins. 

#### Testing instructions:
* Make sure that everything still works as expected in older version of WP. 
* Add the following plugin
```
<?php
/*
Plugin Name: Plugin De/Activation Check
Author: Enej
*/

add_filter( 'map_meta_cap', 'eb_disable_dolly_activation', 10, 4 );

function eb_disable_dolly_activation( $caps, $cap, $user_id, $args ) {
        $plugin_file = isset( $args[0] ) ? $args[0] : '';
        if ( $cap == 'deactivate_plugin' && $plugin_file == 'hello.php' ) {
                $caps = array('do_not_allow');
        }

        if ( $cap == 'activate_plugin' && $plugin_file == 'akismet/akismet.php' ) {
                $caps = array('do_not_allow');
        }
        //if( $cap == 'deactivate_plugins' ) {
        //      $caps[$cap] = false;
        // }
        // error_log( print_r( array( $caps, $cap, $args ),1 ) );
        return $caps;
}
``` 

Activate the plugin. Make sure that if you are running WP 4.9 or greater you are not able to 
activate akismet and deactivate the hello dolly plugin. In calypso. 

YOu should modify the plugin as well and check that if you filter out stop the 'deactivate_plugins' capability with 
```
if( $cap == 'deactivate_plugins' ) {
$caps[$cap] = false;
}
```

That you are not able to deactivate any plugins as expected. 

cc: @beaulebens, @lezama 
<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
