### PR TITLE
Sync: Sync previous state when sycing post saves. 

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -41,7 +41,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'jetpack_published_post', $callable, 10, 2 );
 
 		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
-		add_filter( 'jetpack_sync_before_enqueue_jetpack_save_post', array( $this, 'filter_blacklisted_post_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_save_post', array( $this, 'filter_blacklisted_post_types' ) );
 
 		// listen for meta changes
 		$this->init_listeners_for_meta_type( 'post', $callable );
@@ -123,7 +123,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_save_post', array( $this, 'expand_jetpack_save_post' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_post', array( $this, 'expand_jetpack_sync_save_post' ) );
 
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
@@ -166,7 +166,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	 *
 	 * @return array
 	 */
-	function expand_jetpack_save_post( $args ) {
+	function expand_jetpack_sync_save_post( $args ) {
 		list( $post_id, $post, $update, $previous_state ) = $args;
 		return array( $post_id, $this->filter_post_content_and_add_links( $post ), $update, $previous_state );
 	}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	private $action_handler;
 	private $import_end = false;
 
-	const PREVIOUS_STATE = 'new';
+	const DEFAULT_PREVIOUS_STATE = 'new';
 
 	public function name() {
 		return 'posts';
@@ -317,7 +317,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function save_published( $new_status, $old_status, $post ) {
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
-			$this->just_published[$post->ID] = true;
+			$this->just_published[ $post->ID ] = true;
 		}
 
 		$this->previous_status[ $post->ID ] = $old_status;
@@ -335,7 +335,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$previous_status = isset( $this->previous_status[ $post_ID ] ) ?
 			$this->previous_status[ $post_ID ] :
-			self::PREVIOUS_STATE;
+			self::DEFAULT_PREVIOUS_STATE;
 
 		$just_published = isset( $this->just_published[ $post_ID ] ) ?
 			$this->just_published[ $post_ID ] :
@@ -346,8 +346,18 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			'previous_status' => $previous_status,
 			'just_published' => $just_published
 		);
-
+		/**
+		 * Filter that is used to add to the post flags ( meta data ) when a post gets published
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param int $post_ID the post ID
+		 * @param mixed $post WP_POST object
+		 * @param bool  $update Whether this is an existing post being updated or not.
+		 * @param mixed $state state
+		 */
 		do_action( 'jetpack_sync_save_post', $post_ID, $post, $update, $state );
+		unset( $this->previous_status[ $post_ID ] );
 		$this->send_published( $post_ID, $post );
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -35,7 +35,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$priority = version_compare( $wp_version, '4.7-alpha', '<' ) ? 0 : 11;
 
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), $priority, 3 );
-		add_action( 'jetpack_save_post', $callable, 10, 5 );
+		add_action( 'jetpack_save_post', $callable, 10, 4 );
 
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -35,7 +35,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$priority = version_compare( $wp_version, '4.7-alpha', '<' ) ? 0 : 11;
 
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), $priority, 3 );
-		add_action( 'jetpack_save_post', $callable, 10, 4 );
+		add_action( 'jetpack_sync_save_post', $callable, 10, 4 );
 
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );
@@ -347,7 +347,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			'just_published' => $just_published
 		);
 
-		do_action( 'jetpack_save_post', $post_ID, $post, $update, $state );
+		do_action( 'jetpack_sync_save_post', $post_ID, $post, $update, $state );
 		$this->send_published( $post_ID, $post );
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -355,6 +355,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 * @param mixed $post WP_POST object
 		 * @param bool  $update Whether this is an existing post being updated or not.
 		 * @param mixed $state state
+		 *
+		 * @module sync
 		 */
 		do_action( 'jetpack_sync_save_post', $post_ID, $post, $update, $state );
 		unset( $this->previous_status[ $post_ID ] );

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -19,7 +19,7 @@ class Jetpack_Sync_Server_Replicator {
 
 		switch ( $action_name ) {
 			// posts
-			case 'jetpack_save_post':
+			case 'jetpack_sync_save_post':
 				list( $post_id, $post ) = $args;
 				$this->store->upsert_post( $post, $silent );
 				break;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -20,7 +20,6 @@ class Jetpack_Sync_Server_Replicator {
 		switch ( $action_name ) {
 			// posts
 			case 'jetpack_save_post':
-			case 'wp_insert_post':
 				list( $post_id, $post ) = $args;
 				$this->store->upsert_post( $post, $silent );
 				break;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -19,6 +19,7 @@ class Jetpack_Sync_Server_Replicator {
 
 		switch ( $action_name ) {
 			// posts
+			case 'jetpack_save_post':
 			case 'wp_insert_post':
 				list( $post_id, $post ) = $args;
 				$this->store->upsert_post( $post, $silent );

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -30,7 +30,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	// This is trickier than you would expect because we only check against
 	// maximum queue size periodically (to avoid a counts on every request), and then
 	// we cache the "blocked on queue size" status.
-	// In addition, we should only enforce the queue size limit if the oldest (aka frontmost) 
+	// In addition, we should only enforce the queue size limit if the oldest (aka frontmost)
 	// item in the queue is gt 15 minutes old.
 	function test_detects_if_exceeded_queue_size_limit_and_oldest_item_gt_15_mins() {
 		$this->listener->get_sync_queue()->reset();
@@ -116,7 +116,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
-		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->silent );
+		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' ) );
+		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->silent );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -116,7 +116,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' ) );
-		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->silent );
+		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' ) );
+		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' )->silent );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -22,7 +22,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_add_post_syncs_event() {
 		// event stored by server should event fired by client
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertEquals( $this->post->ID, $event->args[0] );
 
 		$post_sync_module = Jetpack_Sync_Modules::get_module( "posts" );
@@ -43,7 +43,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_add_post_syncs_request_is_auto_save() {
 		//Sync from setup should not be auto save
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertFalse( $event->args[3]['is_auto_save'] );
 
 		Jetpack_Constants::set_constant( 'DOING_AUTOSAVE', true );
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create( array( 'post_author' => $user_id ) );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertTrue( $event->args[3]['is_auto_save'] );
 	}
 
@@ -63,7 +63,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		wp_delete_post( $this->post->ID );
 
 		$this->sender->do_sync();
-		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 
 		$this->assertEquals( $insert_event->args[1]->post_status, 'trash' );
 		$this->assertEquals( $insert_event->args[0], $this->post->ID );
@@ -77,7 +77,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		// Since the post status is not changing here we don't expect the post to be trashed again.
 		$delete_event = $this->server_event_storage->get_most_recent_event( 'deleted_post' );
-		$save_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$save_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertFalse( $save_event );
 		$this->assertTrue( (bool) $delete_event );
 	}
@@ -87,7 +87,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->server_event_storage->reset();
 		wp_delete_post( $this->post->ID );
 		$this->sender->do_sync();
-		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertEquals( 'trash', $insert_event->args[1]->post_status ); //
 		$this->assertEquals( 'publish', $insert_event->args[3]['previous_status'] );
 	}
@@ -432,7 +432,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_permalink_and_shortlink() {
-		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$post              = $insert_post_event->args[1];
 
 		$this->assertObjectHasAttribute( 'permalink', $post );
@@ -453,7 +453,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->args[1];
+		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' )->args[1];
 		$this->assertObjectHasAttribute( 'featured_image', $post_on_server );
 		$this->assertInternalType( 'string', $post_on_server->featured_image );
 		$this->assertContains( 'test_image.png', $post_on_server->featured_image );
@@ -464,7 +464,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->args[1];
+		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' )->args[1];
 		$this->assertObjectNotHasAttribute( 'featured_image', $post_on_server );
 	}
 
@@ -508,7 +508,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 
 		$this->assertEquals( 2, $this->server_replica_storage->post_count() ); // the post and its revision
-		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$post              = $insert_post_event->args[1];
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.
 
@@ -611,7 +611,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		// get the synced object
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$synced_post = $event->args[1];
 
 		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
@@ -991,11 +991,11 @@ That was a cool video.';
 		$events = array_slice( $events, -4);
 
 		$this->assertEquals( $events[0]->args[0], $events[1]->args[0] );
-		$this->assertEquals( $events[0]->action, 'jetpack_save_post' );
+		$this->assertEquals( $events[0]->action, 'jetpack_sync_save_post' );
 		$this->assertEquals( $events[1]->action, 'jetpack_published_post' );
 
 		$this->assertEquals( $events[2]->args[0], $events[3]->args[0] );
-		$this->assertEquals( $events[2]->action, 'jetpack_save_post' );
+		$this->assertEquals( $events[2]->action, 'jetpack_sync_save_post' );
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -22,9 +22,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_add_post_syncs_event() {
 		// event stored by server should event fired by client
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
-
-		$this->assertEquals( 'wp_insert_post', $event->action );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$this->assertEquals( $this->post->ID, $event->args[0] );
 
 		$post_sync_module = Jetpack_Sync_Modules::get_module( "posts" );
@@ -45,7 +43,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_add_post_syncs_request_is_auto_save() {
 		//Sync from setup should not be auto save
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$this->assertFalse( $event->args[3] );
 
 		Jetpack_Constants::set_constant( 'DOING_AUTOSAVE', true );//define( 'DOING_AUTOSAVE', true );
@@ -55,7 +53,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create( array( 'post_author' => $user_id ) );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$this->assertTrue( $event->args[3] );
 	}
 
@@ -65,35 +63,32 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		wp_delete_post( $this->post->ID );
 
 		$this->sender->do_sync();
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
-		$insert_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 
-		$this->assertEquals( 'post', $event->args[1] );
-		$this->assertTrue( (bool) $event );
-		$this->assertTrue( $insert_event->args[5], 'wp_insert_post set to false as trashed' );
+		$this->assertEquals( $insert_event->args[1]->post_status, 'trash' );
 		$this->assertEquals( $insert_event->args[0], $this->post->ID );
 
 		$this->server_event_storage->reset();
 
 		$this->assertEquals( 0, $this->server_replica_storage->post_count( 'publish' ) );
 		$this->assertEquals( 1, $this->server_replica_storage->post_count( 'trash' ) );
-
 		wp_delete_post( $this->post->ID );
 		$this->sender->do_sync();
 
 		// Since the post status is not changing here we don't expect the post to be trashed again.
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
-		$this->assertFalse( (bool) $event );
+		$delete_event = $this->server_event_storage->get_most_recent_event( 'deleted_post' );
+		$save_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$this->assertFalse( $save_event );
+		$this->assertTrue( (bool) $delete_event );
 	}
 
 	public function test_sync_post_event_includes_previous_state() {
 		// $this->assertEquals( 1, $this->server_replica_storage->post_count( 'publish' ) );
 		$this->server_event_storage->reset();
 		wp_delete_post( $this->post->ID );
-
 		$this->sender->do_sync();
 		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
-
+		$this->assertEquals( 'trash', $insert_event->args[1]->post_status ); //
 		$this->assertEquals( 'publish', $insert_event->args[4] );
 	}
 
@@ -437,7 +432,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_permalink_and_shortlink() {
-		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$post              = $insert_post_event->args[1];
 
 		$this->assertObjectHasAttribute( 'permalink', $post );
@@ -458,7 +453,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
+		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->args[1];
 		$this->assertObjectHasAttribute( 'featured_image', $post_on_server );
 		$this->assertInternalType( 'string', $post_on_server->featured_image );
 		$this->assertContains( 'test_image.png', $post_on_server->featured_image );
@@ -469,7 +464,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
+		$post_on_server = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' )->args[1];
 		$this->assertObjectNotHasAttribute( 'featured_image', $post_on_server );
 	}
 
@@ -513,7 +508,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 
 		$this->assertEquals( 2, $this->server_replica_storage->post_count() ); // the post and its revision
-		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$post              = $insert_post_event->args[1];
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.
 
@@ -616,7 +611,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		// get the synced object
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$synced_post = $event->args[1];
 
 		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
@@ -801,8 +796,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
 		// this only applies to rendered content, which is off by default
 		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
-
-		global $wp_version;
 
 		$content =
 			'Check out this cool video:
@@ -998,11 +991,11 @@ That was a cool video.';
 		$events = array_slice( $events, -4);
 
 		$this->assertEquals( $events[0]->args[0], $events[1]->args[0] );
-		$this->assertEquals( $events[0]->action, 'wp_insert_post' );
+		$this->assertEquals( $events[0]->action, 'jetpack_save_post' );
 		$this->assertEquals( $events[1]->action, 'jetpack_published_post' );
 
 		$this->assertEquals( $events[2]->args[0], $events[3]->args[0] );
-		$this->assertEquals( $events[2]->action, 'wp_insert_post' );
+		$this->assertEquals( $events[2]->action, 'jetpack_save_post' );
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -44,9 +44,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	public function test_add_post_syncs_request_is_auto_save() {
 		//Sync from setup should not be auto save
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
-		$this->assertFalse( $event->args[3] );
+		$this->assertFalse( $event->args[3]['is_auto_save'] );
 
-		Jetpack_Constants::set_constant( 'DOING_AUTOSAVE', true );//define( 'DOING_AUTOSAVE', true );
+		Jetpack_Constants::set_constant( 'DOING_AUTOSAVE', true );
 
 		//Performing sync here (even though setup() does it) to sync REQUEST_URI
 		$user_id = $this->factory->user->create();
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
-		$this->assertTrue( $event->args[3] );
+		$this->assertTrue( $event->args[3]['is_auto_save'] );
 	}
 
 	public function test_trash_post_trashes_data() {
@@ -83,13 +83,13 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_post_event_includes_previous_state() {
-		// $this->assertEquals( 1, $this->server_replica_storage->post_count( 'publish' ) );
+		$this->assertEquals( 1, $this->server_replica_storage->post_count( 'publish' ) );
 		$this->server_event_storage->reset();
 		wp_delete_post( $this->post->ID );
 		$this->sender->do_sync();
 		$insert_event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 		$this->assertEquals( 'trash', $insert_event->args[1]->post_status ); //
-		$this->assertEquals( 'publish', $insert_event->args[4] );
+		$this->assertEquals( 'publish', $insert_event->args[3]['previous_status'] );
 	}
 
 	public function test_delete_post_deletes_data() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -203,7 +203,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 
 		$this->assertTrue( $event->timestamp > $beginning_of_test );
 		$this->assertTrue( $event->timestamp < microtime( true ) );
@@ -216,7 +216,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 
 		$this->assertEquals( $user_id, $event->user_id );
 	}
@@ -232,7 +232,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$after_sync = microtime( true );
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 
 		$this->assertTrue( $event->sent_timestamp > $beginning_of_test );
 		$this->assertTrue( $event->sent_timestamp > $before_sync );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -203,7 +203,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 
 		$this->assertTrue( $event->timestamp > $beginning_of_test );
 		$this->assertTrue( $event->timestamp < microtime( true ) );
@@ -216,7 +216,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 
 		$this->assertEquals( $user_id, $event->user_id );
 	}
@@ -232,7 +232,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$after_sync = microtime( true );
 
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_save_post' );
 
 		$this->assertTrue( $event->sent_timestamp > $beginning_of_test );
 		$this->assertTrue( $event->sent_timestamp > $before_sync );
@@ -267,7 +267,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $full_sync->is_started() );
 
 		$full_sync->reset_data();
-		
+
 		$this->assertFalse( $full_sync->is_started() );
 	}
 
@@ -296,7 +296,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$processed_item_ids = $this->server->receive( $data, null, $sent_timestamp );
 
 		// add an error at the end
-		$processed_item_ids[] = new WP_Error( 'an_error', 'An Error Occurred' );		
+		$processed_item_ids[] = new WP_Error( 'an_error', 'An Error Occurred' );
 
 		return $processed_item_ids;
 	}
@@ -324,7 +324,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );	
+		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );
 	}
 
 	function test_default_value_for_max_execution_time() {
@@ -384,7 +384,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		register_post_type( 'http_listener', $args );
 
 		// register a trivial action we use to force sync
-		add_action( 'my_action', array( $this->listener, 'action_handler' ) ); 
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
 
 		// log http_listener during send data, since in test we're not sending real HTTP requests
 		add_filter( 'jetpack_sync_send_data', array( $this, 'create_http_listener_post_and_return_processed_ids' ), 10, 1 );


### PR DESCRIPTION
Sync previous state with in the wp_insert_post

Currently we don't have a good way to tell what the previous state was previous state with we sync posts.

Creating a new action would help keep things backwards compatible. 


#### Changes proposed in this Pull Request:

*

#### Testing instructions:

* Do the tests pass? 
* With the .com patch do you does you site still publicize and send subscription emails? 
* Does the data save and are you able to get the post to show up in related posts?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

  