### PR TITLE
JITMs: Remove the need for sending user roles

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -244,7 +244,6 @@ class Jetpack_JITM {
 		// build our jitm request
 		$path = add_query_arg( array(
 			'external_user_id' => urlencode_deep( $user->ID ),
-			'user_roles'       => urlencode_deep( implode( ',', $user->roles ) ),
 			'query_string'     => urlencode_deep( $query ),
 		), sprintf( '/sites/%d/jitm/%s', $site_id, $message_path ) );
 


### PR DESCRIPTION
We were sending user roles via a jitm request. We shouldn't do this. This PR removes it.

#### Changes proposed in this Pull Request:

* Don't send user roles in a JITM request

#### Testing instructions:

* Verify you still see JITMs as an admin on a free Jetpack site and you do not see them as any other user level.