### PR TITLE
Google Analytics: Add support for universal analytics for eCommerce

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+* Jetpack_Google_Analytics_Legacy hooks and enqueues support for ga.js
+* https://developers.google.com/analytics/devguides/collection/gajs/
+*
+* @author allendav 
+*/
+
+/**
+* Bail if accessed directly
+*/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Jetpack_Google_Analytics_Legacy {
+	public function __construct() {
+		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
+		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
+		add_action( 'wp_footer', array( $this, 'insert_code' ) );
+		add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
+	}
+
+	/**
+	 * Used to generate a tracking URL
+	 * Called exclusively by insert_code
+	 *
+	 * @param array $track - Must have ['data'] and ['code'].
+	 * @return string - Tracking URL
+	 */
+	private function _get_url( $track ) {
+		$site_url = ( is_ssl() ? 'https://':'http://' ) . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ); // Input var okay.
+		foreach ( $track as $k => $value ) {
+			if ( strpos( strtolower( $value ), strtolower( $site_url ) ) === 0 ) {
+				$track[ $k ] = substr( $track[ $k ], strlen( $site_url ) );
+			}
+			if ( 'data' === $k ) {
+				$track[ $k ] = preg_replace( '/^https?:\/\/|^\/+/i', '', $track[ $k ] );
+			}
+
+			// This way we don't lose search data.
+			if ( 'data' === $k && 'search' === $track['code'] ) {
+				$track[ $k ] = rawurlencode( $track[ $k ] );
+			} else {
+				$track[ $k ] = preg_replace( '/[^a-z0-9\.\/\+\?=-]+/i', '_', $track[ $k ] );
+			}
+
+			$track[ $k ] = trim( $track[ $k ], '_' );
+		}
+		$char = ( strpos( $track['data'], '?' ) === false ) ? '?' : '&amp;';
+		return str_replace( "'", "\'", "/{$track['code']}/{$track['data']}{$char}referer=" . rawurlencode( isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' ) ); // Input var okay.
+	}
+
+	/**
+	 * This injects the Google Analytics code into the footer of the page.
+	 * Called exclusively by wp_footer action
+	 */
+	public function insert_code() {
+		$tracking_id = Jetpack_Google_Analytics_Options::get_tracking_code();
+		if ( empty( $tracking_id ) ) {
+			echo "<!-- Your Google Analytics Plugin is missing the tracking ID -->\r\n";
+			return;
+		}
+
+		// If we're in the admin_area, return without inserting code.
+		if ( is_admin() ) {
+			return;
+		}
+
+		$custom_vars = array(
+			"_gaq.push(['_setAccount', '{$tracking_id}']);",
+		);
+
+		$track = array();
+		if ( is_404() ) {
+			// This is a 404 and we are supposed to track them.
+			$custom_vars[] = "_gaq.push(['_trackEvent', '404', document.location.href, document.referrer]);";
+		} elseif ( is_search() ) {
+			// Set track for searches, if it's a search, and we are supposed to.
+			$track['data'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ); // Input var okay.
+			$track['code'] = 'search';
+		}
+
+		if ( ! empty( $track ) ) {
+			$track['url'] = $this->_get_url( $track );
+			// adjust the code that we output, account for both types of tracking.
+			$track['url'] = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
+			$custom_vars[] = "_gaq.push(['_trackPageview','{$track['url']}']);";
+		} else {
+			$custom_vars[] = "_gaq.push(['_trackPageview']);";
+		}
+
+		/**
+		 * Allow for additional elements to be added to the classic Google Analytics queue (_gaq) array
+		 *
+		 * @since 5.4.0
+		 *
+		 * @param array $custom_vars Array of classic Google Analytics queue elements
+		 */
+		$custom_vars = apply_filters( 'jetpack_wga_classic_custom_vars', $custom_vars );
+
+		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
+		$async_code = "<!-- Jetpack Google Analytics -->
+			<script type='text/javascript'>
+				var _gaq = _gaq || [];
+				%custom_vars%
+
+				(function() {
+					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+				})();
+			</script>";
+
+		$custom_vars_string = implode( "\r\n", $custom_vars );
+		$async_code = str_replace( '%custom_vars%', $custom_vars_string, $async_code );
+
+		echo "$async_code\r\n";
+	}
+
+	/**
+	 * Used to filter in the anonymize IP snippet to the custom vars array for classic analytics
+	 * Ref https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizelp
+	 * @param array custom vars to be filtered
+	 * @return array possibly updated custom vars
+	 */
+	public function jetpack_wga_classic_anonymize_ip( $custom_vars ) {
+		if ( Jetpack_Google_Analytics_Options::anonymize_ip_is_enabled() ) {
+			array_push( $custom_vars, "_gaq.push(['_gat._anonymizeIp']);" );
+		}
+
+		return $custom_vars;
+	}
+
+	/**
+	 * Used to filter in the order details to the custom vars array for classic analytics
+	 * @param array custom vars to be filtered
+	 * @return array possibly updated custom vars
+	 */
+	public function jetpack_wga_classic_track_purchases( $custom_vars ) {
+		global $wp;
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return $custom_vars;
+		}
+
+		if ( ! Jetpack_Google_Analytics_Options::has_tracking_code() ) {
+			return;
+		}
+
+		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
+		if ( ! Jetpack_Google_Analytics_Options::track_purchases_is_enabled() ) {
+			return $custom_vars;
+		}
+
+		$minimum_woocommerce_active = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.0', '>=' );
+		if ( $minimum_woocommerce_active && is_order_received_page() ) {
+			$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
+			if ( 0 < $order_id && 1 != get_post_meta( $order_id, '_ga_tracked', true ) ) {
+				$order = new WC_Order( $order_id );
+
+				// [ '_add_Trans', '123', 'Site Title', '21.00', '1.00', '5.00', 'Snohomish', 'WA', 'USA' ]
+				array_push(
+					$custom_vars,
+					sprintf(
+						'_gaq.push( %s );', json_encode(
+							array(
+								'_addTrans',
+								(string) $order->get_order_number(),
+								get_bloginfo( 'name' ),
+								(string) $order->get_total(),
+								(string) $order->get_total_tax(),
+								(string) $order->get_total_shipping(),
+								(string) $order->get_billing_city(),
+								(string) $order->get_billing_state(),
+								(string) $order->get_billing_country()
+							)
+						)
+					)
+				);
+
+				// Order items
+				if ( $order->get_items() ) {
+					foreach ( $order->get_items() as $item ) {
+						$product = $order->get_product_from_item( $item );
+						$product_sku_or_id = $product->get_sku() ? $product->get_sku() : $product->get_id();
+
+						array_push(
+							$custom_vars,
+							sprintf(
+								'_gaq.push( %s );', json_encode(
+									array(
+										'_addItem',
+										(string) $order->get_order_number(),
+										(string) $product_sku_or_id,
+										$item['name'],
+										self::get_product_categories_concatenated( $product ),
+										(string) $order->get_item_total( $item ),
+										(string) $item['qty']
+									)
+								)
+							)
+						);
+					}
+				} // get_items
+
+				// Mark the order as tracked
+				update_post_meta( $order_id, '_ga_tracked', 1 );
+				array_push( $custom_vars, "_gaq.push(['_trackTrans']);" );
+			} // order not yet tracked
+		} // is order received page
+
+		return $custom_vars;
+	}
+
+	/**
+	 * Gets product categories or varation attributes as a formatted concatenated string
+	 * @param WC_Product
+	 * @return string
+	 */
+	public function get_product_categories_concatenated( $product ) {
+		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : '';
+		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
+			$line = wc_get_formatted_variation( $variation_data, true );
+		} else {
+			$out = array();
+			$categories = get_the_terms( $product->get_id(), 'product_cat' );
+			if ( $categories ) {
+				foreach ( $categories as $category ) {
+					$out[] = $category->name;
+				}
+			}
+			$line = join( "/", $out );
+		}
+		return $line;
+	}
+
+	/**
+	 * Used to add footer javascript to track user clicking on add-to-cart buttons
+	 * on single views (.single_add_to_cart_button) and list views (.add_to_cart_button)
+	 */
+	public function jetpack_wga_classic_track_add_to_cart() {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
+		if ( ! Jetpack_Google_Analytics_Options::has_tracking_code() ) {
+			return;
+		}
+
+		if ( ! Jetpack_Google_Analytics_Options::track_add_to_cart_is_enabled() ) {
+			return;
+		}
+
+		if ( is_product() ) { // product page
+			global $product;
+			$product_sku_or_id = $product->get_sku() ? $product->get_sku() : "#" + $product->get_id();
+			wc_enqueue_js(
+				"jQuery( function( $ ) {
+					$( '.single_add_to_cart_button' ).click( function() {
+						_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
+					} );
+				} );"
+			);
+		} else if ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
+			wc_enqueue_js(
+				"jQuery( function( $ ) {
+					$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
+						var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );
+						_gaq.push(['_trackEvent', 'Products', 'Add to Cart', label]);
+					} );
+				} );"
+			);
+		}
+	}
+}

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -4,7 +4,8 @@
 * Jetpack_Google_Analytics_Legacy hooks and enqueues support for ga.js
 * https://developers.google.com/analytics/devguides/collection/gajs/
 *
-* @author allendav 
+* @author Aaron D. Campbell (original)
+* @author allendav
 */
 
 /**

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -195,7 +195,7 @@ class Jetpack_Google_Analytics_Legacy {
 										(string) $order->get_order_number(),
 										(string) $product_sku_or_id,
 										$item['name'],
-										self::get_product_categories_concatenated( $product ),
+										Jetpack_Google_Analytics_Utils::get_product_categories_concatenated( $product ),
 										(string) $order->get_item_total( $item ),
 										(string) $item['qty']
 									)
@@ -212,28 +212,6 @@ class Jetpack_Google_Analytics_Legacy {
 		} // is order received page
 
 		return $custom_vars;
-	}
-
-	/**
-	 * Gets product categories or varation attributes as a formatted concatenated string
-	 * @param WC_Product
-	 * @return string
-	 */
-	public function get_product_categories_concatenated( $product ) {
-		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : '';
-		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
-			$line = wc_get_formatted_variation( $variation_data, true );
-		} else {
-			$out = array();
-			$categories = get_the_terms( $product->get_id(), 'product_cat' );
-			if ( $categories ) {
-				foreach ( $categories as $category ) {
-					$out[] = $category->name;
-				}
-			}
-			$line = join( "/", $out );
-		}
-		return $line;
 	}
 
 	/**

--- a/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
 * Jetpack_Google_Analytics_Options provides a single interface to module options
 *

--- a/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -1,0 +1,95 @@
+<?php
+
+
+/**
+* Jetpack_Google_Analytics_Options provides a single interface to module options
+*
+* @author allendav 
+*/
+
+/**
+* Bail if accessed directly
+*/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Jetpack_Google_Analytics_Options {
+	public static function get_option( $option_name, $default = false ) {
+		$o = get_option( 'jetpack_wga' );
+		return isset( $o[ $option_name ] ) ? $o[ $option_name ] : $default;
+	}
+
+	public static function get_tracking_code() {
+		return self::get_option( 'code', '' );
+	}
+
+	public static function has_tracking_code() {
+		$code = self::get_tracking_code();
+		return ! empty( $code );
+	}
+
+	// Options used by both legacy and universal analytics
+	public static function anonymize_ip_is_enabled() {
+		return self::get_option( 'anonymize_ip' );
+	}
+
+	// eCommerce options used by both legacy and universal analytics
+	public static function track_purchases_is_enabled() {
+		return self::get_option( 'ec_track_purchases' );
+	}
+
+	public static function track_add_to_cart_is_enabled() {
+		return self::get_option( 'ec_track_add_to_cart' );
+	}
+
+	// Enhanced eCommerce options
+	public static function enhanced_ecommerce_tracking_is_enabled() {
+		return self::get_option( 'enh_ec_tracking' );
+	}
+
+	public static function track_remove_from_cart_is_enabled() {
+		return self::get_option( 'enh_ec_track_remove_from_cart' );
+	}
+
+	public static function track_product_impressions_is_enabled() {
+		return self::get_option( 'enh_ec_track_prod_impression' );
+	}
+
+	public static function track_product_clicks_is_enabled() {
+		return self::get_option( 'enh_ec_track_prod_click' );
+	}
+
+	public static function track_product_detail_view_is_enabled() {
+		return self::get_option( 'enh_ec_track_prod_detail_view' );
+	}
+
+	public static function track_checkout_started_is_enabled() {
+		return self::get_option( 'enh_ec_track_checkout_started' );
+	}
+
+	public static function debug_dump() {
+		$messages = array( 'Jetpack_Google_Analytics_Options' );
+		$tracking_code = self::has_tracking_code() ? self::get_tracking_code() : '(empty)';
+		array_push( $messages, "get_tracking_code: $tracking_code" );
+
+		$flags = array(
+			'anonymize_ip_is_enabled',
+			'track_purchases_is_enabled',
+			'track_add_to_cart_is_enabled',
+			'enhanced_ecommerce_tracking_is_enabled',
+			'track_remove_from_cart_is_enabled',
+			'track_product_impressions_is_enabled',
+			'track_product_clicks_is_enabled',
+			'track_product_detail_view_is_enabled',
+			'track_checkout_started_is_enabled',
+		);
+
+		foreach( $flags as $flag ) {
+			$value = call_user_func( 'Jetpack_Google_Analytics_Options::' . $flag ) ? 'true' : 'false';
+			array_push( $messages, "$flag: $value" );
+		}
+
+		return $messages;
+	}
+}

--- a/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -47,26 +47,6 @@ class Jetpack_Google_Analytics_Options {
 		return self::get_option( 'enh_ec_tracking' );
 	}
 
-	public static function track_remove_from_cart_is_enabled() {
-		return self::get_option( 'enh_ec_track_remove_from_cart' );
-	}
-
-	public static function track_product_impressions_is_enabled() {
-		return self::get_option( 'enh_ec_track_prod_impression' );
-	}
-
-	public static function track_product_clicks_is_enabled() {
-		return self::get_option( 'enh_ec_track_prod_click' );
-	}
-
-	public static function track_product_detail_view_is_enabled() {
-		return self::get_option( 'enh_ec_track_prod_detail_view' );
-	}
-
-	public static function track_checkout_started_is_enabled() {
-		return self::get_option( 'enh_ec_track_checkout_started' );
-	}
-
 	public static function debug_dump() {
 		$messages = array( 'Jetpack_Google_Analytics_Options' );
 		$tracking_code = self::has_tracking_code() ? self::get_tracking_code() : '(empty)';
@@ -77,11 +57,6 @@ class Jetpack_Google_Analytics_Options {
 			'track_purchases_is_enabled',
 			'track_add_to_cart_is_enabled',
 			'enhanced_ecommerce_tracking_is_enabled',
-			'track_remove_from_cart_is_enabled',
-			'track_product_impressions_is_enabled',
-			'track_product_clicks_is_enabled',
-			'track_product_detail_view_is_enabled',
-			'track_checkout_started_is_enabled',
 		);
 
 		foreach( $flags as $flag ) {

--- a/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -46,24 +46,4 @@ class Jetpack_Google_Analytics_Options {
 	public static function enhanced_ecommerce_tracking_is_enabled() {
 		return self::get_option( 'enh_ec_tracking' );
 	}
-
-	public static function debug_dump() {
-		$messages = array( 'Jetpack_Google_Analytics_Options' );
-		$tracking_code = self::has_tracking_code() ? self::get_tracking_code() : '(empty)';
-		array_push( $messages, "get_tracking_code: $tracking_code" );
-
-		$flags = array(
-			'anonymize_ip_is_enabled',
-			'track_purchases_is_enabled',
-			'track_add_to_cart_is_enabled',
-			'enhanced_ecommerce_tracking_is_enabled',
-		);
-
-		foreach( $flags as $flag ) {
-			$value = call_user_func( 'Jetpack_Google_Analytics_Options::' . $flag ) ? 'true' : 'false';
-			array_push( $messages, "$flag: $value" );
-		}
-
-		return $messages;
-	}
 }

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+* Jetpack_Google_Analytics_Universal hooks and and enqueues support for analytics.js
+* https://developers.google.com/analytics/devguides/collection/analyticsjs/
+*
+* @author allendav 
+*/
+
+/**
+* Bail if accessed directly
+*/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Jetpack_Google_Analytics_Universal {
+	public function __construct() {
+		// TODO add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
+		// TODO add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
+		// TODO add_action( 'wp_footer', array( $this, 'insert_code' ) );
+		// TODO add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
+	}
+
+	public function insert_code() {
+
+	}
+}

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -16,13 +16,159 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Jetpack_Google_Analytics_Universal {
 	public function __construct() {
-		// TODO add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
-		// TODO add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
-		// TODO add_action( 'wp_footer', array( $this, 'insert_code' ) );
-		// TODO add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
+		add_filter( 'jetpack_wga_universal_commands', array( $this, 'maybe_anonymize_ip' ) );
+		add_filter( 'jetpack_wga_universal_commands', array( $this, 'maybe_track_purchases' ) );
+
+		add_action( 'wp_head', array( $this, 'wp_head' ), 999999 );
+
+		//TODO add_action( 'woocommerce_after_add_to_cart_button', array( $this, 'add_to_cart' ) );
+		//TODO add_action( 'wp_footer', array( $this, 'loop_add_to_cart' ) );
+		//TODO add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
+		//TODO add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
+
+		//TODO add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+
+		//TODO add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
+		//TODO add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
+		//TODO add_action( 'woocommerce_after_single_product', array( $this, 'product_detail' ) );
+		//TODO add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
+
+		add_action( 'wp_footer', array( $this, 'wp_footer' ) );
 	}
 
-	public function insert_code() {
+	public function wp_head() {
+		$tracking_code = Jetpack_Google_Analytics_Options::get_tracking_code();
+		if ( empty( $tracking_code ) ) {
+			echo "<!-- No tracking ID configured for Jetpack Google Analytics -->\r\n";
+			return;
+		}
 
+		// If we're in the admin_area, return without inserting code.
+		if ( is_admin() ) {
+			return;
+		}
+
+		/**
+		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param array $custom_vars Array of universal Google Analytics queue elements
+		 */
+		$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
+
+		$async_code = "
+			<!-- Jetpack Google Analytics -->
+			<script>
+				window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;
+				ga( 'create', '%tracking_id%', 'auto' );
+				%universal_commands%
+			</script>
+			<script async src='https://www.google-analytics.com/analytics.js'></script>
+			<!-- End Jetpack Google Analytics -->
+		";
+		$async_code = str_replace( '%tracking_id%', $tracking_code, $async_code );
+
+		$universal_commands_string = implode( "\r\n", $universal_commands );
+		$async_code = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
+
+		echo "$async_code\r\n";
+	}
+
+	public function maybe_anonymize_ip( $command_array ) {
+		if ( Jetpack_Google_Analytics_Options::anonymize_ip_is_enabled() ) {
+			array_push( $command_array, "ga( 'set', 'anonymizeIp', true );" );
+		}
+
+		return $command_array;
+	}
+
+	public function maybe_track_purchases( $command_array ) {
+		global $wp;
+
+		if ( ! Jetpack_Google_Analytics_Options::track_purchases_is_enabled() ) {
+			return $command_array;
+		}
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return $command_array;
+		}
+
+		$minimum_woocommerce_active = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.0', '>=' );
+		if ( ! $minimum_woocommerce_active ) {
+			return $command_array;
+		}
+
+		if ( ! is_order_received_page() ) {
+			return $command_array;
+		}
+
+		$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
+		if ( 0 == $order_id ) {
+			return $command_array;
+		}
+
+		// A 1 indicates we've already tracked this order - don't do it again
+		if ( 1 == get_post_meta( $order_id, '_ga_tracked', true ) ) {
+			return $command_array;
+		}
+
+		$order = new WC_Order( $order_id );
+		$order_currency = $order->get_currency();
+		$command = "ga( 'set', '&cu', '" . esc_js( $order_currency ) . "' );";
+		array_push( $command_array, $command );
+
+		// Order items
+		if ( $order->get_items() ) {
+			foreach ( $order->get_items() as $item ) {
+				$product = $order->get_product_from_item( $item );
+				$sku_or_id = $product->get_sku() ? $product->get_sku() : $product->get_id();
+
+				$item_details = array(
+					'id' => $sku_or_id,
+					'name' => $item['name'],
+					'category' => Jetpack_Google_Analytics_Utils::get_product_categories_concatenated( $product ),
+					'price' => $order->get_item_total( $item ),
+					'quantity' => $item['qty'],
+				);
+				$command = "ga( 'ec:addProduct', " . wp_json_encode( $item_details ) . " );";
+				array_push( $command_array, $command );
+			}
+		}
+
+		// Order summary
+		$summary = array(
+			'id' => $order->get_order_number(),
+			'affiliation' => get_bloginfo( 'name' ),
+			'revenue' => $order->get_total(),
+			'tax' => $order->get_total_tax(),
+			'shipping' => $order->get_total_shipping()
+		);
+		$command = "ga( 'ec:setAction', 'purchase', " . wp_json_encode( $summary ) . " );";
+		array_push( $command_array, $command );
+
+		update_post_meta( $order_id, '_ga_tracked', 1 );
+
+		return $command_array;
+	}
+
+	public function wp_footer() {
+		if ( ! Jetpack_Google_Analytics_Options::has_tracking_code() ) {
+			return;
+		}
+
+		if ( is_admin() ) {
+			return;
+		}
+
+		$async_code = "
+			<!-- Jetpack Google Analytics -->
+			<script>
+				ga( 'send', 'pageview' );
+			</script>
+			<!-- End Jetpack Google Analytics -->
+		";
+
+		echo "$async_code\r\n";
 	}
 }

--- a/modules/google-analytics/classes/wp-google-analytics-utils.php
+++ b/modules/google-analytics/classes/wp-google-analytics-utils.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+* Jetpack_Google_Analytics_Options provides a single interface to module options
+*
+* @author allendav 
+*/
+
+/**
+* Bail if accessed directly
+*/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Jetpack_Google_Analytics_Utils {
+	/**
+	 * Gets product categories or varation attributes as a formatted concatenated string
+	 * @param WC_Product
+	 * @return string
+	 */
+	public static function get_product_categories_concatenated( $product ) {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return '';
+		}
+
+		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : '';
+		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
+			$line = wc_get_formatted_variation( $variation_data, true );
+		} else {
+			$out = array();
+			$categories = get_the_terms( $product->get_id(), 'product_cat' );
+			if ( $categories ) {
+				foreach ( $categories as $category ) {
+					$out[] = $category->name;
+				}
+			}
+			$line = join( "/", $out );
+		}
+		return $line;
+	}
+}

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -50,10 +50,6 @@ class Jetpack_Google_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( print_r( Jetpack_Google_Analytics_Options::debug_dump(), true ) );
-		}
-
 		if ( Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() ) {
 			$analytics = new Jetpack_Google_Analytics_Universal();
 		} else {

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once( plugin_basename( 'classes/wp-google-analytics-utils.php' ) );
 require_once( plugin_basename( 'classes/wp-google-analytics-options.php' ) );
 require_once( plugin_basename( 'classes/wp-google-analytics-legacy.php' ) );
 require_once( plugin_basename( 'classes/wp-google-analytics-universal.php' ) );

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -1,6 +1,6 @@
 <?php
 /*
-		Copyright 2006  Aaron D. Campbell  (email : wp_plugins@xavisys.com)
+    Copyright 2006 Aaron D. Campbell (email : wp_plugins@xavisys.com)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,6 +22,15 @@
  * It helps us avoid name collisions
  * http://codex.wordpress.org/Writing_a_Plugin#Avoiding_Function_Name_Collisions
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once( plugin_basename( 'classes/wp-google-analytics-options.php' ) );
+require_once( plugin_basename( 'classes/wp-google-analytics-legacy.php' ) );
+require_once( plugin_basename( 'classes/wp-google-analytics-universal.php' ) );
+
 class Jetpack_Google_Analytics {
 
 	/**
@@ -30,17 +39,26 @@ class Jetpack_Google_Analytics {
 	static $instance = false;
 
 	/**
+	 * @var Static property to hold concrete analytics impl that does the work (universal or legacy)
+	 */
+	static $analytics = false;
+
+	/**
 	 * This is our constructor, which is private to force the use of get_instance()
 	 *
 	 * @return void
 	 */
 	private function __construct() {
-		// TODO - support both legacy/classic (ga.js) and universal analytics (analytics.js)
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( print_r( Jetpack_Google_Analytics_Options::debug_dump(), true ) );
+		}
 
-		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
-		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
-		add_action( 'wp_footer', array( $this, 'insert_code' ) );
-		add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
+		if ( Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() ) {
+			$analytics = new Jetpack_Google_Analytics_Universal();
+		} else {
+			$analytics = new Jetpack_Google_Analytics_Legacy();
+		}
+
 	}
 
 	/**
@@ -52,284 +70,6 @@ class Jetpack_Google_Analytics {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * Used to generate a tracking URL
-	 *
-	 * @param array $track - Must have ['data'] and ['code'].
-	 * @return string - Tracking URL
-	 */
-	private function _get_url( $track ) {
-		$site_url = ( is_ssl() ? 'https://':'http://' ) . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ); // Input var okay.
-		foreach ( $track as $k => $value ) {
-			if ( strpos( strtolower( $value ), strtolower( $site_url ) ) === 0 ) {
-				$track[ $k ] = substr( $track[ $k ], strlen( $site_url ) );
-			}
-			if ( 'data' === $k ) {
-				$track[ $k ] = preg_replace( '/^https?:\/\/|^\/+/i', '', $track[ $k ] );
-			}
-
-			// This way we don't lose search data.
-			if ( 'data' === $k && 'search' === $track['code'] ) {
-				$track[ $k ] = rawurlencode( $track[ $k ] );
-			} else {
-				$track[ $k ] = preg_replace( '/[^a-z0-9\.\/\+\?=-]+/i', '_', $track[ $k ] );
-			}
-
-			$track[ $k ] = trim( $track[ $k ], '_' );
-		}
-		$char = ( strpos( $track['data'], '?' ) === false ) ? '?' : '&amp;';
-		return str_replace( "'", "\'", "/{$track['code']}/{$track['data']}{$char}referer=" . rawurlencode( isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' ) ); // Input var okay.
-	}
-
-	/**
-	 * Maybe output or return, depending on the context
-	 */
-	private function _output_or_return( $val, $maybe ) {
-		if ( $maybe ) {
-			echo $val . "\r\n";
-		} else {
-			return $val;
-		}
-	}
-
-	/**
-	 * This injects the Google Analytics code into the footer of the page.
-	 *
-	 * @param bool[optional] $output - defaults to true, false returns but does NOT echo the code.
-	 */
-	public function insert_code( $output = true ) {
-		// If $output is not a boolean false, set it to true (default).
-		$output = ( false !== $output);
-
-		$tracking_id = $this->_get_tracking_code();
-		if ( empty( $tracking_id ) ) {
-			return $this->_output_or_return( '<!-- Your Google Analytics Plugin is missing the tracking ID -->', $output );
-		}
-
-		// If we're in the admin_area, return without inserting code.
-		if ( is_admin() ) {
-			return $this->_output_or_return( '<!-- Your Google Analytics Plugin is set to ignore Admin area -->', $output );
-		}
-
-		$custom_vars = array(
-			"_gaq.push(['_setAccount', '{$tracking_id}']);",
-		);
-
-		$track = array();
-		if ( is_404() ) {
-			// This is a 404 and we are supposed to track them.
-			$custom_vars[] = "_gaq.push(['_trackEvent', '404', document.location.href, document.referrer]);";
-		} elseif ( is_search() ) {
-			// Set track for searches, if it's a search, and we are supposed to.
-			$track['data'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ); // Input var okay.
-			$track['code'] = 'search';
-		}
-
-		if ( ! empty( $track ) ) {
-			$track['url'] = $this->_get_url( $track );
-			// adjust the code that we output, account for both types of tracking.
-			$track['url'] = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
-			$custom_vars[] = "_gaq.push(['_trackPageview','{$track['url']}']);";
-		} else {
-			$custom_vars[] = "_gaq.push(['_trackPageview']);";
-		}
-
-		/**
-		 * Allow for additional elements to be added to the classic Google Analytics queue (_gaq) array
-		 *
-		 * @since 5.4.0
-		 *
-		 * @param array $custom_vars Array of classic Google Analytics queue elements
-		 */
-		$custom_vars = apply_filters( 'jetpack_wga_classic_custom_vars', $custom_vars );
-
-		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
-		$async_code = "<!-- Jetpack Google Analytics -->
-			<script type='text/javascript'>
-				var _gaq = _gaq || [];
-				%custom_vars%
-
-				(function() {
-					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-				})();
-			</script>";
-
-		$custom_vars_string = implode( "\r\n", $custom_vars );
-		$async_code = str_replace( '%custom_vars%', $custom_vars_string, $async_code );
-
-		return $this->_output_or_return( $async_code, $output );
-	}
-
-	/**
-	 * Used to get the tracking code option
-	 *
-	 * @return tracking code option value.
-	 */
-	private function _get_tracking_code() {
-		$o = get_option( 'jetpack_wga' );
-
-		if ( isset( $o['code'] ) && preg_match( '#UA-[\d-]+#', $o['code'], $matches ) ) {
-				return $o['code'];
-		}
-
-		return '';
-	}
-
-	/**
-	 * Used to filter in the anonymize IP snippet to the custom vars array for classic analytics
-	 * Ref https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizelp
-	 * @param array custom vars to be filtered
-	 * @return array possibly updated custom vars
-	 */
-	public function jetpack_wga_classic_anonymize_ip( $custom_vars ) {
-		$o = get_option( 'jetpack_wga' );
-		$anonymize_ip = isset( $o[ 'anonymize_ip' ] ) ? $o[ 'anonymize_ip' ] : false;
-		if ( $anonymize_ip ) {
-			array_push( $custom_vars, "_gaq.push(['_gat._anonymizeIp']);" );
-		}
-
-		return $custom_vars;
-	}
-
-	/**
-	 * Used to filter in the order details to the custom vars array for classic analytics
-	 * @param array custom vars to be filtered
-	 * @return array possibly updated custom vars
-	 */
-	public function jetpack_wga_classic_track_purchases( $custom_vars ) {
-		global $wp;
-
-		if ( ! class_exists( 'WooCommerce' ) ) {
-			return $custom_vars;
-		}
-
-		// Ref: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example
-		$o = get_option( 'jetpack_wga' );
-		$ec_track_purchases = isset( $o[ 'ec_track_purchases' ] ) ? $o[ 'ec_track_purchases' ] : false;
-		$minimum_woocommerce_active = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.0', '>=' );
-		if ( $ec_track_purchases && $minimum_woocommerce_active && is_order_received_page() ) {
-			$order_id = isset( $wp->query_vars['order-received'] ) ? $wp->query_vars['order-received'] : 0;
-			if ( 0 < $order_id && 1 != get_post_meta( $order_id, '_ga_tracked', true ) ) {
-				$order = new WC_Order( $order_id );
-
-				// [ '_add_Trans', '123', 'Site Title', '21.00', '1.00', '5.00', 'Snohomish', 'WA', 'USA' ]
-				array_push(
-					$custom_vars,
-					sprintf(
-						'_gaq.push( %s );', json_encode(
-							array(
-								'_addTrans',
-								(string) $order->get_order_number(),
-								get_bloginfo( 'name' ),
-								(string) $order->get_total(),
-								(string) $order->get_total_tax(),
-								(string) $order->get_total_shipping(),
-								(string) $order->get_billing_city(),
-								(string) $order->get_billing_state(),
-								(string) $order->get_billing_country()
-							)
-						)
-					)
-				);
-
-				// Order items
-				if ( $order->get_items() ) {
-					foreach ( $order->get_items() as $item ) {
-						$product = $order->get_product_from_item( $item );
-						$product_sku_or_id = $product->get_sku() ? $product->get_sku() : $product->get_id();
-
-						array_push(
-							$custom_vars,
-							sprintf(
-								'_gaq.push( %s );', json_encode(
-									array(
-										'_addItem',
-										(string) $order->get_order_number(),
-										(string) $product_sku_or_id,
-										$item['name'],
-										self::get_product_categories_concatenated( $product ),
-										(string) $order->get_item_total( $item ),
-										(string) $item['qty']
-									)
-								)
-							)
-						);
-					}
-				} // get_items
-
-				// Mark the order as tracked
-				update_post_meta( $order_id, '_ga_tracked', 1 );
-				array_push( $custom_vars, "_gaq.push(['_trackTrans']);" );
-			} // order not yet tracked
-		} // is order received page
-
-		return $custom_vars;
-	}
-
-	/**
-	 * Gets product categories or varation attributes as a formatted concatenated string
-	 * @param WC_Product
-	 * @return string
-	 */
-	public function get_product_categories_concatenated( $product ) {
-		$variation_data = $product->is_type( 'variation' ) ? wc_get_product_variation_attributes( $product->get_id() ) : '';
-		if ( is_array( $variation_data ) && ! empty( $variation_data ) ) {
-			$line = wc_get_formatted_variation( $variation_data, true );
-		} else {
-			$out = array();
-			$categories = get_the_terms( $product->get_id(), 'product_cat' );
-			if ( $categories ) {
-				foreach ( $categories as $category ) {
-					$out[] = $category->name;
-				}
-			}
-			$line = join( "/", $out );
-		}
-		return $line;
-	}
-
-	/**
-	 * Used to add footer javascript to track user clicking on add-to-cart buttons
-	 * on single views (.single_add_to_cart_button) and list views (.add_to_cart_button)
-	 */
-	public function jetpack_wga_classic_track_add_to_cart() {
-		if ( ! class_exists( 'WooCommerce' ) ) {
-			return;
-		}
-
-		$tracking_id = $this->_get_tracking_code();
-		if ( empty( $tracking_id ) ) {
-			return;
-		}
-
-		$o = get_option( 'jetpack_wga' );
-		$ec_track_add_to_cart = isset( $o[ 'ec_track_add_to_cart' ] ) ? $o[ 'ec_track_add_to_cart' ] : false;
-		if ( $ec_track_add_to_cart ) {
-			if ( is_product() ) { // product page
-				global $product;
-				$product_sku_or_id = $product->get_sku() ? $product->get_sku() : "#" + $product->get_id();
-				wc_enqueue_js(
-					"jQuery( function( $ ) {
-						$( '.single_add_to_cart_button' ).click( function() {
-							_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
-						} );
-					} );"
-				);
-			} else if ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
-				wc_enqueue_js(
-					"jQuery( function( $ ) {
-						$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
-							var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );
-							_gaq.push(['_trackEvent', 'Products', 'Add to Cart', label]);
-						} );
-					} );"
-				);
-			}
-		}
 	}
 }
 

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -35,6 +35,8 @@ class Jetpack_Google_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
+		// TODO - support both legacy/classic (ga.js) and universal analytics (analytics.js)
+
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
 		add_action( 'wp_footer', array( $this, 'insert_code' ) );


### PR DESCRIPTION
Ready to test.

Fixes #8181 

#### Background:

* The Jetpack Google Analytics module currently only supports "legacy" (ga.js) analytics
* This PR refactors the  module in Jetpack to add support for "universal" (analytics.js) analytics and the ecommerce plugin while maintaining support for legacy analytics.
* Which is used is driven by a new field in the jetpack_wga option: `enh_ec_tracking`
* Both "modes" support IP anonymization, tracking new orders and tracking when products are added to the cart (on single or loop pages)

* A follow-on PR will expand on this PR further by adding support for these additional enhanced analytics behaviors:

enh_ec_track_remove_from_cart
enh_ec_track_prod_impression
enh_ec_track_prod_click
enh_ec_track_prod_detail_view
enh_ec_track_checkout_started

#### Changes proposed in this Pull Request:

* Note: The original `wp-google-analytics.php` file was copied to `modules/google-analytics/classes/wp-google-analytics-legacy.php` with minor editing.
* Note: The original `wp-google-analytics.php` file was then modified to either load that legacy implementation or the new universal analytics implementation.
* Note: A `classes/wp-google-analytics-options.php` file was also added to provide a consistent interface to options for both implementations, including the following new enh_ec_tracking (on/off) flag

#### Testing instructions:

* Sign up for a Google Analytics tracking code for your test site
* Install, activate and connect Jetpack and get a Jetpack Professional Plan
* Install and activate WooCommerce
* Create a product with no SKU and at least two categories
* Create another product with a SKU and at least two categories
* Replace modules/google-analytics with the files from this branch
* Install and activate the Jetpack Google Analytics Helper plugin ( https://github.com/Automattic/jetpack-google-analytics-helper )
* Use the helper plugin (wp-admin > Tools > Jetpack Google Analytics Helper) to set the following:

```
Google Analytics Tracking / Property ID: (empty)
Anonymize IP Addresses: unchecked
Track Purchase Transactions: unchecked
Track Add to Cart Events: unchecked
Enable Enhanced eCommerce: unchecked
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is never referenced and 2) no jQuery is present to hook .single_add_to_cart_button or .add_to_cart_button
Elements.
* Note: You should see this in the page source (for legacy/classic analytics only): <!-- Your Google Analytics Plugin is missing the tracking ID -->

* Use the helper plugin (wp-admin > Tools > Jetpack Google Analytics Helper) to set the following:

```
Google Analytics Tracking / Property ID: UA-12345678-1
Anonymize IP Addresses: unchecked
Track Purchase Transactions: unchecked
Track Add to Cart Events: unchecked
Enable Enhanced eCommerce: unchecked
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is present, 2) that the Tracking ID is present, but 3) that no jQuery is present to hook .single_add_to_cart_button or .add_to_cart_button elements.

* Use the helper plugin (wp-admin > Tools > Jetpack Google Analytics Helper) to set the following:

```
Google Analytics Tracking / Property ID: UA-12345678-1
Anonymize IP Addresses: CHECKED
Track Purchase Transactions: unchecked
Track Add to Cart Events: unchecked
Enable Enhanced eCommerce: unchecked
```

* Visit either product page.
* View the source and 1) ensure the Google Analytics script (ga.js) is present and that the _anonymizeIp element is present, e.g. for legacy/classic:

```
_gaq.push(['_gat._anonymizeIp']);
```

For universal:

```
ga( 'set', 'anonymizeIp', true );
```

* Use the helper plugin (wp-admin > Tools > Jetpack Google Analytics Helper) to set the following:

```
Google Analytics Tracking / Property ID: UA-12345678-1
Anonymize IP Addresses: unchecked
Track Purchase Transactions: CHECKED
Track Add to Cart Events: unchecked
Enable Enhanced eCommerce: unchecked
```

* In your Google Analytics Dashboard ( https://analytics.google.com/ ), go to Admin for your site (it looks like a gear in the lower left corner)
* Under View select Ecommerce Settings
* Enable Ecommerce if you haven't already. DO NOT ENABLE ENHANCED ECOMMERCE AT THIS TIME.

<img width="1283" alt="screen shot 2017-11-20 at 12 33 54 pm" src="https://user-images.githubusercontent.com/1595739/33041195-5a356a70-cdf2-11e7-9f7f-a86391b17f18.png">

* Back on your test site, Complete the purchase of one of each product using a gateway like Check Payment.
* Return to your Google Analytics Dashboard and go to Conversions and then Ecommerce
* Set the date range to today
* Make sure you see the sale and that the details are correct (note: it can take a few minutes for the transaction to appear in GA)

* Use the helper plugin (wp-admin > Tools > Jetpack Google Analytics Helper) to set the following:

```
Google Analytics Tracking / Property ID: UA-12345678-1
Anonymize IP Addresses: unchecked
Track Purchase Transactions: CHECKED
Track Add to Cart Events: CHECKED
Enable Enhanced eCommerce: unchecked
```

* On the product listing page, choose Add to Cart for one of your products
* Then, visit the other product’s product page and add that product to your cart there.
* In your Google Analytics Dashboard, go to Real-time and then Events
* Make sure you see the addition of the SKU less and the SKU product and that the details are correct (Note: for legacy/classic ecommerce the event appears as Product: Add to Cart. For enhanced ecommerce the event is stored as UX/click/Add to Cart)

<img width="1037" alt="screen shot 2017-11-20 at 12 40 44 pm" src="https://user-images.githubusercontent.com/1595739/33041206-63eb73e8-cdf2-11e7-905b-342592d51382.png">

* In your Google Analytics Dashboard, go to Admin for your site
* Under View select Ecommerce Settings
* Enable ENHANCED Ecommerce
* Now, repeat all the tests above but with *Enable Enhanced eCommerce* CHECKED

#### Proposed changelog entry for your changes:

* Google Analytics: Add support for Universal Analytics / Enhanced eCommerce

#### See also:

* https://github.com/Automattic/jetpack/pull/7817 (earlier PR that added anonymization and basic ecommerce tracking)

cc @justinshreve 