### PR TITLE
Fix queries containing single quotes as apostrophes in words

### DIFF
--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
@@ -392,9 +392,9 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 			$phrase_prefix = $matches[1][0];
 			$this->current_query = preg_replace( '/"([^"]+)$/', '', $this->current_query );
 		}
-		if ( preg_match_all( "/'([^']+)$/", $this->current_query, $matches ) ) {
+		if ( preg_match_all( "/(?:'\B|\B')([^']+)$/", $this->current_query, $matches ) ) {
 			$phrase_prefix = $matches[1][0];
-			$this->current_query = preg_replace( "/'([^']+)$/", '', $this->current_query );
+			$this->current_query = preg_replace( "/(?:'\B|\B')([^']+)$/", '', $this->current_query );
 		}
 
 		if ( $phrase_prefix ) {


### PR DESCRIPTION
Currently the code assumes that one (1) single quote in the query means that the user has forgotten the second one and wanted to quote a string.

For example searching for `can't login` would have the query rewritten to `can "t login"` (because it assumed you wanted to write `can't login'`, thus quoting `t login`) and this doesn't make a lot of sense for English.

By changing the regular expression to look at word boundaries we can make sure that such a single quote is only considered as "missing a partner" if no text is adjacent on both sides. See p1510734114000357-slack-mgs-next

This commit syncs r165510-wpcom.