### PR TITLE
Fixed the sitemap query to disregard trashed posts.

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1059,13 +1059,14 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * rebuild : Rebuild all sitemaps
+	 * --purge : if set, will remove all existing sitemap data before rebuilding
 	 *
 	 * ## EXAMPLES
 	 *
 	 * wp jetpack sitemap rebuild
 	 *
 	 * @subcommand sitemap
-	 * @synopsis <rebuild>
+	 * @synopsis <rebuild> [--purge]
 	 */
 	public function sitemap( $args, $assoc_args ) {
 		if ( ! Jetpack::is_active() ) {
@@ -1076,6 +1077,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 		if ( ! class_exists( 'Jetpack_Sitemap_Builder' ) ) {
 			WP_CLI::error( __( 'Jetpack Sitemaps module is active, but unavailable. This can happen if your site is set to discourage search engine indexing. Please enable search engine indexing to allow sitemap generation.', 'jetpack' ) );
+		}
+
+		if ( isset( $assoc_args['purge'] ) && $assoc_args['purge'] ) {
+			$librarian = new Jetpack_Sitemap_Librarian();
+			$librarian->delete_all_stored_sitemap_data();
 		}
 
 		$sitemap_builder = new Jetpack_Sitemap_Builder();

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -225,10 +225,12 @@ class Jetpack_Sitemap_Librarian {
 				"SELECT *
 					FROM $wpdb->posts
 					WHERE post_type=%s
+						AND post_status=%s
 						AND ID>%d
 					ORDER BY ID ASC
 					LIMIT %d;",
 				$type,
+				'draft',
 				$from_id,
 				$num_posts
 			),


### PR DESCRIPTION
Fixes a problem where after a complete regeneration of the sitemap old index files would still be included into the sitemap.

#### Changes proposed in this Pull Request:
* Fixed sitemap custom post type query.
* Added a `--purge` switch to the CLI rebuild command to be able to rebuild sitemaps from scratch.

#### Testing instructions:
* Rebuild sitemaps using `wp jetpack sitemap rebuild --purge`.
* Make sure index sitemaps do not have duplicate entries.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed the sitemap generation mechanism.