### PR TITLE
Lazy Images: Add callback for processing image attributes array

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -51,12 +51,14 @@ class Jetpack_Lazy_Images {
 		add_filter( 'the_content', array( $this, 'add_image_placeholders' ), 99 ); // run this later, so other content filters have run, including image_add_wh on WP.com
 		add_filter( 'post_thumbnail_html', array( $this, 'add_image_placeholders' ), 11 );
 		add_filter( 'get_avatar', array( $this, 'add_image_placeholders' ), 11 );
+		add_filter( 'wp_get_attachment_image_attributes', array( __CLASS__, 'process_image_attributes' ), PHP_INT_MAX );
 	}
 
 	public function remove_filters() {
 		remove_filter( 'the_content', array( $this, 'add_image_placeholders' ), 99 );
 		remove_filter( 'post_thumbnail_html', array( $this, 'add_image_placeholders' ), 11 );
 		remove_filter( 'get_avatar', array( $this, 'add_image_placeholders' ), 11 );
+		remove_filter( 'wp_get_attachment_image_attributes', array( __CLASS__, 'process_image_attributes' ), PHP_INT_MAX );
 	}
 
 	public function add_image_placeholders( $content ) {
@@ -81,6 +83,15 @@ class Jetpack_Lazy_Images {
 		return $content;
 	}
 
+	/**
+	 * Processes images in content by acting as the preg_replace_callback
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param array $matches
+	 *
+	 * @return string The image with updated lazy attributes
+	 */
 	static function process_image( $matches ) {
 		$old_attributes_str = $matches[2];
 		$old_attributes_kses_hair = wp_kses_hair( $old_attributes_str, wp_allowed_protocols() );
@@ -90,22 +101,43 @@ class Jetpack_Lazy_Images {
 		}
 
 		$old_attributes = self::flatten_kses_hair_data( $old_attributes_kses_hair );
-		$new_attributes = $old_attributes;
+		$new_attributes = self::process_image_attributes( $old_attributes );
+		$new_attributes_str = self::build_attributes_string( $new_attributes );
+
+		return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );
+	}
+
+	/**
+	 * Given an array of image attributes, updates the `src`, `srcset`, and `sizes` attributes so
+	 * that they load lazily.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param array $attributes
+	 *
+	 * @return array The updated image attributes array with lazy load attributes
+	 */
+	static function process_image_attributes( $attributes ) {
+		if ( empty( $attributes['src'] ) ) {
+			return $attributes;
+		}
+
+		$old_attributes = $attributes;
 
 		// Set placeholder and lazy-src
-		$new_attributes['src'] = self::get_placeholder_image();
-		$new_attributes['data-lazy-src'] = $old_attributes['src'];
+		$attributes['src'] = self::get_placeholder_image();
+		$attributes['data-lazy-src'] = $old_attributes['src'];
 
 		// Handle `srcset`
-		if ( ! empty( $new_attributes['srcset'] ) ) {
-			$new_attributes['data-lazy-srcset'] = $old_attributes['srcset'];
-			unset( $new_attributes['srcset'] );
+		if ( ! empty( $attributes['srcset'] ) ) {
+			$attributes['data-lazy-srcset'] = $old_attributes['srcset'];
+			unset( $attributes['srcset'] );
 		}
 
 		// Handle `sizes`
-		if ( ! empty( $new_attributes['sizes'] ) ) {
-			$new_attributes['data-lazy-sizes'] = $old_attributes['sizes'];
-			unset( $new_attributes['sizes'] );
+		if ( ! empty( $attributes['sizes'] ) ) {
+			$attributes['data-lazy-sizes'] = $old_attributes['sizes'];
+			unset( $attributes['sizes'] );
 		}
 
 		/**
@@ -113,7 +145,7 @@ class Jetpack_Lazy_Images {
 		 *
 		 * One potential use of this filter is for themes that set `height:auto` on the `img` tag.
 		 * With this filter, the theme could get the width and height attributes from the
-		 * $new_attributes array and then add a style tag that sets those values as well, which could
+		 * $attributes array and then add a style tag that sets those values as well, which could
 		 * minimize reflow as images load.
 		 *
 		 * @module lazy-images
@@ -123,10 +155,7 @@ class Jetpack_Lazy_Images {
 		 * @param array An array containing the attributes for the image, where the key is the attribute name
 		 *              and the value is the attribute value.
 		 */
-		$new_attributes = apply_filters( 'jetpack_lazy_images_new_attributes', $new_attributes );
-		$new_attributes_str = self::build_attributes_string( $new_attributes );
-
-		return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );
+		return apply_filters( 'jetpack_lazy_images_new_attributes', $attributes );
 	}
 
 	private static function get_placeholder_image() {


### PR DESCRIPTION
Fixes #8320

In #8320, @galbaras reported that Lazy Images wasn't working on archive pages in Genesis. He further determined that this is because Genesis uses the `wp_get_attachment_image` function to display images on the archive page. Because of this, we weren't hooking in to lazily load those images.

This PR fixes that by refactoring Lazy Images so that there is a static method to modify an array of image attributes. This method is now called by `Jetpack_Lazy_Images::process_image()`, but it can also be used to handle lazy loading images generated via `wp_get_attachment_image`, since that function sends an array of attributes via the `wp_get_attachment_image_attributes` filter.

To test:

- Test that lazy images continue to load properly on a test site
- `phpunit --filter=WP_Test_Lazy_Images`
- In `wp shell`, run the following and ensure lazy load attributes get added.


```php
add_filter( 'wp_get_attachment_image_attributes', array( 'Jetpack_Lazy_Images', 'process_image_attributes' ), PHP_INT_MAX );
return wp_get_attachment_image( $some_attachment_id_here );
```