### PR TITLE
WPCOM API: Fix incompatible method signature in json endpoints inheriting from the update endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -35,8 +35,8 @@ new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/delete
-	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
-	function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
+	// The unused $object parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $object = null ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -35,7 +35,8 @@ new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/delete
-	function callback( $path = '', $blog_id = 0 ) {
+	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -35,8 +35,8 @@ new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/delete
-	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
-	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
+	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -35,8 +35,8 @@ new WPCOM_JSON_API_Bulk_Restore_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Restore_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/restore
-	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
-	function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
+	// The unused $object parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $object = null ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -35,8 +35,8 @@ new WPCOM_JSON_API_Bulk_Restore_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Restore_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/restore
-	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
-	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
+	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -35,7 +35,8 @@ new WPCOM_JSON_API_Bulk_Restore_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Restore_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/restore
-	function callback( $path = '', $blog_id = 0 ) {
+	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
+	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;

--- a/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
@@ -2,7 +2,8 @@
 
 class Jetpack_JSON_API_Check_Capabilities_Endpoint extends Jetpack_JSON_API_Modules_Endpoint {
 	// GET /sites/%s/me/capability
-	public function callback( $path = '', $_blog_id = 0 ) {
+	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $_blog_id = 0, $post_id = 0 ) {
 		// Check minimum capability and blog membership first
 		if ( is_wp_error( $error = $this->validate_call( $_blog_id, 'read', false ) ) ) {
 			return $error;

--- a/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
@@ -2,8 +2,8 @@
 
 class Jetpack_JSON_API_Check_Capabilities_Endpoint extends Jetpack_JSON_API_Modules_Endpoint {
 	// GET /sites/%s/me/capability
-	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
-	public function callback( $path = '', $_blog_id = 0, $post_id = 0 ) {
+	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $_blog_id = 0, $object_id = 0 ) {
 		// Check minimum capability and blog membership first
 		if ( is_wp_error( $error = $this->validate_call( $_blog_id, 'read', false ) ) ) {
 			return $error;

--- a/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
@@ -2,8 +2,8 @@
 
 class Jetpack_JSON_API_Check_Capabilities_Endpoint extends Jetpack_JSON_API_Modules_Endpoint {
 	// GET /sites/%s/me/capability
-	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
-	public function callback( $path = '', $_blog_id = 0, $object_id = 0 ) {
+	// The unused $object parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $_blog_id = 0, $object = null ) {
 		// Check minimum capability and blog membership first
 		if ( is_wp_error( $error = $this->validate_call( $_blog_id, 'read', false ) ) ) {
 			return $error;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -3,7 +3,8 @@
 class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
 	// GET  /sites/%s/themes/mine => current theme
 	// POST /sites/%s/themes/mine => switch theme
-	public function callback( $path = '', $blog_id = 0  ) {
+	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
 
 		if ( is_wp_error( $error = $this->validate_call( $blog_id, 'switch_themes', true ) ) ) {
 			return $error;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -3,8 +3,8 @@
 class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
 	// GET  /sites/%s/themes/mine => current theme
 	// POST /sites/%s/themes/mine => switch theme
-	// The unused $post_id parameter is for making the method signature compatible with its parent class method.
-	public function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
+	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
 
 		if ( is_wp_error( $error = $this->validate_call( $blog_id, 'switch_themes', true ) ) ) {
 			return $error;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -3,8 +3,8 @@
 class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
 	// GET  /sites/%s/themes/mine => current theme
 	// POST /sites/%s/themes/mine => switch theme
-	// The unused $object_id parameter is for making the method signature compatible with its parent class method.
-	public function callback( $path = '', $blog_id = 0, $object_id = 0 ) {
+	// The unused $object parameter is for making the method signature compatible with its parent class method.
+	public function callback( $path = '', $blog_id = 0, $object = null ) {
 
 		if ( is_wp_error( $error = $this->validate_call( $blog_id, 'switch_themes', true ) ) ) {
 			return $error;


### PR DESCRIPTION
Updates the signature for the `callback()` method overriden by these classes.

Fixes #8186

#### Changes proposed in this Pull Request:

Modifies the following endpoints to have the same signature as the update endpoint for their `calback()` method.

* Bulk Restore Endpoint
* Bulk Delete Endpoint
* Active Theme endpoint
* Check compatibility endpoint

#### Testing instructions:

1. Start with a site running on PHP 7.2RC and Jetpack connected...
1. Get to calypso and try to run a full sync from [Settings/General/Manage Connection](https://wordpress.com/settings/manage-connection).
1. Verify you get an error.
1. Repeat after checking out this PR (Can be done easily by using the [Jetpack Beta Tester Plugin](github.com/Automattic/jetpack-beta))
1. Confirm that triggering he full sync works and you get no errors.

#### Before

![image](https://user-images.githubusercontent.com/746152/32967938-2a03fad2-cbbe-11e7-88fd-104a0b16497e.png)


#### After

![image](https://user-images.githubusercontent.com/746152/32967866-ed1d4394-cbbd-11e7-96aa-3df18122a6fb.png)

![image](https://user-images.githubusercontent.com/746152/32967883-f7e9824c-cbbd-11e7-979a-b65276f079ec.png)

![image](https://user-images.githubusercontent.com/746152/32968396-daba8048-cbbf-11e7-84e0-6d206e77a94d.png)
