### PR TITLE
Onboarding: Enable token-auth'ed GET settings endpoint

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5313,7 +5313,7 @@ p {
 		if ( isset( $this->HTTP_RAW_POST_DATA ) ) {
 			$jpo = json_decode( $this->HTTP_RAW_POST_DATA );
 		} else {
-			$jpo = json_decode( json_encode( $_GET ), FALSE );
+			$jpo = json_decode( json_encode( $_GET ), false );
 		}
 			if (
 				isset( $jpo->onboarding ) &&

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5312,6 +5312,9 @@ p {
 		// Let's see if this is onboarding. In such case, use user token type and the provided user id.
 		if ( isset( $this->HTTP_RAW_POST_DATA ) ) {
 			$jpo = json_decode( $this->HTTP_RAW_POST_DATA );
+		} else {
+			$jpo = json_decode( json_encode( $_GET ), FALSE );
+		}
 			if (
 				isset( $jpo->onboarding ) &&
 				isset( $jpo->onboarding->jpUser ) && isset( $jpo->onboarding->token ) &&
@@ -5331,7 +5334,7 @@ p {
 					}
 				}
 			}
-		}
+		//}
 
 		$this->xmlrpc_verification = array(
 			'type'    => $token_type,


### PR DESCRIPTION
WIP. Companion PR to https://github.com/Automattic/wp-calypso/pull/21013.

#### Changes proposed in this Pull Request:

* Allow access to `GET` `/settings` endpoint with an onboarding token.

#### Testing instructions:

* See https://github.com/Automattic/wp-calypso/pull/21013

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

TBD