### PR TITLE
Comment likes: fix width of comment likes iframe

### DIFF
--- a/modules/likes/queuehandler.js
+++ b/modules/likes/queuehandler.js
@@ -302,7 +302,7 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 		commentLikesFrame.name = $wrapper.data( 'name' );
 		commentLikesFrame.src = $wrapper.data( 'src' );
 		commentLikesFrame.height = '18px';
-		commentLikesFrame.width = '200px';
+		commentLikesFrame.width = '100%';
 		commentLikesFrame.frameBorder = '0';
 		commentLikesFrame.scrolling = 'no';
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/8228
More info: https://github.com/Automattic/jetpack/pull/8228#issuecomment-346507519

With new translations some parts of the comment likes widget text were cropped due to fixed widget width. 

<img src="https://user-images.githubusercontent.com/1182160/33154850-a1a9493a-cfeb-11e7-8338-3155ceaf2246.png">

Update the widget width to assume the one of parent container in order to resolve this.

### Testing instructions

1. Use test Jetpack sites with Comment Likes module enabled.
2. Like one comment with two separate WP.com accounts in order to obtain `Liked by you and one other person` message.
3. Verify that all of the widget text is visible.