### PR TITLE
Admin Page: Add check for dependencies before attempting to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "url": "https://github.com/Automattic/jetpack/issues"
   },
   "scripts": {
-    "watch": "./node_modules/.bin/gulp watch",
+    "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
     "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
+    "install-if-deps-outdated": "yarn check || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
-    "build": "yarn && yarn build-client",
+    "build": "yarn install-if-deps-outdated && yarn build-client",
     "build-client": "gulp",
     "build-production": "yarn distclean && yarn --prod && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build-client",
     "build-languages": "gulp languages",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
     "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
-    "install-if-deps-outdated": "yarn check || yarn install --check-files",
+    "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn install-if-deps-outdated && yarn build-client",
     "build-client": "gulp",


### PR DESCRIPTION
This would make the Admin Page build process a little bit more reliable for folks not developing the admin page for a long time, or onboarding.


#### Changes proposed in this Pull Request:

* Introduces an npm-script `install-if-deps-outdated` which runs `yarn check` and `yarn install --check-files` if needed.
* Runs `install-if-deps-outdated` before the `yarn watch` and `yarn build` are run.


#### Testing instructions:

* Checkout this branch
* Remove one of the modules already present in your env (`rm -rf node_modules/react`).
* Run `yarn build` and expect nothing to fail. (This means the missing dependency will be installed)
* Remove another module.
* Run `yarn watch` and expect nothing to tail.
