### PR TITLE
Sharing: Press This + 4.9

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -217,15 +217,6 @@ function sharing_add_plugin_settings($links, $file) {
 	return $links;
 }
 
-function sharing_restrict_to_single( $services ) {
-	// This removes Press This from non-multisite blogs - doesn't make much sense
-	if ( is_multisite() === false ) {
-		unset( $services['press-this'] );
-	}
-
-	return $services;
-}
-
 function sharing_init() {
 	if ( Jetpack_Options::get_option_and_ensure_autoload( 'sharedaddy_disable_resources', '0' ) ) {
 		add_filter( 'sharing_js', 'sharing_disable_js' );
@@ -277,7 +268,6 @@ add_action( 'sharing_email_send_post', 'sharing_email_send_post' );
 add_filter( 'sharing_email_can_send', 'sharing_email_check_for_spam_via_akismet' );
 add_action( 'sharing_global_options', 'sharing_global_resources', 30 );
 add_action( 'sharing_admin_update', 'sharing_global_resources_save' );
-add_filter( 'sharing_services', 'sharing_restrict_to_single' );
 add_action( 'plugin_action_links_'.basename( dirname( __FILE__ ) ).'/'.basename( __FILE__ ), 'sharing_plugin_settings', 10, 4 );
 add_filter( 'plugin_row_meta', 'sharing_add_plugin_settings', 10, 2 );
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -40,6 +40,7 @@ class Sharing_Service {
 	 * Gets a list of all available service names and classes
 	 */
 	public function get_all_services( $include_custom = true ) {
+		global $wp_version;
 		// Default services
 		// if you update this list, please update the REST API tests
 		// in bin/tests/api/suites/SharingTest.php
@@ -49,7 +50,6 @@ class Sharing_Service {
 			'linkedin'          => 'Share_LinkedIn',
 			'reddit'            => 'Share_Reddit',
 			'twitter'           => 'Share_Twitter',
-			'press-this'        => 'Share_PressThis',
 			'google-plus-1'     => 'Share_GooglePlus1',
 			'tumblr'            => 'Share_Tumblr',
 			'pinterest'         => 'Share_Pinterest',
@@ -71,6 +71,10 @@ class Sharing_Service {
 		 */
 		if ( apply_filters( 'sharing_services_email', Jetpack::is_akismet_active() ) ) {
 			$services['email'] = 'Share_Email';
+		}
+
+		if ( is_multisite() && ( version_compare( $wp_version, '4.9', '<' ) || is_plugin_active( 'press-this/press-this-plugin.php' ) ) ) {
+			$services['press-this'] = 'Share_PressThis';
 		}
 
 		if ( $include_custom ) {

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -73,7 +73,7 @@ class Sharing_Service {
 			$services['email'] = 'Share_Email';
 		}
 
-		if ( is_multisite() && ( version_compare( $wp_version, '4.9', '<' ) || is_plugin_active( 'press-this/press-this-plugin.php' ) ) ) {
+		if ( is_multisite() && ( version_compare( $wp_version, '4.9-RC1-42107', '<' ) || is_plugin_active( 'press-this/press-this-plugin.php' ) ) ) {
 			$services['press-this'] = 'Share_PressThis';
 		}
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -151,7 +151,7 @@ abstract class Sharing_Source {
 		if ( ! empty( $query ) ) {
 			if ( false === stripos( $url, '?' ) ) {
 				$url .= '?' . $query;
-			} else { 
+			} else {
 				$url .= '&amp;' . $query;
 			}
 		}
@@ -376,7 +376,7 @@ class Share_Email extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -472,14 +472,14 @@ class Share_Email extends Sharing_Source {
 				}
 
 				die();
-			} else { 
+			} else {
 				$error = 2;	  // Email check failed
 			}
 		}
 
 		if ( $ajax ) {
 			echo $error;
-		} else { 
+		} else {
 			wp_safe_redirect( get_permalink( $post->ID ) . '?shared=email&msg=fail' );
 		}
 
@@ -564,7 +564,7 @@ class Share_Twitter extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -759,7 +759,7 @@ class Share_Reddit extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -771,7 +771,7 @@ class Share_Reddit extends Sharing_Source {
 	public function get_display( $post ) {
 		if ( $this->smart ) {
 			return '<div class="reddit_button"><iframe src="' . $this->http() . '://www.reddit.com/static/button/button1.html?newwindow=true&width=120&amp;url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&amp;title=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" height="22" width="120" scrolling="no" frameborder="0"></iframe></div>';
-		} else { 
+		} else {
 			return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Reddit', 'share to', 'jetpack' ), __( 'Click to share on Reddit', 'jetpack' ), 'share=reddit' );
 		}
 	}
@@ -796,7 +796,7 @@ class Share_LinkedIn extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -878,7 +878,7 @@ class Share_Facebook extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1007,7 +1007,7 @@ class Share_Print extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1029,7 +1029,7 @@ class Share_PressThis extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1039,7 +1039,7 @@ class Share_PressThis extends Sharing_Source {
 	}
 
 	public function process_request( $post, array $post_data ) {
-		global $current_user;
+		global $current_user, $wp_version;
 
 		$primary_blog = (int) get_user_meta( $current_user->ID, 'primary_blog', true );
 		if ( $primary_blog ) {
@@ -1066,11 +1066,23 @@ class Share_PressThis extends Sharing_Source {
 
 		$blog = current( $blogs );
 
-		$url = $blog->siteurl . '/wp-admin/press-this.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
+		$args = array(
+			'u' => rawurlencode( $this->get_share_url( $post->ID ) ),
+			);
 
-		if ( isset( $_GET['sel'] ) ) {
-			$url .= '&s=' . rawurlencode( $_GET['sel'] );
+		if ( version_compare( $wp_version, '4.9-RC1-42107', '>=' ) ) {
+			$args[ 'url-scan-submit' ] = 'Scan';
+			$args[ '_wpnonce' ]        = wp_create_nonce( 'scan-site' );
+
+		} else { // Remove once 4.9 is the minimum.
+			$args['t'] = rawurlencode( $this->get_share_title( $post->ID ) );
+				if ( isset( $_GET['sel'] ) ) {
+					$args['s'] = rawurlencode( $_GET['sel'] );
+				}
 		}
+
+		$url = $blog->siteurl . '/wp-admin/press-this.php';
+		$url = add_query_arg( $args, $url );
 
 		// Record stats
 		parent::process_request( $post, $post_data );
@@ -1095,7 +1107,7 @@ class Share_GooglePlus1 extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1393,7 +1405,7 @@ class Share_Tumblr extends Sharing_Source {
 		parent::__construct( $id, $settings );
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1442,7 +1454,7 @@ class Share_Pinterest extends Sharing_Source {
 		parent::__construct( $id, $settings );
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1553,7 +1565,7 @@ class Share_Pinterest extends Sharing_Source {
 				var s = document.createElement("script");
 				s.type = "text/javascript";
 				s.async = true;
-				<?php if ( $jetpack_pinit_over ) { 
+				<?php if ( $jetpack_pinit_over ) {
 				echo "s.setAttribute('data-pin-hover', true);";
 				} ?>
 				s.src = window.location.protocol + "//assets.pinterest.com/js/pinit.js";
@@ -1595,7 +1607,7 @@ class Share_Pocket extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1076,9 +1076,9 @@ class Share_PressThis extends Sharing_Source {
 
 		} else { // Remove once 4.9 is the minimum.
 			$args['t'] = rawurlencode( $this->get_share_title( $post->ID ) );
-				if ( isset( $_GET['sel'] ) ) {
-					$args['s'] = rawurlencode( $_GET['sel'] );
-				}
+			if ( isset( $_GET['sel'] ) ) {
+				$args['s'] = rawurlencode( $_GET['sel'] );
+			}
 		}
 
 		$url = $blog->siteurl . '/wp-admin/press-this.php';

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1088,7 +1088,7 @@ class Share_PressThis extends Sharing_Source {
 		parent::process_request( $post, $post_data );
 
 		// Redirect to Press This
-		wp_safe_redirect( $url );
+		wp_redirect( $url );
 		die();
 	}
 


### PR DESCRIPTION
Jetpack uses the bookmarklet usage which is now removed from Press This, starting in WP 4.9+.

Fixes #8097

#### Changes proposed in this Pull Request:
Updated to work with 4.9 Press This.