### PR TITLE
Implement a "Simple Payments" widget

### DIFF
--- a/modules/simple-payments/money-format.php
+++ b/modules/simple-payments/money-format.php
@@ -184,7 +184,12 @@ class Jetpack_Money_Format {
 		if ( ! $currency ) {
 			return $price . ' ' . $currency_code;
 		}
-		return number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] ) . ' ' . $currency['symbol'];
+		$amount = number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] );
+		$symbol = $currency['symbol'];
+		if ( $currency_code === 'USD' ) { // TODO: Move this information to the $currencies map
+			return $symbol . $amount;
+		}
+		return $amount . ' ' . $symbol;
 	}
 
 	public static function format_price_amount( $currency_code, $price ) {

--- a/modules/simple-payments/money-format.php
+++ b/modules/simple-payments/money-format.php
@@ -1,0 +1,209 @@
+<?php
+
+class Jetpack_Money_Format {
+
+	private static $currencies = array(
+		'USD' => array(
+			'symbol' => '$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'EUR' => array(
+			'symbol' => '€',
+			'grouping' => '.',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'AUD' => array(
+			'symbol' => 'A$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'BRL' => array(
+			'symbol' => 'R$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'CAD' => array(
+			'symbol' => 'C$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'CZK' => array(
+			'symbol' => 'Kč',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'DKK' => array(
+			'symbol' => 'kr.',
+			'grouping' => '',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'HKD' => array(
+			'symbol' => 'HK$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'HUF' => array(
+			'symbol' => 'Ft',
+			'grouping' => '.',
+			'decimal' => ',',
+			'precision' => 0,
+		),
+		'ILS' => array(
+			'symbol' => '₪',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'JPY' => array(
+			'symbol' => '¥',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 0,
+		),
+		'MYR' => array(
+			'symbol' => 'RM',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'MXN' => array(
+			'symbol' => 'MX$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'TWD' => array(
+			'symbol' => 'NT$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'NZD' => array(
+			'symbol' => 'NZ$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'NOK' => array(
+			'symbol' => 'kr',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'PHP' => array(
+			'symbol' => '₱',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'PLN' => array(
+			'symbol' => 'zł',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'GBP' => array(
+			'symbol' => '£',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'RUB' => array(
+			'symbol' => '₽',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => 2,
+		),
+		'SGD' => array(
+			'symbol' => '$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'SEK' => array(
+			'symbol' => 'kr',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'CHF' => array(
+			'symbol' => 'CHF',
+			'grouping' => '\'',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+		'THB' => array(
+			'symbol' => '฿',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => 2,
+		),
+	);
+
+	public static function sanitize_price( $currency_code, $price ) {
+		if ( '-' === substr( $price, 0, 1 ) ) {
+			return false;
+		}
+		$currency = self::$currencies[ $currency_code ];
+		if ( ! isset( $currency ) ) {
+			return false;
+		}
+		$decimal = $currency['decimal'];
+		$precision = $currency['precision'];
+		$chars = count_chars( $price, 1 );
+		for( $i = 0; $i <= 9; $i++ ) {
+			unset( $chars[ ord( (string) $i ) ] );
+		}
+		if ( count( $chars ) > 1 || reset( $chars ) > 1 ) {
+			return false;
+		}
+
+		// Allow the decimal separator to be the currency decimal separator or "."
+		if ( ! empty( $chars ) ) {
+			$decimal_char = chr( key( $chars ) );
+			if ( $decimal_char !== $decimal && $decimal_char !== '.' ) {
+				return false;
+			}
+			$price = str_replace( $decimal_char, '.', $price );
+		}
+
+		return round( (float) $price, $precision );
+	}
+
+	public static function format_price( $currency_code, $price ) {
+		$currency = self::$currencies[ $currency_code ];
+		if ( ! $currency ) {
+			return $price . ' ' . $currency_code;
+		}
+		return number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] ) . ' ' . $currency['symbol'];
+	}
+
+	public static function format_price_amount( $currency_code, $price ) {
+		$currency = self::$currencies[ $currency_code ];
+		if ( ! $currency ) {
+			return number_format( $price, 2, '.', '' );
+		}
+		return number_format( (double) $price, $currency['precision'], $currency['decimal'], '' );
+	}
+
+	public static function is_valid_currency( $currency_code ) {
+		return isset( self::$currencies[ $currency_code ] );
+	}
+
+	public static function get_currencies_map() {
+		$map = array();
+		foreach( self::$currencies as $code => $currency ) {
+			$map[ $code ] = $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) );
+		}
+		return $map;
+	}
+}

--- a/modules/simple-payments/money-format.php
+++ b/modules/simple-payments/money-format.php
@@ -1,7 +1,15 @@
 <?php
 
+/**
+ * Class with utility functions to format money amounts. Used primarly by the Simple Payments widget/shortcode
+ */
 class Jetpack_Money_Format {
 
+	/*
+	 * Copied from wp-calypso/client/lib/format-currency/currencies.js
+	 * Only includes the currencies supported by Paypal, see
+	 * wp-calypso/client/components/tinymce/plugins/simple-payments/dialog/form.jsx#SUPPORTED_CURRENCY_LIST
+	 */
 	private static $currencies = array(
 		'USD' => array(
 			'symbol' => '$',
@@ -149,25 +157,35 @@ class Jetpack_Money_Format {
 		),
 	);
 
+	/**
+	 * Validates and sanitizes a price amount in the form of a string
+	 * @param $currency_code string Currency code that this amount is in
+	 * @param $price string Amount, as entered by the user
+	 * @return false|float FALSE if the input is invalid, a float representing the money amount otherwise
+	 */
 	public static function sanitize_price( $currency_code, $price ) {
+		// Forbid negative amounts
 		if ( '-' === substr( $price, 0, 1 ) ) {
 			return false;
 		}
+		// Forbid unsupported amounts
 		$currency = self::$currencies[ $currency_code ];
 		if ( ! isset( $currency ) ) {
 			return false;
 		}
 		$decimal = $currency['decimal'];
 		$precision = $currency['precision'];
+		// Get all the characters in the string that aren't digits
 		$chars = count_chars( $price, 1 );
 		for( $i = 0; $i <= 9; $i++ ) {
 			unset( $chars[ ord( (string) $i ) ] );
 		}
+		// The only non-digit char expected is the decimal separator, so if there's more than 1 it's invalid
 		if ( count( $chars ) > 1 || reset( $chars ) > 1 ) {
 			return false;
 		}
 
-		// Allow the decimal separator to be the currency decimal separator or "."
+		// Allow the decimal separator to be the currency decimal separator or "." (as a fallback)
 		if ( ! empty( $chars ) ) {
 			$decimal_char = chr( key( $chars ) );
 			if ( $decimal_char !== $decimal && $decimal_char !== '.' ) {
@@ -179,9 +197,17 @@ class Jetpack_Money_Format {
 		return round( (float) $price, $precision );
 	}
 
+
+	/**
+	 * Formats a price to display it to the user, including the currency symbol
+	 * @param $currency_code string Currency code
+	 * @param $price float Monetary amount
+	 * @return string The price and currency, formatted
+	 */
 	public static function format_price( $currency_code, $price ) {
 		$currency = self::$currencies[ $currency_code ];
 		if ( ! $currency ) {
+			// Fallback to a "best effort" formatting, but this should never happen (merchant shouldn't be able to use an unknown currency)
 			return $price . ' ' . $currency_code;
 		}
 		$amount = number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] );
@@ -192,18 +218,32 @@ class Jetpack_Money_Format {
 		return $amount . ' ' . $symbol;
 	}
 
+	/**
+	 * Formats a price to display it to the user
+	 * @param $currency_code string Currency code
+	 * @param $price float Monetary amount
+	 * @return string The price, formatted
+	 */
 	public static function format_price_amount( $currency_code, $price ) {
 		$currency = self::$currencies[ $currency_code ];
 		if ( ! $currency ) {
+			// Fallback to a "best effort" formatting, but this should never happen (merchant shouldn't be able to use an unknown currency)
 			return number_format( $price, 2, '.', '' );
 		}
 		return number_format( (double) $price, $currency['precision'], $currency['decimal'], '' );
 	}
 
+	/**
+	 * @param $currency_code string Currency code
+	 * @return bool Whether the given currency code is valid
+	 */
 	public static function is_valid_currency( $currency_code ) {
 		return isset( self::$currencies[ $currency_code ] );
 	}
 
+	/**
+	 * @return array The keys are the currency codes, and the values are human-readable representations of those currencies
+	 */
 	public static function get_currencies_map() {
 		$map = array();
 		foreach( self::$currencies as $code => $currency ) {

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -145,6 +145,17 @@ var PaypalExpressCheckout = {
 				color: 'silver'
 			},
 
+			validate: function( actions ) {
+				// disable button if it's iframed into calypso.
+				var iframed = document.location.href.indexOf('calypso_token') >= 0;
+				if ( iframed ) {
+					console.log( 'disable button for ' + document.location.host + ' host.' );
+					actions.disable();	
+				} else {
+					actions.enable();
+				}
+			},
+
 			payment: function() {
 				PaypalExpressCheckout.cleanAndHideMessage( domId );
 

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -149,8 +149,7 @@ var PaypalExpressCheckout = {
 				// disable button if it's iframed into calypso.
 				var iframed = document.location.href.indexOf('calypso_token') >= 0;
 				if ( iframed ) {
-					console.log( 'disable button for ' + document.location.host + ' host.' );
-					actions.disable();	
+					actions.disable();
 				} else {
 					actions.enable();
 				}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once( __DIR__ . '/money-format.php' );
+
 /*
  * Simple Payments lets users embed a PayPal button fully integrated with wpcom to sell products on the site.
  * This is not a proper module yet, because not all the pieces are in place. Until everything is shipped, it can be turned
@@ -147,10 +150,8 @@ class Jetpack_Simple_Payments {
 	}
 
 	function format_price( $formatted_price, $price, $currency, $all_data ) {
-		if ( $formatted_price ) {
-			return $formatted_price;
-		}
-		return "$price $currency";
+		// TODO: remove $formatted_price entirely
+		return Jetpack_Money_Format::format_price( $currency, $price );
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -27,14 +27,15 @@ class Jetpack_Simple_Payments {
 		return self::$instance;
 	}
 
-	private function register_scripts() {
+	private function enqueue_scripts_and_styles() {
 		/**
 		 * Paypal heavily discourages putting that script in your own server:
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ),
+		wp_enqueue_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ),
 			array( 'jquery', 'paypal-checkout-js' ), self::$version );
+		wp_enqueue_style( 'simple-payments', plugins_url( '/simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 	}
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
@@ -46,7 +47,6 @@ class Jetpack_Simple_Payments {
 	public function init_hook_action() {
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
-		$this->register_scripts();
 		$this->register_shortcode();
 		$this->setup_cpts();
 
@@ -100,12 +100,8 @@ class Jetpack_Simple_Payments {
 		);
 
 		$data['id'] = $attrs['id'];
-		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
-			wp_enqueue_script( 'paypal-express-checkout' );
-		}
-		if ( ! wp_style_is( 'simple-payments', 'enqueued' ) ) {
-			wp_enqueue_style( 'simple-payments', plugins_url( 'simple-payments.css', __FILE__ ), array( 'dashicons' ) );
-		}
+
+		$this->enqueue_scripts_and_styles();
 
 		wp_add_inline_script( 'paypal-express-checkout', sprintf(
 			"try{PaypalExpressCheckout.renderButton( '%d', '%d', '%s', '%d' );}catch(e){}",
@@ -213,7 +209,7 @@ class Jetpack_Simple_Payments {
 			'read_private_posts'    => 'read_private_posts',
 		);
 		$order_args = array(
-			'label'                 => esc_html__( 'Order', 'jetpack' ),
+			'label'                 => esc_html_x( 'Order', 'noun: a quantity of goods or items purchased or sold', 'jetpack' ),
 			'description'           => esc_html__( 'Simple Payments orders', 'jetpack' ),
 			'supports'              => array( 'custom-fields', 'excerpt' ),
 			'hierarchical'          => false,

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once( __DIR__ . '/money-format.php' );
+require_once( dirname( __FILE__ ) . '/money-format.php' );
 
 /*
  * Simple Payments lets users embed a PayPal button fully integrated with wpcom to sell products on the site.

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -273,6 +273,11 @@ class Simple_Payments_Widget extends WP_Widget {
 		if ( ! $product || is_wp_error( $product ) || $product->post_type !== Jetpack_Simple_Payments::$post_type_product ) {
 			$product_id = 0;
 		}
+
+		// TODO: validate this (or use image modal)
+		$image_url = isset( $old_instance['image'] ) ? $old_instance['product_id'] : '';
+		if ( $image_url ) media_sideload_image( $image_url, $product_id );
+
 		return array(
 			'title' => $new_instance['title'],
 			'product_id' => wp_insert_post( array(
@@ -301,6 +306,8 @@ class Simple_Payments_Widget extends WP_Widget {
 		) );
 
 		$product_args = $this->get_product_args( $instance['product_id'] );
+
+		$image = ( has_post_thumbnail( $instance['product_id'] ) ) ? get_the_post_thumbnail_url( $instance['product_id'] ) : '';
         ?>
 
 	<div class="simple-payments">
@@ -311,6 +318,10 @@ class Simple_Payments_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'name' ); ?>"><?php _e( 'What are you selling?', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'name' ); ?>" name="<?php echo $this->get_field_name( 'name' ); ?>" type="text" placeholder="<?php echo esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php echo esc_attr( $product_args['name'] ); ?>" />
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'image' ); ?>"><?php _e( 'Image', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'image' ); ?>" name="<?php echo $this->get_field_name( 'image' ); ?>" type="text" value="<?php echo esc_attr( $image ); ?>" />
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'description' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -195,9 +195,9 @@ class Simple_Payments_Widget extends WP_Widget {
 
 	public static function enqueue_admin_styles( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
-			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '201710151225' );
+			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '201710151520' );
 			wp_enqueue_media();
-			wp_enqueue_script( 'simple-payments-widget-admin', self::$url . '/simple-payments/admin.js', array( 'jquery' ), '20171014', true );
+			wp_enqueue_script( 'simple-payments-widget-admin', self::$url . '/simple-payments/admin.js', array( 'jquery' ), '20171015', true );
 		}
 	}
 
@@ -343,22 +343,33 @@ class Simple_Payments_Widget extends WP_Widget {
 			);
 
 			$products = get_posts( $args );
-			echo '<ul class="simple-payments-products">';
-			foreach ( $products as $product ){
+			?>
+		<div class="add-product">
+			<button id="simple-payments-add-product" class="button"><?php _e( 'Add New', 'jetpack' ); ?></button>
+		</div>
+		<ul class="simple-payments-products">
+			<?php
+			foreach ( $products as $product ):
 				$meta = get_post_meta( $product->ID );
 				$product->price = $meta['spay_price'][0] . " " . $meta['spay_currency'][0];
 
 				// start building the product list
 				$image = ( has_post_thumbnail( $product->ID ) ) ? get_the_post_thumbnail( $product->ID, 'medium' ) : '';
-
-				echo '<li>';
-				echo '<input type="radio" name="simple-payments-products_' . $this->id . '" value="' . $product->ID . '">';
-				echo '<div class="product-info">' . $product->post_title . '<br> ' . $product->price . '</div>';
-				echo '<div class="image">' . $image . '</div>';
-				echo '</li>';
-			}
-			echo '</ul>';
-
+			?>
+			<li>
+				<input type="radio" name="simple-payments-products_<?php echo $this->id; ?>" value="<?php esc_html_e( $product->ID ); ?>">
+				<div class="product-info">
+					<?php esc_html_e( $product->post_title ); ?><br>
+					<?php esc_html_e( $product->price ); ?>
+				</div>
+				<div class="image"><?php echo $image; ?></div>
+			</li>
+			<?php endforeach; ?>
+		</ul>
+		<div class="insert-product">
+			<button id="simple-payments-insert-product" class="button"><?php _e( 'Insert', 'jetpack' ); ?></button>
+		</div>
+		<?php
 		}
 
 		$product_args = $this->get_product_args( $instance['product_id'] );

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -190,12 +190,12 @@ class Simple_Payments_Widget extends WP_Widget {
 		*/
 
 		// add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
-		// add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
+		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin_styles' ) );
 	}
 
-	public static function enqueue_admin( $hook_suffix ) {
+	public static function enqueue_admin_styles( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
-			// wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
+			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '20171014' );
 		}
 	}
 
@@ -287,7 +287,7 @@ class Simple_Payments_Widget extends WP_Widget {
 					// grab source of full size images (so no 300x150 nonsense in path)
 					$image = wp_get_attachment_image_src( $attachment->ID, 'full' );
 					// determine if in the $media image we created, the string of the URL exists
-					if ( strpos( $media, $image[0] ) !== false ) {
+					if ( strpos( $image, $image[0] ) !== false ) {
 						// if so, we found our image. set it as thumbnail
 						set_post_thumbnail( $product_id, $attachment->ID );
 						// only want one image
@@ -338,11 +338,14 @@ class Simple_Payments_Widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'name' ); ?>"><?php _e( 'What are you selling?', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'name' ); ?>" name="<?php echo $this->get_field_name( 'name' ); ?>" type="text" placeholder="<?php echo esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php echo esc_attr( $product_args['name'] ); ?>" />
 		</p>
+		<div class="simple-payments-image">
 		<?php
 			if ( ! empty( $image ) ){
 				// display image
+				echo get_the_post_thumbnail( $instance['product_id'], array( 200, 200 ) );
 			}
 		?>
+		</div>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'image' ); ?>"><?php _e( 'Image', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'image' ); ?>" name="<?php echo $this->get_field_name( 'image' ); ?>" type="text" value="<?php echo esc_attr( $image ); ?>" />
@@ -351,16 +354,16 @@ class Simple_Payments_Widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'description' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
 			<textarea class="widefat" rows=5 id="<?php echo $this->get_field_id( 'description' ); ?>" name="<?php echo $this->get_field_name( 'description' ); ?>"><?php echo esc_html( $product_args['description'] ); ?></textarea>
 		</p>
-		<p>
+		<p class="cost">
 			<label for="<?php echo $this->get_field_id( 'price' ); ?>"><?php _e( 'Price', 'jetpack' ); ?></label>
-			<select class="widefat" id="<?php echo $this->get_field_id( 'currency' ); ?>" name="<?php echo $this->get_field_name( 'currency' ); ?>">
+			<select class="currency widefat" id="<?php echo $this->get_field_id( 'currency' ); ?>" name="<?php echo $this->get_field_name( 'currency' ); ?>">
 				<?php foreach( self::$currencies as $code => $currency ) { ?>
 					<option value="<?php echo esc_attr( $code ) ?>" <?php if ( $code === $product_args['currency'] ) { ?>selected="selected"<?php } ?>>
 						<?php echo esc_html( $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) ) ) ?>
 					</option>
 				<?php } ?>
 			</select>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo esc_attr( $product_args['price'] ); ?>" />
+			<input class="price widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo esc_attr( $product_args['price'] ); ?>" />
 		</p>
 		<p>
 			<input id="<?php echo $this->get_field_id( 'multiple' ); ?>" name="<?php echo $this->get_field_name( 'multiple' ); ?>" type="checkbox" <?php if ( '1' === $product_args['multiple'] ) { ?>checked="checked"<?php } ?> />

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -104,12 +104,20 @@ class Simple_Payments_Widget extends WP_Widget {
 		echo '<div class="simple-payments-content">';
 
 		// display the product on the front end here
+		/*
 		echo '#' . $instance['product_id'] . '<br>';
 		echo '<ul>';
 		foreach( $product_args as $key => $value ) {
 			echo '<li>' . $key . ': ' . $value . '</li>';
 		}
 		echo '</ul>';
+		*/
+
+		$attrs = array( 'id' => $instance['product_id'] );
+
+		$JSP = Jetpack_Simple_Payments::getInstance();
+
+		echo $JSP->parse_shortcode( $attrs );
 
 		echo '</div><!--simple-payments-->';
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -275,8 +275,27 @@ class Simple_Payments_Widget extends WP_Widget {
 		}
 
 		// TODO: validate this (or use image modal)
-		$image_url = isset( $old_instance['image'] ) ? $old_instance['product_id'] : '';
-		if ( $image_url ) media_sideload_image( $image_url, $product_id );
+		if ( $new_instance['image'] ){
+			$image = media_sideload_image( $new_instance['image'], $product_id );
+		}
+
+		if ( ! empty( $image ) && ! is_wp_error( $image ) ) {
+		    $attachments = get_attached_media( 'image', $product_id );
+
+		    if ( isset( $attachments ) && is_array( $attachments ) ) {
+				foreach( $attachments as $attachment ) {
+					// grab source of full size images (so no 300x150 nonsense in path)
+					$image = wp_get_attachment_image_src( $attachment->ID, 'full' );
+					// determine if in the $media image we created, the string of the URL exists
+					if ( strpos( $media, $image[0] ) !== false ) {
+						// if so, we found our image. set it as thumbnail
+						set_post_thumbnail( $product_id, $attachment->ID );
+						// only want one image
+						break;
+					}
+				}
+		    }
+		}
 
 		return array(
 			'title' => $new_instance['title'],
@@ -319,6 +338,11 @@ class Simple_Payments_Widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'name' ); ?>"><?php _e( 'What are you selling?', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'name' ); ?>" name="<?php echo $this->get_field_name( 'name' ); ?>" type="text" placeholder="<?php echo esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php echo esc_attr( $product_args['name'] ); ?>" />
 		</p>
+		<?php
+			if ( ! empty( $image ) ){
+				// display image
+			}
+		?>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'image' ); ?>"><?php _e( 'Image', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'image' ); ?>" name="<?php echo $this->get_field_name( 'image' ); ?>" type="text" value="<?php echo esc_attr( $image ); ?>" />

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -318,6 +318,7 @@ class Simple_Payments_Widget extends WP_Widget {
 			'title' => '',
 			'product_id' => null,
 		) );
+
 		if ( ! $instance['product_id'] ) {
 			$output = array();
 
@@ -332,7 +333,7 @@ class Simple_Payments_Widget extends WP_Widget {
 			?>
 	<div class="simple-payments-product-list">
 		<div class="control_add-product">
-			<button id="simple-payments-add-product" class="button"><?php _e( 'Add New', 'jetpack' ); ?></button>
+			<button id="simple-payments-add-product" class="button"><?php esc_html_e( 'Add New', 'jetpack' ); ?></button>
 		</div>
 		<ul class="simple-payments-products">
 			<?php
@@ -349,7 +350,7 @@ class Simple_Payments_Widget extends WP_Widget {
 					<?php esc_html_e( $product->post_title ); ?><br>
 					<?php esc_html_e( $product->price ); ?>
 				</div>
-				<div class="image"><?php esc_html_e( $image ); ?></div>
+				<div class="image"><?php $image; ?></div>
 			</li>
 			<?php endforeach; ?>
 		</ul>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -181,6 +181,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		self::$url = plugin_dir_url( __FILE__ );
 
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin_styles' ) );
+		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_widget_styles' ) );
 	}
 
 	public static function enqueue_admin_styles( $hook_suffix ) {
@@ -189,6 +190,13 @@ class Simple_Payments_Widget extends WP_Widget {
 			wp_enqueue_media();
 			wp_enqueue_script( 'simple-payments-widget-admin', self::$url . '/simple-payments/admin.js', array( 'jquery' ), false, true );
 		}
+	}
+
+	public static function enqueue_widget_styles() {
+		// This would be nice, but I don't know how this function works.
+		// if ( is_active_widget( false, false, 'Simple_Payments_Widget' ) ) {
+			wp_enqueue_style( 'simple-payments-widget', self::$url . '/simple-payments/style.css', array() );
+		// }
 	}
 
 	protected function get_product_args( $product_id ) {
@@ -310,7 +318,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		if ( ! $currency ) {
 			return $price . ' ' . $currency_code;
 		}
-		return number_format( $price, $currency['precision'], $currency['decimal'], $currency['grouping'] ) . ' ' . $currency['symbol'];
+		return number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] ) . ' ' . $currency['symbol'];
 	}
 
 	protected function format_price_amount( $currency_code, $price ) {
@@ -318,14 +326,14 @@ class Simple_Payments_Widget extends WP_Widget {
 		if ( ! $currency ) {
 			return number_format( $price, 2, '.', '' );
 		}
-		return number_format( $price, $currency['precision'], $currency['decimal'], '' );
+		return number_format( (double) $price, $currency['precision'], $currency['decimal'], '' );
 	}
 
 	/**
 	 * Update
 	 */
 	function update( $new_instance, $old_instance ) {
-    	if ( $new_instance['product_id'] ) {
+    	if ( isset( $new_instance['product_id'] ) ) {
     		$product_id = $new_instance['product_id'];
 		} else {
     		if ( ! isset( $new_instance['name'] ) ) {

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -210,7 +210,10 @@ class Simple_Payments_Widget extends WP_Widget {
 					if ( ! empty( $products ) ) {
 						?>
 						<div class="simple-payments-product-list">
-							<button class="button simple-payments-add-product"><?php esc_html_e( 'Add New', 'jetpack' ); ?></button>
+							<div>
+								<span class="simple-payments-product-count"><?php printf( _n( '%d product', '%d products', count( $products ), 'Jetpack' ), number_format_i18n( count( $products ) ) ) ?></span>
+								<button class="button simple-payments-add-product"><?php esc_html_e( 'Add New', 'jetpack' ); ?></button>
+							</div>
 							<ul class="simple-payments-products">
 								<?php
 								foreach ( $products as $product ):
@@ -259,10 +262,10 @@ class Simple_Payments_Widget extends WP_Widget {
 				$price = ( $product_args['price'] ) ? esc_attr( Jetpack_Money_Format::format_price_amount( $product_args['currency'], $product_args['price'] ) ) : '';
 				?>
 
+				<?php if ( ! empty( $products ) ) { ?>
+					<button class="button simple-payments-back-product-list" style="display:none;"><?php _e( 'Cancel', 'jetpack' ); ?></button>
+				<?php } ?>
 				<div class="simple-payments-form" <?php if ( ! empty( $products ) ) echo 'style="display:none;"'; ?>>
-					<?php if ( ! empty( $products ) ) { ?>
-						<button class="button simple-payments-back-product-list"><?php _e( 'Cancel', 'jetpack' ); ?></button>
-					<?php } ?>
 					<p>
 						<label for="<?php esc_attr_e( $this->get_field_id( 'name' ) ); ?>"><?php esc_html_e( 'What are you selling?', 'jetpack' ); ?></label>
 						<input <?php echo empty( $products ) ? '' : 'disabled'; ?> class="widefat field-name" id="<?php esc_attr_e( $this->get_field_id( 'name' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'name' ) ); ?>" type="text" placeholder="<?php esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php esc_attr_e( $product_args['name'] ); ?>" />

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -226,8 +226,8 @@ class Simple_Payments_Widget extends WP_Widget {
 									$field_id = $this->get_field_id( 'product_id' ) . '_' . esc_attr( $product->ID );
 								?>
 								<li>
+									<input type="radio" id="<?php echo $field_id; ?>" name="<?php echo $this->get_field_name( 'product_id' ); ?>" value="<?php esc_html_e( $product->ID ); ?>">
 									<label for="<?php echo $field_id; ?>">
-										<input type="radio" id="<?php echo $field_id; ?>" name="<?php echo $this->get_field_name( 'product_id' ); ?>" value="<?php esc_html_e( $product->ID ); ?>">
 										<div class="product-info">
 											<?php esc_html_e( $product_args['name'] ); ?><br>
 											<?php esc_html_e( Jetpack_Money_Format::format_price( $product_args['currency'], $product_args['price'] ) ); ?>
@@ -245,7 +245,7 @@ class Simple_Payments_Widget extends WP_Widget {
 													data-image-id="<?php echo $image_id; ?>"
 												<?php } ?>
 										>
-											<?php _e( 'Edit', 'jetpack' ); ?>
+											<span class="screen-reader-text"><?php _e( 'Edit', 'jetpack' ); ?></span>
 										</button>
 									</label>
 								</li>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -194,7 +194,7 @@ class Simple_Payments_Widget extends WP_Widget {
 
 	public static function enqueue_widget_styles() {
 		// This would be nice, but I don't know how this function works.
-		// if ( is_active_widget( false, false, 'Simple_Payments_Widget' ) ) {
+		// if ( is_active_widget( false, false, $this->id_base, true ) ) {
 			wp_enqueue_style( 'simple-payments-widget', self::$url . '/simple-payments/style.css', array() );
 		// }
 	}
@@ -383,7 +383,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		<div class="simple-payments">
 			<p>
 				<label for="<?php esc_attr_e( $this->get_field_id( 'title' ) ); ?>">
-					<?php esc_html_e( 'Title', 'jetpack' ); ?></label>
+					<?php esc_html_e( 'Widget Title', 'jetpack' ); ?></label>
 				<input class="widefat" id="<?php esc_attr_e( $this->get_field_id( 'title' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php esc_attr_e( $instance['title'] ); ?>" />
 			</p>
 			<?php

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -207,15 +207,43 @@ class Simple_Payments_Widget extends WP_Widget {
 			$product_id = null;
 		}
 
-		$current_user = wp_get_current_user();
-		return wp_parse_args( $product_args, array(
+
+		$product_args = wp_parse_args( $product_args, array(
 			'name' => '',
 			'description' => '',
-			'currency' => 'USD', // TODO: Geo-locate?
+			'currency' => null,
 			'price' => '',
-			'multiple' => '0',
-			'email' => $current_user->user_email,
+			'multiple' => null,
+			'email' => null,
 		) );
+
+		if ( isset( $product_args['currency'] ) && isset( $product_args['multiple'] ) && isset( $product_args['email'] ) ) {
+			return $product_args;
+		}
+		$products = get_posts( array(
+			'numberposts' => 1,
+			'orderby' => 'date',
+			'post_type' => Jetpack_Simple_Payments::$post_type_product,
+		) );
+		$current_user = wp_get_current_user();
+		$default_email = $current_user->user_email;
+		$default_multiple = '0';
+		$default_currency = 'USD';
+		if ( ! empty( $products ) ) {
+			$default_email = get_post_meta( $products[0]->ID, 'spay_email', true );
+			$default_multiple = get_post_meta( $products[0]->ID, 'spay_multiple', true );
+			$default_currency = get_post_meta( $products[0]->ID, 'spay_currency', true );
+		}
+		if ( ! isset( $product_args['email'] ) ) {
+			$product_args['email'] = $default_email;
+		}
+		if ( ! isset( $product_args['multiple'] ) ) {
+			$product_args['multiple'] = $default_multiple;
+		}
+		if ( ! isset( $product_args['currency'] ) ) {
+			$product_args['currency'] = $default_currency;
+		}
+		return $product_args;
 	}
 
     /**

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -390,20 +390,18 @@ class Simple_Payments_Widget extends WP_Widget {
 			<input class="widefat" id="<?php echo $this->get_field_id( 'name' ); ?>" name="<?php echo $this->get_field_name( 'name' ); ?>" type="text" placeholder="<?php echo esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php echo esc_attr( $product_args['name'] ); ?>" />
 		</p>
 		<div class="simple-payments-image-fieldset">
-			<div class="placeholder <?php if ( has_post_thumbnail( $instance['product_id'] ) ) echo 'hide'; ?>">No image selected</div> <!-- TODO: actual placeholder, i18n -->
+			<label><?php _e( 'Product image', 'jetpack' ); ?></label>
+			<div class="placeholder" <?php if ( has_post_thumbnail( $instance['product_id'] ) ) echo 'style="display:none;"'; ?>>Select an image</div> <!-- TODO: actual placeholder, i18n -->
 			<div class="simple-payments-image" data-image-field="<?php echo $this->get_field_name( 'image' ); ?>"> <!-- TODO: hide if empty, CSS? -->
 				<?php
 					if ( has_post_thumbnail( $instance['product_id'] ) ) {
 						$image_id = get_post_thumbnail_id( $instance['product_id'] );
-						list( $src, $width, $height ) = wp_get_attachment_image_src( $image_id, 'full' );
-						// TODO: caption, title
-						echo '<img width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" src="' . esc_attr( $src ) . '" />';
+						echo '<img src="' . esc_attr( wp_get_attachment_image_url( $image_id, 'full' ) ) . '" />';
 						echo '<input type="hidden" name="' . $this->get_field_name( 'image' ) . '" value="' . esc_attr( $image_id ) . '" />';
 					}
 				?>
+				<button class="button simple-payments-remove-image"><span class="screen-reader-text"><?php _e( 'Remove image' ); ?></span></button>
 			</div>
-			<button class="button simple-payments-add-image">Add Image</button>
-			<button class="button simple-payments-remove-image">Remove Image</button>
 		</div>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'description' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -17,153 +17,6 @@ class Simple_Payments_Widget extends WP_Widget {
 	private static $dir       = null;
 	private static $url       = null;
 
-	private static $currencies = array(
-		'USD' => array(
-			'symbol' => '$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'EUR' => array(
-			'symbol' => '€',
-			'grouping' => '.',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'AUD' => array(
-			'symbol' => 'A$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'BRL' => array(
-			'symbol' => 'R$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'CAD' => array(
-			'symbol' => 'C$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'CZK' => array(
-			'symbol' => 'Kč',
-			'grouping' => ' ',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'DKK' => array(
-			'symbol' => 'kr.',
-			'grouping' => '',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'HKD' => array(
-			'symbol' => 'HK$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'HUF' => array(
-			'symbol' => 'Ft',
-			'grouping' => '.',
-			'decimal' => ',',
-			'precision' => 0,
-		),
-		'ILS' => array(
-			'symbol' => '₪',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'JPY' => array(
-			'symbol' => '¥',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 0,
-		),
-		'MYR' => array(
-			'symbol' => 'RM',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'MXN' => array(
-			'symbol' => 'MX$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'TWD' => array(
-			'symbol' => 'NT$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'NZD' => array(
-			'symbol' => 'NZ$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'NOK' => array(
-			'symbol' => 'kr',
-			'grouping' => ' ',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'PHP' => array(
-			'symbol' => '₱',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'PLN' => array(
-			'symbol' => 'zł',
-			'grouping' => ' ',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'GBP' => array(
-			'symbol' => '£',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'RUB' => array(
-			'symbol' => '₽',
-			'grouping' => ' ',
-			'decimal' => ',',
-			'precision' => 2,
-		),
-		'SGD' => array(
-			'symbol' => '$',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'SEK' => array(
-			'symbol' => 'kr',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'CHF' => array(
-			'symbol' => 'CHF',
-			'grouping' => '\'',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-		'THB' => array(
-			'symbol' => '฿',
-			'grouping' => ',',
-			'decimal' => '.',
-			'precision' => 2,
-		),
-	);
-
 	function __construct() {
 		$widget = array(
 			'classname'   => 'simple-payments',
@@ -286,49 +139,6 @@ class Simple_Payments_Widget extends WP_Widget {
 	    do_action( 'jetpack_stats_extra', 'widget_view', 'simple-payments' );
     }
 
-    protected function sanitize_price( $currency_code, $price ) {
-		if ( '-' === substr( $price, 0, 1 ) ) {
-			return false;
-		}
-		$currency = self::$currencies[ $currency_code ];
-		$decimal = $currency['decimal'];
-		$precision = $currency['precision'];
-		$chars = count_chars( $price, 1 );
-		for( $i = 0; $i <= 9; $i++ ) {
-			unset( $chars[ ord( (string) $i ) ] );
-		}
-		if ( count( $chars ) > 1 || reset( $chars ) > 1 ) {
-			return false;
-		}
-
-		// Allow the decimal separator to be the currency decimal separator or "."
-		if ( ! empty( $chars ) ) {
-			$decimal_char = chr( key( $chars ) );
-			if ( $decimal_char !== $decimal && $decimal_char !== '.' ) {
-				return false;
-			}
-			$price = str_replace( $decimal_char, '.', $price );
-		}
-
-		return round( (float) $price, $precision );
-	}
-
-	protected function format_price( $currency_code, $price ) {
-		$currency = self::$currencies[ $currency_code ];
-		if ( ! $currency ) {
-			return $price . ' ' . $currency_code;
-		}
-		return number_format( (double) $price, $currency['precision'], $currency['decimal'], $currency['grouping'] ) . ' ' . $currency['symbol'];
-	}
-
-	protected function format_price_amount( $currency_code, $price ) {
-		$currency = self::$currencies[ $currency_code ];
-		if ( ! $currency ) {
-			return number_format( $price, 2, '.', '' );
-		}
-		return number_format( (double) $price, $currency['precision'], $currency['decimal'], '' );
-	}
-
 	/**
 	 * Update
 	 */
@@ -355,8 +165,8 @@ class Simple_Payments_Widget extends WP_Widget {
 				'post_content' => sanitize_textarea_field( $new_instance['description'] ),
 				'_thumbnail_id' => isset( $new_instance['image'] ) ? $new_instance['image'] : -1,
 				'meta_input' => array(
-					'spay_currency' => isset( self::$currencies[ $new_instance['currency'] ] ) ? $new_instance['currency'] : 'USD',
-					'spay_price' => $this->sanitize_price( $new_instance['currency'], $new_instance['price'] ),
+					'spay_currency' => Jetpack_Money_Format::is_valid_currency( $new_instance['currency'] ) ? $new_instance['currency'] : 'USD',
+					'spay_price' => Jetpack_Money_Format::sanitize_price( $new_instance['currency'], $new_instance['price'] ),
 					'spay_multiple' => isset( $new_instance['multiple'] ) ? intval( $new_instance['multiple'] ) : 0,
 					'spay_email' => is_email( $new_instance['email'] ),
 				),
@@ -417,14 +227,14 @@ class Simple_Payments_Widget extends WP_Widget {
 										<input type="radio" id="<?php echo $field_id; ?>" name="<?php echo $this->get_field_name( 'product_id' ); ?>" value="<?php esc_html_e( $product->ID ); ?>">
 										<div class="product-info">
 											<?php esc_html_e( $product_args['name'] ); ?><br>
-											<?php esc_html_e( $this->format_price( $product_args['currency'], $product_args['price'] ) ); ?>
+											<?php esc_html_e( Jetpack_Money_Format::format_price( $product_args['currency'], $product_args['price'] ) ); ?>
 										</div>
 										<div class="image"><?php echo $image; ?></div>
 										<button class="button simple-payments-edit-product"
 												data-name="<?php esc_attr_e( $product_args['name'] ); ?>"
 												data-description="<?php esc_attr_e( $product_args['description'] ); ?>"
 												data-currency="<?php esc_attr_e( $product_args['currency'] ); ?>"
-												data-price="<?php esc_attr_e( $this->format_price_amount( $product_args['currency'], $product_args['price'] ) ); ?>"
+												data-price="<?php esc_attr_e( Jetpack_Money_Format::format_price_amount( $product_args['currency'], $product_args['price'] ) ); ?>"
 												data-multiple="<?php esc_attr_e( $product_args['multiple'] ); ?>"
 												data-email="<?php esc_attr_e( $product_args['email'] ); ?>"
 												<?php if ( ! empty( $image ) ) { ?>
@@ -446,7 +256,7 @@ class Simple_Payments_Widget extends WP_Widget {
 				// form code for adding a new product
 				$product_args = $this->get_product_args( $instance['product_id'] );
 
-				$price = ( $product_args['price'] ) ? esc_attr(  $this->format_price_amount( $product_args['currency'], $product_args['price'] ) ) : '';
+				$price = ( $product_args['price'] ) ? esc_attr( Jetpack_Money_Format::format_price_amount( $product_args['currency'], $product_args['price'] ) ) : '';
 				?>
 
 				<div class="simple-payments-form" <?php if ( ! empty( $products ) ) echo 'style="display:none;"'; ?>>
@@ -478,9 +288,9 @@ class Simple_Payments_Widget extends WP_Widget {
 					<p class="cost">
 						<label for="<?php esc_attr_e( $this->get_field_id( 'price' ) ); ?>"><?php esc_html_e( 'Price', 'jetpack' ); ?></label>
 						<select class="field-currency widefat" id="<?php esc_attr_e( $this->get_field_id( 'currency' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'currency' ) ); ?>">
-							<?php foreach( self::$currencies as $code => $currency ) { ?>
+							<?php foreach( Jetpack_Money_Format::get_currencies_map() as $code => $currency ) { ?>
 								<option value="<?php esc_attr_e( $code ) ?>"<?php selected( $product_args['currency'], $code ); ?>>
-									<?php esc_html_e( $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) ) ) ?>
+									<?php esc_html_e( $currency ) ?>
 								</option>
 							<?php } ?>
 						</select>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -103,20 +103,10 @@ class Simple_Payments_Widget extends WP_Widget {
 
 		echo '<div class="simple-payments-content">';
 
-		// display the product on the front end here
-		/*
-		echo '#' . $instance['product_id'] . '<br>';
-		echo '<ul>';
-		foreach( $product_args as $key => $value ) {
-			echo '<li>' . $key . ': ' . $value . '</li>';
-		}
-		echo '</ul>';
-		*/
-
 		$attrs = array( 'id' => $instance['product_id'] );
 
 		$JSP = Jetpack_Simple_Payments::getInstance();
-
+		// display the product on the front end here
 		echo $JSP->parse_shortcode( $attrs );
 
 		echo '</div><!--simple-payments-->';

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -195,7 +195,7 @@ class Simple_Payments_Widget extends WP_Widget {
 
 	public static function enqueue_admin_styles( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
-			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '201710151520' );
+			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '201710151556' );
 			wp_enqueue_media();
 			wp_enqueue_script( 'simple-payments-widget-admin', self::$url . '/simple-payments/admin.js', array( 'jquery' ), '20171015', true );
 		}
@@ -344,7 +344,8 @@ class Simple_Payments_Widget extends WP_Widget {
 
 			$products = get_posts( $args );
 			?>
-		<div class="add-product">
+	<div class="simple-payments-product-list">
+		<div class="control_add-product">
 			<button id="simple-payments-add-product" class="button"><?php _e( 'Add New', 'jetpack' ); ?></button>
 		</div>
 		<ul class="simple-payments-products">
@@ -366,12 +367,14 @@ class Simple_Payments_Widget extends WP_Widget {
 			</li>
 			<?php endforeach; ?>
 		</ul>
-		<div class="insert-product">
+		<div class="control_insert-product">
 			<button id="simple-payments-insert-product" class="button"><?php _e( 'Insert', 'jetpack' ); ?></button>
 		</div>
+	</div>
 		<?php
 		}
 
+		// form code for adding a new product
 		$product_args = $this->get_product_args( $instance['product_id'] );
 
 		$price = ( $product_args['price'] ) ? esc_attr(  number_format( $product_args['price'], self::$currencies[ $product_args['currency'] ]['precision'], '.', '' ) ) : '';

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -16,9 +16,6 @@ add_action( 'widgets_init', 'jetpack_register_widget_simple_payments' );
 class Simple_Payments_Widget extends WP_Widget {
 	private static $dir       = null;
 	private static $url       = null;
-	private static $labels    = null;
-	private static $defaults  = null;
-	private static $config_js = null;
 
 	private static $currencies = array(
 		'USD' => array(
@@ -299,7 +296,7 @@ class Simple_Payments_Widget extends WP_Widget {
 				'post_content' => sanitize_textarea_field( $new_instance['description'] ),
 				'_thumbnail_id' => isset( $new_instance['image'] ) ? $new_instance['image'] : -1,
 				'meta_input' => array(
-					'spay_currency' => in_array( $new_instance['currency'], $this->currencies ) ? $new_instance['currency'] : 'USD',
+					'spay_currency' => in_array( $new_instance['currency'], self::$currencies ) ? $new_instance['currency'] : 'USD',
 					'spay_price' => $this->sanitize_price( $new_instance['currency'], $new_instance['price'] ),
 					'spay_multiple' => isset( $new_instance['multiple'] ) ? intval( $new_instance['multiple'] ) : 0,
 					'spay_email' => is_email( $new_instance['email'] ),
@@ -347,12 +344,12 @@ class Simple_Payments_Widget extends WP_Widget {
 				$image = ( has_post_thumbnail( $product->ID ) ) ? get_the_post_thumbnail( $product->ID, 'medium' ) : '';
 			?>
 			<li>
-				<input type="radio" name="simple-payments-products_<?php echo $this->id; ?>" value="<?php esc_html_e( $product->ID ); ?>">
+				<input type="radio" name="simple-payments-products_<?php esc_attr_e( $this->id ); ?>" value="<?php esc_html_e( $product->ID ); ?>">
 				<div class="product-info">
 					<?php esc_html_e( $product->post_title ); ?><br>
 					<?php esc_html_e( $product->price ); ?>
 				</div>
-				<div class="image"><?php echo $image; ?></div>
+				<div class="image"><?php esc_html_e( $image ); ?></div>
 			</li>
 			<?php endforeach; ?>
 		</ul>
@@ -370,50 +367,52 @@ class Simple_Payments_Widget extends WP_Widget {
         ?>
 
 	<div class="simple-payments">
+		<input type="hidden" name="<?php esc_attr_e( $this->get_field_name( 'product_id' ) ); ?>" value="<?php esc_attr_e( $instance['product_id'] ); ?>">
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			<label for="<?php esc_attr_e( $this->get_field_id( 'title' ) ); ?>">
+			<?php esc_html_e( 'Title', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php esc_attr_e( $this->get_field_id( 'title' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php esc_attr_e( $instance['title'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'name' ); ?>"><?php _e( 'What are you selling?', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'name' ); ?>" name="<?php echo $this->get_field_name( 'name' ); ?>" type="text" placeholder="<?php echo esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php echo esc_attr( $product_args['name'] ); ?>" />
+			<label for="<?php esc_attr_e( $this->get_field_id( 'name' ) ); ?>"><?php esc_html_e( 'What are you selling?', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php esc_attr_e( $this->get_field_id( 'name' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'name' ) ); ?>" type="text" placeholder="<?php esc_attr_e( 'Product name', 'jetpack' ); ?>" value="<?php esc_attr_e( $product_args['name'] ); ?>" />
 		</p>
 		<div class="simple-payments-image-fieldset">
-			<label><?php _e( 'Product image', 'jetpack' ); ?></label>
-			<div class="placeholder" <?php if ( has_post_thumbnail( $instance['product_id'] ) ) echo 'style="display:none;"'; ?>>Select an image</div> <!-- TODO: actual placeholder, i18n -->
-			<div class="simple-payments-image" data-image-field="<?php echo $this->get_field_name( 'image' ); ?>"> <!-- TODO: hide if empty, CSS? -->
+			<label><?php esc_html_e( 'Product image', 'jetpack' ); ?></label>
+			<div class="placeholder" <?php if ( has_post_thumbnail( $instance['product_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image', 'jetpack' ); ?></div> <!-- TODO: actual placeholder -->
+			<div class="simple-payments-image" data-image-field="<?php esc_attr_e( $this->get_field_name( 'image' ) ); ?>"> <!-- TODO: hide if empty, CSS? -->
 				<?php
 					if ( has_post_thumbnail( $instance['product_id'] ) ) {
 						$image_id = get_post_thumbnail_id( $instance['product_id'] );
-						echo '<img src="' . esc_attr( wp_get_attachment_image_url( $image_id, 'full' ) ) . '" />';
+						echo '<img src="' . esc_url( wp_get_attachment_image_url( $image_id, 'full' ) ) . '" />';
 						echo '<input type="hidden" name="' . $this->get_field_name( 'image' ) . '" value="' . esc_attr( $image_id ) . '" />';
 					}
 				?>
-				<button class="button simple-payments-remove-image"><span class="screen-reader-text"><?php _e( 'Remove image' ); ?></span></button>
+				<button class="button simple-payments-remove-image"><span class="screen-reader-text"><?php esc_html_e( 'Remove image', 'jetpack' ); ?></span></button>
 			</div>
 		</div>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'description' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
-			<textarea class="widefat" rows=5 id="<?php echo $this->get_field_id( 'description' ); ?>" name="<?php echo $this->get_field_name( 'description' ); ?>"><?php echo esc_html( $product_args['description'] ); ?></textarea>
+			<label for="<?php esc_attr_e( $this->get_field_id( 'description' ) ); ?>"><?php esc_html_e( 'Description', 'jetpack' ); ?></label>
+			<textarea class="widefat" rows=5 id="<?php esc_attr_e( $this->get_field_id( 'description' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'description' ) ); ?>"><?php  esc_html_e( $product_args['description'] ); ?></textarea>
 		</p>
 		<p class="cost">
-			<label for="<?php echo $this->get_field_id( 'price' ); ?>"><?php _e( 'Price', 'jetpack' ); ?></label>
-			<select class="currency widefat" id="<?php echo $this->get_field_id( 'currency' ); ?>" name="<?php echo $this->get_field_name( 'currency' ); ?>">
+			<label for="<?php esc_attr_e( $this->get_field_id( 'price' ) ); ?>"><?php esc_html_e( 'Price', 'jetpack' ); ?></label>
+			<select class="currency widefat" id="<?php esc_attr_e( $this->get_field_id( 'currency' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'currency' ) ); ?>">
 				<?php foreach( self::$currencies as $code => $currency ) { ?>
-					<option value="<?php echo esc_attr( $code ) ?>" <?php if ( $code === $product_args['currency'] ) { ?>selected="selected"<?php } ?>>
-						<?php echo esc_html( $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) ) ) ?>
+					<option value="<?php esc_attr_e( $code ) ?>"<?php selected( $product_args['currency'], $code ); ?>>
+						<?php esc_html_e( $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) ) ) ?>
 					</option>
 				<?php } ?>
 			</select>
-			<input class="price widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo $price; ?>" />
+			<input class="price widefat" id="<?php esc_attr_e( $this->get_field_id( 'price' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'price' ) ); ?>" type="text" value="<?php esc_attr_e( $price ); ?>" />
 		</p>
 		<p>
-			<input id="<?php echo $this->get_field_id( 'multiple' ); ?>" name="<?php echo $this->get_field_name( 'multiple' ); ?>" type="checkbox" value="1"<?php checked( $product_args['multiple'], '1' ); ?>/>
-			<label for="<?php echo $this->get_field_id( 'multiple' ); ?>"><?php _e( 'Allow people to buy more than one item at a time.', 'jetpack' ); ?></label>
+			<input id="<?php esc_attr_e( $this->get_field_id( 'multiple' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'multiple' ) ); ?>" type="checkbox" value="1"<?php checked( $product_args['multiple'], '1' ); ?>/>
+			<label for="<?php esc_attr_e( $this->get_field_id( 'multiple' ) ); ?>"><?php esc_html_e( 'Allow people to buy more than one item at a time.', 'jetpack' ); ?></label>
 		</p>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'email' ); ?>"><?php _e( 'Email', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'email' ); ?>" name="<?php echo $this->get_field_name( 'email' ); ?>" type="email" value="<?php echo esc_attr( $product_args['email'] ); ?>" />
+			<label for="<?php esc_attr_e( $this->get_field_id( 'email' ) ); ?>"><?php esc_html_e( 'Email', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php esc_attr_e( $this->get_field_id( 'email' ) ); ?>" name="<?php esc_attr_e( $this->get_field_name( 'email' ) ); ?>" type="email" value="<?php  esc_attr_e( $product_args['email'] ); ?>" />
 			<em><?php printf( esc_html__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a %1$sPayPal account%2$s connected to a bank account.', 'jetpack' ), '<a href="https://paypal.com" target="_blank">', '</a>' ) ?></em>
 		</p>
 	</div>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -1,0 +1,120 @@
+<?php
+/*
+Plugin Name: Simple Payments
+Description: Simple Payments button implemented as a widget.
+Version: 1.0
+Author: Automattic Inc.
+Author URI: http://automattic.com/
+License: GPLv2 or later
+*/
+
+function jetpack_register_widget_simple_payments() {
+	register_widget( 'Simple_Payments_Widget' );
+}
+add_action( 'widgets_init', 'jetpack_register_widget_simple_payments' );
+
+class Simple_Payments_Widget extends WP_Widget {
+	private static $dir       = null;
+	private static $url       = null;
+	private static $labels    = null;
+	private static $defaults  = null;
+	private static $config_js = null;
+
+	function __construct() {
+		$widget = array(
+			'classname'   => 'simple-payments',
+			'description' => __( 'Add a simple payment button.', 'jetpack' ),
+		);
+
+		parent::__construct(
+			'Simple_Payments_Widget',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Simple Payments', 'jetpack' ) ),
+			$widget
+		);
+
+		self::$dir = trailingslashit( dirname( __FILE__ ) );
+		self::$url = plugin_dir_url( __FILE__ );
+		// add form labels for translation
+		/*
+		self::$labels = array(
+			'year'    => __( 'year', 'jetpack' ),
+		);
+		*/
+
+		// add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
+		// add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
+	}
+
+	public static function enqueue_admin( $hook_suffix ) {
+		if ( 'widgets.php' == $hook_suffix ) {
+			// wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
+		}
+	}
+
+	public static function enqueue_template() {
+		// wp_enqueue_script( 'milestone', self::$url . 'milestone.js', array( 'jquery' ), '20160520', true );
+	}
+
+    /**
+     * Widget
+     */
+    function widget( $args, $instance ) {
+		$instance = $this->sanitize_instance( $instance );
+
+
+		echo $args['before_widget'];
+
+		$title = apply_filters( 'widget_title', $instance['title'] );
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
+
+		echo '<div class="simple-payments-content">';
+
+		// display the product on the front end here
+		echo 'Hello World!';
+
+		echo '</div><!--simple-payments-->';
+
+		echo $args['after_widget'];
+
+	    /** This action is documented in modules/widgets/gravatar-profile.php */
+	    do_action( 'jetpack_stats_extra', 'widget_view', 'simple-payments' );
+    }
+
+    /**
+     * Update
+     */
+    function update( $new_instance, $old_instance ) {
+
+    }
+
+    /**
+     * Form
+     */
+    function form( $instance ) {
+		// $instance = $this->sanitize_instance( $instance );
+        ?>
+
+	<div class="simple-payments">
+		<p>Clone the simple payment button UI from Calypso here.</p>
+        <!--p>
+        	<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'jetpack' ); ?></label>
+        	<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+        </p>
+
+        <p>
+        	<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
+        	<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'description' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
+        </p>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Message', 'jetpack' ); ?></label>
+			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
+		</p-->
+	</div>
+
+		<?php
+    }
+}

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -25,145 +25,145 @@ class Simple_Payments_Widget extends WP_Widget {
 			'symbol' => '$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'EUR' => array(
 			'symbol' => '€',
 			'grouping' => '.',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'AUD' => array(
 			'symbol' => 'A$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'BRL' => array(
 			'symbol' => 'R$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'CAD' => array(
 			'symbol' => 'C$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'CZK' => array(
 			'symbol' => 'Kč',
 			'grouping' => ' ',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'DKK' => array(
 			'symbol' => 'kr.',
 			'grouping' => '',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'HKD' => array(
 			'symbol' => 'HK$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'HUF' => array(
 			'symbol' => 'Ft',
 			'grouping' => '.',
 			'decimal' => ',',
-			'precision' => '0',
+			'precision' => 0,
 		),
 		'ILS' => array(
 			'symbol' => '₪',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'JPY' => array(
 			'symbol' => '¥',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '0',
+			'precision' => 0,
 		),
 		'MYR' => array(
 			'symbol' => 'RM',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'MXN' => array(
 			'symbol' => 'MX$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'TWD' => array(
 			'symbol' => 'NT$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'NZD' => array(
 			'symbol' => 'NZ$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'NOK' => array(
 			'symbol' => 'kr',
 			'grouping' => ' ',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'PHP' => array(
 			'symbol' => '₱',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'PLN' => array(
 			'symbol' => 'zł',
 			'grouping' => ' ',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'GBP' => array(
 			'symbol' => '£',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'RUB' => array(
 			'symbol' => '₽',
 			'grouping' => ' ',
 			'decimal' => ',',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'SGD' => array(
 			'symbol' => '$',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'SEK' => array(
 			'symbol' => 'kr',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'CHF' => array(
 			'symbol' => 'CHF',
 			'grouping' => '\'',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 		'THB' => array(
 			'symbol' => '฿',
 			'grouping' => ',',
 			'decimal' => '.',
-			'precision' => '2',
+			'precision' => 2,
 		),
 	);
 
@@ -223,7 +223,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		return wp_parse_args( $product_args, array(
 			'name' => '',
 			'description' => '',
-			'currency' => 'USD', // TODO: Geo-localize?
+			'currency' => 'USD', // TODO: Geo-locate?
 			'price' => 1000,
 			'multiple' => '0',
 			'email' => $current_user->user_email,
@@ -263,6 +263,31 @@ class Simple_Payments_Widget extends WP_Widget {
 	    /** This action is documented in modules/widgets/gravatar-profile.php */
 	    do_action( 'jetpack_stats_extra', 'widget_view', 'simple-payments' );
     }
+
+    protected function sanitize_price( $currency_code, $price ) {
+		if ( '-' === substr( $price, 0, 1 ) ) {
+			return false;
+		}
+		$currency = self::$currencies[ $currency_code ];
+		$decimal = $currency['decimal'];
+		$precision = $currency['precision'];
+		$chars = count_chars( $price, 1 );
+		for( $i = 0; $i <= 9; $i++ ) {
+			unset( $chars[ ord( (string) $i ) ] );
+		}
+		if ( count( $chars ) > 1 || reset( $chars ) > 1 ) {
+			return false;
+		}
+
+		// Allow the decimal separator to be the currency decimal separator or "."
+		$decimal_char = chr( key( $chars ) );
+		if ( $decimal_char !== $decimal && $decimal_char !== '.' ) {
+			return false;
+		}
+		$price = str_replace( $decimal_char, '.', $price );
+
+		return round( (float) $price, $precision );
+	}
 
     /**
      * Update
@@ -307,9 +332,9 @@ class Simple_Payments_Widget extends WP_Widget {
 				'post_content' => $new_instance['description'],
 				'meta_input' => array(
 					'spay_currency' => $new_instance['currency'],
-					'spay_price' => $new_instance['price'],
+					'spay_price' => $this->sanitize_price( $new_instance['currency'], $new_instance['price'] ),
 					'spay_multiple' => $new_instance['multiple'],
-					'spay_email' => $new_instance['email'],
+					'spay_email' => is_email( $new_instance['email'] ),
 				),
 			) ),
 		);
@@ -363,7 +388,7 @@ class Simple_Payments_Widget extends WP_Widget {
 					</option>
 				<?php } ?>
 			</select>
-			<input class="price widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo esc_attr( $product_args['price'] ); ?>" />
+			<input class="price widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo esc_attr(  number_format( $product_args['price'], self::$currencies[ $product_args['currency'] ]['precision'], '.', '' ) ); ?>" />
 		</p>
 		<p>
 			<input id="<?php echo $this->get_field_id( 'multiple' ); ?>" name="<?php echo $this->get_field_name( 'multiple' ); ?>" type="checkbox" <?php if ( '1' === $product_args['multiple'] ) { ?>checked="checked"<?php } ?> />

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -207,7 +207,6 @@ class Simple_Payments_Widget extends WP_Widget {
 			$product_id = null;
 		}
 
-
 		$product_args = wp_parse_args( $product_args, array(
 			'name' => '',
 			'description' => '',

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -196,6 +196,8 @@ class Simple_Payments_Widget extends WP_Widget {
 	public static function enqueue_admin_styles( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
 			wp_enqueue_style( 'simple-payments-widget-admin', self::$url . '/simple-payments/style-admin.css', array(), '20171014' );
+			wp_enqueue_media();
+			wp_enqueue_script( 'simple-payments-widget-admin', self::$url . '/simple-payments/admin.js', array( 'jquery' ), '20171014', true );
 		}
 	}
 
@@ -374,6 +376,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'image' ); ?>"><?php _e( 'Image', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'image' ); ?>" name="<?php echo $this->get_field_name( 'image' ); ?>" type="text" value="<?php echo esc_attr( $image ); ?>" />
+			<button class="button simple-payments-add-image">Add Image</button>
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'description' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -334,7 +334,7 @@ class Simple_Payments_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'email' ); ?>"><?php _e( 'Email', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'email' ); ?>" name="<?php echo $this->get_field_name( 'email' ); ?>" type="email" value="<?php echo esc_attr( $product_args['email'] ); ?>" />
-			This is where PayPal will send your money. To claim a payment, you'll need a PayPal account connected to a bank account.
+			<em><?php printf( esc_html__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a %1$sPayPal account%2$s connected to a bank account.', 'jetpack' ), '<a href="https://paypal.com" target="_blank">', '</a>' ) ?></em>
 		</p>
 	</div>
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -163,7 +163,7 @@ class Simple_Payments_Widget extends WP_Widget {
 			$product_id = 0;
 		}
 
-		if ( isset( $new_instance['name'] ) ) {
+		if ( isset( $new_instance['name'] ) && $new_instance['name'] ) {
 			$product_id = wp_insert_post( array(
 				'ID' => $product_id,
 				'post_type' => Jetpack_Simple_Payments::$post_type_product,

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -20,6 +20,153 @@ class Simple_Payments_Widget extends WP_Widget {
 	private static $defaults  = null;
 	private static $config_js = null;
 
+	private static $currencies = array(
+		'USD' => array(
+			'symbol' => '$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'EUR' => array(
+			'symbol' => '€',
+			'grouping' => '.',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'AUD' => array(
+			'symbol' => 'A$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'BRL' => array(
+			'symbol' => 'R$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'CAD' => array(
+			'symbol' => 'C$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'CZK' => array(
+			'symbol' => 'Kč',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'DKK' => array(
+			'symbol' => 'kr.',
+			'grouping' => '',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'HKD' => array(
+			'symbol' => 'HK$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'HUF' => array(
+			'symbol' => 'Ft',
+			'grouping' => '.',
+			'decimal' => ',',
+			'precision' => '0',
+		),
+		'ILS' => array(
+			'symbol' => '₪',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'JPY' => array(
+			'symbol' => '¥',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '0',
+		),
+		'MYR' => array(
+			'symbol' => 'RM',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'MXN' => array(
+			'symbol' => 'MX$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'TWD' => array(
+			'symbol' => 'NT$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'NZD' => array(
+			'symbol' => 'NZ$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'NOK' => array(
+			'symbol' => 'kr',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'PHP' => array(
+			'symbol' => '₱',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'PLN' => array(
+			'symbol' => 'zł',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'GBP' => array(
+			'symbol' => '£',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'RUB' => array(
+			'symbol' => '₽',
+			'grouping' => ' ',
+			'decimal' => ',',
+			'precision' => '2',
+		),
+		'SGD' => array(
+			'symbol' => '$',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'SEK' => array(
+			'symbol' => 'kr',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'CHF' => array(
+			'symbol' => 'CHF',
+			'grouping' => '\'',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+		'THB' => array(
+			'symbol' => '฿',
+			'grouping' => ',',
+			'decimal' => '.',
+			'precision' => '2',
+		),
+	);
+
 	function __construct() {
 		$widget = array(
 			'classname'   => 'simple-payments',
@@ -170,11 +317,14 @@ class Simple_Payments_Widget extends WP_Widget {
 			<textarea class="widefat" rows=5 id="<?php echo $this->get_field_id( 'description' ); ?>" name="<?php echo $this->get_field_name( 'description' ); ?>"><?php echo esc_html( $product_args['description'] ); ?></textarea>
 		</p>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'currency' ); ?>"><?php _e( 'Currency', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'currency' ); ?>" name="<?php echo $this->get_field_name( 'currency' ); ?>" type="text" value="<?php echo esc_attr( $product_args['currency'] ); ?>" />
-		</p>
-		<p>
 			<label for="<?php echo $this->get_field_id( 'price' ); ?>"><?php _e( 'Price', 'jetpack' ); ?></label>
+			<select class="widefat" id="<?php echo $this->get_field_id( 'currency' ); ?>" name="<?php echo $this->get_field_name( 'currency' ); ?>">
+				<?php foreach( self::$currencies as $code => $currency ) { ?>
+					<option value="<?php echo esc_attr( $code ) ?>" <?php if ( $code === $product_args['currency'] ) { ?>selected="selected"<?php } ?>>
+						<?php echo esc_html( $currency['symbol'] === $code ? $code : ( $code . ' ' . rtrim( $currency['symbol'], '.' ) ) ) ?>
+					</option>
+				<?php } ?>
+			</select>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'price' ); ?>" name="<?php echo $this->get_field_name( 'price' ); ?>" type="text" value="<?php echo esc_attr( $product_args['price'] ); ?>" />
 		</p>
 		<p>

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -1,8 +1,36 @@
 (function($) {
 	$(document).ready( function() {
-		$( document.body ).on( 'click', '.simple-payments-remove-image', function( event ) {
+		$( document.body ).on( 'click', '.simple-payments-add-product', function( event ) {
 			event.preventDefault();
 			var root = $( this ).closest( '.simple-payments' );
+			root.find( '.simple-payments-product-list input[type="radio"]' ).prop( 'checked', false );
+			root.find( '.simple-payments-product-list' ).hide();
+			root.find( '.simple-payments-form' ).show()
+				.find( '.field-name' ).prop( 'disabled', false );
+			// TODO: Reset fields
+		} );
+
+		$( document.body ).on( 'click', '.simple-payments-edit-product', function( event ) {
+			event.preventDefault();
+			$( this ).closest( 'label' ).click();
+			var root = $( this ).closest( '.simple-payments' );
+			root.find( '.simple-payments-product-list' ).hide();
+			root.find( '.simple-payments-form' ).show()
+				.find( '.field-name' ).prop( 'disabled', false );
+			// TODO: Populate fields
+		} );
+
+		$( document.body ).on( 'click', '.simple-payments-back-product-list', function( event ) {
+			event.preventDefault();
+			var root = $( this ).closest( '.simple-payments' );
+			root.find( '.simple-payments-form' ).hide()
+				.find( '.field-name' ).prop( 'disabled', true );
+			root.find( '.simple-payments-product-list' ).show();
+		} );
+
+		$( document.body ).on( 'click', '.simple-payments-remove-image', function( event ) {
+			event.preventDefault();
+			var root = $( this ).closest( '.simple-payments-form' );
 			var imageContainer = root.find( '.simple-payments-image' );
 			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
 			imageContainer.find( 'img, input[type=hidden]' ).remove();
@@ -10,7 +38,7 @@
 		} );
 
 		$( document.body ).on( 'click', '.simple-payments-image-fieldset .placeholder, .simple-payments-image > img', function( event ) {
-			var root = $( this ).closest( '.simple-payments' );
+			var root = $( this ).closest( '.simple-payments-form' );
 			var imageContainer = root.find( '.simple-payments-image' );
 
 			event.preventDefault();

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -40,7 +40,7 @@
 
 		$( document.body ).on( 'click', '.simple-payments-edit-product', function( event ) {
 			event.preventDefault();
-			$( this ).closest( 'label' ).click();
+			$( this ).closest( 'li' ).find( 'input[type="radio"]' ).click();
 			var root = $( this ).closest( '.simple-payments' );
 			root.find( '.simple-payments-back-product-list' ).show();
 			root.find( '.simple-payments-product-list' ).hide();

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -8,6 +8,7 @@
 
 			var imageContainer = root.find( '.simple-payments-image' );
 			imageContainer.find( 'img, input[type=hidden]' ).remove();
+			root.find( '.simple-payments-back-product-list' ).show();
 			root.find( '.simple-payments-form' ).show();
 			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
 			root.find( '.field-name' ).prop( 'disabled', false ).val( root.find( '.field-name' ).prop( 'defaultValue' ) );
@@ -41,6 +42,7 @@
 			event.preventDefault();
 			$( this ).closest( 'label' ).click();
 			var root = $( this ).closest( '.simple-payments' );
+			root.find( '.simple-payments-back-product-list' ).show();
 			root.find( '.simple-payments-product-list' ).hide();
 			var imageContainer = root.find( '.simple-payments-image' );
 			imageContainer.find( 'img, input[type=hidden]' ).remove();
@@ -71,6 +73,7 @@
 
 		$( document.body ).on( 'click', '.simple-payments-back-product-list', function( event ) {
 			event.preventDefault();
+			$( this ).hide();
 			var root = $( this ).closest( '.simple-payments' );
 			root.find( '.simple-payments-form' ).hide()
 				.find( '.field-name' ).prop( 'disabled', true );

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -1,17 +1,26 @@
 (function($) {
 	$(document).ready( function() {
-		$('.simple-payments-add-image').on( 'click', function( event ) {
+		$( document.body ).on( 'click', '.simple-payments-remove-image', function( event ) {
+			event.preventDefault();
+			var root = $( this ).closest( '.simple-payments' );
+			var imageContainer = root.find( '.simple-payments-image' );
+			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
+			imageContainer.empty();
+		} );
+
+		$( document.body ).on( 'click', '.simple-payments-add-image', function( event ) {
+			var root = $( this ).closest( '.simple-payments' );
+			var imageContainer = root.find( '.simple-payments-image' );
+
 			event.preventDefault();
 			var frame = new wp.media.view.MediaFrame.Select({
-				title: 'Choose Product Image',
+				title: 'Choose Product Image', // TODO: i18n
 
 				// Enable/disable multiple select
 				multiple: false,
 
 				// Library WordPress query arguments.
 				library: {
-					order: 'ASC',
-					orderby: 'title',
 					type: 'image',
 				},
 
@@ -24,21 +33,27 @@
 			// @see media.view.MediaFrame.Post.mainInsertToolbar()
 			frame.on( 'select', function() {
 				var selection = frame.state().get('selection').first().toJSON();
-				console.log( selection );
 
 				// First, make sure that we have the URL of an image to display
 				if ( 0 > $.trim( selection.url.length ) ) {
 					return;
 				}
 
-				console.log( $( '.simple-payments-image' ).children( 'img' ) );
+				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
 
-				// After that, set the properties of the image and display it
-				$( '.simple-payments-image' )
-					.children( 'img' )
-				        .attr( 'src', selection.url )
-				        .attr( 'alt', selection.caption )
-				        .attr( 'title', selection.title );
+				imageContainer.empty()
+					.append( $( '<img/>', {
+						src: selection.url,
+						alt: selection.caption,
+						title: selection.title,
+						width: selection.width,
+						height: selection.height,
+					} ) )
+					.append( $( '<input/>', {
+						type: 'hidden',
+						name: imageContainer.data( 'image-field' ),
+						value: selection.id,
+					} ) );
 
 
 			} );

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -50,7 +50,7 @@
 			root.find( '.field-description' ).val( $( this ).data( 'description' ) );
 			root.find( '.field-currency' ).val( $( this ).data( 'currency' ) );
 			root.find( '.field-price' ).val( $( this ).data( 'price' ) );
-			root.find( '.field-multiple' ).prop( 'checked', $( this ).data( 'multiple' ) === '1' );
+			root.find( '.field-multiple' ).prop( 'checked', String( $( this ).data( 'multiple' ) ) === '1' );
 			root.find( '.field-email' ).val( $( this ).data( 'email' ) );
 
 			if ( $( this ).data( 'image-url' ) ) {

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -5,10 +5,11 @@
 			var root = $( this ).closest( '.simple-payments' );
 			var imageContainer = root.find( '.simple-payments-image' );
 			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
-			imageContainer.empty();
+			imageContainer.find( 'img, input[type=hidden]' ).remove();
+			imageContainer.hide();
 		} );
 
-		$( document.body ).on( 'click', '.simple-payments-add-image', function( event ) {
+		$( document.body ).on( 'click', '.simple-payments-image-fieldset .placeholder, .simple-payments-image > img', function( event ) {
 			var root = $( this ).closest( '.simple-payments' );
 			var imageContainer = root.find( '.simple-payments-image' );
 
@@ -41,13 +42,12 @@
 
 				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
 
-				imageContainer.empty()
+				imageContainer.find( 'img, input[type=hidden]' ).remove();
+				imageContainer.show()
 					.append( $( '<img/>', {
 						src: selection.url,
 						alt: selection.caption,
 						title: selection.title,
-						width: selection.width,
-						height: selection.height,
 					} ) )
 					.append( $( '<input/>', {
 						type: 'hidden',

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -5,9 +5,36 @@
 			var root = $( this ).closest( '.simple-payments' );
 			root.find( '.simple-payments-product-list input[type="radio"]' ).prop( 'checked', false );
 			root.find( '.simple-payments-product-list' ).hide();
-			root.find( '.simple-payments-form' ).show()
-				.find( '.field-name' ).prop( 'disabled', false );
-			// TODO: Reset fields
+
+			var imageContainer = root.find( '.simple-payments-image' );
+			imageContainer.find( 'img, input[type=hidden]' ).remove();
+			root.find( '.simple-payments-form' ).show();
+			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
+			root.find( '.field-name' ).prop( 'disabled', false ).val( root.find( '.field-name' ).prop( 'defaultValue' ) );
+			root.find( '.field-description' ).val( root.find( '.field-description' ).prop( 'defaultValue' ) );
+			root.find( '.field-currency' ).val( function() { // Reset the dropdown to the default value
+				return $( this ).find( 'option' ).filter( function() {
+					return $( this ).prop( 'defaultSelected' );
+				} ).val();
+			} );
+			root.find( '.field-price' ).val( root.find( '.field-price' ).prop( 'defaultValue' ) );
+			root.find( '.field-multiple' ).prop( 'checked', root.find( '.field-multiple' ).prop( 'defaultChecked' ) );
+			root.find( '.field-email' ).val( root.find( '.field-email' ).prop( 'defaultValue' ) );
+
+			if ( $( this ).data( 'image-url' ) ) {
+				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
+				imageContainer.show()
+					.append( $( '<img/>', {
+						src: $( this ).data( 'image-url' ),
+					} ) )
+					.append( $( '<input/>', {
+						type: 'hidden',
+						name: imageContainer.data( 'image-field' ),
+						value: $( this ).data( 'image-url' ),
+					} ) );
+			} else {
+				root.find( '.simple-payments-image-fieldset .placeholder' ).show();
+			}
 		} );
 
 		$( document.body ).on( 'click', '.simple-payments-edit-product', function( event ) {
@@ -15,9 +42,31 @@
 			$( this ).closest( 'label' ).click();
 			var root = $( this ).closest( '.simple-payments' );
 			root.find( '.simple-payments-product-list' ).hide();
-			root.find( '.simple-payments-form' ).show()
-				.find( '.field-name' ).prop( 'disabled', false );
-			// TODO: Populate fields
+			var imageContainer = root.find( '.simple-payments-image' );
+			imageContainer.find( 'img, input[type=hidden]' ).remove();
+
+			root.find( '.simple-payments-form' ).show();
+			root.find( '.field-name' ).prop( 'disabled', false ).val( $( this ).data( 'name' ) );
+			root.find( '.field-description' ).val( $( this ).data( 'description' ) );
+			root.find( '.field-currency' ).val( $( this ).data( 'currency' ) );
+			root.find( '.field-price' ).val( $( this ).data( 'price' ) );
+			root.find( '.field-multiple' ).prop( 'checked', $( this ).data( 'multiple' ) === '1' );
+			root.find( '.field-email' ).val( $( this ).data( 'email' ) );
+
+			if ( $( this ).data( 'image-url' ) ) {
+				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
+				imageContainer.show()
+					.append( $( '<img/>', {
+						src: $( this ).data( 'image-url' ),
+					} ) )
+					.append( $( '<input/>', {
+						type: 'hidden',
+						name: imageContainer.data( 'image-field' ),
+						value: $( this ).data( 'image-url' ),
+					} ) );
+			} else {
+				root.find( '.simple-payments-image-fieldset .placeholder' ).show();
+			}
 		} );
 
 		$( document.body ).on( 'click', '.simple-payments-back-product-list', function( event ) {

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -1,0 +1,50 @@
+(function($) {
+	$(document).ready( function() {
+		$('.simple-payments-add-image').on( 'click', function( event ) {
+			event.preventDefault();
+			var frame = new wp.media.view.MediaFrame.Select({
+				title: 'Choose Product Image',
+
+				// Enable/disable multiple select
+				multiple: false,
+
+				// Library WordPress query arguments.
+				library: {
+					order: 'ASC',
+					orderby: 'title',
+					type: 'image',
+				},
+
+				button: {
+					text: 'Choose Image'
+				}
+			});
+
+			// Fires when a user has selected attachment(s) and clicked the select button.
+			// @see media.view.MediaFrame.Post.mainInsertToolbar()
+			frame.on( 'select', function() {
+				var selection = frame.state().get('selection').first().toJSON();
+				console.log( selection );
+
+				// First, make sure that we have the URL of an image to display
+				if ( 0 > $.trim( selection.url.length ) ) {
+					return;
+				}
+
+				console.log( $( '.simple-payments-image' ).children( 'img' ) );
+
+				// After that, set the properties of the image and display it
+				$( '.simple-payments-image' )
+					.children( 'img' )
+				        .attr( 'src', selection.url )
+				        .attr( 'alt', selection.caption )
+				        .attr( 'title', selection.title );
+
+
+			} );
+
+			// Open the modal.
+			frame.open();
+		});
+	});
+})(jQuery);

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -1,76 +1,74 @@
-(function($) {
-	$(document).ready( function() {
+( function( $ ) {
+	function showEditProductForm( root, values ) {
+		if ( ! values ) {
+			values = {
+				name: root.find( '.field-name' ).prop( 'defaultValue' ),
+				description: root.find( '.field-description' ).prop( 'defaultValue' ),
+				currency: root.find( '.field-currency' ).find( 'option' ).filter( function() {
+					return $( this ).prop( 'defaultSelected' );
+				} ).val(),
+				price: root.find( '.field-price' ).prop( 'defaultValue' ),
+				multiple: root.find( '.field-multiple' ).prop( 'defaultChecked' ),
+				email: root.find( '.field-email' ).prop( 'defaultValue' ),
+			};
+		}
+		root.find( '.simple-payments-back-product-list' ).show();
+		root.find( '.simple-payments-product-list' ).hide();
+
+		root.find( '.simple-payments-form' ).show();
+		root.find( '.field-name' ).prop( 'disabled', false ).val( values.name );
+		root.find( '.field-description' ).val( values.description );
+		root.find( '.field-currency' ).val( values.currency );
+		root.find( '.field-price' ).val( values.price );
+		root.find( '.field-multiple' ).prop( 'checked', values.multiple );
+		root.find( '.field-email' ).val( values.email );
+
+		var imageContainer = root.find( '.simple-payments-image' );
+		imageContainer.find( 'img, input[type=hidden]' ).remove();
+		if ( values.image ) {
+			root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
+			imageContainer.show()
+				.append( $( '<img/>', {
+					src: values.image,
+				} ) )
+				.append( $( '<input/>', {
+					type: 'hidden',
+					name: imageContainer.data( 'image-field' ),
+					value: values.image,
+				} ) );
+		} else {
+			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
+		}
+	}
+
+	$( document ).ready( function() {
+		// Open the "Add new product" view
 		$( document.body ).on( 'click', '.simple-payments-add-product', function( event ) {
 			event.preventDefault();
 			var root = $( this ).closest( '.simple-payments' );
 			root.find( '.simple-payments-product-list input[type="radio"]' ).prop( 'checked', false );
-			root.find( '.simple-payments-product-list' ).hide();
 
-			var imageContainer = root.find( '.simple-payments-image' );
-			imageContainer.find( 'img, input[type=hidden]' ).remove();
-			root.find( '.simple-payments-back-product-list' ).show();
-			root.find( '.simple-payments-form' ).show();
-			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
-			root.find( '.field-name' ).prop( 'disabled', false ).val( root.find( '.field-name' ).prop( 'defaultValue' ) );
-			root.find( '.field-description' ).val( root.find( '.field-description' ).prop( 'defaultValue' ) );
-			root.find( '.field-currency' ).val( function() { // Reset the dropdown to the default value
-				return $( this ).find( 'option' ).filter( function() {
-					return $( this ).prop( 'defaultSelected' );
-				} ).val();
-			} );
-			root.find( '.field-price' ).val( root.find( '.field-price' ).prop( 'defaultValue' ) );
-			root.find( '.field-multiple' ).prop( 'checked', root.find( '.field-multiple' ).prop( 'defaultChecked' ) );
-			root.find( '.field-email' ).val( root.find( '.field-email' ).prop( 'defaultValue' ) );
-
-			if ( $( this ).data( 'image-url' ) ) {
-				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
-				imageContainer.show()
-					.append( $( '<img/>', {
-						src: $( this ).data( 'image-url' ),
-					} ) )
-					.append( $( '<input/>', {
-						type: 'hidden',
-						name: imageContainer.data( 'image-field' ),
-						value: $( this ).data( 'image-url' ),
-					} ) );
-			} else {
-				root.find( '.simple-payments-image-fieldset .placeholder' ).show();
-			}
+			showEditProductForm( root );
 		} );
 
+		// Open the "Edit product" view
 		$( document.body ).on( 'click', '.simple-payments-edit-product', function( event ) {
 			event.preventDefault();
 			$( this ).closest( 'li' ).find( 'input[type="radio"]' ).click();
 			var root = $( this ).closest( '.simple-payments' );
-			root.find( '.simple-payments-back-product-list' ).show();
-			root.find( '.simple-payments-product-list' ).hide();
-			var imageContainer = root.find( '.simple-payments-image' );
-			imageContainer.find( 'img, input[type=hidden]' ).remove();
 
-			root.find( '.simple-payments-form' ).show();
-			root.find( '.field-name' ).prop( 'disabled', false ).val( $( this ).data( 'name' ) );
-			root.find( '.field-description' ).val( $( this ).data( 'description' ) );
-			root.find( '.field-currency' ).val( $( this ).data( 'currency' ) );
-			root.find( '.field-price' ).val( $( this ).data( 'price' ) );
-			root.find( '.field-multiple' ).prop( 'checked', String( $( this ).data( 'multiple' ) ) === '1' );
-			root.find( '.field-email' ).val( $( this ).data( 'email' ) );
-
-			if ( $( this ).data( 'image-url' ) ) {
-				root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
-				imageContainer.show()
-					.append( $( '<img/>', {
-						src: $( this ).data( 'image-url' ),
-					} ) )
-					.append( $( '<input/>', {
-						type: 'hidden',
-						name: imageContainer.data( 'image-field' ),
-						value: $( this ).data( 'image-url' ),
-					} ) );
-			} else {
-				root.find( '.simple-payments-image-fieldset .placeholder' ).show();
-			}
+			showEditProductForm( root, {
+				name: $( this ).data( 'name' ),
+				description: $( this ).data( 'description' ),
+				currency: $( this ).data( 'currency' ),
+				price: $( this ).data( 'price' ),
+				multiple: String( $( this ).data( 'multiple' ) ) === '1',
+				email: $( this ).data( 'email' ),
+				image: $( this ).data( 'image-url' ),
+			} );
 		} );
 
+		// "Back" link that cancels the changes on the Product currently being edited/added
 		$( document.body ).on( 'click', '.simple-payments-back-product-list', function( event ) {
 			event.preventDefault();
 			$( this ).hide();
@@ -80,6 +78,7 @@
 			root.find( '.simple-payments-product-list' ).show();
 		} );
 
+		// When the user clicks the "x" button in the Product image, remove the image value and restore the placeholder
 		$( document.body ).on( 'click', '.simple-payments-remove-image', function( event ) {
 			event.preventDefault();
 			var root = $( this ).closest( '.simple-payments-form' );
@@ -89,33 +88,28 @@
 			imageContainer.hide();
 		} );
 
+		// Open the image picker when the user clicks on the Product image (or placeholder)
 		$( document.body ).on( 'click', '.simple-payments-image-fieldset .placeholder, .simple-payments-image > img', function( event ) {
 			var root = $( this ).closest( '.simple-payments-form' );
 			var imageContainer = root.find( '.simple-payments-image' );
 
 			event.preventDefault();
-			var frame = new wp.media.view.MediaFrame.Select({
+			var frame = new wp.media.view.MediaFrame.Select( {
 				title: 'Choose Product Image', // TODO: i18n
-
-				// Enable/disable multiple select
 				multiple: false,
-
-				// Library WordPress query arguments.
 				library: {
-					type: 'image',
+					type: 'image'
 				},
-
 				button: {
-					text: 'Choose Image'
+					text: 'Choose Image' // TODO: i18n
 				}
-			});
+			} );
 
 			// Fires when a user has selected attachment(s) and clicked the select button.
 			// @see media.view.MediaFrame.Post.mainInsertToolbar()
 			frame.on( 'select', function() {
-				var selection = frame.state().get('selection').first().toJSON();
+				var selection = frame.state().get( 'selection' ).first().toJSON();
 
-				// First, make sure that we have the URL of an image to display
 				if ( 0 > $.trim( selection.url.length ) ) {
 					return;
 				}
@@ -134,12 +128,10 @@
 						name: imageContainer.data( 'image-field' ),
 						value: selection.id,
 					} ) );
-
-
 			} );
 
 			// Open the modal.
 			frame.open();
-		});
-	});
-})(jQuery);
+		} );
+	} );
+} )( jQuery );

--- a/modules/widgets/simple-payments/admin.js
+++ b/modules/widgets/simple-payments/admin.js
@@ -9,7 +9,7 @@
 				} ).val(),
 				price: root.find( '.field-price' ).prop( 'defaultValue' ),
 				multiple: root.find( '.field-multiple' ).prop( 'defaultChecked' ),
-				email: root.find( '.field-email' ).prop( 'defaultValue' ),
+				email: root.find( '.field-email' ).prop( 'defaultValue' )
 			};
 		}
 		root.find( '.simple-payments-back-product-list' ).show();
@@ -29,12 +29,12 @@
 			root.find( '.simple-payments-image-fieldset .placeholder' ).hide();
 			imageContainer.show()
 				.append( $( '<img/>', {
-					src: values.image,
+					src: values.image
 				} ) )
 				.append( $( '<input/>', {
 					type: 'hidden',
 					name: imageContainer.data( 'image-field' ),
-					value: values.image,
+					value: values.image
 				} ) );
 		} else {
 			root.find( '.simple-payments-image-fieldset .placeholder' ).show();
@@ -64,7 +64,7 @@
 				price: $( this ).data( 'price' ),
 				multiple: String( $( this ).data( 'multiple' ) ) === '1',
 				email: $( this ).data( 'email' ),
-				image: $( this ).data( 'image-url' ),
+				image: $( this ).data( 'image-url' )
 			} );
 		} );
 
@@ -121,12 +121,12 @@
 					.append( $( '<img/>', {
 						src: selection.url,
 						alt: selection.caption,
-						title: selection.title,
+						title: selection.title
 					} ) )
 					.append( $( '<input/>', {
 						type: 'hidden',
 						name: imageContainer.data( 'image-field' ),
-						value: selection.id,
+						value: selection.id
 					} ) );
 			} );
 

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -2,6 +2,10 @@
 	text-align: center;
 }
 
+.widget-content .simple-payments {
+	clear: both;
+}
+
 .widget-content .simple-payments .cost label {
 	display: block;
 }
@@ -11,9 +15,31 @@
 	vertical-align: top;
 	width: 19%;
 }
+
 .widget-content .simple-payments .price {
 	display: inline-block;
 	line-height: 20px;
 	width: 80%;
+}
+
+.widget-content .simple-payments-products li:after {
+	content: "";
+	display: table;
+	clear: both;
+}
+
+.widget-content .simple-payments-products input[type=radio] {
+	float: left;
+}
+
+.widget-content .simple-payments-products .product-info {
+	float: left;
+	margin-left: 24px;
+}
+
+.widget-content .simple-payments-products .image img {
+	float: right;
+	height: auto;
+	width: 80px;
 }
 

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -112,7 +112,8 @@
 	padding: 8px 0;
 }
 
-.widget-content .simple-payments-products li:after {
+.widget-content .simple-payments-products li:after,
+.widget-content .simple-payments-products li label:after {
 	content: "";
 	display: table;
 	clear: both;

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -1,18 +1,8 @@
-.simple-payments-image {
-	text-align: center;
-}
-
 .widget-content .simple-payments {
 	clear: both;
 }
 
-.widget-content .simple-payments-product-list .control_add-product,
-.widget-content .simple-payments-product-list .control_insert-product {
-	margin: 1em 0;
-	text-align: right;
-}
-
-.widget-content .simple-payments .cost label {
+.widget-content .simple-payments-form .cost label {
 	display: block;
 }
 
@@ -26,18 +16,18 @@
 	box-sizing: border-box;
 	cursor: pointer;
 	line-height: 20px;
-	margin: 1em 0;
 	padding: 9px 0;
 	position: relative;
 	text-align: center;
 	width: 100%;
-	margin-top: 4px;
+	margin: 4px 0 1em;
 }
 
 .widget-content .simple-payments-image {
 	max-width: 100%;
 	margin-top: 4px;
 	position: relative;
+	text-align: center;
 }
 
 .widget-content .simple-payments-image img {
@@ -53,7 +43,7 @@
 	border-style: solid;
 }
 
-.widget-content .simple-payments .currency {
+.widget-content .simple-payments-form .currency {
 	display: inline-block;
 	vertical-align: top;
 	width: 28%;
@@ -97,10 +87,17 @@
 	display: block;
 }
 
-.widget-content .simple-payments .price {
+.widget-content .simple-payments-form .field-price {
 	display: inline-block;
 	line-height: 20px;
 	width: 70%;
+}
+
+/* Product list */
+
+.widget-content .simple-payments-add-product {
+	margin: 1em 0;
+	text-align: right;
 }
 
 .widget-content .simple-payments-products {

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -10,25 +10,31 @@
 	display: block;
 }
 
+.widget-content .simple-payments-image img {
+	max-width: 100%;
+	height: auto;
+}
+
 .widget-content .simple-payments .currency {
 	display: inline-block;
 	vertical-align: top;
-	width: 19%;
+	width: 28%;
 }
 
 .widget-content .simple-payments .price {
 	display: inline-block;
 	line-height: 20px;
-	width: 80%;
+	width: 70%;
 }
 
 .widget-content .simple-payments-products {
 	border-bottom: 1px solid #ccc;
 }
+
 .widget-content .simple-payments-products li {
 	border-top: 1px solid #ccc;
 	margin-bottom: 0;
-	padding: 4px 0;
+	padding: 8px 0;
 }
 
 .widget-content .simple-payments-products li:after {
@@ -39,12 +45,12 @@
 
 .widget-content .simple-payments-products input[type=radio] {
 	float: left;
-	margin: 4px 0;
+	margin: 8px 0;
 }
 
 .widget-content .simple-payments-products .product-info {
 	float: left;
-	margin-left: 24px;
+	margin-left: 8px;
 }
 
 .widget-content .simple-payments-products .image img {
@@ -52,4 +58,3 @@
 	height: auto;
 	width: 80px;
 }
-

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -6,8 +6,25 @@
 	clear: both;
 }
 
+.widget-content .simple-payments-product-list .control_add-product,
+.widget-content .simple-payments-product-list .control_insert-product {
+	margin: 1em 0;
+	text-align: right;
+}
+
 .widget-content .simple-payments .cost label {
 	display: block;
+}
+
+.simple-payments-image-fieldset .placeholder {
+	border: 1px dashed #b4b9be;
+	box-sizing: border-box;
+	cursor: default;
+	line-height: 20px;
+	padding: 9px 0;
+	position: relative;
+	text-align: center;
+	width: 100%;
 }
 
 .widget-content .simple-payments-image img {
@@ -28,11 +45,11 @@
 }
 
 .widget-content .simple-payments-products {
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #e5e5e5;
 }
 
 .widget-content .simple-payments-products li {
-	border-top: 1px solid #ccc;
+	border-top: 1px solid #e5e5e5;
 	margin-bottom: 0;
 	padding: 8px 0;
 }
@@ -50,6 +67,7 @@
 
 .widget-content .simple-payments-products .product-info {
 	float: left;
+	line-height: 1.5;
 	margin-left: 8px;
 }
 

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -1,0 +1,19 @@
+.simple-payments-image {
+	text-align: center;
+}
+
+.widget-content .simple-payments .cost label {
+	display: block;
+}
+
+.widget-content .simple-payments .currency {
+	display: inline-block;
+	vertical-align: top;
+	width: 19%;
+}
+.widget-content .simple-payments .price {
+	display: inline-block;
+	line-height: 20px;
+	width: 80%;
+}
+

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -16,27 +16,85 @@
 	display: block;
 }
 
-.simple-payments-image-fieldset .placeholder {
+.widget-content .simple-payments-image-fieldset {
+	position: relative;
+	width: 100%;
+}
+
+.widget-content .simple-payments-image-fieldset .placeholder {
 	border: 1px dashed #b4b9be;
 	box-sizing: border-box;
-	cursor: default;
+	cursor: pointer;
 	line-height: 20px;
 	margin: 1em 0;
 	padding: 9px 0;
 	position: relative;
 	text-align: center;
 	width: 100%;
+	margin-top: 4px;
+}
+
+.widget-content .simple-payments-image {
+	max-width: 100%;
+	margin-top: 4px;
+	position: relative;
 }
 
 .widget-content .simple-payments-image img {
 	max-width: 100%;
+	box-sizing: border-box;
+	border: 1px dashed #b4b9be;
+	padding: 4px;
 	height: auto;
+	cursor: pointer;
+}
+
+.widget-content .simple-payments-image img:hover {
+	border-style: solid;
 }
 
 .widget-content .simple-payments .currency {
 	display: inline-block;
 	vertical-align: top;
 	width: 28%;
+}
+
+.widget-content .simple-payments-remove-image,
+.widget-content .simple-payments-remove-image:hover,
+.widget-content .simple-payments-remove-image:focus,
+.widget-content .simple-payments-remove-image:active
+{
+	display: none;
+	cursor: pointer;
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	height: 28px;
+	width: 28px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	outline: 0;
+}
+
+.widget-content .simple-payments-remove-image:before {
+	font-family: Dashicons;
+	content: "\f158";
+	display: inline-block;
+	speak: none;
+	font-size: 24pt;
+	color: #a00;
+}
+
+.widget-content .simple-payments-remove-image:hover:before,
+.widget-content .simple-payments-remove-image:focus:before {
+	color: #dc3232;
+}
+
+
+.widget-content .simple-payments-image:hover .simple-payments-remove-image {
+	display: block;
 }
 
 .widget-content .simple-payments .price {

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -117,7 +117,7 @@
 .widget-content .simple-payments-products li {
 	border-top: 1px solid #e5e5e5;
 	margin-bottom: 0;
-	padding: 8px 0;
+	padding: 0;
 }
 
 .widget-content .simple-payments-products li:hover {
@@ -129,12 +129,6 @@
 	content: "";
 	display: table;
 	clear: both;
-}
-
-.widget-content .simple-payments-products .simple-payments-edit-product {
-	display: none;
-	float: right;
-	margin-right: 8px;
 }
 
 .widget-content .simple-payments-products li:hover .simple-payments-edit-product {
@@ -158,3 +152,46 @@
 	width: 80px;
 }
 
+.widget-content .simple-payments-products label {
+	display: block;
+	padding: 8px 0;
+}
+
+.widget-content .simple-payments-products input[type="radio"] {
+	display: none;
+}
+
+.widget-content .simple-payments-products input[type="radio"]:checked + label {
+	background-color: #ddf6ff;
+}
+
+.widget-content .simple-payments-edit-product,
+.widget-content .simple-payments-edit-product:hover,
+.widget-content .simple-payments-edit-product:focus,
+.widget-content .simple-payments-edit-product:active
+{
+	display: none;
+	margin-right: 8px;
+	cursor: pointer;
+	height: 24px;
+	width: 24px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	outline: 0;
+}
+
+.widget-content .simple-payments-edit-product:before {
+	font-family: Dashicons;
+	content: "\f464"; /* Pencil */
+	display: inline-block;
+	speak: none;
+	font-size: 20pt;
+	color: #0073aa;
+}
+
+.widget-content .simple-payments-edit-product:hover:before,
+.widget-content .simple-payments-edit-product:focus:before {
+	color: #00a0d2;
+}

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -135,15 +135,11 @@
 	display: block;
 }
 
-.widget-content .simple-payments-products input[type=radio] {
-	float: left;
-	margin: 4px 0;
-}
-
 .widget-content .simple-payments-products .product-info {
 	float: left;
-	line-height: 1.5;
-	margin-left: 8px;
+	line-height: 2;
+	margin-left: 12px;
+	margin-right: 12px;
 }
 
 .widget-content .simple-payments-products .image img {

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -102,6 +102,8 @@
 
 .widget-content .simple-payments-products {
 	border-bottom: 1px solid #e5e5e5;
+	max-height: 350px;
+	overflow: auto;
 }
 
 .widget-content .simple-payments-products li {
@@ -114,6 +116,16 @@
 	content: "";
 	display: table;
 	clear: both;
+}
+
+.widget-content .simple-payments-products .simple-payments-edit-product {
+	display: none;
+	float: right;
+	margin-right: 8px;
+}
+
+.widget-content .simple-payments-products li:hover .simple-payments-edit-product {
+	display: block;
 }
 
 .widget-content .simple-payments-products input[type=radio] {
@@ -132,3 +144,4 @@
 	height: auto;
 	width: 80px;
 }
+

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -1,4 +1,5 @@
-.widget-content .simple-payments {
+.widget-content .simple-payments,
+.widget-content .simple-payments-form {
 	clear: both;
 }
 
@@ -95,21 +96,32 @@
 
 /* Product list */
 
-.widget-content .simple-payments-add-product {
+.widget-content .simple-payments-add-product,
+.widget-content .simple-payments-back-product-list
+{
 	margin: 1em 0;
-	text-align: right;
+	float: right;
+}
+
+.widget-content .simple-payments-product-count {
+	text-transform: uppercase;
 }
 
 .widget-content .simple-payments-products {
 	border-bottom: 1px solid #e5e5e5;
 	max-height: 350px;
 	overflow: auto;
+	clear: both;
 }
 
 .widget-content .simple-payments-products li {
 	border-top: 1px solid #e5e5e5;
 	margin-bottom: 0;
 	padding: 8px 0;
+}
+
+.widget-content .simple-payments-products li:hover {
+	background-color: #f7f7f7;
 }
 
 .widget-content .simple-payments-products li:after,

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -21,6 +21,7 @@
 	box-sizing: border-box;
 	cursor: default;
 	line-height: 20px;
+	margin: 1em 0;
 	padding: 9px 0;
 	position: relative;
 	text-align: center;
@@ -62,7 +63,7 @@
 
 .widget-content .simple-payments-products input[type=radio] {
 	float: left;
-	margin: 8px 0;
+	margin: 4px 0;
 }
 
 .widget-content .simple-payments-products .product-info {

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -22,6 +22,15 @@
 	width: 80%;
 }
 
+.widget-content .simple-payments-products {
+	border-bottom: 1px solid #ccc;
+}
+.widget-content .simple-payments-products li {
+	border-top: 1px solid #ccc;
+	margin-bottom: 0;
+	padding: 4px 0;
+}
+
 .widget-content .simple-payments-products li:after {
 	content: "";
 	display: table;
@@ -30,6 +39,7 @@
 
 .widget-content .simple-payments-products input[type=radio] {
 	float: left;
+	margin: 4px 0;
 }
 
 .widget-content .simple-payments-products .product-info {

--- a/modules/widgets/simple-payments/style-admin.css
+++ b/modules/widgets/simple-payments/style-admin.css
@@ -43,7 +43,7 @@
 	border-style: solid;
 }
 
-.widget-content .simple-payments-form .currency {
+.widget-content .simple-payments-form .field-currency {
 	display: inline-block;
 	vertical-align: top;
 	width: 28%;

--- a/modules/widgets/simple-payments/style.css
+++ b/modules/widgets/simple-payments/style.css
@@ -1,0 +1,29 @@
+.widget .jetpack-simple-payments-product {
+    display: block;
+    max-width: 620px;
+    margin: 0 auto;
+}
+.widget .jetpack-simple-payments-image {
+    padding-top: 0;
+    box-sizing: content-box;
+}
+.widget .jetpack-simple-payments-wrapper .jetpack-simple-payments-product-image .jetpack-simple-payments-image img.size-full {
+    left: 0;
+    position: static;
+    top: 0;
+    transform: none;
+    width: auto;
+}
+.widget .jetpack-simple-payments-image {
+    border: 0;
+}
+.widget .jetpack-simple-payments-image img {
+    border: 1px solid rgba(0,0,0,0.1);
+}
+.widget .jetpack-simple-payments-details {
+    max-width: 620px;
+    padding: 0;
+}
+.widget .jetpack-simple-payments-product-image + .jetpack-simple-payments-details {
+    padding: 0;
+}


### PR DESCRIPTION
This was implemented by @crunnells and me at the GM.

Previously, the `Simple payments` feature only allowed to include a product by shortcode. This PR adds a new widget type, called "Simpla payments", which allows adding a product to a widget area.

Features:
* Everything can be operated in `WP-Admin`. The Payments widget is added like any other widget.
* Uses the same custom post type as the Calypso side, with the same data format, so you can seamlessly edit/create products in Calypso and use them in WP-Admin, and vice-versa.
* When configuring a new Payment widget, you're presented with a list of the existing products. You then can:
  * Select a product and save the widget.
  * Edit an existing product and save the widget (this will change all the widgets/shortcodes that already use that product).
  * Create a new product and save the widget.
* When editing an existing widget instance, the only option is to edit the product being used.
* When creating a new product, the `email` field, `currency` dropdown and `multiple` checkbox are prefilled with sensible defaults (such as the user's email, or the options selected by the most recently created product).

Missing features (you decide if they're blockers):
- [ ] The feature is available for all. Would it make sense to restrict it to Jetpack Premium?
- [ ] There were some problems with the Customizer, it created *a lot* of products due to the auto-save. @crunnells can you check if that's still an issue?
- [ ] Admin styles could use some work.
- [ ] Products can't be deleted.
- [ ] Changes on one widget instance aren't reflected on the others until the page is refreshed. Same happens when you add a new widget, any new products you created won't be in the list until the page is refreshed.
