### PR TITLE
Call do_stats() on shutdown instead of on __destruct

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -655,6 +655,11 @@ class Jetpack {
 		 * These are sync actions that we need to keep track of for jitms
 		 */
 		add_filter( 'jetpack_sync_before_send_updated_option', array( $this, 'jetpack_track_last_sync_callback' ), 99 );
+
+		// Actually push the stats on shutdown.
+		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
+			add_action( 'shutdown', array( $this, 'push_stats' ) );
+		}
 	}
 
 	function point_edit_links_to_calypso( $default_url, $post_id ) {
@@ -808,7 +813,7 @@ class Jetpack {
 	/**
 	 * If there are any stats that need to be pushed, but haven't been, push them now.
 	 */
-	function __destruct() {
+	function push_stats() {
 		if ( ! empty( $this->stats ) ) {
 			$this->do_stats( 'server_side' );
 		}


### PR DESCRIPTION
Somehow `$wp_object_cache` (used by `wp_cache_get()`) is not defined by the time we reach
`Jetpack::__destruct`. Looks like using cache from the `shutdown` callback is fine though.

#### Changes proposed in this Pull Request:

* Removes the `__destruct` method as currently only is pushing stats.
* Adds a `push_stats()` method that will check if any stats are pending and send the to .com
* Hooks `push_stats()` to `shutdown` in the class constructor.

#### Testing instructions:

*

#### References

* [PHP Fatal Error in cache.php on line 123 $wp_object_cache is non-object](https://wordpress.stackexchange.com/questions/283085/php-fatal-error-in-cache-php-on-line-123-wp-object-cache-is-non-object).