### PR TITLE
Allow enabling connection-free modules when onboarding

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1566,7 +1566,7 @@ class Jetpack {
 	 * @access public
 	 * @static
 	 *
-	 * @return bool True the site is currently onboarding, false otherwise
+	 * @return bool True if the site is currently onboarding, false otherwise
 	 */
 	public static function is_onboarding() {
 		return Jetpack_Options::get_option( 'onboarding' ) !== false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2775,7 +2775,8 @@ class Jetpack {
 		$module_data = Jetpack::get_module( $module );
 
 		if ( ! Jetpack::is_active() ) {
-			if ( !Jetpack::is_development_mode() )
+			$is_onboarding = Jetpack_Options::get_option( 'onboarding' ) !== false;
+			if ( ! Jetpack::is_development_mode() && ! $is_onboarding )
 				return false;
 
 			// If we're not connected but in development mode, make sure the module doesn't require a connection

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1563,6 +1563,8 @@ class Jetpack {
 	 * Whether the site is currently onboarding or not.
 	 * A site is considered as being onboarded if it currently has an onboarding token.
 	 *
+	 * @since 5.8
+	 *
 	 * @access public
 	 * @static
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1560,6 +1560,19 @@ class Jetpack {
 	}
 
 	/**
+	 * Whether the site is currently onboarding or not.
+	 * A site is considered as being onboarded if it currently has an onboarding token.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool True the site is currently onboarding, false otherwise
+	 */
+	public static function is_onboarding() {
+		return Jetpack_Options::get_option( 'onboarding' ) !== false;
+	}
+
+	/**
 	* Get Jetpack development mode notice text and notice class.
 	*
 	* Mirrors the checks made in Jetpack::is_development_mode
@@ -2775,8 +2788,7 @@ class Jetpack {
 		$module_data = Jetpack::get_module( $module );
 
 		if ( ! Jetpack::is_active() ) {
-			$is_onboarding = Jetpack_Options::get_option( 'onboarding' ) !== false;
-			if ( ! Jetpack::is_development_mode() && ! $is_onboarding )
+			if ( ! Jetpack::is_development_mode() && ! Jetpack::is_onboarding() )
 				return false;
 
 			// If we're not connected but in development mode, make sure the module doesn't require a connection


### PR DESCRIPTION
Currently, if dev mode is disabled and you're not connected, you're not able to enable modules that don't require connection. We'll need to be able to do it for JPO - this is what this PR suggests.

To test:
* Checkout this branch
* Disable dev mode.
* Pick a fresh unconnected, site that doesn't have an onboarding token yet.
* Try enabling contact form module (`wp jetpack module activate contact-form`)
* Verify module is not activated.
* Generate an onboarding token (`/wp-admin/admin.php?page=jetpack&action=onboard` can do it for you)
* Try enabling contact form module (`wp jetpack module activate contact-form`).
* Verify module is activated.
* Try activating a module that requires connection (like photon). Verify it doesn't activate, even if you have an onboarding token.