### PR TITLE
Fix Scan card description if there are threats found.

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { numberFormat, translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
 import get from 'lodash/get';
@@ -18,7 +18,11 @@ import {
 } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import { getVaultPressData, isFetchingVaultPressData } from 'state/at-a-glance';
+import {
+	getVaultPressData,
+	isFetchingVaultPressData,
+	getVaultPressScanThreatCount,
+} from 'state/at-a-glance';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import includes from 'lodash/includes';
 
@@ -49,7 +53,27 @@ export const BackupsScan = moduleSettingsForm(
 			// We check if the features are active first, rather than the plan because it's possible the site is on a
 			// VP-only plan, purchased before Jetpack plans existed.
 			if ( backupsEnabled && scanEnabled ) {
-				return __( 'Your site is backed up and threat-free.' );
+				const threats = this.props.hasThreats;
+				if ( threats ) {
+					return <div>
+						<strong>
+							{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
+								{
+									count: threats,
+									args: {
+										number: numberFormat( threats )
+									}
+								}
+							) }
+						</strong>
+						<br /><br />
+						{ __( '{{a}}View details{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } ) }
+						<br />
+						{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href="https://jetpack.com/support" /> } } ) }
+					</div>;
+				} else {
+					return __( 'Your site is backed up and threat-free.' );
+				}
 			}
 
 			// Only return here if backups enabled and site on on free/personal plan.  If they're on a higher plan,
@@ -108,5 +132,6 @@ export default connect( state => {
 		isFetchingSiteData: isFetchingSiteData( state ),
 		vaultPressData: getVaultPressData( state ),
 		isFetchingVaultPressData: isFetchingVaultPressData( state ),
+		hasThreats: getVaultPressScanThreatCount( state ),
 	};
 } )( BackupsScan );


### PR DESCRIPTION
Fixes #7483

If threats are found, the messaging was not clear.  See the screenshot in the linked issue.  

This PR updates the description to [what we have](https://github.com/Automattic/jetpack/blob/branch-5.4/_inc/client/at-a-glance/scan.jsx#L58-L72) in the dashboard.  It includes number of threats and links to VP dashboard and support.  I think we should not worry too much about design here.  

To test: 
- Hack the `getVaultPressScanThreatCount()` selector to return a number.  it's [here](https://github.com/Automattic/jetpack/blob/branch-5.4/_inc/client/state/at-a-glance/reducer.js#L281).
- View the scan card in the `/security` tab.  
- Make sure the links work. 
- Make sure it looks fine with no threats.  