### PR TITLE
Use platform.js for Google+ sharing functionality

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1175,7 +1175,7 @@ class Share_GooglePlus1 extends Sharing_Source {
 
 			(function() {
 				var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-				po.src = 'https://apis.google.com/js/plusone.min.js';
+				po.src = 'https://apis.google.com/js/platform.js';
 				po.innerHTML = '{"parsetags": "explicit"}';
 				po.onload = renderGooglePlus1;
 				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);

--- a/modules/shortcodes/googleplus.php
+++ b/modules/shortcodes/googleplus.php
@@ -11,7 +11,7 @@ define( 'JETPACK_GOOGLEPLUS_EMBED_REGEX', '#^https?://plus\.(sandbox\.)?google\.
 wp_embed_register_handler( 'googleplus', JETPACK_GOOGLEPLUS_EMBED_REGEX, 'jetpack_googleplus_embed_handler' );
 
 function jetpack_googleplus_embed_handler( $matches, $attr, $url ) {
-	wp_enqueue_script( 'jetpack-gplus-api', 'https://apis.google.com/js/plusone.min.js', array(), null, true );
+	wp_enqueue_script( 'jetpack-gplus-api', 'https://apis.google.com/js/platform.js', array(), null, true );
 	return sprintf( '<div class="g-post" data-href="%s"></div>', esc_url( $url ) );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

plusone.min.js and platform.min.js are currently broken, gapi.plusone is undefined. The documentation at https://developers.google.com/+/web/+1button/ uses platform.js, which is working fine.