### PR TITLE
Carousel: Added post type and status specification to the query.

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -361,8 +361,11 @@ class Jetpack_Carousel {
 		if ( empty( $selected_images ) ) {
 			return $content;
 		}
+
 		$attachments = get_posts( array(
 			'include' => array_keys( $selected_images ),
+			'post_type' => 'any',
+			'post_status' => 'any'
 		) );
 
 		foreach ( $attachments as $attachment ) {


### PR DESCRIPTION
Without it the query would return an empty result set trying to get results using only IDs because attachment images have status set to `inherit` and type set to `attachment`.

Fixes #8103 

#### Changes proposed in this Pull Request:
* Tweaks the query introduced in #7943 to include attachments.

#### Testing instructions:
* Enable Carousel.
* Create a post with an image that should link to the attachment page.
* Observe that the carousel overlay doesn't open, instead you go to the attachment page.
* Roll this PR on.
* Observe the carousel overlay.
