### PR TITLE
Fix undefined index on bare image tags

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -348,7 +348,6 @@ class Jetpack_Carousel {
 		foreach( $matches[0] as $image_html ) {
 			if ( preg_match( '/wp-image-([0-9]+)/i', $image_html, $class_id ) &&
 				( $attachment_id = absint( $class_id[1] ) ) ) {
-
 				/*
 				 * If exactly the same image tag is used more than once, overwrite it.
 				 * All identical tags will be replaced later with 'str_replace()'.
@@ -359,6 +358,9 @@ class Jetpack_Carousel {
 
 		$find        = array();
 		$replace     = array();
+		if ( empty( $selected_images ) ) {
+			return $content;
+		}
 		$attachments = get_posts( array(
 			'include' => array_keys( $selected_images ),
 		) );


### PR DESCRIPTION
Fixes an issue where `<img>` tags without a `wp-image-N` class would cause an undefined index notice and load all WordPress attachments into RAM (!)

To reproduce:

1. Add a regular image tag, like `<img src="https://www.blog.google/static/blog/images/google-200x200.7714256da16f.png" />`

2. Render the page

3. Observe errors like:

```
Notice: Undefined offset: 568 in /srv/www/wordpress-default/public_html/wp-content/plugins/jetpack/modules/carousel/jetpack-carousel.php on line 374
```