### PR TITLE
Admin Page: Proposal - Add lazy images settings

### DIFF
--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -45,6 +45,7 @@ describe( 'SettingsCard', () => {
 			'markdown',
 			'infinite-scroll',
 			'gravatar-hovercards',
+			'lazy-images',
 			'custom-css',
 			'sharedaddy',
 			'widgets',

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -26,6 +26,7 @@ describe( 'SettingsGroup', () => {
 			'markdown',
 			'infinite-scroll',
 			'gravatar-hovercards',
+			'lazy-images',
 			'custom-css',
 			'sharedaddy',
 			'widgets',

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -46,6 +46,7 @@ export const Writing = React.createClass( {
 			'carousel',
 			'post-by-email',
 			'infinite-scroll',
+			'lazy-images',
 			'minileven',
 			'videopress'
 		].some( this.props.isModuleFound );

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -72,9 +72,10 @@ const Media = moduleSettingsForm(
 		render() {
 			const foundPhoton = this.props.isModuleFound( 'photon' ),
 				foundCarousel = this.props.isModuleFound( 'carousel' ),
+				foundLazyImages = this.props.isModuleFound( 'lazy-images' ),
 				foundVideoPress = this.props.isModuleFound( 'videopress' );
 
-			if ( ! foundCarousel && ! foundPhoton && ! foundVideoPress ) {
+			if ( ! foundCarousel && ! foundPhoton && ! foundVideoPress && ! foundLazyImages ) {
 				return null;
 			}
 
@@ -82,6 +83,7 @@ const Media = moduleSettingsForm(
 				carousel = this.props.module( 'carousel' ),
 				isCarouselActive = this.props.getOptionValue( 'carousel' ),
 				videoPress = this.props.module( 'videopress' ),
+				lazyImages = this.props.module( 'lazy-images' ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 
 			const photonSettings = (
@@ -172,6 +174,27 @@ const Media = moduleSettingsForm(
 					</ModuleToggle>
 				</SettingsGroup>
 			);
+			const lazyImagesSettings = (
+
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ lazyImages }>
+					<ModuleToggle
+						slug="lazy-images"
+						disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
+						activated={ this.props.getOptionValue( 'lazy-images' ) }
+						toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{
+								lazyImages.description
+							}
+						</span>
+					</ModuleToggle>
+				</SettingsGroup>
+			)
 
 			return (
 				<SettingsCard
@@ -183,6 +206,7 @@ const Media = moduleSettingsForm(
 				>
 					{ foundPhoton && photonSettings }
 					{ foundCarousel && carouselSettings }
+					{ foundLazyImages && lazyImagesSettings }
 					{ foundVideoPress && videoPressSettings }
 				</SettingsCard>
 			);


### PR DESCRIPTION
Fixes #8193.

This PR adds a Lazy image card to Writing Settings

The label here is being taken from the module headings, so any text changes, should take place there.

**Screenshots**

![image](https://user-images.githubusercontent.com/746152/33232141-8e6d820a-d1df-11e7-9d74-278fa900eeaa.png)

![image](https://user-images.githubusercontent.com/746152/33899983-d806fddc-df4b-11e7-8fa0-02dd9f2b4c97.png)


#### Changes proposed in this Pull Request:

* Shows a toggle in the Media Settings page enabling the activation of the Lazy Images module

#### Testing instructions:

* Check this branch
* Build the admin page
* Visit Jetpack/Settings/Media
* Confirm that you a see a toggle for Lazy Images


