### PR TITLE
Fix register post types unit test under PHP 5.2.

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -620,10 +620,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_register_post_types_callback_error() {
-		if ( version_compare(PHP_VERSION, '5.4', '<' ) ) {
-			$this->markTestSkipped( 'Callbacks are only available in PHP 5.4 and greater' );
-		}
-		register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
+		register_post_type( 'testing', array( 'register_meta_box_cb' => '__return_null' ) );
 		$this->sender->do_sync();
 
 		$post_types =  $this->server_replica_storage->get_callable( 'post_types' );


### PR DESCRIPTION
Apparently version switching doesn't work as intended on Travis CI?

See https://travis-ci.org/Automattic/jetpack/jobs/324450213#L614