### PR TITLE
SimplePayments: add `author` into product supports.

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -258,7 +258,7 @@ class Jetpack_Simple_Payments {
 		$product_args = array(
 			'label'                 => esc_html__( 'Product', 'jetpack' ),
 			'description'           => esc_html__( 'Simple Payments products', 'jetpack' ),
-			'supports'              => array( 'title', 'editor','thumbnail', 'custom-fields' ),
+			'supports'              => array( 'title', 'editor','thumbnail', 'custom-fields', 'author' ),
 			'hierarchical'          => false,
 			'public'                => false,
 			'show_ui'               => false,


### PR DESCRIPTION
This PR allows editing the author of the simple payments product adding the `author` key into the `supports` field.

#### Testing instructions:

Using the WP COM REST API, after applying the patch tries to edit the product author passing a valid `author` value into the body request.