### PR TITLE
Removed styles targeting a .vaultpress selector

### DIFF
--- a/scss/templates/_settings.scss
+++ b/scss/templates/_settings.scss
@@ -149,9 +149,6 @@
 		&.unavailable {
 			opacity: 0.3;
 		}
-		&#vaultpress {
-			opacity: 1;
-		}
 		td .row-actions span a {
 			opacity: 0;
 			&:focus {


### PR DESCRIPTION
Removed styles targeting a .vaultpress selector, as per Issue #8266

Fixes #

#### Changes proposed in this Pull Request:

* Removed styles targeting a .vaultpress selector, as per Issue #8266

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
