### PR TITLE
Fixes Issue #6573: sharing icons are not aligned in wp-admin

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -448,7 +448,7 @@ body .sd-content ul li.share-custom a.share-icon span
 	margin-left: 0;
 	padding: 0 0 0 19px;
 	display: inline-block;
-	height: 16px;
+	height: 21px;
 	line-height: 16px;
 }
 


### PR DESCRIPTION
Fixes #6573

#### Changes proposed in this Pull Request:

* Aligns sharing icons for custom sharing services in wp-admin:

![image](https://user-images.githubusercontent.com/10421239/32082932-60205b40-ba7c-11e7-8fe9-cf46de5424de.png)


#### Testing instructions:

* Go to Settings > Sharing in your dashboard.
* Click "Add a new service" and add a new sharing service
* Select the "Icon + Text" button style.
* The icon for the custom service should now be aligned with the text in the Live Preview

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
