### PR TITLE
Twitter Cards: Use site title if no post title exists

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -38,6 +38,12 @@ class Jetpack_Twitter_Cards {
 		if ( ! is_singular() || ! empty( $og_tags['twitter:card'] ) ) {
 			return $og_tags;
 		}
+		
+		$the_title = get_the_title();
+		if ( ! $the_title ) {
+			$the_title = get_bloginfo( 'name' );
+		}
+		$og_tags['twitter:text:title'] = $the_title;
 
 		/*
 		 * The following tags only apply to single pages.


### PR DESCRIPTION
Syncs r156982-wpcom