### PR TITLE
Admin Page: Transform a noop string value into empty string if post by email address is not set yet

### DIFF
--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -37,7 +37,8 @@ const PostByEmail = moduleSettingsForm(
 			const currentValue = this.props.getOptionValue( 'post_by_email_address' );
 			// If the module Post-by-email is enabled BUT it's configured as disabled
 			// Its value is set to false
-			if ( false === currentValue || '1' === currentValue ) {
+			// At some point the API started returning noop here, so we check for that too.
+			if ( false === currentValue || '1' === currentValue || 'noop' === currentValue ) {
 				return '';
 			}
 			return currentValue;


### PR DESCRIPTION

Fixes #8099

#### Changes proposed in this Pull Request:

* Checks if the value returned by the API is `noop` and shows `''` instead.

#### Testing instructions:

* Start with a fresh site that is connected.
* Build this branch (or try this PR out on Jetpack Beta plugin)
* Vist the Jetpack Admin settings page
* Confirm that the input for Post By Email Address is blank instead of showing the text `noop`.

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

Fixes bug that showed wrong content in the Post By Email Address setting if it hadn't been configured before.
