### PR TITLE
Admin Page: Remove all usages of this.isMounted

### DIFF
--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -58,23 +58,21 @@ module.exports = React.createClass( {
 	},
 
 	resize: function() {
-		if ( this.isMounted() ) {
-			var node = this.refs.chart,
-				width = node.clientWidth - 82,
-				maxBars;
+		var node = this.refs.chart,
+			width = node.clientWidth - 82,
+			maxBars;
 
-			if ( touchDetect.hasTouch() ) {
-				width = ( width <= 0 ) ? 350 : width; // mobile safari bug with zero width
-				maxBars = Math.floor( width / this.props.minTouchBarWidth );
-			} else {
-				maxBars = Math.floor( width / this.props.minBarWidth );
-			}
-
-			this.setState( {
-				maxBars: maxBars,
-				width: width
-			} );
+		if ( touchDetect.hasTouch() ) {
+			width = ( width <= 0 ) ? 350 : width; // mobile safari bug with zero width
+			maxBars = Math.floor( width / this.props.minTouchBarWidth );
+		} else {
+			maxBars = Math.floor( width / this.props.minBarWidth );
 		}
+
+		this.setState( {
+			maxBars: maxBars,
+			width: width
+		} );
 	},
 
 	getYAxisMax: function( values ) {

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	PropTypes = require( 'prop-types' ),
 	noop = require( 'lodash/noop' ),
 	throttle = require( 'lodash/throttle' );
 
@@ -17,11 +18,11 @@ module.exports = React.createClass( {
 	displayName: 'ModuleChart',
 
 	propTypes: {
-		loading: React.PropTypes.bool,
-		data: React.PropTypes.array,
-		minTouchBarWidth: React.PropTypes.number,
-		minBarWidth: React.PropTypes.number,
-		barClick: React.PropTypes.func
+		loading: PropTypes.bool,
+		data: PropTypes.array,
+		minTouchBarWidth: PropTypes.number,
+		minBarWidth: PropTypes.number,
+		barClick: PropTypes.func
 	},
 
 	getInitialState: function() {

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -44,40 +44,38 @@ module.exports = React.createClass( {
 	},
 
 	resize: function( nextProps ) {
-		if ( this.isMounted() ) {
-			var node,
-				props = this.props,
-				width,
-				dataCount,
-				spacing,
-				labelWidth,
-				divisor;
+		var node,
+			props = this.props,
+			width,
+			dataCount,
+			spacing,
+			labelWidth,
+			divisor;
 
-			node = this.refs.axis;
+		node = this.refs.axis;
 
-			if ( nextProps && ! ( nextProps instanceof Event ) ) {
-				props = nextProps;
-			}
-
-			/**
-			 * Overflow needs to be hidden to calculate the desired width,
-			 * but visible to display each labels' overflow :/
-			 */
-
-			node.style.overflow = 'hidden';
-			width = node.clientWidth;
-			node.style.overflow = 'visible';
-
-			dataCount = props.data.length || 1;
-			spacing = width / dataCount;
-			labelWidth = props.labelWidth;
-			divisor = Math.ceil( labelWidth / spacing );
-
-			this.setState( {
-				divisor: divisor,
-				spacing: spacing
-			} );
+		if ( nextProps && ! ( nextProps instanceof Event ) ) {
+			props = nextProps;
 		}
+
+		/**
+		 * Overflow needs to be hidden to calculate the desired width,
+		 * but visible to display each labels' overflow :/
+		 */
+
+		node.style.overflow = 'hidden';
+		width = node.clientWidth;
+		node.style.overflow = 'visible';
+
+		dataCount = props.data.length || 1;
+		spacing = width / dataCount;
+		labelWidth = props.labelWidth;
+		divisor = Math.ceil( labelWidth / spacing );
+
+		this.setState( {
+			divisor: divisor,
+			spacing: spacing
+		} );
 	},
 
 	render: function() {

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	PropTypes = require( 'prop-types' ),
 	throttle = require( 'lodash/throttle' );
 
 /**
@@ -13,8 +14,8 @@ module.exports = React.createClass( {
 	displayName: 'ModuleChartXAxis',
 
 	propTypes: {
-		labelWidth: React.PropTypes.number.isRequired,
-		data: React.PropTypes.array.isRequired
+		labelWidth: PropTypes.number.isRequired,
+		data: PropTypes.array.isRequired
 	},
 
 	getInitialState: function() {


### PR DESCRIPTION
Part of #8405

The component code is already removing listeners and cancelling throttled functions on unmounting.

#### Changes proposed in this Pull Request:

* Removes unnecessary usage of ismounted in the components `chart` and `chart/x-axis`.
* Updates requires for PropTypes to use `prop-types` module in these two components.

#### Testing instructions:

* Checkout this branch. 
* Build the admin page
* Visit the Jetpack Dashboard 
* Expect to see the stats charts.
* Expect to see no errors in the dev console.
* Switch to the Settings page and expect to see no errors in the dev console.
