### PR TITLE
JPC: Support onboarding in register step

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3967,7 +3967,13 @@ p {
 					'from' => $from
 				) );
 
-				wp_redirect( $this->build_connect_url( true, $redirect, $from ) );
+				$url = $this->build_connect_url( true, $redirect, $from );
+
+				if ( ! empty( $_GET['onboarding'] ) ) {
+					$url = add_query_arg( 'onboarding', sanitize_key( $_GET['onboarding'] ), $url );
+				}
+
+				wp_redirect( $url );
 				exit;
 			case 'activate' :
 				if ( ! current_user_can( 'jetpack_activate_modules' ) ) {


### PR DESCRIPTION
As @oskosk correctly identified and explained in https://github.com/Automattic/jetpack/pull/8414#issuecomment-354473595, with a fresh JP site we're unable to initiate the onboarding process. This is because in the initial JPC registration step, we didn't support the onboarding parameter when isolating JPO logic in #8414.

To test:
* Go through steps in https://github.com/Automattic/jetpack/pull/8414#issuecomment-354473595
* Verify you're able to arrive to the onboardng page in all cases.
* Verify you're still able to connect and reconnect a JP site properly.