### PR TITLE
CLI: JPS: If site is active, do not SSO as redirect_uri

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -933,11 +933,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			? get_site_icon_url()
 			: false;
 
+		$auto_enable_sso = ( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) );
+
 		/** This filter is documented in class.jetpack-cli.php */
-		if (
-			( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) ) &&
-			apply_filters( 'jetpack_start_enable_sso', true )
-		) {
+		if ( apply_filters( 'jetpack_start_enable_sso', $auto_enable_sso ) ) {
 			$redirect_uri = add_query_arg(
 				array( 'action' => 'jetpack-sso', 'redirect_to' => urlencode( admin_url() ) ),
 				wp_login_url() // TODO: come back to Jetpack dashboard?

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -934,7 +934,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			: false;
 
 		/** This filter is documented in class.jetpack-cli.php */
-		if ( apply_filters( 'jetpack_start_enable_sso', true ) ) {
+		if (
+			( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) ) &&
+			apply_filters( 'jetpack_start_enable_sso', true )
+		) {
 			$redirect_uri = add_query_arg(
 				array( 'action' => 'jetpack-sso', 'redirect_to' => urlencode( admin_url() ) ),
 				wp_login_url() // TODO: come back to Jetpack dashboard?


### PR DESCRIPTION
Currently, if a site is active and a hosting partner then runs the `bin/partner-provision.sh` script, we return an SSO login URL as the next step, regardless if the site has SSO enabled or not.

This PR will check if the site is connected, and if so, if SSO is active, before setting the redirect_uri to an SSO login URL.

To test:

- Connect Jetpack site
- Run `bin/partner-provision.sh` with whitelisted client ID and secret
- Ensure you get a longer authorization URL 
- urldecode that and visit the URL to finish the process
- Run `bin/partner-cancel.sh` to cancel the plan out
- Run `bin/partner-provision.sh` again to ensure you get a next_url that is to your admin dashboard this time