### PR TITLE
Update Security Settings card to reflect Rewind

### DIFF
--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -96,3 +96,25 @@
 		}
 	}
 }
+
+.jp-banner__no-border {
+	border-left: none !important;
+
+	.dops-banner__icon-circle {
+		background: none !important;
+		padding: 0 0 0 3px;
+	}
+
+	svg.gridicon.gridicons-checkmark-circle {
+		width: 28px;
+		height: 28px;
+		color: #4ab866;
+	}
+
+	.dops-banner__description {
+		font-size: .875rem;
+		line-height: 1.65;
+		color: #537994;
+		margin-top: 0;
+	}
+}

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -95,6 +95,12 @@ const ProStatus = React.createClass( {
 				action = __( 'Invalid key', { context: 'Short warning message about an invalid key being used for Akismet.' } );
 				actionUrl = this.props.siteAdminUrl + 'admin.php?page=akismet-key-config';
 				break;
+			case 'rewind_connected':
+				return (
+					<SimpleNotice showDismiss={ false } status="is-success" isCompact>
+						{ __( 'Connected' ) }
+					</SimpleNotice>
+				);
 			case 'active':
 				return <span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>;
 		}
@@ -149,6 +155,10 @@ const ProStatus = React.createClass( {
 		const getStatus = ( feature, active, installed ) => {
 			if ( this.props.isDevMode ) {
 				return '';
+			}
+
+			if ( 'rewind' === feature ) {
+				return this.getProActions( 'rewind_connected', 'rewind' );
 			}
 
 			if ( 'backups' === feature ) {

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -8,6 +8,7 @@ import Card from 'components/card';
 import analytics from 'lib/analytics';
 import get from 'lodash/get';
 import { getPlanClass } from 'lib/plans/constants';
+import Banner from 'components/banner';
 
 /**
  * Internal dependencies
@@ -24,7 +25,58 @@ import {
 	getVaultPressScanThreatCount,
 } from 'state/at-a-glance';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
+import { isFetchingRewindStatus } from 'state/rewind';
 import includes from 'lodash/includes';
+
+class LoadingCard extends Component {
+	render() {
+		return (
+			<SettingsCard
+				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+				hideButton
+			>
+				<SettingsGroup
+					disableInDevMode
+					module={ { module: 'backups' } }
+					support="https://help.vaultpress.com/get-to-know/">
+					{
+						__( 'Checking site status…' )
+					}
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+}
+
+class BackupsScanRewind extends Component {
+	getCardText = () => {
+		if ( this.props.isDevMode ) {
+			return __( 'Unavailable in Dev Mode.' );
+		}
+
+		return <Banner
+			title={ __( 'Connected' ) }
+			icon="checkmark-circle"
+			feature={ 'rewind' }
+			description={ __( 'Your site is being backed up in real time and regularly scanned for securtiy threats.' ) }
+			className="is-upgrade-premium jp-banner__no-border"
+			href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl }
+		/>;
+	};
+
+	render() {
+		return (
+			<SettingsCard
+				feature={ 'rewind' }
+				{ ...this.props }
+				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+				action={ 'rewind' }
+				hideButton>
+				{ this.getCardText() }
+			</SettingsCard>
+		);
+	}
+}
 
 export const BackupsScan = moduleSettingsForm(
 	class extends Component {
@@ -41,10 +93,6 @@ export const BackupsScan = moduleSettingsForm(
 				scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 			let cardText = '';
-
-			if ( this.props.isFetchingSiteData || this.props.isFetchingVaultPressData ) {
-				return __( 'Checking site status…' );
-			}
 
 			if ( this.props.isDevMode ) {
 				return __( 'Unavailable in Dev Mode.' );
@@ -96,16 +144,27 @@ export const BackupsScan = moduleSettingsForm(
 			}
 
 			return cardText;
-		};
+		}
 
 		render() {
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
+			const rewindActive = 'unavailable' === get( this.props.rewindStatus, [ 'state' ], false );
+			const isFetchingData = this.props.isFetchingSiteData || this.props.isFetchingVaultPressData || this.props.isFetchingRewindData;
+
+			if ( isFetchingData ) {
+				return <LoadingCard />;
+			}
+
+			if ( rewindActive ) {
+				return <BackupsScanRewind { ...this.props } />;
+			}
+
 			return (
 				<SettingsCard
-					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
+					feature={ rewindActive ? 'rewind' : FEATURE_SECURITY_SCANNING_JETPACK }
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
-					action="scan"
+					action={ rewindActive ? 'rewind' : 'scan' }
 					hideButton>
 					<SettingsGroup
 						disableInDevMode
@@ -133,5 +192,6 @@ export default connect( state => {
 		vaultPressData: getVaultPressData( state ),
 		isFetchingVaultPressData: isFetchingVaultPressData( state ),
 		hasThreats: getVaultPressScanThreatCount( state ),
+		isFetchingRewindData: isFetchingRewindStatus( state ),
 	};
 } )( BackupsScan );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -148,7 +148,7 @@ export const BackupsScan = moduleSettingsForm(
 
 		render() {
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
-			const rewindActive = 'unavailable' === get( this.props.rewindStatus, [ 'state' ], false );
+			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
 			const isFetchingData = this.props.isFetchingSiteData || this.props.isFetchingVaultPressData || this.props.isFetchingRewindData;
 
 			if ( isFetchingData ) {
@@ -161,10 +161,10 @@ export const BackupsScan = moduleSettingsForm(
 
 			return (
 				<SettingsCard
-					feature={ rewindActive ? 'rewind' : FEATURE_SECURITY_SCANNING_JETPACK }
+					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
-					action={ rewindActive ? 'rewind' : 'scan' }
+					action={ 'scan' }
 					hideButton>
 					<SettingsGroup
 						disableInDevMode

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -164,7 +164,7 @@ export const BackupsScan = moduleSettingsForm(
 					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
-					action={ 'scan' }
+					action="scan"
 					hideButton>
 					<SettingsGroup
 						disableInDevMode

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -58,7 +58,7 @@ class BackupsScanRewind extends Component {
 			title={ __( 'Connected' ) }
 			icon="checkmark-circle"
 			feature={ 'rewind' }
-			description={ __( 'Your site is being backed up in real time and regularly scanned for securtiy threats.' ) }
+			description={ __( 'Your site is being backed up in real time and regularly scanned for security threats.' ) }
 			className="is-upgrade-premium jp-banner__no-border"
 			href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl }
 		/>;

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -66,7 +66,7 @@ export class Security extends Component {
 		const foundProtect = this.props.isModuleFound( 'protect' ),
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
-			rewindActive = 'unavailable' === get( this.props.rewindStatus, [ 'state' ], false ),
+			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive;
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -58,12 +59,15 @@ export class Security extends Component {
 			getModule: this.props.module,
 			isDevMode: this.props.isDevMode,
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			rewindStatus: this.props.rewindStatus,
+			siteRawUrl: this.props.siteRawUrl,
 		};
 
 		const foundProtect = this.props.isModuleFound( 'protect' ),
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
-			foundBackups = this.props.isModuleFound( 'vaultpress' );
+			rewindActive = 'unavailable' === get( this.props.rewindStatus, [ 'state' ], false ),
+			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive;
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -20,7 +20,8 @@ export default React.createClass( {
 	render() {
 		const commonProps = {
 			route: this.props.route,
-			searchTerm: this.props.searchTerm
+			searchTerm: this.props.searchTerm,
+			rewindStatus: this.props.rewindStatus,
 		};
 
 		return (
@@ -45,6 +46,7 @@ export default React.createClass( {
 				/>
 				<Security
 					siteAdminUrl={ this.props.siteAdminUrl }
+					siteRawUrl={ this.props.siteRawUrl }
 					active={ ( '/security' === this.props.route.path ) }
 					{ ...commonProps }
 				/>


### PR DESCRIPTION
For #8264

![screen shot 2017-12-18 at 9 21 31 pm](https://user-images.githubusercontent.com/7129409/34137527-73224622-e439-11e7-85dc-72b546db800b.png)

- For a site that has Rewind active, the scan/backups card in /security should reflect rewind.  
- If a site does not have rewind active, then it will continue to show the VaultPress card. 