### PR TITLE
Widgets: Hook into Media Gallery Widget from a more general place in the code.

### DIFF
--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -26,6 +26,26 @@ class Jetpack_Gallery_Settings {
 			add_action( 'wp_enqueue_media', array( $this, 'wp_enqueue_media' ) );
 			add_action( 'print_media_templates', array( $this, 'print_media_templates' ) );
 		}
+		// Add Slideshow and Galleries functionality to core's media gallery widget.
+		add_filter( 'widget_media_gallery_instance_schema', array( $this, 'core_media_widget_compat' ) );
+	}
+
+	/**
+	 * Updates the schema of the core gallery widget so we can save the
+	 * fields that we add to Gallery Widgets, like `type` and `conditions`
+	 *
+	 * @param $schema The current schema for the core gallery widget
+	 *
+	 * @return array  the updated schema
+	 */
+	public function core_media_widget_compat( $schema ) {
+		$schema['type'] = array(
+			'type' => 'string',
+			'enum' => array_keys( $this->gallery_types ),
+			'description' => __( 'Type of gallery.', 'jetpack' ),
+			'default' => 'default',
+		);
+		return $schema;
 	}
 
 	/**

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -17,18 +17,7 @@ class Jetpack_Tiled_Gallery {
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
 		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
 
-		// Add Tiled Galleries functionality to core's media gallery widget.
-		add_filter( 'widget_media_gallery_instance_schema', array( $this, 'core_media_widget_compat' ) );
-	}
 
-	public function core_media_widget_compat( $schema ) {
-		$schema['type'] = array(
-			'type' => 'string',
-			'enum' => array( 'default', 'rectangular', 'square', 'circle', 'columns', 'slideshow' ),
-			'description' => __( 'Type of gallery.', 'jetpack' ),
-			'default' => 'default',
-		);
-		return $schema;
 	}
 
 	public function tiles_enabled() {


### PR DESCRIPTION
This allows to also save the types when Tiled Galleries module is inactive, and also when the Slideshow shortcode is disabled too. We can still store visibility options now even when those modules are inactive.

Fixes #8113

#### Changes proposed in this Pull Request:

* Moves the filter hooking from the gallery module to the Gallery settings where types are filtered. 

#### Testing instructions:

* Checkout this branch
* Get to Appearance -> Widgets
* Add a new Gallery core Widget. Set one of the types like 'Slideshow' and save.
* Refresh the Widgets page and check that the type setting is maintained.
* Repeat under these conditions
  * Tiled Gallery module inactive.
  * Shortcodes module inactive.
  * Tiled Gallery and Shortcode modules inactive. Here you can save visibility options and verify they're stored.
* Confirm that options are persisted in every case

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

_Should be the same entry text as the changelog entry that states that we added support for core's media widget_