### PR TITLE
Remove var_dump() from unit test

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -512,7 +512,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$post_type_object->register_taxonomies();
 
 		$sanitized = Jetpack_Sync_Functions::sanitize_post_type( $post_type_object );
-		var_dump( $sanitized );
 		$this->assert_sanitized_post_type_default( $sanitized, $label );
 
 	}


### PR DESCRIPTION
The `var_dump()` that was added in https://github.com/Automattic/jetpack/commit/0aabd5172a6615492d3453d14ae14803273ccbcc is polluting the unit test results. Example:

https://travis-ci.org/Automattic/jetpack/jobs/324279199#L653-L801