### PR TITLE
JITM: Fix JITM display when the first result has been dismissed.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -69,6 +69,10 @@ jQuery( document ).ready( function( $ ) {
 			query: query,
 			_wpnonce: $el.data( 'nonce' )
 		} ).then( function( response ) {
+			if ( 'object' === typeof response && response['1'] ) {
+				response = [ response['1'] ];
+			}
+
 			// properly handle the case of an empty array or no content set
 			if ( 0 === response.length || ! response[ 0 ].content ) {
 				return;


### PR DESCRIPTION
On a page where two JITMs exist, but the first has been dismissed, the response back from the API [here](https://github.com/Automattic/jetpack/blob/master/_inc/jetpack-jitm.js#L71) will be an object with a key of `1`:

```javascript
{ 1: [...] }
```
...instead of the zero-indexed array expected in [the code handling the response](https://github.com/Automattic/jetpack/blob/master/_inc/jetpack-jitm.js#L73-L78), giving an uncaught type error (and no JITM displayed).

<img width="862" alt="screen shot 2017-11-24 at 4 25 59 pm" src="https://user-images.githubusercontent.com/349751/33225850-4eabb6ba-d134-11e7-83aa-5c86cc1b0c54.png">

This PR hacks Humpty back together again, but I'm not sure how better to handle it. It seems we should be leaving the response coming from the API alone, to keep open the possibility of handling multiple JITMs on the client [in the future](https://github.com/Automattic/jetpack/blob/master/_inc/jetpack-jitm.js#L77). This PR also doesn't take into account any other variations that may creep in to the client somehow. I'm also unclear as to how dismissals are handled, or where the variation between the return of `get_jitm()` on the server side (an array with two values) and the client-side response (object with only one value) happens.

Any suggestions @withinboredom ?