### PR TITLE
Explicitly setting max version for a deprecated endpoint.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
@@ -7,6 +7,7 @@ new WPCOM_JSON_API_Update_Media_Endpoint( array(
 	'method'      => 'POST',
 	'path'        => '/sites/%s/media/%d',
 	'deprecated'  => true,
+	'max_version' => '1',
 	'new_version' => '1.1',
 	'path_labels' => array(
 		'$site'    => '(int|string) Site ID or domain',


### PR DESCRIPTION
Without this change POST requests to a v1.1 endpoint would get served by a v1 endpoint.

This syncs r162000-wpcom.

#### Testing instructions:
* Make sure the /sites/%site%/media endpoint returns the results that the v1.1 media endpoint should return.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed JSON API endpoint that handles media updating.