### PR TITLE
Search: widget styling and design improvements

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1197,6 +1197,11 @@ class Jetpack_Search {
 				$buckets = (array) $aggregation['buckets'];
 			}
 
+			if ( 'date_histogram' == $type ) {
+				//re-order newest to oldest
+				$buckets = array_reverse( $buckets );
+			}
+
 			// Some aggregation types like date_histogram don't support the max results parameter
 			if ( is_int( $this->aggregations[ $label ]['count'] ) && count( $buckets ) > $this->aggregations[ $label ]['count'] ) {
 				$buckets = array_slice( $buckets, 0, $this->aggregations[ $label ]['count'] );


### PR DESCRIPTION
Moves us closer to #8372 design for JP Search
- added search box
- restyling of headers and added some css classes
- adjust defaults for number of items
- adjust name and description since this is now a generic search widget
- reorder the dates so earliest first

I tested in a bunch of popular themes:
- 2010, 2011, 2012, 2013 (has no sidebar), 2014, 2015, 2016, 2017
- Storefront
- Astra
- Shapely
- ColorMag

Took these from https://wordpress.org/themes/browse/popular/ and went for themes with more than 50k active installs.

Mostly all look ok. A few minor spacing issues (Shapely in particular for the search box). I don't love that I resorted to breaks. :/ Not sure if there is a better way.

Would like to get this into 5.7.