### PR TITLE
Gutenblocks: Subscription form block

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -81,17 +81,6 @@ class Jetpack_Subscriptions {
 		// Gutenberg!
 		add_action( 'init', array( __CLASS__, 'register_block_type' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
-
-		// Add REST API route to get the total number of subscribers.
-		add_action( 'rest_api_init', array( $this, 'rest_api_get_subscriber_count' ) );
-	}
-
-	function rest_api_get_subscriber_count() {
-		register_rest_route( 'jetpack', '/get_subscriber_count', array(
-			'methods' => 'GET',
-			'callback' => array( 'Jetpack_Subscriptions_Widget', 'fetch_subscriber_count' ),
-		) );
-
 	}
 
 	/**
@@ -766,6 +755,8 @@ class Jetpack_Subscriptions {
 	}
 
 	public static function enqueue_block_editor_assets() {
+		$subscriber_count = Jetpack_Subscriptions_Widget::fetch_subscriber_count();
+
 		wp_register_script(
 			'jetpack-block-subscription-form',
 			plugins_url( 'subscriptions/block.js', __FILE__ ),
@@ -781,7 +772,8 @@ class Jetpack_Subscriptions {
 			'Subscribe' => __( 'Subscribe', 'jetpack' ),
 			"Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
 				=> __( "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing.", 'jetpack' ),
-			'Join %s other subscribers' => __( 'Join %s other subscribers', 'jetpack' ),
+			'subscriberCount' => $subscriber_count['value'],
+			'Join %s other subscribers' => sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscriber_count['value'], 'jetpack' ), number_format_i18n( $subscriber_count['value'] ) ),
 			'Widget title:' => __( 'Widget title:', 'jetpack' ),
 			'Subscription Form settings' => __( 'Subscription Form settings', 'jetpack' ),
 			'Optional text to display to your readers:' => __( 'Optional text to display to your readers:', 'jetpack' ),

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -50,10 +50,6 @@ registerBlockType( 'jetpack/subscription-form', {
 			// Keep this in sync with server defaults
 			default: false,
 		},
-		subscribersCount: {
-			type: 'number',
-			default: -1,
-		},
 	},
 
 	edit: function( { attributes, setAttributes, focus, setFocus } ) {
@@ -63,21 +59,10 @@ registerBlockType( 'jetpack/subscription-form', {
 			show_subscribers_total,
 			subscribe_button,
 			success_message,
-			subscribersCount,
 		} = attributes;
 
 		const toggleshow_subscribers_total = () =>
 			setAttributes( { show_subscribers_total: ! show_subscribers_total } );
-
-		const getSubscriberCount = () => {
-			const restRootUrl = wp.api.utils.getRootUrl();
-
-			return jQuery.getJSON( `${ restRootUrl }wp-json/jetpack/get_subscriber_count` );
-		};
-
-		if ( subscribersCount === -1 ) {
-			getSubscriberCount().then( data => setAttributes( { subscribersCount: data[ 'value' ] } ) );
-		}
 
 		return [
 			<div key="subscription-form" className="subscription-form">
@@ -99,9 +84,9 @@ registerBlockType( 'jetpack/subscription-form', {
 								/>
 							</div> }
 						{ !! show_subscribers_total &&
-							subscribersCount > 0 &&
+							i18n.subscriberCount > 0 &&
 							<p className="subscription-form__subscribers">
-								{ i18n[ 'Join %s other subscribers' ].replace( '%s', subscribersCount ) }
+								{ i18n[ 'Join %s other subscribers' ] }
 							</p> }
 						<div id="subscribe-email">
 							<label id="jetpack-subscribe-label" className="subscription-form__email-label">

--- a/modules/subscriptions/block.jsx
+++ b/modules/subscriptions/block.jsx
@@ -1,0 +1,156 @@
+/** @format */
+const {
+	registerBlockType,
+	InspectorControls,
+	BlockDescription,
+	Editable,
+	InspectorControls: { CheckboxControl, TextControl },
+} = wp.blocks;
+const { createElement } = wp.element;
+
+const i18n = jpSubBlockI18n;
+
+registerBlockType( 'jetpack/subscription-form', {
+	title: i18n[ 'Subscription Form' ],
+	icon: 'email-alt',
+	category: 'common',
+	attributes: {
+		title: {
+			type: 'string',
+			default: 'Subscribe to this site',
+		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		subscribe_text: {
+			type: 'string',
+			default:
+				i18n[
+					'Enter your email address to subscribe to this blog and receive notifications of new posts by email.'
+				],
+		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		subscribe_button: {
+			type: 'string',
+			default: i18n[ 'Subscribe' ],
+		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		success_message: {
+			type: 'string',
+			default:
+				i18n[
+					"Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing."
+				],
+		},
+		// Using snake_case because the same attributes are passed to the
+		// `jetpack_do_subscription_form` shortcode.
+		show_subscribers_total: {
+			type: 'bool',
+			// Keep this in sync with server defaults
+			default: false,
+		},
+		subscribersCount: {
+			type: 'number',
+			default: -1,
+		},
+	},
+
+	edit: function( { attributes, setAttributes, focus, setFocus } ) {
+		const {
+			title,
+			subscribe_text,
+			show_subscribers_total,
+			subscribe_button,
+			success_message,
+			subscribersCount,
+		} = attributes;
+
+		const toggleshow_subscribers_total = () =>
+			setAttributes( { show_subscribers_total: ! show_subscribers_total } );
+
+		const getSubscriberCount = () => {
+			const restRootUrl = wp.api.utils.getRootUrl();
+
+			return jQuery.getJSON( `${ restRootUrl }wp-json/jetpack/get_subscriber_count` );
+		};
+
+		if ( subscribersCount === -1 ) {
+			getSubscriberCount().then( data => setAttributes( { subscribersCount: data[ 'value' ] } ) );
+		}
+
+		return [
+			<div key="subscription-form" className="subscription-form">
+				{ !! title &&
+					<h2 className="subscription-form__title">
+						<input
+							type="text"
+							value={ title }
+							onChange={ e => setAttributes( { title: e.target.value } ) }
+						/>
+					</h2> }
+				<form>
+					<fieldset>
+						{ !! subscribe_text &&
+							<div id="subscribe-text" className="subscription-form__text">
+								<textarea
+									value={ subscribe_text }
+									onChange={ e => setAttributes( { subscribe_text: e.target.value } ) }
+								/>
+							</div> }
+						{ !! show_subscribers_total &&
+							subscribersCount > 0 &&
+							<p className="subscription-form__subscribers">
+								{ i18n[ 'Join %s other subscribers' ].replace( '%s', subscribersCount ) }
+							</p> }
+						<div id="subscribe-email">
+							<label id="jetpack-subscribe-label" className="subscription-form__email-label">
+								{ i18n[ 'Email Address' ] }
+							</label>
+							<input
+								type="email"
+								className="required"
+								placeholder={ i18n[ 'Email Address' ] }
+								style={ { display: 'block' } }
+								required
+								disabled
+							/>
+						</div>
+						<div id="subscribe-submit">
+							<span className="button">
+								{ subscribe_button }
+							</span>
+						</div>
+					</fieldset>
+				</form>
+			</div>,
+			!! focus &&
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<h3>
+							{ i18n[ 'Subscription Form settings' ] }
+						</h3>
+					</BlockDescription>
+					<CheckboxControl
+						label={ i18n[ 'Show total number of subscribers?' ] }
+						checked={ show_subscribers_total }
+						onChange={ toggleshow_subscribers_total }
+					/>
+					<TextControl
+						label={ i18n[ 'Subscribe Button:' ] }
+						value={ subscribe_button }
+						onChange={ value => setAttributes( { subscribe_button: value } ) }
+					/>
+					<TextControl
+						label={ i18n[ 'Success Message Text:' ] }
+						value={ success_message }
+						onChange={ value => setAttributes( { success_message: value } ) }
+					/>
+				</InspectorControls>,
+		];
+	},
+
+	save: function() {
+		return null;
+	},
+} );

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -1,7 +1,47 @@
-#subscribe-email input {
-	width: 95%;
+.subscription-form {
+	margin: 0 0 0;
+	padding: 20px;
+	border: 4px solid black;
+	background: rgba( 255, 255, 255, .9 );
 }
 
-.comment-subscription-form .subscribe-label {
-	display: inline !important;
+.subscription-form__title {
+	margin: 0;
+}
+
+.subscription-form__title.subscription-form__title input,
+.subscription-form__text.subscription-form__text textarea  {
+	width: 100%;
+	margin: 0 0 0;
+	outline: 0;
+	box-shadow: none;
+	margin-bottom: 16px;
+}
+
+.subscription-form__title.subscription-form__title input {
+	font-size: 20px;
+	font-weight: 600;
+}
+
+.subscription-form__text p {
+	font-size: 14px;
+}
+
+p.subscription-form__subscribers {
+	font-size: 12px;
+	color: #555d66;
+}
+
+.subscription-form__email-label {
+	font-size: 14px;
+	font-weight: 600;
+	margin-left: 2px;
+}
+
+#subscribe-email input {
+	width: 100%;
+}
+
+#subscribe-submit {
+	margin: 16px 0 0;
 }


### PR DESCRIPTION
Even more scoped version of our gutenblocks.  I was seeing a lot of errors with the shortcode blocks (recipe and quiz), so maybe we can add those in a separate PR.  

With Gutenberg active, you should see a block for Subscription form.  

To Test: 
- Activate Gutenberg, activate Jetpack shortcodes and Subscription form feature.  
- You should see the options to add blocks for the mentioned above. 
- Make sure things work well
- Make sure it looks good on the front end
- Make sure there are no errors when Gutenberg is not active or installed.  