### PR TITLE
Publicize: update message length to match Twitter's new limit.

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -326,7 +326,7 @@ jQuery( function($) {
 		wpasTitle = $('#wpas-title').keyup( function() {
 		var length = wpasTitle.val().length;
 		wpasTitleCounter.text( length );
-		if ( wpasTwitterCheckbox && length > 116 ) {
+		if ( wpasTwitterCheckbox && length > 256 ) {
 			wpasTitleCounter.addClass( 'wpas-twitter-length-limit' );
 		} else {
 			wpasTitleCounter.removeClass( 'wpas-twitter-length-limit' );


### PR DESCRIPTION
Fixes #8134

#### Things to test
1. Starting in Posts > Add New.
2. If you use Publicize on your site, you will see the following box:

![screenshot 2017-11-09 at 13 37 59](https://user-images.githubusercontent.com/426388/32605811-398f391a-c553-11e7-9357-4be7f9642ceb.png)

Since Twitter now supports more characters, we need to expand the limit accordingly (280 characters minus 23 characters for the link, and a space):
https://blog.twitter.com/official/en_us/topics/product/2017/tweetingmadeeasier.html

#### Proposed changelog entry for your changes:
* Publicize: update message length to match Twitter's new 280 character limit.