### PR TITLE
Search: Set default filter count to 5 for all filters

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -7,6 +7,8 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 	protected $jetpack_search;
 
+	const DEFAULT_FILTER_COUNT = 5;
+
 	function __construct() {
 		if ( ! class_exists( 'Jetpack_Search' ) ) {
 			return;
@@ -33,8 +35,14 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	}
 
 	function widget_admin_setup() {
+		wp_register_script( 'widget-jetpack-search-filters', plugins_url( 'js/search-widget-filters-admin.js', __FILE__ ), array( 'jquery' ) );
 		wp_enqueue_style( 'widget-jetpack-search-filters', plugins_url( 'css/search-widget-filters-admin-ui.css', __FILE__ ) );
-		wp_enqueue_script( 'widget-jetpack-search-filters', plugins_url( 'js/search-widget-filters-admin.js', __FILE__ ), array( 'jquery' ) );
+
+		wp_localize_script( 'widget-jetpack-search-filters', 'jetpack_search_filter_admin', array(
+			'defaultFilterCount' => self::DEFAULT_FILTER_COUNT,
+		) );
+
+		wp_enqueue_script( 'widget-jetpack-search-filters' );
 	}
 
 	function is_for_current_widget( $item ) {
@@ -266,7 +274,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			'post_type' => '',
 			'date_histogram_field' => '',
 			'date_histogram_interval' => '',
-			'count' => 5,
+			'count' => self::DEFAULT_FILTER_COUNT,
 		) );
 
 		$classes = sprintf(

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -3,7 +3,7 @@
 ( function( $, args ) {
 	var defaultFilterCount = ( 'undefined' !== typeof args && args.defaultFilterCount ) ?
 		args.defaultFilterCount :
-		10;
+		5; // Just in case we couldn't find the defaultFiltercount arg
 
 	var setListeners = function() {
 		var widget = $( '.jetpack-search-filters-widget' );

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -1,4 +1,10 @@
-( function( $ ) {
+/* globals jetpack_search_filter_admin, jQuery */
+
+( function( $, args ) {
+	var defaultFilterCount = ( 'undefined' !== typeof args && args.defaultFilterCount ) ?
+		args.defaultFilterCount :
+		10;
+
 	var setListeners = function() {
 		var widget = $( '.jetpack-search-filters-widget' );
 
@@ -19,7 +25,7 @@
 					.clone()
 					.attr( 'class', 'jetpack-search-filters-widget__filter' );
 
-			clone.find( 'input[type="number"]' ).val( 10 );
+			clone.find( 'input[type="number"]' ).val( defaultFilterCount );
 			clone.find( 'input[type="text"]' ).val( '' );
 			clone.find( 'select option:first-child' ).attr( 'selected', 'selected' );
 
@@ -49,4 +55,4 @@
 		widget.off( 'change', '.jetpack-search-filters-widget__use-filters' );
 		setListeners();
 	} );
-} )( jQuery );
+} )( jQuery, jetpack_search_filter_admin );


### PR DESCRIPTION
In #8372, @gibrown suggested setting the default number of everything to 5. This PR sets the default number of buckets to return for each filter to 5.

We set the number as the `DEFAULT_FILTER_COUNT` constant on the `Jetpack_Search_Widget_Filters` widget. We then use that constant throughout the widget code and we also pass it to JS so it uses that value as well.

To test:

- Checkout branch on a site with a professional plan
- Add the Jetpack search widget to a sidebar
- Add a filter
- Ensure the number of filters is set to 5 by default