### PR TITLE
Bug: Fix undefined `mb_convert_encoding` error

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -122,7 +122,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 
 	public function set_plugin_action_links() {
-		if ( ! class_exists( 'DOMDocument' ) ) {
+		if (
+			! class_exists( 'DOMDocument' ) ||
+			! function_exists ( 'libxml_use_internal_errors' ) ||
+			! function_exists ( 'mb_convert_encoding' )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Jetpack Fatals on servers without `mbstring`

big props for @zinigor for catching this 👍 

