### PR TITLE
Admin Page: Add explanation below Ignored Phrases input under composing settings

### DIFF
--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -153,6 +153,9 @@ const Composing = moduleSettingsForm(
 								: []
 							}
 							onChange={ this.props.onOptionChange } />
+						<span className="jp-form-setting-explanation">
+							{ __( 'Confirm each new phrase you add by pressing enter.' ) }
+						</span>
 					</FormFieldset>
 				</SettingsGroup>
 			);


### PR DESCRIPTION
Fixes issue reported by @ebinnion in p8oabR-6W-p2 where after entering a new phrase, it was unnatural to not be able to save the settings right away

#### Changes proposed in this Pull Request:

* Adds and explanation below Ignored Phrased input in Admin Page composing settings prompting the user to press enter after they've entered a new phrase. Reads: `Confirm each new phrase you add by pressing enter afterwards.`

#### Testing instructions:

* Checkout this branch
* Build the admin page
* Visit the Jetpack Settings page.
* Expand the `Check your spelling, style, and grammar` card.
* Confirm that the explanation below the Ignored Phrases input is fine.

#### Screenshots

**Before**

![image](https://user-images.githubusercontent.com/746152/32374827-0b91d2a4-c07e-11e7-9a85-55839cbbdc88.png)


**After**

![image](https://user-images.githubusercontent.com/746152/32374923-79192c00-c07e-11e7-9b7b-0e6d37fc1205.png)


