### PR TITLE
Comments: Redirect front-end comment edit links to Calypso.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -671,6 +671,7 @@ class Jetpack {
 	}
 
 	function point_edit_comment_links_to_calypso( $url ) {
+		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
 		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
 		return esc_url( sprintf( 'https://wordpress.com/comments/all/%s/?commentId=%d&action=edit',
 			Jetpack::build_raw_urls( get_home_url() ),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -618,7 +618,7 @@ class Jetpack {
 		// We should make sure to only do this for front end links.
 		if ( Jetpack::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
 			add_filter( 'get_edit_post_link', array( $this, 'point_edit_post_links_to_calypso' ), 1, 2 );
-			add_filter( 'edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1, 3 );
+			add_filter( 'get_edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1 );
 		}
 
 		// Update the Jetpack plan from API on heartbeats
@@ -670,13 +670,12 @@ class Jetpack {
 		return esc_url( sprintf( 'https://wordpress.com/%s/%s/%d', $path_prefix, $site_slug, $post_id ) );
 	}
 
-	function point_edit_comment_links_to_calypso( $link, $comment_id, $text ) {
-		$url = wp_parse_url( get_home_url() );
-		$html = sprintf( '<a class="comment-edit-link" href="%s">%s</a>',
-			esc_url( "https://wordpress.com/comments/all/{$url['host']}?commentId={$comment_id}&action=edit" ),
-			$text
-		);
-		return $html;
+	function point_edit_comment_links_to_calypso( $url ) {
+		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+		return esc_url( sprintf( 'https://wordpress.com/comments/all/%s/?commentId=%d&action=edit',
+			Jetpack::build_raw_urls( get_home_url() ),
+			$query_args['amp;c']
+		) );
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -614,10 +614,11 @@ class Jetpack {
 		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
-		// If enabled, point edit post and page links to Calypso instead of WP-Admin.
+		// If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.
 		// We should make sure to only do this for front end links.
-		if ( Jetpack_Options::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
-			add_filter( 'get_edit_post_link', array( $this, 'point_edit_links_to_calypso' ), 1, 2 );
+		if ( Jetpack::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
+			add_filter( 'get_edit_post_link', array( $this, 'point_edit_post_links_to_calypso' ), 1, 2 );
+			add_filter( 'edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1, 3 );
 		}
 
 		// Update the Jetpack plan from API on heartbeats
@@ -640,7 +641,7 @@ class Jetpack {
 		add_filter( 'jetpack_sync_before_send_updated_option', array( $this, 'jetpack_track_last_sync_callback' ), 99 );
 	}
 
-	function point_edit_links_to_calypso( $default_url, $post_id ) {
+	function point_edit_post_links_to_calypso( $default_url, $post_id ) {
 		$post = get_post( $post_id );
 
 		if ( empty( $post ) ) {
@@ -667,6 +668,15 @@ class Jetpack {
 		$site_slug  = Jetpack::build_raw_urls( get_home_url() );
 
 		return esc_url( sprintf( 'https://wordpress.com/%s/%s/%d', $path_prefix, $site_slug, $post_id ) );
+	}
+
+	function point_edit_comment_links_to_calypso( $link, $comment_id, $text ) {
+		$url = wp_parse_url( get_home_url() );
+		$html = sprintf( '<a class="comment-edit-link" href="%s">%s</a>',
+			esc_url( "https://wordpress.com/comments/all/{$url['host']}?commentId={$comment_id}&action=edit" ),
+			$text
+		);
+		return $html;
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -673,7 +673,7 @@ class Jetpack {
 	function point_edit_comment_links_to_calypso( $url ) {
 		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
 		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
-		return esc_url( sprintf( 'https://wordpress.com/comments/all/%s/?commentId=%d&action=edit',
+		return esc_url( sprintf( 'https://wordpress.com/comment/%s/%d?action=edit',
 			Jetpack::build_raw_urls( get_home_url() ),
 			$query_args['amp;c']
 		) );


### PR DESCRIPTION
Needs https://github.com/Automattic/wp-calypso/pull/20777.

Just as we've added the ability to redirect front-end post and page edit links to Calypso in #7732 , this PR gives the same treatment to front-end comment edit links. The same Jetpack option is used for activating (`edit_links_calypso_redirect`).

<img width="458" alt="screen shot 2017-10-27 at 4 18 33 pm" src="https://user-images.githubusercontent.com/349751/32128444-94466372-bb32-11e7-8203-1dddf840d378.png">

When this option is enabled, comment edit links will be filtered with an `href` pointing to Calypso, in the format `/comments/all/:site?commentId=:comment-id&action=edit`.

See https://github.com/Automattic/wp-calypso/issues/17221.

**Testing**
* Switch to this branch.
* Ensure the option returns as enabled. One way is to edit `class.jetpack.php` L619 and replace the first check `Jetpack::get_option( 'edit_links_calypso_redirect' )` with just `true`.
* Verify that a front-end Edit link for a comment redirects to Calypso.