### PR TITLE
Photon: Do not remove width and height attributes when known

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -344,9 +344,11 @@ class Jetpack_Photon {
 							unset( $placeholder_src );
 						}
 
-						// If we do not have both width and height, then we should remove the width and height arguments
-						// from the image to prevent distortion. Otherwise, let's update the height and width arguments
-						// to what we're going to resize the image to.
+						// If we are not transforming the image with resize, fit, or letterbox (lb), then we should remove
+						// the width and height arguments from the image to prevent distortion. Even if $args['w'] and $args['h']
+						// are present, Photon does not crop to those dimensions. Instead, it appears to favor height.
+						//
+						// If we are transforming the image via one of those methods, let's update the width and height attributes.
 						if ( empty( $args['resize'] ) && empty( $args['fit'] ) && empty( $args['lb'] ) ) {
 							$new_tag = preg_replace( '#(?<=\s)(width|height)=["|\']?[\d%]+["|\']?\s?#i', '', $new_tag );
 						} else {

--- a/class.photon.php
+++ b/class.photon.php
@@ -347,11 +347,24 @@ class Jetpack_Photon {
 						// If we do not have both width and height, then we should remove the width and height arguments
 						// from the image to prevent distortion. Otherwise, let's update the height and width arguments
 						// to what we're going to resize the image to.
-						if ( ! $width || ! $height ) {
+						if ( empty( $args['resize'] ) && empty( $args['fit'] ) && empty( $args['lb'] ) ) {
 							$new_tag = preg_replace( '#(?<=\s)(width|height)=["|\']?[\d%]+["|\']?\s?#i', '', $new_tag );
 						} else {
-							$new_tag = preg_replace( '#(?<=\s)(width=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $width ), $new_tag );
-							$new_tag = preg_replace( '#(?<=\s)(height=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $height ), $new_tag );
+							$resize_args = isset( $args['resize'] ) ? $args['resize'] : false;
+							if ( false == $resize_args ) {
+								$resize_args = ( ! $resize_args && isset( $args['fit'] ) )
+									? $args['fit']
+									: false;
+							}
+							if ( false == $resize_args ) {
+								$resize_args = ( ! $resize_args && isset( $args['lb'] ) )
+									? $args['lb']
+									: false;
+							}
+
+							$resize_args = array_map( 'trim', explode( ',', $resize_args ) );
+							$new_tag = preg_replace( '#(?<=\s)(width=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $resize_args[0] ), $new_tag );
+							$new_tag = preg_replace( '#(?<=\s)(height=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $resize_args[1] ), $new_tag );
 						}
 
 						// Tag an image for dimension checking

--- a/class.photon.php
+++ b/class.photon.php
@@ -344,8 +344,15 @@ class Jetpack_Photon {
 							unset( $placeholder_src );
 						}
 
-						// Remove the width and height arguments from the tag to prevent distortion
-						$new_tag = preg_replace( '#(?<=\s)(width|height)=["|\']?[\d%]+["|\']?\s?#i', '', $new_tag );
+						// If we do not have both width and height, then we should remove the width and height arguments
+						// from the image to prevent distortion. Otherwise, let's update the height and width arguments
+						// to what we're going to resize the image to.
+						if ( ! $width || ! $height ) {
+							$new_tag = preg_replace( '#(?<=\s)(width|height)=["|\']?[\d%]+["|\']?\s?#i', '', $new_tag );
+						} else {
+							$new_tag = preg_replace( '#(?<=\s)(width=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $width ), $new_tag );
+							$new_tag = preg_replace( '#(?<=\s)(height=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $height ), $new_tag );
+						}
 
 						// Tag an image for dimension checking
 						$new_tag = preg_replace( '#(\s?/)?>(\s*</a>)?$#i', ' data-recalc-dims="1"\1>\2', $new_tag );

--- a/class.photon.php
+++ b/class.photon.php
@@ -365,6 +365,12 @@ class Jetpack_Photon {
 							}
 
 							$resize_args = array_map( 'trim', explode( ',', $resize_args ) );
+
+							// (?<=\s)         - Ensure width or height attribute is preceded by a space
+							// (width=["|\']?) - Matches, and captures, width=, width=", or width='
+							// [\d%]+          - Matches 1 or more digits
+							// (["|\']?)       - Matches, and captures, ", ', or empty string
+							// \s              - Ensures there's a space after the attribute
 							$new_tag = preg_replace( '#(?<=\s)(width=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $resize_args[0] ), $new_tag );
 							$new_tag = preg_replace( '#(?<=\s)(height=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $resize_args[1] ), $new_tag );
 						}

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -788,4 +788,86 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$this->assertArrayNotHasKey( 'width', $attributes );
 		$this->assertArrayNotHasKey( 'height', $attributes );
 	}
+
+	/**
+	 * @author ebinnion
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @dataProvider photon_attributes_when_filtered_data_provider
+	 * @since 5.6.0
+	 */
+	public function test_photon_filter_the_content_width_height_attributes_when_image_args_filtered( $filter_callback, $has_attributes, $width, $height ) {
+		list( $sample_html ) = $this->get_photon_sample_content( 'a-tags-without-images.html' );
+
+		add_filter( 'jetpack_photon_post_image_args', array( $this, $filter_callback ) );
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		remove_filter( 'jetpack_photon_post_image_args', array( $this, $filter_callback ) );
+
+		$first_line = strtok( $filtered_content, "\n" ); // Should contain an image tag on the first line
+		$attributes = wp_kses_hair( $first_line, wp_allowed_protocols() );
+
+		if ( $has_attributes ) {
+			$this->assertArrayHasKey( 'width', $attributes );
+			$this->assertArrayHasKey( 'height', $attributes );
+
+			// These values obtained from first image in sample content
+			$this->assertEquals( $width, $attributes['width']['value'] );
+			$this->assertEquals( $height, $attributes['height']['value'] );
+		} else {
+			$this->assertArrayNotHasKey( 'width', $attributes );
+			$this->assertArrayNotHasKey( 'height', $attributes );
+		}
+	}
+
+	public function photon_attributes_when_filtered_data_provider() {
+		return array(
+			'photon_post_image_args_force_resize' => array(
+				'photon_post_image_args_force_resize',
+				true,
+				300,
+				250
+			),
+			'photon_post_image_args_force_fit' => array(
+				'photon_post_image_args_force_fit',
+				true,
+				600,
+				600
+			),
+			'photon_post_image_args_force_lb' => array(
+				'photon_post_image_args_force_lb',
+				true,
+				800,
+				100
+			),
+			'photon_post_image_args_force_width_only' => array(
+				'photon_post_image_args_force_width_only',
+				false,
+				false,
+				false
+			),
+		);
+	}
+
+	public function photon_post_image_args_force_resize() {
+		return array(
+			'resize' => '300,250'
+		);
+	}
+
+	public function photon_post_image_args_force_fit() {
+		return array(
+			'fit' => '600,600'
+		);
+	}
+
+	public function photon_post_image_args_force_lb() {
+		return array(
+			'lb' => '800,100,000000'
+		);
+	}
+
+	public function photon_post_image_args_force_width_only() {
+		return array(
+			'w' => '104'
+		);
+	}
 }

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -755,4 +755,37 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		wp_delete_attachment( $test_image );
 		$this->_remove_image_sizes();
 	}
+
+	/**
+	 * @author ebinnion
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @since 5.6.0
+	 */
+	public function test_photon_filter_the_content_does_not_remove_width_height_when_both_known() {
+		list( $sample_html ) = $this->get_photon_sample_content( 'a-tags-without-images.html' );
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$first_line = strtok( $filtered_content, "\n" ); // Should contain an image tag on the first line
+		$attributes = wp_kses_hair( $first_line, wp_allowed_protocols() );
+
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertArrayHasKey( 'height', $attributes );
+
+		// These values obtained from first image in sample content
+		$this->assertEquals( 631, $attributes['width']['value'] );
+		$this->assertEquals( 376, $attributes['height']['value'] );
+	}
+
+	/**
+	 * @author ebinnion
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @since 5.6.0
+	 */
+	public function test_photon_filter_the_content_does_not_have_width_height_when_at_least_one_not_known() {
+		$sample_html = '<img class="aligncenter  wp-image-6372" title="Tube Bomber salmon dry fly" alt="Tube Bomber salmon dry fly" src="http://www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg" width="631" />';
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$attributes = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+
+		$this->assertArrayNotHasKey( 'width', $attributes );
+		$this->assertArrayNotHasKey( 'height', $attributes );
+	}
 }


### PR DESCRIPTION
Fixes #8191

Until now, when filtering content, Photon has removed width and height attributes from img tags. This makes sense in certain cases since we optimize and resize the image on WordPress.com. If we resize the image, but left the width and height attributes the same, it could cause distortion.

But, it also causes issues, which are described in #8191. 

To address the issue, I am proposing that instead of always removing the width and height attributes, that we update the width and height instead.

To test:

- Checkout branch
- Run tests
- Place various images in posts/pages. Observe that when there are height/width attributes for the image, that we don't strip the height/width tags. Ensure that you're "viewing source" as oppose to using dev tools.