### PR TITLE
Related Posts: add docblock to existing filter

### DIFF
--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -156,6 +156,13 @@ class Jetpack_Related_Posts_Customize {
 			restore_previous_locale();
 		}
 
+		/**
+		 * Filter that is used to customize related posts option.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param mixed array post customize option.
+		 */
 		return apply_filters(
 			'jetpack_related_posts_customize_options', array(
 				'enabled'       => array(

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -157,11 +157,13 @@ class Jetpack_Related_Posts_Customize {
 		}
 
 		/**
-		 * Filter that is used to customize related posts option.
+		 * The filter allows you to change the options used to display Related Posts in the Customizer.
+		 *
+		 * @module related-posts
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param mixed array post customize option.
+		 * @param array $options Array of options used to display Related Posts in the Customizer.
 		 */
 		return apply_filters(
 			'jetpack_related_posts_customize_options', array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Comment is not write on "jetpack_related_posts_customize_options filter" in class.ralated-posts-customize.php file so I add comment. 

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
