### PR TITLE
Post Images: allow passing size when searching for images in HTML.

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -564,9 +564,9 @@ class Jetpack_PostImages {
 			$media = self::from_attachment( $post_id, $args['width'], $args['height'] );
 		if ( !$media && $args['from_html'] ) {
 			if ( empty( $args['html_content'] ) )
-				$media = self::from_html( $post_id ); // Use the post_id, which will load the content
+				$media = self::from_html( $post_id, $args['width'], $args['height'] ); // Use the post_id, which will load the content
 			else
-				$media = self::from_html( $args['html_content'] ); // If html_content is provided, use that
+				$media = self::from_html( $args['html_content'], $args['width'], $args['height'] ); // If html_content is provided, use that
 		}
 
 		if ( !$media && $args['fallback_to_avatars'] ) {

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -336,6 +336,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 					$post['post_id'],
 					array(
 						'fallback_to_avatars' => true,
+						'width'               => (int) $width,
+						'height'              => (int) $height,
 						'avatar_size'         => (int) $get_image_options['avatar_size'],
 					)
 				);


### PR DESCRIPTION
#### Testing instructions:

1. Insert an image in a post. It should be a big image. It can be hosted somewhere else.
2. Publish the post.
3. Visit that post a few times while logged out.
4. Add the Top Posts widget to your site and configure it to show images list.
5. The post should use the image from the post, and not a fallback image.

#### Proposed changelog entry for your changes:
* Post Images: allow passing size when searching for images in HTML.