### PR TITLE
Carousel: add media modal notice to galleries

### DIFF
--- a/_inc/gallery-settings.js
+++ b/_inc/gallery-settings.js
@@ -5,11 +5,16 @@
 	var media = wp.media;
 
 	// Wrap the render() function to append controls.
+	// If there's some other code extending the Gallery render, let's use that...
+	// Otherwise, just extend the basic Settings render
+	var oldRender = media.view.Settings.Gallery.prototype.render ?
+		media.view.Settings.Gallery.prototype.render :
+		media.view.Settings.prototype.render;
 	media.view.Settings.Gallery = media.view.Settings.Gallery.extend({
 		render: function() {
 			var $el = this.$el;
 
-			media.view.Settings.prototype.render.apply( this, arguments );
+			oldRender.apply( this, arguments );
 
 			// Append the type template and update the settings.
 			$el.append( media.template( 'jetpack-gallery-settings' ) );

--- a/modules/carousel/carousel-media-modal.js
+++ b/modules/carousel/carousel-media-modal.js
@@ -1,0 +1,20 @@
+/* global wp */
+( function( $, wp ) {
+	var media = wp.media;
+
+	// Wrap the render() function to prepend notice.
+	media.view.Settings.Gallery = media.view.Settings.Gallery.extend( {
+		render: function() {
+			var $el = this.$el;
+
+			// This brings in all the default settings not related to carousel.
+			media.view.Settings.prototype.render.apply( this, arguments );
+
+			// Prepend a nice little message about how Carousel works.
+			$el.prepend( media.template( 'jetpack-carousel-media-notice' ) );
+
+			return this;
+		}
+	} );
+
+}( jQuery, wp ) );

--- a/modules/carousel/carousel-media-modal.js
+++ b/modules/carousel/carousel-media-modal.js
@@ -3,12 +3,17 @@
 	var media = wp.media;
 
 	// Wrap the render() function to prepend notice.
+	// If there's some other code extending the Gallery render, let's use that...
+	// Otherwise, just extend the basic Settings render
+	var oldRender = media.view.Settings.Gallery.prototype.render ?
+		media.view.Settings.Gallery.prototype.render :
+		media.view.Settings.prototype.render;
 	media.view.Settings.Gallery = media.view.Settings.Gallery.extend( {
 		render: function() {
 			var $el = this.$el;
 
 			// This brings in all the default settings not related to carousel.
-			media.view.Settings.prototype.render.apply( this, arguments );
+			oldRender.apply( this, arguments );
 
 			// Prepend a nice little message about how Carousel works.
 			$el.prepend( media.template( 'jetpack-carousel-media-notice' ) );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -53,6 +53,10 @@ class Jetpack_Carousel {
 			add_action( 'wp_ajax_nopriv_get_attachment_comments', array( $this, 'get_attachment_comments' ) );
 			add_action( 'wp_ajax_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
 			add_action( 'wp_ajax_nopriv_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
+
+			// Enqueue admin-only scripts
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ), 1 );
+			add_action( 'print_media_templates', array( $this, 'print_carousel_media_template' ) );
 		} else {
 			if ( ! $this->in_jetpack ) {
 				if ( 0 == $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) )
@@ -193,6 +197,24 @@ class Jetpack_Carousel {
 		$this->enqueue_assets();
 
 		return $output;
+	}
+
+	function enqueue_admin_assets() {
+		wp_enqueue_script(
+			'jetpack-carousel',
+			plugins_url( 'modules/carousel/carousel-media-modal.js', JETPACK__PLUGIN_FILE ),
+			array( 'media-views', 'jquery', 'media-widgets' )
+		);
+	}
+
+	function print_carousel_media_template() {
+		?>
+		<script type="text/html" id="tmpl-jetpack-carousel-media-notice">
+			<div style="background-color: white;">
+				Clicking thumbnails will always open a <a href="#">Carousel</a>
+			</div>
+		</script>
+		<?php
 	}
 
 	function enqueue_assets() {


### PR DESCRIPTION
addresses #8332

In progress for now.  It's being written for .com first in D8810-code

- Add or edit a new gallery in post or widget
- Make sure the "Carousel" feature is enabled
- In the "Edit Gallery" modal, you should see a notice at the top right of the settings area.
- You should see this in all gallery modals: widgets & posts