### PR TITLE
JSON API: add `autosave` param to posts/new endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -11,6 +11,9 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint( array(
 	'path_labels' => array(
 		'$site' => '(int|string) Site ID or domain',
 	),
+	'query_parameters' => array(
+		'autosave' => '(bool) True if the post was saved automatically.',
+	),
 
 	'request_format' => array(
 		// explicitly document all input


### PR DESCRIPTION
 Adds an `autosave` parameter to the posts/new endpoint which if true, will define `DOING_AUTOSAVE` to true.

This cleans noise from the Activity Log and allows us to be more
correct / accurate with the definition of DOING_AUTOSAVE.

Changes already deployed server side: 165562-r
See: p7rcWF-FO-p2