### PR TITLE
Google Analytics: Test for WooCommerce before using wc_enqueue_js

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -49,6 +49,12 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
+		// At this time, we only leverage universal analytics for enhanced ecommerce. If WooCommerce is not
+		// present, don't bother emitting the tracking ID or fetching analytics.js
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
 		/**
 		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
 		 *
@@ -394,6 +400,10 @@ class Jetpack_Google_Analytics_Universal {
 		}
 
 		if ( is_admin() ) {
+			return;
+		}
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #8258 

#### Changes proposed in this Pull Request:

* Don't attempt to use `wc_enqueue_js` when WooCommerce plugin is deactivated/not present

#### Testing instructions:

* WP_DEBUG true
* Use https://github.com/automattic/jetpack-google-analytics-helper to enable everything, especially enhanced eCommerce. Don't forget to give a tracking ID too.
* Deactivate the WooCommerce plugin
* Visit a front side page
* Ensure no error is logged to the PHP error log
