### PR TITLE
Comments: Ensure all values from the `comment-counts` endpoint are returned as integers.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
@@ -62,13 +62,13 @@ class WPCOM_JSON_API_GET_Comment_Counts_Endpoint extends WPCOM_JSON_API_Endpoint
 		// Keys coming from wp_count_comments don't match the ones that we use in
 		// wp-admin and Calypso and are not consistent. Let's normalize the response.
 		return array(
-			'all'            => $comment_counts['all'],
-			'approved'       => $comment_counts['approved'],
-			'pending'        => $comment_counts['moderated'],
-			'trash'          => $comment_counts['trash'],
-			'spam'           => $comment_counts['spam'],
-			'post_trashed'   => $comment_counts['post-trashed'],
-			'total_comments' => $comment_counts['total_comments']
+			'all'            => (int) $comment_counts['all'],
+			'approved'       => (int) $comment_counts['approved'],
+			'pending'        => (int) $comment_counts['moderated'],
+			'trash'          => (int) $comment_counts['trash'],
+			'spam'           => (int) $comment_counts['spam'],
+			'post_trashed'   => (int) $comment_counts['post-trashed'],
+			'total_comments' => (int) $comment_counts['total_comments']
 		);
 	}
 }


### PR DESCRIPTION
Add integer typecasting to the returned values of `comment-counts`.

<img width="549" alt="screen shot 2017-12-08 at 4 21 27 pm" src="https://user-images.githubusercontent.com/349751/33963319-63b35c50-e009-11e7-926a-a40c88462b0e.png">

_Before_


<img width="550" alt="screen shot 2017-12-08 at 4 14 26 pm" src="https://user-images.githubusercontent.com/349751/33963318-63a10672-e009-11e7-9bc2-5cd4c742ebb7.png">

_After_

Dotcom: D8722-code, r166736-wpcom