### PR TITLE
Sync: Expect Navigation Menu instead on widget changes test

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -348,10 +348,14 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $event->args[1], 'nav_menu-1', 'Recent removed widget not found' );
 
 		$this->assertEquals( $event->args[2], $sidebar_name, 'Added sidebar name not found' );
-		// WordPress 4.9 changed Custom Menu for Navigation menu
-		// so we need to get the label from core to assert this comparison
-		// Otherwise, checking againt Navigation Menu works when testing for 4.9 but fails when on 4.8.x
-		$this->assertEquals( $event->args[3], 'Navigation Menu', 'Added widget name not found' );
+
+		// WordPress 4.9 changed the label "Custom Menu" for "Navigation menu"
+		if ( version_compare( $wp_version, '4.9', '>=' ) ) {
+			$this->assertEquals( $event->args[3], 'Navigation Menu', 'Added widget name not found' );
+		}
+		if ( version_compare( $wp_version, '4.9', '<' ) ) {
+			$this->assertEquals( $event->args[3], 'Custom Menu', 'Added widget name not found' );
+		}
 
 		// Moved to inactive
 		$sidebar_widgets  = array(

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -348,6 +348,9 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $event->args[1], 'nav_menu-1', 'Recent removed widget not found' );
 
 		$this->assertEquals( $event->args[2], $sidebar_name, 'Added sidebar name not found' );
+		// WordPress 4.9 changed Custom Menu for Navigation menu
+		// so we need to get the label from core to assert this comparison
+		// Otherwise, checking againt Navigation Menu works when testing for 4.9 but fails when on 4.8.x
 		$this->assertEquals( $event->args[3], 'Navigation Menu', 'Added widget name not found' );
 
 		// Moved to inactive

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -112,7 +112,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$local_value = get_option( 'theme_mods_' . $this->theme );
 		$remote_value = $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme );
-		
+
 		if ( isset( $local_value[0] ) ) {
 			// this is a spurious value that sometimes gets set during tests, and is
 			// actively removed before sending to WPCOM
@@ -288,7 +288,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$sidebar_id = 'sidebar-1';
 		$sidebar_name = $wp_registered_sidebars[ $sidebar_id ]['name'];
-		
+
 		$sidebar_widgets = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
 			'sidebar-1' => array( 'nav_menu-1' ),
@@ -348,7 +348,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $event->args[1], 'nav_menu-1', 'Recent removed widget not found' );
 
 		$this->assertEquals( $event->args[2], $sidebar_name, 'Added sidebar name not found' );
-		$this->assertEquals( $event->args[3], 'Custom Menu', 'Added widget name not found' );
+		$this->assertEquals( $event->args[3], 'Navigation Menu', 'Added widget name not found' );
 
 		// Moved to inactive
 		$sidebar_widgets  = array(
@@ -362,7 +362,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_moved_to_inactive' );
 		$this->assertEquals( $event->args[0], array( 'calendar-1' ), 'Moved to inactive not present' );
 		$this->assertEquals( $event->args[1], array( 'Calendar' ), 'Moved to inactive not present' );
-		
+
 		// Cleared inavite
 		$sidebar_widgets  = array(
 			'wp_inactive_widgets' => array(),


### PR DESCRIPTION
[Core changed the label](https://core.trac.wordpress.org/changeset/41868/trunk) `Custom Menu` for `Navigation Menu`. Tests are failing

#### Changes proposed in this Pull Request:

* Expect string to be `Navigation Menu` instead in `test_widgets_changes_get_synced` test.

#### Testing instructions:

* Confirm that test are not failing for this PR.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Updated test to handle new naming of Navigation Menu in Core