### PR TITLE
WordPress.com Toolbar: prevent dns prefetching for logged out users

### DIFF
--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -13,13 +13,4 @@
 
 include dirname( __FILE__ ) . '/masterbar/masterbar.php';
 
-Jetpack::dns_prefetch( array(
-	'//s0.wp.com',
-	'//s1.wp.com',
-	'//s2.wp.com',
-	'//0.gravatar.com',
-	'//1.gravatar.com',
-	'//2.gravatar.com',
-) );
-
 new A8C_WPCOM_Masterbar;

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -31,6 +31,15 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
+		Jetpack::dns_prefetch( array(
+			'//s0.wp.com',
+			'//s1.wp.com',
+			'//s2.wp.com',
+			'//0.gravatar.com',
+			'//1.gravatar.com',
+			'//2.gravatar.com',
+		) );
+
 		// Atomic only - override user setting that hides masterbar from site's front.
 		// https://github.com/Automattic/jetpack/issues/7667
 		if ( jetpack_is_atomic_site() ) {


### PR DESCRIPTION
Do not perform dns prefetching for logged out users since they won't be able to see the masterbar anyway.

We are relying on the fact that the masterbar is an extension of the default admin bar, which is only loading for logged in users. Further more, the `dns_prefetch` call is placed after the bail that checks if current user is WP.com connected one, so this will be executed only for users that will actually see the masterbar.

Fixes #8089

#### Testing instructions:

1. Use a test Jetpack site with WordPress.com Toolbar module activated.
2. When viewing the homepage while logged in you should be able to see the following lines in HTML source:

```
<link rel='dns-prefetch' href='//s0.wp.com'/>
<link rel='dns-prefetch' href='//s1.wp.com'/>
<link rel='dns-prefetch' href='//s2.wp.com'/>
<link rel='dns-prefetch' href='//0.gravatar.com'/> 
<link rel='dns-prefetch' href='//1.gravatar.com'/>
<link rel='dns-prefetch' href='//2.gravatar.com'/>
```

3. Verify that the lines above are not present when viewing the page logged out.

*Note*: some other active modules may also prefetch these URLs. 