### PR TITLE
Gallery Widget Migration: Move migrated gallery widgets to inactive sidebar

### DIFF
--- a/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/modules/widgets/migrate-to-core/gallery-widget.php
@@ -165,6 +165,12 @@ function jetpack_migrate_gallery_widget_update_sidebars( $sidebars_widgets, $id,
 			&& false !== ( $key = array_search( "gallery-{$id}", $widgets, true ) )
 		) {
 			$sidebars_widgets[ $sidebar ][ $key ] = "media_gallery-{$new_id}";
+			// Check if the inactive widgets sidebar exists
+			// Related: https://core.trac.wordpress.org/ticket/14893
+			if ( ! isset( $sidebars_widgets['wp_inactive_widgets'] ) || ! is_array( $sidebars_widgets['wp_inactive_widgets'] ) ) {
+				$sidebars_widgets['wp_inactive_widgets'] = array();
+			}
+			$sidebars_widgets['wp_inactive_widgets'][ $key ] = "gallery-{$id}";
 		}
 	}
 	return $sidebars_widgets;

--- a/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
+++ b/tests/php/modules/widgets/migrate-to-core/test_migrate-to-core-gallery-widget.php
@@ -131,14 +131,19 @@ class WP_Test_Jetpack_Migrate_Gallery_Widget extends WP_UnitTestCase {
 			)
 		);
 		$output1 = array(
-			'wp_inactive_widgets' => array(),
+			'wp_inactive_widgets' => array(
+				'gallery-1',
+			),
 			'sidebar-1' => array(
 				'media_gallery-1',
 				'gallery-2',
 			)
 		);
 		$output2 = array(
-			'wp_inactive_widgets' => array(),
+			'wp_inactive_widgets' => array(
+				'gallery-1',
+				'gallery-2',
+			),
 			'sidebar-1' => array(
 				'media_gallery-1',
 				'media_gallery-2',


### PR DESCRIPTION
This PR proposes to store references in the `wp_inactive_widgets` sidebar for the old Gallery Widgets that have been successfully migrated to new Core Media Gallery widgets.

## Background

After migrating Gallery Widgets successfully to the new Media Gallery widgets, the user ends up with this:

1. **New Widget** (Reads _Gallery_, instead of _Gallery (Jetpack)_
2. **No longer has access to the Gallery (Jetpack) widget type** for creating them and adding to sidebars (We don't load the code for Gallery widgets anymore, instead we hook on core's).
    <img src="https://user-images.githubusercontent.com/746152/32510827-98e8a740-c3d0-11e7-84e4-15aaa4ea1cce.png" width="300" />


### Usage of filter for force-enabling the old Jetpack Gallery widget type after migration

If then, the user decides to use the filter

```
add_filter( 'jetpack_force_enable_gallery_widget', '__return_true' );
```

#### Both types of widgets are there:

<img src="https://user-images.githubusercontent.com/746152/32510938-1372d30a-c3d1-11e7-956e-7762f5eb8bc7.png" width="300" />

#### But no inactive widgets are present, so they can not access the old widgets anymore through the UI.

<img src="https://user-images.githubusercontent.com/746152/32511000-42a3c1f2-c3d1-11e7-93a9-a26e91423232.png" width="300" />


## Changes proposed in this Pull Request:

Before removing the old widgets from the original sidebar, adds them to the `wp_inactive_widgets` sidebar.

### Pros & Cons.

1. By using the filter, the user can reposition the old gallery widgets if they want, but we won't be supporting them in the future.

2. By not using the filter, the user will see that there are inactive widgets, but won't know what they are as we don't event register the widget type now on WordPress 4.9 if there was ever a migration done. The only thing that they can do with them (unless the filter is in place) is press the button and delete them forever.

### How things will look

#### Before using the filter for force-enabling the old widget type

WordPress says that there are inactive widgets but is unable to show them because it doesn't know about its type.

![image](https://user-images.githubusercontent.com/746152/32511449-8c70c0c2-c3d2-11e7-865a-e167dfca9f97.png)

#### After using the filter for force-enabling the old widget type

![image](https://user-images.githubusercontent.com/746152/32511078-743dd46e-c3d1-11e7-8e58-9a9388e34ebd.png)


#### Testing instructions:

* Create a Jetpack Gallery Widget while on WordPress 4.8.3
* Checkout this branch (or try with Jetpack Beta)
* Upgrade to WordPress 4.9
* Expect to see your widget sucessfully migrated
* Expect to see that there are inactive widgets but that you cannot see the widget itself .
* Apply the `jetpack_force_enable_gallery_widget` with `__return_true`.
* Expect to see the old Gallery widget listed as an inactive widget

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
