### PR TITLE
REST API Tests: Expect proper http status code instead of previously hardcoded 403 with WordPress >= 5.0-alpha

### DIFF
--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -63,6 +63,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_token_or_signature() {
+		global $wp_version;
 		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/module/protect' );
 		$response = $this->server->dispatch( $this->request );
 		// Starting with https://core.trac.wordpress.org/ticket/42828, Core uses rest_authorization_required_code()

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -66,7 +66,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/module/protect' );
 		$response = $this->server->dispatch( $this->request );
 		// From https://github.com/WordPress/WordPress/blob/4.7/wp-includes/rest-api/class-wp-rest-server.php#L902
-		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
 		$this->assertEquals( 0, get_current_user_id() );
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -65,8 +65,11 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	public function test_jetpack_rest_api_authentication_fail_no_token_or_signature() {
 		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/module/protect' );
 		$response = $this->server->dispatch( $this->request );
+		// Starting with https://core.trac.wordpress.org/ticket/42828, Core uses rest_authorization_required_code()
+		// to get the appropriate status code instead of a hardcoded 403.
+		$expected_status_code = version_compare( $wp_version, '5.0-alpha', '>=' ) ? rest_authorization_required_code() : 403;
 		// From https://github.com/WordPress/WordPress/blob/4.7/wp-includes/rest-api/class-wp-rest-server.php#L902
-		$this->assertErrorResponse( 'rest_forbidden', $response, rest_authorization_required_code() );
+		$this->assertErrorResponse( 'rest_forbidden', $response, $expected_status_code );
 		$this->assertEquals( 0, get_current_user_id() );
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -66,7 +66,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/module/protect' );
 		$response = $this->server->dispatch( $this->request );
 		// From https://github.com/WordPress/WordPress/blob/4.7/wp-includes/rest-api/class-wp-rest-server.php#L902
-		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+		$this->assertErrorResponse( 'rest_forbidden', $response, rest_authorization_required_code() );
 		$this->assertEquals( 0, get_current_user_id() );
 	}
 


### PR DESCRIPTION
Fixes failing unit test that expects status code `403`. This was introduced in latest core master here: https://github.com/WordPress/WordPress/commit/a7870062981b3200802b3059b6d65bf5d6ee5369

#### Changes proposed in this Pull Request:

Updates the test `WP_Test_Jetpack_REST_API_Authentication::test_jetpack_rest_api_authentication_fail_no_token_or_signature` to expect `401` instead of `403`.

#### Testing instructions:

* Run the tests and expect them to pass. (Which is the same as seeing this PR passing the tests).

