### PR TITLE
XHTML Compliance For Stats Script

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -164,7 +164,7 @@ function stats_template_redirect() {
 	$data_stats_array = stats_array( $data );
 
 	$stats_footer = <<<END
-<script type='text/javascript' src='{$script}' async defer></script>
+<script type='text/javascript' src='{$script}' async='async' defer='defer'></script>
 <script type='text/javascript'>
 	_stq = window._stq || [];
 	_stq.push([ 'view', {{$data_stats_array}} ]);


### PR DESCRIPTION
XHTML compliance requires that attributes not be minimized and this fix was in an earlier version but appears to have been removed or edited for some reason this pull request simply adds back the necessary tags. 

Fixes #8415 