### PR TITLE
REST API: Take in account desirable null values when preparing options before assigning default_value to current_value

### DIFF
--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -37,8 +37,7 @@ const PostByEmail = moduleSettingsForm(
 			const currentValue = this.props.getOptionValue( 'post_by_email_address' );
 			// If the module Post-by-email is enabled BUT it's configured as disabled
 			// Its value is set to false
-			// At some point the API started returning noop here, so we check for that too.
-			if ( false === currentValue || '1' === currentValue || 'noop' === currentValue ) {
+			if ( false === currentValue || '1' === currentValue ) {
 				return '';
 			}
 			return currentValue;

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2447,7 +2447,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				unset( $options[ $key ]['validate_callback'] );
 			}
 			$default_value = isset( $options[ $key ]['default'] ) ? $options[ $key ]['default'] : '';
-			if ( ! isset( $options[ $key ]['current_value'] ) ) {
+			if ( ! array_key_exists( 'current_value', $options[ $key ] ) ) {
 				$options[ $key ]['current_value'] = self::cast_value( $default_value, $options[ $key ] );
 			}
 		}


### PR DESCRIPTION
Also fixes #8099 but with a more comprehensive approach.

Turned out that the setting `post_by_email_address` has a valid value of `null` if it's not set and evaluating with `isset()` does not favor this case against the ones that have no `current_value`. This problem was introduced by #8053 and is a problem only for this particular setting. No other setting has a valid value of `null`.

#### Changes proposed in this Pull Request:

* Uses `array_key_exists()` instead of `isset` for checking the absence of the `current_value` key when iterating through passed options.
* Reverts changed introduced by #8107 which are not needed anymore as the problem is handled at a lower level. 

#### Testing instructions:

* Checkout this branch
* With a user that has never linked to .com or generated a post-by-email address, check the Jetpack Admin Page settings tab.
* Confirm that the post by email input is blank.

