### PR TITLE
JPS: CLI: Allow hosts to override home and siteurl via partner provision script

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -4,7 +4,7 @@
 # executes wp-cli command to provision Jetpack site for given partner
 
 usage () {
-	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root]"
+	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url]"
 }
 
 GLOBAL_ARGS=""
@@ -36,6 +36,12 @@ for i in "$@"; do
 			shift
 			;;
 		--force_connect=* )         FORCE_CONNECT="${i#*=}"
+			shift
+			;;
+		--site_url=* )              WP_SITEURL="${i#*=}"
+			shift
+			;;
+		--home_url=* )              WP_HOME="${i#*=}"
 			shift
 			;;
 		--allow-root )              GLOBAL_ARGS="--allow-root"
@@ -98,6 +104,14 @@ fi
 
 if [ ! -z "$FORCE_CONNECT" ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_connect=$FORCE_CONNECT"
+fi
+
+if [ ! -z "$WP_SITEURL" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --site_url=$WP_SITEURL"
+fi
+
+if [ ! -z "$WP_HOME" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --home_url=$WP_HOME"
 fi
 
 # Remove leading whitespace


### PR DESCRIPTION
With one of our hosting partners, we're noticing an issue that I believe is related to how they set the URL. They set the URL via the `WP_HOME` and `WP_SITEURL` constants, which seems to work well for web traffic. But, from the CLI, it appears that we're incorrectly getting the `home/siteurl` values from the `wp_options` table.

In this specific case, the option in the db is a development URL that is no longer accessible. So, when the partner runs the script, the register step fails because we can not reach the site.

To address this, I suggest we expose `--home_url` and `--site_url` arguments to allow the host to override the home/siteurl values when provisioning a plan. This will allow hosting partners who run into similar issues with CLI to set the URL as it should be.

Backstory in Slack: p1511816396000633-slack-pressable-public

To test:

For instructions on setting up a partner ID and secret, see: PCYsg-eDL-p2

- Checkout branch
- Update `home` and `siteurl` options to non-reachable URL
- Use the following command, replacing partner the arguments, and test that you get an error:
    - `sh jetpack/bin/partner-provision.sh --partner_id={PARTNER_ID} --partner_secret={PARTNER_SECRET} --user={LOCAL_WP_USER_ID} --plan=professional`
- Add the following to the above command, with the correct `home`/`siteurl` values, and ensure you get an object with `success:true`:
    - `--site_url={SITE_URL} --home_url={HOME_URL}`