### PR TITLE
Pass nojquery to Likes widget

### DIFF
--- a/modules/likes/jetpack-likes-master-iframe.php
+++ b/modules/likes/jetpack-likes-master-iframe.php
@@ -24,7 +24,7 @@ function jetpack_likes_master_iframe() {
 	$likes_locale = ( '' == $_locale || 'en' == $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 
 	$src = sprintf(
-		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s',
+		'https://widgets.wp.com/likes/master.html?nojquery&ver=%1$s#ver=%1$s%2$s',
 		$version,
 		$likes_locale
 	);


### PR DESCRIPTION
*NOTE:* this is not intended to be merged. It's just a way of testing the new Like button implementation.

jQuery is bulky and we don't need it for Likes, particularly when it can't share the local WP jQuery. This branch loads an experimental alternative implementation that doesn't use jQuery.

To test:
- apply D8710-code to your sandbox
- ensure that widgets.wp.com, wordpress.com are both aliased to your sandbox in /etc/hosts
- try loading any page with Likes or Comment Likes enabled
- try in different languages
- try on a page with reblogs enabled
- try on WPCOM too!