### PR TITLE
REST API: JPO - Install WooCommerce

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -936,9 +936,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @param string $slug Plugin slug.
 	 *
-	 * @return bool True if installation succeeded, error object otherwise.
+	 * @return bool|WP_Error True if installation succeeded, error object otherwise.
 	 */
-	static function _install_plugin( $slug ) {
+	static function install_plugin( $slug ) {
 		if ( is_multisite() && ! current_user_can( 'manage_network' ) ) {
 			return new WP_Error( 'not_allowed', 'You are not allowed to install plugins on this site.' );
 		}
@@ -954,13 +954,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	}
 
 	/**
-	 * Install the WooCommerce plugin.
+	 * Activate the WooCommerce plugin; install if it's not yet present.
 	 *
 	 * @since 5.8.0
 	 *
-	 * @return bool True if installation succeeded, error object otherwise.
+	 * @return bool|WP_Error True if the plugin could be activated, error object otherwise.
 	 */
-	static function _install_woocommerce() {
+	static function install_and_activate_woocommerce() {
 		// Check if get_plugins() function exists. This is required on the front end of the
 		// site, since it is in a file that is normally only loaded in the admin.
 		if ( ! function_exists( 'get_plugins' ) ) {
@@ -971,7 +971,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$WOOCOMMERCE_SLUG = 'woocommerce';
 
 		if ( ! array_key_exists( $WOOCOMMERCE_ID, get_plugins() ) ) {
-			$installed = self::_install_plugin( $WOOCOMMERCE_SLUG );
+			$installed = self::install_plugin( $WOOCOMMERCE_SLUG );
 			if ( is_wp_error( $installed ) ) {
 				return $installed;
 			}
@@ -1095,7 +1095,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		if ( isset( $data['installWooCommerce'] ) && $data['installWooCommerce'] ) {
-			$wc_install_result = self::_install_woocommerce();
+			$wc_install_result = self::install_and_activate_woocommerce();
 			if ( is_wp_error( $wc_install_result ) ) {
 				$error[] = 'woocommerce installation';
 			}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -970,22 +970,16 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$WOOCOMMERCE_ID = 'woocommerce/woocommerce.php';
 		$WOOCOMMERCE_SLUG = 'woocommerce';
 
-		$result = true;
 		if ( ! array_key_exists( $WOOCOMMERCE_ID, get_plugins() ) ) {
 			$installed = self::_install_plugin( $WOOCOMMERCE_SLUG );
 			if ( is_wp_error( $installed ) ) {
-				$result = $installed;
-			} else {
-				$result = activate_plugin( $WOOCOMMERCE_ID );
+				return $installed;
 			}
+			return activate_plugin( $WOOCOMMERCE_ID );
 		} else if ( ! is_plugin_active( $WOOCOMMERCE_ID ) ) {
-			$result = activate_plugin( $WOOCOMMERCE_ID );
+			return activate_plugin( $WOOCOMMERCE_ID );
 		}
-		if ( is_wp_error( $result ) ) {
-			wp_send_json_error( 'Could not install WooCommerce: ' . $result->get_error_message() );
-		} else {
-			wp_send_json_success();
-		}
+		return true; // Already installed and active
 	}
 
 	/**
@@ -1101,7 +1095,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		if ( isset( $data['installWooCommerce'] ) && $data['installWooCommerce'] ) {
-			self::_install_woocommerce();
+			$wc_install_result = self::_install_woocommerce();
+			if ( is_wp_error( $wc_install_result ) ) {
+				$error[] = 'woocommerce installation';
+			}
 		}
 
 		return empty( $error )

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1094,7 +1094,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
-		if ( isset( $data['installWooCommerce'] ) && $data['installWooCommerce'] ) {
+		if ( ! empty( $data['installWooCommerce'] ) ) {
 			$wc_install_result = self::install_and_activate_woocommerce();
 			if ( is_wp_error( $wc_install_result ) ) {
 				$error[] = 'woocommerce installation';


### PR DESCRIPTION
Counterpart to https://github.com/Automattic/wp-calypso/pull/21237.
 
Code mostly stolen from https://github.com/Automattic/jetpack-onboarding/blob/06c6c51417b95d7b766ee5aad762769b9c208571/class.jetpack-onboarding-end-points.php#L582-L615. I tried to find prior art for plugin installation in Jetpack itself, but only found a dedicated endpoint. If we were to use code from there, we'd have to move it to a shared file; not sure that makes sense, since the [install endpoint code](https://github.com/Automattic/jetpack/blob/b364f229bf5243aea244f3b81e63d1c728adda8f/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php#L57-L99) also included bulk install logic which we don't need.

I've also noted that @tyxla left some [comments](https://github.com/Automattic/jetpack-onboarding/pull/36/files#r77328714) on the PR that originally added WooCommerce installation to the JPO plugin, but I don't know the mentioned core functions well enough to make sense of it 😳.