### PR TITLE
REST API: Allow CORS requests for JPO

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4020,6 +4020,14 @@ p {
 					wp_safe_redirect( Jetpack::admin_url( array( 'page' => $redirect ) ) );
 				}
 				exit;
+			case 'get-onboarding-token' :
+				if ( ! current_user_can( 'manage_options' ) ) {
+					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
+				} else {
+					$token = Jetpack::create_onboarding_token();
+					wp_redirect( 'http://calypso.localhost:3000/onboarding/token?token=' . $token );
+				}
+				exit;
 			default:
 				/**
 				 * Fires when a Jetpack admin page is loaded with an unrecognized parameter.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -665,6 +665,22 @@ class Jetpack {
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
 		}
+
+		// Allow CORS requests to the settings endpoint for onboarding requests
+		add_action( 'rest_api_init', function() {
+			add_filter( 'rest_pre_serve_request', function( $served, $result, $request ) {
+				if ( $request->get_route() === '/jetpack/v4/settings' ) {
+					remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+
+					header( 'Access-Control-Allow-Origin: *' );
+					header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE' );
+					header( 'Access-Control-Allow-Credentials: true' );
+				}
+
+				return $served;
+
+			}, 9, 3 );
+		}, 15 );
 	}
 
 	function point_edit_links_to_calypso( $default_url, $post_id ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4025,7 +4025,11 @@ p {
 					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				} else {
 					$token = Jetpack::create_onboarding_token();
-					wp_redirect( 'http://calypso.localhost:3000/onboarding/token?token=' . $token );
+					$redirect = add_query_arg( array(
+						'url' => Jetpack::build_raw_urls( home_url() ),
+						'token' => $token,
+					), 'http://calypso.localhost:3000/onboarding/token' );
+					wp_redirect( $redirect );
 				}
 				exit;
 			default:


### PR DESCRIPTION
This PR updates the settings REST API endpoint to allow CORS requests for JPO.

Note: we're not planning to merge this for now, so we're not worried about code style, or features that are not supported in PHP 5.2 (e.g. anonymous functions).

To be used for experimental purposes, DO NOT MERGE. Used in conjunction with Automattic/wp-calypso#20160.