### PR TITLE
Admin Page: Don't load w.js until it's necessary

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -198,7 +198,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Enqueue jp.js and localize it
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
 
-		if ( ! $is_dev_mode ) {
+		if ( ! $is_dev_mode && Jetpack::is_active() ) {
 			// Required for Analytics
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Updates the check to see whether we need to load `w.js` to also check if the site is connected.

#### Testing instructions:

* On a disconnected Jetpack with the changes proposed here.
* Get to the Jetpack's Admin Page. View the source code. 
* Verify `w.js` is not loaded.

