### PR TITLE
Related Posts: Define array before foreach loop

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -772,9 +772,9 @@ EOT;
 		 */
 		$args['exclude_post_ids'] = apply_filters( 'jetpack_relatedposts_filter_exclude_post_ids', $args['exclude_post_ids'], $post_id );
 		if ( !empty( $args['exclude_post_ids'] ) && is_array( $args['exclude_post_ids'] ) ) {
+			$excluded_post_ids = array();
 			foreach ( $args['exclude_post_ids'] as $exclude_post_id) {
 				$exclude_post_id = (int)$exclude_post_id;
-				$excluded_post_ids = array();
 				if ( $exclude_post_id > 0 )
 					$excluded_post_ids[] = $exclude_post_id;
 			}


### PR DESCRIPTION
fix #8030

The excluded_post_ids array is getting reset each time in the foreach loop, so it is good to define excluded_post_ids  array before foreach loop then we overcome the issue.

Thanks