### PR TITLE
Sharing: Fix email sharing submit validation error.

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -380,6 +380,8 @@ var updateLinkedInCount = function( data ) {
 					// Submit validation
 					$( '#sharing_email input[type=submit]' ).unbind( 'click' ).click( function() {
 						var form = $( this ).parents( 'form' );
+						var source_email_input = form.find( 'input[name=source_email]' );
+						var target_email_input = form.find( 'input[name=target_email]' );
 
 						// Disable buttons + enable loading icon
 						$( this ).prop( 'disabled', true );
@@ -389,12 +391,12 @@ var updateLinkedInCount = function( data ) {
 						$( '#sharing_email .errors' ).hide();
 						$( '#sharing_email .error' ).removeClass( 'error' );
 
-						if ( ! $( '#sharing_email input[name=source_email]' ).share_is_email() ) {
-							$( '#sharing_email input[name=source_email]' ).addClass( 'error' );
+						if ( ! source_email_input.share_is_email() ) {
+							source_email_input.addClass( 'error' );
 						}
 
-						if ( ! $( '#sharing_email input[name=target_email]' ).share_is_email() ) {
-							$( '#sharing_email input[name=target_email]' ).addClass( 'error' );
+						if ( ! target_email_input.share_is_email() ) {
+							target_email_input.addClass( 'error' );
 						}
 
 						if ( $( '#sharing_email .error' ).length === 0 ) {


### PR DESCRIPTION
Fix email sharing submit validation error when two instance of the widget are present in the same post.

Fixes #8154

There was a problem with jQuery selectors for source and target email inputs when the email sharing button is rendered more than one time in the same page.
The .val() method was always returning empty, causing an unexpected validation error.

The approach to fix the problem here is to use a selector relative to the current form element.

