### PR TITLE
Carousel :  escaping of translated strings

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -216,22 +216,22 @@ class Jetpack_Carousel {
 				'single_image_gallery' => $this->single_image_gallery_enabled,
 				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'     => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
-				'comment'              => __( 'Comment', 'jetpack' ),
-				'post_comment'         => __( 'Post Comment', 'jetpack' ),
-				'write_comment'        => __( 'Write a Comment...', 'jetpack' ),
-				'loading_comments'     => __( 'Loading Comments...', 'jetpack' ),
+				'comment'              => esc_html__( 'Comment', 'jetpack' ),
+				'post_comment'         => esc_html__( 'Post Comment', 'jetpack' ),
+				'write_comment'        => esc_html__( 'Write a Comment...', 'jetpack' ),
+				'loading_comments'     => esc_html__( 'Loading Comments...', 'jetpack' ),
 				'download_original'    => sprintf( __( 'View full size <span class="photo-size">%1$s<span class="photo-size-times">&times;</span>%2$s</span>', 'jetpack' ), '{0}', '{1}' ),
-				'no_comment_text'      => __( 'Please be sure to submit some text with your comment.', 'jetpack' ),
-				'no_comment_email'     => __( 'Please provide an email address to comment.', 'jetpack' ),
-				'no_comment_author'    => __( 'Please provide your name to comment.', 'jetpack' ),
-				'comment_post_error'   => __( 'Sorry, but there was an error posting your comment. Please try again later.', 'jetpack' ),
-				'comment_approved'     => __( 'Your comment was approved.', 'jetpack' ),
-				'comment_unapproved'   => __( 'Your comment is in moderation.', 'jetpack' ),
-				'camera'               => __( 'Camera', 'jetpack' ),
-				'aperture'             => __( 'Aperture', 'jetpack' ),
-				'shutter_speed'        => __( 'Shutter Speed', 'jetpack' ),
-				'focal_length'         => __( 'Focal Length', 'jetpack' ),
-				'copyright'            => __( 'Copyright', 'jetpack' ),
+				'no_comment_text'      => esc_html__( 'Please be sure to submit some text with your comment.', 'jetpack' ),
+				'no_comment_email'     => esc_html__( 'Please provide an email address to comment.', 'jetpack' ),
+				'no_comment_author'    => esc_html__( 'Please provide your name to comment.', 'jetpack' ),
+				'comment_post_error'   => esc_html__( 'Sorry, but there was an error posting your comment. Please try again later.', 'jetpack' ),
+				'comment_approved'     => esc_html__( 'Your comment was approved.', 'jetpack' ),
+				'comment_unapproved'   => esc_html__( 'Your comment is in moderation.', 'jetpack' ),
+				'camera'               => esc_html__( 'Camera', 'jetpack' ),
+				'aperture'             => esc_html__( 'Aperture', 'jetpack' ),
+				'shutter_speed'        => esc_html__( 'Shutter Speed', 'jetpack' ),
+				'focal_length'         => esc_html__( 'Focal Length', 'jetpack' ),
+				'copyright'            => esc_html__( 'Copyright', 'jetpack' ),
 				'comment_registration' => $comment_registration,
 				'require_name_email'   => $require_name_email,
 				/** This action is documented in core/src/wp-includes/link-template.php */
@@ -244,18 +244,18 @@ class Jetpack_Carousel {
 				// We're not using Comments after all, so fallback to standard local comments.
 
 				if ( $is_logged_in ) {
-					$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . sprintf( __( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) . '</p>';
+					$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . sprintf( esc_html__( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) . '</p>';
 				} else {
 					if ( $comment_registration ) {
 						$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . __( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ) . '</p>';
 					} else {
-						$required = ( $require_name_email ) ? __( '%s (Required)', 'jetpack' ) : '%s';
+						$required = ( $require_name_email ) ? esc_html__( '%s (Required)', 'jetpack' ) : '%s';
 						$localize_strings['local_comments_commenting_as'] = ''
-							. '<fieldset><label for="email">' . sprintf( $required, __( 'Email', 'jetpack' ) ) . '</label> '
+							. '<fieldset><label for="email">' . sprintf( $required, esc_html__( 'Email', 'jetpack' ) ) . '</label> '
 							. '<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" /></fieldset>'
-							. '<fieldset><label for="author">' . sprintf( $required, __( 'Name', 'jetpack' ) ) . '</label> '
+							. '<fieldset><label for="author">' . sprintf( $required, esc_html__( 'Name', 'jetpack' ) ) . '</label> '
 							. '<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" /></fieldset>'
-							. '<fieldset><label for="url">' . __( 'Website', 'jetpack' ) . '</label> '
+							. '<fieldset><label for="url">' . esc_html__( 'Website', 'jetpack' ) . '</label> '
 							. '<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" /></fieldset>';
 						}
 				}
@@ -498,7 +498,7 @@ class Jetpack_Carousel {
 		$offset        = ( isset( $_REQUEST['offset'] ) ) ? (int) $_REQUEST['offset'] : 0;
 
 		if ( ! $attachment_id ) {
-			echo json_encode( __( 'Missing attachment ID.', 'jetpack' ) );
+			echo json_encode( esc_html__( 'Missing attachment ID.', 'jetpack' ) );
 			die();
 		}
 
@@ -538,20 +538,20 @@ class Jetpack_Carousel {
 			header('Content-type: text/javascript');
 
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce($_POST['nonce'], 'carousel_nonce') )
-			die( json_encode( array( 'error' => __( 'Nonce verification failed.', 'jetpack' ) ) ) );
+			die( json_encode( array( 'error' => esc_html__( 'Nonce verification failed.', 'jetpack' ) ) ) );
 
 		$_blog_id = (int) $_POST['blog_id'];
 		$_post_id = (int) $_POST['id'];
 		$comment = $_POST['comment'];
 
 		if ( empty( $_blog_id ) )
-			die( json_encode( array( 'error' => __( 'Missing target blog ID.', 'jetpack' ) ) ) );
+			die( json_encode( array( 'error' => esc_html__( 'Missing target blog ID.', 'jetpack' ) ) ) );
 
 		if ( empty( $_post_id ) )
-			die( json_encode( array( 'error' => __( 'Missing target post ID.', 'jetpack' ) ) ) );
+			die( json_encode( array( 'error' => esc_html__( 'Missing target post ID.', 'jetpack' ) ) ) );
 
 		if ( empty( $comment ) )
-			die( json_encode( array( 'error' => __( 'No comment text was submitted.', 'jetpack' ) ) ) );
+			die( json_encode( array( 'error' => esc_html__( 'No comment text was submitted.', 'jetpack' ) ) ) );
 
 		// Used in context like NewDash
 		$switched = false;
@@ -564,32 +564,32 @@ class Jetpack_Carousel {
 		do_action('jp_carousel_check_blog_user_privileges');
 
 		if ( ! comments_open( $_post_id ) )
-			die( json_encode( array( 'error' => __( 'Comments on this post are closed.', 'jetpack' ) ) ) );
+			die( json_encode( array( 'error' => esc_html__( 'Comments on this post are closed.', 'jetpack' ) ) ) );
 
 		if ( is_user_logged_in() ) {
 			$user         = wp_get_current_user();
-			$user_id      = $user->ID;
+			$user_id      = (int) $user->ID;
 			$display_name = $user->display_name;
 			$email        = $user->user_email;
 			$url          = $user->user_url;
 
 			if ( empty( $user_id ) )
-				die( json_encode( array( 'error' => __( 'Sorry, but we could not authenticate your request.', 'jetpack' ) ) ) );
+				die( json_encode( array( 'error' => esc_html__( 'Sorry, but we could not authenticate your request.', 'jetpack' ) ) ) );
 		} else {
 			$user_id      = 0;
 			$display_name = $_POST['author'];
 			$email        = $_POST['email'];
-			$url          = $_POST['url'];
+			$url          = esc_url($_POST['url']);
 
 			if ( get_option( 'require_name_email' ) ) {
 				if ( empty( $display_name ) )
-					die( json_encode( array( 'error' => __( 'Please provide your name.', 'jetpack' ) ) ) );
+					die( json_encode( array( 'error' => esc_html__( 'Please provide your name.', 'jetpack' ) ) ) );
 
 				if ( empty( $email ) )
-					die( json_encode( array( 'error' => __( 'Please provide an email address.', 'jetpack' ) ) ) );
+					die( json_encode( array( 'error' => esc_html__( 'Please provide an email address.', 'jetpack' ) ) ) );
 
 				if ( ! is_email( $email ) )
-					die( json_encode( array( 'error' => __( 'Please provide a valid email address.', 'jetpack' ) ) ) );
+					die( json_encode( array( 'error' => esc_html__( 'Please provide a valid email address.', 'jetpack' ) ) ) );
 			}
 		}
 
@@ -626,17 +626,17 @@ class Jetpack_Carousel {
 	}
 
 	function register_settings() {
-		add_settings_section('carousel_section', __( 'Image Gallery Carousel', 'jetpack' ), array( $this, 'carousel_section_callback' ), 'media');
+		add_settings_section('carousel_section', esc_html__( 'Image Gallery Carousel', 'jetpack' ), array( $this, 'carousel_section_callback' ), 'media');
 
 		if ( ! $this->in_jetpack ) {
-			add_settings_field('carousel_enable_it', __( 'Enable carousel', 'jetpack' ), array( $this, 'carousel_enable_it_callback' ), 'media', 'carousel_section' );
+			add_settings_field('carousel_enable_it', esc_html__( 'Enable carousel', 'jetpack' ), array( $this, 'carousel_enable_it_callback' ), 'media', 'carousel_section' );
 			register_setting( 'media', 'carousel_enable_it', array( $this, 'carousel_enable_it_sanitize' ) );
 		}
 
-		add_settings_field('carousel_background_color', __( 'Background color', 'jetpack' ), array( $this, 'carousel_background_color_callback' ), 'media', 'carousel_section' );
+		add_settings_field('carousel_background_color', esc_html__( 'Background color', 'jetpack' ), array( $this, 'carousel_background_color_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_background_color', array( $this, 'carousel_background_color_sanitize' ) );
 
-		add_settings_field('carousel_display_exif', __( 'Metadata', 'jetpack'), array( $this, 'carousel_display_exif_callback' ), 'media', 'carousel_section' );
+		add_settings_field('carousel_display_exif', esc_html__( 'Metadata', 'jetpack'), array( $this, 'carousel_display_exif_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_display_exif', array( $this, 'carousel_display_exif_sanitize' ) );
 
 		// No geo setting yet, need to "fuzzify" data first, for privacy
@@ -701,7 +701,7 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_display_geo_callback() {
-		$this->settings_checkbox( 'carousel_display_geo', __( 'Show map of photo location in carousel, when available.', 'jetpack' ) );
+		$this->settings_checkbox( 'carousel_display_geo', esc_html__( 'Show map of photo location in carousel, when available.', 'jetpack' ) );
 	}
 
 	function carousel_display_geo_sanitize( $value ) {
@@ -709,7 +709,7 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_background_color_callback() {
-		$this->settings_select( 'carousel_background_color', array( 'black' => __( 'Black', 'jetpack' ), 'white' => __( 'White', 'jetpack', 'jetpack' ) ) );
+		$this->settings_select( 'carousel_background_color', array( 'black' => esc_html__( 'Black', 'jetpack' ), 'white' => esc_html__( 'White', 'jetpack', 'jetpack' ) ) );
 	}
 
 	function carousel_background_color_sanitize( $value ) {
@@ -717,7 +717,7 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_enable_it_callback() {
-		$this->settings_checkbox( 'carousel_enable_it', __( 'Display images in full-size carousel slideshow.', 'jetpack' ) );
+		$this->settings_checkbox( 'carousel_enable_it', esc_html__( 'Display images in full-size carousel slideshow.', 'jetpack' ) );
 	}
 
 	function carousel_enable_it_sanitize( $value ) {


### PR DESCRIPTION
Instead of using the generic __ () function, something like esc_html__() might be more appropriate.
Instead of using the generic _e() function, esc_html_e() would instead be used.

Thanks
