### PR TITLE
Update/plugin api endpoint

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -187,12 +187,13 @@ class Jetpack_Sync_Defaults {
 		'sso_bypass_default_login_form'    => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 		'wp_version'                       => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
-		'get_plugins_action_links'		   => array( 'Jetpack_Sync_functions', 'get_plugins_action_links' ),
+		'get_plugins_action_links'         => array( 'Jetpack_Sync_Functions', 'get_plugins_action_links' ),
+		'get_plugin_org_info'              => array( 'Jetpack_Sync_Functions', 'get_plugin_org_info' ),
 		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
 		'hosting_provider'                 => array( 'Jetpack_Sync_Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
-		'roles'                            =>  array( 'Jetpack_Sync_Functions', 'roles' ),
+		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 	);
 
 	public static function get_callable_whitelist() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -303,6 +303,27 @@ class Jetpack_Sync_Functions {
 		return $wp_version;
 	}
 
+	public static function get_plugin_org_info() {
+		$update_plugins = get_site_transient( 'update_plugins' );
+		$org_plugin_data = array();
+		if ( isset( $update_plugins->no_update ) ) {
+			$org_plugin_data = (array) $update_plugins->no_update;
+		}
+		if ( isset( $update_plugins->response ) ) {
+			$org_plugin_data = array_merge( $org_plugin_data, $update_plugins->response );
+		}
+		$valid_org_plugin_data = array();
+		foreach ( $org_plugin_data as $plugin_file => $plugin_data ) {
+			$id = ( isset( $plugin_data->id ) ? explode( '/', (string) $plugin_data->id ) : null );
+			$icons = is_array( $plugin_data->icons ) ? $plugin_data->icons : null;
+			$valid_org_plugin_data[ $plugin_file ] = array_filter( array(
+				'icons' => $icons,
+				'slug' => $plugin_data->slug
+			) );
+			$valid_org_plugin_data[ $plugin_file ]['is_org'] = ( 'w.org' === $id[0] );
+		}
+		return $valid_org_plugin_data;
+	}
 	public static function site_icon_url() {
 		if ( ! function_exists( 'get_site_icon_url' ) || ! has_site_icon() ) {
 			return get_option( 'jetpack_site_icon_url' );


### PR DESCRIPTION
Adds the icons and whether the plugin is in the .org repo or not.

#### Changes proposed in this Pull Request:
* Adds the icons and whether the plugin is in the .org repo or not.
* Sync .org data to the jetpack shadow site.

#### Testing instructions:
* Do the tests pass?
* is the data available on the api. 


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
