### PR TITLE
Plugin API: Installing plugins always returns an error.

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -83,8 +83,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 			$this->log[ $plugin ] = (array) $upgrader->skin->get_upgrade_messages();
 		}
 
-		if ( ! $this->bulk && isset( $error ) ) {
-
+		if ( ! $this->bulk && ! empty( $error ) ) {
 			if ( 'download_failed' === $error_code ) {
 				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
 				$error_code = 'no_package';


### PR DESCRIPTION
Recently we added some bug fixes. This introduced a bug where we would always be returning an error when we install an plugin.

This PR fixes this by making sure that $error is being checked for the empty case.

#### Changes proposed in this Pull Request:

*

#### Testing instructions:
Run this PR Go to calypso and install a plugin. Notice that this doesn't error.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
