### PR TITLE
Make masterbar tracks js dependent upon jquery

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -124,7 +124,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array(), JETPACK__VERSION );
+		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array( 'jquery' ), JETPACK__VERSION );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
 	}


### PR DESCRIPTION
This ensures it gets enqueued in the correct order.

#### Changes proposed in this Pull Request:

* Makes the masterbar dependent on jquery

#### Testing instructions:

* Make sure it works :p
* `$wp_scripts->registered['a8c_wpcom_masterbar_tracks_events']->deps` should have `'jquery'` in the array

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
