### PR TITLE
CLI: JPS: Return request body for partner cancel CLI command

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -857,7 +857,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( $result );
 		}
 
-		WP_CLI::log( json_encode( $result ) );
+		WP_CLI::log( wp_remote_retrieve_body( $result ) );
 	}
 
 	/**


### PR DESCRIPTION
When running the partner CLI scripts, the `wp partner_provision` command returns something like:

```
{ "success": true, "next_url" : {$URL} }
```

But, the `wp partner_cancel` command returned something like:

```
{"headers":{},"body":"{\"success\":true}","response":{"code":200,"message":"OK"},"cookies":[],"filename":null,"http_response":{"data":null,"headers":null,"status":null}}
```

To assist partners in integrating, these responses should be the same.

To test:

- You'll need to run the `bin/partner-provision.sh` script and the `bin/partner-cancel.sh` script with a whitelisted client ID and secret. See @gravityrail or @ebinnion about that.
- For both requests, you should get back a JSON object with a key of `success`.