### PR TITLE
Calypso Nudges: Add admin notices nudging the user to the equivalent WordPress.com page.

### DIFF
--- a/modules/calypso-nudges.php
+++ b/modules/calypso-nudges.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Module Name: WordPress.com Nudges
+ * Module Description: Display admin tips that nudge the user to equivalent admin pages on WordPress.com.
+ * Jumpstart Description: Display admin tips that nudge the user to equivalent admin pages on WordPress.com.
+ * Sort Order: 15
+ * Recommendation Order: 14
+ * First Introduced: 5.6
+ * Requires Connection: Yes
+ * Auto Activate: No
+ * Module Tags: Other
+ */
+
+if ( is_admin() && Jetpack_Options::get_option( 'edit_links_calypso_redirect' ) ) {
+	require_once dirname( __FILE__ ) . '/calypso-nudges/class.calypso-nudges.php';
+}

--- a/modules/calypso-nudges/calypso-nudges.css
+++ b/modules/calypso-nudges/calypso-nudges.css
@@ -1,0 +1,17 @@
+.jetpack-calypso-nudge {
+  position: relative;
+  padding-right: 24px;
+}
+
+.jetpack-calypso-nudge .noticon-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 12px 10px;
+  white-space: nowrap;
+}
+
+.jetpack-calypso-nudge .dashicons-external {
+  margin-left: 0.2em;
+  text-decoration: none;
+}

--- a/modules/calypso-nudges/calypso-nudges.js
+++ b/modules/calypso-nudges/calypso-nudges.js
@@ -1,0 +1,21 @@
+( function( $ ) {
+    $( document ).on( 'click', '.jetpack-calypso-nudge button', function( event ) {
+        // Remove the nudge and record the dismissal stat.
+        event.preventDefault();
+        $( this ).closest( '.jetpack-calypso-nudge' ).remove();
+        $.ajax( {
+            url: ajaxurl,
+            data: {
+                action: 'calypso_nudges_register_dismiss_stats',
+                cookieGroup: jetpackCalypsoNudges.cookieGroup,
+                nonce: jetpackCalypsoNudges.nonce
+            }
+        } );
+
+        // Get an expiry date of about six months.
+        var expires = new Date( new Date().getTime() + 15778458000 );
+
+        // Create the updated cookie.
+        document.cookie = 'jetpack_nudge_dismissed_' + jetpackCalypsoNudges.cookieGroup + '=1;expires=' + expires.toUTCString();
+    } );
+} )( jQuery );

--- a/modules/calypso-nudges/class.calypso-nudges.php
+++ b/modules/calypso-nudges/class.calypso-nudges.php
@@ -1,0 +1,467 @@
+<?php
+
+class Jetpack_Calypso_Nudges {
+	public function __construct() {
+		$enabled = apply_filters( 'jetpack_calypso_nudges_enable', '__return_true' );
+		if ( ! $enabled ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( $this, 'nudge_to_calypso' ) );
+		add_action( 'admin_post_calypso_nudge', array( $this, 'redirect_to_calypso' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_ajax_calypso_nudges_register_dismiss_stats', array( $this, 'register_dismiss_stats' ) );
+		add_filter( 'allowed_redirect_hosts', array( $this, 'update_allowed_redirect_hosts' ) );
+	}
+
+	public function nudge_to_calypso() {
+		$screen = $this->get_screen();
+		if ( ! $screen || $this->is_dismissed( $screen ) ) {
+			return;
+		}
+
+		$url = $this->get_nudge_url( $screen );
+
+		if ( 'add' === $screen['type'] ) {
+			$this->display_editor_nudge( $url, $screen['desc'] );
+		} else {
+			$this->display_management_nudge( $url, $screen['desc'] );
+		}
+	}
+
+	protected function get_screen() {
+		switch ( get_current_screen()->id ) {
+			case 'edit-post':
+				$type = 'manage';
+				$desc = 'post';
+				break;
+			case 'post':
+				$type = 'add';
+				$desc = 'post';
+				break;
+			case 'edit-category':
+				$type = 'manage';
+				$desc = 'category';
+				break;
+			case 'edit-post_tag':
+				$type = 'manage';
+				$desc = 'tag';
+				break;
+			case 'upload':
+				$type = 'manage';
+				$desc = 'media';
+				break;
+			case 'media':
+				$type = 'add';
+				$desc = 'media';
+				break;
+			case 'edit-page':
+				$type = 'manage';
+				$desc = 'page';
+				break;
+			case 'page':
+				$type = 'add';
+				$desc = 'page';
+				break;
+			case 'edit-comments':
+				$type = 'manage';
+				$desc = 'comment';
+				break;
+			case 'edit-jetpack-testimonial':
+				$type = 'manage';
+				$desc = 'testimonial';
+				break;
+			case 'jetpack-testimonial':
+				$type = 'add';
+				$desc = 'testimonial';
+				break;
+			case 'edit-jetpack-portfolio':
+				$type = 'manage';
+				$desc = 'portfolio';
+				break;
+			case 'jetpack-portfolio':
+				$type = 'add';
+				$desc = 'portfolio';
+				break;
+			case 'edit-nova_menu_item':
+				$type = 'manage';
+				$desc = 'food_menu';
+				break;
+			case 'nova_menu_item':
+				$type = 'add';
+				$desc = 'food_menu';
+				break;
+			case 'edit-jetpack-comic':
+				$type = 'manage';
+				$desc = 'comic';
+				break;
+			case 'jetpack-comic':
+				$type = 'add';
+				$desc = 'comic';
+				break;
+			default:
+				return false;
+		}
+		return array(
+			'id' => "{$type}_{$desc}",
+			'type' => $type,
+			'desc' => $desc,
+		);
+	}
+
+	protected function get_nudge_url( $screen ) {
+		$nudge_url = get_admin_url( null, 'admin-post.php' );
+
+		$nudge_url = add_query_arg( array(
+			'action' => 'calypso_nudge',
+			'screen' => $screen['id'],
+			'calypso_nudge_nonce' => wp_create_nonce( $screen['id'] )
+		), $nudge_url );
+
+		return $nudge_url;
+	}
+
+	protected function display_editor_nudge( $nudge_url, $desc ) {
+		switch ( $desc ) {
+			case 'post':
+				$notice = __( 'There\'s an easier way to create posts on WordPress.com.' );
+				break;
+			case 'page':
+				$notice = __( 'There\'s an easier way to create pages on WordPress.com.' );
+				break;
+			case 'media':
+				$notice = __( 'There\'s an easier way to add media on WordPress.com.' );
+				break;
+			case 'tag':
+				$notice = __( 'There\'s an easier way to create tags on WordPress.com.' );
+				break;
+			case 'category':
+				$notice = __( 'There\'s an easier way to create categories on WordPress.com.' );
+				break;
+			case 'testimonial':
+				$notice = __( 'There\'s an easier way to create testimonials on WordPress.com.' );
+				break;
+			case 'portfolio':
+				$notice = __( 'There\'s an easier way to create portfolio projects on WordPress.com.' );
+				break;
+			case 'food_menu':
+				$notice = __( 'There\'s an easier way to create menu items on WordPress.com.' );
+				break;
+			case 'comic':
+				$notice = __( 'There\'s an easier way to create comics on WordPress.com.' );
+				break;
+			default:
+				$notice = __( 'There\'s an easier way to create on WordPress.com.' );
+		}
+		?>
+		<div class="jetpack-calypso-nudge notice notice-info is-dismissible">
+			<p>
+				<?php echo esc_html( $notice ); ?>
+				<a href="<?php echo esc_url( $nudge_url ); ?>">
+					<?php esc_html_e('Switch to the improved editor.'); ?><span class="dashicons dashicons-external"></span>
+				</a>
+				<?php static $script_included = true; //wpcom_hide_tip_link( 'calypso_nudges' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	protected function display_management_nudge( $nudge_url, $desc ) {
+		switch ( $desc ) {
+			case 'post':
+				$notice = __( 'There\'s an easier way to manage posts on WordPress.com.' );
+				break;
+			case 'page':
+				$notice = __( 'There\'s an easier way to manage pages on WordPress.com.' );
+				break;
+			case 'comment':
+				$notice = __( 'There\'s an easier way to manage comments on WordPress.com.' );
+				break;
+			case 'media':
+				$notice = __( 'There\'s an easier way to manage media on WordPress.com.' );
+				break;
+			case 'tag':
+				$notice = __( 'There\'s an easier way to manage tags on WordPress.com.' );
+				break;
+			case 'category':
+				$notice = __( 'There\'s an easier way to manage categories on WordPress.com.' );
+				break;
+			case 'testimonial':
+				$notice = __( 'There\'s an easier way to manage testimonials on WordPress.com.' );
+				break;
+			case 'portfolio':
+				$notice = __( 'There\'s an easier way to manage portfolio projects on WordPress.com.' );
+				break;
+			case 'food_menu':
+				$notice = __( 'There\'s an easier way to manage menu items on WordPress.com.' );
+				break;
+			case 'comic':
+				$notice = __( 'There\'s an easier way to manage comics on WordPress.com.' );
+				break;
+			default:
+				$notice = __( 'There\'s an easier way to manage on WordPress.com.' );
+		}
+		?>
+		<div class="jetpack-calypso-nudge notice notice-info is-dismissible">
+			<p>
+				<?php echo esc_html( $notice ); ?>
+				<a href="<?php echo esc_url( $nudge_url ); ?>">
+					<?php esc_html_e('Switch to the improved experience.'); ?><span class="dashicons dashicons-external"></span>
+				</a>
+				<?php static $script_included = true; //wpcom_hide_tip_link( 'calypso_nudges' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	public function redirect_to_calypso() {
+		$screen = $_GET['screen'];
+		$this->verify_nonce( $screen );
+		$this->register_follow_stats( $screen );
+		$this->redirect_with_slug( $screen );
+	}
+
+	protected function verify_nonce( $screen ) {
+		if ( isset( $_GET['calypso_nudge_nonce'] )
+			&& wp_verify_nonce( $_GET['calypso_nudge_nonce'], $screen ) ) {
+			return;
+		}
+
+		// redirect to dashboard if nonce is not set
+		wp_safe_redirect( get_dashboard_url() );
+		exit;
+	}
+
+	protected function register_follow_stats( $screen ) {
+		// Make $event a full string for better discoverability.
+		switch ( $screen ) {
+			case 'manage_post':
+				$event = 'jetpack_calypso_nudge_follow_manage_post';
+				break;
+			case 'add_post':
+				$event = 'jetpack_calypso_nudge_follow_add_post';
+				break;
+			case 'manage_page':
+				$event = 'jetpack_calypso_nudge_follow_manage_page';
+				break;
+			case 'add_page':
+				$event = 'jetpack_calypso_nudge_follow_add_page';
+				break;
+			case 'manage_media':
+				$event = 'jetpack_calypso_nudge_follow_manage_media';
+				break;
+			case 'add_media':
+				$event = 'jetpack_calypso_nudge_follow_add_media';
+				break;
+			case 'manage_testimonial':
+				$event = 'jetpack_calypso_nudge_follow_manage_testimonial';
+				break;
+			case 'add_testimonial':
+				$event = 'jetpack_calypso_nudge_follow_add_testimonial';
+				break;
+			case 'manage_portfolio':
+				$event = 'jetpack_calypso_nudge_follow_manage_portfolio';
+				break;
+			case 'add_portfolio':
+				$event = 'jetpack_calypso_nudge_follow_add_portfolio';
+				break;
+			case 'manage_food_menu':
+				$event = 'jetpack_calypso_nudge_follow_manage_food_menu';
+				break;
+			case 'add_food_menu':
+				$event = 'jetpack_calypso_nudge_follow_add_food_menu';
+				break;
+			case 'manage_comic':
+				$event = 'jetpack_calypso_nudge_follow_manage_comic';
+				break;
+			case 'add_comic':
+				$event = 'jetpack_calypso_nudge_follow_add_comic';
+				break;
+			case 'manage_comment':
+				$event = 'jetpack_calypso_nudge_follow_manage_comment';
+				break;
+			case 'manage_category':
+				$event = 'jetpack_calypso_nudge_follow_manage_category';
+				break;
+			case 'manage_tag':
+				$event = 'jetpack_calypso_nudge_follow_manage_tag';
+				break;
+			default:
+				return;
+		}
+
+		// record in Tracks
+		jetpack_tracks_record_event( wp_get_current_user(), $event );
+	}
+
+	public function register_dismiss_stats() {
+		check_ajax_referer( 'jetpack-calypso-nudges-dismiss-nonce', 'nonce' );
+
+		// Make $event a full string for better discoverability.
+		switch ( $_GET['cookieGroup'] ) {
+			case 'posts':
+				$event = 'jetpack_calypso_nudge_dismiss_posts';
+				break;
+			case 'pages':
+				$event = 'jetpack_calypso_nudge_dismiss_pages';
+				break;
+			case 'media':
+				$event = 'jetpack_calypso_nudge_dismiss_media';
+				break;
+			case 'testimonials':
+				$event = 'jetpack_calypso_nudge_dismiss_testimonials';
+				break;
+			case 'portfolios':
+				$event = 'jetpack_calypso_nudge_dismiss_portfolios';
+				break;
+			case 'food_menus':
+				$event = 'jetpack_calypso_nudge_dismiss_food_menus';
+				break;
+			case 'comics':
+				$event = 'jetpack_calypso_nudge_dismiss_comics';
+				break;
+			case 'comments':
+				$event = 'jetpack_calypso_nudge_dismiss_comments';
+				break;
+			case 'taxonomies':
+				$event = 'jetpack_calypso_nudge_dismiss_taxonomies';
+				break;
+			default:
+				return;
+		}
+
+		// record in Tracks
+		jetpack_tracks_record_event( wp_get_current_user(), $event );
+	}
+
+	protected function redirect_with_slug( $screen ) {
+		switch ( $screen ) {
+			case 'manage_post':
+				$url = 'https://wordpress.com/posts/';
+				break;
+			case 'add_post':
+				$url = 'https://wordpress.com/post/';
+				break;
+			case 'manage_page':
+				$url = 'https://wordpress.com/pages/';
+				break;
+			case 'add_page':
+				$url = 'https://wordpress.com/page/';
+				break;
+			case 'manage_media':
+			case 'add_media':
+				$url = 'https://wordpress.com/media/';
+				break;
+			case 'manage_testimonial':
+				$url = 'https://wordpress.com/types/jetpack-testimonial/';
+				break;
+			case 'add_testimonial':
+				$url = 'https://wordpress.com/edit/jetpack-testimonial/';
+				break;
+			case 'manage_portfolio':
+				$url = 'https://wordpress.com/types/jetpack-portfolio/';
+				break;
+			case 'add_portfolio':
+				$url = 'https://wordpress.com/edit/jetpack-portfolio/';
+				break;
+			case 'manage_food_menu':
+				$url = 'https://wordpress.com/types/nova_menu_item/';
+				break;
+			case 'add_food_menu':
+				$url = 'https://wordpress.com/edit/nova_menu_item/';
+				break;
+			case 'manage_comic':
+				$url = 'https://wordpress.com/types/jetpack-comic/';
+				break;
+			case 'add_comic':
+				$url = 'https://wordpress.com/edit/jetpack-comic/';
+				break;
+			case 'manage_comment':
+				$url = 'https://wordpress.com/comments/all/';
+				break;
+			case 'manage_category':
+				$url = 'https://wordpress.com/settings/taxonomies/category/';
+				break;
+			case 'manage_tag':
+				$url = 'https://wordpress.com/settings/taxonomies/post_tag/';
+				break;
+			default:
+				wp_safe_redirect( get_dashboard_url() );
+				exit;
+		}
+
+		$site_slug = Jetpack::build_raw_urls( get_home_url() );
+		wp_safe_redirect( $url . $site_slug );
+		exit;
+	}
+
+	public function enqueue_scripts() {
+		$screen = $this->get_screen();
+		if ( ! $screen ) {
+			return;
+		}
+
+		wp_enqueue_script( 'jetpack-calypso-nudges-js', plugins_url( 'calypso-nudges.js', __FILE__ ), array(), '20171114', true );
+		wp_enqueue_style( 'jetpack-calypso-nudges-css', plugins_url( 'calypso-nudges.css' , __FILE__ ), array(), '20171114' );
+		wp_style_add_data( 'jetpack-calypso-nudges-css', 'rtl', 'replace' );
+
+		wp_localize_script( 'jetpack-calypso-nudges-js', 'jetpackCalypsoNudges', array(
+			'cookieGroup' => $this->get_cookie_group( $screen['id'] ),
+			'nonce' => wp_create_nonce( 'jetpack-calypso-nudges-dismiss-nonce' ),
+		) );
+	}
+
+	protected function is_dismissed( $screen ) {
+		$group = $this->get_cookie_group( $screen['id']);
+		$cookie = "jetpack_nudge_dismissed_{$group}";
+		return ! empty( $_COOKIE[ $cookie ] );
+	}
+
+	protected function get_cookie_group( $screen_id ) {
+		switch ( $screen_id ) {
+			case 'manage_post':
+			case 'add_post':
+				return 'posts';
+				break;
+			case 'manage_page':
+			case 'add_page':
+				return 'pages';
+				break;
+			case 'manage_media':
+			case 'add_media':
+				return 'media';
+				break;
+			case 'manage_testimonial':
+			case 'add_testimonial':
+				return 'testimonials';
+				break;
+			case 'manage_portfolio':
+			case 'add_portfolio':
+				return 'portfolios';				
+				break;
+			case 'manage_food_menu':
+			case 'add_food_menu':
+				return 'food_menus';				
+				break;
+			case 'manage_comic':
+			case 'add_comic':
+				return 'comics';				
+				break;
+			case 'manage_comment':
+				return 'comments';
+				break;
+			case 'manage_category':
+			case 'manage_tag':
+				return 'taxonomies';
+				break;
+		}
+		return false;
+	}
+
+	public function update_allowed_redirect_hosts( $allowed ) {
+		array_push( $allowed, 'wordpress.com' );
+		return array_unique( $allowed );
+	}
+}
+
+new Jetpack_Calypso_Nudges();

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -17,6 +17,12 @@ function jetpack_get_module_i18n( $key ) {
 				'description' => _x( 'Check your spelling, style, and grammar', 'Module Description', 'jetpack' ),
 			),
 
+			'calypso-nudges' => array(
+				'name' => _x( 'Calypso Nudges', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Display admin tips that nudge the user to equivalent admin pages in Calypso.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Display admin tips that nudge the user to equivalent admin pages in Calypso.', 'Jumpstart Description', 'jetpack' ),
+			),
+
 			'carousel' => array(
 				'name' => _x( 'Carousel', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience', 'Module Description', 'jetpack' ),
@@ -255,6 +261,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 	if ( ! isset( $module_tags ) ) {
 		$module_tags = array(
 			// Modules with `Other` tag:
+			//  - modules/calypso-nudges.php
 			//  - modules/contact-form.php
 			//  - modules/notes.php
 			'Other' =>_x( 'Other', 'Module Tag', 'jetpack' ),

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -650,3 +650,18 @@ function jetpack_google_analytics_more_info() {
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_google-analytics', 'jetpack_google_analytics_more_info' );
+
+/**
+ * Calypso Redirects and Nudges
+ */
+function jetpack_learn_more_calypso_redirects() {
+	echo 'https://jetpack.com/support/wordpresscom-admin';
+}
+add_action( 'jetpack_learn_more_button_calypso-nudges', 'jetpack_learn_more_calypso_redirects' );
+
+function jetpack_calypso_redirects_more_info() {
+	esc_html_e(
+		'Update WP Admin links to point to the new WordPress.com admin interface, with helpful tips to remind users.'
+		, 'jetpack' );
+}
+add_action( 'jetpack_module_more_info_calypso-nudges', 'jetpack_calypso_redirects_more_info' );

--- a/tools/builder/admin-css.js
+++ b/tools/builder/admin-css.js
@@ -16,9 +16,9 @@ const admincss = [
 	'modules/custom-post-types/comics/comics.css',
 	'modules/shortcodes/css/recipes.css',
 	'modules/shortcodes/css/recipes-print.css',
-
 	'modules/after-the-deadline/atd.css',
 	'modules/after-the-deadline/tinymce/css/content.css',
+	'modules/calypso-nudges/calypso-nudges.css',
 	'modules/contact-form/css/editor-inline-editing-style.css',
 	'modules/contact-form/css/editor-style.css',
 	'modules/contact-form/css/editor-ui.css',


### PR DESCRIPTION
![screen shot 2017-11-14 at 4 00 35 pm](https://user-images.githubusercontent.com/349751/33104302-2c5d2e90-cedc-11e7-9ea4-ac2cca50977c.png)

If the sites has the `edit_links_calypso_redirect` option returning `true`, these admin notices will be displayed for the following sections:

- Posts > All Posts
- Posts > Add New
- Pages > All Pages
- Pages > Add New
- Tags
- Categories
- Media > Library
- Media > Add New
- Comments
- Testimonials > All Testimonials
- Testimonials > Add New
- Portfolio > All Projects
- Portfolio > Add New
- Comics > All Comics
- Comics > Add New
- Comics > Categories
- Comics > Tags
- Food Menus > All Food Menus
- Food Menus > Add One Item

Note that the portfolio and food menu taxonomies don't have nudges, like the categories and tags do (comics use the core categories and tags, so you will see those). I started implementing them, but they're quite particular to their custom post type, and have no management equivalent in Calypso (even though you can //apply// them in the CPT UI).

Dismissing a notice will add a cookie set to expire in six months. The key's value will simply be `1`, and the various pages that can see the nudge are grouped together by type of content; for example, dismissing on either the Categories or Tags admin pages will dismiss the nudge for both of those pages, with a `jetpack_nudge_dismissed_taxonomies` key.

A separate PR will create a proper site setting to `edit_links_calypso_redirect`, under the existing WordPress.com section with the masterbar setting.

The equivalent functionality was added to the WordPress.com WP Admin in d7557-code.

Testing instructions to come.