### PR TITLE
JSON API: WPCOM_JSON_API_Bulk_Delete_Post_Endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -35,7 +35,7 @@ new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
 
 class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
 	// /sites/%s/posts/delete
-	function callback( $path = '', $blog_id = 0 ) {
+	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;


### PR DESCRIPTION
Callback should be called with the same params as the parent's callback.

fixes #8186

@oskosk can you verify this fixes the fatal in php 7.2?