### PR TITLE
Use to_array to convert a user to an array; don't just cast it

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
@@ -23,7 +23,7 @@ class Jetpack_JSON_API_Get_User_Backup_Endpoint extends Jetpack_JSON_API_Endpoin
 		}
 
 		return array(
-			'user' => (array)$user,
+			'user' => $user->to_array(),
 			'meta' => get_user_meta( $user->ID ),
 		);
 	}


### PR DESCRIPTION
Fixes User backup endpoint

#### Changes proposed in this Pull Request:
* Use `to_array` instead of array casting to convert WP_User object to an array. It's the correct method, and produces more predictable results.

#### Testing instructions:
* Call the `/user/x/backup` endpoint using a site token.