### PR TITLE
Search: add to plans and settings dashboards

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -59,6 +59,11 @@ const PlanBody = React.createClass( {
 		this.trackPlansClick( 'activate_publicize' );
 	},
 
+	activateSearch() {
+		this.props.activateModule( 'search' );
+		this.trackPlansClick( 'activate_search' );
+	},
+
 	activateVideoPress() {
 		this.props.activateModule( 'videopress' );
 		this.trackPlansClick( 'activate_videopress' );
@@ -203,6 +208,31 @@ const PlanBody = React.createClass( {
 											disabled={ this.props.isActivatingModule( 'wordads' ) }
 										>
 											{ __( 'Activate Ads' ) }
+										</Button>
+									)
+								}
+							</div>
+						)
+					}
+
+					{
+						( 'is-business-plan' === planClass ) && (
+							<div className="jp-landing__plan-features-card">
+								<h3 className="jp-landing__plan-features-title">{ __( 'Search (Beta)' ) }</h3>
+								<p>{ __( 'Replace the default WordPress search with better results that will help your users find what they are looking for.' ) }</p>
+								{
+									this.props.isModuleActivated( 'search' ) ? (
+										<Button onClick={ () => this.trackPlansClick( 'search_customize' ) } href={ this.props.siteAdminUrl + 'widgets.php' } className="is-primary">
+											{ __( 'Customize Search Widget' ) }
+										</Button>
+									)
+										: (
+										<Button
+											onClick={ this.activateSearch }
+											className="is-primary"
+											disabled={ this.props.isActivatingModule( 'search' ) }
+										>
+											{ __( 'Activate Search' ) }
 										</Button>
 									)
 								}

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -39,7 +39,7 @@ export const Traffic = React.createClass( {
 			foundRelated = this.props.isModuleFound( 'related-posts' ),
 			foundVerification = this.props.isModuleFound( 'verification-tools' ),
 			foundSitemaps = this.props.isModuleFound( 'sitemaps' ),
-			foundSearch = false, // this.props.isModuleFound( 'search' ),
+			foundSearch = this.props.isModuleFound( 'search' ),
 			foundAnalytics = this.props.isModuleFound( 'google-analytics' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -21,7 +21,6 @@ import { FormFieldset } from 'components/forms';
 const Search = moduleSettingsForm(
 	React.createClass( {
 		render() {
-			const search = this.props.getModule( 'search' );
 			let planClass = null;
 
 			if ( this.props.sitePlan ) {

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -16,6 +16,7 @@ import { getSiteAdminUrl } from 'state/initial-state';
 import { getPlanClass } from 'lib/plans/constants';
 import { getSitePlan } from 'state/site';
 import { isFetchingSiteData } from 'state/site';
+import { FormFieldset } from 'components/forms';
 
 const Search = moduleSettingsForm(
 	React.createClass( {
@@ -43,6 +44,17 @@ const Search = moduleSettingsForm(
 								toggleModule={ this.props.toggleModuleNow }>
 								{ __( 'Replace WordPress built-in search with an improved search experience (Beta)' ) }
 							</ModuleToggle>
+							{ this.props.getOptionValue( 'search' ) && (
+								<FormFieldset>
+									<p className="jp-form-setting-explanation">
+										{ __( 'To configure search filters add the {{link}}Jetpack Search widget to your sidebar{{/link}}.', {
+											components: {
+												link: <a href="widgets.php" />
+											}
+										} ) }
+									</p>
+									</FormFieldset>
+							) }
 						</SettingsGroup>
 					</SettingsCard>
 				);

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -34,14 +34,14 @@ const Search = moduleSettingsForm(
 						module="search"
 						hideButton
 					>
-						<SettingsGroup module={ { module: 'search' } } hasChild support={ search.learn_more_button }>
+						<SettingsGroup module={ { module: 'search' } } hasChild support="https://jetpack.com/support/search">
 							<ModuleToggle
 								slug="search"
 								compact
 								activated={ this.props.getOptionValue( 'search' ) }
 								toggling={ this.props.isSavingAnyOption( 'search' ) }
 								toggleModule={ this.props.toggleModuleNow }>
-								{ __( 'Enhanced site-wide search, powered by Elasticsearch (Beta)' ) }
+								{ __( 'Replace WordPress built-in search with an improved search experience (Beta)' ) }
 							</ModuleToggle>
 						</SettingsGroup>
 					</SettingsCard>


### PR DESCRIPTION
- Adds a toggle for turning on search to the JP settings->traffic page
- Adds a toggle for turning on search to the JP Plans page - and a link to the widgets admin when it is already enabled

This should complete cleaning up the purchase flow from buying a Pro plan to enabling and configuring search.

