### PR TITLE
Widget Visibility: fix widget minor conditions dropdown entities

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -30,7 +30,7 @@ class Jetpack_Widget_Conditions {
 				'modules/widget-visibility/widget-conditions/widget-conditions.js'
 			),
 			array( 'jquery', 'jquery-ui-core' ),
-			20140721,
+			20171227,
 			true
 		);
 

--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -224,12 +224,12 @@ jQuery( function( $ ) {
 					subkey = majorData[i][1][j][0];
 					subval = majorData[i][1][j][1];
 
-					optgroup.append( $( '<option/>' ).val( subkey ).text( subval.replace( /&nbsp;/g, '\xA0' ) ) );
+					optgroup.append( $( '<option/>' ).val( subkey ).text( decodeEntities( subval.replace( /&nbsp;/g, '\xA0' ) ) ) );
 				}
 
 				select.append( optgroup );
 			} else {
-				select.append( $( '<option/>' ).val( key ).text( val.replace( /&nbsp;/g, '\xA0' ) ) );
+				select.append( $( '<option/>' ).val( key ).text( decodeEntities( val.replace( /&nbsp;/g, '\xA0' ) ) ) );
 			}
 		}
 
@@ -255,5 +255,11 @@ jQuery( function( $ ) {
 				$( this ).attr( 'name', 'conditions[page_children][' + index + ']' );
 				index++;
 			} );
+	}
+
+	function decodeEntities( encodedString ) {
+		var textarea = document.createElement( 'textarea' );
+		textarea.innerHTML = encodedString;
+		return textarea.value;
 	}
 } );


### PR DESCRIPTION
The option items of the minor conditions dropdown in the widget visibility settings are being correctly handled with esc_attr in the backend. However, some of the category names may contain entities (e.g. ampersands), so those option items must be decoded in the frontend to make the text human-readable in these cases.

#### Changes proposed in this Pull Request:

* Adding a decodeEntities function in widget-conditions.js to handle entity decoding for the minor conditions dropdown.

#### Testing instructions:

* Check the minor conditions dropdown with a category name that contains an entity (e.g. ampersand) in the widget visibility settings with and without this patch. Don't forget to bump the version number of the javascript file while it is enqueued.