### PR TITLE
Widget Visibility - Save button enabled on removal of conditional

### DIFF
--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -116,6 +116,7 @@ jQuery( function( $ ) {
 			$( this ).closest( 'div.widget' ).find( 'a.display-options' ).click();
 			$condition.find( 'select.conditions-rule-major' ).val( '' ).change();
 		} else {
+            $condition.find( 'select.conditions-rule-major' ).change();
 			$condition.detach();
 		}
 

--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -116,7 +116,7 @@ jQuery( function( $ ) {
 			$( this ).closest( 'div.widget' ).find( 'a.display-options' ).click();
 			$condition.find( 'select.conditions-rule-major' ).val( '' ).change();
 		} else {
-            $condition.find( 'select.conditions-rule-major' ).change();
+			$condition.find( 'select.conditions-rule-major' ).change();
 			$condition.detach();
 		}
 


### PR DESCRIPTION
Fixes #8338

#### Changes proposed in this Pull Request:

* Trigger Change event when a Visibility Condition is deleted

#### Testing instructions:

* Create a Widget with 3 visibility conditions and Save
* On created Widget click visibility
* Click "delete" link for 1 of the visibility conditions
* Verify the "Save" button becomes enabled.
* Click "Save"
* Verify the condition was removed from the widget.

