### PR TITLE
Sync: Don't sync user if the user is null.

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -70,23 +70,39 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function sanitize_user_and_expand( $user ) {
+		$user = $this->get_user( $user );
 		$user = $this->add_to_user( $user );
 		return $this->sanitize_user( $user );
 	}
 
+	private function get_user( $user ) {
+		if ( $user && ! is_object( $user ) && is_numeric( $user ) ) {
+			$user = get_user_by( 'id', $user );
+		}
+		if ( $user instanceof WP_User ) {
+			return $user;
+		}
+		return null;
+	}
+
 	public function sanitize_user( $user ) {
+		$user = $this->get_user( $user );
 		// this create a new user object and stops the passing of the object by reference.
 		$user = unserialize( serialize( $user ) );
 
 		if ( is_object( $user ) && is_object( $user->data ) ) {
 			unset( $user->data->user_pass );
 		}
-
-		$user->allcaps = $this->get_real_user_capabilities( $user );
+		if ( $user ) {
+			$user->allcaps = $this->get_real_user_capabilities( $user );
+		}
 		return $user;
 	}
 
 	public function add_to_user( $user ) {
+		if ( ! is_object( $user ) ) {
+			return null;
+		}
 		$user->allowed_mime_types = get_allowed_mime_types( $user );
 
 		if ( function_exists( 'get_user_locale' ) ) {
@@ -130,9 +146,14 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function expand_logout_username( $args, $user_id ) {
 		$user  = get_userdata( $user_id );
 		$user  = $this->sanitize_user( $user );
+		
 		$login = '';
 		if ( is_object( $user ) && is_object( $user->data ) ) {
 			$login = $user->data->user_login;
+		}
+		// if we don't have a user here lets not send anything.
+		if ( empty( $login ) ) {
+			return false;
 		}
 
 		return array( $login, $user );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -400,6 +400,19 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( isset( $user_data_sent_to_server->data->user_pass ) );
 	}
 
+	public function test_syncs_user_logout_event_without_user() {
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( 0 );
+		do_action( 'wp_logout' );
+
+		$this->sender->do_sync();
+
+		wp_set_current_user( $current_user_id );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_logout' );
+		$this->assertFalse( $event );
+	}
+
 	public function test_deleted_user_during_sync_doesnt_cause_error() {
 		$this->server_event_storage->reset();
 


### PR DESCRIPTION
Lets not send the user on logout if the user is empty.

Fixes #8175 

#### Changes proposed in this Pull Request:

* For some reason some sites try to send us an empy value when the user logs out. It could be that the user is already logged out. 

This prevents the event from being sent.

#### Testing instructions:
* Do the tests pass? 