### PR TITLE
Hide all mentions of VaultPress if rewind is available but not active

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -76,6 +76,7 @@ class AtAGlance extends Component {
 				</div>
 			);
 		const isRewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
+		const hideVaultPressCards = ! isRewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 		const securityCards = [
 			<DashProtect { ...settingsProps } />,
 			<DashScan
@@ -92,6 +93,10 @@ class AtAGlance extends Component {
 			<DashAkismet { ...urls } />,
 			<DashPluginUpdates { ...settingsProps } { ...urls } />
 		];
+
+		// Hack to remove VP cards if rewind is in a weird state; not active but available.
+		// @todo we need some actual messaging here.
+		hideVaultPressCards && securityCards.splice( 1, 2 );
 
 		// Maybe add the rewind card
 		isRewindActive && securityCards.unshift( <DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -80,9 +80,14 @@ const PlanBody = React.createClass( {
 			? getPlanClass( this.props.plan )
 			: 'dev';
 		const premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES ),
-			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
+			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
+			hideVaultPressCard = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 
 		const getRewindVaultPressCard = () => {
+			if ( hideVaultPressCard ) {
+				return;
+			}
+
 			let description = '';
 
 			switch ( planClass ) {

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -68,7 +68,6 @@ export class Security extends Component {
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
-			// hideVaultPressCards = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 			hideVaultPressCards = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -67,7 +67,9 @@ export class Security extends Component {
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
-			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive;
+			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
+			// hideVaultPressCards = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
+			hideVaultPressCards = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
@@ -80,7 +82,7 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ foundBackups && <BackupsScan { ...commonProps } /> }
+				{ foundBackups && ! hideVaultPressCards && <BackupsScan { ...commonProps } /> }
 				{ foundAkismet &&
 					<div>
 						<Antispam { ...commonProps } />


### PR DESCRIPTION
If Rewind is not active, but available for some reason, hide all mentions of VaultPress.

Test: 
- If a site is unavailable for Rewind, everything should behave as normal 
- If a site has rewind active, continue to show mentions/cards for rewind
- If a site is not either of those, i.e. "available", then you should not see any cards for VaultPress in neither /plans, nor /settings/, nor /dashboard.