### PR TITLE
Add wp-cli argument to override user_email for partner-provision

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -4,7 +4,7 @@
 # executes wp-cli command to provision Jetpack site for given partner
 
 usage () {
-	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url]"
+	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--wpcom_user_email=wpcom_user_email] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url]"
 }
 
 GLOBAL_ARGS=""
@@ -21,6 +21,9 @@ for i in "$@"; do
 			shift
 			;;
 		-w=* | --wpcom_user_id=* )  WPCOM_USER_ID="${i#*=}"
+			shift
+			;;
+		-e=* | --wpcom_user_email=* ) WPCOM_USER_EMAIL="${i#*=}"
 			shift
 			;;
 		-p=* | --plan=* )           PLAN_NAME="${i#*=}"
@@ -96,6 +99,10 @@ fi
 
 if [ ! -z "$WPCOM_USER_ID" ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
+fi
+
+if [ ! -z "$WPCOM_USER_EMAIL" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_email=$WPCOM_USER_EMAIL"
 fi
 
 if [ ! -z "$FORCE_REGISTER" ]; then

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -882,7 +882,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : Slug of the requested plan, e.g. premium
 	 * [--wpcom_user_id=<user_id>]
 	 * : WordPress.com ID of user to connect as (must be whitelisted against partner key)
-	 * [--user_email=<user_email>]
+	 * [--wpcom_user_email=<wpcom_user_email>]
 	 * : Override the email we send to WordPress.com for registration
 	 * [--onboarding=<onboarding>]
 	 * : Guide the user through an onboarding wizard
@@ -1014,8 +1014,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 
 		// override email of selected user
-		if ( isset( $named_args['user_email'] ) && ! empty( $named_args['user_email'] ) ) {
-			$request_body['user_email'] = $named_args['user_email'];
+		if ( isset( $named_args['wpcom_user_email'] ) && ! empty( $named_args['wpcom_user_email'] ) ) {
+			$request_body['user_email'] = $named_args['wpcom_user_email'];
 		}
 
 		if ( isset( $named_args['plan'] ) && ! empty( $named_args['plan'] ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -882,6 +882,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : Slug of the requested plan, e.g. premium
 	 * [--wpcom_user_id=<user_id>]
 	 * : WordPress.com ID of user to connect as (must be whitelisted against partner key)
+	 * [--user_email=<user_email>]
+	 * : Override the email we send to WordPress.com for registration
 	 * [--onboarding=<onboarding>]
 	 * : Guide the user through an onboarding wizard
 	 * [--force_register=<register>]
@@ -1009,6 +1011,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 		// optional additional params
 		if ( isset( $named_args['wpcom_user_id'] ) && ! empty( $named_args['wpcom_user_id'] ) ) {
 			$request_body['wpcom_user_id'] = $named_args['wpcom_user_id'];
+		}
+
+		// override email of selected user
+		if ( isset( $named_args['user_email'] ) && ! empty( $named_args['user_email'] ) ) {
+			$request_body['user_email'] = $named_args['user_email'];
 		}
 
 		if ( isset( $named_args['plan'] ) && ! empty( $named_args['plan'] ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -900,7 +900,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>] [--wpcom_user_email=<wpcom_user_email>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;


### PR DESCRIPTION
Overrides the email sent to WPCOM for the "Partner Provision" request. 

For partners that are auto-connecting, this allows them to re-provision with an email that matches an existing account, in case the user didn't want to create a new account or connect to the one that matches their WP user email.