### PR TITLE
Search: Improve Faceting Configuration Widget

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -14,10 +14,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		parent::__construct(
 			'jetpack-search-filters',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
-			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Filters', 'jetpack' ) ),
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Facets & Filters', 'jetpack' ) ),
 			array(
 				'classname'   => 'jetpack-filters',
-				'description' => __( 'Displays search result filters when viewing search results.', 'jetpack' ),
+				'description' => __( 'Displays search result faceting and filters when viewing search results.', 'jetpack' ),
 			)
 		);
 	}
@@ -53,23 +53,26 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		$title = $instance['title'];
 
-		if ( empty( $title ) ) {
-			$title = __( 'Filter By', 'jetpack' );
-		}
-
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		if ( !empty( $title ) ) {
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		}
 
 		if ( ! empty( $active_buckets ) ) {
-			echo '<h3>' . esc_html__( 'Current Filters', 'jetpack' ) . '</h3>';
+			//TODO: add config option
+			$current_filters_header = '';
+			if ( !empty( $current_filters_header ) ) {
+				echo '<h4>' . esc_html( $current_filters_header ) . '</h4>';
+			}
 
 			echo '<ul>';
 
 			foreach ( $active_buckets as $item ) {
+				//TODO: add a button with a Genericon close. Similar styling to like buttons
 				echo '<li><a href="' . esc_url( $item['remove_url'] ) . '">' . sprintf( _x( '(X) %1$s: %2$s', 'aggregation widget: active filter type and name', 'jetpack' ), esc_html( $item['type_label'] ), esc_html( $item['name'] ) ) . '</a></li>';
 			}
 
@@ -77,7 +80,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				echo '<li><a href="' . esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ) . '">' . esc_html__( 'Remove All Filters', 'jetpack' ) . '</a></li>';
 			}
 
-			echo '</ul>';
+			echo '</ul><br />';
 		}
 
 		foreach ( $filters as $label => $filter ) {
@@ -85,7 +88,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				continue;
 			}
 
-			echo '<h3>' . esc_html( $label ) . '</h3>';
+			echo '<h4>' . esc_html( $label ) . '</h4>';
 
 			echo '<ul>';
 
@@ -97,7 +100,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				echo '<li><a href="' . esc_url( $item['url'] ) . '">' . esc_html( $item['name'] ) . '</a> (' . number_format_i18n( absint( $item['count'] ) ) . ')</li>';
 			}
 
-			echo '</ul>';
+			echo '</ul><br />';
 		}
 
 		echo $args['after_widget'];


### PR DESCRIPTION
Currently faceting requires both enabling the widget and also adding code that configures the widget. We should make all of the configuration available through the widget customizer code.

Also, there are a number of ways the widget can probably work better in more themes

Proposed Changes:
- Change the name of the widget to mention faceting
- Adjust default titles and sizing
- Change to a button rather than a link for removing filters - should look better
- Adjust the spacing around the headings of each section
- Build UI for configuring common facets: https://jetpack.com/support/search/customize-search/
- Should detect if the site already has that code running
- Should show potential fields to facet on
- Optionally we could add the search box to this widget rather than relying on the separate widget. I think this would make it easier to control the spacing and integrate things like auto correction.

Testing:
- need to test in a bunch of common themes to make sure it looks good
