### PR TITLE
Responsive Videos: Don't add Jetpack video wrapper for video embeds if WordPress core supports responsiveness for them already

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -33,6 +33,18 @@ function jetpack_responsive_videos_embed_html( $html ) {
 		return $html;
 	}
 
+	// The customizer video widget wraps videos with a class of wp-video
+	// mejs as of 4.9 apparently resizes videos too which causes issues
+	// skip the video if it is wrapped in wp-video.
+	$video_widget_wrapper = 'class="wp-video"';
+
+	$mejs_wrapped = strpos( $html, $video_widget_wrapper );
+
+	// If this is a video widget wrapped by mejs, return the html.
+	if ( false !== $mejs_wrapped ) {
+		return $html;
+	}
+
 	if ( defined( 'SCRIPT_DEBUG' ) && true == SCRIPT_DEBUG ) {
 		wp_enqueue_script( 'jetpack-responsive-videos-script', plugins_url( 'responsive-videos/responsive-videos.js', __FILE__ ), array( 'jquery' ), '1.2', true );
 	} else {


### PR DESCRIPTION
Fixes #8215 for Jetpack sites running WordPress 4.9 and with a theme that supports the `jetpack-responsive-video` features.

Sequel to r165801-wpcom.

WordPress 4.9 already provides responsiveness for video embeds and widgets, so this PR makes Jetpack not attempt to achieve responsiveness for them too.

#### Testing instructions:

* Start with a connected Jetpack site running on WordPress 4.9.
  * Checkout this branch.
  * Activate theme Twenty Sixteen or any other that support `jetpack-responsive-videos` on the site.
  * Add a Video Widget with a Vimeo video.
  * Add a Video Widget with a Youtube video.
  * On the customizer add this CSS:
  ```
  .site-inner {
    max-width: 5000px ;
  }
  ```
* With Chrome Dev Tools, try to emulate a device with resolution like `4500x1800`.
* Confirm that both videos play well without going into fullscreen. Audio and video should be perceived.
* Confirm that going fullscreen in videos fills the whole screen and play well.


