### PR TITLE
Admin Page: Apply codemod for prop-types

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
@@ -131,8 +132,8 @@ class DashAkismet extends Component {
 }
 
 DashAkismet.propTypes = {
-	siteRawUrl: React.PropTypes.string.isRequired,
-	siteAdminUrl: React.PropTypes.string.isRequired
+	siteRawUrl: PropTypes.string.isRequired,
+	siteAdminUrl: PropTypes.string.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
@@ -104,10 +105,10 @@ class DashBackups extends Component {
 }
 
 DashBackups.propTypes = {
-	vaultPressData: React.PropTypes.any.isRequired,
-	isDevMode: React.PropTypes.bool.isRequired,
-	siteRawUrl: React.PropTypes.string.isRequired,
-	sitePlan: React.PropTypes.object.isRequired
+	vaultPressData: PropTypes.any.isRequired,
+	isDevMode: PropTypes.bool.isRequired,
+	siteRawUrl: PropTypes.string.isRequired,
+	sitePlan: PropTypes.object.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -194,15 +195,15 @@ export class DashConnections extends Component {
 }
 
 DashConnections.propTypes = {
-	siteConnectionStatus: React.PropTypes.any.isRequired,
-	isDevMode: React.PropTypes.bool.isRequired,
-	userCanDisconnectSite: React.PropTypes.bool.isRequired,
-	userIsMaster: React.PropTypes.bool.isRequired,
-	isLinked: React.PropTypes.bool.isRequired,
-	userWpComLogin: React.PropTypes.any.isRequired,
-	userWpComEmail: React.PropTypes.any.isRequired,
-	userWpComAvatar: React.PropTypes.any.isRequired,
-	username: React.PropTypes.any.isRequired
+	siteConnectionStatus: PropTypes.any.isRequired,
+	isDevMode: PropTypes.bool.isRequired,
+	userCanDisconnectSite: PropTypes.bool.isRequired,
+	userIsMaster: PropTypes.bool.isRequired,
+	isLinked: PropTypes.bool.isRequired,
+	userWpComLogin: PropTypes.any.isRequired,
+	userWpComEmail: PropTypes.any.isRequired,
+	userWpComAvatar: PropTypes.any.isRequired,
+	username: PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -77,7 +78,7 @@ class DashMonitor extends Component {
 }
 
 DashMonitor.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired
+	isDevMode: PropTypes.bool.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
@@ -64,7 +65,7 @@ class DashPhoton extends Component {
 }
 
 DashPhoton.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired
+	isDevMode: PropTypes.bool.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
@@ -105,10 +106,10 @@ class DashPluginUpdates extends Component {
 }
 
 DashPluginUpdates.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired,
-	siteRawUrl: React.PropTypes.string.isRequired,
-	siteAdminUrl: React.PropTypes.string.isRequired,
-	pluginUpdates: React.PropTypes.any.isRequired
+	isDevMode: PropTypes.bool.isRequired,
+	siteRawUrl: PropTypes.string.isRequired,
+	siteAdminUrl: PropTypes.string.isRequired,
+	pluginUpdates: PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
@@ -84,8 +85,8 @@ class DashProtect extends Component {
 }
 
 DashProtect.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired,
-	protectCount: React.PropTypes.any.isRequired
+	isDevMode: PropTypes.bool.isRequired,
+	protectCount: PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
@@ -143,11 +144,11 @@ class DashScan extends Component {
 }
 
 DashScan.propTypes = {
-	vaultPressData: React.PropTypes.any.isRequired,
-	scanThreats: React.PropTypes.any.isRequired,
-	isDevMode: React.PropTypes.bool.isRequired,
-	siteRawUrl: React.PropTypes.string.isRequired,
-	sitePlan: React.PropTypes.object.isRequired
+	vaultPressData: PropTypes.any.isRequired,
+	scanThreats: PropTypes.any.isRequired,
+	isDevMode: PropTypes.bool.isRequired,
+	siteRawUrl: PropTypes.string.isRequired,
+	sitePlan: PropTypes.object.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
@@ -141,10 +142,10 @@ class DashStatsBottom extends Component {
 }
 
 DashStatsBottom.propTypes = {
-	siteRawUrl: React.PropTypes.string.isRequired,
-	siteAdminUrl: React.PropTypes.string.isRequired,
-	statsData: React.PropTypes.object.isRequired,
-	isLinked: React.PropTypes.bool.isRequired
+	siteRawUrl: PropTypes.string.isRequired,
+	siteAdminUrl: PropTypes.string.isRequired,
+	statsData: PropTypes.object.isRequired,
+	isLinked: PropTypes.bool.isRequired
 };
 
 DashStatsBottom.defaultProps = {

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import forEach from 'lodash/forEach';
 import get from 'lodash/get';
@@ -288,10 +289,10 @@ class DashStats extends Component {
 }
 
 DashStats.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired,
-	siteRawUrl: React.PropTypes.string.isRequired,
-	siteAdminUrl: React.PropTypes.string.isRequired,
-	statsData: React.PropTypes.any.isRequired
+	isDevMode: PropTypes.bool.isRequired,
+	siteRawUrl: PropTypes.string.isRequired,
+	siteAdminUrl: PropTypes.string.isRequired,
+	statsData: PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -85,7 +86,7 @@ const AppsCard = React.createClass( {
 } );
 
 AppsCard.propTypes = {
-	className: React.PropTypes.string
+	className: PropTypes.string
 };
 
 export default connect(

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -28,9 +29,9 @@ export const ConnectButton = React.createClass( {
 	displayName: 'ConnectButton',
 
 	propTypes: {
-		connectUser: React.PropTypes.bool,
-		from: React.PropTypes.string,
-		asLink: React.PropTypes.bool
+		connectUser: PropTypes.bool,
+		from: PropTypes.string,
+		asLink: PropTypes.bool
 	},
 
 	getDefaultProps() {

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -134,13 +135,13 @@ export class DashItem extends Component {
 }
 
 DashItem.propTypes = {
-	label: React.PropTypes.string,
-	status: React.PropTypes.string,
-	statusText: React.PropTypes.string,
-	disabled: React.PropTypes.bool,
-	module: React.PropTypes.string,
-	pro: React.PropTypes.bool,
-	isModule: React.PropTypes.bool,
+	label: PropTypes.string,
+	status: PropTypes.string,
+	statusText: PropTypes.string,
+	disabled: PropTypes.bool,
+	module: PropTypes.string,
+	pro: PropTypes.bool,
+	isModule: PropTypes.bool,
 };
 
 DashItem.defaultProps = {

--- a/_inc/client/components/dash-section-header/index.jsx
+++ b/_inc/client/components/dash-section-header/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -11,11 +12,11 @@ export const DashSectionHeader = React.createClass( {
 	displayName: 'DashSectionHeader',
 
 	propTypes: {
-		label: React.PropTypes.string.isRequired,
-		settingsPath: React.PropTypes.string,
-		externalLinkPath: React.PropTypes.string,
-		externalLink: React.PropTypes.string,
-		externalLinkClick: React.PropTypes.func
+		label: PropTypes.string.isRequired,
+		settingsPath: PropTypes.string,
+		externalLinkPath: PropTypes.string,
+		externalLink: PropTypes.string,
+		externalLinkClick: PropTypes.func
 	},
 
 	getDefaultProps() {

--- a/_inc/client/components/data/query-site/index.jsx
+++ b/_inc/client/components/data/query-site/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 

--- a/_inc/client/components/inline-expand/index.jsx
+++ b/_inc/client/components/inline-expand/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
@@ -13,14 +14,14 @@ import onKeyDownCallback from 'utils/onkeydown-callback';
 export const InlineExpand = React.createClass( {
 
 	propTypes: {
-		label: React.PropTypes.string.isRequired,
-		icon: React.PropTypes.string,
-		cardKey: React.PropTypes.string,
-		disabled: React.PropTypes.bool,
-		expanded: React.PropTypes.bool,
-		onClick: React.PropTypes.func,
-		onClose: React.PropTypes.func,
-		onOpen: React.PropTypes.func
+		label: PropTypes.string.isRequired,
+		icon: PropTypes.string,
+		cardKey: PropTypes.string,
+		disabled: PropTypes.bool,
+		expanded: PropTypes.bool,
+		onClick: PropTypes.func,
+		onClose: PropTypes.func,
+		onOpen: PropTypes.func
 	},
 
 	getInitialState: function() {

--- a/_inc/client/components/jetpack-banner/index.jsx
+++ b/_inc/client/components/jetpack-banner/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
@@ -15,18 +16,18 @@ import { userCanManageModules } from 'state/initial-state';
 class JetpackBanner extends Banner {
 
 	static propTypes = {
-		callToAction: React.PropTypes.string,
-		className: React.PropTypes.string,
-		description: React.PropTypes.string,
-		event: React.PropTypes.string,
-		feature: React.PropTypes.string,
-		href: React.PropTypes.string,
-		icon: React.PropTypes.string,
-		list: React.PropTypes.arrayOf( React.PropTypes.string ),
-		onClick: React.PropTypes.func,
-		plan: React.PropTypes.string,
-		siteSlug: React.PropTypes.string,
-		title: React.PropTypes.string.isRequired
+		callToAction: PropTypes.string,
+		className: PropTypes.string,
+		description: PropTypes.string,
+		event: PropTypes.string,
+		feature: PropTypes.string,
+		href: PropTypes.string,
+		icon: PropTypes.string,
+		list: PropTypes.arrayOf( PropTypes.string ),
+		onClick: PropTypes.func,
+		plan: PropTypes.string,
+		siteSlug: PropTypes.string,
+		title: PropTypes.string.isRequired
 	};
 
 	static defaultProps = {

--- a/_inc/client/components/jetpack-dialogue/index.jsx
+++ b/_inc/client/components/jetpack-dialogue/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
@@ -55,21 +56,21 @@ class JetpackDialogue extends Component {
 }
 
 JetpackDialogue.propTypes = {
-	content: React.PropTypes.oneOfType( [
-		React.PropTypes.string,
-		React.PropTypes.object,
+	content: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.object,
 	] ).isRequired,
-	belowContent: React.PropTypes.oneOfType( [
-		React.PropTypes.string,
-		React.PropTypes.object,
+	belowContent: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.object,
 	] ).isRequired,
-	svg: React.PropTypes.oneOfType( [
-		React.PropTypes.bool,
-		React.PropTypes.object,
+	svg: PropTypes.oneOfType( [
+		PropTypes.bool,
+		PropTypes.object,
 	] ),
-	dismissOnClick: React.PropTypes.func,
-	showDismiss: React.PropTypes.bool,
-	title: React.PropTypes.string
+	dismissOnClick: PropTypes.func,
+	showDismiss: PropTypes.bool,
+	title: PropTypes.string
 };
 
 JetpackDialogue.defaultProps = {

--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -24,9 +25,9 @@ import { getSiteRawUrl } from 'state/initial-state';
 
 export const JetpackDisconnectDialog = React.createClass( {
 	propTypes: {
-		show: React.PropTypes.bool,
-		toggleModal: React.PropTypes.func,
-		disconnectSite: React.PropTypes.func
+		show: PropTypes.bool,
+		toggleModal: PropTypes.func,
+		disconnectSite: PropTypes.func
 	},
 
 	getDefaultProps() {

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import SimpleNotice from 'components/notice';
@@ -44,8 +45,8 @@ export const DevVersionNotice = React.createClass( {
 } );
 
 DevVersionNotice.propTypes = {
-	isDevVersion: React.PropTypes.bool.isRequired,
-	userIsSubscriber: React.PropTypes.bool.isRequired
+	isDevVersion: PropTypes.bool.isRequired,
+	userIsSubscriber: PropTypes.bool.isRequired
 };
 
 export const StagingSiteNotice = React.createClass( {
@@ -77,8 +78,8 @@ export const StagingSiteNotice = React.createClass( {
 } );
 
 StagingSiteNotice.propTypes = {
-	isStaging: React.PropTypes.bool.isRequired,
-	isInIdentityCrisis: React.PropTypes.bool.isRequired
+	isStaging: PropTypes.bool.isRequired,
+	isInIdentityCrisis: PropTypes.bool.isRequired
 };
 
 export const DevModeNotice = React.createClass( {
@@ -144,13 +145,13 @@ export const DevModeNotice = React.createClass( {
 } );
 
 DevModeNotice.propTypes = {
-	siteConnectionStatus: React.PropTypes.oneOfType( [
-		React.PropTypes.string,
-		React.PropTypes.bool
+	siteConnectionStatus: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.bool
 	] ).isRequired,
-	siteDevMode: React.PropTypes.oneOfType( [
-		React.PropTypes.bool,
-		React.PropTypes.object
+	siteDevMode: PropTypes.oneOfType( [
+		PropTypes.bool,
+		PropTypes.object
 	] ).isRequired
 };
 
@@ -181,8 +182,8 @@ export const UserUnlinked = React.createClass( {
 } );
 
 UserUnlinked.propTypes = {
-	connectUrl: React.PropTypes.string.isRequired,
-	siteConnected: React.PropTypes.bool.isRequired
+	connectUrl: PropTypes.string.isRequired,
+	siteConnected: PropTypes.bool.isRequired
 };
 
 const JetpackNotices = React.createClass( {

--- a/_inc/client/components/module-toggle/index.jsx
+++ b/_inc/client/components/module-toggle/index.jsx
@@ -2,18 +2,19 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 import analytics from 'lib/analytics';
 
 export const ModuleToggle = React.createClass( {
 	propTypes: {
-		toggleModule: React.PropTypes.func,
-		activated: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		className: React.PropTypes.string,
-		compact: React.PropTypes.bool,
-		id: React.PropTypes.string
+		toggleModule: PropTypes.func,
+		activated: PropTypes.bool,
+		disabled: PropTypes.bool,
+		className: PropTypes.string,
+		compact: PropTypes.bool,
+		id: PropTypes.string
 	},
 
 	getDefaultProps: function() {

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import SectionNav from 'components/section-nav';
@@ -247,17 +248,17 @@ export const NavigationSettings = React.createClass( {
 } );
 
 NavigationSettings.contextTypes = {
-	router: React.PropTypes.object.isRequired
+	router: PropTypes.object.isRequired
 };
 
 NavigationSettings.propTypes = {
-	userCanManageModules: React.PropTypes.bool.isRequired,
-	isSubscriber: React.PropTypes.bool.isRequired,
-	userCanPublish: React.PropTypes.bool.isRequired,
-	isLinked: React.PropTypes.bool.isRequired,
-	isSiteConnected: React.PropTypes.bool.isRequired,
-	isModuleActivated: React.PropTypes.func.isRequired,
-	searchHasFocus: React.PropTypes.bool.isRequired
+	userCanManageModules: PropTypes.bool.isRequired,
+	isSubscriber: PropTypes.bool.isRequired,
+	userCanPublish: PropTypes.bool.isRequired,
+	isLinked: PropTypes.bool.isRequired,
+	isSiteConnected: PropTypes.bool.isRequired,
+	isModuleActivated: PropTypes.func.isRequired,
+	searchHasFocus: PropTypes.bool.isRequired
 };
 
 NavigationSettings.defaultProps = {

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import SectionNav from 'components/section-nav';
@@ -65,7 +66,7 @@ export const Navigation = React.createClass( {
 } );
 
 Navigation.propTypes = {
-	route: React.PropTypes.object.isRequired
+	route: PropTypes.object.isRequired
 };
 
 export default connect(

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -65,9 +66,9 @@ const NonAdminView = React.createClass( {
 } );
 
 NonAdminView.propTypes = {
-	userCanViewStats: React.PropTypes.bool.isRequired,
-	isSubscriber: React.PropTypes.bool.isRequired,
-	siteConnectionStatus: React.PropTypes.any.isRequired
+	userCanViewStats: PropTypes.bool.isRequired,
+	isSubscriber: PropTypes.bool.isRequired,
+	siteConnectionStatus: PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/components/setting-toggle/index.jsx
+++ b/_inc/client/components/setting-toggle/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -10,11 +11,11 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 
 export const SettingToggle = React.createClass( {
 	propTypes: {
-		toggleSetting: React.PropTypes.func,
-		activated: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		className: React.PropTypes.string,
-		id: React.PropTypes.string
+		toggleSetting: PropTypes.func,
+		activated: PropTypes.bool,
+		disabled: PropTypes.bool,
+		className: PropTypes.string,
+		id: PropTypes.string
 	},
 	getDefaultProps: function() {
 		return {

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -277,8 +278,8 @@ export const SettingsCard = props => {
 };
 
 SettingsCard.propTypes = {
-	action: React.PropTypes.string,
-	saveDisabled: React.PropTypes.bool
+	action: PropTypes.string,
+	saveDisabled: PropTypes.bool
 };
 
 SettingsCard.defaultProps = {

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -89,14 +90,14 @@ export const SettingsGroup = props => {
 };
 
 SettingsGroup.propTypes = {
-	support: React.PropTypes.string,
-	module: React.PropTypes.object,
-	disableInDevMode: React.PropTypes.bool.isRequired,
-	isDevMode: React.PropTypes.bool.isRequired,
-	isSitePublic: React.PropTypes.bool.isRequired,
-	userCanManageModules: React.PropTypes.bool.isRequired,
-	isLinked: React.PropTypes.bool.isRequired,
-	isUnavailableInDevMode: React.PropTypes.func.isRequired
+	support: PropTypes.string,
+	module: PropTypes.object,
+	disableInDevMode: PropTypes.bool.isRequired,
+	isDevMode: PropTypes.bool.isRequired,
+	isSitePublic: PropTypes.bool.isRequired,
+	userCanManageModules: PropTypes.bool.isRequired,
+	isLinked: PropTypes.bool.isRequired,
+	isUnavailableInDevMode: PropTypes.func.isRequired
 };
 
 SettingsGroup.defaultProps = {

--- a/_inc/client/components/settings/index.jsx
+++ b/_inc/client/components/settings/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -18,10 +19,10 @@ import { SettingToggle } from 'components/setting-toggle';
 
 export const Settings = React.createClass( {
 	propTypes: {
-		slug: React.PropTypes.string,
-		activated: React.PropTypes.bool,
-		toggleSetting: React.PropTypes.func,
-		disabled: React.PropTypes.bool
+		slug: PropTypes.string,
+		activated: PropTypes.bool,
+		toggleSetting: PropTypes.func,
+		disabled: PropTypes.bool
 	},
 
 	componentDidMount() {

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -129,8 +130,8 @@ const SupportCard = React.createClass( {
 } );
 
 SupportCard.propTypes = {
-	siteConnectionStatus: React.PropTypes.any.isRequired,
-	className: React.PropTypes.string
+	siteConnectionStatus: PropTypes.any.isRequired,
+	className: PropTypes.string
 };
 
 export default connect(

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { translate as __ } from 'i18n-calypso';
@@ -99,8 +100,8 @@ const ThemesPromoCard = React.createClass( {
 } );
 
 ThemesPromoCard.propTypes = {
-	className: React.PropTypes.string,
-	plan: React.PropTypes.string
+	className: PropTypes.string,
+	plan: PropTypes.string
 };
 
 export default ThemesPromoCard;

--- a/_inc/client/components/tracker/index.jsx
+++ b/_inc/client/components/tracker/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/_inc/client/components/tracker/index.jsx
+++ b/_inc/client/components/tracker/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -24,8 +25,8 @@ export class Tracker extends Component {
 }
 
 Tracker.propTypes = {
-	analytics: React.PropTypes.object,
-	searchTerm: React.PropTypes.string
+	analytics: PropTypes.object,
+	searchTerm: PropTypes.string
 };
 
 export default connect(

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
@@ -66,7 +67,7 @@ class UpgradeNoticeContent extends Component {
 }
 
 JetpackDialogue.propTypes = {
-	dismiss: React.PropTypes.func
+	dismiss: PropTypes.func
 };
 
 export default UpgradeNoticeContent;

--- a/_inc/client/components/welcome-new-plan/index.jsx
+++ b/_inc/client/components/welcome-new-plan/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Component } from 'react';
@@ -63,9 +64,9 @@ class WelcomeNewPlan extends Component {
 }
 
 WelcomeNewPlan.propTypes = {
-	dismiss: React.PropTypes.func,
-	newPlanActivated: React.PropTypes.bool,
-	userCanManageModules: React.PropTypes.bool,
+	dismiss: PropTypes.func,
+	newPlanActivated: PropTypes.bool,
+	userCanManageModules: PropTypes.bool,
 };
 
 WelcomeNewPlan.defaultProps = {

--- a/_inc/client/components/welcome-new-plan/personal.jsx
+++ b/_inc/client/components/welcome-new-plan/personal.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
@@ -75,7 +76,7 @@ class WelcomePersonal extends Component {
 }
 
 WelcomePersonal.propTypes = {
-	dismiss: React.PropTypes.func
+	dismiss: PropTypes.func
 };
 
 export default WelcomePersonal;

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
@@ -110,7 +111,7 @@ class WelcomePremium extends Component {
 }
 
 WelcomePremium.propTypes = {
-	dismiss: React.PropTypes.func
+	dismiss: PropTypes.func
 };
 
 export default WelcomePremium;

--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
@@ -120,7 +121,7 @@ class WelcomeProfessional extends Component {
 }
 
 WelcomeProfessional.propTypes = {
-	dismiss: React.PropTypes.func
+	dismiss: PropTypes.func
 };
 
 export default WelcomeProfessional;

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -30,7 +31,7 @@ import QuerySitePlugins from 'components/data/query-site-plugins';
 
 const PlanBody = React.createClass( {
 	propTypes: {
-		plan: React.PropTypes.string
+		plan: PropTypes.string
 	},
 
 	getDefaultProps: function() {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -40,8 +41,8 @@ import {
 
 const ProStatus = React.createClass( {
 	propTypes: {
-		isCompact: React.PropTypes.bool,
-		proFeature: React.PropTypes.string
+		isCompact: PropTypes.bool,
+		proFeature: PropTypes.string
 	},
 
 	getDefaultProps: function() {

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -88,7 +89,7 @@ export const SearchableModules = moduleSettingsForm(
 );
 
 SearchableModules.propTypes = {
-	searchTerm: React.PropTypes.string
+	searchTerm: PropTypes.string
 };
 
 SearchableModules.defaultProps = {


### PR DESCRIPTION
Part of #8159 .

Fixes warnings in console and while building.

#### Changes proposed in this Pull Request:

* Changes every occurrence of imports of `PropTypes` coming from React, to come from the module `prop-types`.
* Adds `prop-types` package as dependency.


#### Testing instructions:

* Build the Admin Page.
* Confirm it builds well.
* Visit the admin page. Confirm it's there.

