### PR TITLE
Masterbar: Proposal - Do not sign out by default from wpcom when clicking the Sign out link

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -40,10 +40,13 @@ class A8C_WPCOM_Masterbar {
 			'//2.gravatar.com',
 		) );
 
-		// Atomic only - override user setting that hides masterbar from site's front.
-		// https://github.com/Automattic/jetpack/issues/7667
+		// Atomic only
 		if ( jetpack_is_atomic_site() ) {
+			// override user setting that hides masterbar from site's front.
+			// https://github.com/Automattic/jetpack/issues/7667
 			add_filter( 'show_admin_bar', '__return_true' );
+			// Always sign out from .com from the masterbar
+			add_filter( 'jetpack_masterbar_should_logout_from_wpcom', '__return_true' );
 		}
 
 		$this->user_data = Jetpack::get_connected_user_data( $this->user_id );
@@ -84,7 +87,19 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	public function maybe_logout_user_from_wpcom() {
-		if ( isset( $_GET['context'] ) && 'masterbar' === $_GET['context'] ) {
+		 /**
+		  * Whether we should sign out from wpcom too when signing out from the masterbar.
+		  *
+		  * @since 5.6.0
+		  *
+		  * @param bool $masterbar_should_logout_from_wpcom False by default.
+		  */
+		$masterbar_should_logout_from_wpcom = apply_filters( 'jetpack_masterbar_should_logout_from_wpcom', false );
+		if (
+			isset( $_GET['context'] ) &&
+			'masterbar' === $_GET['context'] &&
+			$masterbar_should_logout_from_wpcom
+		) {
 			do_action( 'wp_masterbar_logout' );
 		}
 	}

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -87,13 +87,13 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	public function maybe_logout_user_from_wpcom() {
-		 /**
-		  * Whether we should sign out from wpcom too when signing out from the masterbar.
-		  *
-		  * @since 5.9.0
-		  *
-		  * @param bool $masterbar_should_logout_from_wpcom False by default.
-		  */
+		/**
+		 * Whether we should sign out from wpcom too when signing out from the masterbar.
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param bool $masterbar_should_logout_from_wpcom False by default.
+		 */
 		$masterbar_should_logout_from_wpcom = apply_filters( 'jetpack_masterbar_should_logout_from_wpcom', false );
 		if (
 			isset( $_GET['context'] ) &&

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -90,7 +90,7 @@ class A8C_WPCOM_Masterbar {
 		 /**
 		  * Whether we should sign out from wpcom too when signing out from the masterbar.
 		  *
-		  * @since 5.6.0
+		  * @since 5.9.0
 		  *
 		  * @param bool $masterbar_should_logout_from_wpcom False by default.
 		  */


### PR DESCRIPTION
This is a proposal so it can be tested with the Jetpack Beta Plugin when the PR finishes being unit-tested by Travis.

Context: p1HpG7-4Fe-p2

#### Changes proposed in this Pull Request:

* Adds a filter `jetpack_masterbar_should_logout_from_wpcom` defaulting to `false`. 
* Make the value be filtered to true for AT sites.

#### Testing instructions:

* Start by being signed in to WordPress.com (non-proxied).
* Then, on a connected Jetpack site...
* Install the [Jetpack Beta Tester Plugin](https://github.com/Automattic/jetpack-beta)
* Select this PR ( #8243 ).
* Enable the Masterbar from the Jetpack Settings Page..
* Sign out from the Masterbar.
* Go back to WordPress.com.
* Expect to be logged in.

Repeat steps on an AT site but expect to be logged out from WordPress.com in the end.

* Start by being signed in to WordPress.com (non-proxied).
* Then, on an AT site...
* Install the [Jetpack Beta Tester Plugin](https://github.com/Automattic/jetpack-beta)
* Select this PR ( #8243 ).
* Enable the Masterbar from the Jetpack Settings Page..
* Sign out from the Masterbar.
* Go back to WordPress.com.
* Expect to be logged out.