### PR TITLE
Admin Page: Don't show publicize activation toggle for users that cannot manage modules

### DIFF
--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -11,7 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
 import { isModuleFound as _isModuleFound } from 'state/search';
-import { getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
+import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
 import QuerySite from 'components/data/query-site';
 import { Publicize } from './publicize';
 import { ShareButtons } from './share-buttons';
@@ -28,7 +28,8 @@ class Sharing extends Component {
 			isLinked: this.props.isLinked,
 			connectUrl: this.props.connectUrl,
 			siteRawUrl: this.props.siteRawUrl,
-			siteAdminUrl: this.props.siteAdminUrl
+			siteAdminUrl: this.props.siteAdminUrl,
+			userCanManageModules: this.props.userCanManageModules,
 		};
 
 		const foundPublicize = this.props.isModuleFound( 'publicize' ),
@@ -87,7 +88,8 @@ export default connect(
 			isLinked: isCurrentUserLinked( state ),
 			connectUrl: getConnectUrl( state ),
 			siteRawUrl: getSiteRawUrl( state ),
-			siteAdminUrl: getSiteAdminUrl( state )
+			siteAdminUrl: getSiteAdminUrl( state ),
+			userCanManageModules: userCanManageModules( state ),
 		};
 	}
 )( Sharing );

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -28,7 +28,8 @@ export const Publicize = moduleSettingsForm(
 				isLinked = this.props.isLinked,
 				connectUrl = this.props.connectUrl,
 				siteRawUrl = this.props.siteRawUrl,
-				isActive = this.props.getOptionValue( 'publicize' );
+				isActive = this.props.getOptionValue( 'publicize' ),
+				userCanManageModules = this.props.userCanManageModules;
 
 			const configCard = () => {
 				if ( unavailableInDevMode ) {
@@ -55,24 +56,34 @@ export const Publicize = moduleSettingsForm(
 					);
 			};
 
+			if ( ! userCanManageModules && ! isActive ) {
+				return null;
+			}
+
 			return (
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Publicize connections', { context: 'Settings header' } ) }
 					module="publicize"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'publicize' } } support="https://jetpack.com/support/publicize/">
-						<ModuleToggle
-							slug="publicize"
-							disabled={ unavailableInDevMode }
-							activated={ isActive }
-							toggling={ this.props.isSavingAnyOption( 'publicize' ) }
-							toggleModule={ this.props.toggleModuleNow }>
-							{
-								__( 'Automatically share your posts to social networks' )
-							}
-							</ModuleToggle>
-					</SettingsGroup>
+					{
+						userCanManageModules && (
+							<SettingsGroup disableInDevMode module={ { module: 'publicize' } }
+								support="https://jetpack.com/support/publicize/"
+							>
+								<ModuleToggle
+									slug="publicize"
+									disabled={ unavailableInDevMode }
+									activated={ isActive }
+									toggling={ this.props.isSavingAnyOption( 'publicize' ) }
+									toggleModule={ this.props.toggleModuleNow }>
+									{
+										__( 'Automatically share your posts to social networks' )
+									}
+								</ModuleToggle>
+							</SettingsGroup>
+						)
+					}
 					{
 						isActive && configCard()
 					}


### PR DESCRIPTION
Fixes #8098 

#### Changes proposed in this Pull Request:

* Hides the publicize activation toggle if user cannot manage modules

#### Testing instructions:

* Check this branch and build the admin page
* Log in as an user with an editor role
* Get to the Admin Page settings, and confirm that you get the publicize activation toggle disabled for the user.


#### Screenshots

**Before**

![image](https://user-images.githubusercontent.com/746152/32388911-f523cd18-c0a7-11e7-964c-3062b77c5ea7.png)



**After**


![image](https://user-images.githubusercontent.com/746152/32388945-0b6dffb2-c0a8-11e7-962d-3ef3c0302fe7.png)

![image](https://user-images.githubusercontent.com/746152/32388970-164a0142-c0a8-11e7-92fd-41e1d17bce4b.png)

![image](https://user-images.githubusercontent.com/746152/32388974-1c02d0d2-c0a8-11e7-8620-3bb256b932c4.png)

