### PR TITLE
Add filter to allow Tiled Galleries on the new Core media gallery widget

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -24,7 +24,7 @@ class Jetpack_Tiled_Gallery {
 	public function core_media_widget_compat( $schema ) {
 		$schema['type'] = array(
 			'type' => 'string',
-			'enum' => array( 'default', 'rectangular', 'square', 'circle', 'columns' ),
+			'enum' => array( 'default', 'rectangular', 'square', 'circle', 'columns', 'slideshow' ),
 			'description' => __( 'Type of gallery.', 'jetpack' ),
 			'default' => 'default',
 		);

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -16,6 +16,19 @@ class Jetpack_Tiled_Gallery {
 		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
 		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
+
+		// Add Tiled Galleries functionality to core's media gallery widget.
+		add_filter( 'widget_media_gallery_instance_schema', array( $this, 'core_media_widget_compat' ) );
+	}
+
+	public function core_media_widget_compat( $schema ) {
+		$schema['type'] = array(
+			'type' => 'string',
+			'enum' => array( 'default', 'rectangular', 'square', 'circle', 'columns' ),
+			'description' => __( 'Type of gallery.', 'jetpack' ),
+			'default' => 'default',
+		);
+		return $schema;
 	}
 
 	public function tiles_enabled() {


### PR DESCRIPTION
Fixes #7830

Thank you @westonruter for [this patch](https://core.trac.wordpress.org/ticket/42285), which, once merged, allows us to seamlessly integrate TG functionality into the new Core widget.  

To Test: 
- Activate Tiled Galleries
- On a site running WP trunk, add a core media gallery widget
- Choose a `type` of gallery
- Make sure it saves the value correctly and displays the right type on the front end
- Make sure there is no conflicts when not running trunk 
