### PR TITLE
Search: First pass at adding working admin UI for filters widget

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 _inc/client/**/test/*.js
 modules/lazy-images/js/lazy-images.js
+modules/search/js/search-widget-filters-admin.js

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -133,18 +133,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			}
 		}
 
-		/**
-		 * Fires after a Jetpack search filters widget is updated.
-		 *
-		 * @module search
-		 *
-		 * @since 5.7.0
-		 *
-		 * @param string $this->id The current widget's ID
-		 * @param array  $filters  The filters for this widget
-		 *
-		 */
-		do_action( 'jetpack_search_widget_filters_updated', $this->id , $filters );
+		if ( ! empty( $filters ) ) {
+			$instance['filters'] = $filters;
+		}
+
+		error_log( print_r( $instance, true ) );
 
 		return $instance;
 	}
@@ -152,11 +145,8 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
 			'title' => '',
+			'filters' => array( array() )
 		) );
-		$instance['filters'] = get_option(
-			Jetpack_Search::get_widget_filters_option_name( $this->id ),
-			array( array() )
-		);
 
 		$title = strip_tags( $instance['title'] );
 		?>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -33,7 +33,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		wp_enqueue_script( 'widget-jetpack-search-filters', plugins_url( 'js/search-widget-filters-admin.js', __FILE__ ), array( 'jquery' ) );
 	}
 
-	function filter_for_widget_id( $item ) {
+	function is_for_current_widget( $item ) {
 		return isset( $item['widget_id'] ) && $this->id == $item['widget_id'];
 	}
 
@@ -44,9 +44,9 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		$search = Jetpack_Search::instance();
 
-		$filters = array_filter( $search->get_filters(), array( $this, 'filter_for_widget_id' ) );
+		$filters = array_filter( $search->get_filters(), array( $this, 'is_for_current_widget' ) );
 
-		$active_buckets = array_filter( $search->get_active_filter_buckets(), array( $this, 'filter_for_widget_id' ) );
+		$active_buckets = array_filter( $search->get_active_filter_buckets(), array( $this, 'is_for_current_widget' ) );
 
 		if ( empty( $filters ) && empty( $active_buckets ) ) {
 			return;

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -133,10 +133,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			}
 		}
 
-		if ( ! empty( $filters ) ) {
-			update_option( Jetpack_Search::get_widget_filters_option_name( $this->id ), $filters );
-		}
-
 		/**
 		 * Fires after a Jetpack search filters widget is updated.
 		 *
@@ -145,9 +141,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		 * @since 5.7.0
 		 *
 		 * @param string $this->id The current widget's ID
+		 * @param array  $filters  The filters for this widget
 		 *
 		 */
-		do_action( 'jetpack_search_widget_filters_updated', $this->id );
+		do_action( 'jetpack_search_widget_filters_updated', $this->id , $filters );
 
 		return $instance;
 	}

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -130,6 +130,15 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 						'count' => intval( $new_instance['num_filters'][ $index ] ),
 					);
 					break;
+				case 'date_histogram':
+					$filters[] = array(
+						'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+						'type' => 'date_histogram',
+						'count' => intval( $new_instance['num_filters'][ $index ] ),
+						'field' => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
+						'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
+					);
+					break;
 			}
 		}
 
@@ -174,6 +183,8 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			'type' => 'taxonomy',
 			'taxonomy' => '',
 			'post_type' => '',
+			'date_histogram_field' => '',
+			'date_histogram_interval' => '',
 			'count' => 10,
 		) );
 
@@ -221,6 +232,43 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 								<?php echo esc_html( $taxonomy->label ); ?>
 							</option>
 						<?php endforeach; ?>
+					</select>
+				</label>
+			</p>
+
+			<p class="jetpack-search-filters-widget__date-histogram-select">
+				<label>
+					<?php esc_html_e( 'Choose a field:', 'jetpack' ); ?>
+					<select name="<?php echo esc_attr( $this->get_field_name( 'date_histogram_field' ) ); ?>[]" class="widefat">
+						<option value="post_date" <?php selected( 'post_date', $args['date_histogram_field'] ); ?>>
+							<?php esc_html_e( 'Date', 'jetpack' ); ?>
+						</option>
+						<option value="post_date_gmt" <?php selected( 'post_date_gmt', $args['date_histogram_field'] ); ?>>
+							<?php esc_html_e( 'Date GMT', 'jetpack' ); ?>
+						</option>
+						<option value="post_modified" <?php selected( 'post_modified', $args['date_histogram_field'] ); ?>>
+							<?php esc_html_e( 'Modified', 'jetpack' ); ?>
+						</option>
+						<option value="post_modified" <?php selected( 'post_modified_gmt', $args['date_histogram_field'] ); ?>>
+							<?php esc_html_e( 'Modified GMT', 'jetpack' ); ?>
+						</option>
+					</select>
+				</label>
+			</p>
+
+			<p class="jetpack-search-filters-widget__date-histogram-select">
+				<label>
+					<?php esc_html_e( 'Choose an interval:' ); ?>
+					<select name="<?php echo esc_attr( $this->get_field_name( 'date_histogram_interval' ) ); ?>[]" class="widefat">
+					<option value="day" <?php selected( 'day', $args['date_histogram_interval'] ); ?>>
+							<?php esc_html_e( 'Day', 'jetpack' ); ?>
+						</option>
+						<option value="month" <?php selected( 'month', $args['date_histogram_interval'] ); ?>>
+							<?php esc_html_e( 'Month', 'jetpack' ); ?>
+						</option>
+						<option value="year" <?php selected( 'year', $args['date_histogram_interval'] ); ?>>
+							<?php esc_html_e( 'Year', 'jetpack' ); ?>
+						</option>
 					</select>
 				</label>
 			</p>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -137,8 +137,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			$instance['filters'] = $filters;
 		}
 
-		error_log( print_r( $instance, true ) );
-
 		return $instance;
 	}
 

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -220,7 +220,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 							</option>
 						<?php endforeach; ?>
 					</select>
-				</select>
 				</label>
 			</p>
 

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -123,7 +123,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 					$filters[] = array(
 						'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 						'type' => 'post_type',
-						'post_type' => sanitize_key( $new_instance['post_type'][ $index ] ),
 						'count' => intval( $new_instance['num_filters'][ $index ] ),
 					);
 					break;

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -225,19 +225,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				</label>
 			</p>
 
-			<p class="jetpack-search-filters-widget__post-type-select">
-				<label>
-					<?php esc_html_e( 'Choose a post type:', 'jetpack' ); ?>
-					<select name="<?php echo esc_attr( $this->get_field_name( 'post_type' ) ); ?>[]" class="widefat">
-						<?php foreach ( get_post_types( false, 'objects' ) as $post_type ) : ?>
-							<option value="<?php echo esc_attr( $post_type->name ); ?>" <?php selected( $post_type->name, $args['post_type'] ); ?>>
-								<?php echo esc_html( $post_type->label ); ?>
-							</option>
-						<?php endforeach; ?>
-					</select>
-				</label>
-			</p>
-
 			<p>
 				<label>
 					<?php esc_html_e( 'Number of filters to display:', 'jetpack' ); ?>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -260,9 +260,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				<label>
 					<?php esc_html_e( 'Choose an interval:' ); ?>
 					<select name="<?php echo esc_attr( $this->get_field_name( 'date_histogram_interval' ) ); ?>[]" class="widefat">
-					<option value="day" <?php selected( 'day', $args['date_histogram_interval'] ); ?>>
-							<?php esc_html_e( 'Day', 'jetpack' ); ?>
-						</option>
 						<option value="month" <?php selected( 'month', $args['date_histogram_interval'] ); ?>>
 							<?php esc_html_e( 'Month', 'jetpack' ); ?>
 						</option>

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1041,9 +1041,9 @@ class Jetpack_Search {
 	 * @param array $aggregations Array of filters (aggregations) to apply to the search
 	 */
 	public function set_filters( array $aggregations ) {
-		foreach ( (array) $aggregations as $key => &$agg ) {
+		foreach ( (array) $aggregations as $key => $agg ) {
 			if ( empty( $agg['name'] ) ) {
-				$agg['name'] = $key;
+				$aggregations[ $key ]['name'] = $key;
 			}
 		}
 		$this->aggregations = $aggregations;

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -96,10 +96,6 @@ class Jetpack_Search {
 
 			add_action( 'did_jetpack_search_query', array( $this, 'store_query_success' ) );
 			add_action( 'failed_jetpack_search_query', array( $this, 'store_query_failure' ) );
-
-			// add_action( 'init', array( $this, 'set_filters_from_widget' ) );
-			add_action( 'wp_register_sidebar_widget', array( $this, 'set_filters_from_widget' ) );
-			add_filter( 'widget_update_callback', array( $this, 'widget_update' ), 10, 3 );
 		}
 	}
 
@@ -127,16 +123,6 @@ class Jetpack_Search {
 		if ( $this->last_query_info ) {
 			echo '<!-- Jetpack Search took ' . intval( $this->last_query_info['elapsed_time'] ) . ' ms, ES time ' . $this->last_query_info['es_time'] . ' ms -->';
 		}
-	}
-
-	public function set_filters_from_widget( $widget ) {
-		// error_log( wp_json_encode( $widget ) );
-	}
-
-	public function widget_update( $instance, $new_instance, $old_instance ) {
-		error_log( print_r( $new_instance, true ) );
-
-		return $instance;
 	}
 
 	/*

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -140,6 +140,15 @@ class Jetpack_Search {
 		}
 	}
 
+	/**
+	 * When a Jetpack Search Filters widget is updated, stash the widget ID in an option
+	 * for easy retrieval later by this class.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param string $widget_id The widget ID
+	 * @return void
+	 */
 	function handle_filters_widget_update( $widget_id ) {
 		$widgets = get_option( self::KNOWN_WIDGETS_OPTION_NAME, array() );
 		if ( ! in_array( $widget_id, $widgets ) ) {
@@ -148,6 +157,14 @@ class Jetpack_Search {
 		}
 	}
 
+	/**
+	 * Retrives a list of known Jetpack search filters widget IDs, gets the filters for each widget,
+	 * and applies those filters to this Jetpack_Search object.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @return void
+	 */
 	function set_filters_from_widgets() {
 		$widget_ids = get_option( self::KNOWN_WIDGETS_OPTION_NAME, array() );
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -101,7 +101,7 @@ class Jetpack_Search {
 	public function init_hooks() {
 		add_action( 'widgets_init', array( $this, 'action__widgets_init' ) );
 		add_action( 'delete_widget', array( $this, 'handle_widget_deletion' ), 10, 3 );
-		add_action( 'jetpack_search_widget_filters_updated', array( $this, 'handle_filters_widget_update' ) );
+		add_action( 'jetpack_search_widget_filters_updated', array( $this, 'handle_filters_widget_update' ), 10, 2 );
 
 		if ( ! is_admin() ) {
 			add_filter( 'posts_pre_query', array( $this, 'filter__posts_pre_query' ), 10, 2 );
@@ -161,6 +161,8 @@ class Jetpack_Search {
 			unset( $widgets[ $key ] );
 			update_option( self::KNOWN_WIDGETS_OPTION_NAME, $widgets );
 		}
+
+		delete_option( self::get_widget_filters_option_name( $widget_id ) );
 	}
 
 	/**
@@ -172,12 +174,14 @@ class Jetpack_Search {
 	 * @param string $widget_id The widget ID
 	 * @return void
 	 */
-	function handle_filters_widget_update( $widget_id ) {
+	function handle_filters_widget_update( $widget_id, $filters ) {
 		$widgets = get_option( self::KNOWN_WIDGETS_OPTION_NAME, array() );
 		if ( ! in_array( $widget_id, $widgets ) ) {
 			$widgets[] = $widget_id;
 			update_option( self::KNOWN_WIDGETS_OPTION_NAME, $widgets );
 		}
+
+		update_option( self::get_widget_filters_option_name( $widget_id ), $filters );
 	}
 
 	/**

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -100,6 +100,7 @@ class Jetpack_Search {
 	 */
 	public function init_hooks() {
 		add_action( 'widgets_init', array( $this, 'action__widgets_init' ) );
+		add_action( 'delete_widget', array( $this, 'handle_widget_deletion' ), 10, 3 );
 		add_action( 'jetpack_search_widget_filters_updated', array( $this, 'handle_filters_widget_update' ) );
 
 		if ( ! is_admin() ) {
@@ -137,6 +138,28 @@ class Jetpack_Search {
 	public function print_query_success() {
 		if ( $this->last_query_info ) {
 			echo '<!-- Jetpack Search took ' . intval( $this->last_query_info['elapsed_time'] ) . ' ms, ES time ' . $this->last_query_info['es_time'] . ' ms -->';
+		}
+	}
+
+	/**
+	 * When a Jetpack Search Filters widget is deleted, this method handles removing the
+	 * widget ID from the known widgets list.
+	 *
+	 * @param string $widget_id
+	 * @param string $sidebar_id
+	 * @param string $id_base
+	 * @return void
+	 */
+	function handle_widget_deletion( $widget_id, $sidebar_id, $id_base ) {
+		if ( 'jetpack-search-filters' != $id_base ) {
+			return;
+		}
+
+		$widgets = get_option( self::KNOWN_WIDGETS_OPTION_NAME, array() );
+		$key = array_search( $widget_id, $widgets );
+		if ( false !== $key ) {
+			unset( $widgets[ $key ] );
+			update_option( self::KNOWN_WIDGETS_OPTION_NAME, $widgets );
 		}
 	}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -96,6 +96,10 @@ class Jetpack_Search {
 
 			add_action( 'did_jetpack_search_query', array( $this, 'store_query_success' ) );
 			add_action( 'failed_jetpack_search_query', array( $this, 'store_query_failure' ) );
+
+			// add_action( 'init', array( $this, 'set_filters_from_widget' ) );
+			add_action( 'wp_register_sidebar_widget', array( $this, 'set_filters_from_widget' ) );
+			add_filter( 'widget_update_callback', array( $this, 'widget_update' ), 10, 3 );
 		}
 	}
 
@@ -123,6 +127,16 @@ class Jetpack_Search {
 		if ( $this->last_query_info ) {
 			echo '<!-- Jetpack Search took ' . intval( $this->last_query_info['elapsed_time'] ) . ' ms, ES time ' . $this->last_query_info['es_time'] . ' ms -->';
 		}
+	}
+
+	public function set_filters_from_widget( $widget ) {
+		// error_log( wp_json_encode( $widget ) );
+	}
+
+	public function widget_update( $instance, $new_instance, $old_instance ) {
+		error_log( print_r( $new_instance, true ) );
+
+		return $instance;
 	}
 
 	/*

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -28,10 +28,6 @@
 }
 
 /* When post type is selected, remove the other controls */
-.jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__post-type-select {
-	display: inline;
-}
-
 .jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__taxonomy-select {
 	display: none;
 }

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -31,3 +31,8 @@
 .jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__taxonomy-select {
 	display: none;
 }
+
+/* When date is selected, remove the other controls */
+.jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__taxonomy-select {
+	display: none;
+}

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -1,0 +1,37 @@
+.jetpack-search-filters-widget__filter {
+	background: #f9f9f9;
+	border: 1px solid #dfdfdf;
+	padding: 0 12px;
+	margin-bottom: 12px;
+}
+
+.jetpack-search-filters-widget__controls {
+	text-align: right;
+}
+
+.jetpack-search-filters-widget__controls .delete {
+	color: #a00;
+}
+
+/* If there's only one filter, do not show the control to delete it */
+.jetpack-search-filters-widget__filter:only-of-type .jetpack-search-filters-widget__controls .delete {
+	display: none;
+}
+
+.jetpack-search-filters-widget__filter:only-of-type .jetpack-search-filters-widget__controls .control-separator {
+	display: none;
+}
+
+/* Assume that taxonomy select is the default selected. Other controls should be hidden here. */
+.jetpack-search-filters-widget__post-type-select {
+	display: none;
+}
+
+/* When post type is selected, remove the other controls */
+.jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__post-type-select {
+	display: inline;
+}
+
+.jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__taxonomy-select {
+	display: none;
+}

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -27,12 +27,20 @@
 	display: none;
 }
 
+.jetpack-search-filters-widget__date-histogram-select {
+	display: none;
+}
+
 /* When post type is selected, remove the other controls */
 .jetpack-search-filters-widget__filter.is-post_type .jetpack-search-filters-widget__taxonomy-select {
 	display: none;
 }
 
 /* When date is selected, remove the other controls */
+.jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__date-histogram-select {
+	display: inline;
+}
+
 .jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__taxonomy-select {
 	display: none;
 }

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -1,5 +1,5 @@
 ( function( $ ) {
-	$( document ).ready( function() {
+	var setListeners = function() {
 		var widget = $( '.jetpack-search-filters-widget' );
 
 		widget.on( 'change', '.filter-select', function() {
@@ -30,5 +30,18 @@
 			e.preventDefault();
 			$( this ).closest( '.jetpack-search-filters-widget__filter' ).remove();
 		} );
+	};
+
+	$( document ).ready( function() {
+		setListeners();
+	} );
+
+	// When widgets are updated, remove and re-add listeners
+	$( document ).on( 'widget-updated', function() {
+		var widget = $( '.jetpack-search-filters-widget' );
+		widget.off( 'change', '.filter-select' );
+		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );
+		widget.off( 'click', '.jetpack-search-filters-widget__controls .delete' );
+		setListeners();
 	} );
 } )( jQuery );

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -1,0 +1,34 @@
+( function( $ ) {
+	$( document ).ready( function() {
+		var widget = $( '.jetpack-search-filters-widget' );
+
+		widget.on( 'change', '.filter-select', function() {
+			var select = $( this ),
+				selectVal = select.val();
+
+			select
+				.closest( '.jetpack-search-filters-widget__filter' )
+				.attr( 'class', 'jetpack-search-filters-widget__filter' )
+				.addClass( 'is-' + selectVal );
+		} );
+
+		widget.on( 'click', '.jetpack-search-filters-widget__controls .add', function( e ) {
+			e.preventDefault();
+			var closest = $( this ).closest( '.jetpack-search-filters-widget__filter' ),
+				clone = closest
+					.clone()
+					.attr( 'class', 'jetpack-search-filters-widget__filter' );
+
+			clone.find( 'input[type="number"]' ).val( 10 );
+			clone.find( 'input[type="text"]' ).val( '' );
+			clone.find( 'select option:first-child' ).attr( 'selected', 'selected' );
+
+			clone.insertAfter( closest );
+		} );
+
+		widget.on( 'click', '.jetpack-search-filters-widget__controls .delete', function( e ) {
+			e.preventDefault();
+			$( this ).closest( '.jetpack-search-filters-widget__filter' ).remove();
+		} );
+	} );
+} )( jQuery );

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -37,7 +37,7 @@
 	} );
 
 	// When widgets are updated, remove and re-add listeners
-	$( document ).on( 'widget-updated', function() {
+	$( document ).on( 'widget-updated widget-added', function() {
 		var widget = $( '.jetpack-search-filters-widget' );
 		widget.off( 'change', '.filter-select' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );


### PR DESCRIPTION
This is a rough first pass at adding UI to the search filters widget so that users can add filters without having to write code.

At this point, the UI is mostly functional for post types and taxonomies. You should be able to add one of those. Then, if you save and refresh, your choice should show again.

Known issues:

- Customizer preview is not great. User has to refresh page to get widget filters added to search

To test:

- Setup a Jetpack site with a professional plan
- Turn on the search module
- Go to the widget administration page
- Add the Jetpack search filters widget
- Tinker with UI 
- Set different filters and ensure the filters are applied on the frontend after performing a search