### PR TITLE
Widgets: Migrate Gallery Widget instances to core 4.9 Media Gallery widgets

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -88,6 +88,7 @@ class Jetpack_Options {
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
+			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget
 		);
 	}
 
@@ -438,7 +439,7 @@ class Jetpack_Options {
 		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_options', array() );
 		return isset( $disabled_raw_options[ $name ] );
 	}
-	
+
 	/**
 	 * Gets all known options that are used by Jetpack and managed by Jetpack_Options.
 	 *

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -33,6 +33,7 @@ function jetpack_load_widgets() {
 	}
 
 	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/image-widget.php';
+	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/gallery-widget.php';
 }
 
 add_action( 'jetpack_modules_loaded', 'jetpack_widgets_loaded' );

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -426,6 +426,9 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 add_action( 'widgets_init', 'jetpack_gallery_widget_init' );
 
 function jetpack_gallery_widget_init() {
+	if ( class_exists( 'WP_Widget_Media_Gallery' ) && Jetpack_Options::get_option( 'gallery_widget_migration' ) ) {
+		return;
+ 	}
 	if ( ! method_exists( 'Jetpack', 'is_module_active' ) || Jetpack::is_module_active( 'tiled-gallery' ) )
 		register_widget( 'Jetpack_Gallery_Widget' );
 }

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -426,7 +426,16 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 add_action( 'widgets_init', 'jetpack_gallery_widget_init' );
 
 function jetpack_gallery_widget_init() {
-	if ( class_exists( 'WP_Widget_Media_Gallery' ) && Jetpack_Options::get_option( 'gallery_widget_migration' ) ) {
+	/**
+	 * Allow the Gallery Widget to be enabled even when Core supports the Media Gallery Widget
+	 *
+	 * @module widgets
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param bool false Whether to force-enable the gallery widget
+	 */
+	if ( apply_filters( 'jetpack_force_enable_gallery_widget', false ) || ( class_exists( 'WP_Widget_Media_Gallery' ) && Jetpack_Options::get_option( 'gallery_widget_migration' ) ) ) {
 		return;
  	}
 	if ( ! method_exists( 'Jetpack', 'is_module_active' ) || Jetpack::is_module_active( 'tiled-gallery' ) )

--- a/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/modules/widgets/migrate-to-core/gallery-widget.php
@@ -125,7 +125,7 @@ function jetpack_migrate_gallery_widget_upgrade_widget( $widget ) {
 	$non_whitelisted_keys = array_diff_key( $widget_copy, $whitelisted_keys );
 	if ( count( $non_whitelisted_keys ) > 0 ) {
 		foreach( $non_whitelisted_keys as $key => $value ) {
-			jetpack_migrate_gallery_widget_bump_stats( "widget_had_extra_key_$key" );
+			jetpack_migrate_gallery_widget_bump_stats( "extra-key-$key", "migration-extra-key" );
 		}
 	}
 
@@ -172,14 +172,14 @@ function jetpack_migrate_gallery_widget_update_sidebars( $sidebars_widgets, $id,
  *
  * @param string $bin  The bin to log into.
  */
-function jetpack_migrate_gallery_widget_bump_stats( $bin ) {
+function jetpack_migrate_gallery_widget_bump_stats( $bin, $group = '' ) {
 	// If this is being run on .com bumps_stats_extra exists, but using the filter looks more elegant.
 	if ( function_exists( 'bump_stats_extras' ) ) {
-		$group = 'jetpack-widget-migration';
+		$group = empty( $group  ) ? 'jetpack-widget-migration' : "jetpack-$group";
 		do_action( 'jetpack_bump_stats_extra', $group, $bin );
 	} else {
 		// $group is prepended with 'jetpack-'
-		$group = 'widget-migration';
+		$group = empty( $group ) ? 'widget-migration' : $group;
 		$jetpack = Jetpack::init();
 		$jetpack->stat( $group, $bin ) ;
 	}

--- a/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/modules/widgets/migrate-to-core/gallery-widget.php
@@ -122,8 +122,11 @@ function jetpack_migrate_gallery_widget_upgrade_widget( $widget ) {
 	// Ensure widget has no keys other than those expected.
 	// Not all widgets have conditions, so lets add it in.
 	$widget_copy = array_merge( array( 'conditions' => null ), $widget );
-	if ( count( array_diff_key( $widget_copy, $whitelisted_keys ) ) > 0 ) {
-		return null;
+	$non_whitelisted_keys = array_diff_key( $widget_copy, $whitelisted_keys );
+	if ( count( $non_whitelisted_keys ) > 0 ) {
+		foreach( $non_whitelisted_keys as $key => $value ) {
+			jetpack_migrate_gallery_widget_bump_stats( "widget_had_extra_key_$key" );
+		}
 	}
 
 	$widget_copy = array_merge( $default_data, $widget, array(

--- a/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/modules/widgets/migrate-to-core/gallery-widget.php
@@ -50,7 +50,6 @@ function jetpack_migrate_gallery_widget() {
 	}
 
 	if ( update_option( 'widget_media_gallery', $media_gallery ) ) {
-		delete_option( 'widget_gallery' );
 
 		// Now un-register old widgets and register new.
 		foreach ( $widgets_to_unregister as $id => $new_id ) {
@@ -72,11 +71,6 @@ function jetpack_migrate_gallery_widget() {
 		// We need to refresh on widgets page for changes to take effect.
 		// The jetpack_refresh_on_widget_page function is already defined in migrate-to-core/image-widget.php
 		add_action( 'current_screen', 'jetpack_refresh_on_widget_page' );
-	} else {
-		$widget_media_gallery = get_option( 'widget_media_gallery' );
-		if ( is_array( $widget_media_gallery ) ) {
-			delete_option( 'widget_gallery' );
-		}
 	}
 	Jetpack_Options::update_option( 'gallery_widget_migration', true );
 }

--- a/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/modules/widgets/migrate-to-core/gallery-widget.php
@@ -124,7 +124,10 @@ function jetpack_migrate_gallery_widget_upgrade_widget( $widget ) {
 	$widget_copy = array_merge( array( 'conditions' => null ), $widget );
 	$non_whitelisted_keys = array_diff_key( $widget_copy, $whitelisted_keys );
 	if ( count( $non_whitelisted_keys ) > 0 ) {
-		foreach( $non_whitelisted_keys as $key => $value ) {
+		jetpack_migrate_gallery_widget_bump_stats( 'extra-key' );
+
+		// Log the names of the keys not in our whitelist.
+		foreach ( $non_whitelisted_keys as $key => $value ) {
 			jetpack_migrate_gallery_widget_bump_stats( "extra-key-$key", "migration-extra-key" );
 		}
 	}
@@ -170,16 +173,16 @@ function jetpack_migrate_gallery_widget_update_sidebars( $sidebars_widgets, $id,
 /**
  * Will bump stat in jetpack_gallery_widget_migration group.
  *
- * @param string $bin  The bin to log into.
+ * @param string $bin   The bin to log into.
+ * @param string $group The group name. Defaults to "widget-migration".
  */
-function jetpack_migrate_gallery_widget_bump_stats( $bin, $group = '' ) {
+function jetpack_migrate_gallery_widget_bump_stats( $bin, $group = 'widget-migration' ) {
 	// If this is being run on .com bumps_stats_extra exists, but using the filter looks more elegant.
 	if ( function_exists( 'bump_stats_extras' ) ) {
-		$group = empty( $group  ) ? 'jetpack-widget-migration' : "jetpack-$group";
+		$group = "jetpack-$group";
 		do_action( 'jetpack_bump_stats_extra', $group, $bin );
 	} else {
 		// $group is prepended with 'jetpack-'
-		$group = empty( $group ) ? 'widget-migration' : $group;
 		$jetpack = Jetpack::init();
 		$jetpack->stat( $group, $bin ) ;
 	}

--- a/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
+++ b/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
@@ -1,0 +1,163 @@
+<?php
+
+require dirname( __FILE__ ) . '/../../../../../modules/widgets/migrate-to-core/gallery-widget.php';
+
+
+class WP_Test_Jetpack_Migrate_Gallery_Widget extends WP_UnitTestCase {
+	/**
+	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with a non-array
+	 */
+	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_string() {
+		$this->assertEquals( null, jetpack_migrate_gallery_widget_upgrade_widget( 'string' ) );
+	}
+
+	/**
+	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with an empty value
+	 */
+	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_empty() {
+		$this->assertEquals( null, jetpack_migrate_gallery_widget_upgrade_widget( array() ) );
+	}
+	/**
+	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with an widget with extra keys
+	 */
+	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_extra_keys() {
+		$input = array(
+			'title' => 'Jetpack Gallery',
+			'ids' => '13,21,41,61,63,83',
+			'link' => 'carousel',
+			'type' => 'rectangular',
+			'extra' => 'extra',
+		);
+		$this->assertEquals( null, jetpack_migrate_gallery_widget_upgrade_widget( $input ) );
+	}
+
+	/**
+	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with valid widgets
+	 */
+	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_valid_widget() {
+		$input = array(
+			'title' => 'Jetpack Gallery',
+			'ids' => '13,21,41,61,63,83',
+			'link' => 'carousel',
+			'type' => 'rectangular',
+		);
+		$input2 = array(
+			'title' => 'Jetpack Gallery',
+			'ids' => '13,21,41,61,63,83',
+			'link' => 'carousel',
+			'type' => 'rectangular',
+			'random' => 'on',
+		);
+		$input3 = array(
+			'title' => 'Jetpack Gallery',
+			'ids' => '13,21,41,61,63,83',
+			'link' => 'carousel',
+			'type' => 'rectangular',
+			'random' => 'on',
+			'conditions' => array(
+				'action' => 'show',
+				'match_all' => '1',
+				'rules' => array(
+					array(
+						'major' => 'author',
+						'minor' => '1',
+						'has_children' => false,
+					)
+				)
+			),
+		);
+		$output = array(
+			'columns' => 3,
+			'title' => 'Jetpack Gallery',
+			'ids' => array(
+				'13',
+				'21',
+				'41',
+				'61',
+				'63',
+				'83',
+			),
+			'link_type' => 'carousel',
+			'orderby_random' => false,
+			'size' => 'thumbnail',
+			'type' => 'rectangular',
+		);
+		$output2 = array(
+			'columns' => 3,
+			'title' => 'Jetpack Gallery',
+			'ids' => array(
+				'13',
+				'21',
+				'41',
+				'61',
+				'63',
+				'83',
+			),
+			'link_type' => 'carousel',
+			'orderby_random' => true,
+			'size' => 'thumbnail',
+			'type' => 'rectangular',
+		);
+		$output3 = array(
+			'columns' => 3,
+			'title' => 'Jetpack Gallery',
+			'ids' => array(
+				'13',
+				'21',
+				'41',
+				'61',
+				'63',
+				'83',
+			),
+			'link_type' => 'carousel',
+			'orderby_random' => true,
+			'size' => 'thumbnail',
+			'type' => 'rectangular',
+			'conditions' => array(
+				'action' => 'show',
+				'match_all' => '1',
+				'rules' => array(
+					array(
+						'major' => 'author',
+						'minor' => '1',
+						'has_children' => false,
+					)
+				)
+			),
+		);
+
+		$this->assertEquals( $output, jetpack_migrate_gallery_widget_upgrade_widget( $input ) );
+		$this->assertEquals( $output2, jetpack_migrate_gallery_widget_upgrade_widget( $input2 ) );
+		$this->assertEquals( $output3, jetpack_migrate_gallery_widget_upgrade_widget( $input3 ) );
+	}
+
+	/**
+	 * Test jetpack_migrate_gallery_widget_update_sidebars
+	 */
+	function test_jetpack_migrate_gallery_widget_update_sidebars()
+	{
+		$input = array(
+			'wp_inactive_widgets' => array(),
+			'sidebar-1' => array(
+				'gallery-1',
+				'gallery-2',
+			)
+		);
+		$output1 = array(
+			'wp_inactive_widgets' => array(),
+			'sidebar-1' => array(
+				'media_gallery-1',
+				'gallery-2',
+			)
+		);
+		$output2 = array(
+			'wp_inactive_widgets' => array(),
+			'sidebar-1' => array(
+				'media_gallery-1',
+				'media_gallery-2',
+			)
+		);
+		$this->assertEquals( $output1, jetpack_migrate_gallery_widget_update_sidebars( $input, 1, 1 ) );
+		$this->assertEquals( $output2, jetpack_migrate_gallery_widget_update_sidebars( $output1, 2, 2 ) );
+	}
+}

--- a/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
+++ b/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
@@ -17,19 +17,6 @@ class WP_Test_Jetpack_Migrate_Gallery_Widget extends WP_UnitTestCase {
 	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_empty() {
 		$this->assertEquals( null, jetpack_migrate_gallery_widget_upgrade_widget( array() ) );
 	}
-	/**
-	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with an widget with extra keys
-	 */
-	function test_jetpack_migrate_gallery_widget_upgrade_widget_with_extra_keys() {
-		$input = array(
-			'title' => 'Jetpack Gallery',
-			'ids' => '13,21,41,61,63,83',
-			'link' => 'carousel',
-			'type' => 'rectangular',
-			'extra' => 'extra',
-		);
-		$this->assertEquals( null, jetpack_migrate_gallery_widget_upgrade_widget( $input ) );
-	}
 
 	/**
 	 * Test jetpack_migrate_gallery_widget_upgrade_widget when called with valid widgets


### PR DESCRIPTION
Allows active Jetpack Gallery Widgets to be upgraded to Core's Media Gallery widgets, maintaining type, random and visibility options for each widget.

Will try to keep the same id for every widget, unles this collides with an already existing Core Media Gallery Widget id. ~This is just an edge case that can come up if the user upgrades their WordPress with Jetpack inactive, creates a Media Gallery widget and then decides to activate and connect Jetpack. If existing Jetpack Gallery widgets are there with ids similar to the new ones created by the user, the imported widgets will try to have a non-colliding id~.

### Changes proposed in this Pull Request:

* Creates an importer that hooks on `widgets_init` for transforming Jetpack Gallery Widgets into Media Gallery widgets introduced in WordPress 4.9
* Makes the Gallery widget don't be initialized if running on 4.9 and the importer function has already been used
* If a widget already exists with an id of `media-gallery-xxx` where `xxx`, then that id is not used for any of the newly imported widgets
* Adds unit test for some of the functions introduced by the importer.

### Testing instructions:

* On a 4.8.2 or 4.9 installation, create a few Jetpack Gallery widgets.
* If started with 4.8.2 upgrade your WordPress to 4.9-beta4. 
* Load any admin page and visit the widgets page.
* Expect to see your widgets imported to be Core Media Gallery ones. (They read **Gallery: title** instead of **Gallery (Jetpack): title**). 
* Run tests and expect them to pass. Run the following standing in the jetpack directory:
  ```
   $ phpunit tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
  ```
**To rollback the changes:**

* Delete all of the imported core widget galleries one by one.
* Create the widgets again
* run `wp jetpack options delete gallery_widget_migration` or set it to `0` via `wp-admin/options.php`.

#### Proposed changelog entry for your changes:

Adds ability to migrate Jetpack Gallery widget to new core Media Gallery widgets