### PR TITLE
Infinite Scroll: Apply post_gallery action with integer as third parameter

### DIFF
--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -220,7 +220,7 @@ class Jetpack_Infinite_Scroll_Extras {
 		// Fire the post_gallery action early so Carousel scripts are present.
 		if ( Jetpack::is_module_active( 'carousel' ) ) {
 			/** This filter is already documented in core/wp-includes/media.php */
-			do_action( 'post_gallery', '', '' );
+			do_action( 'post_gallery', '', '', 0 );
 		}
 
 		// Always enqueue Tiled Gallery scripts when both IS and Tiled Galleries are enabled


### PR DESCRIPTION
This parameter [has been present since 4.2](https://github.com/WordPress/WordPress/commit/fa86f3ef9cdc01954269fea4870e334bef6b5fcd) and by applying the filter here, we are currently breaking all callbacks that expect the $instance as third param.

Fixes #7939

#### Changes proposed in this Pull Request:

* Makes the application of the `post_gallery` filter include a third parameter to not make PHP throw when calling callbacks that expect it.

