### PR TITLE
Admin Page: Hide Masterbar toggle for Atomic Sites

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -24,6 +24,7 @@ import CustomContentTypes from './custom-content-types';
 import ThemeEnhancements from './theme-enhancements';
 import PostByEmail from './post-by-email';
 import { Masterbar } from './masterbar';
+import { isAtomicSite } from 'state/initial-state';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -67,7 +68,7 @@ export const Writing = React.createClass( {
 			<div>
 				<QuerySite />
 				{
-					this.props.isModuleFound( 'masterbar' ) && (
+					this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
 						<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
 					)
 				}
@@ -108,6 +109,7 @@ export default connect(
 		return {
 			module: module_name => getModule( state, module_name ),
 			settings: getSettings( state ),
+			masterbarIsAlwaysActive: isAtomicSite( state ),
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 			userCanEditPosts: userCanEditPosts( state ),

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,13 +13,14 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
+import { isAtomicSite } from 'state/initial-state';
 
-export const Masterbar = moduleSettingsForm(
+const MasterbarComponent = moduleSettingsForm(
 	class extends Component {
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
-				isLinked = this.props.isLinked;
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' );
+			const { isAtomicSite, isLinked } = this.props;
 
 			return (
 				<SettingsCard
@@ -29,7 +31,7 @@ export const Masterbar = moduleSettingsForm(
 					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
 						<ModuleToggle
 							slug="masterbar"
-							disabled={ unavailableInDevMode || ! isLinked }
+							disabled={ unavailableInDevMode || ! isLinked || isAtomicSite }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
@@ -61,3 +63,11 @@ export const Masterbar = moduleSettingsForm(
 		}
 	}
 );
+
+export const Masterbar = connect(
+	state => {
+		return {
+			isAtomicSite: isAtomicSite( state ),
+		};
+	}
+)( MasterbarComponent );

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,14 +12,13 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
-import { isAtomicSite } from 'state/initial-state';
 
-const MasterbarComponent = moduleSettingsForm(
+export const Masterbar = moduleSettingsForm(
 	class extends Component {
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' );
-			const { isAtomicSite, isLinked } = this.props;
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
+				isLinked = this.props.isLinked;
 
 			return (
 				<SettingsCard
@@ -31,7 +29,7 @@ const MasterbarComponent = moduleSettingsForm(
 					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
 						<ModuleToggle
 							slug="masterbar"
-							disabled={ unavailableInDevMode || ! isLinked || isAtomicSite }
+							disabled={ unavailableInDevMode || ! isLinked }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
@@ -63,11 +61,3 @@ const MasterbarComponent = moduleSettingsForm(
 		}
 	}
 );
-
-export const Masterbar = connect(
-	state => {
-		return {
-			isAtomicSite: isAtomicSite( state ),
-		};
-	}
-)( MasterbarComponent );


### PR DESCRIPTION
Users of Atomic sites are currently seeing this toggle and being able to interact with it. This results in a weird experience when they try to deactivate the Masterbar as the toggle ends up moving, the page refreshing and the masterbar stays active.

#### Changes proposed in this Pull Request:

* Checks if the site is an atomic site and skips rendering the Masterbar settings card if it's the case.

#### Testing instructions:

* On an atomic site, with Jetpack Beta, check this PR
* Confirm that the card is not shown under the Writing tab. 

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/34258452-c9081e18-e63c-11e7-87df-ea2253444cae.png)

![image](https://user-images.githubusercontent.com/746152/34258468-d85ad41e-e63c-11e7-9290-470fdbb79a80.png)


#### Proposed changelog entry for your changes:

Hide the Master bar settings card for Atomic Sites. 
