### PR TITLE
Update Goodreads URL for HTTPS support

### DIFF
--- a/modules/widgets/goodreads.php
+++ b/modules/widgets/goodreads.php
@@ -59,7 +59,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 				echo '<p>' . sprintf(
 					__( 'You need to enter your numeric user ID for the <a href="%1$s">Goodreads Widget</a> to work correctly. <a href="%2$s" target="_blank">Full instructions</a>.', 'jetpack' ),
 					esc_url( admin_url( 'widgets.php' ) ),
-					'http://support.wordpress.com/widgets/goodreads-widget/#goodreads-user-id'
+					'https://support.wordpress.com/widgets/goodreads-widget/#goodreads-user-id'
 				) . '</p>';
 				echo $args['after_widget'];
 			}
@@ -88,12 +88,13 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 	}
 
 	function goodreads_user_id_exists( $user_id ) {
-		$url = "http://www.goodreads.com/user/show/$user_id/";
-		$response = wp_remote_head( $url, array( 'httpversion'=>'1.1', 'timeout'=>3, 'redirection'=> 2 ) );
-		if ( wp_remote_retrieve_response_code( $response ) === 200 )
+		$url = "https://www.goodreads.com/user/show/$user_id/";
+		$response = wp_remote_head( $url, array( 'httpversion' => '1.1', 'timeout' => 3, 'redirection' => 2 ) );
+		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
 			return true;
-		else
+		} else {
 			return false;
+		}
 	}
 
 	function update( $new_instance, $old_instance ) {


### PR DESCRIPTION
See 7920-wpcom patch ready for commit on WP.com side.

#### Changes proposed in this Pull Request:

* Update WP.com support link to support HTTPS
* Update Goodreads URLs to support HTTPS

#### Testing instructions:

* Add the widget to a sidebar, test with an author ID like `68367616` [Author page](https://www.goodreads.com/author/show/8071273.Joanna_Kafarowskil)
* Test also with a normal, non-author user like `16499599` [Lance](https://www.goodreads.com/user/show/16499599-lance-willettl)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets: update Goodreads URL for HTTPS support