### PR TITLE
Release Branch Build: Run yarn clean-client before building the Admin Page

### DIFF
--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -204,9 +204,14 @@ hash yarn 2>/dev/null || {
     exit 1;
 }
 
+# Start clean by removing previously installed dependencies and built files
 yarn run distclean
+yarn run clean-client
+# Clean yarn's cache
 yarn cache clean
+# Install dependencies
 yarn
+# Build the Admin Page
 NODE_ENV=production yarn run build-client
 echo "Done"
 


### PR DESCRIPTION
While creating a built branch I realized that some git-ignored files from the release branch (the not-built one) were still added to git tracking by the `tools/build-release-branch.sh` script because they were there from a previous unrelated build run in `master`. As the files were .gitignored I didn't notice them until they were commited to the built branch (consequence of an `git add .` from the same scripts.

#### Changes proposed in this Pull Request:

* Adds a line before installing dependencies  running `yarn clean-client`.

#### Testing instructions:

* Don't test it. Just review the code

