### PR TITLE
Sitemaps: Make the reporter log success messages only if JETPACK_DEV_DEBUG is defined 

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -123,7 +123,8 @@ class Jetpack_Sitemap_Builder {
 						. 'XML support is highly recommended for WordPress and Jetpack, please enable '
 						. 'it or contact your hosting provider about it.',
 						'jetpack'
-					)
+					),
+					true
 				);
 			}
 		}

--- a/modules/sitemaps/sitemap-logger.php
+++ b/modules/sitemaps/sitemap-logger.php
@@ -58,12 +58,18 @@ class Jetpack_Sitemap_Logger {
 	 * @access public
 	 * @since 4.8.0
 	 *
-	 * @param string $message The string to be written to the log.
+	 * @param string  $message  The string to be written to the log.
+	 * @param boolean $is_error If true, $message will be logged even if JETPACK_DEV_DEBUG is not enabled
 	 */
-	public function report( $message ) {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( 'jp-sitemap-' . $this->key . ': ' . $message );
+	public function report( $message, $is_error = false ) {
+		$message = 'jp-sitemap-' . $this->key . ': ' . $message;
+		if ( ! ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
+			return;
 		}
+		if ( ! $is_error && ! ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) ) {
+			return;
+		}
+		error_log( $message );
 		return;
 	}
 


### PR DESCRIPTION
Makes the report method `Jetpack_Sitemap_Logger ::report()` only log success messages if `JETPACK_DEV_DEBUG` is defined.

Error logs in several sites I'm using are filled with this piece of information which is not actually useful, specially when `WP_DEBUG` is turned on to observe possible errors happening. Message are like:
```
jp-sitemap-fDyFX: -- Building sitemap-1.xml
jp-sitemap-WTjbS: 0.123 seconds elapsed.
jp-sitemap-fDyFX: -- Cleaning Up jp_sitemap
jp-sitemap-fDyFX: -- Cleaning Up jp_sitemap_index
```

#### Changes proposed in this Pull Request:

* Updates the check for `WP_DEBUG` to be a check for both `WP_DEBUG` and `JETPACK_DEV_DEBUG` instead for success messages and just a check for `WP_DEBUG` for error messages.

#### Testing instructions:

* Activate sitemaps
* Define  `WP_DEBUG` to `true`.
* Rebuild the sitemaps (`wp jetpack sitemaps rebuild`).
* Define `JETPACK_DEV_DEBUG` to `true`.
* Expect to see the success messages only when JETPACK_DEV_DEBUG is defined.

