### PR TITLE
REST: Change /sites/:site/posts date range queries to use post_date_gmt

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -277,11 +277,11 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			}
 		}
 
-		if ( isset( $args['before'] ) ) {
-			$this->date_range['before'] = $args['before'];
+		if ( isset( $args['before_gmt'] ) ) {
+			$this->date_range['before'] = $args['before_gmt'];
 		}
-		if ( isset( $args['after'] ) ) {
-			$this->date_range['after'] = $args['after'];
+		if ( isset( $args['after_gmt'] ) ) {
+			$this->date_range['after'] = $args['after_gmt'];
 		}
 
 		if ( isset( $args['modified_before_gmt'] ) ) {
@@ -439,7 +439,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 	}
 
 	function handle_date_range( $where ) {
-		return $this->_build_date_range_query( 'post_date', $this->date_range, $where );
+		return $this->_build_date_range_query( 'post_date_gmt', $this->date_range, $where );
 	}
 
 	function handle_modified_range( $where ) {


### PR DESCRIPTION
Currently we assume that that dates being passed to date range queries with /sites/:site/posts are in the same TZ as the site. That's pretty fragile assumption and can easily break depending on client preference. This patch changes how we build the query to always use UTC dates and post_date_gmt when querying, which allows clients to use any TZ they like in the query.

Differential Revision: D9104-code

This commit syncs r167670-wpcom.
  