### PR TITLE
Changes include to include_once in shortcode files.

### DIFF
--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -68,7 +68,7 @@ function jetpack_load_shortcodes() {
 	$shortcode_includes = apply_filters( 'jetpack_shortcodes_to_include', $shortcode_includes );
 
 	foreach ( $shortcode_includes as $include ) {
-		include $include;
+		include_once $include;
 	}
 }
 


### PR DESCRIPTION
This is needed since #7991 has landed in Jetpack. There is a particular edge case that illustrates the problem. After #7991 the widget would check if a shortcode is present, and would load it if it wasn't. If then the shortcode would try to include that file again, it would fatal. This could happen when you have the widgets module enabled, and shortcode modules disabled. The fatal would appear in the request when you're trying to enable the shortcodes module.

#### Changes proposed in this Pull Request:
* Changes `include` to `include_once` for shortcode files.

#### Testing instructions:
* Disable shortcodes module.
* Enable widgets module.
* Try enabling the shortcodes module again using the legacy modules page.
* Observe the fatal error.
* Try to do the same thing again with this PR, observe no fatal.
