### PR TITLE
Stats: Remove usage of create_function() in stats_convert_image_urls()

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -654,6 +654,11 @@ function stats_convert_image_urls( $html ) {
 	return $html;
 }
 
+function stats_convert_chart_urls_preg_replace_callback( $matches ) {
+	// If there is a query string, change the beginning '?' to a '&' so it fits into the middle of this query string.
+	return 'admin.php?page=stats&noheader&chart=' . $matches[1] . str_replace( '?', '&', $matches[2] );
+}
+
 /**
  * Stats Convert Chart URLs.
  *
@@ -662,13 +667,11 @@ function stats_convert_image_urls( $html ) {
  * @return string
  */
 function stats_convert_chart_urls( $html ) {
-	$html = preg_replace_callback( '|https?://[-.a-z0-9]+/wp-includes/charts/([-.a-z0-9]+).php(\??)|',
-		create_function(
-			'$matches',
-			// If there is a query string, change the beginning '?' to a '&' so it fits into the middle of this query string.
-			'return "admin.php?page=stats&noheader&chart=" . $matches[1] . str_replace( "?", "&", $matches[2] );'
-		),
-		$html );
+	$html = preg_replace_callback(
+		'|https?://[-.a-z0-9]+/wp-includes/charts/([-.a-z0-9]+).php(\??)|',
+		'stats_convert_chart_urls_preg_replace_callback',
+		$html
+	);
 	return $html;
 }
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -654,7 +654,15 @@ function stats_convert_image_urls( $html ) {
 	return $html;
 }
 
-function stats_convert_chart_urls_preg_replace_callback( $matches ) {
+/**
+ * Callback for preg_replace_callback used in stats_convert_chart_urls()
+ *
+ * @since 5.6.0
+ *
+ * @param  array  $matches The matches resulting from the preg_replace_callback call.
+ * @return string          The admin url for the chart.
+ */
+function jetpack_stats_convert_chart_urls_callback( $matches ) {
 	// If there is a query string, change the beginning '?' to a '&' so it fits into the middle of this query string.
 	return 'admin.php?page=stats&noheader&chart=' . $matches[1] . str_replace( '?', '&', $matches[2] );
 }
@@ -669,7 +677,7 @@ function stats_convert_chart_urls_preg_replace_callback( $matches ) {
 function stats_convert_chart_urls( $html ) {
 	$html = preg_replace_callback(
 		'|https?://[-.a-z0-9]+/wp-includes/charts/([-.a-z0-9]+).php(\??)|',
-		'stats_convert_chart_urls_preg_replace_callback',
+		'jetpack_stats_convert_chart_urls_callback',
 		$html
 	);
 	return $html;


### PR DESCRIPTION
Fixes #8010

#### Changes proposed in this Pull Request:

* Replaces a function created with `create_function` for passing as callback to `preg_replace_callback`. A new  function called `stats_convert_chart_urls_preg_replace_callback` which does the same is introduced.

#### Testing instructions:

* Start with a site running on PHP 7.2 with `WP_DEBUG` (and maybe `WP_DEBUG_LOG` too) (`/specialops`, can help)
* Connect Jetpack
* Check this branch and visit Jetpack's admin page dashboard
* Expect to see not logged message about `create_function` being deprecated.


