### PR TITLE
Masterbar: fixes Site link from wp-admin is undefined bug

### DIFF
--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -97,7 +97,7 @@
 			'#wp-admin-bar-user-info .ab-item,' +
 			'.mb-trackable .ab-secondary';
 
-			$( trackableLinks ).on( 'click touchstart', function( e ) {
+		$( trackableLinks ).on( 'click touchstart', function( e ) {
 			if ( ! window.jpTracksAJAX || 'function' !== typeof( window.jpTracksAJAX.record_ajax_event ) ) {
 				return;
 			}
@@ -105,7 +105,11 @@
 			var $target = $( e.target ),
 					$parent = $target.closest( 'li' );
 
-			if ( ! $parent ) {
+			if ( ! $target.is( 'a' ) ) {
+				$target = $target.closest( 'a' );
+			}
+
+			if ( ! $parent || ! $target ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #8272 

#### Changes proposed in this Pull Request:

* Updates the Masterbar Tracks script to target the correct address when clicking on the blog infor elements.

#### Testing instructions:

* Enable the WP.com toolbar (masterbar)
* Go to any page in wp-admin
* Click "My Sites" in the top-left
* Click the Site Icon or label of the site at the top of the menu to visit the site

You should navigate away to the site url. There should be no regressions on other links.
