### PR TITLE
Search: Fixes an undefined index when filters were disabled via filter

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -147,39 +147,40 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		$instance['use_filters'] = empty( $new_instance['use_filters'] ) ? '0' : '1';
 
-		$filters = array();
-
-		foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
-			switch ( $type ) {
-				case 'taxonomy':
-					$filters[] = array(
-						'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type' => 'taxonomy',
-						'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
-						'count' => intval( $new_instance['num_filters'][ $index ] ),
-					);
-					break;
-				case 'post_type':
-					$filters[] = array(
-						'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type' => 'post_type',
-						'count' => intval( $new_instance['num_filters'][ $index ] ),
-					);
-					break;
-				case 'date_histogram':
-					$filters[] = array(
-						'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type' => 'date_histogram',
-						'count' => intval( $new_instance['num_filters'][ $index ] ),
-						'field' => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
-						'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
-					);
-					break;
+		if ( $instance['use_filters'] ) {
+			$filters = array();
+			foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
+				switch ( $type ) {
+					case 'taxonomy':
+						$filters[] = array(
+							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type' => 'taxonomy',
+							'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
+							'count' => intval( $new_instance['num_filters'][ $index ] ),
+						);
+						break;
+					case 'post_type':
+						$filters[] = array(
+							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type' => 'post_type',
+							'count' => intval( $new_instance['num_filters'][ $index ] ),
+						);
+						break;
+					case 'date_histogram':
+						$filters[] = array(
+							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type' => 'date_histogram',
+							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'field' => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
+							'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
+						);
+						break;
+				}
 			}
-		}
 
-		if ( ! empty( $filters ) ) {
-			$instance['filters'] = $filters;
+			if ( ! empty( $filters ) ) {
+				$instance['filters'] = $filters;
+			}
 		}
 
 		return $instance;


### PR DESCRIPTION
If a site had disabled search filters via the `jetpack_search_disable_widget_filters` filter, then when a widget was saved, it caused an undefined index notice:

```
PHP Notice:  Undefined index: filter_type in .../jetpack/modules/search/class.jetpack-search-widget-filters.php on line 152
```

I didn't catch this before because I was testing on widgets where I had previously configured a filter.

To fix this, I added a condition to not check `$new_instance['filter_type']` if widget wasn't supposed to use filters.

To test:

- On a site with a professional plan
- Checkout Jetpack master
- Set `add_filter( 'jetpack_search_disable_widget_filters', '__return_true' );`
- Add a new Jetpack search filters widget
- Check error log for undefined index notice
- Checkout this branch
- Add a new Jetpack search filters widget
- Ensure there is no notice