### PR TITLE
Add revisions to Portfolios

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -252,6 +252,7 @@ class Jetpack_Portfolio {
 				'comments',
 				'publicize',
 				'wpcom-markdown',
+				'revisions',
 			),
 			'rewrite' => array(
 				'slug'       => 'portfolio',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* enables revisions for `jetpack-portfolio` post type
* ensures feature parity with r120738-wpcom which is in place for 2 years already

#### Testing instructions:

* make a new post with post type `jetpack-revisions`
* save the draft few times
* confirm you can see revisions in the sidebar, just as you would see for posts or pages

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Added ability to create revisions of Portfolio Projects.