### PR TITLE
At a glance: update Backups dashboard card based on Rewind availability

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -142,18 +142,12 @@ class DashBackups extends Component {
 				<QueryVaultPressData />
 				{
 					this.props.isRewindActive
-						? (
-							<div className="jp-dash-item__interior">
-								{
-									renderCard( {
-										className: 'jp-dash-item__is-active',
-										status: 'is-working',
-										content: __( 'Your site is being backed up in real-time.' ),
-										feature: 'rewind',
-									} )
-								}
-							</div>
-						)
+						? renderCard( {
+							className: 'jp-dash-item__is-active',
+							status: 'is-working',
+							content: __( 'Your site is being backed up in real-time.' ),
+							feature: 'rewind',
+						} )
 						: this.getVPContent()
 				}
 			</div>

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -6,7 +6,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
-import { noop } from 'lodash/noop';
+import noop from 'lodash/noop';
+import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -65,62 +67,62 @@ class DashBackups extends Component {
 			isVaultPressInstalled,
 			getOptionValue,
 			siteRawUrl,
+			vaultPressData,
 		} = this.props;
-		const hasSitePlan = false !== sitePlan && 'jetpack_free' !== sitePlan.product_slug;
-		const inactiveOrUninstalled = isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled';
 
-		if ( getOptionValue( 'vaultpress' ) ) {
-			const vpData = this.props.vaultPressData;
-
-			if ( vpData === 'N/A' ) {
-				return renderCard( {
-					className: '',
-					status: '',
-					content: __( 'Loading…' )
-				} );
-			}
-
-			if ( vpData.code === 'success' ) {
-				return renderCard( {
-					className: 'jp-dash-item__is-active',
-					status: 'is-working',
-					content: (
-						<span>
-							{ vpData.message }
-							&nbsp;
-							{ __( '{{a}}View backup details{{/a}}.', {
-								components: {
-									a: <a href="https://dashboard.vaultpress.com" target="_blank" rel="noopener noreferrer" />
-								}
-							} ) }
-						</span>
-					),
-				} );
-			}
+		if ( getOptionValue( 'vaultpress' ) && 'success' === get( vaultPressData, 'code', '' ) ) {
+			return renderCard( {
+				className: 'jp-dash-item__is-active',
+				status: 'is-working',
+				content: (
+					<span>
+						{ get( vaultPressData, 'message', '' ) }
+						&nbsp;
+						{ __( '{{a}}View backup details{{/a}}.', {
+							components: {
+								a: <a href="https://dashboard.vaultpress.com" target="_blank" rel="noopener noreferrer" />
+							}
+						} ) }
+					</span>
+				),
+			} );
 		}
 
-		return renderCard( {
-			className: 'jp-dash-item__is-inactive',
-			status: hasSitePlan
-				? inactiveOrUninstalled
-				: 'no-pro-uninstalled-or-inactive',
-			content: hasSitePlan
-				? __( 'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.', {
-					components: {
-						a: <a href="https://wordpress.com/plugins/vaultpress" target="_blank" rel="noopener noreferrer" />
-					}
-				} )
-				: __( 'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.', {
+		if ( ! isEmpty( sitePlan ) ) {
+			// If site has a paid plan
+			if ( 'jetpack_free' !== get( sitePlan, 'product_slug', 'jetpack_free' ) ) {
+				return renderCard( {
+					className: 'jp-dash-item__is-inactive',
+					status: isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled',
+					content: __( 'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.', {
+						components: {
+							a: <a href="https://wordpress.com/plugins/vaultpress" target="_blank" rel="noopener noreferrer" />
+						}
+					} )
+				} );
+			}
+
+			return renderCard( {
+				className: 'jp-dash-item__is-inactive',
+				status: 'no-pro-uninstalled-or-inactive',
+				content: __( 'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.', {
 					components: {
 						a:
 							<a href={ `https://jetpack.com/redirect/?source=aag-backups&site=${ siteRawUrl }` } target="_blank" rel="noopener noreferrer" />
 					}
 				} ),
+			} );
+		}
+
+		return renderCard( {
+			className: '',
+			status: '',
+			content: __( 'Loading…' )
 		} );
 	}
 
 	render() {
-		if ( this.props.inDevMode ) {
+		if ( this.props.isDevMode ) {
 			return (
 				<div className="jp-dash-item__interior">
 					{
@@ -162,7 +164,7 @@ export default connect(
 		return {
 			vaultPressData: getVaultPressData( state ),
 			sitePlan: getSitePlan( state ),
-			inDevMode: isDevMode( state ),
+			isDevMode: isDevMode( state ),
 			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' )
 		};
 	}

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -28,10 +28,11 @@ import { isDevMode } from 'state/connection';
 const renderCard = ( props ) => (
 	<DashItem
 		label={ __( 'Backups' ) }
-		module="backups"
+		module={ props.feature || 'backups' }
 		className={ props.className }
 		status={ props.status }
-		pro={ true } >
+		pro={ true }
+	>
 		<p className="jp-dash-item__description">
 			{ props.content }
 		</p>
@@ -148,6 +149,7 @@ class DashBackups extends Component {
 										className: 'jp-dash-item__is-active',
 										status: 'is-working',
 										content: __( 'Your site is being backed up in real-time.' ),
+										feature: 'rewind',
 									} )
 								}
 							</div>

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
+import { noop } from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -16,34 +17,75 @@ import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
 
-class DashBackups extends Component {
-	getContent() {
-		const labelName = __( 'Backups' ),
-			hasSitePlan = false !== this.props.sitePlan && 'jetpack_free' !== this.props.sitePlan.product_slug,
-			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
+/**
+ * Displays a card for Backups based on the props given.
+ *
+ * @param   {object} props Settings to render the card.
+ * @returns {object}       Backups card
+ */
+const renderCard = ( props ) => (
+	<DashItem
+		label={ __( 'Backups' ) }
+		module="backups"
+		className={ props.className }
+		status={ props.status }
+		pro={ true } >
+		<p className="jp-dash-item__description">
+			{ props.content }
+		</p>
+	</DashItem>
+);
 
-		if ( this.props.getOptionValue( 'vaultpress' ) ) {
+class DashBackups extends Component {
+	static propTypes = {
+		siteRawUrl: PropTypes.string.isRequired,
+		getOptionValue: PropTypes.func.isRequired,
+		isRewindActive: PropTypes.bool.isRequired,
+
+		// Connected props
+		vaultPressData: PropTypes.any.isRequired,
+		sitePlan: PropTypes.object.isRequired,
+		isDevMode: PropTypes.bool.isRequired,
+		isVaultPressInstalled: PropTypes.bool.isRequired,
+	};
+
+	static defaultProps = {
+		siteRawUrl: '',
+		getOptionValue: noop,
+		isRewindActive: false,
+		vaultPressData: '',
+		sitePlan: '',
+		isDevMode: false,
+		isVaultPressInstalled: false,
+	};
+
+	getVPContent() {
+		const {
+			sitePlan,
+			isVaultPressInstalled,
+			getOptionValue,
+			siteRawUrl,
+		} = this.props;
+		const hasSitePlan = false !== sitePlan && 'jetpack_free' !== sitePlan.product_slug;
+		const inactiveOrUninstalled = isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled';
+
+		if ( getOptionValue( 'vaultpress' ) ) {
 			const vpData = this.props.vaultPressData;
 
 			if ( vpData === 'N/A' ) {
-				return (
-					<DashItem label={ labelName }>
-						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
-					</DashItem>
-				);
+				return renderCard( {
+					className: '',
+					status: '',
+					content: __( 'Loading…' )
+				} );
 			}
 
 			if ( vpData.code === 'success' ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="backups"
-						status="is-working"
-						className="jp-dash-item__is-active"
-						pro={ true }
-					>
-
-						<p className="jp-dash-item__description">
+				return renderCard( {
+					className: 'jp-dash-item__is-active',
+					status: 'is-working',
+					content: (
+						<span>
 							{ vpData.message }
 							&nbsp;
 							{ __( '{{a}}View backup details{{/a}}.', {
@@ -51,73 +93,77 @@ class DashBackups extends Component {
 									a: <a href="https://dashboard.vaultpress.com" target="_blank" rel="noopener noreferrer" />
 								}
 							} ) }
-						</p>
-					</DashItem>
-				);
+						</span>
+					),
+				} );
 			}
 		}
 
-		const upgradeOrActivateText = () => {
-			if ( hasSitePlan ) {
-				return (
-					__( 'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.', {
-						components: {
-							a: <a href="https://wordpress.com/plugins/vaultpress" target="_blank" rel="noopener noreferrer" />
-						}
-					} )
-				);
-			}
-
-			return (
-				__( 'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.', {
+		return renderCard( {
+			className: 'jp-dash-item__is-inactive',
+			status: hasSitePlan
+				? inactiveOrUninstalled
+				: 'no-pro-uninstalled-or-inactive',
+			content: hasSitePlan
+				? __( 'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.', {
 					components: {
-						a: <a href={ 'https://jetpack.com/redirect/?source=aag-backups&site=' + this.props.siteRawUrl } target="_blank" rel="noopener noreferrer" />
+						a: <a href="https://wordpress.com/plugins/vaultpress" target="_blank" rel="noopener noreferrer" />
 					}
 				} )
-			);
-		};
-
-		return (
-			<DashItem
-				label={ labelName }
-				module="backups"
-				className="jp-dash-item__is-inactive"
-				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
-				pro={ true } >
-				<p className="jp-dash-item__description">
-					{
-						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' )
-							: upgradeOrActivateText()
+				: __( 'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.', {
+					components: {
+						a:
+							<a href={ `https://jetpack.com/redirect/?source=aag-backups&site=${ siteRawUrl }` } target="_blank" rel="noopener noreferrer" />
 					}
-				</p>
-			</DashItem>
-		);
+				} ),
+		} );
 	}
 
 	render() {
+		if ( this.props.inDevMode ) {
+			return (
+				<div className="jp-dash-item__interior">
+					{
+						renderCard( {
+							className: 'jp-dash-item__is-inactive',
+							status: 'no-pro-uninstalled-or-inactive',
+							content: __( 'Unavailable in Dev Mode.' ),
+						} )
+					}
+				</div>
+			);
+		}
+
 		return (
 			<div className="jp-dash-item__interior">
 				<QueryVaultPressData />
-				{ this.getContent() }
+				{
+					this.props.isRewindActive
+						? (
+							<div className="jp-dash-item__interior">
+								{
+									renderCard( {
+										className: 'jp-dash-item__is-active',
+										status: 'is-working',
+										content: __( 'Your site is being backed up in real-time.' ),
+									} )
+								}
+							</div>
+						)
+						: this.getVPContent()
+				}
 			</div>
 		);
 	}
 }
-
-DashBackups.propTypes = {
-	vaultPressData: PropTypes.any.isRequired,
-	isDevMode: PropTypes.bool.isRequired,
-	siteRawUrl: PropTypes.string.isRequired,
-	sitePlan: PropTypes.object.isRequired
-};
 
 export default connect(
 	( state ) => {
 		return {
 			vaultPressData: getVaultPressData( state ),
 			sitePlan: getSitePlan( state ),
-			isDevMode: isDevMode( state ),
-			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
+			inDevMode: isDevMode( state ),
+			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' )
 		};
 	}
 )( DashBackups );

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -32,7 +32,7 @@ import {
  *
  * @returns {undefined}
  */
-const trackMonitorSettingsClick = () =>	analytics.tracks.recordJetpackClick( {
+const trackMonitorSettingsClick = () => analytics.tracks.recordJetpackClick( {
 	target: 'monitor-settings',
 	page: 'aag'
 } );

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -27,13 +27,33 @@ import {
 	userCanManageModules
 } from 'state/initial-state';
 
+/**
+ * Track clicks on monitor settings
+ *
+ * @returns {undefined}
+ */
+const trackMonitorSettingsClick = () =>	analytics.tracks.recordJetpackClick( {
+	target: 'monitor-settings',
+	page: 'aag'
+} );
+
 export class DashItem extends Component {
-	trackMonitorSettingsClick() {
-		analytics.tracks.recordJetpackClick( {
-			target: 'monitor-settings',
-			page: 'aag'
-		} );
-	}
+	static propTypes = {
+		label: PropTypes.string,
+		status: PropTypes.string,
+		statusText: PropTypes.string,
+		disabled: PropTypes.bool,
+		module: PropTypes.string,
+		pro: PropTypes.bool,
+		isModule: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		label: '',
+		module: '',
+		pro: false,
+		isModule: true,
+	};
 
 	render() {
 		let toggle, proButton = '';
@@ -89,7 +109,7 @@ export class DashItem extends Component {
 			if ( 'monitor' === this.props.module ) {
 				toggle = ! this.props.isDevMode && this.props.getOptionValue( this.props.module ) && (
 					<Button
-						onClick={ this.trackMonitorSettingsClick }
+						onClick={ trackMonitorSettingsClick }
 						href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
 						compact>
 						{
@@ -97,6 +117,10 @@ export class DashItem extends Component {
 						}
 					</Button>
 				);
+			}
+
+			if ( 'rewind' === this.props.module ) {
+				toggle = null;
 			}
 		}
 
@@ -133,23 +157,6 @@ export class DashItem extends Component {
 		);
 	}
 }
-
-DashItem.propTypes = {
-	label: PropTypes.string,
-	status: PropTypes.string,
-	statusText: PropTypes.string,
-	disabled: PropTypes.bool,
-	module: PropTypes.string,
-	pro: PropTypes.bool,
-	isModule: PropTypes.bool,
-};
-
-DashItem.defaultProps = {
-	label: '',
-	module: '',
-	pro: false,
-	isModule: true,
-};
 
 export default connect(
 	( state ) => {

--- a/_inc/client/state/site/plugins/reducer.js
+++ b/_inc/client/state/site/plugins/reducer.js
@@ -76,5 +76,5 @@ export function isPluginActive( state, plugin ) {
  * @return {Boolean} True if plugin is installed, false otherwise.
  */
 export function isPluginInstalled( state, plugin ) {
-	return state.jetpack.pluginsData.items[ plugin ];
+	return !! state.jetpack.pluginsData.items[ plugin ];
 }


### PR DESCRIPTION
Related #8266

#### Changes proposed in this Pull Request:

* the Backups card in dashboard will be updated based on VP or Rewind availability
* fix issue where during load and without VP plugin deactivated, the "Loading..." text wasn't shown and instead the text to install VP plugin was shown
* refactored to clean up code and make things more reusable
* updated DashItem so the Set Up button or the toggle are hidden when it's a Rewind feature

#### Testing instructions:

* test with a Rewind-enabled site and another without it