### PR TITLE
Dashboard: fix undefined version number on footer

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -151,7 +151,7 @@ export const Footer = React.createClass( {
 						>
 							{
 								version
-									? __( 'Jetpack version %(version)s', { args: { version: version } } )
+									? __( 'Jetpack version %(version)s', { args: { version } } )
 									: __( 'Jetpack' )
 							}
 						</a>

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -149,7 +149,11 @@ export const Footer = React.createClass( {
 							className="jp-footer__link"
 							title={ __( 'Jetpack version' ) }
 						>
-							{ __( 'Jetpack version ' ) + version }
+							{
+								version
+									? __( 'Jetpack version %(version)s', { args: { version: version } } )
+									: __( 'Jetpack' )
+							}
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
@@ -193,7 +197,7 @@ export default connect(
 			siteAdminUrl: getSiteAdminUrl( state ),
 			isInIdentityCrisis: isInIdentityCrisis( state ),
 			displayDevCard: canDisplayDevCard( state )
-		}
+		};
 	},
 	( dispatch ) => {
 		return {

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -42,10 +42,10 @@ export function isDevVersion( state ) {
  * by JETPACK__VERSION
  *
  * @param  {Object}  state  Global state tree
- * @return {string}         Version number
+ * @return {string}         Version number. Empty string if the data is not yet available.
  */
 export function getCurrentVersion( state ) {
-	return state.jetpack.initialState.currentVersion;
+	return get( state.jetpack.initialState, 'currentVersion', '' );
 }
 
 export function getSiteRoles( state ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* fixes an issue where the Jetpack version at the footer was shown as `undefined` since data wasn't still available. This will now show Jetpack when the version is unavailable and the complete Jetpack version xx when it's available.

#### Before

<img width="338" alt="captura de pantalla 2017-12-19 a la s 18 46 32" src="https://user-images.githubusercontent.com/1041600/34213089-05193362-e57d-11e7-90ec-67b5b9e475f7.png">

#### After

<img width="287" alt="captura de pantalla 2017-12-20 a la s 11 50 11" src="https://user-images.githubusercontent.com/1041600/34213092-06f8a730-e57d-11e7-9b85-a8fdc16ccc4e.png">
<img width="373" alt="captura de pantalla 2017-12-20 a la s 11 58 18" src="https://user-images.githubusercontent.com/1041600/34213110-197cc1c0-e57d-11e7-83ad-b50384a2f858.png">



#### Testing instructions:

* throttle or use a slow network and load the admin and verify it doesn't show undefined for the version on the footer

