### PR TITLE
Search: Provides backwards-compat for the filters widget

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -157,6 +157,10 @@ class Jetpack_Search {
 				continue;
 			}
 
+			if ( empty( $settings['use_filters'] ) ) {
+				continue;
+			}
+
 			foreach ( (array) $settings['filters'] as $widget_filter ) {
 				$widget_filter['widget_id'] = $widget_id;
 				$key = sprintf( '%s_%d', $widget_filter['type'], count( $filters ) );

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -129,6 +129,20 @@ class Jetpack_Search {
 		}
 	}
 
+	function are_filters_by_widget_disabled() {
+		/**
+		 * Allows developers to disable filters being set by widget, in favor of manually
+		 * setting filters via `Jetpack_Search::set_filters()`.
+		 *
+		 * @module search
+		 *
+		 * @since 5.7.0
+		 *
+		 * @param bool false
+		 */
+		return apply_filters( 'jetpack_search_disable_widget_filters', false );
+	}
+
 	/**
 	 * Retrives a list of known Jetpack search filters widget IDs, gets the filters for each widget,
 	 * and applies those filters to this Jetpack_Search object.
@@ -138,6 +152,10 @@ class Jetpack_Search {
 	 * @return void
 	 */
 	function set_filters_from_widgets() {
+		if ( $this->are_filters_by_widget_disabled() ) {
+			return;
+		}
+
 		$widget_options = get_option( sprintf( 'widget_%s', self::FILTER_WIDGET_BASE ) );
 
 		if ( empty( $widget_options ) ) {

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -13,6 +13,10 @@
 	color: #a00;
 }
 
+.jetpack-search-filters-widget.hide-filters .jetpack-search-filters-widget__filter {
+	display: none;
+}
+
 /* If there's only one filter, do not show the control to delete it */
 .jetpack-search-filters-widget__filter:only-of-type .jetpack-search-filters-widget__controls .delete {
 	display: none;

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -30,6 +30,10 @@
 			e.preventDefault();
 			$( this ).closest( '.jetpack-search-filters-widget__filter' ).remove();
 		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__use-filters', function() {
+			$( this ).closest( '.jetpack-search-filters-widget' ).toggleClass( 'hide-filters' );
+		} );
 	};
 
 	$( document ).ready( function() {
@@ -42,6 +46,7 @@
 		widget.off( 'change', '.filter-select' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .delete' );
+		widget.off( 'change', '.jetpack-search-filters-widget__use-filters' );
 		setListeners();
 	} );
 } )( jQuery );


### PR DESCRIPTION
Fixes #8374

In #8358, I broke the filters widget for users that had manually been setting the filters via `Jetpack_Search::set_filters()`, with the understanding that I would fix it in a follow-up PR. That is this PR.

This PR adds a checkbox that turns on the filter admin UI in the widget. If there are no active widgets that have that checkbox checked, the widget will default to displaying global filters.

If any widget has that checkbox checked, the widgets will only display their own filters.

To test:

- Checkout branch on a site with a professional plan
- Ensure that you have some filters manually set: https://jetpack.com/support/search/customize-search/
- Ensure that your filters show on the front-end when searching
- Check the "Add filters" checkbox and set a filter
- Refresh search results
- Ensure that the filters configured by the widget are showing now
- Set `add_filter( 'jetpack_search_disable_widget_filters', '__return_true' );`, and ensure that the filters that are manually set are now showing