### PR TITLE
CLI: Do not change directory within partner scripts

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -2,10 +2,6 @@
 
 # cancel a the plan provided for the current site using the given partner keys
 
-# change to script directory so that wp finds the wordpress install part for this Jetpack instance
-SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
-cd "$SCRIPT_DIR" || exit
-
 usage () {
     echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com]"
 }
@@ -37,7 +33,7 @@ fi
 # default API host that can be overridden
 if [ -z "$JETPACK_START_API_HOST" ]; then
     JETPACK_START_API_HOST='public-api.wordpress.com'
-fi 
+fi
 
 # fetch an access token using our client ID/secret
 ACCESS_TOKEN_JSON=$(curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner")
@@ -48,7 +44,7 @@ if [ ! -z "$SITE_URL" ]; then
 fi
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1 --allow-root
+wp plugin activate jetpack "$ADDITIONAL_ARGS" >/dev/null 2>&1 --allow-root
 
 # cancel the partner plan
-wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS --allow-root
+wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" "$ADDITIONAL_ARGS" --allow-root

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -3,10 +3,6 @@
 # accepts: partner client ID and secret key, and some site info
 # executes wp-cli command to provision Jetpack site for given partner
 
-# change to script directory so that wp finds the wordpress install part for this Jetpack instance
-SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
-cd "$SCRIPT_DIR" || exit
-
 usage () {
     echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1]"
 }
@@ -67,7 +63,7 @@ if [ ! -z "$SITE_URL" ]; then
 fi
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1 --allow-root
+wp plugin activate jetpack "$ADDITIONAL_ARGS" >/dev/null 2>&1 --allow-root
 
 # add extra args if available
 if [ ! -z "$WP_USER" ]; then
@@ -76,15 +72,15 @@ fi
 
 if [ ! -z "$ONBOARDING" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --onboarding=$ONBOARDING"
-fi 
+fi
 
 if [ ! -z "$PLAN_NAME" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --plan=$PLAN_NAME"
-fi 
+fi
 
 if [ ! -z "$WPCOM_USER_ID" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
-fi 
+fi
 
 if [ ! -z "$FORCE_REGISTER" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_register=$FORCE_REGISTER"
@@ -92,7 +88,7 @@ fi
 
 if [ ! -z "$FORCE_CONNECT" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_connect=$FORCE_CONNECT"
-fi 
+fi
 
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS --allow-root
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" "$ADDITIONAL_ARGS" --allow-root


### PR DESCRIPTION
To provide flexibility in implementation, let's not assume where we need to change directory to.

This came up in my testing of JPS v2 where I had symlinked my Jetpack directory to another copy of Jetpack in another WordPress installation. I was able to get around this by going one directory up and running the partner provision script.

By removing the `cd` command going one directory above `jetapck` to `wp-content/plugins` I was able to get the script to successfully run.

To test:

- Check out branch
- Run `sh jetpack/bin/partner-provision.sh --partner_id={$id} --partner_secret={$secret} --plan={$plan} --url={$url} --user=1` with proper variables. See @gravityrail or @ebinnion for details
- Ensure `next_url` returned in response is a proper authorization URL