### PR TITLE
Search: Fix the remove month+year filter link

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1250,7 +1250,7 @@ class Jetpack_Search {
 								     ! empty( $current_month ) && (int) $current_month === $month ) {
 									$active = true;
 
-									$remove_url = remove_query_arg( array( 'monthnum', 'day' ) );
+									$remove_url = remove_query_arg( array( 'year', 'monthnum' ) );
 								}
 
 								break;


### PR DESCRIPTION
When filtering by month+year, such as "December 2017", the remove URL for that filter cleared the month and day, not the month and year.

Fixes #8328.

#### Testing instructions:

1. Enable search beta.
2. Enable Jetpack search filter widget.
3. Enable a month filter using code described here: https://jetpack.com/support/search/customize-search/#basic-facets
4. Search for something on your test site.
5. Click on one of the month filters in the widget.
6. Click the remove filter link for that month.
7. Verify that the year has been removed from the URL.