### PR TITLE
Admin Page: Get the connection URL from initial state instead of fetching it

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -21,7 +21,6 @@ import {
 	isUnlinkingUser as _isUnlinkingUser
 } from 'state/connection';
 import { getSiteRawUrl } from 'state/initial-state';
-import QueryConnectUrl from 'components/data/query-connect-url';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 import JetpackDisconnectDialog from 'components/jetpack-disconnect-dialog';
 
@@ -136,14 +135,13 @@ export const ConnectButton = React.createClass( {
 	render() {
 		return (
 			<div>
-				<QueryConnectUrl />
 				{ this.renderContent() }
 				{ this.props.children }
-				{ ! this.props.isSiteConnected && 
+				{ ! this.props.isSiteConnected &&
 					<p className="jp-banner__tos-blurb">
-					{ __( 
+					{ __(
 						'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
-						{ 
+						{
 							components: {
 								tosLink: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"/>,
 								shareDetailsLink: <a href="https://jetpack.com/support/what-data-does-jetpack-sync" rel="noopener noreferrer" target="_blank"/>

--- a/_inc/client/components/connect-button/test/component.js
+++ b/_inc/client/components/connect-button/test/component.js
@@ -29,10 +29,6 @@ describe( 'ConnectButton', () => {
 
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
-		it( 'queries URL to connect', () => {
-			expect( wrapper.find( 'QueryConnectUrl' ) ).to.exist;
-		} );
-
 		it( 'renders a button to connect or link', () => {
 			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
 		} );

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -10,7 +10,7 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import ConnectButton from 'components/connect-button';
-import { getConnectUrl as _getConnectUrl } from 'state/connection';
+import { getConnectUrl as getConnectUrl } from 'state/connection';
 import { imagePath } from 'constants';
 
 const JetpackConnect = React.createClass( {
@@ -214,7 +214,7 @@ const JetpackConnect = React.createClass( {
 export default connect(
 	state => {
 		return {
-			connectUrl: _getConnectUrl( state )
+			connectUrl: getConnectUrl( state )
 		}
 	}
 )( JetpackConnect );

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -16,7 +16,6 @@ import { getSiteConnectionStatus, getSiteDevMode, isStaging, isInIdentityCrisis,
 import { isDevVersion, userCanManageModules, userIsSubscriber } from 'state/initial-state';
 import DismissableNotices from './dismissable';
 import { getConnectUrl as _getConnectUrl } from 'state/connection';
-import QueryConnectUrl from 'components/data/query-connect-url';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants';
 
@@ -192,7 +191,6 @@ const JetpackNotices = React.createClass( {
 	render() {
 		return (
 			<div aria-live="polite">
-				<QueryConnectUrl />
 				<NoticesList />
 				<JetpackStateNotices />
 				<DevVersionNotice isDevVersion={ this.props.isDevVersion } userIsSubscriber={ this.props.userIsSubscriber } />

--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -85,6 +85,8 @@ export const disconnectSite = () => {
 				disconnectingSite: disconnectingSite
 			} );
 			dispatch( removeNotice( 'disconnect-jetpack' ) );
+		} ).then( () => {
+			dispatch( fetchConnectUrl() );
 		} ).catch( error => {
 			dispatch( {
 				type: DISCONNECT_SITE_FAIL,

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -12,6 +12,7 @@ import includes from 'lodash/includes';
  */
 import {
 	JETPACK_CONNECTION_STATUS_FETCH,
+	JETPACK_SET_INITIAL_STATE,
 	CONNECT_URL_FETCH,
 	CONNECT_URL_FETCH_FAIL,
 	CONNECT_URL_FETCH_SUCCESS,
@@ -42,9 +43,10 @@ export const status = ( state = { siteConnected: window.Initial_State.connection
 
 export const connectUrl = ( state = '', action ) => {
 	switch ( action.type ) {
+		case JETPACK_SET_INITIAL_STATE:
+			return action.initialState.connectUrl;
 		case CONNECT_URL_FETCH_SUCCESS:
 			return action.connectUrl;
-
 		default:
 			return state;
 	}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -266,6 +266,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
 			),
+			'connectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),
 			'currentVersion' => JETPACK__VERSION,


### PR DESCRIPTION
Makes the components that use the connection URL, get the data from the initial state instead of attempting to fetch. 

Problem here is that any given output or error that any other plugin putos on the php output will make the user not be able to connect. This is a general problem, but it's critical for us to at least allow the user to connect.

Fixes #7979

#### Changes proposed in this Pull Request:

* Makes the `connection` reducer react to `JETPACK_SET_INITIAL_STATE` by loading the `state.jetpack.connectUrl` with the data coming from the server via `wp_localize_script`.
* Removes every usage of `<QueryJetpackConnect />` because there's no more need for it.
* Makes the promise chain in the `disconnectSite()` action also call `fetchConnectUrl()` after disconnection is successful. 

#### Testing instructions:

* Start with a disconnected site and user.
* Visit the dashboard and confirm that the Connect button has an appropriate URL and that you can connect
* After connecting, login in with a non-admin user and confirm that the banner button that reads "Connect to WordPress.com" works and has a good `href`.
* *Confirm that you can cycle the connection*. Connect Jetpack, get back to the admin page. Disconnect, and try to connet again without refreshing the page.