### PR TITLE
Remove CPT from API if it isn't public

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1673,15 +1673,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return true;
 		}
 
-		if ( $post_type_object = get_post_type_object( $post_type ) ) {
-			if ( ! empty( $post_type_object->show_in_rest ) ) {
-				return $post_type_object->show_in_rest;
-			}
-			if ( ! empty( $post_type_object->publicly_queryable ) ) {
-				return $post_type_object->publicly_queryable;
-			}
-		}
-
+		$post_type_object = get_post_type_object( $post_type );
 		return ! empty( $post_type_object->public );
 	}
 


### PR DESCRIPTION
If the custom post type is not public and it has `show_in_rest`, the custom post type will be shown on Calypso.
The post type shouldn't shown if it is not in `whitelisted_post_type` and it is not public.

We don't have any solution to hide the custom post type on calypso, if we want to create non-public custom post type that has `show_in_rest`.