### PR TITLE
Minify more JS

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -1014,6 +1014,15 @@ class Jetpack_Photon {
 	 * @return null
 	 */
 	public function action_wp_enqueue_scripts() {
-		wp_enqueue_script( 'jetpack-photon', plugins_url( 'modules/photon/photon.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), 20130122, true );
+		wp_enqueue_script(
+			'jetpack-photon',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/photon/photon.min.js',
+				plugins_url( 'modules/photon/photon.js', JETPACK__PLUGIN_FILE )
+			),
+			array( 'jquery' ),
+			20130122,
+			true
+		);
 	}
 }

--- a/class.photon.php
+++ b/class.photon.php
@@ -1018,7 +1018,7 @@ class Jetpack_Photon {
 			'jetpack-photon',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/photon/photon.min.js',
-				plugins_url( 'modules/photon/photon.js', JETPACK__PLUGIN_FILE )
+				'modules/photon/photon.js'
 			),
 			array( 'jquery' ),
 			20130122,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -82,7 +82,8 @@ function onBuild( done ) {
 		const supportedModules = [
 			'shortcodes',
 			'widgets',
-			'after-the-deadline'
+			'after-the-deadline',
+			'widget-visibility'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -88,7 +88,8 @@ function onBuild( done ) {
 			'publicize',
 			'custom-post-types',
 			'sharedaddy',
-			'contact-form'
+			'contact-form',
+			'photon'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -97,7 +97,8 @@ function onBuild( done ) {
 			'minileven',
 			'infinite-scroll',
 			'masterbar',
-			'videopress'
+			'videopress',
+			'comment-likes'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -95,7 +95,8 @@ function onBuild( done ) {
 			'tiled-gallery',
 			'likes',
 			'minileven',
-			'infinite-scroll'
+			'infinite-scroll',
+			'masterbar'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -85,7 +85,8 @@ function onBuild( done ) {
 			'after-the-deadline',
 			'widget-visibility',
 			'custom-css',
-			'publicize'
+			'publicize',
+			'custom-post-types'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -92,7 +92,8 @@ function onBuild( done ) {
 			'photon',
 			'carousel',
 			'related-posts',
-			'tiled-gallery'
+			'tiled-gallery',
+			'likes'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -90,7 +90,8 @@ function onBuild( done ) {
 			'sharedaddy',
 			'contact-form',
 			'photon',
-			'carousel'
+			'carousel',
+			'related-posts'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -98,7 +98,8 @@ function onBuild( done ) {
 			'infinite-scroll',
 			'masterbar',
 			'videopress',
-			'comment-likes'
+			'comment-likes',
+			'lazy-images'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -85,6 +85,7 @@ function onBuild( done ) {
 			'after-the-deadline',
 			'widget-visibility',
 			'custom-css',
+			'publicize'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -80,7 +80,8 @@ function onBuild( done ) {
 		const is_prod = 'production' === process.env.NODE_ENV;
 
 		const supportedModules = [
-			'shortcodes'
+			'shortcodes',
+			'widgets'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -96,7 +96,8 @@ function onBuild( done ) {
 			'likes',
 			'minileven',
 			'infinite-scroll',
-			'masterbar'
+			'masterbar',
+			'videopress'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -91,7 +91,8 @@ function onBuild( done ) {
 			'contact-form',
 			'photon',
 			'carousel',
-			'related-posts'
+			'related-posts',
+			'tiled-gallery'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -83,7 +83,8 @@ function onBuild( done ) {
 			'shortcodes',
 			'widgets',
 			'after-the-deadline',
-			'widget-visibility'
+			'widget-visibility',
+			'custom-css',
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -94,7 +94,8 @@ function onBuild( done ) {
 			'related-posts',
 			'tiled-gallery',
 			'likes',
-			'minileven'
+			'minileven',
+			'infinite-scroll'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -93,7 +93,8 @@ function onBuild( done ) {
 			'carousel',
 			'related-posts',
 			'tiled-gallery',
-			'likes'
+			'likes',
+			'minileven'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -81,7 +81,8 @@ function onBuild( done ) {
 
 		const supportedModules = [
 			'shortcodes',
-			'widgets'
+			'widgets',
+			'after-the-deadline'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -87,7 +87,8 @@ function onBuild( done ) {
 			'custom-css',
 			'publicize',
 			'custom-post-types',
-			'sharedaddy'
+			'sharedaddy',
+			'contact-form'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -86,7 +86,8 @@ function onBuild( done ) {
 			'widget-visibility',
 			'custom-css',
 			'publicize',
-			'custom-post-types'
+			'custom-post-types',
+			'sharedaddy'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -89,7 +89,8 @@ function onBuild( done ) {
 			'custom-post-types',
 			'sharedaddy',
 			'contact-form',
-			'photon'
+			'photon',
+			'carousel'
 		];
 
 		// Source any JS for whitelisted modules, which will minimize us shipping much

--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -200,7 +200,7 @@ function AtD_load_javascripts() {
 			'AtD_core',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/after-the-deadline/atd.core.min.js',
-				plugins_url( '/after-the-deadline/atd.core.js', __FILE__ )
+				'modules/after-the-deadline/atd.core.js'
 			),
 			array(),
 			ATD_VERSION
@@ -209,7 +209,7 @@ function AtD_load_javascripts() {
 			'AtD_quicktags',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/after-the-deadline/atd-nonvis-editor-plugin.min.js',
-				plugins_url( '/after-the-deadline/atd-nonvis-editor-plugin.js', __FILE__ )
+				'modules/after-the-deadline/atd-nonvis-editor-plugin.js'
 			),
 			array('quicktags'),
 			ATD_VERSION
@@ -218,7 +218,7 @@ function AtD_load_javascripts() {
 			'AtD_jquery',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/after-the-deadline/jquery.atd.min.js',
-				plugins_url( '/after-the-deadline/jquery.atd.js', __FILE__ )
+				'modules/after-the-deadline/jquery.atd.js'
 			),
 			array('jquery'),
 			ATD_VERSION
@@ -228,7 +228,7 @@ function AtD_load_javascripts() {
 			'AtD_autoproofread',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/after-the-deadline/atd-autoproofread.min.js',
-				plugins_url( '/after-the-deadline/atd-autoproofread.js', __FILE__ )
+				'modules/after-the-deadline/atd-autoproofread.js'
 			),
 			array('AtD_jquery'),
 			ATD_VERSION

--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -196,11 +196,43 @@ function AtD_settings() {
 
 function AtD_load_javascripts() {
 	if ( AtD_should_load_on_page() ) {
-		wp_enqueue_script( 'AtD_core', plugins_url( '/after-the-deadline/atd.core.js', __FILE__ ), array(), ATD_VERSION );
-		wp_enqueue_script( 'AtD_quicktags', plugins_url( '/after-the-deadline/atd-nonvis-editor-plugin.js', __FILE__ ), array('quicktags'), ATD_VERSION );
-		wp_enqueue_script( 'AtD_jquery', plugins_url( '/after-the-deadline/jquery.atd.js', __FILE__ ), array('jquery'), ATD_VERSION );
+		wp_enqueue_script(
+			'AtD_core',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/after-the-deadline/atd.core.min.js',
+				plugins_url( '/after-the-deadline/atd.core.js', __FILE__ )
+			),
+			array(),
+			ATD_VERSION
+		);
+		wp_enqueue_script(
+			'AtD_quicktags',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/after-the-deadline/atd-nonvis-editor-plugin.min.js',
+				plugins_url( '/after-the-deadline/atd-nonvis-editor-plugin.js', __FILE__ )
+			),
+			array('quicktags'),
+			ATD_VERSION
+		);
+		wp_enqueue_script(
+			'AtD_jquery',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/after-the-deadline/jquery.atd.min.js',
+				plugins_url( '/after-the-deadline/jquery.atd.js', __FILE__ )
+			),
+			array('jquery'),
+			ATD_VERSION
+		);
 		wp_enqueue_script( 'AtD_settings', admin_url() . 'admin-ajax.php?action=atd_settings', array('AtD_jquery'), ATD_VERSION );
-		wp_enqueue_script( 'AtD_autoproofread', plugins_url( '/after-the-deadline/atd-autoproofread.js', __FILE__ ), array('AtD_jquery'), ATD_VERSION );
+		wp_enqueue_script(
+			'AtD_autoproofread',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/after-the-deadline/atd-autoproofread.min.js',
+				plugins_url( '/after-the-deadline/atd-autoproofread.js', __FILE__ )
+			),
+			array('AtD_jquery'),
+			ATD_VERSION
+		);
 
 		/* load localized strings for AtD */
 		wp_localize_script( 'AtD_core', 'AtD_l10n_r0ar', array (

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -197,7 +197,16 @@ class Jetpack_Carousel {
 
 	function enqueue_assets() {
 		if ( $this->first_run ) {
-			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20170209' ), true );
+			wp_enqueue_script(
+				'jetpack-carousel',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/carousel/jetpack-carousel.min.js',
+					plugins_url( 'jetpack-carousel.js', __FILE__ )
+				),
+				array( 'jquery.spin' ),
+				$this->asset_version( '20170209' ),
+				true
+			);
 
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted)
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -201,7 +201,7 @@ class Jetpack_Carousel {
 				'jetpack-carousel',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/carousel/jetpack-carousel.min.js',
-					plugins_url( 'jetpack-carousel.js', __FILE__ )
+					'modules/carousel/jetpack-carousel.js'
 				),
 				array( 'jquery.spin' ),
 				$this->asset_version( '20170209' ),

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -107,7 +107,7 @@ class Jetpack_Comment_Likes {
 			'comment-like-count',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/comment-likes/comment-like-count.min.js',
-				plugins_url( 'comment-likes/comment-like-count.js', __FILE__ )
+				'modules/comment-likes/comment-like-count.js'
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -103,7 +103,15 @@ class Jetpack_Comment_Likes {
 
 	function enqueue_admin_styles_scripts() {
 		wp_enqueue_style( 'comment-like-count', plugins_url( 'comment-likes/admin-style.css', __FILE__ ), array(), JETPACK__VERSION );
-		wp_enqueue_script( 'comment-like-count', plugins_url( 'comment-likes/comment-like-count.js', __FILE__ ), array( 'jquery' ), JETPACK__VERSION );
+		wp_enqueue_script(
+			'comment-like-count',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/comment-likes/comment-like-count.min.js',
+				plugins_url( 'comment-likes/comment-like-count.js', __FILE__ )
+			),
+			array( 'jquery' ),
+			JETPACK__VERSION
+		);
 	}
 
 	public function add_like_count_column( $columns ) {

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -787,7 +787,14 @@ function grunion_enable_spam_recheck() {
 	}
 
 	// Add the scripts that handle the spam check event.
-	wp_register_script( 'grunion-admin', plugin_dir_url( __FILE__ ) . 'js/grunion-admin.js', array( 'jquery' ) );
+	wp_register_script(
+		'grunion-admin',
+		Jetpack::get_file_url_for_environment(
+			'_inc/build/contact-form/js/grunion-admin.min.js',
+			plugin_dir_url( __FILE__ ) . 'js/grunion-admin.js'
+		),
+		array( 'jquery' )
+	);
 	wp_enqueue_script( 'grunion-admin' );
 
 	wp_enqueue_style( 'grunion.css' );

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -791,7 +791,7 @@ function grunion_enable_spam_recheck() {
 		'grunion-admin',
 		Jetpack::get_file_url_for_environment(
 			'_inc/build/contact-form/js/grunion-admin.min.js',
-			plugin_dir_url( __FILE__ ) . 'js/grunion-admin.js'
+			'modules/contact-form/js/grunion-admin.js'
 		),
 		array( 'jquery' )
 	);

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2683,7 +2683,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t\t<input type='text' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
 				$r .= "\t</div>\n";
 
-				wp_enqueue_script( 'grunion-frontend', plugins_url( 'js/grunion-frontend.js', __FILE__ ), array( 'jquery', 'jquery-ui-datepicker' ) );
+				wp_enqueue_script(
+					'grunion-frontend',
+					Jetpack::get_file_url_for_environment(
+						'_inc/build/contact-form/js/grunion-frontend.min.js',
+						plugins_url( 'js/grunion-frontend.js', __FILE__ )
+					),
+					array( 'jquery', 'jquery-ui-datepicker' )
+				);
 				wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( 'css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
 
 				// Using Core's built-in datepicker localization routine

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2687,7 +2687,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 					'grunion-frontend',
 					Jetpack::get_file_url_for_environment(
 						'_inc/build/contact-form/js/grunion-frontend.min.js',
-						plugins_url( 'js/grunion-frontend.js', __FILE__ )
+						'modules/contact-form/js/grunion-frontend.js'
 					),
 					array( 'jquery', 'jquery-ui-datepicker' )
 				);

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -39,7 +39,10 @@ class Grunion_Editor_View {
 	}
 
 	public static function mce_external_plugins( $plugin_array ) {
-		$plugin_array['grunion_form'] =  plugins_url( 'js/tinymce-plugin-form-button.js', __FILE__ );
+		$plugin_array['grunion_form'] = Jetpack::get_file_url_for_environment(
+			'_inc/build/contact-form/js/tinymce-plugin-form-button.min.js',
+			plugins_url( 'js/tinymce-plugin-form-button.js', __FILE__ )
+		);
 		return $plugin_array;
 	}
 
@@ -64,7 +67,16 @@ class Grunion_Editor_View {
 
 		wp_enqueue_style( 'grunion-editor-ui', plugins_url( 'css/editor-ui.css', __FILE__ ) );
 		wp_style_add_data( 'grunion-editor-ui', 'rtl', 'replace' );
-		wp_enqueue_script( 'grunion-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery', 'quicktags' ), false, true );
+		wp_enqueue_script(
+			'grunion-editor-view',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/contact-form/js/editor-view.min.js',
+				plugins_url( 'js/editor-view.js', __FILE__ )
+			),
+			array( 'wp-util', 'jquery', 'quicktags' ),
+			false,
+			true
+		);
 		wp_localize_script( 'grunion-editor-view', 'grunionEditorView', array(
 			'inline_editing_style' => plugins_url( 'css/editor-inline-editing-style.css', __FILE__ ),
 			'inline_editing_style_rtl' => plugins_url( 'css/editor-inline-editing-style-rtl.css', __FILE__ ),

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -41,7 +41,7 @@ class Grunion_Editor_View {
 	public static function mce_external_plugins( $plugin_array ) {
 		$plugin_array['grunion_form'] = Jetpack::get_file_url_for_environment(
 			'_inc/build/contact-form/js/tinymce-plugin-form-button.min.js',
-			plugins_url( 'js/tinymce-plugin-form-button.js', __FILE__ )
+			'modules/contact-form/js/tinymce-plugin-form-button.js'
 		);
 		return $plugin_array;
 	}
@@ -71,7 +71,7 @@ class Grunion_Editor_View {
 			'grunion-editor-view',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/contact-form/js/editor-view.min.js',
-				plugins_url( 'js/editor-view.js', __FILE__ )
+				'modules/contact-form/js/editor-view.js'
 			),
 			array( 'wp-util', 'jquery', 'quicktags' ),
 			false,

--- a/modules/contact-form/grunion-form-view.php
+++ b/modules/contact-form/grunion-form-view.php
@@ -18,7 +18,7 @@ wp_register_script(
 	'grunion',
 	Jetpack::get_file_url_for_environment(
 		'_inc/build/contact-form/js/grunion.min.js',
-		GRUNION_PLUGIN_URL . 'js/grunion.js'
+		'modules/contact-form/js/grunion.js'
 	),
 	array( 'jquery-ui-sortable', 'jquery-ui-draggable' ),
 	JETPACK__VERSION

--- a/modules/contact-form/grunion-form-view.php
+++ b/modules/contact-form/grunion-form-view.php
@@ -14,7 +14,16 @@
  */
 $max_new_fields = apply_filters( 'grunion_max_new_fields', 5 );
 
-wp_register_script( 'grunion', GRUNION_PLUGIN_URL . 'js/grunion.js', array( 'jquery-ui-sortable', 'jquery-ui-draggable' ), JETPACK__VERSION );
+wp_register_script(
+	'grunion',
+	Jetpack::get_file_url_for_environment(
+		'_inc/build/contact-form/js/grunion.min.js',
+		GRUNION_PLUGIN_URL . 'js/grunion.js'
+	),
+	array( 'jquery-ui-sortable', 'jquery-ui-draggable' ),
+	JETPACK__VERSION
+);
+
 wp_localize_script( 'grunion', 'GrunionFB_i18n', array(
 	'nameLabel' => esc_attr( _x( 'Name', 'Label for HTML form "Name" field in contact form builder', 'jetpack' ) ),
 	'emailLabel' => esc_attr( _x( 'Email', 'Label for HTML form "Email" field in contact form builder', 'jetpack' ) ),

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -69,14 +69,14 @@ class Jetpack_Custom_CSS_Enhancements {
 		$deps = array( 'customize-controls', 'underscore' );
 		$src  = Jetpack::get_file_url_for_environment(
 			'_inc/build/custom-css/custom-css/js/core-customizer-css.core-4.9.min.js',
-			plugins_url( 'custom-css/js/core-customizer-css.core-4.9.js', __FILE__ )
+			'modules/custom-css/js/core-customizer-css.core-4.9.js'
 		);
 		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
 			// If Core < 4.9
 			$deps[] = 'jetpack-codemirror';
 			$src = Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/core-customizer-css.min.js',
-				plugins_url( 'custom-css/js/core-customizer-css.js', __FILE__ )
+				'modules/custom-css/js/core-customizer-css.js'
 			);
 		}
 		wp_register_script( 'jetpack-customizer-css', $src, $deps, JETPACK__VERSION, true );
@@ -85,7 +85,7 @@ class Jetpack_Custom_CSS_Enhancements {
 			'jetpack-customizer-css-preview',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/core-customizer-css-preview.min.js',
-				plugins_url( 'custom-css/js/core-customizer-css-preview.js', __FILE__ )
+				'modules/custom-css/js/core-customizer-css-preview.js'
 			),
 			array( 'customize-selective-refresh' ),
 			JETPACK__VERSION,

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -67,15 +67,30 @@ class Jetpack_Custom_CSS_Enhancements {
 		wp_register_style( 'jetpack-customizer-css',  plugins_url( 'custom-css/css/customizer-control.css', __FILE__ ), $deps, '20140728' );
 		wp_register_script( 'jetpack-codemirror',     plugins_url( 'custom-css/js/codemirror.min.js', __FILE__ ), array(), '3.16', true );
 		$deps = array( 'customize-controls', 'underscore' );
-		$src  = plugins_url( 'custom-css/js/core-customizer-css.core-4.9.js', __FILE__ );
+		$src  = Jetpack::get_file_url_for_environment(
+			'_inc/build/custom-css/custom-css/js/core-customizer-css.core-4.9.min.js',
+			plugins_url( 'custom-css/js/core-customizer-css.core-4.9.js', __FILE__ )
+		);
 		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
 			// If Core < 4.9
 			$deps[] = 'jetpack-codemirror';
-			$src = plugins_url( 'custom-css/js/core-customizer-css.js', __FILE__ );
+			$src = Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-css/custom-css/js/core-customizer-css.min.js',
+				plugins_url( 'custom-css/js/core-customizer-css.js', __FILE__ )
+			);
 		}
 		wp_register_script( 'jetpack-customizer-css', $src, $deps, JETPACK__VERSION, true );
 
-		wp_register_script( 'jetpack-customizer-css-preview', plugins_url( 'custom-css/js/core-customizer-css-preview.js', __FILE__ ), array( 'customize-selective-refresh' ), JETPACK__VERSION, true );
+		wp_register_script(
+			'jetpack-customizer-css-preview',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-css/custom-css/js/core-customizer-css-preview.min.js',
+				plugins_url( 'custom-css/js/core-customizer-css-preview.js', __FILE__ )
+			),
+			array( 'customize-selective-refresh' ),
+			JETPACK__VERSION,
+			true
+		);
 
 		remove_action( 'wp_head', 'wp_custom_css_cb', 11 ); // 4.7.0 had it at 11, 4.7.1 moved it to 101.
 		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -69,14 +69,14 @@ class Jetpack_Custom_CSS_Enhancements {
 		$deps = array( 'customize-controls', 'underscore' );
 		$src  = Jetpack::get_file_url_for_environment(
 			'_inc/build/custom-css/custom-css/js/core-customizer-css.core-4.9.min.js',
-			'modules/custom-css/js/core-customizer-css.core-4.9.js'
+			'modules/custom-css/custom-css/js/core-customizer-css.core-4.9.js'
 		);
 		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
 			// If Core < 4.9
 			$deps[] = 'jetpack-codemirror';
 			$src = Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/core-customizer-css.min.js',
-				'modules/custom-css/js/core-customizer-css.js'
+				'modules/custom-css/custom-css/js/core-customizer-css.js'
 			);
 		}
 		wp_register_script( 'jetpack-customizer-css', $src, $deps, JETPACK__VERSION, true );
@@ -85,7 +85,7 @@ class Jetpack_Custom_CSS_Enhancements {
 			'jetpack-customizer-css-preview',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/core-customizer-css-preview.min.js',
-				'modules/custom-css/js/core-customizer-css-preview.js'
+				'modules/custom-css/custom-css/js/core-customizer-css-preview.js'
 			),
 			array( 'customize-selective-refresh' ),
 			JETPACK__VERSION,

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -934,7 +934,7 @@ class Jetpack_Custom_CSS {
 			'custom-css-editor',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/css-editor.min.js',
-				'modules/custom-css/js/css-editor.js'
+				'modules/custom-css/custom-css/js/css-editor.js'
 			),
 			'jquery',
 			'20130325',
@@ -951,7 +951,7 @@ class Jetpack_Custom_CSS {
 				'jetpack-css-use-codemirror',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/custom-css/custom-css/js/use-codemirror.min.js',
-					'modules/custom-css/js/use-codemirror.js'
+					'modules/custom-css/custom-css/js/use-codemirror.js'
 				),
 				array( 'jquery', 'underscore', 'jetpack-css-codemirror' ),
 				'20131009',

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -930,7 +930,16 @@ class Jetpack_Custom_CSS {
 			return;
 
 		wp_enqueue_script( 'postbox' );
-		wp_enqueue_script( 'custom-css-editor', plugins_url( 'custom-css/js/css-editor.js', __FILE__ ), 'jquery', '20130325', true );
+		wp_enqueue_script(
+			'custom-css-editor',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-css/custom-css/js/css-editor.min.js',
+				plugins_url( 'custom-css/js/css-editor.js', __FILE__ )
+			),
+			'jquery',
+			'20130325',
+			true
+		);
 		wp_enqueue_style( 'custom-css-editor', plugins_url( 'custom-css/css/css-editor.css', __FILE__ ) );
 
 		if ( defined( 'SAFECSS_USE_ACE' ) && SAFECSS_USE_ACE ) {
@@ -938,7 +947,16 @@ class Jetpack_Custom_CSS {
 			wp_enqueue_style( 'jetpack-css-use-codemirror', plugins_url( 'custom-css/css/use-codemirror.css', __FILE__ ), array( 'jetpack-css-codemirror' ), '20120905' );
 
 			wp_register_script( 'jetpack-css-codemirror', plugins_url( 'custom-css/js/codemirror.min.js', __FILE__ ), array(), '3.16', true );
-			wp_enqueue_script( 'jetpack-css-use-codemirror', plugins_url( 'custom-css/js/use-codemirror.js', __FILE__ ), array( 'jquery', 'underscore', 'jetpack-css-codemirror' ), '20131009', true );
+			wp_enqueue_script(
+				'jetpack-css-use-codemirror',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/custom-css/custom-css/js/use-codemirror.min.js',
+					plugins_url( 'custom-css/js/use-codemirror.js', __FILE__ )
+				),
+				array( 'jquery', 'underscore', 'jetpack-css-codemirror' ),
+				'20131009',
+				true
+			);
 		}
 	}
 

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -934,7 +934,7 @@ class Jetpack_Custom_CSS {
 			'custom-css-editor',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-css/custom-css/js/css-editor.min.js',
-				plugins_url( 'custom-css/js/css-editor.js', __FILE__ )
+				'modules/custom-css/js/css-editor.js'
 			),
 			'jquery',
 			'20130325',
@@ -951,7 +951,7 @@ class Jetpack_Custom_CSS {
 				'jetpack-css-use-codemirror',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/custom-css/custom-css/js/use-codemirror.min.js',
-					plugins_url( 'custom-css/js/use-codemirror.js', __FILE__ )
+					'modules/custom-css/js/use-codemirror.js'
 				),
 				array( 'jquery', 'underscore', 'jetpack-css-codemirror' ),
 				'20131009',

--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -176,7 +176,14 @@ class Jetpack_Comic {
 		wp_enqueue_style( 'jetpack-comics-style', plugins_url( 'comics/comics.css', __FILE__ ) );
 		wp_style_add_data( 'jetpack-comics-style', 'rtl', 'replace' );
 
-		wp_enqueue_script( 'jetpack-comics', plugins_url( 'comics/comics.js', __FILE__ ), array( 'jquery', 'jquery.spin' ) );
+		wp_enqueue_script(
+			'jetpack-comics',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-post-types/comics/comics.min.js',
+				plugins_url( 'comics/comics.js', __FILE__ )
+			),
+			array( 'jquery', 'jquery.spin' )
+		);
 
 		$options = array(
 			'nonce' => wp_create_nonce( 'jetpack_comic_upload_nonce' ),

--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -180,7 +180,7 @@ class Jetpack_Comic {
 			'jetpack-comics',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-post-types/comics/comics.min.js',
-				plugins_url( 'comics/comics.js', __FILE__ )
+				'modules/custom-post-types/comics/comics.js'
 			),
 			array( 'jquery', 'jquery.spin' )
 		);

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -446,7 +446,7 @@ class Nova_Restaurant {
 			'nova-menu-checkboxes',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-post-types/js/menu-checkboxes.min.js',
-				plugins_url( 'js/menu-checkboxes.js', __FILE__ )
+				'modules/custom-post-types/js/menu-checkboxes.js'
 			),
 			array( 'jquery' ),
 			$this->version,
@@ -623,7 +623,7 @@ class Nova_Restaurant {
 			'nova-drag-drop',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-post-types/js/nova-drag-drop.min.js',
-				plugins_url( 'js/nova-drag-drop.js', __FILE__ )
+				'modules/custom-post-types/js/nova-drag-drop.js'
 			),
 			array( 'jquery-ui-sortable' ),
 			$this->version,
@@ -870,7 +870,7 @@ class Nova_Restaurant {
 			'nova-many-items',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/custom-post-types/js/many-items.min.js',
-				plugins_url( 'js/many-items.js', __FILE__ )
+				'modules/custom-post-types/js/many-items.js'
 			),
 			array( 'jquery' ),
 			$this->version,

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -442,7 +442,16 @@ class Nova_Restaurant {
 
 		$this->setup_menu_item_columns();
 
-		wp_register_script( 'nova-menu-checkboxes', plugins_url( 'js/menu-checkboxes.js', __FILE__ ), array( 'jquery' ), $this->version, true );
+		wp_register_script(
+			'nova-menu-checkboxes',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-post-types/js/menu-checkboxes.min.js',
+				plugins_url( 'js/menu-checkboxes.js', __FILE__ )
+			),
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
 	}
 
 
@@ -610,7 +619,17 @@ class Nova_Restaurant {
 
 		$this->maybe_reorder_menu_items();
 
-		wp_enqueue_script( 'nova-drag-drop', plugins_url( 'js/nova-drag-drop.js', __FILE__ ), array( 'jquery-ui-sortable' ), $this->version, true );
+		wp_enqueue_script(
+			'nova-drag-drop',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-post-types/js/nova-drag-drop.min.js',
+				plugins_url( 'js/nova-drag-drop.js', __FILE__ )
+			),
+			array( 'jquery-ui-sortable' ),
+			$this->version,
+			true
+		);
+
 		wp_localize_script( 'nova-drag-drop', '_novaDragDrop', array(
 			'nonce'       => wp_create_nonce( 'drag-drop-reorder' ),
 			'nonceName'   => 'drag-drop-reorder',
@@ -847,7 +866,16 @@ class Nova_Restaurant {
 	}
 
 	function enqueue_many_items_scripts() {
-		wp_enqueue_script( 'nova-many-items', plugins_url( 'js/many-items.js', __FILE__ ), array( 'jquery' ), $this->version, true );
+		wp_enqueue_script(
+			'nova-many-items',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/custom-post-types/js/many-items.min.js',
+				plugins_url( 'js/many-items.js', __FILE__ )
+			),
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
 	}
 
 	function process_form_request() {

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -410,7 +410,7 @@ class The_Neverending_Home_Page {
 			'the-neverending-homepage',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/infinite-scroll/infinity.min.js',
-				plugins_url( 'infinity.js', __FILE__ )
+				'modules/infinite-scroll/infinity.js'
 			),
 			array( 'jquery' ),
 			'4.0.0',

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -406,7 +406,16 @@ class The_Neverending_Home_Page {
 			return;
 
 		// Add our scripts.
-		wp_register_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), '4.0.0', true );
+		wp_register_script(
+			'the-neverending-homepage',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/infinite-scroll/infinity.min.js',
+				plugins_url( 'infinity.js', __FILE__ )
+			),
+			array( 'jquery' ),
+			'4.0.0',
+			true
+		);
 
 		// Add our default styles.
 		wp_register_style( 'the-neverending-homepage', plugins_url( 'infinity.css', __FILE__ ), array(), '20140422' );

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -171,7 +171,10 @@ class Jetpack_Lazy_Images {
 	public function enqueue_assets() {
 		wp_enqueue_script(
 			'jetpack-lazy-images',
-			plugins_url( 'modules/lazy-images/js/lazy-images.js', JETPACK__PLUGIN_FILE ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/lazy-images/js/lazy-images.min.js',
+				plugins_url( 'modules/lazy-images/js/lazy-images.js', JETPACK__PLUGIN_FILE )
+			),
 			array( 'jquery' ),
 			JETPACK__VERSION,
 			true

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -173,7 +173,7 @@ class Jetpack_Lazy_Images {
 			'jetpack-lazy-images',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/lazy-images/js/lazy-images.min.js',
-				plugins_url( 'modules/lazy-images/js/lazy-images.js', JETPACK__PLUGIN_FILE )
+				'modules/lazy-images/js/lazy-images.js'
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION,

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -300,7 +300,7 @@ class Jetpack_Likes {
 			'jetpack_likes_queuehandler',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/likes/queuehandler.min.js',
-				plugins_url( 'likes/queuehandler.js' , __FILE__ )
+				'modules/likes/queuehandler.js'
 			),
 			array( 'jquery', 'postmessage', 'jetpack_resize' ),
 			JETPACK__VERSION,
@@ -361,7 +361,7 @@ class Jetpack_Likes {
 					'likes-post-count',
 					Jetpack::get_file_url_for_environment(
 						'_inc/build/likes/post-count.min.js',
-						plugins_url( 'modules/likes/post-count.js', dirname( __FILE__ ) )
+						'modules/likes/post-count.js'
 					),
 					array( 'jquery' ),
 					JETPACK__VERSION
@@ -370,9 +370,8 @@ class Jetpack_Likes {
 					'likes-post-count-jetpack',
 					Jetpack::get_file_url_for_environment(
 						'_inc/build/likes/post-count-jetpack.min.js',
-						plugins_url( 'modules/likes/post-count-jetpack.js'
+						'modules/likes/post-count-jetpack.js'
 					),
-					dirname( __FILE__ ) ),
 					array( 'likes-post-count' ),
 					JETPACK__VERSION
 				);

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -296,7 +296,16 @@ class Jetpack_Likes {
 			JETPACK__VERSION,
 			false
 		);
-		wp_register_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
+		wp_register_script(
+			'jetpack_likes_queuehandler',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/likes/queuehandler.min.js',
+				plugins_url( 'likes/queuehandler.js' , __FILE__ )
+			),
+			array( 'jquery', 'postmessage', 'jetpack_resize' ),
+			JETPACK__VERSION,
+			true
+		);
 	}
 
 	/**
@@ -348,8 +357,25 @@ class Jetpack_Likes {
 	function enqueue_admin_scripts() {
 		if ( empty( $_GET['post_type'] ) || 'post' == $_GET['post_type'] || 'page' == $_GET['post_type'] ) {
 			if ( $this->in_jetpack ) {
-				wp_enqueue_script( 'likes-post-count', plugins_url( 'modules/likes/post-count.js', dirname( __FILE__ ) ), array( 'jquery' ), JETPACK__VERSION );
-				wp_enqueue_script( 'likes-post-count-jetpack', plugins_url( 'modules/likes/post-count-jetpack.js', dirname( __FILE__ ) ), array( 'likes-post-count' ), JETPACK__VERSION );
+				wp_enqueue_script(
+					'likes-post-count',
+					Jetpack::get_file_url_for_environment(
+						'_inc/build/likes/post-count.min.js',
+						plugins_url( 'modules/likes/post-count.js', dirname( __FILE__ ) )
+					),
+					array( 'jquery' ),
+					JETPACK__VERSION
+				);
+				wp_enqueue_script(
+					'likes-post-count-jetpack',
+					Jetpack::get_file_url_for_environment(
+						'_inc/build/likes/post-count-jetpack.min.js',
+						plugins_url( 'modules/likes/post-count-jetpack.js'
+					),
+					dirname( __FILE__ ) ),
+					array( 'likes-post-count' ),
+					JETPACK__VERSION
+				);
 			} else {
 				wp_enqueue_script( 'jquery.wpcom-proxy-request', "/wp-content/js/jquery/jquery.wpcom-proxy-request.js", array('jquery'), NULL, true );
 				wp_enqueue_script( 'likes-post-count', plugins_url( 'likes/post-count.js', dirname( __FILE__ ) ), array( 'jquery' ), JETPACK__VERSION );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -142,7 +142,7 @@ class A8C_WPCOM_Masterbar {
 			'a8c_wpcom_masterbar_tracks_events',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/masterbar/tracks-events.min.js',
-				plugins_url( 'tracks-events.js', __FILE__ )
+				'modules/masterbar/tracks-events.js'
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -138,7 +138,15 @@ class A8C_WPCOM_Masterbar {
 			array(),
 			JETPACK__VERSION
 		);
-		wp_enqueue_script( 'a8c_wpcom_masterbar_tracks_events', plugins_url( 'tracks-events.js', __FILE__ ), array( 'jquery' ), JETPACK__VERSION );
+		wp_enqueue_script(
+			'a8c_wpcom_masterbar_tracks_events',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/masterbar/tracks-events.min.js',
+				plugins_url( 'tracks-events.js', __FILE__ )
+			),
+			array( 'jquery' ),
+			JETPACK__VERSION
+		);
 
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
 	}

--- a/modules/minileven/theme/pub/minileven/functions.php
+++ b/modules/minileven/theme/pub/minileven/functions.php
@@ -83,7 +83,7 @@ function minileven_scripts() {
 		'small-menu',
 		Jetpack::get_file_url_for_environment(
 			'_inc/build/minileven/theme/pub/minileven/js/small-menu.min.js',
-			get_template_directory_uri() . '/js/small-menu.js'
+			'modules/minileven/theme/pub/minileven/js/small-menu.js'
 		),
 		array( 'jquery' ),
 		'20120206',

--- a/modules/minileven/theme/pub/minileven/functions.php
+++ b/modules/minileven/theme/pub/minileven/functions.php
@@ -79,7 +79,16 @@ function minileven_scripts() {
 
 	wp_enqueue_style( 'style', get_stylesheet_uri() );
 
-	wp_enqueue_script( 'small-menu', get_template_directory_uri() . '/js/small-menu.js', array( 'jquery' ), '20120206', true );
+	wp_enqueue_script(
+		'small-menu',
+		Jetpack::get_file_url_for_environment(
+			'_inc/build/minileven/theme/pub/minileven/js/small-menu.min.js',
+			get_template_directory_uri() . '/js/small-menu.js'
+		),
+		array( 'jquery' ),
+		'20120206',
+		true
+	);
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -80,7 +80,7 @@ class Publicize_UI {
 			'publicize',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/publicize/assets/publicize.min.js',
-				plugins_url( 'assets/publicize.js', __FILE__ )
+				'modules/publicize/assets/publicize.js'
 			),
 			array( 'jquery', 'thickbox' ),
 			'20121019'

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -78,7 +78,10 @@ class Publicize_UI {
 	function load_assets() {
 		wp_enqueue_script(
 			'publicize',
-			plugins_url( 'assets/publicize.js', __FILE__ ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/publicize/assets/publicize.min.js',
+				plugins_url( 'assets/publicize.js', __FILE__ )
+			),
 			array( 'jquery', 'thickbox' ),
 			'20121019'
 		);

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -235,7 +235,15 @@ class Jetpack_Related_Posts_Customize {
 	 * @since 4.4.0
 	 */
 	function customize_controls_enqueue_scripts() {
-		wp_enqueue_script( 'jetpack_related-posts-customizer', plugins_url( 'related-posts-customizer.js', __FILE__ ), array( 'customize-controls' ), JETPACK__VERSION);
+		wp_enqueue_script(
+			'jetpack_related-posts-customizer',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/related-posts/related-posts-customizer.min.js',
+				plugins_url( 'related-posts-customizer.js', __FILE__ )
+			),
+			array( 'customize-controls' ),
+			JETPACK__VERSION
+		);
 	}
 
 } // class end

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -239,7 +239,7 @@ class Jetpack_Related_Posts_Customize {
 			'jetpack_related-posts-customizer',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/related-posts/related-posts-customizer.min.js',
-				plugins_url( 'related-posts-customizer.js', __FILE__ )
+				'modules/related-posts/related-posts-customizer.js'
 			),
 			array( 'customize-controls' ),
 			JETPACK__VERSION

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1453,7 +1453,7 @@ EOT;
 				'jetpack_related-posts',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/related-posts/related-posts.min.js',
-					plugins_url( 'related-posts.js', __FILE__ )
+					'modules/related-posts/related-posts.js'
 				),
 				$dependencies,
 				self::VERSION

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1449,7 +1449,15 @@ EOT;
 	protected function _enqueue_assets( $script, $style ) {
 		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array( 'jquery' );
 		if ( $script ) {
-			wp_enqueue_script( 'jetpack_related-posts', plugins_url( 'related-posts.js', __FILE__ ), $dependencies, self::VERSION );
+			wp_enqueue_script(
+				'jetpack_related-posts',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/related-posts/related-posts.min.js',
+					plugins_url( 'related-posts.js', __FILE__ )
+				),
+				$dependencies,
+				self::VERSION
+			);
 			$related_posts_js_options = array(
 				/**
 				 * Filter each Related Post Heading structure.

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -795,7 +795,7 @@ function sharing_display( $text = '', $echo = false ) {
 				'sharing-js',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/sharedaddy/sharing.min.js',
-					plugin_dir_url( __FILE__ ).'sharing.js'
+					'modules/sharedaddy/sharing.js'
 				),
 				array( 'jquery' ),
 				$ver

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -791,7 +791,15 @@ function sharing_display( $text = '', $echo = false ) {
 			} else {
 				$ver = '20141212';
 			}
-			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), $ver );
+			wp_register_script(
+				'sharing-js',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/sharedaddy/sharing.min.js',
+					plugin_dir_url( __FILE__ ).'sharing.js'
+				),
+				array( 'jquery' ),
+				$ver
+			);
 
 			// Enqueue scripts for the footer
 			add_action( 'wp_footer', 'sharing_add_footer' );

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -23,7 +23,15 @@ class Sharing_Admin {
 	}
 
 	public function sharing_head() {
-		wp_enqueue_script( 'sharing-js', WP_SHARING_PLUGIN_URL . 'admin-sharing.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ), 2 );
+		wp_enqueue_script(
+			'sharing-js',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/sharedaddy/admin-sharing.min.js',
+				WP_SHARING_PLUGIN_URL . 'admin-sharing.js'
+			),
+			array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
+			2
+		);
 		$postfix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'sharing-admin', WP_SHARING_PLUGIN_URL . 'admin-sharing-rtl' . $postfix . '.css', false, JETPACK__VERSION );
@@ -376,10 +384,10 @@ class Sharing_Admin {
 										$label = $post_type_object->labels->name;
 									}
 								?>
-								<?php 
-								if ( $br ) { 
+								<?php
+								if ( $br ) {
 									echo '<br />';
-								} 
+								}
 								?>
 								<label><input type="checkbox"<?php checked( in_array( $show, $global['show'] ) ); ?> name="show[]" value="<?php echo esc_attr( $show ); ?>" /> <?php echo esc_html( $label ); ?></label>
 								<?php

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -27,7 +27,7 @@ class Sharing_Admin {
 			'sharing-js',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/sharedaddy/admin-sharing.min.js',
-				WP_SHARING_PLUGIN_URL . 'admin-sharing.js'
+				'modules/sharedaddy/admin-sharing.js'
 			),
 			array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
 			2

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -91,7 +91,14 @@ class Jetpack_Tiled_Gallery {
 	}
 
 	public static function default_scripts_and_styles() {
-		wp_enqueue_script( 'tiled-gallery', plugins_url( 'tiled-gallery/tiled-gallery.js', __FILE__ ), array( 'jquery' ) );
+		wp_enqueue_script(
+			'tiled-gallery',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/tiled-gallery/tiled-gallery/tiled-gallery.min.js',
+				plugins_url( 'tiled-gallery/tiled-gallery.js', __FILE__ )
+			),
+			array( 'jquery' )
+		);
 		wp_enqueue_style( 'tiled-gallery', plugins_url( 'tiled-gallery/tiled-gallery.css', __FILE__ ), array(), '2012-09-21' );
 		wp_style_add_data( 'tiled-gallery', 'rtl', 'replace' );
 	}

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -95,7 +95,7 @@ class Jetpack_Tiled_Gallery {
 			'tiled-gallery',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/tiled-gallery/tiled-gallery/tiled-gallery.min.js',
-				plugins_url( 'tiled-gallery/tiled-gallery.js', __FILE__ )
+				'modules/tiled-gallery/tiled-gallery/tiled-gallery.js'
 			),
 			array( 'jquery' )
 		);

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -130,7 +130,10 @@ class Jetpack_VideoPress {
 		if ( $this->should_override_media_uploader() ) {
 			wp_enqueue_script(
 				'videopress-plupload',
-				plugins_url( 'js/videopress-plupload.js', __FILE__ ),
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/videopress/js/videopress-plupload.min.js',
+					plugins_url( 'js/videopress-plupload.js', __FILE__ )
+				),
 				array(
 					'jquery',
 					'wp-plupload'
@@ -140,7 +143,10 @@ class Jetpack_VideoPress {
 
 			wp_enqueue_script(
 				'videopress-uploader',
-				plugins_url( 'js/videopress-uploader.js', __FILE__ ),
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/videopress/js/videopress-uploader.min.js',
+					plugins_url( 'js/videopress-uploader.js', __FILE__ )
+				),
 				array(
 					'videopress-plupload'
 				),
@@ -149,7 +155,10 @@ class Jetpack_VideoPress {
 
 			wp_enqueue_script(
 				'media-video-widget-extensions',
-				plugins_url( 'js/media-video-widget-extensions.js', __FILE__ ),
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/videopress/js/media-video-widget-extensions.min.js',
+					plugins_url( 'js/media-video-widget-extensions.js', __FILE__ )
+				),
 				array(),
 				$this->version,
 				true

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -132,7 +132,7 @@ class Jetpack_VideoPress {
 				'videopress-plupload',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/videopress/js/videopress-plupload.min.js',
-					plugins_url( 'js/videopress-plupload.js', __FILE__ )
+					'modules/videopress/js/videopress-plupload.js'
 				),
 				array(
 					'jquery',
@@ -145,7 +145,7 @@ class Jetpack_VideoPress {
 				'videopress-uploader',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/videopress/js/videopress-uploader.min.js',
-					plugins_url( 'js/videopress-uploader.js', __FILE__ )
+					'modules/videopress/js/videopress-uploader.js'
 				),
 				array(
 					'videopress-plupload'
@@ -157,7 +157,7 @@ class Jetpack_VideoPress {
 				'media-video-widget-extensions',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/videopress/js/media-video-widget-extensions.min.js',
-					plugins_url( 'js/media-video-widget-extensions.js', __FILE__ )
+					'modules/videopress/js/media-video-widget-extensions.js'
 				),
 				array(),
 				$this->version,

--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -17,7 +17,7 @@ function videopress_handle_editor_view_js() {
 		'videopress-editor-view',
 		Jetpack::get_file_url_for_environment(
 			'_inc/build/videopress/js/editor-view.min.js',
-			plugins_url( 'js/editor-view.js', __FILE__ )
+			'modules/videopress/js/editor-view.js'
 		),
 		array( 'wp-util', 'jquery' ),
 		false,

--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -13,7 +13,16 @@ function videopress_handle_editor_view_js() {
 	add_action( 'admin_print_footer_scripts', 'videopress_editor_view_js_templates' );
 
 	wp_enqueue_style( 'videopress-editor-ui', plugins_url( 'css/editor.css', __FILE__ ) );
-	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery' ), false, true );
+	wp_enqueue_script(
+		'videopress-editor-view',
+		Jetpack::get_file_url_for_environment(
+			'_inc/build/videopress/js/editor-view.min.js',
+			plugins_url( 'js/editor-view.js', __FILE__ )
+		),
+		array( 'wp-util', 'jquery' ),
+		false,
+		true
+	);
 	wp_localize_script( 'videopress-editor-view', 'vpEditorView', array(
 		'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),
 		'min_content_width' => VIDEOPRESS_MIN_WIDTH,

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -23,7 +23,16 @@ class Jetpack_Widget_Conditions {
 	public static function widget_admin_setup() {
 		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ) );
 		wp_style_add_data( 'widget-conditions', 'rtl', 'replace' );
-		wp_enqueue_script( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.js', __FILE__ ), array( 'jquery', 'jquery-ui-core' ), 20140721, true );
+		wp_enqueue_script(
+			'widget-conditions',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/widget-visibility/widget-conditions/widget-conditions.min.js',
+				plugins_url( 'widget-conditions/widget-conditions.js', __FILE__ )
+			),
+			array( 'jquery', 'jquery-ui-core' ),
+			20140721,
+			true
+		);
 
 		// Set up a single copy of all of the data that Widget Visibility needs.
 		// This allows all widget conditions to reuse the same data, keeping page size down

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -27,7 +27,7 @@ class Jetpack_Widget_Conditions {
 			'widget-conditions',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/widget-visibility/widget-conditions/widget-conditions.min.js',
-				plugins_url( 'widget-conditions/widget-conditions.js', __FILE__ )
+				'modules/widget-visibility/widget-conditions/widget-conditions.js'
 			),
 			array( 'jquery', 'jquery-ui-core' ),
 			20140721,

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				'contact-info-admin',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/contact-info/contact-info-admin.min.js',
-					plugins_url( 'contact-info/contact-info-admin.js', __FILE__ )
+					'modules/widgets/contact-info/contact-info-admin.js'
 				),
 				array( 'jquery' ),
 				20160727

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -246,7 +246,15 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 */
 		function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
-			wp_enqueue_script( 'contact-info-admin', plugins_url( 'contact-info/contact-info-admin.js', __FILE__ ), array( 'jquery' ), 20160727 );
+			wp_enqueue_script(
+				'contact-info-admin',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/contact-info/contact-info-admin.min.js',
+					plugins_url( 'contact-info/contact-info-admin.js', __FILE__ )
+				),
+				array( 'jquery' ),
+				20160727
+			);
 
 			?>
 			<p>

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -94,7 +94,16 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		 */
 		function enqueue_frontend_scripts() {
 			wp_enqueue_style( 'eu-cookie-law-style', plugins_url( 'eu-cookie-law/style.css', __FILE__ ), array(), '20170403' );
-			wp_enqueue_script( 'eu-cookie-law-script', plugins_url( 'eu-cookie-law/eu-cookie-law.js', __FILE__ ), array( 'jquery' ), '20170404', true );
+			wp_enqueue_script(
+				'eu-cookie-law-script',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/eu-cookie-law/eu-cookie-law.min.js',
+					plugins_url( 'eu-cookie-law/eu-cookie-law.js', __FILE__ )
+				),
+				array( 'jquery' ),
+				'20170404',
+				true
+			);
 		}
 
 		/**

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 				'eu-cookie-law-script',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/eu-cookie-law/eu-cookie-law.min.js',
-					plugins_url( 'eu-cookie-law/eu-cookie-law.js', __FILE__ )
+					'modules/widgets/eu-cookie-law/eu-cookie-law.js'
 				),
 				array( 'jquery' ),
 				'20170404',

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -398,7 +398,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			'gallery-widget',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/widgets/gallery/js/gallery.min.js',
-				plugins_url( '/gallery/js/gallery.js', __FILE__ )
+				'modules/widgets/gallery/js/gallery.js'
 			)
 		);
 

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -394,7 +394,13 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 	}
 
 	public function enqueue_frontend_scripts() {
-		wp_register_script( 'gallery-widget', plugins_url( '/gallery/js/gallery.js', __FILE__ ) );
+		wp_register_script(
+			'gallery-widget',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/widgets/gallery/js/gallery.min.js',
+				plugins_url( '/gallery/js/gallery.js', __FILE__ )
+			)
+		);
 
 		wp_enqueue_script( 'gallery-widget' );
 	}
@@ -405,7 +411,13 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 		if ( 'widgets.php' == $pagenow || 'customize.php' == $pagenow ) {
 			wp_enqueue_media();
 
-			wp_enqueue_script( 'gallery-widget-admin', plugins_url( '/gallery/js/admin.js', __FILE__ ), array(
+			wp_enqueue_script(
+				'gallery-widget-admin',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/gallery/js/admin.min.js',
+					plugins_url( '/gallery/js/admin.js', __FILE__ )
+				),
+				array(
 					'media-models',
 					'media-views'
 				),

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -415,7 +415,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 				'gallery-widget-admin',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/gallery/js/admin.min.js',
-					plugins_url( '/gallery/js/admin.js', __FILE__ )
+					'modules/widgets/gallery/js/admin.js'
 				),
 				array(
 					'media-models',

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -44,7 +44,13 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 	 * Enqueue frontend JS scripts.
 	 */
 	public function enqueue_scripts() {
-		wp_register_script( 'google-translate-init', plugins_url( 'google-translate/google-translate.js', __FILE__ ) );
+		wp_register_script(
+			'google-translate-init',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/widgets/google-translate/google-translate.min.js',
+				plugins_url( 'google-translate/google-translate.js', __FILE__ )
+			)
+		);
 		wp_register_script( 'google-translate', '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit', array( 'google-translate-init' ) );
 		// Admin bar is also displayed on top of the site which causes google translate bar to hide beneath.
 		// This is a hack to show google translate bar a bit lower.

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -48,7 +48,7 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 			'google-translate-init',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/widgets/google-translate/google-translate.min.js',
-				plugins_url( 'google-translate/google-translate.js', __FILE__ )
+				'modules/widgets/google-translate/google-translate.js'
 			)
 		);
 		wp_register_script( 'google-translate', '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit', array( 'google-translate-init' ) );

--- a/modules/widgets/googleplus-badge.php
+++ b/modules/widgets/googleplus-badge.php
@@ -71,7 +71,14 @@ class WPCOM_Widget_GooglePlus_Badge extends WP_Widget {
 		global $pagenow;
 
 		if ( 'widgets.php' == $pagenow || 'customize.php' == $pagenow ) {
-			wp_enqueue_script( 'googleplus-widget-admin', plugins_url( '/google-plus/js/admin.js', __FILE__ ), array( 'jquery' ) );
+			wp_enqueue_script(
+				'googleplus-widget-admin',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/google-plus/js/admin.min.js',
+					plugins_url( '/google-plus/js/admin.js', __FILE__ )
+				),
+				array( 'jquery' )
+			);
 		}
 	}
 

--- a/modules/widgets/googleplus-badge.php
+++ b/modules/widgets/googleplus-badge.php
@@ -75,7 +75,7 @@ class WPCOM_Widget_GooglePlus_Badge extends WP_Widget {
 				'googleplus-widget-admin',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/google-plus/js/admin.min.js',
-					plugins_url( '/google-plus/js/admin.js', __FILE__ )
+					'modules/widgets/google-plus/js/admin.js'
 				),
 				array( 'jquery' )
 			);

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -60,12 +60,30 @@ class Milestone_Widget extends WP_Widget {
 	public static function enqueue_admin( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
 			wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
-			wp_enqueue_script( 'milestone-admin-js', self::$url . 'admin.js', array( 'jquery' ), '20170915', true );
+			wp_enqueue_script(
+				'milestone-admin-js',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/milestone/admin.min.js',
+					self::$url . 'admin.js'
+				),
+				array( 'jquery' ),
+				'20170915',
+				true
+			);
 		}
 	}
 
 	public static function enqueue_template() {
-		wp_enqueue_script( 'milestone', self::$url . 'milestone.js', array( 'jquery' ), '20160520', true );
+		wp_enqueue_script(
+			'milestone',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/widgets/milestone/milestone.min.js',
+				self::$url . 'milestone.js'
+			),
+			array( 'jquery' ),
+			'20160520',
+			true
+		);
 	}
 
 	public static function styles_template() {

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -64,7 +64,7 @@ class Milestone_Widget extends WP_Widget {
 				'milestone-admin-js',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/milestone/admin.min.js',
-					self::$url . 'admin.js'
+					'modules/widgets/milestone/admin.js'
 				),
 				array( 'jquery' ),
 				'20170915',
@@ -78,7 +78,7 @@ class Milestone_Widget extends WP_Widget {
 			'milestone',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/widgets/milestone/milestone.min.js',
-				self::$url . 'milestone.js'
+				'modules/widgets/milestone/milestone.js'
 			),
 			array( 'jquery' ),
 			'20160520',

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -63,7 +63,14 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	public function admin_scripts( $hook ) {
 		// This is still 'widgets.php' when managing widgets via the Customizer.
 		if ( 'widgets.php' === $hook ) {
-			wp_enqueue_script( 'twitter-timeline-admin', plugins_url( 'twitter-timeline-admin.js', __FILE__ ) );
+			wp_enqueue_script(
+				'twitter-timeline-admin',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/twitter-timeline-admin.min.js',
+					plugins_url( 'twitter-timeline-admin.js'
+				),
+				__FILE__ )
+			);
 		}
 	}
 

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -67,9 +67,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				'twitter-timeline-admin',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/widgets/twitter-timeline-admin.min.js',
-					plugins_url( 'twitter-timeline-admin.js'
-				),
-				__FILE__ )
+					'modules/widgets/twitter-timeline-admin.js'
+				)
 			);
 		}
 	}


### PR DESCRIPTION
Minifies javascript for more modules.

Running tally:
- widgets
- AtD
- widget-visibility
- custom-css
- publicize
- custom-post-types
- sharedaddy
- contact-form
- photon
- carousel
- related-posts
- tiled-gallery
- likes
- minileven
- infinite-scroll
- videopress
- comment-likes
- lazy-images

### Results

While it's hard (and not always useful) to generalise regarding performance, on a typical page with a bunch of features enabled - contact form, carousel, related posts, videopress, etc - these changes can shave around 25% off the total javascript payload. 

Most of these files achieved a compression ratio of about 50%. 

To get even better results, we should look at reducing the size of hosted JS, for example removing jQuery from the Likes widget. This would shave another 100kb or so from every (uncached) page load.
