### PR TITLE
Modules: Allow filtering of active modules.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2532,6 +2532,17 @@ class Jetpack {
 			$active = array();
 		}
 
+		if ( class_exists( 'VaultPress' ) || function_exists( 'vaultpress_contact_service' ) ) {
+			$active[] = 'vaultpress';
+		} else {
+			$active = array_diff( $active, array( 'vaultpress' ) );
+		}
+
+		//If protect is active on the main site of a multisite, it should be active on all sites.
+		if ( ! in_array( 'protect', $active ) && is_multisite() && get_site_option( 'jetpack_protect_active' ) ) {
+			$active[] = 'protect';
+		}
+
 		/**
 		 * Allow filtering of the active modules.
 		 *
@@ -2543,17 +2554,6 @@ class Jetpack {
 		 * @param array $active Array of active module slugs.
 		 */
 		$active = apply_filters( 'jetpack_active_modules', $active );
-
-		if ( class_exists( 'VaultPress' ) || function_exists( 'vaultpress_contact_service' ) ) {
-			$active[] = 'vaultpress';
-		} else {
-			$active = array_diff( $active, array( 'vaultpress' ) );
-		}
-
-		//If protect is active on the main site of a multisite, it should be active on all sites.
-		if ( ! in_array( 'protect', $active ) && is_multisite() && get_site_option( 'jetpack_protect_active' ) ) {
-			$active[] = 'protect';
-		}
 
 		return array_unique( $active );
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2532,6 +2532,18 @@ class Jetpack {
 			$active = array();
 		}
 
+		/**
+		 * Allow filtering of the active modules.
+		 *
+		 * Gives theme and plugin developers the power to alter the modules that
+		 * are activated on the fly.
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param array $active Array of active module slugs.
+		 */
+		$active = apply_filters( 'jetpack_active_modules', $active );
+
 		if ( class_exists( 'VaultPress' ) || function_exists( 'vaultpress_contact_service' ) ) {
 			$active[] = 'vaultpress';
 		} else {


### PR DESCRIPTION
This change introduces a filter (`jetpack_active_modules`) that allows theme and plugin developers to modify the list of active Jetpack modules.

For some projects, there will be multiple copies of a site in different environments (e.g. development, QA, staging as well as production) and maintaining consistency across environments is important for quality assurance. Manually enabling/disabling modules across multiple environments is time consuming, inefficient and susceptible to human error. This change allows active modules to be defined in code, under version control, helping to ensure consistency across environments.