### PR TITLE
Sync: Update how we sync User data

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -335,10 +335,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
-		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
-		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
-			return;
-		}
 		// if a user is currently being removed as a member of this blog, we don't fire the event
 		if ( current_filter() === 'deleted_user_meta'
 		     &&
@@ -439,20 +435,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	private function is_add_new_user_to_blog() {
 		return Jetpack::is_function_in_backtrace( 'add_new_user_to_blog' );
-	}
-
-	private function is_add_user_to_blog() {
-		return Jetpack::is_function_in_backtrace( 'add_user_to_blog' );
-	}
-
-	private function is_create_user() {
-		$functions = array(
-			'add_new_user_to_blog', // Used to suppress jetpack_sync_save_user in save_user_cap_handler when user registered on multi site
-			'wp_create_user', // Used to suppress jetpack_sync_save_user in save_user_role_handler when user registered on multi site
-			'wp_insert_user', // Used to suppress jetpack_sync_save_user in save_user_cap_handler and save_user_role_handler when user registered on single site
-		);
-
-		return Jetpack::is_function_in_backtrace( $functions );
 	}
 
 	private function get_reassigned_network_user_id() {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -91,6 +91,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_register_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ), 10, 2 );
+		add_filter( 'jetpack_sync_before_send_jetpack_user_edited', array( $this, 'expand_user' ) );
+
 		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 
@@ -129,6 +131,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function add_to_user( $user ) {
+		$user = $this->get_user( $user );
 		if ( ! is_object( $user ) ) {
 			return null;
 		}
@@ -162,7 +165,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		list( $user ) = $args;
 
 		if ( $user ) {
-			return array( $this->add_to_user( $user ) );
+			return array( $this->sanitize_user( $this->add_to_user( $user ) ) );
 		}
 
 		return false;

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -123,6 +123,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 		if ( is_object( $user ) && is_object( $user->data ) ) {
 			unset( $user->data->user_pass );
+			unset( $user->data->user_activation_key );
 		}
 		if ( $user ) {
 			$user->allcaps = $this->get_real_user_capabilities( $user );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -121,8 +121,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	private function get_user( $user ) {
-		error_log( 'get USEEEEEER');
-		error_log( print_r($user,1));
 		if ( $user && ! is_object( $user ) && is_numeric( $user ) ) {
 			$user = get_user_by( 'id', $user );
 		}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -352,7 +352,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			 *
 			 * @param object The Sanitized WP_User object
 			 */
-			do_action( 'jetpack_sync_edit_user', $user );
+			do_action( 'jetpack_sync_save_user', $user );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -116,6 +116,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function sanitize_user_and_expand( $user ) {
 		$user = $this->get_user( $user );
 		$user = $this->add_to_user( $user );
+
 		return $this->sanitize_user( $user );
 	}
 
@@ -126,6 +127,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $user instanceof WP_User ) {
 			return $user;
 		}
+
 		return null;
 	}
 
@@ -141,6 +143,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $user ) {
 			$user->allcaps = $this->get_real_user_capabilities( $user );
 		}
+
 		return $user;
 	}
 
@@ -167,11 +170,12 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( is_wp_error( $user ) ) {
 			return $user_capabilities;
 		}
-		foreach( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
-			if ( $user_has_capabilities = user_can( $user , $capability ) ) {
+		foreach ( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
+			if ( $user_has_capabilities = user_can( $user, $capability ) ) {
 				$user_capabilities[ $capability ] = true;
 			}
 		}
+
 		return $user_capabilities;
 	}
 
@@ -193,9 +197,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_logout_username( $args, $user_id ) {
-		$user  = get_userdata( $user_id );
-		$user  = $this->sanitize_user( $user );
-		
+		$user = get_userdata( $user_id );
+		$user = $this->sanitize_user( $user );
+
 		$login = '';
 		if ( is_object( $user ) && is_object( $user->data ) ) {
 			$login = $user->data->user_login;
@@ -232,7 +236,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_user_edited', $user_id );
 	}
-	
+
 	function save_user_handler( $user_id, $old_user_data = null ) {
 		// ensure we only sync users who are members of the current blog
 		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
@@ -329,10 +333,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
-		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
-		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
-			return;
-		}
 		// if a user is currently being removed as a member of this blog, we don't fire the event
 		if ( current_filter() === 'deleted_user_meta'
 		     &&
@@ -433,20 +433,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	private function is_add_new_user_to_blog() {
 		return Jetpack::is_function_in_backtrace( 'add_new_user_to_blog' );
-	}
-
-	private function is_add_user_to_blog() {
-		return Jetpack::is_function_in_backtrace( 'add_user_to_blog' );
-	}
-
-	private function is_create_user() {
-		$functions = array(
-			'add_new_user_to_blog', // Used to suppress jetpack_sync_save_user in save_user_cap_handler when user registered on multi site
-			'wp_create_user', // Used to suppress jetpack_sync_save_user in save_user_role_handler when user registered on multi site
-			'wp_insert_user', // Used to suppress jetpack_sync_save_user in save_user_cap_handler and save_user_role_handler when user registered on single site
-		);
-
-		return Jetpack::is_function_in_backtrace( $functions );
 	}
 
 	private function get_reassigned_network_user_id() {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -116,7 +116,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function sanitize_user_and_expand( $user ) {
 		$user = $this->get_user( $user );
 		$user = $this->add_to_user( $user );
-
 		return $this->sanitize_user( $user );
 	}
 
@@ -127,7 +126,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $user instanceof WP_User ) {
 			return $user;
 		}
-
 		return null;
 	}
 
@@ -143,7 +141,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $user ) {
 			$user->allcaps = $this->get_real_user_capabilities( $user );
 		}
-
 		return $user;
 	}
 
@@ -170,12 +167,11 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( is_wp_error( $user ) ) {
 			return $user_capabilities;
 		}
-		foreach ( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
-			if ( $user_has_capabilities = user_can( $user, $capability ) ) {
+		foreach( Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
+			if ( $user_has_capabilities = user_can( $user , $capability ) ) {
 				$user_capabilities[ $capability ] = true;
 			}
 		}
-
 		return $user_capabilities;
 	}
 
@@ -197,9 +193,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_logout_username( $args, $user_id ) {
-		$user = get_userdata( $user_id );
-		$user = $this->sanitize_user( $user );
-
+		$user  = get_userdata( $user_id );
+		$user  = $this->sanitize_user( $user );
+		
 		$login = '';
 		if ( is_object( $user ) && is_object( $user->data ) ) {
 			$login = $user->data->user_login;
@@ -236,7 +232,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_user_edited', $user_id );
 	}
-
+	
 	function save_user_handler( $user_id, $old_user_data = null ) {
 		// ensure we only sync users who are members of the current blog
 		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
@@ -333,6 +329,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
+		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
+		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
+			return;
+		}
 		// if a user is currently being removed as a member of this blog, we don't fire the event
 		if ( current_filter() === 'deleted_user_meta'
 		     &&
@@ -433,6 +433,20 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	private function is_add_new_user_to_blog() {
 		return Jetpack::is_function_in_backtrace( 'add_new_user_to_blog' );
+	}
+
+	private function is_add_user_to_blog() {
+		return Jetpack::is_function_in_backtrace( 'add_user_to_blog' );
+	}
+
+	private function is_create_user() {
+		$functions = array(
+			'add_new_user_to_blog', // Used to suppress jetpack_sync_save_user in save_user_cap_handler when user registered on multi site
+			'wp_create_user', // Used to suppress jetpack_sync_save_user in save_user_role_handler when user registered on multi site
+			'wp_insert_user', // Used to suppress jetpack_sync_save_user in save_user_cap_handler and save_user_role_handler when user registered on single site
+		);
+
+		return Jetpack::is_function_in_backtrace( $functions );
 	}
 
 	private function get_reassigned_network_user_id() {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -19,10 +19,11 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		return false;
 	}
 
-	var $callable;
+	static $callable;
 
 	public function init_listeners( $callable ) {
-		$this->callable = $callable;
+		self::$callable = $callable;
+
 		add_action( 'user_register', array( $this, 'enqueue_within_wp_insert_user_calls' ), 11 );
 		add_action( 'profile_update', array( $this, 'enqueue_within_wp_insert_user_calls' ), 11 );
 
@@ -67,13 +68,14 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function maybe_within_wp_insert_user() {
-		if ( ! Jetpack::is_function_in_backtrace('enqueue_within_wp_insert_user_calls') ) {
-			if ( Jetpack::is_function_in_backtrace('wp_insert_user' )  ) {
+		if ( ! Jetpack::is_function_in_backtrace( 'enqueue_within_wp_insert_user_calls' ) ) {
+			if ( Jetpack::is_function_in_backtrace( 'wp_insert_user' ) ) {
 				self::$calls_within_wp_insert_user[ current_action() ][] = func_get_args();
+
 				return;
 			}
 		}
-		call_user_func( $this->callable, func_get_args() );
+		call_user_func( self::$callable, func_get_args() );
 	}
 
 	public function enqueue_within_wp_insert_user_calls() {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -83,14 +83,12 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function do_delayed_calls() {
-		var_dump( 'do delayed calls' );
 		// We want the save user action to be synced first
 		self::$calls_within_wp_insert_user = $this->prepend_event(
 			self::$calls_within_wp_insert_user, 'jetpack_sync_save_user'
 		);
 
 		foreach ( self::$calls_within_wp_insert_user as $action => $calls ) {
-			var_dump( $action );
 			foreach ( $calls as $arguments ) {
 				if ( 'user_register' === current_filter() ) {
 					if ( in_array( $action,
@@ -104,7 +102,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 				// do_action( $action, $arguments[0], $arguments[1], ... );
 				call_user_func_array( 'do_action', array_merge( array( $action ), $arguments ) );
-
 			}
 		}
 		// clear to make tests pass.

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -67,7 +67,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function maybe_within_wp_insert_user() {
-		error_log('jetpack_sync_user_locale_arg');
 		if ( ! Jetpack::is_function_in_backtrace('enqueue_within_wp_insert_user_calls') ) {
 			if ( Jetpack::is_function_in_backtrace('wp_insert_user' )  ) {
 				self::$calls_within_wp_insert_user[ current_action() ][] = func_get_args();
@@ -222,7 +221,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function edited_user_handler( $user_id ) {
-		error_log('edited_user_handler');
 		/**
 		 * Fires when a user is edited on a site
 		 *
@@ -234,7 +232,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 	
 	function save_user_handler( $user_id, $old_user_data = null ) {
-		error_log('save_user_handler');
 		// ensure we only sync users who are members of the current blog
 		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
 			return;
@@ -331,11 +328,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
 		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
-		error_log('save_user_cap_handler_1');
 		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
 			return;
 		}
-		error_log('save_user_cap_handler_2');
 		// if a user is currently being removed as a member of this blog, we don't fire the event
 		if ( current_filter() === 'deleted_user_meta'
 		     &&

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -27,9 +27,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 		unset( $user->allcaps['subscriber'] );
 		unset( $user->allcaps['level_0'] );
+		unset( $user->data->user_activation_key );
+
 		$this->assertEqualsObject( $user, $server_user );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );
+
 
 		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
 		$synced_user = $event->args[0];
@@ -43,6 +46,10 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
+		unset( $retrieved_user->data->user_pass );
+		unset( $retrieved_user->data->user_activation_key );
+		unset( $retrieved_user->allcaps['level_0'] );
+		unset( $retrieved_user->allcaps['subscriber'] );
 
 		$this->assertEquals( $synced_user, $retrieved_user );
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -44,12 +44,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 			$user_sync_module->get_object_by_id( 'user', $this->user_id )
 		) );
 
-		// TODO: this is to address a testing bug, alas :/
-		unset( $retrieved_user->data->allowed_mime_types );
 		unset( $retrieved_user->data->user_pass );
 		unset( $retrieved_user->data->user_activation_key );
 		unset( $retrieved_user->allcaps['level_0'] );
 		unset( $retrieved_user->allcaps['subscriber'] );
+		// TODO: this is to address a testing bug, alas :/
+		unset( $retrieved_user->data->allowed_mime_types );
 
 		$this->assertEquals( $synced_user, $retrieved_user );
 
@@ -477,6 +477,10 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 			$user_sync_module->get_object_by_id( 'user', $this->user_id )
 		) );
 
+		unset( $retrieved_user->data->user_pass );
+		unset( $retrieved_user->data->user_activation_key );
+		unset( $retrieved_user->allcaps['level_0'] );
+		unset( $retrieved_user->allcaps['subscriber'] );
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -368,8 +368,13 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		) );
 
 		// TODO: this is to address a testing bug, alas :/
+		unset( $retrieved_user->data->user_pass );
+		unset( $retrieved_user->data->user_activation_key );
+		// lets not compare all caps
+		unset( $retrieved_user->allcaps );
+		unset( $synced_user->allcaps );
+		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
-
 		$this->assertEquals( $synced_user, $retrieved_user );
 	}
 


### PR DESCRIPTION
If applied, this diff will:
- change the order of sync actions for user-related events by delaying certain syncs to happen after wp_insert_user
- create a new sync event for when a user's role is changed.

Still in progress, Unit tests need updating.

To test:
With this diff applied try
- adding a new user
- editing a user
- adding / editing via API
- editing your profile
- add existing user to multi-site
- invite user -> user accepts invite
- user registers via registration form
- delete user

Ensure stuff is syncing properly upstream.

  