### PR TITLE
Lazy Images: Add react admin UI

### DIFF
--- a/_inc/client/lib/decode-entities/index.js
+++ b/_inc/client/lib/decode-entities/index.js
@@ -1,0 +1,16 @@
+/**
+ * Decodes HTML entities using DOMParser if available
+ *
+ * @since 5.8.0
+ *
+ * @param  {String} text The text to decode
+ * @return {String}      Returns the string with HTML entities decoded if DOMParser is available. Returns the original text otherwise.
+ */
+export default function decodeEntities( text ) {
+	if ( 'undefined' === typeof DOMParser ) {
+		return text;
+	}
+
+	const document = new DOMParser().parseFromString( text, 'text/html' );
+	return document.documentElement.textContent;
+}

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -25,6 +25,7 @@ import ThemeEnhancements from './theme-enhancements';
 import PostByEmail from './post-by-email';
 import { Masterbar } from './masterbar';
 import { isAtomicSite } from 'state/initial-state';
+import SpeedUpSite from './speed-up-site';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -78,6 +79,7 @@ export const Writing = React.createClass( {
 					)
 				}
 				<Media { ...commonProps } />
+				<SpeedUpSite { ...commonProps } />
 				{
 					this.props.isModuleFound( 'custom-content-types' ) && (
 						<CustomContentTypes { ...commonProps } />

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -49,7 +49,8 @@ export const Writing = React.createClass( {
 			'post-by-email',
 			'infinite-scroll',
 			'minileven',
-			'videopress'
+			'videopress',
+			'lazy-images'
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -56,61 +56,18 @@ const Media = moduleSettingsForm(
 			);
 		},
 
-		toggleModule( name, value ) {
-			if ( 'photon' === name ) {
-				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
-				if ( false === ! value ) {
-					this.props.updateOptions( { photon: false, 'tiled-gallery': false, tiled_galleries: false } );
-				} else {
-					this.props.updateOptions( { photon: true, 'tiled-gallery': true, tiled_galleries: true } );
-				}
-			} else {
-				this.props.updateFormStateOptionValue( name, ! value );
-			}
-		},
-
 		render() {
-			const foundPhoton = this.props.isModuleFound( 'photon' ),
-				foundCarousel = this.props.isModuleFound( 'carousel' ),
+			const foundCarousel = this.props.isModuleFound( 'carousel' ),
 				foundVideoPress = this.props.isModuleFound( 'videopress' );
 
-			if ( ! foundCarousel && ! foundPhoton && ! foundVideoPress ) {
+			if ( ! foundCarousel && ! foundVideoPress ) {
 				return null;
 			}
 
-			const photon = this.props.module( 'photon' ),
-				carousel = this.props.module( 'carousel' ),
+			const carousel = this.props.module( 'carousel' ),
 				isCarouselActive = this.props.getOptionValue( 'carousel' ),
 				videoPress = this.props.module( 'videopress' ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
-
-			const photonSettings = (
-				<SettingsGroup
-					hasChild
-					disableInDevMode
-					module={ photon }>
-					<ModuleToggle
-						slug="photon"
-						disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
-						activated={ this.props.getOptionValue( 'photon' ) }
-						toggling={ this.props.isSavingAnyOption( 'photon' ) }
-						toggleModule={ this.toggleModule }
-					>
-						<span className="jp-form-toggle-explanation">
-							{
-								photon.description
-							}
-						</span>
-					</ModuleToggle>
-					<FormFieldset>
-						<span className="jp-form-setting-explanation">
-							{
-								__( 'Must be enabled to use tiled galleries.' )
-							}
-						</span>
-					</FormFieldset>
-				</SettingsGroup>
-			);
 
 			const carouselSettings = (
 				<SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
@@ -181,7 +138,6 @@ const Media = moduleSettingsForm(
 					feature={ FEATURE_VIDEO_HOSTING_JETPACK }
 					saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
 				>
-					{ foundPhoton && photonSettings }
 					{ foundCarousel && carouselSettings }
 					{ foundVideoPress && videoPressSettings }
 				</SettingsCard>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 
@@ -17,8 +17,8 @@ import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
 
 const SpeedUpSite = moduleSettingsForm(
-	React.createClass( {
-		toggleModule( name, value ) {
+	class extends Component {
+		toggleModule = ( name, value ) => {
 			if ( 'photon' === name ) {
 				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
 				if ( false === ! value ) {
@@ -29,7 +29,7 @@ const SpeedUpSite = moduleSettingsForm(
 			} else {
 				this.props.updateOptions( { [ name ]: ! value } );
 			}
-		},
+		};
 
 		decodeEntities( text ) {
 			if ( 'undefined' === typeof DOMParser ) {
@@ -38,18 +38,18 @@ const SpeedUpSite = moduleSettingsForm(
 
 			const document = new DOMParser().parseFromString( text, 'text/html' );
 			return document.documentElement.textContent;
-		},
+		}
 
 		render() {
-			const foundPhoton = this.props.isModuleFound( 'photon' ),
-				foundLazyImages = this.props.isModuleFound( 'lazy-images' );
+			const foundPhoton = this.props.isModuleFound( 'photon' );
+			const foundLazyImages = this.props.isModuleFound( 'lazy-images' );
 
 			if ( ! foundPhoton && ! foundLazyImages ) {
 				return null;
 			}
 
-			const photon = this.props.module( 'photon' ),
-				lazyImages = this.props.module( 'lazy-images' );
+			const photon = this.props.module( 'photon' );
+			const lazyImages = this.props.module( 'lazy-images' );
 
 			return (
 				<SettingsCard
@@ -102,7 +102,7 @@ const SpeedUpSite = moduleSettingsForm(
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );
 
 export default connect(

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -8,6 +8,7 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import decodeEntities from 'lib/decode-entities';
 import { FormFieldset } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { getModule } from 'state/modules';
@@ -30,15 +31,6 @@ const SpeedUpSite = moduleSettingsForm(
 				this.props.updateOptions( { [ name ]: ! value } );
 			}
 		};
-
-		decodeEntities( text ) {
-			if ( 'undefined' === typeof DOMParser ) {
-				return text;
-			}
-
-			const document = new DOMParser().parseFromString( text, 'text/html' );
-			return document.documentElement.textContent;
-		}
 
 		render() {
 			const foundPhoton = this.props.isModuleFound( 'photon' );
@@ -69,12 +61,12 @@ const SpeedUpSite = moduleSettingsForm(
 							toggleModule={ this.toggleModule }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ this.decodeEntities( photon.description ) }
+								{ decodeEntities( photon.description ) }
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
 							<span className="jp-form-setting-explanation">
-								{ this.decodeEntities( photon.long_description ) }
+								{ decodeEntities( photon.long_description ) }
 							</span>
 						</FormFieldset>
 					</SettingsGroup>
@@ -90,12 +82,12 @@ const SpeedUpSite = moduleSettingsForm(
 							toggleModule={ this.toggleModule }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ this.decodeEntities( lazyImages.description ) }
+								{ decodeEntities( lazyImages.description ) }
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
 							<span className="jp-form-setting-explanation">
-								{ this.decodeEntities( lazyImages.long_description ) }
+								{ decodeEntities( lazyImages.long_description ) }
 							</span>
 						</FormFieldset>
 					</SettingsGroup>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
+import { unescape } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +30,15 @@ const SpeedUpSite = moduleSettingsForm(
 			} else {
 				this.props.updateOptions( { [ name ]: ! value } );
 			}
+		},
+
+		decodeEntities( text ) {
+			if ( 'undefined' === typeof DOMParser ) {
+				return text;
+			}
+
+			const document = new DOMParser().parseFromString( text, 'text/html' );
+			return document.documentElement.textContent;
 		},
 
 		render() {
@@ -60,12 +70,12 @@ const SpeedUpSite = moduleSettingsForm(
 							toggleModule={ this.toggleModule }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ photon.description }
+								{ this.decodeEntities( photon.description ) }
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
 							<span className="jp-form-setting-explanation">
-								{ photon.long_description }
+								{ this.decodeEntities( photon.long_description ) }
 							</span>
 						</FormFieldset>
 					</SettingsGroup>
@@ -81,12 +91,12 @@ const SpeedUpSite = moduleSettingsForm(
 							toggleModule={ this.toggleModule }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ lazyImages.description }
+								{ this.decodeEntities( lazyImages.description ) }
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
 							<span className="jp-form-setting-explanation">
-								{ lazyImages.long_description }
+								{ this.decodeEntities( lazyImages.long_description ) }
 							</span>
 						</FormFieldset>
 					</SettingsGroup>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import { unescape } from 'lodash';
 
 /**
  * Internal dependencies

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldset } from 'components/forms';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { getModule } from 'state/modules';
+import { isModuleFound as _isModuleFound } from 'state/search';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+
+const SpeedUpSite = moduleSettingsForm(
+	React.createClass( {
+		toggleModule( name, value ) {
+			if ( 'photon' === name ) {
+				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
+				if ( false === ! value ) {
+					this.props.updateOptions( { photon: false, 'tiled-gallery': false, tiled_galleries: false } );
+				} else {
+					this.props.updateOptions( { photon: true, 'tiled-gallery': true, tiled_galleries: true } );
+				}
+			} else {
+				this.props.updateOptions( { [ name ]: ! value } );
+			}
+		},
+
+		render() {
+			const foundPhoton = this.props.isModuleFound( 'photon' ),
+				foundLazyImages = this.props.isModuleFound( 'lazy-images' );
+
+			if ( ! foundPhoton && ! foundLazyImages ) {
+				return null;
+			}
+
+			const photon = this.props.module( 'photon' ),
+				lazyImages = this.props.module( 'lazy-images' );
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Speed up your site' ) }
+					hideButton>
+
+					<SettingsGroup
+						hasChild
+						disableInDevMode
+						module={ photon }>
+						<ModuleToggle
+							slug="photon"
+							disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+							activated={ this.props.getOptionValue( 'photon' ) }
+							toggling={ this.props.isSavingAnyOption( 'photon' ) }
+							toggleModule={ this.toggleModule }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ photon.description }
+							</span>
+						</ModuleToggle>
+						<FormFieldset>
+							<span className="jp-form-setting-explanation">
+								{ photon.long_description }
+							</span>
+						</FormFieldset>
+					</SettingsGroup>
+
+					<SettingsGroup
+						hasChild
+						module={ lazyImages }>
+						<ModuleToggle
+							slug="lazy-images"
+							disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
+							activated={ this.props.getOptionValue( 'lazy-images' ) }
+							toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
+							toggleModule={ this.toggleModule }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ lazyImages.description }
+							</span>
+						</ModuleToggle>
+						<FormFieldset>
+							<span className="jp-form-setting-explanation">
+								{ lazyImages.long_description }
+							</span>
+						</FormFieldset>
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	} )
+);
+
+export default connect(
+	( state ) => {
+		return {
+			module: ( module_name ) => getModule( state, module_name ),
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
+		};
+	}
+)( SpeedUpSite );

--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Lazy Images
- * Module Description: Improve performance by loading images just before they scroll into view
+ * Module Description: "Lazy load" images
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0

--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Lazy Images
- * Module Description: "Lazy load" images
+ * Module Description: "Lazy-load" images
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0

--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -10,7 +10,7 @@
  * Auto Activate: No
  * Module Tags: Appearance, Recommended
  * Feature: Appearance
- * Additional Search Queries: mobile, theme, performance
+ * Additional Search Queries: mobile, theme, performance, image
  */
 
 /**

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -125,7 +125,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'photon' => array(
 				'name' => _x( 'Photon', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Speed up images and photos', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Serve images from our servers', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.', 'Jumpstart Description', 'jetpack' ),
 			),
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -82,7 +82,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'lazy-images' => array(
 				'name' => _x( 'Lazy Images', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Improve performance by loading images just before they scroll into view', 'Module Description', 'jetpack' ),
+				'description' => _x( '"Lazy load" images', 'Module Description', 'jetpack' ),
 			),
 
 			'likes' => array(

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -82,7 +82,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'lazy-images' => array(
 				'name' => _x( 'Lazy Images', 'Module Name', 'jetpack' ),
-				'description' => _x( '"Lazy load" images', 'Module Description', 'jetpack' ),
+				'description' => _x( '"Lazy-load" images', 'Module Description', 'jetpack' ),
 			),
 
 			'likes' => array(

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -405,7 +405,7 @@ add_action( 'jetpack_learn_more_button_photon', 'jetpack_photon_more_link' );
 function jetpack_photon_more_info() {
 	esc_html_e(
 		'Jetpack will optimize your images and serve them from the server location nearest
-		to your visitors. Using our global \'content delivery network\' will boost the loading speed of your site.'
+		to your visitors. Using our global content delivery network will boost the loading speed of your site.'
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_photon', 'jetpack_photon_more_info' );
@@ -420,9 +420,9 @@ add_action( 'jetpack_learn_more_button_lazy-images', 'jetpack_lazy_images_more_l
 
 function jetpack_lazy_images_more_info() {
 	esc_html_e(
-		'Normally, opening a web page causes it to load every image it contains, even those
-		that a reader hasn\'t yet scrolled down to see. "Lazy loading" means that only the images
-		actually visible on the screen will load.'
+		'Improve your site\'s speed by only loading images visible on the screen.
+		New images will load just before they scroll into view. This prevents viewers
+		from having to download all the images on a page all at once, even ones they can\'t see.'
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_lazy-images', 'jetpack_lazy_images_more_info' );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -404,11 +404,28 @@ add_action( 'jetpack_learn_more_button_photon', 'jetpack_photon_more_link' );
 
 function jetpack_photon_more_info() {
 	esc_html_e(
-		"Jetpack will optimize your images and serve them from the server location nearest
-		to your visitors. Using our global 'content delivery network' will boost the loading speed of your site."
+		'Jetpack will optimize your images and serve them from the server location nearest
+		to your visitors. Using our global \'content delivery network\' will boost the loading speed of your site.'
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_photon', 'jetpack_photon_more_info' );
+
+/**
+ * Lazy Images
+ */
+function jetpack_lazy_images_more_link() {
+	echo 'https://jetpack.com/support/lazy-images/';
+}
+add_action( 'jetpack_learn_more_button_lazy-images', 'jetpack_lazy_images_more_link' );
+
+function jetpack_lazy_images_more_info() {
+	esc_html_e(
+		'Normally, opening a web page causes it to load every image it contains, even those
+		that a reader hasn\'t yet scrolled down to see. "Lazy loading" means that only the images
+		actually visible on the screen will load.'
+		, 'jetpack' );
+}
+add_action( 'jetpack_module_more_info_lazy-images', 'jetpack_lazy_images_more_info' );
 
 /**
  * Tiled Galleries

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -404,8 +404,8 @@ add_action( 'jetpack_learn_more_button_photon', 'jetpack_photon_more_link' );
 
 function jetpack_photon_more_info() {
 	esc_html_e(
-		"Your images are automatically optimized for different display resolutions to serve the best
-		possible image quality. We also cache and serve them from our fast, global network (CDN)."
+		"Jetpack will optimize your images and serve them from the server location nearest
+		to your visitors. Using our global 'content delivery network' will boost the loading speed of your site."
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_photon', 'jetpack_photon_more_info' );

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Photon
- * Module Description: Speed up images and photos
+ * Module Description: Serve images from our servers
  * Jumpstart Description: Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.
  * Sort Order: 25
  * Recommendation Order: 1


### PR DESCRIPTION
Closes #8193

When we launched lazy images in 5.7, we did not ship any react admin UI. This was partly because we wanted to do a soft launch and also because we would be releasing a new feature just before the holidays.

Now that we're past the holidays and have had some time to test the feature, let's get it out there!

Following the advice of @rickybanister, @michelleweber, and others in #8193, this PR creates a new section within the "Writing" tab called "Speed up your site". This PR, then moves the photon setting into this section and adds the lazy images setting as well. Further, this PR updates the descriptions for the Photon module to match what was suggested in #8193.

To test:

- Checkout branch
- Do a fresh `yarn build` to rebuild module translations
- Go to "Writing" tab of Jetpack settings
- Toggle both Photon and Lazy Images settings
- Ensure that modules are properly enabled/disabled when they are toggled via UI

Screenshot:

<img width="765" alt="screen shot 2018-01-04 at 4 01 21 pm" src="https://user-images.githubusercontent.com/1126811/34586196-937e89d0-f168-11e7-89bd-edce52ceaaee.png">
