### PR TITLE
Call s.js method from PHP

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -151,12 +151,12 @@ function stats_template_redirect() {
 	}
 
 	// Should we be counting this user's views?
-	// if ( ! empty( $current_user->ID ) ) {
-	// 	$count_roles = stats_get_option( 'count_roles' );
-	// 	if ( ! is_array( $count_roles ) || ! array_intersect( $current_user->roles, $count_roles ) ) {
-	// 		return;
-	// 	}
-	// }
+	 if ( ! empty( $current_user->ID ) ) {
+	 	$count_roles = stats_get_option( 'count_roles' );
+	 	if ( ! is_array( $count_roles ) || ! array_intersect( $current_user->roles, $count_roles ) ) {
+	 		return;
+	 	}
+	 }
 
 	add_action( 'wp_footer', 'stats_footer', 101 );
 	add_action( 'wp_head', 'stats_add_shutdown_action' );
@@ -164,7 +164,6 @@ function stats_template_redirect() {
 	$script = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js';
 	$data = stats_build_view_data();
 	$data_stats_array = stats_array( $data );
-	// $store_stats_script = WC_Stats::getScriptTag();
 
 	$stats_footer = <<<END
 <script type='text/javascript' src='{$script}' async defer></script>
@@ -173,7 +172,6 @@ function stats_template_redirect() {
 	_stq.push([ 'view', {{$data_stats_array}} ]);
 	_stq.push([ 'clickTrackerInit', '{$data['blog']}', '{$data['post']}' ]);
 </script>
-$store_stats_script
 END;
 }
 


### PR DESCRIPTION
This is a pull request onto an ongoing pull request https://github.com/Automattic/jetpack/pull/8123

cc @greenafrican 

### Main Change
Instead of placing information in a javascript object on the page for the Analytics repo to read, call the Analytics methods directly. Reasons for this include:
* Avoid having the analytics library include logic on when to fire an event or not.
* Allow `add-to-cart` events that use an AJAX request to fire an analytics event without a page refresh

### Other Changes
* Add a product page view event on "add-to-cart" from non-product page in addition to `add-to-cart` event.
* Use `add_action( 'woocommerce_add_to_cart' ...)` to capture a product added via a product page.
* Create a `handle_purchase_event` function. (Currently needs work)
* Change the API of the Analytics library from `track` to `push` so it can happen before or after initialization of `s.js`

### Issues
The ajax call to add a product to the cart can come from a cached page. This means any cart information coming from PHP can't be reliable. A cart hash and session id are available via cookies, but information on the contents of the cart aren't not. I see three possible solutions:

1. Fire `add-to-cart` events from PHP and keep track of cart details in session storage. The problem here is cookies such as `tk_rl`, `tk_ro`, `tk_ai` won't be available.
2. Sync cart tables via Jetpack and use cart hashes to match events with cart contents in the Tracks ETL process.
3. Keep cart details in cookies to be retrieved anytime.