### PR TITLE
Update Calypso theme showcase URLs to /themes

### DIFF
--- a/modules/manage/confirm-admin.php
+++ b/modules/manage/confirm-admin.php
@@ -28,7 +28,7 @@ switch( $section ) {
 		break;
 
 	case 'themes':
-		$link = 'https://wordpress.com/design/' . $normalized_site_url;
+		$link = 'https://wordpress.com/themes/' . $normalized_site_url;
 		$link_title = __( 'Manage Your Themes', 'jetpack' );
 		break;
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -852,7 +852,7 @@ class A8C_WPCOM_Masterbar {
 
 			$theme_title = $this->create_menu_item_pair(
 				array(
-					'url'   => 'https://wordpress.com/design/' . esc_attr( $this->primary_site_slug ),
+					'url'   => 'https://wordpress.com/themes/' . esc_attr( $this->primary_site_slug ),
 					'id'    => 'wp-admin-bar-themes',
 					'label' => esc_html__( 'Themes', 'jetpack' ),
 				),


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/20416 and https://github.com/Automattic/wp-calypso/issues/20617

#### Changes proposed in this Pull Request:

* Change `/design` to `/themes` for Calypso Theme Showcase URLs.

#### Testing instructions:

* Load the branch, check your site's "masterbar" navigation: click "Themes" under Personalize to go to the correct URL.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix WP.com Theme Showcase URLs in toolbar navigation.