### PR TITLE
Check file_exists after call filemtime()

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6539,7 +6539,13 @@ p {
 
 		add_filter( 'style_loader_tag', array( $this, 'concat_remove_style_loader_tag' ), 10, 2 );
 
-		$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' ) : JETPACK__VERSION;
+		if( file_exists( JETPACK__PLUGIN_DIR . 'css/jetpack.css' )) {
+			$filemtime = filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' );
+		} else {
+			$filemtime = '';
+		}
+
+		$version = Jetpack::is_development_version() ? $filemtime : JETPACK__VERSION;
 
 		wp_enqueue_style( 'jetpack_css', plugins_url( 'css/jetpack.css', __FILE__ ), array(), $version );
 		wp_style_add_data( 'jetpack_css', 'rtl', 'replace' );


### PR DESCRIPTION
Need Testing.
fix issue #8162
Check path exists ( filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' ) ) after call  filemtime() to overcome the problem.