### PR TITLE
Build: Enqueue non-minified _inc JS when SCRIPT_DEBUG true

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -179,6 +179,11 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 	// Javascript logic specific to the list table
 	function page_admin_scripts() {
-		wp_enqueue_script( 'jetpack-admin-js', plugins_url( '_inc/build/jetpack-admin.min.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION );
+		wp_enqueue_script(
+			'jetpack-admin-js',
+			Jetpack::get_file_url_for_environment( '_inc/build/jetpack-admin.min.js', '_inc/jetpack-admin.js' ),
+			array( 'jquery' ),
+			JETPACK__VERSION
+		);
 	}
 }

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -141,7 +141,10 @@ class Jetpack_Connection_Banner {
 	function enqueue_banner_scripts() {
 		wp_enqueue_script(
 			'jetpack-connection-banner-js',
-			plugins_url( '_inc/build/jetpack-connection-banner.min.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jetpack-connection-banner.min.js',
+				'_inc/jetpack-connection-banner.js'
+			),
 			array( 'jquery' ),
 			JETPACK__VERSION,
 			true

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -246,7 +246,7 @@ class Jetpack_IDC {
 
 		wp_enqueue_script(
 			'jetpack-idc-js',
-			plugins_url( '_inc/build/idc-notice.min.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment( '_inc/build/idc-notice.min.js', '_inc/idc-notice.js' ),
 			array( 'jquery' ),
 			JETPACK__VERSION,
 			true

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -175,7 +175,13 @@ class Jetpack_JITM {
 		wp_style_add_data( 'jetpack-jitm-css', 'suffix', $min );
 		wp_enqueue_style( 'jetpack-jitm-css' );
 
-		wp_enqueue_script( 'jetpack-jitm-new', plugins_url( '_inc/build/jetpack-jitm.min.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, true );
+		wp_enqueue_script(
+			'jetpack-jitm-new',
+			Jetpack::get_file_url_for_environment( '_inc/build/jetpack-jitm.min.js', '_inc/jetpack-jitm.js' ),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			true
+		);
 		wp_localize_script( 'jetpack-jitm-new', 'jitm_config', array(
 			'api_root' => esc_url_raw( rest_url() ),
 		) );

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -31,19 +31,28 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 
 		wp_register_script(
 			'models.jetpack-modules',
-			plugins_url( '_inc/build/jetpack-modules.models.min.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jetpack-modules.models.min.js',
+				'_inc/jetpack-modules.models.js'
+			),
 			array( 'backbone', 'underscore' ),
 			JETPACK__VERSION
 		);
 		wp_register_script(
 			'views.jetpack-modules',
-			plugins_url( '_inc/build/jetpack-modules.views.min.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jetpack-modules.views.min.js',
+				'_inc/jetpack-modules.views.js'
+			),
 			array( 'backbone', 'underscore', 'wp-util' ),
 			JETPACK__VERSION
 		);
 		wp_register_script(
 			'jetpack-modules-list-table',
-			plugins_url( '_inc/build/jetpack-modules.min.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jetpack-modules.min.js',
+				'_inc/jetpack-modules.js'
+			),
 			array(
 				'views.jetpack-modules',
 				'models.jetpack-modules',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -921,23 +921,50 @@ class Jetpack {
 	 */
 	public function register_assets() {
 		if ( ! wp_script_is( 'spin', 'registered' ) ) {
-			wp_register_script( 'spin', plugins_url( '_inc/build/spin.min.js', JETPACK__PLUGIN_FILE ), false, '1.3' );
+			wp_register_script(
+				'spin',
+				self::get_file_url_for_environment( '_inc/build/spin.min.js', '_inc/spin.js' ),
+				false,
+				'1.3'
+			);
 		}
 
 		if ( ! wp_script_is( 'jquery.spin', 'registered' ) ) {
-			wp_register_script( 'jquery.spin', plugins_url( '_inc/build/jquery.spin.min.js', JETPACK__PLUGIN_FILE ) , array( 'jquery', 'spin' ), '1.3' );
+			wp_register_script(
+				'jquery.spin',
+				self::get_file_url_for_environment( '_inc/build/jquery.spin.min.js', '_inc/jquery.spin.js' ),
+				array( 'jquery', 'spin' ),
+				'1.3'
+			);
 		}
 
 		if ( ! wp_script_is( 'jetpack-gallery-settings', 'registered' ) ) {
-			wp_register_script( 'jetpack-gallery-settings', plugins_url( '_inc/build/gallery-settings.min.js', JETPACK__PLUGIN_FILE ), array( 'media-views' ), '20121225' );
+			wp_register_script(
+				'jetpack-gallery-settings',
+				self::get_file_url_for_environment( '_inc/build/gallery-settings.min.js', '_inc/gallery-settings.js' ),
+				array( 'media-views' ),
+				'20121225'
+			);
 		}
 
 		if ( ! wp_script_is( 'jetpack-twitter-timeline', 'registered' ) ) {
-			wp_register_script( 'jetpack-twitter-timeline', plugins_url( '_inc/build/twitter-timeline.min.js', JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '4.0.0', true );
+			wp_register_script(
+				'jetpack-twitter-timeline',
+				self::get_file_url_for_environment( '_inc/build/twitter-timeline.min.js', '_inc/twitter-timeline.js' ),
+				array( 'jquery' ),
+				'4.0.0',
+				true
+			);
 		}
 
 		if ( ! wp_script_is( 'jetpack-facebook-embed', 'registered' ) ) {
-			wp_register_script( 'jetpack-facebook-embed', plugins_url( '_inc/build/facebook-embed.min.js', __FILE__ ), array( 'jquery' ), null, true );
+			wp_register_script(
+				'jetpack-facebook-embed',
+				self::get_file_url_for_environment( '_inc/build/facebook-embed.min.js', '_inc/facebook-embed.js' ),
+				array( 'jquery' ),
+				null,
+				true
+			);
 
 			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
 			$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );

--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -57,7 +57,12 @@ class Jetpack_Gallery_Settings {
 			 * This only happens if we're not in Jetpack, but on WPCOM instead.
 			 * This is the correct path for WPCOM.
 			 */
-			wp_register_script( 'jetpack-gallery-settings', plugins_url( '_inc/build/gallery-settings.min.js', JETPACK__PLUGIN_FILE ), array( 'media-views' ), '20121225' );
+			wp_register_script(
+				'jetpack-gallery-settings',
+				Jetpack::get_file_url_for_environment( '_inc/build/gallery-settings.min.js', '_inc/gallery-settings.js' ),
+				array( 'media-views' ),
+				'20121225'
+			);
 		}
 
 		wp_enqueue_script( 'jetpack-gallery-settings' );

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -126,8 +126,23 @@ class Jetpack_Comment_Likes {
 			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
 		}
 		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
-		wp_enqueue_script( 'postmessage', plugins_url( '_inc/build/postmessage.min.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, false );
-		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/build/jquery.jetpack-resize.min.js' , JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, false );
+		wp_enqueue_script(
+			'postmessage',
+			Jetpack::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			false
+		);
+		wp_enqueue_script(
+			'jetpack_resize',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jquery.jetpack-resize.min.js',
+				'_inc/jquery.jetpack-resize.js'
+			),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			false
+		);
 		wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 	}
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -279,8 +279,23 @@ class Jetpack_Likes {
 	* Register scripts
 	*/
 	function register_scripts() {
-		wp_register_script( 'postmessage', plugins_url( '_inc/build/postmessage.min.js', dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
-		wp_register_script( 'jetpack_resize', plugins_url( '_inc/build/jquery.jetpack-resize.min.js' , dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
+		wp_register_script(
+			'postmessage',
+			Jetpack::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			false
+		);
+		wp_register_script(
+			'jetpack_resize',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/jquery.jetpack-resize.min.js',
+				'_inc/jquery.jetpack-resize.js'
+			),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			false
+		);
 		wp_register_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 	}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -123,7 +123,12 @@ class A8C_WPCOM_Masterbar {
 			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK__VERSION . '-' . gmdate( 'oW' ) );
 		}
 
-		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/build/accessible-focus.min.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_script(
+			'jetpack-accessible-focus',
+			Jetpack::get_file_url_for_environment( '_inc/build/accessible-focus.min.js', '_inc/accessible-focus.js' ),
+			array(),
+			JETPACK__VERSION
+		);
 		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array( 'jquery' ), JETPACK__VERSION );
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );


### PR DESCRIPTION
After a [comment](https://github.com/Automattic/jetpack/pull/8076#issuecomment-344840965) from @enejb, we made some changes to how we enqueue minified/non-minified JS in #8153.

Because of that, we now need to update how the JS in `_inc` is enqueued to be sure that we enqueue minified or non-minified JS files correctly.

To test:

- Checkout PR
- `yarn build`
- Test various parts of Jetpack
    - Test IDC by triggering an IDC and ensuring the notice shows
    - Trigger connection banner by deactivating and then reactivating Jetpack
    - Visit `$site.com/wp-admin/admin.php?page=jetpack_modules` to trigger the modules js files
    - Embed a Facebook post
    - etc.
- Set `define( 'SCRIPT_DEBUG', true );` in your `wp-config.php` and ensure that non-minified JS files are enqueued when you run the above again