### PR TITLE
SEO Tools: remove duplicate meta tags when another SEO plugin is active

### DIFF
--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -26,7 +26,11 @@ $jetpack_seo_conflicting_plugins = array(
 
 foreach( $jetpack_seo_conflicting_plugins as $seo_plugin ) {
 	if ( Jetpack::is_plugin_active( $seo_plugin ) ) {
+		// Disable all custom meta tags that SEO tools manages.
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+
+		// Also disable default meta tags.
+		add_filter( 'jetpack_seo_meta_tags_enabled', '__return_false' );
 		break;
 	}
 }

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -18,10 +18,7 @@ class Jetpack_SEO {
 		 *
 		 * @param bool true Should Jetpack's SEO Meta Tags be enabled. Defaults to true.
 		 */
-		if (
-			apply_filters( 'jetpack_seo_meta_tags_enabled', true )
-			&& Jetpack_SEO_Utils::is_enabled_jetpack_seo()
-		) {
+		if ( apply_filters( 'jetpack_seo_meta_tags_enabled', true ) ) {
 			add_action( 'wp_head', array( $this, 'meta_tags' ) );
 
 			// Add support for editing page excerpts in pages, regardless of theme support.


### PR DESCRIPTION
In case when 3rd party SEO plugin is active on the site we should prevent SEO tools from outputting duplicate meta tags.

Fixes https://github.com/Automattic/jetpack/issues/7962

This is another take at https://github.com/Automattic/jetpack/pull/7976 and reverts changes that were introduced there. The reason behind this is that the code in it was causing issues on Dotcom when synced.

#### Testing instructions:

* Follow the steps in the original issue; make sure no duplicate meta description tag is added.

#### Proposed changelog entry for your changes:

- SEO Tools: do not output any meta tags if another SEO plugin is already active.