### PR TITLE
Sync: Update blacklisted post types

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -210,22 +210,22 @@ class Jetpack_Sync_Defaults {
 
 	static $blacklisted_post_types = array(
 		'ai1ec_event',
-		'snitch',
-		'secupress_log_action',
-		'http',
-		'bwg_gallery',
 		'bwg_album',
-		'idx_page',
-		'postman_sent_mail',
-		'rssmi_feed_item',
-		'rssap-feed',
-		'wp_automatic',
-		'jetpack_migration',
+		'bwg_gallery',
 		'customize_changeset', // WP built-in post type for Customizer changesets
 		'dn_wp_yt_log',
+		'http',
+		'idx_page',
+		'jetpack_migration',
+		'postman_sent_mail',
+		'rssap-feed',
+		'rssmi_feed_item',
+		'secupress_log_action',
+		'sg_optimizer_jobs',
+		'snitch',
 		'wpephpcompat_jobs',
 		'wprss_feed_item',
-		'sg_optimizer_jobs',
+		'wp_automatic',
 	);
 
 	static $default_post_checksum_columns = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -210,17 +210,18 @@ class Jetpack_Sync_Defaults {
 
 	static $blacklisted_post_types = array(
 		'ai1ec_event',
-		'bwg_album',
-		'bwg_gallery',
-		'customize_changeset', // WP built-in post type for Customizer changesets
+		'snitch',
+		'secupress_log_action',
 		'http',
+		'bwg_gallery',
+		'bwg_album',
 		'idx_page',
 		'postman_sent_mail',
-		'rssap-feed',
 		'rssmi_feed_item',
-		'secupress_log_action',
-		'snitch',
+		'rssap-feed',
 		'wp_automatic',
+		'jetpack_migration',
+		'customize_changeset', // WP built-in post type for Customizer changesets
 		'dn_wp_yt_log',
 		'wpephpcompat_jobs',
 		'wprss_feed_item',

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -221,6 +221,10 @@ class Jetpack_Sync_Defaults {
 		'secupress_log_action',
 		'snitch',
 		'wp_automatic',
+		'dn_wp_yt_log',
+		'wpephpcompat_jobs',
+		'wprss_feed_item',
+		'sg_optimizer_jobs',
 	);
 
 	static $default_post_checksum_columns = array(


### PR DESCRIPTION
Update blacklisted post types.

These post types aren't useful to the end user or happen too often and could break sync. Saving resources :)