### PR TITLE
Search: Fix jqmigrate warning due to using attr instead of prop

### DIFF
--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -21,7 +21,7 @@
 
 			clone.find( 'input[type="number"]' ).val( 10 );
 			clone.find( 'input[type="text"]' ).val( '' );
-			clone.find( 'select option:first-child' ).attr( 'selected', 'selected' );
+			clone.find( 'select option:first-child' ).prop( 'selected', true );
 
 			clone.insertAfter( closest );
 		} );


### PR DESCRIPTION
I noticed that when I added a new filter by clicking the "add" link at the bottom of an existing filter, that I got a JQMIGRATE warning in the console:

```
jQuery.fn.attr('selected') might use property instead of attribute
```

The issue is that while we do set the selected value in HTML by adding a `selected` attribute, that corresponds to the `defaultSelected` prop and not to a `selected` prop, and it should only be used to set the initial value. That is per the jQuery documentation, under the Attributes vs. Properties heading, here: http://api.jquery.com/prop/

To fix this, we simply needed to swap out the usage of `attr` with `prop`.

To test:

- Checkout branch on a site with a professional plan
- Add Jetpack search widget to a sidebar
- Ensure that you create at least two filters
- Ensure there is not a JQMIGRATE warning like the one I mentioned above