### PR TITLE
Protect: Fix Pressable

### DIFF
--- a/modules/protect/blocked-login-page.php
+++ b/modules/protect/blocked-login-page.php
@@ -282,7 +282,7 @@ class Jetpack_Protect_Blocked_Login_Page {
 			$content = "<style>html{ background-color: #fff; } #error-page { margin:0 auto; padding: 1em; box-shadow: none; } </style>" . $content;
 		}
 
-		wp_die( $content, $this->page_title, array( 'back_link' => $back_link ) );
+		wp_die( $content, $this->page_title, array( 'back_link' => $back_link, 'response' => 200 ) );
 	}
 
 	function render_recovery_form() {


### PR DESCRIPTION
500, 403 headers produce custom errror messages on pressable.
Making sure that we went 200 fixes the issue and show the message as expeceted.

Fixes issue were we were returning a 500 error on pressable and any other host that implemenets custom error messages.

#### Changes proposed in this Pull Request:

* update the response code from the default 500 to 200.

#### Testing instructions:
* Do you see the 500 error message on pressable? 
