### PR TITLE
Sharing: remove inline JS used in the hidden email sharing form.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -516,7 +516,6 @@ class Share_Email extends Sharing_Source {
 
 			<?php endif; ?>
 			<input type="text" id="jetpack-source_f_name" name="source_f_name" class="input" value="" size="25" autocomplete="off" title="<?php esc_attr_e( 'This field is for validation and should not be changed', 'jetpack' ); ?>" />
-			<script>jQuery( document ).ready( function(){ document.getElementById('jetpack-source_f_name').value = '' });</script>
 			<?php
 				/**
 				 * Fires when the Email sharing dialog is loaded.


### PR DESCRIPTION
This JS was previously removed in #6339, but then added back (I think during a rebase) in #6332.

#### Proposed changelog entry for your changes:
* Sharing: remove inline JavaScript used in the email sharing form.

Related: 774824-zen