### PR TITLE
Build: Make the languages task fail if the export-translations.php tool exits with code different than zero.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -420,6 +420,9 @@ gulp.task( 'languages:get', function( callback ) {
 	process.on( 'exit', function( code ) {
 		if ( 0 !== code ) {
 			util.log( 'Failed getting languages: process exited with code ', code );
+			// Make the task fail if there was a problem as this could mean that we were going to ship a Jetpack version
+			// with the languages not properly built
+			return callback( new Error() );
 		}
 		callback();
 	} );


### PR DESCRIPTION
Fixes issue when building languages and for example, `msgfmt` is not installed in the system.

#### Changes proposed in this Pull Request:

* In gulpfile.babel.js, calls `callback()` with an error as parameter if `export-translations.php` exited with non zero code.

#### Testing instructions:

*  check this branch
* Edit `export-translations.php` adding `exit 1` on the first line of the file. Save and exit the editor.
* Run `yarn build-languages`.
* Expect the command to fail and stop execution of the other language-related gulp tasks.

<!-- Add the following only if this is meant to be in changelog -->
  
  