### PR TITLE
REST API: Check if Akismet plugin file is readable in REST API endpoints code

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -418,7 +418,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						$response[ $setting ] = '';
 					} else {
 						if ( ! class_exists( 'Akismet' ) ) {
-							if ( file_exists( WP_PLUGIN_DIR . '/akismet/class.akismet.php' ) ) {
+							$path = WP_PLUGIN_DIR . '/akismet/class.akismet.php';
+							if ( file_exists( $path ) && is_readable( $path ) ) {
 								require_once WP_PLUGIN_DIR . '/akismet/class.akismet.php';
 							}
 						}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -418,8 +418,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						$response[ $setting ] = '';
 					} else {
 						if ( ! class_exists( 'Akismet' ) ) {
-							$path = WP_PLUGIN_DIR . '/akismet/class.akismet.php';
-							if ( file_exists( $path ) && is_readable( $path ) ) {
+							if ( is_readable( WP_PLUGIN_DIR . '/akismet/class.akismet.php' ) ) {
 								require_once WP_PLUGIN_DIR . '/akismet/class.akismet.php';
 							}
 						}


### PR DESCRIPTION
Fixes #8399

#### Changes proposed in this Pull Request:

* Adds a check with `is_readable` in case PHP can see the `akismet/akismet.php` file exists but can't read its contents.

#### Testing instructions:

* On a connected Jetpack site with Akismet present.
* Remove reading permissions from the `akismet/akismet.php` file
* Visit the Jetpack admin dashboard
* Expect to see no fatal errors (e.g. in debug.log)

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:
* Fixes a fatal error caused when hittin an endpoint api and akismet files are present but not readable.