### PR TITLE
Sync: Fix issue with syncing raw URLs for multisites

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -81,10 +81,10 @@ class Jetpack_Sync_Functions {
 		}
 		if ( defined( 'MM_BASE_DIR' ) ) {
 			return 'bh';
-		} 
+		}
 		if ( defined( 'IS_PRESSABLE' ) ) {
 			return 'pressable';
-		} 
+		}
 		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
 			return 'wpe';
 		}
@@ -225,7 +225,9 @@ class Jetpack_Sync_Functions {
 			? 'WP_HOME'
 			: 'WP_SITEURL';
 
-		if ( Jetpack_Constants::is_defined( $constant ) ) {
+		// Since we disregard the constant for multisites in ms-default-filters.php,
+		// let's also use the db value if this is a multisite.
+		if ( ! is_multisite() && Jetpack_Constants::is_defined( $constant ) ) {
 			$value = Jetpack_Constants::get_constant( $constant );
 		} else {
 			// Let's get the option from the database so that we can bypass filters. This will help

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -146,7 +146,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		Jetpack::update_active_modules( array( 'stats' ) );
 
 		$this->sender->do_sync();
-		
+
 		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
 		$this->assertEquals(  array( 'stats' ), $synced_value  );
 
@@ -394,7 +394,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_subdomain_switching_to_www_does_not_cause_sync() {
-		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of 
+		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of
 		// switching back and forth, so we force the domain to be the one in the siteurl option
 		$this->setSyncClientDefaults();
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
@@ -429,7 +429,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'site_url' ) );
-		
+
 		Jetpack_Sync_Settings::set_doing_cron( false );
 		$this->sender->do_sync();
 		$this->assertEquals( site_url(), $this->server_replica_storage->get_callable( 'site_url' ) );
@@ -481,7 +481,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sanitize_sync_taxonomies_method() {
-		
+
 		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'meta_box_cb' => 'post_tags_meta_box' ) );
 		$this->assertEquals( $sanitized->meta_box_cb, 'post_tags_meta_box' );
 
@@ -513,8 +513,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'option_home', array( $this, '__return_filtered_url' ) );
 		add_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
 
-		$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'home' ) );
-		$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'siteurl' ) );
+		if ( is_multisite() ) {
+			$this->assertTrue( $this->__return_filtered_url() !== Jetpack_Sync_Functions::get_raw_url( 'home' ) );
+			$this->assertTrue( $this->__return_filtered_url() !== Jetpack_Sync_Functions::get_raw_url( 'siteurl' ) );
+		} else {
+			$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'home' ) );
+			$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'siteurl' ) );
+		}
 
 		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
 		remove_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
@@ -601,7 +606,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	function __return_filtered_url() {
 		return 'http://filteredurl.com';
 	}
-	
+
 	function add_www_subdomain_to_siteurl( $url ) {
 		$parsed_url = parse_url( $url );
 


### PR DESCRIPTION
Fixes #7997

In #7997, @enejb reported an issue where his multisite was syncing an incorrect URL, the base URL for the site. This was caused by #5852 when we/I started syncing the raw URLs.

While I did test multisites, I apparently didn't test multisites with the constant set. Or, I would've noticed the wrong URL was being synced.

I was able to narrow this down to these lines in core WordPress:
```php
// WP_HOME and WP_SITEURL should not have any effect in MS
remove_filter( 'option_siteurl', '_config_wp_siteurl' );
remove_filter( 'option_home',    '_config_wp_home'    );
```

The `_config_wp_siteurl` and `_config_wp_home` filters check if the `WP_HOME` or `WP_SITEURL` constants are set, and if so, uses those constants. **BUT** ... the filters that call those functions are removed for multisites. 

In #5852, I was always returning the constant value, which is the incorrect behavior.

To test:

- Connect a subsite on a network
- Run a full sync and ensure values are synced correctly in network admin