### PR TITLE
Lazy Images: Add filter for modifying lazy image attributes

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -108,6 +108,20 @@ class Jetpack_Lazy_Images {
 			unset( $new_attributes['sizes'] );
 		}
 
+		/**
+		 * Allow plugins and themes to override the attributes on the image before the content is updated.
+		 *
+		 * One potential use of this filter is for themes that set `height:auto` on the `img` tag.
+		 * With this filter, the theme could get the width and height attributes from the
+		 * $new_attributes array and then add a style tag that sets those values as well, which could
+		 * minimize reflow as images load.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param array An array containing the attributes for the image, where the key is the attribute name
+		 *              and the value is the attribute value.
+		 */
+		$new_attributes = apply_filters( 'jetpack_lazy_images_new_attributes', $new_attributes );
 		$new_attributes_str = self::build_attributes_string( $new_attributes );
 
 		return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -116,6 +116,8 @@ class Jetpack_Lazy_Images {
 		 * $new_attributes array and then add a style tag that sets those values as well, which could
 		 * minimize reflow as images load.
 		 *
+		 * @module lazy-images
+		 *
 		 * @since 5.6.0
 		 *
 		 * @param array An array containing the attributes for the image, where the key is the attribute name

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -60,6 +60,21 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 		);
 	}
 
+	function test_process_image_attribute_filter() {
+		add_filter( 'jetpack_lazy_images_new_attributes', array( $this, '__set_height_attribute' ) );
+
+		$html = Jetpack_Lazy_Images::process_image( array(
+			'<img src="image.jpg" height="100px" />',
+			'img',
+			' src="image.jpg" height="100px"',
+
+		) );
+
+		remove_filter( 'jetpack_lazy_images_new_attributes', array( $this, '__set_height_attribute' ) );
+
+		$expected_html = '<img src="placeholder.jpg" data-lazy-src="image.jpg" style="height: 100px;"><noscript><img src="image.jpg" sizes="(min-width: 36em) 33.3vw, 100vw" /></noscript>';
+	}
+
 	/**
 	 * @dataProvider get_process_image_test_data
 	 */
@@ -79,6 +94,13 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 
 	public function __override_image_placeholder() {
 		return 'placeholder.jpg';
+	}
+
+	public function __set_height_attribute( $attributes ) {
+		if ( ! empty( $attributes['height'] ) ) {
+			$attributes['style'] = sprintf( 'height: %d;', $attributes['height'] );
+		}
+		return $attributes;
 	}
 
 	public function __get_input_content() {


### PR DESCRIPTION
The only thing I am 100% certain about is that we can never 100% predict where and how users will implement our products. Because of this, I am suggesting that we add a `jetpack_lazy_images_new_attributes` filter so that plugins and theme could hook in and provide better integration with lazy images in the case that there are some compatibility issues.

One potential case where this might come in handy is with themes that set `height: auto`. On themes that set `height: auto`, the `height` attribute on the image tag will be ignored. This has the effect of not reserving space in the page for the image, which causes reflow when we do actually load the image.

Themes could attempt to provide better support by hooking in and manually setting the height values via the `style` attribute:

```php
add_filter( 'jetpack_lazy_images_new_attributes', function( $attributes ) {
    if ( ! empty( $attributes['height'] ) ) {
        $attributes['style'] = sprintf( 'height: %d;', $attributes['height'] );
    }
    return $attributes;
} );
```

I don't think the above filter is optimal solution for all cases, which is why it doesn't ship with the lazy images module itself, so it only serves as an example.

To test:

- Checkout branch
- Turn on `lazy-images` module
- Ensure that lazy images load properly on the frontend