### PR TITLE
Admin Page: Remove passing down of unnecessary prop isSubmitting in settings headings button

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -256,7 +256,6 @@ export const SettingsCard = props => {
 						<Button
 							primary
 							compact
-							isSubmitting={ isSaving }
 							onClick={ isSaving ? () => {} : props.onSubmit }
 							disabled={ isSaving || ! props.isDirty() }>
 							{


### PR DESCRIPTION
This was showing a warning due to the React 15 upgrade.

#### Changes proposed in this Pull Request:

* Removes passing down of unnecesary `isSubmitting` prop.

#### Testing instructions:

* Check and build this branch (not production build)
* Get to Jetpack's Admin Page settings.
* Confirm that you don't see a warning about `isSubmitting` being invalid prop.


