### PR TITLE
Reverts the display of Dashboard card for AL

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -12,7 +12,6 @@ import analytics from 'lib/analytics';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import DashSectionHeader from 'components/dash-section-header';
 import DashStats from './stats/index.jsx';
-import DashActivity from './activity';
 import DashProtect from './protect';
 import DashMonitor from './monitor';
 import DashScan from './scan';
@@ -78,15 +77,7 @@ class AtAGlance extends Component {
 					}
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
-						</div>
-						<div className="jp-at-a-glance__right">
 							<DashProtect { ...settingsProps } />
-						</div>
-					</div>
-					<div className="jp-at-a-glance__item-grid">
-						<div className="jp-at-a-glance__left">
-							<DashBackups { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
 						</div>
 						<div className="jp-at-a-glance__right">
 							<DashScan { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
@@ -94,7 +85,7 @@ class AtAGlance extends Component {
 					</div>
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashAkismet { ...urls } />
+							<DashBackups { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
 						</div>
 						<div className="jp-at-a-glance__right">
 							<DashMonitor { ...settingsProps } />
@@ -102,9 +93,13 @@ class AtAGlance extends Component {
 					</div>
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
+							<DashAkismet { ...urls } />
+						</div>
+						<div className="jp-at-a-glance__right">
 							<DashPluginUpdates { ...settingsProps } { ...urls } />
 						</div>
 					</div>
+
 					{
 						<DashSectionHeader
 							label={ __( 'Performance' ) }


### PR DESCRIPTION
Removes the display of the new Dashboard card added in #8199 

Reverts the card from displaying on the dashboard, as it's not quite ready yet.  Left the guts of the card in the repo to make for a smaller changeset later. 

Now it should look like this again 
![screen shot 2017-11-28 at 11 45 11 am](https://user-images.githubusercontent.com/7129409/33332227-af61691e-d431-11e7-85cd-a0ee7647fed5.png)

cc @eliorivero @samhotchkiss 