### PR TITLE
Sync: Better Post type syncing

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -195,6 +195,39 @@ class Jetpack_Sync_Defaults {
 		'roles'                            =>  array( 'Jetpack_Sync_Functions', 'roles' ),
 	);
 
+
+	static $default_post_type_attributes = array(
+		'name'				  => '',
+		'label'               => '',
+		'labels'              => array(),
+		'description'         => '',
+		'public'              => false,
+		'hierarchical'        => false,
+		'exclude_from_search' => true,
+		'publicly_queryable'  => null,
+		'show_ui'             => false,
+		'show_in_menu'        => null,
+		'show_in_nav_menus'   => null,
+		'show_in_admin_bar'   => false,
+		'menu_position'       => null,
+		'menu_icon'           => null,
+		'supports'			  => array(),
+		'capability_type'     => 'post',
+		'capabilities'        => array(),
+		'cap'				  => array(),
+		'map_meta_cap'        => true,
+		'taxonomies'          => array(),
+		'has_archive'         => false,
+		'rewrite'             => true,
+		'query_var'           => true,
+		'can_export'          => true,
+		'delete_with_user'    => null,
+		'show_in_rest'        => false,
+		'rest_base'           => false,
+		'_builtin'            => false,
+		'_edit_link'          => 'post.php?post=%d',
+	);
+
 	public static function get_callable_whitelist() {
 		/**
 		 * Filter the list of callables that are manageable via the JSON API.

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -197,7 +197,7 @@ class Jetpack_Sync_Defaults {
 
 
 	static $default_post_type_attributes = array(
-		'name'				  => '',
+		'name'                => '',
 		'label'               => '',
 		'labels'              => array(),
 		'description'         => '',
@@ -211,10 +211,10 @@ class Jetpack_Sync_Defaults {
 		'show_in_admin_bar'   => false,
 		'menu_position'       => null,
 		'menu_icon'           => null,
-		'supports'			  => array(),
+		'supports'            => array(),
 		'capability_type'     => 'post',
 		'capabilities'        => array(),
-		'cap'				  => array(),
+		'cap'                 => array(),
 		'map_meta_cap'        => true,
 		'taxonomies'          => array(),
 		'has_archive'         => false,

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -80,14 +80,13 @@ class Jetpack_Sync_Functions {
 
 	public static function sanitize_post_type( $post_type ) {
 		// Lets clone the post type object instead of modifing the global one.
-		$cloned_post_type = json_decode( wp_json_encode( $post_type ) );
-		$cleaned_cloned_post_type = array();
+		$sanitized_post_type = array();
 		foreach ( Jetpack_Sync_Defaults::$default_post_type_attributes as $attribute_key => $default_value ) {
-			if ( isset( $cloned_post_type->{ $attribute_key } ) ) {
-				$cleaned_cloned_post_type[ $attribute_key ] = $cloned_post_type->{ $attribute_key };
+			if ( isset( $post_type->{ $attribute_key } ) ) {
+				$sanitized_post_type[ $attribute_key ] = $post_type->{ $attribute_key };
 			}
 		}
-		return (object) $cleaned_cloned_post_type;
+		return (object) $sanitized_post_type;
 	}
 
 	public static function expand_synced_post_type( $sanitized_post_type, $post_type ) {

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -68,6 +68,8 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		wp_insert_post( $this->post->to_array() );
 
 		$this->assertPublicized( false, $this->post );
+
+		unregister_post_type( 'foo' );
 	}
 
 	function assertPublicized( $should_have_publicized, $post ) {
@@ -127,6 +129,8 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$this->assertTrue(
 			$publicize->post_type_is_publicizeable( 'pub-post-type-2' )
 		);
+
+		unregister_post_type( 'pub-post-type-2' );
 	}
 
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -621,7 +621,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_register_post_types_callback_error() {
-		register_post_type( 'testing', [ 'register_meta_box_cb' => function() {} ] );
+		if ( version_compare(PHP_VERSION, '5.4', '<' ) ) {
+			$this->markTestSkipped( 'Callbacks are only available in PHP 5.4 and greater' );
+		}
+		register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
 		$this->sender->do_sync();
 
 		$post_types =  $this->server_replica_storage->get_callable( 'post_types' );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -616,7 +616,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				$post_type_object->supports = array();
 			}
 			$synced_post_type = Jetpack_Sync_Functions::expand_synced_post_type( $synced[ $post_type ], $post_type );
-			$this->assertEqualsObject( $post_type_object, $synced_post_type );
+			$this->assertEqualsObject( $post_type_object, $synced_post_type, 'POST TYPE :'. $post_type . ' not equal' );
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -534,13 +534,12 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $label, $sanitized->name );
 		$this->assertEquals( 'Posts', $sanitized->label );
 		$this->assertEquals( '', $sanitized->description );
-		$this->assertEquals( $label, $sanitized->rewrite->slug );
+		$this->assertEquals( $label, $sanitized->rewrite['slug'] );
 		$this->assertEquals( $label, $sanitized->query_var );
 		$this->assertEquals( 'post', $sanitized->capability_type );
 		$this->assertEquals( array(), $sanitized->taxonomies );
 		$this->assertEquals( array(), $sanitized->supports );
 		$this->assertEquals( '', $sanitized->_edit_link );
-
 
 		$this->assertFalse( $sanitized->public );
 		$this->assertFalse( $sanitized->has_archive );
@@ -557,7 +556,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $sanitized->can_export );
 		$this->assertTrue( $sanitized->map_meta_cap );
 		$this->assertTrue( is_object( $sanitized->labels ) );
-		$this->assertTrue( is_object( $sanitized->rewrite ) );
+		$this->assertTrue( is_array( $sanitized->rewrite ) );
 		$this->assertTrue( is_object( $sanitized->cap ) );
 
 	}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -512,6 +512,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$post_type_object->register_taxonomies();
 
 		$sanitized = Jetpack_Sync_Functions::sanitize_post_type( $post_type_object );
+		var_dump( $sanitized );
 		$this->assert_sanitized_post_type_default( $sanitized, $label );
 
 	}


### PR DESCRIPTION
- Add a whitelist to what we sync.
- Add a way to convert the synced data back to what we expect
- Add tests to show that things work as expected.

Fixes p4IuY0-TS-p2
#### Changes proposed in this Pull Request:
* Only sync sanitized post type data.

#### Testing instructions:
* Do the tests pass? 
* Do we get expected values on the .com side? 
* Do subscription emails, publicize and other things work as expected?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
