### PR TITLE
Likes: Bust iframe cache to facilitate string fix

### DIFF
--- a/modules/likes/jetpack-likes-master-iframe.php
+++ b/modules/likes/jetpack-likes-master-iframe.php
@@ -4,7 +4,7 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version = '20170629';
+	$version = '20171126';
 	$in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
 
 	$_locale = get_locale();


### PR DESCRIPTION
We need to pull down new translations for comment likes.

Fixes #7958

#### Changes proposed in this Pull Request:

From the backend [when cache is busted]:
* New comment like strings with better context for translators.
* Denesting of some `if`s in `likes-rest.js`.

#### Testing instructions:

* Apply D8423-code
* Point widgets.wp.com to your SB.
* Clone this to your test site.
* Use a language that has translations for the new comment like strings.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixed comment likes localization bugs.