### PR TITLE
Isolate Jetpack Onboarding from Jetpack Connect

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4038,10 +4038,16 @@ p {
 				} else {
 					Jetpack::create_onboarding_token();
 					$url = $this->build_connect_url( true );
+
+					if ( false !== ( $token = Jetpack_Options::get_option( 'onboarding' ) ) ) {
+						$url = add_query_arg( 'onboarding', $token, $url );
+					}
+
 					$calypso_env = ! empty( $_GET[ 'calypso_env' ] ) ? $_GET[ 'calypso_env' ] : false;
 					if ( $calypso_env ) {
 						$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 					}
+
 					wp_redirect( $url );
 					exit;
 				}
@@ -4484,14 +4490,6 @@ p {
 
 		if ( isset( $_GET['calypso_env'] ) ) {
 			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );
-		}
-
-		if ( false !== ( $token = Jetpack_Options::get_option( 'onboarding' ) ) ) {
-			$url = add_query_arg( 'onboarding', $token, $url );
-
-			// Remove this once https://github.com/Automattic/wp-calypso/pull/17094 is merged.
-			// Uncomment for development until it's merged.
-			//$url = add_query_arg( 'calypso_env', 'development', $url );
 		}
 
 		return $raw ? $url : esc_url( $url );

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -613,49 +613,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test connection url build when there's onboarding.
-	 *
-	 * @since 5.4.0
-	 */
-	public function test_build_connect_url_onboarding() {
-
-		// Create a user and set it up as current.
-		$user = $this->create_and_get_user( 'administrator' );
-		wp_set_current_user( $user->ID );
-
-		// Enable connection onboarding
-		$token = Jetpack::create_onboarding_token();
-
-		// Build URL to compare scheme and host with the one in response
-		$admin_url = parse_url( admin_url() );
-
-		// Create REST request in JSON format and dispatch
-		$response = $this->create_and_get_request( 'connection/url' );
-
-		// Format data to test it
-		$response->data = parse_url( $response->data );
-		parse_str( $response->data['query'], $response->data['query'] );
-
-		// Remove nonce for comparing
-		unset( $response->data['query']['_wpnonce'] );
-
-		// The URL was properly built
-		$this->assertResponseData(
-			array(
-				'scheme' => $admin_url['scheme'],
-				'host'   => $admin_url['host'],
-				'path'   => '/wp-admin/admin.php',
-				'query'  =>
-					array(
-						'page'       => 'jetpack',
-						'action'     => 'register',
-						'onboarding' => $token,
-					)
-			), $response
-		);
-	}
-
-	/**
 	 * Test onboarding token and make sure it's a network option.
 	 *
 	 * @since 5.4.0


### PR DESCRIPTION
### The problem

As found independently by @ockham and @oskosk and discussed in p1513787687000060-slack-jetpack-onboarding and p1513970123000089-slack-luna, if a user has an onboarding token, this would cause the connection links to contain the `onboarding=TOKEN` parameter, which would then lead users to a broken JPC flow (because JPO in Calypso is not yet in production).

#### To reproduce the bug:
* Checkout the latest Jetpack master on your **unconnected** Jetpack sandbox.
* While logged in as an admin, load `/wp-admin/admin.php?page=jetpack&action=onboard`
* Go to `/wp-admin/admin.php?page=jetpack#/`
* Inspect the connect button link - it contains the `onboarding=TOKEN` parameter.
* Attempt to connect - you will be dropped at an empty page in WP.com.

### The reason

Seems like this is caused by some code from the previous JPOalypso attempt, where connection URL was directly used to start the onboarding flow. This is no longer the case, so adding the token parameter must be decoupled from the connection URL method - then users with onboarding tokens will be able to use the connection flow like they did before. This is what this PR does, essentially.

### Testing instructions
* Checkout this PR on your **unconnected** Jetpack sandbox.
* While logged in as an admin, load `/wp-admin/admin.php?page=jetpack&action=onboard`
* Go to `/wp-admin/admin.php?page=jetpack#/`
* Inspect the connect button link - it should NOT contain the `onboarding=TOKEN` parameter.
* Attempt to connect - you should be able to connect successfully.
