### PR TITLE
Promo Card: Remove 50% off link

### DIFF
--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -85,13 +85,6 @@ const ThemesPromoCard = React.createClass( {
 								{ __( 'Compare All Plans' ) }
 							</Button>
 						</p>
-
-						<a
-							onClick={ this.trackGetStarted }
-							href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }
-						>
-							{ __( 'Limited time 50% introductory discount on Jetpack Professional.' ) }
-						</a>
 					</div>
 				</Card>
 			</div>


### PR DESCRIPTION
Before this PR, we were mentioning a 50% discount for Jetpack Professional, which we plan to no longer offer.

![image 2017-11-29 10-35-41](https://user-images.githubusercontent.com/1126811/33386695-32032fe6-d4f1-11e7-8f2d-4a7df63b5631.png)

This PR removes that link.

<img width="744" alt="screen shot 2017-11-29 at 10 35 10 am" src="https://user-images.githubusercontent.com/1126811/33386702-37a9680c-d4f1-11e7-8e76-eca25a96400e.png">

To test:

- Checkout branch
- Ensure site does not have a plan
- Ensure site is connected
- Click plans tab
- Ensure you see the promo above about Jetpack professional, without mention of a 50% discount

