### PR TITLE
Build: Fixes issue where non-minified files in _inc/js were not shipped

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -26,7 +26,6 @@ modules/widgets/follow-button.php
 to-test.md
 .editorconfig
 _inc/client
-_inc/*.js
 _inc/build/*.js.map
 _inc/build/*.css.map
 _inc/build/maps


### PR DESCRIPTION
@oskosk reported an issue to me where we weren't shipping the non-minified JS files in the `_inc/js` directory. This is because we added `_inc/*.js` to the `.svnignore` file.

We did this because, originally, we decided to only ship minified files along with map files. But, for the last release, we found that shipping the non-minified files was actually bit lighter than shipping maps, so we changed that.

Unfortunately, as part of that change, we didn't update the `.svnignore`. And, since the files are only purged when releasing a master-stable build or a build for release, via scripts in the `tools` directory, we didn't notice the issue.

To test:

- Modify the `tools/deploy-to-master-stable-branch.sh` so that the "echo "Finally, Committing and Pushing" until the end of the file are commented out
- `git commit -am 'temp'`
- `sh tools/deploy-to-master-stable-branch.sh`
- `cd /tmp/jetpack`
- Ensure that `_inc/*.js` files exist