### PR TITLE
Masterbar: updates event props to keep them in sync with WordPress.com

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -668,7 +668,7 @@ class A8C_WPCOM_Masterbar {
 			),
 			array(
 				'url'   => 'https://wordpress.com/page/' . esc_attr( $this->primary_site_slug ),
-				'id'    => 'wp-admin-bar-new-page',
+				'id'    => 'wp-admin-bar-new-page-badge',
 				'label' => esc_html_x( 'Add', 'admin bar menu new item label', 'jetpack' ),
 			)
 		);
@@ -700,7 +700,7 @@ class A8C_WPCOM_Masterbar {
 			),
 			array(
 				'url'   => 'https://wordpress.com/post/' . esc_attr( $this->primary_site_slug ),
-				'id'    => 'wp-admin-bar-new-post',
+				'id'    => 'wp-admin-bar-new-post-badge',
 				'label' => esc_html_x( 'Add', 'admin bar menu new item label', 'jetpack' ),
 			)
 		);

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -4,75 +4,74 @@
 
 	var linksTracksEvents = {
 		//top level items
-		'wp-admin-bar-blog'                        : 'my_sites_link',
-		'wp-admin-bar-newdash'                     : 'reader_link',
+		'wp-admin-bar-blog'                        : 'my_sites',
+		'wp-admin-bar-newdash'                     : 'reader',
 		'wp-admin-bar-ab-new-post'                 : 'write_button',
-		'wp-admin-bar-my-account'                  : 'my_account_link',
-		'wp-admin-bar-notes'                       : 'notifications_link',
+		'wp-admin-bar-my-account'                  : 'my_account',
+		'wp-admin-bar-notes'                       : 'notifications',
 		//my sites - top items
-		'wp-admin-bar-switch-site'                 : 'my_sites_switch_site_link',
-		'wp-admin-bar-blog-info'                   : 'my_sites_blog_info_link',
-		'wp-admin-bar-site-view'                   : 'my_sites_view_site_link',
-		'wp-admin-bar-blog-stats'                  : 'my_sites_blog_stats_link',
-		'wp-admin-bar-plan'                        : 'my_sites_plan_link',
-		'wp-admin-bar-plan-badge'                  : 'my_sites_plan_badge_link',
+		'wp-admin-bar-switch-site'                 : 'my_sites_switch_site',
+		'wp-admin-bar-blog-info'                   : 'my_sites_blog_info',
+		'wp-admin-bar-site-view'                   : 'my_sites_view_site',
+		'wp-admin-bar-blog-stats'                  : 'my_sites_blog_stats',
+		'wp-admin-bar-plan'                        : 'my_sites_plan',
+		'wp-admin-bar-plan-badge'                  : 'my_sites_plan_badge',
 		//my sites - manage
-		'wp-admin-bar-edit-page'                   : 'my_sites_manage_site_pages_link',
-		'wp-admin-bar-new-page-badge'              : 'my_sites_manage_add_page_link',
-		'wp-admin-bar-edit-post'                   : 'my_sites_manage_blog_posts_link',
-		'wp-admin-bar-new-post-badge'              : 'my_sites_manage_add_new_post_link',
-		'wp-admin-bar-edit-attachment'             : 'my_sites_manage_media_link',
-		'wp-admin-bar-new-attachment-badge'        : 'my_sites_manage_add_media_link',
-		'wp-admin-bar-comments'                    : 'my_sites_manage_comments_link',
+		'wp-admin-bar-edit-page'                   : 'my_sites_manage_site_pages',
+		'wp-admin-bar-new-page-badge'              : 'my_sites_manage_add_page',
+		'wp-admin-bar-edit-post'                   : 'my_sites_manage_blog_posts',
+		'wp-admin-bar-new-post-badge'              : 'my_sites_manage_add_new_post',
+		'wp-admin-bar-edit-attachment'             : 'my_sites_manage_media',
+		'wp-admin-bar-new-attachment-badge'        : 'my_sites_manage_add_media',
+		'wp-admin-bar-comments'                    : 'my_sites_manage_comments',
 		//my sites - personalize
-		'wp-admin-bar-themes'                      : 'my_sites_personalize_themes_link',
-		'wp-admin-bar-cmz'                         : 'my_sites_personalize_themes_customize_link',
+		'wp-admin-bar-themes'                      : 'my_sites_personalize_themes',
+		'wp-admin-bar-cmz'                         : 'my_sites_personalize_themes_customize',
 		//my sites - configure
-		'wp-admin-bar-sharing'                     : 'my_sites_configure_sharing_link',
-		'wp-admin-bar-people'                      : 'my_sites_configure_people_link',
+		'wp-admin-bar-sharing'                     : 'my_sites_configure_sharing',
+		'wp-admin-bar-people'                      : 'my_sites_configure_people',
 		'wp-admin-bar-people-add'                  : 'my_sites_configure_people_add_button',
-		'wp-admin-bar-plugins'                     : 'my_sites_configure_plugins_link',
-		'wp-admin-bar-domains'                     : 'my_sites_configure_domains_link',
-		'wp-admin-bar-domains-add'                 : 'my_sites_configure_add_domain_link',
-		'wp-admin-bar-blog-settings'               : 'my_sites_configure_settings_link',
-		'wp-admin-bar-legacy-dashboard'            : 'my_sites_configure_wp_admin_link',
+		'wp-admin-bar-plugins'                     : 'my_sites_configure_plugins',
+		'wp-admin-bar-plugins-add'                 : 'my_sites_configure_manage_plugins',
+		'wp-admin-bar-blog-settings'               : 'my_sites_configure_settings',
 		//reader
-		'wp-admin-bar-followed-sites'              : 'reader_followed_sites_link',
-		'wp-admin-bar-reader-followed-sites-manage': 'reader_manage_followed_sites_link',
-		'wp-admin-bar-discover-discover'           : 'reader_discover_link',
-		'wp-admin-bar-discover-search'             : 'reader_search_link',
-		'wp-admin-bar-my-activity-my-likes'        : 'reader_my_likes_link',
+		'wp-admin-bar-followed-sites'              : 'reader_followed_sites',
+		'wp-admin-bar-reader-followed-sites-manage': 'reader_manage_followed_sites',
+		'wp-admin-bar-discover-discover'           : 'reader_discover',
+		'wp-admin-bar-discover-search'             : 'reader_search',
+		'wp-admin-bar-discover-recommended-blogs'  : 'reader_recommendations',
+		'wp-admin-bar-my-activity-my-likes'        : 'reader_my_likes',
 		//account
-		'wp-admin-bar-user-info'                   : 'my_account_user_name_link',
+		'wp-admin-bar-user-info'                   : 'my_account_user_name',
 		// account - profile
-		'wp-admin-bar-my-profile'                  : 'my_account_profile_my_profile_link',
-		'wp-admin-bar-account-settings'            : 'my_account_profile_account_settings_link',
-		'wp-admin-bar-billing'                     : 'my_account_profile_manage_purchases_link',
-		'wp-admin-bar-security'                    : 'my_account_profile_security_link',
-		'wp-admin-bar-notifications'               : 'my_account_profile_notifications_link',
+		'wp-admin-bar-my-profile'                  : 'my_account_profile_my_profile',
+		'wp-admin-bar-account-settings'            : 'my_account_profile_account_settings',
+		'wp-admin-bar-billing'                     : 'my_account_profile_manage_purchases',
+		'wp-admin-bar-security'                    : 'my_account_profile_security',
+		'wp-admin-bar-notifications'               : 'my_account_profile_notifications',
 		//account - special
-		'wp-admin-bar-get-apps'                    : 'my_account_special_get_apps_link',
-		'wp-admin-bar-next-steps'                  : 'my_account_special_next_steps_link',
-		'wp-admin-bar-help'                        : 'my_account_special_help_link'
+		'wp-admin-bar-get-apps'                    : 'my_account_special_get_apps',
+		'wp-admin-bar-next-steps'                  : 'my_account_special_next_steps',
+		'wp-admin-bar-help'                        : 'my_account_special_help'
 	};
 
 	var notesTracksEvents = {
 		openSite: function( data ) {
 			return {
-				clicked: 'masterbar_notifications_panel_site_link',
+				clicked: 'masterbar_notifications_panel_site',
 				site_id: data.siteId
 			};
 		},
 		openPost: function( data ) {
 			return {
-				clicked: 'masterbar_notifications_panel_post_link',
+				clicked: 'masterbar_notifications_panel_post',
 				site_id: data.siteId,
 				post_id: data.postId
 			};
 		},
 		openComment: function( data ) {
 			return {
-				clicked: 'masterbar_notifications_panel_comment_link',
+				clicked: 'masterbar_notifications_panel_comment',
 				site_id: data.siteId,
 				post_id: data.postId,
 				comment_id: data.commentId
@@ -89,7 +88,12 @@
 	}
 
 	$( document ).ready( function() {
-		$( '.mb-trackable .ab-item' ).on( 'click touchstart', function( e ) {
+		var trackableLinks = '.mb-trackable .ab-item:not(div),' +
+			'#wp-admin-bar-notes .ab-item,' +
+			'#wp-admin-bar-user-info .ab-item,' +
+			'.mb-trackable .ab-secondary';
+
+			$( trackableLinks ).on( 'click touchstart', function( e ) {
 			if ( ! window.jpTracksAJAX || 'function' !== typeof( window.jpTracksAJAX.record_ajax_event ) ) {
 				return;
 			}

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -24,6 +24,10 @@
 		'wp-admin-bar-edit-attachment'             : 'my_sites_manage_media',
 		'wp-admin-bar-new-attachment-badge'        : 'my_sites_manage_add_media',
 		'wp-admin-bar-comments'                    : 'my_sites_manage_comments',
+		'wp-admin-bar-edit-testimonial'            : 'my_sites_manage_testimonials',
+		'wp-admin-bar-new-testimonial'             : 'my_sites_manage_add_testimonial',
+		'wp-admin-bar-edit-portfolio'              : 'my_sites_manage_portfolio',
+		'wp-admin-bar-new-portfolio'               : 'my_sites_manage_add_portfolio',
 		//my sites - personalize
 		'wp-admin-bar-themes'                      : 'my_sites_personalize_themes',
 		'wp-admin-bar-cmz'                         : 'my_sites_personalize_themes_customize',

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,30 +1,84 @@
 /*globals JSON */
-(function( $ ) {
+( function( $ ) {
+	var eventName = 'masterbar_click';
+
+	var linksTracksEvents = {
+		//top level items
+		'wp-admin-bar-blog'                        : 'my_sites_link',
+		'wp-admin-bar-newdash'                     : 'reader_link',
+		'wp-admin-bar-ab-new-post'                 : 'write_button',
+		'wp-admin-bar-my-account'                  : 'my_account_link',
+		'wp-admin-bar-notes'                       : 'notifications_link',
+		//my sites - top items
+		'wp-admin-bar-switch-site'                 : 'my_sites_switch_site_link',
+		'wp-admin-bar-blog-info'                   : 'my_sites_blog_info_link',
+		'wp-admin-bar-site-view'                   : 'my_sites_view_site_link',
+		'wp-admin-bar-blog-stats'                  : 'my_sites_blog_stats_link',
+		'wp-admin-bar-plan'                        : 'my_sites_plan_link',
+		'wp-admin-bar-plan-badge'                  : 'my_sites_plan_badge_link',
+		//my sites - manage
+		'wp-admin-bar-edit-page'                   : 'my_sites_manage_site_pages_link',
+		'wp-admin-bar-new-page-badge'              : 'my_sites_manage_add_page_link',
+		'wp-admin-bar-edit-post'                   : 'my_sites_manage_blog_posts_link',
+		'wp-admin-bar-new-post-badge'              : 'my_sites_manage_add_new_post_link',
+		'wp-admin-bar-edit-attachment'             : 'my_sites_manage_media_link',
+		'wp-admin-bar-new-attachment-badge'        : 'my_sites_manage_add_media_link',
+		'wp-admin-bar-comments'                    : 'my_sites_manage_comments_link',
+		//my sites - personalize
+		'wp-admin-bar-themes'                      : 'my_sites_personalize_themes_link',
+		'wp-admin-bar-cmz'                         : 'my_sites_personalize_themes_customize_link',
+		//my sites - configure
+		'wp-admin-bar-sharing'                     : 'my_sites_configure_sharing_link',
+		'wp-admin-bar-people'                      : 'my_sites_configure_people_link',
+		'wp-admin-bar-people-add'                  : 'my_sites_configure_people_add_button',
+		'wp-admin-bar-plugins'                     : 'my_sites_configure_plugins_link',
+		'wp-admin-bar-domains'                     : 'my_sites_configure_domains_link',
+		'wp-admin-bar-domains-add'                 : 'my_sites_configure_add_domain_link',
+		'wp-admin-bar-blog-settings'               : 'my_sites_configure_settings_link',
+		'wp-admin-bar-legacy-dashboard'            : 'my_sites_configure_wp_admin_link',
+		//reader
+		'wp-admin-bar-followed-sites'              : 'reader_followed_sites_link',
+		'wp-admin-bar-reader-followed-sites-manage': 'reader_manage_followed_sites_link',
+		'wp-admin-bar-discover-discover'           : 'reader_discover_link',
+		'wp-admin-bar-discover-search'             : 'reader_search_link',
+		'wp-admin-bar-my-activity-my-likes'        : 'reader_my_likes_link',
+		//account
+		'wp-admin-bar-user-info'                   : 'my_account_user_name_link',
+		// account - profile
+		'wp-admin-bar-my-profile'                  : 'my_account_profile_my_profile_link',
+		'wp-admin-bar-account-settings'            : 'my_account_profile_account_settings_link',
+		'wp-admin-bar-billing'                     : 'my_account_profile_manage_purchases_link',
+		'wp-admin-bar-security'                    : 'my_account_profile_security_link',
+		'wp-admin-bar-notifications'               : 'my_account_profile_notifications_link',
+		//account - special
+		'wp-admin-bar-get-apps'                    : 'my_account_special_get_apps_link',
+		'wp-admin-bar-next-steps'                  : 'my_account_special_next_steps_link',
+		'wp-admin-bar-help'                        : 'my_account_special_help_link'
+	};
+
 	var notesTracksEvents = {
 		openSite: function( data ) {
 			return {
-				source: 'masterbar_notifications_panel',
+				clicked: 'masterbar_notifications_panel_site_link',
 				site_id: data.siteId
 			};
 		},
 		openPost: function( data ) {
 			return {
-				source: 'masterbar_notifications_panel',
+				clicked: 'masterbar_notifications_panel_post_link',
 				site_id: data.siteId,
 				post_id: data.postId
 			};
 		},
 		openComment: function( data ) {
 			return {
-				source: 'masterbar_notifications_panel',
+				clicked: 'masterbar_notifications_panel_comment_link',
 				site_id: data.siteId,
 				post_id: data.postId,
 				comment_id: data.commentId
 			};
 		}
 	};
-
-	var eventName = 'masterbar_click';
 
 	function parseJson( s, defaultValue ) {
 		try {
@@ -49,11 +103,16 @@
 
 			var trackingId = $target.attr( 'ID' ) || $parent.attr( 'ID' );
 
+			if ( ! linksTracksEvents.hasOwnProperty( trackingId ) ) {
+				return;
+			}
+			var eventProps = { 'clicked': linksTracksEvents[ trackingId ] };
+
 			if ( $parent.hasClass( 'menupop' ) ) {
-				window.jpTracksAJAX.record_ajax_event( eventName, 'click', trackingId );
+				window.jpTracksAJAX.record_ajax_event( eventName, 'click', eventProps );
 			} else {
 				e.preventDefault();
-				window.jpTracksAJAX.record_ajax_event( eventName, 'click', trackingId ).always( function() {
+				window.jpTracksAJAX.record_ajax_event( eventName, 'click', eventProps ).always( function() {
 					window.location = $target.attr( 'href' );
 				} );
 			}
@@ -84,4 +143,4 @@
 		window.jpTracksAJAX.record_ajax_event( eventName, 'click', eventData( data ) );
 	} );
 
-})( jQuery );
+} )( jQuery );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the event props sent to Tracks for user activity on the Masterbar to keep them in sync with D7919-code, including:
* Events firing twice for a menu element with a secondary action.
* Click event not firing on the user name links on the my account menu.
* Events not firing for primary and secondary actions on Testimonials and Portfolio links on My Sites.
* Notifications Panel `source` event prop renamed to `clicked` for consistency.

#### Testing instructions:

* Run a WordPress instance with this branch
* Enable WordPress.com Masterbar
* Using an http debugger, any activity on the masterbar, or opening a site, post or comment on the notifications panel should trigger an `admin-ajax.php` request with the `jetpack_tracks` action, and at least the `clicked` event prop corresponding to the clicked element.