### PR TITLE
Sharing : Add wp_sharing_email_send_post_subject filter

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -56,7 +56,7 @@ function sharing_email_send_post( $data ) {
 	 *
 	 * @module sharedaddy
 	 *
-	 * @since 5.7.0
+	 * @since 5.8.0
 	 *
 	 * @param string $var Sharing Email Send Post Subject. Default is "Shared Post".
 	 */

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -51,7 +51,14 @@ function sharing_email_send_post( $data ) {
 	// Make sure to pass the title through the normal sharing filters.
 	$title = $data['sharing_source']->get_share_title( $data['post']->ID );
 
-	$subject = apply_filters('wp_sharing_email_send_post_subject',sprintf(__('Shared Post','jetpack')));
+	/**
+	 * Filter the Sharing Email Send Post Subject.
+	 *
+	 * @module sharedaddy
+	 *
+	 * @param string $var Sharing Email Send Post Subject. Default is "Shared Post".
+	 */
+	$subject = apply_filters( 'wp_sharing_email_send_post_subject', __( 'Shared Post', 'jetpack' ) );
 
 	wp_mail( $data['target'], $subject, $title, $content, $headers );
 }

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -56,6 +56,8 @@ function sharing_email_send_post( $data ) {
 	 *
 	 * @module sharedaddy
 	 *
+	 * @since 5.7.0
+	 *
 	 * @param string $var Sharing Email Send Post Subject. Default is "Shared Post".
 	 */
 	$subject = apply_filters( 'wp_sharing_email_send_post_subject', '[' . __( 'Shared Post', 'jetpack' ) . '] ' );

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -58,7 +58,7 @@ function sharing_email_send_post( $data ) {
 	 *
 	 * @param string $var Sharing Email Send Post Subject. Default is "Shared Post".
 	 */
-	$subject = apply_filters( 'wp_sharing_email_send_post_subject', __( 'Shared Post', 'jetpack' ) );
+	$subject = apply_filters( 'wp_sharing_email_send_post_subject', '[' . __( 'Shared Post', 'jetpack' ) . '] ' );
 
 	wp_mail( $data['target'], $subject, $title, $content, $headers );
 }

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -60,9 +60,9 @@ function sharing_email_send_post( $data ) {
 	 *
 	 * @param string $var Sharing Email Send Post Subject. Default is "Shared Post".
 	 */
-	$subject = apply_filters( 'wp_sharing_email_send_post_subject', '[' . __( 'Shared Post', 'jetpack' ) . '] ' );
+	$subject = apply_filters( 'wp_sharing_email_send_post_subject', '[' . __( 'Shared Post', 'jetpack' ) . '] ' . $title );
 
-	wp_mail( $data['target'], $subject, $title, $content, $headers );
+	wp_mail( $data['target'], $subject, $content, $headers );
 }
 
 

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -51,7 +51,9 @@ function sharing_email_send_post( $data ) {
 	// Make sure to pass the title through the normal sharing filters.
 	$title = $data['sharing_source']->get_share_title( $data['post']->ID );
 
-	wp_mail( $data['target'], '[' . __( 'Shared Post', 'jetpack' ) . '] ' . $title, $content, $headers );
+	$subject = apply_filters('wp_sharing_email_send_post_subject',sprintf(__('Shared Post','jetpack')));
+
+	wp_mail( $data['target'], $subject, $title, $content, $headers );
 }
 
 


### PR DESCRIPTION
Fixes #8165

#### Changes proposed in this Pull Request:

* add wp_sharing_email_send_post_subject  for allow modifying the email share Subject Line

#### Testing instructions:

* 