### PR TITLE
CLI: JPS: Allow site slug fallback when cancelling a plan

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -831,10 +831,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( new WP_Error( 'missing_access_token', __( 'Missing or invalid access token', 'jetpack' ) ) );
 		}
 
-		$blog_id    = Jetpack_Options::get_option( 'id' );
+		$site_identifier = Jetpack_Options::get_option( 'id' );
 
-		if ( ! $blog_id ) {
-			$this->partner_provision_error( new WP_Error( 'site_not_registered',  __( 'This site is not connected to Jetpack', 'jetpack' ) ) );
+		if ( ! $site_identifier ) {
+			$site_identifier = Jetpack::build_raw_urls( get_home_url() );
 		}
 
 		$request = array(
@@ -844,10 +844,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 			),
 			'timeout' => 60,
 			'method'  => 'POST',
-			'body'    => json_encode( array( 'site_id' => $blog_id ) )
 		);
 
-		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%d/partner-cancel', $this->get_api_host(), $blog_id );
+		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%s/partner-cancel', $this->get_api_host(), $site_identifier );
 
 		$result = Jetpack_Client::_wp_remote_request( $url, $request );
 


### PR DESCRIPTION
The current implementation of the wp jetpack partner-cancel command relies on `Jetpack_Options::get_option( 'id' )` being set, but in the case where the user had already disconnected their site before churning from the host, this value would be falsey.

In that case, we should fall back to using the site slug as an identifier.

This patch requires D7924 on the WPCOM side.

To test:

- Checkout D7924 on WPCOM (if not merged already)
- Sandbox API on your host
- Run `bin/partner-provision.sh` with required client ID and secret
- Disconnect site with `wp jetpack disconnect blog && wp option delete jetpack_options`
- Verify that plan exists for site still
- Run `bin/partner-cancel.sh` and verify plan is cancelled