### PR TITLE
Gallery Wdiget: Fix logic for force-enabling Jetpack Gallery widget if filter returns true

### DIFF
--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -435,7 +435,11 @@ function jetpack_gallery_widget_init() {
 	 *
 	 * @param bool false Whether to force-enable the gallery widget
 	 */
-	if ( apply_filters( 'jetpack_force_enable_gallery_widget', false ) || ( class_exists( 'WP_Widget_Media_Gallery' ) && Jetpack_Options::get_option( 'gallery_widget_migration' ) ) ) {
+	if (
+		! apply_filters( 'jetpack_force_enable_gallery_widget', false )
+		&& class_exists( 'WP_Widget_Media_Gallery' )
+		&& Jetpack_Options::get_option( 'gallery_widget_migration' )
+	) {
 		return;
  	}
 	if ( ! method_exists( 'Jetpack', 'is_module_active' ) || Jetpack::is_module_active( 'tiled-gallery' ) )


### PR DESCRIPTION
#8062 introduced a filter `jetpack_force_enable_gallery_widget` for forcing the enabling of the Gallery Widget for WordPress versions that include the Media Gallery Widget introduced by WordPress 4.9

The logic for making this filter be useful was wrong.

#### Changes proposed in this Pull Request:

* Changes the boolean comparison made in `modules/widgets/gallery.php` for forcing the enabling of the Gallery Widget

#### Testing instructions:

* On a test site with WordPress 4.9
* Checkout this branch
* Hook into the filter with `add_filter( 'jetpack_force_enable_gallery_widget', '__return_true' );`
* Visit Appearance -> Widgets and confirm that you get to see `Gallery (Jetpack)` among the available widgets list. 

![image](https://user-images.githubusercontent.com/746152/32274510-ef7afefe-bee5-11e7-9534-c7e9eab7bb81.png)
