### PR TITLE
Fix miscellaneous Jetpack Search issues

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -862,11 +862,17 @@ class Jetpack_Search {
 	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
 	 */
 	public function add_date_histogram_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
+		$args = array(
+			'interval' => $aggregation['interval'],
+			'field'    => ( ! empty( $aggregation['field'] ) && 'post_date_gmt' == $aggregation['field'] ) ? 'date_gmt' : 'date',
+		);
+
+		if ( isset( $aggregation['min_doc_count'] ) ) {
+			$args['min_doc_count'] = intval( $aggregation['min_doc_count'] );
+		}
+
 		$builder->add_aggs( $label, array(
-			'date_histogram' => array(
-				'interval' => $aggregation['interval'],
-				'field'    => ( ! empty( $aggregation['field'] ) && 'post_date_gmt' == $aggregation['field'] ) ? 'date_gmt' : 'date',
-			),
+			'date_histogram' => $args,
 		));
 	}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -232,7 +232,14 @@ class Jetpack_Search {
 	 * @return array Array of matching posts
 	 */
 	public function filter__posts_pre_query( $posts, $query ) {
-		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+		/**
+		 * Determine whether a given WP_Query should be handled by ElasticSearch
+		 *
+		 * @since 5.6
+		 * @param bool $should_handle Should be handled by Jetpack Search
+		 * @param WP_Query $query The wp_query object
+		 */
+		if ( ! apply_filters( 'jetpack_search_should_handle_query', ( $query->is_main_query() && $query->is_search() ), $query ) ) {
 			return $posts;
 		}
 
@@ -276,10 +283,6 @@ class Jetpack_Search {
 	 * @param WP_Query $query The original WP_Query to use for the parameters of our search
 	 */
 	public function do_search( WP_Query $query ) {
-		if ( ! $query->is_main_query() || ! $query->is_search() ) {
-			return;
-		}
-
 		$page = ( $query->get( 'paged' ) ) ? absint( $query->get( 'paged' ) ) : 1;
 
 		$posts_per_page = $query->get( 'posts_per_page' );
@@ -466,7 +469,6 @@ class Jetpack_Search {
 			}
 
 			$post_type_object = get_post_type_object( $post_type );
-
 			if ( ! $post_type_object || $post_type_object->exclude_from_search ) {
 				continue;
 			}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -380,7 +380,7 @@ class Jetpack_Search {
 
 		foreach ( $the_tax_query->queries as $tax_query ) {
 			// Right now we only support slugs...see note above
-			if ( 'slug' !== $tax_query['field'] ) {
+			if ( ! is_array( $tax_query ) || 'slug' !== $tax_query['field'] ) {
 				continue;
 			}
 
@@ -1053,7 +1053,7 @@ class Jetpack_Search {
 
 				if ( ! empty( $query->tax_query ) && ! empty( $query->tax_query->queries ) && is_array( $query->tax_query->queries ) ) {
 					foreach( $query->tax_query->queries as $tax_query ) {
-						if ( $this->aggregations[ $label ]['taxonomy'] === $tax_query['taxonomy'] &&
+						if ( is_array( $tax_query ) && $this->aggregations[ $label ]['taxonomy'] === $tax_query['taxonomy'] &&
 						     'slug' === $tax_query['field'] &&
 						     is_array( $tax_query['terms'] ) ) {
 							$existing_term_slugs = array_merge( $existing_term_slugs, $tax_query['terms'] );
@@ -1286,7 +1286,7 @@ class Jetpack_Search {
 		}
 
 		foreach( $filters as $filter ) {
-			if ( isset( $filters['buckets'] ) && is_array( $filter['buckets'] ) ) {
+			if ( isset( $filter['buckets'] ) && is_array( $filter['buckets'] ) ) {
 				foreach( $filter['buckets'] as $item ) {
 					if ( isset( $item['active'] ) && $item['active'] ) {
 						$active_buckets[] = $item;


### PR DESCRIPTION
Fixes the following:

- `Illegal Offset` warnings when displaying WP Query tax searches that include a relation entry, e.g. 'AND'
- Missing active buckets due to typo in array check
- Allow min_doc_count on aggregations so that we can compress long month/year timescales and not run out of buckets
- Fixes https://github.com/Automattic/jetpack/issues/7946 by outputting query info as HTML comment in footer
- Add a filter which allows plugins to select when a WP_Query is to be handled by ES