### PR TITLE
Update footer text for version to make more verbose

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -147,9 +147,9 @@ export const Footer = React.createClass( {
 							target="_blank"
 							rel="noopener noreferrer"
 							className="jp-footer__link"
-							title={ version }
+							title={ __( 'Jetpack version' ) }
 						>
-							{ version }
+							{ __( 'Jetpack version ' ) + version }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">


### PR DESCRIPTION
Makes the version number more explicit on what it is, rather than just showing a random number.  

Before: 
<img width="393" alt="screen shot 2017-12-04 at 10 06 55 am" src="https://user-images.githubusercontent.com/7129409/33562423-ed6b1e1e-d8da-11e7-8713-b503955236b9.png">

After: 
<img width="326" alt="screen shot 2017-12-04 at 10 07 01 am" src="https://user-images.githubusercontent.com/7129409/33562452-f9b98728-d8da-11e7-8488-3cdcf0e45f8d.png">

cc @rickybanister 