### PR TITLE
Comments: Allow comments to detached attachment pages to load for users with enough capabilities

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1008,7 +1008,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 					if ( !current_user_can( 'read_post', $post->ID ) ) {
 						return new WP_Error( 'unauthorized', 'User cannot view post', 403 );
 					}
-				} elseif ( 'trash' === $post->post_status ) {
+				} elseif ( in_array( $post->post_status, array( 'inherit', 'trash' ) ) ) {
 					if ( !current_user_can( 'edit_post', $post->ID ) ) {
 						return new WP_Error( 'unauthorized', 'User cannot view post', 403 );
 					}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18811
Replication of D7664-code

Comments to detached media attachment pages fail to load in the Calypso Comment Management section and in the API.

Requesting via API the comment to an _attached_ media, works fine: they are the comments that actually appear in the Calypso Comments section.
You can tell them apart in WP Admin because they have an original post, and can be detached:
![https://user-images.githubusercontent.com/2070010/31538947-0911fa8e-afff-11e7-96bd-3dca38393a1d.png](https://user-images.githubusercontent.com/2070010/31538947-0911fa8e-afff-11e7-96bd-3dca38393a1d.png)

On the other hand, requesting a comment to a _detached_ media fails with the { error: "unauthorized", message: "User cannot view post" } error.
In Calypso they’re stuck in a placeholder state, and in WP Admin they are reported as "(Unattached)" and can be attached:
![https://user-images.githubusercontent.com/2070010/31538956-0c577142-afff-11e7-964d-c62f416847d0.png](https://user-images.githubusercontent.com/2070010/31538956-0c577142-afff-11e7-964d-c62f416847d0.png)

---


Posts with `post_type: 'attachment'` can be attached to, or detached from, a parent post.
Detached attachments have `post_parent: 0`, and this is the property used to [tell attached and detached apart](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/class-wp-media-list-table.php#L467).

Detached attachments are generically treated as public posts, and can be commented.
For example, this is a detached attachment on my test blog: https://coponstestfree.wordpress.com/cropped-brodo-prisma/
There are no options to make it private—that I can find, at least.

Now, when we request a comment to a detached attachment page we get into [this situation here](https://github.com/Automattic/jetpack/blob/master/class.json-api-endpoints.php#L988):

- The attachment has `post_status: inherit` and `post_parent: 0`.
- Because of the `post_status: inherit`, we fetch the parent's status which defaults to the attachment itself when `post_parent: 0`, and therefore the status remains `post_status: 'inherit'`.
- The status is not `public`, the user is logged in, but there is no case for `post_status: 'inherit'`.
- The test rolls to the last `else`, and returns a `WP_Error`.

#### Changes proposed in this Pull Request:

* Add a new check on if the `post_status` is `'inherit'`, failing if the user's capabilities aren't enough to edit the post.

#### Testing instructions:

On master:
- Add a new image to a site.
- From `/wp-admin/upload.php`, detach it.
- Open the image permalink and leave a comment.
- From the API console request that comment (`/sites/$site/comments/$comment_ID`).
- It should return `{ error: "unauthorized", message: "User cannot view post" }`.

On this branch:
- Request that comment again.
- It should return the comment, as expected.
- Try again with a non-authorized user (logged out, or with a role lower than editor).
- It should return `{ error: "unauthorized", message: "User cannot view post" }`.