### PR TITLE
CLI: Update script so that global args are directly after wp

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -3,36 +3,41 @@
 # cancel a the plan provided for the current site using the given partner keys
 
 usage () {
-    echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com]"
+	echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com] [--allow-root]"
 }
 
+GLOBAL_ARGS=""
+
 for i in "$@"; do
-    case $i in
-        -c=* | --partner_id=* )     CLIENT_ID="${i#*=}"
-                                    shift
-                                    ;;
-        -s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
-                                    shift
-                                    ;;
-        -u=* | --url=* )            SITE_URL="${i#*=}"
-                                    shift
-                                    ;;
-        -h | --help )               usage
-                                    exit
-                                    ;;
-        * )                         usage
-                                    exit 1
-    esac
+	case $i in
+		-c=* | --partner_id=* )     CLIENT_ID="${i#*=}"
+			shift
+			;;
+		-s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
+			shift
+			;;
+		-u=* | --url=* )            SITE_URL="${i#*=}"
+			shift
+			;;
+		--allow-root )              GLOBAL_ARGS="--allow-root"
+			shift
+			;;
+		-h | --help )               usage
+			exit
+			;;
+		* )                         usage
+			exit 1
+	esac
 done
 
 if [ "$CLIENT_ID" = "" ] || [ "$CLIENT_SECRET" = "" ]; then
-    usage
-    exit 1
+	usage
+	exit 1
 fi
 
 # default API host that can be overridden
 if [ -z "$JETPACK_START_API_HOST" ]; then
-    JETPACK_START_API_HOST='public-api.wordpress.com'
+	JETPACK_START_API_HOST='public-api.wordpress.com'
 fi
 
 # fetch an access token using our client ID/secret
@@ -40,11 +45,16 @@ ACCESS_TOKEN_JSON=$(curl https://$JETPACK_START_API_HOST/oauth2/token --silent -
 
 # set URL arg for multisite compatibility
 if [ ! -z "$SITE_URL" ]; then
-  ADDITIONAL_ARGS="--url=$SITE_URL"
+	GLOBAL_ARGS=" --url=$SITE_URL"
 fi
 
+# Remove leading whitespace
+GLOBAL_ARGS=$(echo "$GLOBAL_ARGS" | xargs echo)
+
+# Intentionally not quoting $GLOBAL_ARGS below so that words in the string are split
+
 # silently ensure Jetpack is active
-wp plugin activate jetpack "$ADDITIONAL_ARGS" >/dev/null 2>&1 --allow-root
+wp $GLOBAL_ARGS plugin activate jetpack >/dev/null 2>&1
 
 # cancel the partner plan
-wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" "$ADDITIONAL_ARGS" --allow-root
+wp $GLOBAL_ARGS jetpack partner_cancel "$ACCESS_TOKEN_JSON"

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -4,91 +4,105 @@
 # executes wp-cli command to provision Jetpack site for given partner
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1]"
+	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root]"
 }
 
+GLOBAL_ARGS=""
+
 for i in "$@"; do
-    case $i in
-        -c=* | --partner_id=* )     CLIENT_ID="${i#*=}"
-                                    shift
-                                    ;;
-        -s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
-                                    shift
-                                    ;;
-        -i=* | --user_id=* | --user=* ) WP_USER="${i#*=}"
-                                    shift
-                                    ;;
-        -w=* | --wpcom_user_id=* )  WPCOM_USER_ID="${i#*=}"
-                                    shift
-                                    ;;
-        -p=* | --plan=* )           PLAN_NAME="${i#*=}"
-                                    shift
-                                    ;;
-        -o=* | --onboarding=* )     ONBOARDING="${i#*=}"
-                                    shift
-                                    ;;
-        -u=* | --url=* )            SITE_URL="${i#*=}"
-                                    shift
-                                    ;;
-        --force_register=* )        FORCE_REGISTER="${i#*=}"
-                                    shift
-                                    ;;
-        --force_connect=* )         FORCE_CONNECT="${i#*=}"
-                                    shift
-                                    ;;
-        -h | --help )               usage
-                                    exit
-                                    ;;
-        * )                         usage
-                                    exit 1
-    esac
+	case $i in
+		-c=* | --partner_id=* )     CLIENT_ID="${i#*=}"
+			shift
+			;;
+		-s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
+			shift
+			;;
+		-i=* | --user_id=* | --user=* ) WP_USER="${i#*=}"
+			shift
+			;;
+		-w=* | --wpcom_user_id=* )  WPCOM_USER_ID="${i#*=}"
+			shift
+			;;
+		-p=* | --plan=* )           PLAN_NAME="${i#*=}"
+			shift
+			;;
+		-o=* | --onboarding=* )     ONBOARDING="${i#*=}"
+			shift
+			;;
+		-u=* | --url=* )            SITE_URL="${i#*=}"
+			shift
+			;;
+		--force_register=* )        FORCE_REGISTER="${i#*=}"
+			shift
+			;;
+		--force_connect=* )         FORCE_CONNECT="${i#*=}"
+			shift
+			;;
+		--allow-root )              GLOBAL_ARGS="--allow-root"
+			shift
+			;;
+		-h | --help )               usage
+			exit
+			;;
+		* )                         usage
+			exit 1
+	esac
 done
 
 if [ "$CLIENT_ID" = "" ] || [ "$CLIENT_SECRET" = "" ]; then
-    usage
-    exit 1
+	usage
+	exit 1
 fi
 
 # default API host that can be overridden
 if [ -z "$JETPACK_START_API_HOST" ]; then
-    JETPACK_START_API_HOST='public-api.wordpress.com'
+	JETPACK_START_API_HOST='public-api.wordpress.com'
 fi
 
 # fetch an access token using our client ID/secret
 ACCESS_TOKEN_JSON=$(curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner")
 
-# set URL arg for multisite compatibility
-if [ ! -z "$SITE_URL" ]; then
-  ADDITIONAL_ARGS="--url=$SITE_URL"
-fi
-
-# silently ensure Jetpack is active
-wp plugin activate jetpack "$ADDITIONAL_ARGS" >/dev/null 2>&1 --allow-root
-
 # add extra args if available
 if [ ! -z "$WP_USER" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --user=$WP_USER"
+	GLOBAL_ARGS="$GLOBAL_ARGS --user=$WP_USER"
 fi
 
+# set URL arg for multisite compatibility
+if [ ! -z "$SITE_URL" ]; then
+	GLOBAL_ARGS="$GLOBAL_ARGS --url=$SITE_URL"
+fi
+
+# Remove leading whitespace
+GLOBAL_ARGS=$(echo "$GLOBAL_ARGS" | xargs echo)
+
+# Silently ensure Jetpack is active
+# Intentionally not quoting $GLOBAL_ARGS so that words in the string are split
+wp $GLOBAL_ARGS plugin activate jetpack >/dev/null 2>&1
+
+ADDITIONAL_ARGS=""
 if [ ! -z "$ONBOARDING" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --onboarding=$ONBOARDING"
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --onboarding=$ONBOARDING"
 fi
 
 if [ ! -z "$PLAN_NAME" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --plan=$PLAN_NAME"
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --plan=$PLAN_NAME"
 fi
 
 if [ ! -z "$WPCOM_USER_ID" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
 fi
 
 if [ ! -z "$FORCE_REGISTER" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_register=$FORCE_REGISTER"
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_register=$FORCE_REGISTER"
 fi
 
 if [ ! -z "$FORCE_CONNECT" ]; then
-  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_connect=$FORCE_CONNECT"
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_connect=$FORCE_CONNECT"
 fi
 
-# provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" "$ADDITIONAL_ARGS" --allow-root
+# Remove leading whitespace
+ADDITIONAL_ARGS=$(echo "$ADDITIONAL_ARGS" | xargs echo)
+
+# Provision the partner plan
+# Intentionally not quoting $GLOBAL_ARGS or $ADDITIONAL_ARGS so that words in the strings are split
+wp $GLOBAL_ARGS jetpack partner_provision "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS


### PR DESCRIPTION
This PR does a few things:

- Fixes a regression I introduced in #8009 where I started quoting `$ADDITIONAL_ARGS`. I did this because `shellcheck` recommended that we quote the variable, which I ran last after doing my functional testing. But, quoting the variable caused the arguments to be counted as one string. We need them to be evaluated as separate words. I have now added a comment above these instances so that we don't change it in the future.

- Moves global arguments to just after the `wp` part of the WP-CLI command. WP-CLI has a special environment variable that removes ambiguity by evaluating all arguments just after `wp` as global arguments and arguments after the command or subcommand as local arguments [#](https://make.wordpress.org/cli/handbook/config/#environment-variables).

- General cleaning up of the file by changing leading indentation with spaces to tabs as well as changing how much indentation we used in some places.

To test:

- Check out branch
- Run `sh jetpack/bin/partner-provision.sh --partner_id={$id} --partner_secret={$secret} --plan={$plan} --url={$url} --user=1` with proper variables
- Ensure `next_url` returned in response is a proper authorization URL
- Ensure site gets a plan on WP.com
- Run `sh jetpack/bin/partner-cancel.sh --partner_id={$id} --partner_secret={$secret} --user=1`
- Ensure plan is cancelled on WPCOM

You can also see @ebinnion or @goldsounds for a demo.