### PR TITLE
Plans: Add VIP as a product slug

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1481,6 +1481,7 @@ class Jetpack {
 			'jetpack_business',
 			'jetpack_business_monthly',
 			'business-bundle',
+			'vip',
 		);
 
 		if ( in_array( $plan['product_slug'], $business_plans ) ) {


### PR DESCRIPTION
@nickdaugherty recently created D8621 to fix an issue where the Jetpack search module wasn't showing for VIP clients. After looking into this, I think the ideal solution is to add `vip` to the business plans array.

We broke search for VIP clients in #7950, when we tried to fix an issue where we were trying to make sure that free users didn't see the Jetpack Search module when they couldn't use it since the API would return an error.

