### PR TITLE
Admin Page: Return state in connection reducer if the initial state is not loaded fully

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -44,7 +44,7 @@ export const status = ( state = { siteConnected: window.Initial_State.connection
 export const connectUrl = ( state = '', action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
-			return action.initialState.connectUrl;
+			return get( action, 'initialState.connectUrl', state );
 		case CONNECT_URL_FETCH_SUCCESS:
 			return action.connectUrl;
 		default:


### PR DESCRIPTION
This helps the code not break static pages building as the initial state is mocked there.

Fixes generation of static files

#### Changes proposed in this Pull Request:

* Access the action props safely with `get` when reducing the `JETPACK_SET_INITIAL_STATE` action. 

#### Testing instructions:

* checkout this branch
* clean you current build with `yarn distclean && yarn clean-client`
* Confirm that running `yarn build` builds everything correctly


