### PR TITLE
Search: Add filter count validation to filters widget

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -162,7 +162,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			$filters = array();
 			foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
 				$count = intval( $new_instance['num_filters'][ $index ] );
-				$count = min( 20, $count ); // Set max boundary at 20
+				$count = min( 50, $count ); // Set max boundary at 20
 				$count = max( 1, $count );  // Set min boundary at 1
 
 				switch ( $type ) {
@@ -362,14 +362,14 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 			<p>
 				<label>
-					<?php esc_html_e( 'Maximum number of filters (1-20):', 'jetpack' ); ?>
+					<?php esc_html_e( 'Maximum number of filters (1-50):', 'jetpack' ); ?>
 					<input
 						class="widefat"
 						name="<?php echo esc_attr( $this->get_field_name( 'num_filters' ) ); ?>[]"
 						type="number"
 						value="<?php echo intval( $args['count'] ); ?>"
 						min="1"
-						max="20"
+						max="50"
 						step="1"
 						required
 					/>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -161,27 +161,31 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		if ( $instance['use_filters'] ) {
 			$filters = array();
 			foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
+				$count = intval( $new_instance['num_filters'][ $index ] );
+				$count = min( 20, $count ); // Set max boundary at 20
+				$count = max( 1, $count );  // Set min boundary at 1
+
 				switch ( $type ) {
 					case 'taxonomy':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'taxonomy',
 							'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 						);
 						break;
 					case 'post_type':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'post_type',
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 						);
 						break;
 					case 'date_histogram':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'date_histogram',
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 							'field' => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
 							'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
 						);
@@ -358,12 +362,16 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 			<p>
 				<label>
-					<?php esc_html_e( 'Maximum number of filters:', 'jetpack' ); ?>
+					<?php esc_html_e( 'Maximum number of filters (1-20):', 'jetpack' ); ?>
 					<input
 						class="widefat"
 						name="<?php echo esc_attr( $this->get_field_name( 'num_filters' ) ); ?>[]"
 						type="number"
 						value="<?php echo intval( $args['count'] ); ?>"
+						min="1"
+						max="20"
+						step="1"
+						required
 					/>
 				</label>
 			</p>


### PR DESCRIPTION
Fixes #8435

Before this PR, a user could enter a negative number of filters or a number that was too high.

After this PR, the values are limited to integers between 1 and 50 inclusive. Any value below 1 will become 1 and any value above 50 will become 50.

To test:

- Checkout branch on a site with Jetpack professional
- Add widget
- Add a filter
- Check different number values and ensure that after saving, the value updates to some integer between 1-50

After screenshot:
<img width="433" alt="screen shot 2018-01-03 at 2 13 39 pm" src="https://user-images.githubusercontent.com/1126811/34538032-547d6266-f090-11e7-9630-82e3e5c698a9.png">

  