### PR TITLE
REST API: add functionality for saving Business Address in JPO

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1046,7 +1046,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		// Add/update business address widget
 		if ( isset( $data['businessAddress'] ) ) {
 			//grab the first sidebar and proceed if it is present
-			$first_sidebar = self::get_first_sidebar();
+			$first_sidebar = Jetpack_Widgets::get_first_sidebar();
 
 			if( $first_sidebar ) {
 				$title = wp_unslash( $data[ 'businessAddress' ][ 'name' ] );
@@ -1080,17 +1080,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		return empty( $error )
 			? ''
 			: join( ', ', $error );
-	}
-
-		public function get_first_sidebar() {
-			$active_sidebars = Jetpack_Widgets::get_active_sidebars();
-
-			unset( $active_sidebars[ 'wp_inactive_widgets' ], $active_sidebars[ 'array_version' ] );
-
-			if ( empty( $active_sidebars ) ) {
-				return false;
-			}
-			return array_shift( array_keys( $active_sidebars ) );
 		}
 
 		public function has_business_info_widget( $sidebar ) {

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1070,7 +1070,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				$has_ba_widget = self::has_business_info_widget( $first_sidebar );
 				if ( $has_ba_widget ) {
-					self::update_widget( $id_base, $first_sidebar, $position, $widget_options);
+					$widget = Jetpack_Widgets::get_widget_by_id_base( $id_base );
+					Jetpack_Widgets::update_widget( $widget['id'], $first_sidebar, $position, $widget_options );
 				}	else {
 					Jetpack_Widgets::activate_widget( $id_base, $first_sidebar, $position, $widget_options);
 				}
@@ -1096,12 +1097,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			return false;
 		}
 
-		public function update_widget( $id_base, $sidebar, $position, $widget_options ) {
-
-			$widget = Jetpack_Widgets::get_widget_by_id_base( $id_base );
-			$widget_id = $widget['id'];
-			Jetpack_Widgets::update_widget($widget_id,  $sidebar, $position, $widget_options );
-		}
 	/**
 	 * Calls WPCOM through authenticated request to create, regenerate or delete the Post by Email address.
 	 * @todo: When all settings are updated to use endpoints, move this to the Post by Email module and replace __process_ajax_proxy_request.

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1082,18 +1082,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			: join( ', ', $error );
 	}
 
-	public function get_first_sidebar() {
+		public function get_first_sidebar() {
 			$active_sidebars = Jetpack_Widgets::get_active_sidebars();
 
-			$excluded_keys = array(
-				'wp_inactive_widgets',
-				'array_version',
-			);
-			foreach ( $excluded_keys as $key ) {
-				if ( isset( $active_sidebars[ $key ] ) ) {
-					unset( $active_sidebars[ $key ] );
-				}
-			}
+			unset( $active_sidebars[ 'wp_inactive_widgets' ], $active_sidebars[ 'array_version' ] );
+
 			if ( empty( $active_sidebars ) ) {
 				return false;
 			}

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -388,6 +388,10 @@ class Jetpack_Widgets {
 		$widget_settings = get_option( $widget_option_name );
 		$instance_key = self::get_widget_instance_key( $widget_id );
 
+		if ( ! $widget = self::get_registered_widget_object( self::get_widget_id_base( $widget_id ) ) ) {
+			return new WP_Error( 'invalid_data', 'Invalid ID base.', 400 );
+		}
+
 		// if the widget's content already exists
 		if ( isset( $widget_settings[ $instance_key ] ) ) {
 			$old_settings = $widget_settings[ $instance_key ];
@@ -508,7 +512,7 @@ class Jetpack_Widgets {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Deletes a widget entirely including all its settings. Returns a WP_Error if
 	 * the widget could not be found. Otherwise returns an empty array.

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -121,6 +121,24 @@ class Jetpack_Widgets {
 	}
 
 	/**
+	 * Return a widget by ID base or null if nothing is found.
+	 *
+	 * @param string $id_base The id of a widget to look for.
+	 *
+	 * @return array|null The matching formatted widget (see format_widget).
+	 */
+	public static function get_widget_by_id_base( $id_base ) {
+		$found = null;
+		foreach ( self::get_all_widgets() as $widget ) {
+			if ( $widget['id_base'] === $id_base ) {
+				$found = $widget;
+			}
+		}
+		return $found;
+	}
+
+
+	/**
 	 * Return an array of all widgets (active and inactive) formatted for output.
 	 *
 	 * @return array An array of all widgets (see format_widget).
@@ -373,16 +391,19 @@ class Jetpack_Widgets {
 		$widget_option_name = self::get_widget_option_name( $widget_id );
 		$widget_settings = get_option( $widget_option_name );
 		$instance_key = self::get_widget_instance_key( $widget_id );
-		$old_settings = $widget_settings[ $instance_key ];
 
-		if ( ! $settings = self::sanitize_widget_settings( $widget_id, $settings, $old_settings ) ) {
-			return new WP_Error( 'invalid_data', 'Update failed.', 500 );
-		}
-		if ( is_array( $old_settings ) ) {
-			// array_filter prevents empty arguments from replacing existing ones
-			$settings = wp_parse_args( array_filter( $settings ), $old_settings );
-		}
+		// if the widget already exists
+		if ( isset( $widget_settings[ $instance_key ] ) ) {
+			$old_settings = $widget_settings[ $instance_key ];
 
+			if ( ! $settings = self::sanitize_widget_settings( $widget_id, $settings, $old_settings ) ) {
+				return new WP_Error( 'invalid_data', 'Update failed.', 500 );
+			}
+			if ( is_array( $old_settings ) ) {
+				// array_filter prevents empty arguments from replacing existing ones
+				$settings = wp_parse_args( array_filter( $settings ), $old_settings );
+			}
+		}
 		$widget_settings[ $instance_key ] = $settings;
 
 		return update_option( $widget_option_name, $widget_settings );
@@ -458,7 +479,7 @@ class Jetpack_Widgets {
 		if ( ! isset( $widgets_in_sidebar ) ) {
 			return new WP_Error( 'invalid_data', 'No such sidebar exists', 400 );
 		}
-		self::move_widget_to_sidebar( $widget, $sidebar, $position );
+
 		$widget_save_status = self::set_widget_settings( $widget_id, $settings );
 		if ( is_wp_error( $widget_save_status ) ) {
 			return $widget_save_status;
@@ -476,6 +497,7 @@ class Jetpack_Widgets {
 	 */
 	public static function delete_widget( $widget_id ) {
 		$widget = self::get_widget_by_id( $widget_id );
+
 		if ( ! $widget ) {
 			return new WP_Error( 'not_found', 'No widget found.', 400 );
 		}
@@ -518,6 +540,7 @@ class Jetpack_Widgets {
 	 * @return array|WP_Error The newly added widget as an associative array with all the above properties except 'id_base' replaced with the generated 'id'.
 	 */
 	public static function activate_widget( $id_base, $sidebar, $position, $settings ) {
+
 		if ( ! isset( $id_base ) || ! self::validate_id_base( $id_base ) ) {
 			return new WP_Error( 'invalid_data', 'Invalid ID base', 400 );
 		}
@@ -548,7 +571,6 @@ class Jetpack_Widgets {
 		if ( self::get_widget_by_id( $widget_id ) ) {
 			return new WP_Error( 'invalid_data', 'Widget ID already exists', 500 );
 		}
-
 		self::add_widget_to_sidebar( $widget_id, $sidebar, $position );
 		$widget_save_status = self::set_widget_settings( $widget_id, $settings );
 		if ( is_wp_error( $widget_save_status ) ) {
@@ -563,7 +585,6 @@ class Jetpack_Widgets {
 				'settings' => json_encode( $settings ),
 			) );
 		}
-
 		return self::get_widget_by_id( $widget_id );
 	}
 

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -495,6 +495,22 @@ class Jetpack_Widgets {
 	}
 
 	/**
+	 * Retrieve the first active sidebar
+	 *
+	 * @return array|false Active sidebar or false if none exists
+	 */
+	public function get_first_sidebar() {
+		$active_sidebars = Jetpack_Widgets::get_active_sidebars();
+
+		unset( $active_sidebars[ 'array_version' ] );
+
+		if ( empty( $active_sidebars ) ) {
+			return false;
+		}
+		return array_shift( array_keys( $active_sidebars ) );
+	}
+
+	/**
 	 * Find a widget in a list of all widgets retrieved from a sidebar
 	 * using get_widgets_in_sidebar()
 	 * @param string $widget The widget we want to look up in the sidebar
@@ -503,7 +519,6 @@ class Jetpack_Widgets {
 	 *
 	 * @return bool Whether present.
 	 */
-
 	public static function is_widget_in_sidebar( $widgets_all, $widget_id ) {
 		foreach ( $widgets_all as $widget_el_id ) {
 			if ( $widget_el_id  === $widget_id ) {


### PR DESCRIPTION
Depends on https://github.com/Automattic/jetpack/pull/8480.

Save Business Address in a sidebar widget during the JPO flow.

#### Changes proposed in this Pull Request:

* This patch extends the onboarding endpoint to inject and subsequently update Business Address info as a sidebar widget. It is not included in the current JPO version.

#### Testing instructions:
* Checkout current master in your local Calypso
* Checkout this branch on your JP sandbox
* Go to `https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`, where `YourJetpackSandbox.com` is the domain of your JP sandbox
* Skip through the flow till the `Add a business address` step
* Add input data and move to the `Next step`
* Go to `https://YourJetpackSandbox.com/wp-admin/widgets.php` and/or your site and verify you see the newly created BA widget in the list of widgets and a post sidebar
* Go back to `Add a business address` and modify the BA input
* Verify that changes apply on your JP site

**Note:** enabling widget module when not done so is a separate PR
  
  
  
  