### PR TITLE
REST API: JPO - enable contact form module when inserting form

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1009,7 +1009,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$contact_page = '';
 
 		if ( isset( $data['addContactForm'] ) && $data['addContactForm'] ) {
-			if ( Jetpack::is_module_active( 'contact-form' ) ) {
+			$contact_form_module_active = Jetpack::is_module_active( 'contact-form' );
+			if ( ! $contact_form_module_active ) {
+				$contact_form_module_active = Jetpack::activate_module( 'contact-form', false, false );
+			}
+
+			if ( $contact_form_module_active ) {
 				$contact_page = '[contact-form][contact-field label="' . esc_html__( 'Name', 'jetpack' ) . '" type="name" required="true" /][contact-field label="' . esc_html__( 'Email', 'jetpack' ) . '" type="email" required="true" /][contact-field label="' . esc_html__( 'Website', 'jetpack' ) . '" type="url" /][contact-field label="' . esc_html__( 'Message', 'jetpack' ) . '" type="textarea" /][/contact-form]';
 			} else {
 				$error[] = 'contact-form activate';


### PR DESCRIPTION
This updates the JPO onboarding request to insert a contact form to automatically enable the contact form module if not enabled already. Previously, it would just bail if the module was disabled.

To test:

Follow the instructions in https://github.com/Automattic/wp-calypso/pull/21065