### PR TITLE
Contact Form: do not process shortcodes in widgets when Core does

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -97,7 +97,10 @@ class Grunion_Contact_Form_Plugin {
 		add_filter( 'widget_text', array( $this, 'widget_atts' ), 0 );
 
 		// If Text Widgets don't get shortcode processed, hack ours into place.
-		if ( ! has_filter( 'widget_text', 'do_shortcode' ) ) {
+		if (
+			version_compare( get_bloginfo( 'version' ), '4.9-z', '<=' )
+			&& ! has_filter( 'widget_text', 'do_shortcode' )
+		) {
 			add_filter( 'widget_text', array( $this, 'widget_shortcode_hack' ), 5 );
 		}
 


### PR DESCRIPTION
Fixes #8059

To test, add a contact form shortcode to a text widget in your sidebar, and make sure it is properly rendered, whether you are running WordPress 4.8.2 or 4.9 Beta.

#### Proposed changelog entry for your changes:
* Contact Form: do not process shortcodes in widgets when WordPress itself does, starting in 4.9