### PR TITLE
wp.me links should always be HTTPS links

### DIFF
--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -53,8 +53,7 @@ function wpme_get_shortlink( $id = 0, $context = 'post', $allow_slugs = true ) {
 		if ( empty( $id ) )
 			$id = $blog_id;
 
-		$wpme_url = 'http://wp.me/' . wpme_dec2sixtwo( $id );
-		return set_url_scheme( $wpme_url );
+		return 'https://wp.me/' . wpme_dec2sixtwo( $id );
 	}
 
 	$post = get_post( $id );
@@ -82,8 +81,7 @@ function wpme_get_shortlink( $id = 0, $context = 'post', $allow_slugs = true ) {
 	if ( empty( $type ) )
 		return '';
 
-	$url = 'http://wp.me/' . $type . wpme_dec2sixtwo( $blog_id ) . '-' . $id;
-	return set_url_scheme( $url );
+	return 'https://wp.me/' . $type . wpme_dec2sixtwo( $blog_id ) . '-' . $id;
 }
 
 function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {


### PR DESCRIPTION
Simple commit. Use HTTPS for wp.me links regardless of the HTTPS? status of the request being rendered for.