### PR TITLE
Activity Log Card: Update text and feature slug 

### DIFF
--- a/_inc/client/at-a-glance/activity.jsx
+++ b/_inc/client/at-a-glance/activity.jsx
@@ -35,18 +35,25 @@ class DashActivity extends Component {
 		const sitePlan = get( this.props.sitePlan, 'product_slug', 'jetpack_free' );
 		const activityLogLink = <a href={ `https://wordpress.com/stats/activity/${ siteRawUrl }` } />;
 		const hasBackups = includes( [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ], sitePlan );
-		const maybeUpgrade = hasBackups
-			? __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and rewind them if you need to.", {
-				components: {
-					a: activityLogLink
-				}
-			} )
-			: __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and, {{plan}}with a plan{{/plan}}, rewind them if you need to.", {
-				components: {
-					a: activityLogLink,
-					plan: <a href={ `https://jetpack.com/redirect/?source=plans-main-bottom&site=${ siteRawUrl }` } />
-				}
-			} );
+		// const maybeUpgrade = hasBackups
+		// 	? __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and rewind them if you need to.", {
+		// 		components: {
+		// 			a: activityLogLink
+		// 		}
+		// 	} )
+		// 	: __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and, {{plan}}with a plan{{/plan}}, rewind them if you need to.", {
+		// 		components: {
+		// 			a: activityLogLink,
+		// 			plan: <a href={ `https://jetpack.com/redirect/?source=plans-main-bottom&site=${ siteRawUrl }` } />
+		// 		}
+		// 	} );
+
+		// @todo: update this to use rewind text/CTA when available
+		const activityLogOnlyText = __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur.", {
+			components: {
+				a: activityLogLink
+			}
+		} );
 
 		return (
 			<div className="jp-dash-item__interior">
@@ -62,7 +69,7 @@ class DashActivity extends Component {
 						{
 							inDevMode
 								? __( 'Unavailable in Dev Mode.' )
-								: maybeUpgrade
+								: activityLogOnlyText
 						}
 					</p>
 				</DashItem>

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -56,7 +56,6 @@ class AtAGlance extends Component {
 			siteAdminUrl: this.props.siteAdminUrl,
 			siteRawUrl: this.props.siteRawUrl
 		};
-		const isRewindActive = includes( this.props.activeFeatures, 'jetpack-rewind' );
 		const trackSecurityClick = () => analytics.tracks.recordJetpackClick( 'aag_manage_security_wpcom' );
 		const securityHeader = <DashSectionHeader
 					label={ __( 'Security' ) }
@@ -87,8 +86,12 @@ class AtAGlance extends Component {
 			<DashPluginUpdates { ...settingsProps } { ...urls } />
 		];
 
+		// @todo: determine if rewind is active or not rather than just activity log
+		// const isRewindActive = includes( this.props.activeFeatures, 'jetpack-rewind' );
+		const showActivityLogCard = includes( this.props.activeFeatures, 'activity-log' );
+		
 		// Maybe add the activity log card
-		isRewindActive && securityCards.unshift( <DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
+		showActivityLogCard && securityCards.unshift( <DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
 
 		// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
 		if ( this.props.userCanManageModules ) {


### PR DESCRIPTION
<img width="778" alt="screen shot 2017-12-05 at 1 28 56 pm" src="https://user-images.githubusercontent.com/7129409/33626485-568a9934-d9c0-11e7-9678-e055e2fdeea6.png">

Updates the card text to only include mentions of Activity Log with a link to view.  When the wpcom diff is deployed, it will show for any plan.  

It also looks for a different feature slug.
