### PR TITLE
Search: Refactors the search module so filters widget can be overridden

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Provides a widget to show available/selected filters on searches
  */
@@ -20,6 +19,9 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				'description' => __( 'Displays search result filters when viewing search results.', 'jetpack' ),
 			)
 		);
+
+		add_action( 'jetpack_search_render_filters_widget_title', array( $this, 'render_widget_title' ), 10, 3 );
+		add_action( 'jetpack_search_render_filters_widget_contents', array( $this, 'render_widget_contents' ), 10, 2 );
 	}
 
 	function widget( $args, $instance ) {
@@ -62,43 +64,31 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		/**
+		 * Responsible for displaying the title of the Jetpack Search filters widget.
+		 *
+		 * @module search
+		 *
+		 * @since 5.7.0
+		 *
+		 * @param string $title                The widget's title
+		 * @param string $args['before_title'] The HTML tag to display before the title
+		 * @param string $args['after_title']  The HTML tag to display after the title
+		 */
+		do_action( 'jetpack_search_render_filters_widget_title', esc_html( $title ), $args['before_title'], $args['after_title'] );
 
-		if ( ! empty( $active_buckets ) ) {
-			echo '<h3>' . esc_html__( 'Current Filters', 'jetpack' ) . '</h3>';
-
-			echo '<ul>';
-
-			foreach ( $active_buckets as $item ) {
-				echo '<li><a href="' . esc_url( $item['remove_url'] ) . '">' . sprintf( _x( '(X) %1$s: %2$s', 'aggregation widget: active filter type and name', 'jetpack' ), esc_html( $item['type_label'] ), esc_html( $item['name'] ) ) . '</a></li>';
-			}
-
-			if ( count( $active_buckets ) > 1 ) {
-				echo '<li><a href="' . esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ) . '">' . esc_html__( 'Remove All Filters', 'jetpack' ) . '</a></li>';
-			}
-
-			echo '</ul>';
-		}
-
-		foreach ( $filters as $label => $filter ) {
-			if ( count( $filter['buckets'] ) < 2 ) {
-				continue;
-			}
-
-			echo '<h3>' . esc_html( $label ) . '</h3>';
-
-			echo '<ul>';
-
-			foreach ( $filter['buckets'] as $item ) {
-				if ( $item['active'] ) {
-					continue;
-				}
-
-				echo '<li><a href="' . esc_url( $item['url'] ) . '">' . esc_html( $item['name'] ) . '</a> (' . number_format_i18n( absint( $item['count'] ) ) . ')</li>';
-			}
-
-			echo '</ul>';
-		}
+		/**
+		 * Responsible for displaying the contents of the Jetpack Search filters widget.
+		 *
+		 * @module search
+		 *
+		 * @since 5.7.0
+		 *
+		 * @param array $filters         The possible filters for the current query
+		 * @param array $active_buckets  The selected filters for the current query
+		 * @param Jetpack_Search $search The Jetpack_Search instance
+		 */
+		do_action( 'jetpack_search_render_filters_widget_contents', $filters, $active_buckets, $search );
 
 		echo $args['after_widget'];
 	}
@@ -123,4 +113,67 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" /></p>
 		<?php
 	}
+
+	function render_widget_contents( $filters, $active_buckets ) {
+		if ( ! empty( $active_buckets ) ) {
+			$this->render_current_filters( $active_buckets );
+		}
+
+		foreach ( $filters as $label => $filter ) {
+			if ( count( $filter['buckets'] ) < 2 ) {
+				continue;
+			}
+
+			$this->render_filter( $label, $filter );
+		}
+	}
+
+	function render_widget_title( $title, $before_title, $after_title ) {
+		echo $before_title . esc_html( $title ) . $after_title;
+	}
+
+	function render_current_filters( $active_buckets ) { ?>
+		<h3><?php echo esc_html__( 'Current Filters', 'jetpack' ); ?></h3>
+		<ul>
+			<?php $this->render_active_buckets( $active_buckets ); ?>
+			<?php if ( count( $active_buckets ) > 1 ) : ?>
+				<li>
+					<a href="<?php esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ); ?>">
+						<?php echo esc_html__( 'x Remove All Filters', 'jetpack' ); ?>
+					</a>
+				</li>
+			<?php endif; ?>
+		</ul>
+	<?php }
+
+	function render_active_buckets( $active_buckets ) {
+		foreach ( $active_buckets as $item ) : ?>
+			<li>
+				<a href="<?php echo esc_url( $item['remove_url'] ); ?>">
+					<?php
+						echo sprintf(
+							_x( '&larr; %1$s: %2$s', 'aggregation widget: active filter type and name', 'jetpack' ),
+							esc_html( $item['type_label'] ),
+							esc_html( $item['name'] )
+						);
+					?>
+				</a>
+			</li>
+		<?php endforeach;
+	}
+
+	function render_filter( $label, $filter ) { ?>
+		<h3><?php echo esc_html( $label ); ?></h3>
+		<ul>
+			<?php foreach ( $filter['buckets'] as $item ) : ?>
+				<li>
+					<a href="<?php echo esc_url( $item['url'] ); ?>">
+						<?php echo esc_html( $item['name'] ); ?>
+					</a>
+
+					(<?php echo number_format_i18n( absint( $item['count'] ) ); ?>)
+				</li>
+			<?php endforeach;?>
+		</ul>
+	<?php }
 }

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -139,7 +139,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			<?php if ( count( $active_buckets ) > 1 ) : ?>
 				<li>
 					<a href="<?php echo esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ); ?>">
-						<?php echo esc_html__( 'x Remove All Filters', 'jetpack' ); ?>
+						<?php echo esc_html__( 'Remove All Filters', 'jetpack' ); ?>
 					</a>
 				</li>
 			<?php endif; ?>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -138,7 +138,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			<?php $this->render_active_buckets( $active_buckets ); ?>
 			<?php if ( count( $active_buckets ) > 1 ) : ?>
 				<li>
-					<a href="<?php esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ); ?>">
+					<a href="<?php echo esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ); ?>">
 						<?php echo esc_html__( 'x Remove All Filters', 'jetpack' ); ?>
 					</a>
 				</li>


### PR DESCRIPTION
This PR refactors the search filters widget so that other plugins/themes can hook in and change its output.

To test:

- You'll need a Jetpack site with a professional plan
- You'll need content with various dates, categories, and tags that has been synced to WordPress.com
- You'll need to manually add a filter(s), which you can find here: https://jetpack.com/support/search/customize-search/
- Go to wp-admin, or the customizer, of your site, and add the Search Filters widget to the sidebar
- Perform a search
- Ensure filters show up