### PR TITLE
Move code from plugins install endpoint to new Plugins Library

### DIFF
--- a/_inc/lib/class.jetpack-automatic-install-skin.php
+++ b/_inc/lib/class.jetpack-automatic-install-skin.php
@@ -1,0 +1,111 @@
+<?php
+
+include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+include_once ABSPATH . 'wp-admin/includes/file.php';
+
+/**
+ * Allows us to capture that the site doesn't have proper file system access.
+ * In order to update the plugin.
+ */
+class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
+	/**
+	 * Stores the last error key;
+	 **/
+	protected $main_error_code = 'install_error';
+
+	/**
+	 * Stores the last error message.
+	 **/
+	protected $main_error_message = 'An unknown error occurred during installation';
+
+	/**
+	 * Overwrites the set_upgrader to be able to tell if we e ven have the ability to write to the files.
+	 *
+	 * @param WP_Upgrader $upgrader
+	 *
+	 */
+	public function set_upgrader( &$upgrader ) {
+		parent::set_upgrader( $upgrader );
+
+		// Check if we even have permission to.
+		$result = $upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
+		if ( ! $result ) {
+			// set the string here since they are not available just yet
+			$upgrader->generic_strings();
+			$this->feedback( 'fs_unavailable' );
+		}
+	}
+
+	/**
+	 * Overwrites the error function
+	 */
+	public function error( $error ) {
+		if ( is_wp_error( $error ) ) {
+			$this->feedback( $error );
+		}
+	}
+
+	private function set_main_error_code( $code ) {
+		// Don't set the process_failed as code since it is not that helpful unless we don't have one already set.
+		$this->main_error_code = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $code );
+	}
+
+	private function set_main_error_message( $message, $code ) {
+		// Don't set the process_failed as message since it is not that helpful unless we don't have one already set.
+		$this->main_error_message = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $message );
+	}
+
+	public function get_main_error_code() {
+		return $this->main_error_code;
+	}
+
+	public function get_main_error_message() {
+		return $this->main_error_message;
+	}
+
+	/**
+	 * Overwrites the feedback function
+	 */
+	public function feedback( $data ) {
+
+		$current_error = null;
+		if ( is_wp_error( $data ) ) {
+			$this->set_main_error_code( $data->get_error_code() );
+			$string = $data->get_error_message();
+		} elseif ( is_array( $data ) ) {
+			return;
+		} else {
+			$string = $data;
+		}
+
+		if ( ! empty( $this->upgrader->strings[$string] ) ) {
+			$this->set_main_error_code( $string );
+
+			$current_error = $string;
+			$string        = $this->upgrader->strings[$string];
+		}
+
+		if ( strpos( $string, '%' ) !== false ) {
+			$args = func_get_args();
+			$args = array_splice( $args, 1 );
+			if ( ! empty( $args ) ) {
+				$string = vsprintf( $string, $args );
+			}
+		}
+
+		$string = trim( $string );
+		$string = wp_kses(
+			$string, array(
+			'a'      => array(
+				'href' => true
+			),
+			'br'     => true,
+			'em'     => true,
+			'strong' => true,
+		)
+		);
+
+		$this->set_main_error_message( $string, $current_error );
+		$this->messages[] = $string;
+	}
+}

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -33,23 +33,23 @@ class Jetpack_Plugins {
 
 		$result = $upgrader->install( $zip_url );
 
-    if ( is_wp_error( $result ) ) {
-      return $result;
-    }
+		if ( is_wp_error( $result ) ) {
+		  return $result;
+		}
 
-    $plugin     = Jetpack_Plugins::get_plugin_id_by_slug( $slug );
-    $error_code = 'install_error';
-    if ( ! $plugin ) {
-      $error = __( 'There was an error installing your plugin', 'jetpack' );
-    }
+		$plugin     = Jetpack_Plugins::get_plugin_id_by_slug( $slug );
+		$error_code = 'install_error';
+		if ( ! $plugin ) {
+		  $error = __( 'There was an error installing your plugin', 'jetpack' );
+		}
 
-    if ( ! $result ) {
-      $error_code                         = $upgrader->skin->get_main_error_code();
-      $message                            = $upgrader->skin->get_main_error_message();
-      $error = $message ? $message : __( 'An unknown error occurred during installation', 'jetpack' );
-    }
+		if ( ! $result ) {
+		  $error_code                         = $upgrader->skin->get_main_error_code();
+		  $message                            = $upgrader->skin->get_main_error_message();
+		  $error = $message ? $message : __( 'An unknown error occurred during installation', 'jetpack' );
+		}
 
-    if ( ! empty( $error ) ) {
+		if ( ! empty( $error ) ) {
 			if ( 'download_failed' === $error_code ) {
 				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
 				$error_code = 'no_package';
@@ -58,7 +58,7 @@ class Jetpack_Plugins {
 			return new WP_Error( $error_code, $error, 400 );
 		}
 
-    return (array) $upgrader->skin->get_upgrade_messages();
+		return (array) $upgrader->skin->get_upgrade_messages();
 	}
 
 	 protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -32,7 +32,34 @@ class Jetpack_Plugins {
 		$upgrader = new Plugin_Upgrader( $skin );
 		$zip_url  = self::generate_wordpress_org_plugin_download_link( $slug );
 
-		return $upgrader->install( $zip_url );
+		$result = $upgrader->install( $zip_url );
+
+    if ( is_wp_error( $result ) ) {
+      return $result;
+    }
+
+    $plugin     = Jetpack_Plugins::get_plugin_id_by_slug( $slug );
+    $error_code = 'install_error';
+    if ( ! $plugin ) {
+      $error = __( 'There was an error installing your plugin', 'jetpack' );
+    }
+
+    if ( ! $result ) {
+      $error_code                         = $upgrader->skin->get_main_error_code();
+      $message                            = $upgrader->skin->get_main_error_message();
+      $error = $message ? $message : __( 'An unknown error occurred during installation', 'jetpack' );
+    }
+
+    if ( ! empty( $error ) ) {
+			if ( 'download_failed' === $error_code ) {
+				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
+				$error_code = 'no_package';
+			}
+
+			return new WP_Error( $error_code, $error, 400 );
+		}
+
+    return (array) $upgrader->skin->get_upgrade_messages();
 	}
 
 	 protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -55,7 +55,7 @@ class Jetpack_Plugins {
 	}
 
 	protected static function get_slug_from_file_path( $plugin_file ) {
-		// Simular to get_plugin_slug() method.
+		// Similar to get_plugin_slug() method.
 		$slug = dirname( $plugin_file );
 		if ( '.' === $slug ) {
 			$slug = preg_replace( "/(.+)\.php$/", "$1", $plugin_file );

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -13,7 +13,7 @@ include_once( 'class.jetpack-automatic-install-skin.php' );
 
 class Jetpack_Plugins {
 
-	 /**
+	/**
 	 * Install a plugin.
 	 *
 	 * @since 5.8.0

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -63,7 +63,7 @@ class Jetpack_Plugins {
 	}
 
 	 protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
-		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
+		return "https://downloads.wordpress.org/plugin/$plugin_slug.latest-stable.zip";
 	 }
 
 	 public static function get_plugin_id_by_slug( $slug ) {

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Plugins Library
+ *
+ * Helper functions for installing and activating plugins.
+ *
+ * Used by the REST API
+ *
+ * @autounit api plugins
+ */
+
+include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+include_once ABSPATH . 'wp-admin/includes/file.php';
+
+class Jetpack_Plugins {
+
+	 /**
+	 * Install a plugin.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param string $slug Plugin slug.
+	 *
+	 * @return bool|WP_Error True if installation succeeded, error object otherwise.
+	 */
+	public static function install_plugin( $slug ) {
+		if ( is_multisite() && ! current_user_can( 'manage_network' ) ) {
+			return new WP_Error( 'not_allowed', 'You are not allowed to install plugins on this site.' );
+		}
+
+		$skin     = new Jetpack_Automatic_Install_Skin();
+		$upgrader = new Plugin_Upgrader( $skin );
+		$zip_url  = self::generate_wordpress_org_plugin_download_link( $slug );
+
+		return $upgrader->install( $zip_url );
+	}
+
+	 protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
+		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
+	 }
+
+	 public static function get_plugin_id_by_slug( $slug ) {
+		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
+		$plugins = apply_filters( 'all_plugins', get_plugins() );
+		if ( ! is_array( $plugins ) ) {
+			return false;
+		}
+		foreach ( $plugins as $plugin_file => $plugin_data ) {
+			if ( self::get_slug_from_file_path( $plugin_file ) === $slug ) {
+				return $plugin_file;
+			}
+		}
+
+		return false;
+	}
+
+	protected static function get_slug_from_file_path( $plugin_file ) {
+		// Simular to get_plugin_slug() method.
+		$slug = dirname( $plugin_file );
+		if ( '.' === $slug ) {
+			$slug = preg_replace( "/(.+)\.php$/", "$1", $plugin_file );
+		}
+
+		return $slug;
+	}
+}
+
+/**
+ * Allows us to capture that the site doesn't have proper file system access.
+ * In order to update the plugin.
+ */
+class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
+	/**
+	 * Stores the last error key;
+	 **/
+	protected $main_error_code = 'install_error';
+
+	/**
+	 * Stores the last error message.
+	 **/
+	protected $main_error_message = 'An unknown error occurred during installation';
+
+	/**
+	 * Overwrites the set_upgrader to be able to tell if we e ven have the ability to write to the files.
+	 *
+	 * @param WP_Upgrader $upgrader
+	 *
+	 */
+	public function set_upgrader( &$upgrader ) {
+		parent::set_upgrader( $upgrader );
+
+		// Check if we even have permission to.
+		$result = $upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
+		if ( ! $result ) {
+			// set the string here since they are not available just yet
+			$upgrader->generic_strings();
+			$this->feedback( 'fs_unavailable' );
+		}
+	}
+
+	/**
+	 * Overwrites the error function
+	 */
+	public function error( $error ) {
+		if ( is_wp_error( $error ) ) {
+			$this->feedback( $error );
+		}
+	}
+
+	private function set_main_error_code( $code ) {
+		// Don't set the process_failed as code since it is not that helpful unless we don't have one already set.
+		$this->main_error_code = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $code );
+	}
+
+	private function set_main_error_message( $message, $code ) {
+		// Don't set the process_failed as message since it is not that helpful unless we don't have one already set.
+		$this->main_error_message = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $message );
+	}
+
+	public function get_main_error_code() {
+		return $this->main_error_code;
+	}
+
+	public function get_main_error_message() {
+		return $this->main_error_message;
+	}
+
+	/**
+	 * Overwrites the feedback function
+	 */
+	public function feedback( $data ) {
+
+		$current_error = null;
+		if ( is_wp_error( $data ) ) {
+			$this->set_main_error_code( $data->get_error_code() );
+			$string = $data->get_error_message();
+		} elseif ( is_array( $data ) ) {
+			return;
+		} else {
+			$string = $data;
+		}
+
+		if ( ! empty( $this->upgrader->strings[$string] ) ) {
+			$this->set_main_error_code( $string );
+
+			$current_error = $string;
+			$string        = $this->upgrader->strings[$string];
+		}
+
+		if ( strpos( $string, '%' ) !== false ) {
+			$args = func_get_args();
+			$args = array_splice( $args, 1 );
+			if ( ! empty( $args ) ) {
+				$string = vsprintf( $string, $args );
+			}
+		}
+
+		$string = trim( $string );
+		$string = wp_kses(
+			$string, array(
+			'a'      => array(
+				'href' => true
+			),
+			'br'     => true,
+			'em'     => true,
+			'strong' => true,
+		)
+		);
+
+		$this->set_main_error_message( $string, $current_error );
+		$this->messages[] = $string;
+	}
+}

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -9,8 +9,7 @@
  * @autounit api plugins
  */
 
-include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-include_once ABSPATH . 'wp-admin/includes/file.php';
+include_once( 'class.jetpack-automatic-install-skin.php' );
 
 class Jetpack_Plugins {
 
@@ -89,112 +88,5 @@ class Jetpack_Plugins {
 		}
 
 		return $slug;
-	}
-}
-
-/**
- * Allows us to capture that the site doesn't have proper file system access.
- * In order to update the plugin.
- */
-class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
-	/**
-	 * Stores the last error key;
-	 **/
-	protected $main_error_code = 'install_error';
-
-	/**
-	 * Stores the last error message.
-	 **/
-	protected $main_error_message = 'An unknown error occurred during installation';
-
-	/**
-	 * Overwrites the set_upgrader to be able to tell if we e ven have the ability to write to the files.
-	 *
-	 * @param WP_Upgrader $upgrader
-	 *
-	 */
-	public function set_upgrader( &$upgrader ) {
-		parent::set_upgrader( $upgrader );
-
-		// Check if we even have permission to.
-		$result = $upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
-		if ( ! $result ) {
-			// set the string here since they are not available just yet
-			$upgrader->generic_strings();
-			$this->feedback( 'fs_unavailable' );
-		}
-	}
-
-	/**
-	 * Overwrites the error function
-	 */
-	public function error( $error ) {
-		if ( is_wp_error( $error ) ) {
-			$this->feedback( $error );
-		}
-	}
-
-	private function set_main_error_code( $code ) {
-		// Don't set the process_failed as code since it is not that helpful unless we don't have one already set.
-		$this->main_error_code = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $code );
-	}
-
-	private function set_main_error_message( $message, $code ) {
-		// Don't set the process_failed as message since it is not that helpful unless we don't have one already set.
-		$this->main_error_message = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $message );
-	}
-
-	public function get_main_error_code() {
-		return $this->main_error_code;
-	}
-
-	public function get_main_error_message() {
-		return $this->main_error_message;
-	}
-
-	/**
-	 * Overwrites the feedback function
-	 */
-	public function feedback( $data ) {
-
-		$current_error = null;
-		if ( is_wp_error( $data ) ) {
-			$this->set_main_error_code( $data->get_error_code() );
-			$string = $data->get_error_message();
-		} elseif ( is_array( $data ) ) {
-			return;
-		} else {
-			$string = $data;
-		}
-
-		if ( ! empty( $this->upgrader->strings[$string] ) ) {
-			$this->set_main_error_code( $string );
-
-			$current_error = $string;
-			$string        = $this->upgrader->strings[$string];
-		}
-
-		if ( strpos( $string, '%' ) !== false ) {
-			$args = func_get_args();
-			$args = array_splice( $args, 1 );
-			if ( ! empty( $args ) ) {
-				$string = vsprintf( $string, $args );
-			}
-		}
-
-		$string = trim( $string );
-		$string = wp_kses(
-			$string, array(
-			'a'      => array(
-				'href' => true
-			),
-			'br'     => true,
-			'em'     => true,
-			'strong' => true,
-		)
-		);
-
-		$this->set_main_error_message( $string, $current_error );
-		$this->messages[] = $string;
 	}
 }

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -25,7 +25,7 @@ class Jetpack_Plugins {
 	 */
 	public static function install_plugin( $slug ) {
 		if ( is_multisite() && ! current_user_can( 'manage_network' ) ) {
-			return new WP_Error( 'not_allowed', 'You are not allowed to install plugins on this site.' );
+			return new WP_Error( 'not_allowed', __( 'You are not allowed to install plugins on this site.', 'jetpack' ) );
 		}
 
 		$skin     = new Jetpack_Automatic_Install_Skin();

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -55,20 +55,16 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	protected $action = 'install';
 
 	protected function install() {
+		jetpack_require_lib( 'plugins' );
 		$error = '';
 		foreach ( $this->plugins as $index => $slug ) {
-
-			$skin     = new Jetpack_Automatic_Install_Skin();
-			$upgrader = new Plugin_Upgrader( $skin );
-			$zip_url  = self::generate_wordpress_org_plugin_download_link( $slug );
-
-			$result = $upgrader->install( $zip_url );
+			$result = Jetpack_Plugins::install_plugin( $slug );
 
 			if ( ! $this->bulk && is_wp_error( $result ) ) {
 				return $result;
 			}
 
-			$plugin     = self::get_plugin_id_by_slug( $slug );
+			$plugin     = Jetpack_Plugins::get_plugin_id_by_slug( $slug );
 			$error_code = 'install_error';
 			if ( ! $plugin ) {
 				$error = $this->log[ $slug ][] = __( 'There was an error installing your plugin', 'jetpack' );
@@ -102,150 +98,16 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		if ( empty( $this->plugins ) || ! is_array( $this->plugins ) ) {
 			return new WP_Error( 'missing_plugins', __( 'No plugins found.', 'jetpack' ) );
 		}
+
+		jetpack_require_lib( 'plugins' );
 		foreach ( $this->plugins as $index => $slug ) {
 			// make sure it is not already installed
-			if ( self::get_plugin_id_by_slug( $slug ) ) {
+			if ( Jetpack_Plugins::get_plugin_id_by_slug( $slug ) ) {
 				return new WP_Error( 'plugin_already_installed', __( 'The plugin is already installed', 'jetpack' ) );
 			}
 
 		}
 
 		return true;
-	}
-
-	protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
-		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
-	}
-
-	protected static function get_plugin_id_by_slug( $slug ) {
-		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-		$plugins = apply_filters( 'all_plugins', get_plugins() );
-		if ( ! is_array( $plugins ) ) {
-			return false;
-		}
-		foreach ( $plugins as $plugin_file => $plugin_data ) {
-			if ( self::get_slug_from_file_path( $plugin_file ) === $slug ) {
-				return $plugin_file;
-			}
-		}
-
-		return false;
-	}
-
-	protected static function get_slug_from_file_path( $plugin_file ) {
-		// Simular to get_plugin_slug() method.
-		$slug = dirname( $plugin_file );
-		if ( '.' === $slug ) {
-			$slug = preg_replace( "/(.+)\.php$/", "$1", $plugin_file );
-		}
-
-		return $slug;
-	}
-}
-
-/**
- * Allows us to capture that the site doesn't have proper file system access.
- * In order to update the plugin.
- */
-class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
-	/**
-	 * Stores the last error key;
-	 **/
-	protected $main_error_code = 'install_error';
-
-	/**
-	 * Stores the last error message.
-	 **/
-	protected $main_error_message = 'An unknown error occurred during installation';
-
-	/**
-	 * Overwrites the set_upgrader to be able to tell if we e ven have the ability to write to the files.
-	 *
-	 * @param WP_Upgrader $upgrader
-	 *
-	 */
-	public function set_upgrader( &$upgrader ) {
-		parent::set_upgrader( $upgrader );
-
-		// Check if we even have permission to.
-		$result = $upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
-		if ( ! $result ) {
-			// set the string here since they are not available just yet
-			$upgrader->generic_strings();
-			$this->feedback( 'fs_unavailable' );
-		}
-	}
-
-	/**
-	 * Overwrites the error function
-	 */
-	public function error( $error ) {
-		if ( is_wp_error( $error ) ) {
-			$this->feedback( $error );
-		}
-	}
-
-	private function set_main_error_code( $code ) {
-		// Don't set the process_failed as code since it is not that helpful unless we don't have one already set.
-		$this->main_error_code = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $code );
-	}
-
-	private function set_main_error_message( $message, $code ) {
-		// Don't set the process_failed as message since it is not that helpful unless we don't have one already set.
-		$this->main_error_message = ( $code === 'process_failed' && $this->main_error_code ? $this->main_error_code : $message );
-	}
-
-	public function get_main_error_code() {
-		return $this->main_error_code;
-	}
-
-	public function get_main_error_message() {
-		return $this->main_error_message;
-	}
-
-	/**
-	 * Overwrites the feedback function
-	 */
-	public function feedback( $data ) {
-
-		$current_error = null;
-		if ( is_wp_error( $data ) ) {
-			$this->set_main_error_code( $data->get_error_code() );
-			$string = $data->get_error_message();
-		} elseif ( is_array( $data ) ) {
-			return;
-		} else {
-			$string = $data;
-		}
-
-		if ( ! empty( $this->upgrader->strings[$string] ) ) {
-			$this->set_main_error_code( $string );
-
-			$current_error = $string;
-			$string        = $this->upgrader->strings[$string];
-		}
-
-		if ( strpos( $string, '%' ) !== false ) {
-			$args = func_get_args();
-			$args = array_splice( $args, 1 );
-			if ( ! empty( $args ) ) {
-				$string = vsprintf( $string, $args );
-			}
-		}
-
-		$string = trim( $string );
-		$string = wp_kses(
-			$string, array(
-			'a'      => array(
-				'href' => true
-			),
-			'br'     => true,
-			'em'     => true,
-			'strong' => true,
-		)
-		);
-
-		$this->set_main_error_message( $string, $current_error );
-		$this->messages[] = $string;
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php
@@ -90,6 +90,7 @@ class Jetpack_JSON_API_Plugins_New_Endpoint extends Jetpack_JSON_API_Plugins_End
 			if ( ! $local_file ) {
 				return new WP_Error( 'local-file-does-not-exist' );
 			}
+			jetpack_require_lib( 'class.jetpack-automatic-install-skin' );
 			$skin     = new Jetpack_Automatic_Install_Skin();
 			$upgrader = new Plugin_Upgrader( $skin );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -38,6 +38,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 			// If the alternative install method was not used, use the standard method.
 			if ( ! $result ) {
+				jetpack_require_lib( 'class.jetpack-automatic-install-skin' );
 				$skin     = new Jetpack_Automatic_Install_Skin();
 				$upgrader = new Theme_Upgrader( $skin );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
@@ -37,6 +37,7 @@ class Jetpack_JSON_API_Themes_New_Endpoint extends Jetpack_JSON_API_Themes_Endpo
 			if ( ! $local_file ) {
 				return new WP_Error( 'local-file-does-not-exist' );
 			}
+			jetpack_require_lib( 'class.jetpack-automatic-install-skin' );
 			$skin      = new Jetpack_Automatic_Install_Skin();
 			$upgrader  = new Theme_Upgrader( $skin );
 


### PR DESCRIPTION
Some prep work for ~#8450~ #8482. De-duplicate all the things!

Move:
* the `Jetpack_Automatic_Install_Skin` helper class to `_inc/lib/class.jetpack-automatic-install-skin.php`
* some static helper methods from `Jetpack_JSON_API_Plugins_Install_Endpoint` to `Jetpack_Plugins` in `_inc/lib/plugins.php`.

To test: Make sure all affected endpoints still work. Note that `Jetpack_Automatic_Install_Skin` is used by a few other endpoints (grep to verify!):
* Plugin installation (from WP.org): `POST` to `/sites/%s/plugins/%s/install` (try `woocommerce`)
* Theme installation (from WP.org): `POST` to `/sites/%s/themes/%s/install` (try `twentyseventeen`) -- *see note at bottom*
* Plugin installation (via upload): `POST` to `/sites/%s/plugins/%s/new` -- use Calypso to test (`wordpress.com/plugins/upload/:site`)
* Theme installation (via upload): `POST` to `/sites/%s/themes/%s/new` -- use Calypso to test (`wordpress.com/themes/upload/:site`) 
  
Note:
* `/sites/%s/themes/%s/install` doesn't work at all, returns a 404. However, that behavior seems to be preexisting!
  
  
  
  