### PR TITLE
API: Tweeks to the plugins api.

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -664,10 +664,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 			break;
 		case 'file_mod_capabilities':
 			$docs           = array(
-				'reasons_modify_files_disabled' => '(array|string) The reasons why files can\'t be modified',
-				'reasons_autoupdate_disabled'   => '(array|string) The reasons why autoupdates aren\'t allowed',
-				'modify_files'                  => '(boolean) true if files can be modified',
-				'autoupdate_files'              => '(boolean) true if autoupdates are allowed',
+				'reasons_modify_files_unavailable' => '(array) The reasons why files can\'t be modified',
+				'reasons_autoupdate_unavailable'   => '(array) The reasons why autoupdates aren\'t allowed',
+				'modify_files'                     => '(boolean) true if files can be modified',
+				'autoupdate_files'                 => '(boolean) true if autoupdates are allowed',
 			);
 			$return[ $key ] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
 			break;

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -226,11 +226,11 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		);
 
 		if ( ! empty( $reasons_can_not_modify_files ) ) {
-			$file_mod_capabilities['reasons_modify_files_disabled'] = $reasons_can_not_modify_files;
+			$file_mod_capabilities['reasons_modify_files_unavailable'] = $reasons_can_not_modify_files;
 		}
 
 		if ( ! $file_mod_capabilities['autoupdate_files'] ) {
-			$file_mod_capabilities['reasons_autoupdate_disabled'] = array_merge( $reasons_can_not_autoupdate, $reasons_can_not_modify_files );
+			$file_mod_capabilities['reasons_autoupdate_unavailable'] = array_merge( $reasons_can_not_autoupdate, $reasons_can_not_modify_files );
 		}
 		return $file_mod_capabilities;
 	}


### PR DESCRIPTION
Does it look like what you expect? Does the output make sense?

Related discussion: p9c7Jx-8V-p2
Related .com changes: D7853-code

@koke, @oguzkocer 


#### Changes proposed in this Pull Request:

* Are these the requested change?

#### Testing instructions:
Update your wp-config.php to have this set

```
define( 'DISALLOW_FILE_MODS', true );
define( 'AUTOMATIC_UPDATER_DISABLED', false );
define( 'WP_AUTO_UPDATE_CORE', false );
```
Reconnect your site to force a resync ( unless you want to wait an hour? )
- Activate a plugin. 
- Does the result look like what you expected? 


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
