### PR TITLE
REST API: JPO - save site type

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -964,6 +964,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$site_title = get_option( 'blogname' );
 		$author = get_current_user_id() || 1;
 
+		if ( ! empty( $data['siteType'] ) ) {
+			if ( ! ( update_option( 'jpo_site_type', $data['siteType'] ) || get_option( 'jpo_site_type' ) == $data['siteType'] ) ) {
+				$error[] = 'siteType';
+			}
+		}
+
 		// If $data['homepageFormat'] is 'posts', we have nothing to do since it's WordPress' default
 		if ( isset( $data['homepageFormat'] ) && 'page' === $data['homepageFormat'] ) {
 			if ( ! ( update_option( 'show_on_front', 'page' ) || get_option( 'show_on_front' ) == 'page' ) ) {

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -533,6 +533,7 @@ class Jetpack_Options {
 			'jetpack_sso_require_two_step',
 			'jetpack_sso_remove_login_form',
 			'jetpack_last_connect_url_check',
+			'jpo_site_type',
 		);
 	}
 


### PR DESCRIPTION
This updates the JPO onboarding request to save the site type in the onboarding request. Previously, the site type was not taken into consideration. Option name is consistent with the original JPO plugin (see https://github.com/Automattic/jetpack-onboarding/blob/master/class.jetpack-onboarding-end-points.php#L7).

To test:

Follow the instructions in https://github.com/Automattic/wp-calypso/pull/21154