### PR TITLE
Remove the Jetpack version lock for directly embedded VideoPress

### DIFF
--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -621,7 +621,6 @@ class VideoPress_Player {
 			}
 
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
-			$js_url = add_query_arg( 'jetpack_version', JETPACK__VERSION, $js_url );
 
 			return "<iframe width='" . esc_attr( $videopress_options['width'] )
 				. "' height='" . esc_attr( $videopress_options['height'] )
@@ -632,7 +631,6 @@ class VideoPress_Player {
 		} else {
 			$videopress_options = json_encode( $videopress_options );
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress.js';
-			$js_url = add_query_arg( 'jetpack_version', JETPACK__VERSION, $js_url );
 
 			return "<div id='{$video_container_id}'></div>
 				<script src='{$js_url}'></script>


### PR DESCRIPTION
Currently, we version lock VideoPress for videos that are directly embedded in a page. This does not affect 90% of videos, as they exist inside of an iframe, so always receive the newest version of VideoPress. However, for directly embedded videos, we never update the version of VideoPress, even when valid fixes are applied.

Case in point, back in early October I released a fix for Safari which had broken VideoPress, thanks to the no autoplay feature they added. During this fix, I accidentally broke some versions of Internet Explorer. While I found and fixed the issue within days, it seems during those days Jetpack 5.4 was released and now that broken version of VideoPress is feature locked for Jetpack 5.4 users... bummer.

While I can appreciate the likely reasoning behind this feature lock, it is ultimately only affecting just a small population of users, and only in a way that prevents them from seeing the newest version of VideoPress.

I would like to remove this feature locking going forward, to prevent this type of scenario from occurring, so that all Jetpack users see the newest version of VideoPress and I don't need to spend unneeded days trying to figure out why some users are seeing errors I fixed over a month ago.

#### Changes proposed in this Pull Request:

* Removes the `?jetpack_version={JETPACK_VERSION}` from javascript url includes for directly embedded versions of VideoPress

#### Testing instructions:

* Add a video with the `embed=0` argument and verify that the script include now lacks the `?jetpack_version={JETPACK_VERSION}` in the page source AND that the video works as expected on the page.

#### Proposed changelog entry for your changes:

* Removed Jetpack version locking for directly embedded VideoPress videos to ensure all users receive the newest version of the player.