### PR TITLE
Add flag to allow access to an endpoint if the site is deleted

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -77,6 +77,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 	// Is this endpoint allowed if the site is red flagged?
 	public $allowed_if_red_flagged = false;
 
+	// Is this endpoint allowed if the site is deleted?
+	public $allowed_if_deleted = false;
+
 	/**
 	 * @var string Version of the API
 	 */
@@ -127,6 +130,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'in_testing'           => false,
 			'allowed_if_flagged'   => false,
 			'allowed_if_red_flagged' => false,
+			'allowed_if_deleted'	=> false,
 			'description'          => '',
 			'group'	               => '',
 			'method'               => 'GET',
@@ -160,6 +164,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		$this->allowed_if_flagged = $args['allowed_if_flagged'];
 		$this->allowed_if_red_flagged = $args['allowed_if_red_flagged'];
+		$this->allowed_if_deleted = $args['allowed_if_deleted'];
 
 		$this->description = $args['description'];
 		$this->group       = $args['group'];


### PR DESCRIPTION
In r165506-wpcom I added a new flag to `class.json-api-endpoints.php` to allow access to selected endpoints (specifically `/read/site/:site`) if the site has been deleted.

In Reader, we use that functionality to return a `410 Gone` response when a site has been deleted rather than a 403.

#### Changes proposed in this Pull Request:

Add the `allowed_if_deleted` configuration flag for an API endpoint. This defaults to false.

#### Testing instructions:

Set the flag to `true` in an endpoint definition. For example:

```
new WPCOM_JSON_API_Read_Site_Endpoint( array(
  'description' => 'Get information about a site',
  'allowed_if_flagged' => true,
  'allowed_if_deleted' => true,
 ...
```

Ensure that you can access a deleted site using the endpoint.
