### PR TITLE
Admin: Introduce onboard action

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4033,11 +4033,7 @@ p {
 				}
 				exit;
 			case 'onboard' :
-				$user_can = is_multisite()
-					? current_user_can_for_blog( get_current_blog_id(), 'manage_options' )
-					: current_user_can( 'manage_options' );
-
-				if ( ! $user_can ) {
+				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				} else {
 					$token = Jetpack::create_onboarding_token();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4040,29 +4040,14 @@ p {
 				if ( ! $user_can ) {
 					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				} else {
-					$user = wp_get_current_user();
-					$client_id = $user->user_email;
 					$token = Jetpack::create_onboarding_token();
-
+					$url = $this->build_connect_url( true );
 					$calypso_env = ! empty( $_GET[ 'calypso_env' ] ) ? $_GET[ 'calypso_env' ] : false;
-					$allowed_envs = array(
-						'development',
-						'wpcalypso',
-						'horizon',
-						'stage',
-						'production',
-					);
-					if ( ! in_array( $calypso_env, $allowed_envs, true ) ) {
-						$calypso_env = 'production';
+					if ( $calypso_env ) {
+						$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 					}
-
-					$redirect = add_query_arg( array(
-						'site'         => Jetpack::build_raw_urls( home_url() ),
-						'client_id'   => $client_id,
-						'token'       => $token,
-						'calypso_env' => $calypso_env,
-					), Jetpack::api_url( 'onboard' ) );
-					wp_redirect( $redirect );
+					wp_redirect( $url );
+					exit;
 				}
 				exit;
 			default:

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4032,6 +4032,23 @@ p {
 					wp_safe_redirect( Jetpack::admin_url( array( 'page' => $redirect ) ) );
 				}
 				exit;
+			case 'onboard' :
+				if ( ! current_user_can( 'manage_options' ) ) {
+					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
+				} else {
+					$user = wp_get_current_user();
+					$client_id = $user->user_email;
+					$token = Jetpack::create_onboarding_token();
+					$redirect = add_query_arg( array(
+						'site'         => Jetpack::build_raw_urls( home_url() ),
+						'client_id'   => $client_id,
+						'token'       => $token,
+						// TODO: Remove calypso_env when we enable JPO in Calypso staging
+						'calypso_env' => 'development',
+					), Jetpack::api_url( 'onboard' ) );
+					wp_redirect( $redirect );
+				}
+				exit;
 			default:
 				/**
 				 * Fires when a Jetpack admin page is loaded with an unrecognized parameter.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4036,7 +4036,7 @@ p {
 				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				} else {
-					$token = Jetpack::create_onboarding_token();
+					Jetpack::create_onboarding_token();
 					$url = $this->build_connect_url( true );
 					$calypso_env = ! empty( $_GET[ 'calypso_env' ] ) ? $_GET[ 'calypso_env' ] : false;
 					if ( $calypso_env ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4033,7 +4033,11 @@ p {
 				}
 				exit;
 			case 'onboard' :
-				if ( ! current_user_can( 'manage_options' ) ) {
+				$user_can = is_multisite()
+					? current_user_can_for_blog( get_current_blog_id(), 'manage_options' )
+					: current_user_can( 'manage_options' );
+
+				if ( ! $user_can ) {
 					wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				} else {
 					$user = wp_get_current_user();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4039,12 +4039,24 @@ p {
 					$user = wp_get_current_user();
 					$client_id = $user->user_email;
 					$token = Jetpack::create_onboarding_token();
+
+					$calypso_env = ! empty( $_GET[ 'calypso_env' ] ) ? $_GET[ 'calypso_env' ] : false;
+					$allowed_envs = array(
+						'development',
+						'wpcalypso',
+						'horizon',
+						'stage',
+						'production',
+					);
+					if ( ! in_array( $calypso_env, $allowed_envs, true ) ) {
+						$calypso_env = 'production';
+					}
+
 					$redirect = add_query_arg( array(
 						'site'         => Jetpack::build_raw_urls( home_url() ),
 						'client_id'   => $client_id,
 						'token'       => $token,
-						// TODO: Remove calypso_env when we enable JPO in Calypso staging
-						'calypso_env' => 'development',
+						'calypso_env' => $calypso_env,
 					), Jetpack::api_url( 'onboard' ) );
 					wp_redirect( $redirect );
 				}


### PR DESCRIPTION
This PR introduces an `onboard` action to the admin page. For a user that's logged in and has enough capabilities to manage site options it:

* Generates an onboarding token (if not generated already).
* Is accessible at `/wp-admin/admin.php?page=jetpack&action=onboard`.
* Redirects to Calypso (through the Jetpack Server) with various parameters we'll use for the Jetpack Onboarding flow.
* Allows to specify the Calypso environment by adding a `calypso_env=ENV` parameter.

To test:

Follow the instructions in https://github.com/Automattic/wp-calypso/pull/20821