### PR TITLE
Sync: Fix Trying to get property of non-object in sync/class.jetpack-sync-module-posts.php

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -199,9 +199,11 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	function is_post_type_allowed( $post_id ) {
-		$post = get_post( $post_id );
-
-		return ! in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) );
+		$post = get_post( intval( $post_id ) );
+		if( $post->post_type ) {
+			return ! in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) );
+		}
+		return false;
 	}
 
 	function remove_embed() {


### PR DESCRIPTION
Fixes #8137
Fixes #7156

#### Changes proposed in this Pull Request:

*  In this file directly call $post->post_type so it given error. If We update the code so we overcome the problem.

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
