### PR TITLE
Comments: add comment history endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -22,6 +22,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-render-endpoint.php' )
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-delete-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comment-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comments-tree-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comment-history-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-post-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-render-shortcode-endpoint.php' );

--- a/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
@@ -1,0 +1,45 @@
+<?php
+
+new WPCOM_JSON_API_GET_Comment_History_Endpoint( array(
+	'description'   => 'Get the audit history for given comment',
+	'group'         => 'comments',
+	'stat'          => 'comments:1:comment-history',
+	'method'        => 'GET',
+	'path'          => '/sites/%s/comment-history/%d',
+	'path_labels'   => array(
+		'$site'       => '(int|string) Site ID or domain',
+		'$comment_ID' => '(int) The comment ID'
+	),
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comment-history/11',
+
+	'response_format' => array(
+		'comment_history' => '(array) Array of arrays representing the comment history objects.'
+	)
+) );
+
+class WPCOM_JSON_API_GET_Comment_History_Endpoint extends WPCOM_JSON_API_Endpoint {
+
+	// /sites/%s/comment-history/%d
+	public function callback( $path = '', $blog_id = 0, $comment_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( ! get_current_user_id() ) {
+			return new WP_Error( 'authorization_required', 'An active access token must be used to retrieve comment history.', 403 );
+		}
+
+		if ( ! current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
+			return new WP_Error( 'authorization_required', 'You are not authorized to view comment history on this blog.', 403 );
+		}
+
+		if ( ! class_exists( 'Akismet' ) || ! method_exists( 'Akismet', 'get_comment_history' ) ) {
+			return new WP_Error( 'akismet_required', 'Akismet plugin must be active for this feature to work', 501 );
+		}
+
+		return array( 'comment_history' => Akismet::get_comment_history( $comment_id ) );
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
@@ -36,10 +36,18 @@ class WPCOM_JSON_API_GET_Comment_History_Endpoint extends WPCOM_JSON_API_Endpoin
 			return new WP_Error( 'authorization_required', 'You are not authorized to view comment history on this blog.', 403 );
 		}
 
-		if ( ! class_exists( 'Akismet' ) || ! method_exists( 'Akismet', 'get_comment_history' ) ) {
-			return new WP_Error( 'akismet_required', 'Akismet plugin must be active for this feature to work', 501 );
+		if ( ! method_exists( 'Akismet', 'get_comment_history' ) ) {
+			return new WP_Error( 'akismet_required', 'Akismet plugin must be active for this feature to work', 503 );
 		}
 
-		return array( 'comment_history' => Akismet::get_comment_history( $comment_id ) );
+		$comment_history = Akismet::get_comment_history( $comment_id );
+
+		foreach ( $comment_history as &$item ) {
+			// Times are stored as floating point values in microseconds.
+			// We don't need that precision on the client so let's get rid of the decimal part.
+			$item['time'] = intval( $item['time'] );
+		}
+
+		return array( 'comment_history' => $comment_history );
 	}
 }


### PR DESCRIPTION
Depends on D8410-code.

Add endpoint that will return comment history for given comment id.
This functionality relies on Akismet plugin.

### Testing instructions

1. Use your test Jetpack site with Akismet plugin activated. 
2. Point Jetpack to your permanent sandbox using `define( ‘JETPACK__API_BASE’, ‘https://hostname.wordpress.com/jetpack.’ )`;
3. Pick a comment and make some changes to it (approve, unapprove, spam etc).
4. Set GET request to `https://public-api.wordpress.com/rest/v1/sites/{site_slug}/comment-history/{comment_id}`
5. Verify that the comment history is correct.
6. Verify that correct error message is returned if Akismet plugin is not active.
