### PR TITLE
JPS: Fix issue where Jumpstart did not show for new JPS sites

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1030,13 +1030,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 			// authorize user and enable SSO
 			Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
 
-			if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
-				Jetpack::delete_active_modules();
-				Jetpack::activate_default_modules( 999, 1, $active_modules, false );
-			} else {
-				Jetpack::activate_default_modules( false, false, array(), false );
-			}
-
 			/**
 			 * Auto-enable SSO module for new Jetpack Start connections
 			 *
@@ -1044,8 +1037,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 			 *
 			 * @param bool $enable_sso Whether to enable the SSO module. Default to true.
 			 */
-			if ( apply_filters( 'jetpack_start_enable_sso', true ) ) {
-				Jetpack::activate_module( 'sso', false, false );
+			$other_modules = apply_filters( 'jetpack_start_enable_sso', true )
+				? array( 'sso' )
+				: array();
+
+			if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
+				Jetpack::delete_active_modules();
+				Jetpack::activate_default_modules( 999, 1, array_merge( $active_modules, $other_modules ), false );
+			} else {
+				Jetpack::activate_default_modules( false, false, $other_modules, false );
 			}
 		}
 


### PR DESCRIPTION
When going through JPS v2, @MichaelArestad pointed out that Jumpstart was not showing, even on a new site. 

After much debugging, I narrowed it down to [this line](https://github.com/Automattic/jetpack/commit/7c6349c132b6d138df9841d4b4d4ab0846597fde#diff-eae3f6a880e55a097f18a5d96c4567b6R137) where we were activating SSO by calling `Jetpack::activate_module( 'sso', false, false );` after the site had been created, provisioned by Jetpack Start, and the user had authorized.

In `Jetpack::activate_module()` there is a condition that will set the Jumpstart option to `jetpack_action_taken` which keeps us from showing the Jumpstart page.

To fix this, I made a change that starts to pass in `sso` in to `Jetpack::activate_default_modules()`, which will activate SSO in the same case, but without changing the Jumpstart option.

This bug did not affect sites that weren't provisioned via SSO since those sites don't redirect to an SSO link by default after being connected.

To test:

Run the following against master to verify the bug, and then against the branch to verify the fix.

Then, run through the standard flow and ensure everything works as expected.

- On a test site run the following:
     - `wp jetpack disconnect blog`
    - `wp jetpack reset modules`
    - `wp jetpack reset options`
- In `wp shell`, run `return urlencode( add_query_arg( array( 'action' => 'jetpack-sso', 'redirect_to' => urlencode( admin_url() ) ), wp_login_url() ) );` to build a `redirect_uri`
- On Jetpack admin page, click the connect button
- On WP.com, grab the URL before it's rewritten. Yea, I know. This is annoying.
- Swap out the `redirect_uri` arg with the `redirect_uri` we built in `wp shell` earlier
    - We do this because the JPS scripts use a different `redirect_uri` by default
- Enter URL in browser, and go through the flow
- Afterwards, check if Jumpstart shows on Jetpack page