### PR TITLE
Add upgrade prompt for Jetpack Search

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -24,6 +24,7 @@ import {
 	FEATURE_GOOGLE_ANALYTICS_JETPACK,
 	FEATURE_WORDADS_JETPACK,
 	FEATURE_SPAM_AKISMET_PLUS,
+	FEATURE_SEARCH_JETPACK,
 	getPlanClass
 } from 'lib/plans/constants';
 
@@ -178,6 +179,22 @@ export const SettingsCard = props => {
 					/>
 				);
 
+			case FEATURE_SEARCH_JETPACK:
+				if ( 'is-business-plan' === planClass ) {
+					return '';
+				}
+
+				return (
+					<JetpackBanner
+						callToAction={ upgradeLabel }
+						title={ __( 'Add enterprise-grade search to your site with Jetpack Search.' ) }
+						plan={ PLAN_JETPACK_BUSINESS }
+						feature={ feature }
+						onClick={ () => trackBannerClick( feature ) }
+						href={ 'https://jetpack.com/redirect/?source=settings-search&site=' + siteRawUrl }
+					/>
+				);
+
 			case FEATURE_SPAM_AKISMET_PLUS:
 				if ( props.isCheckingAkismetKey || props.isAkismetKeyValid ||
 					includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
@@ -232,6 +249,13 @@ export const SettingsCard = props => {
 				break;
 
 			case FEATURE_SEO_TOOLS_JETPACK:
+				if ( 'is-business-plan' !== planClass ) {
+					return false;
+				}
+
+				break;
+
+			case FEATURE_SEARCH_JETPACK:
 				if ( 'is-business-plan' !== planClass ) {
 					return false;
 				}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -187,7 +187,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Faster, more relevant and more powerful sitewide search with Jetpack Search.' ) }
+						title={ __( 'Faster, more relevant and more powerful sitewide search.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
 						onClick={ () => trackBannerClick( feature ) }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -187,7 +187,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Add enterprise-grade search to your site with Jetpack Search.' ) }
+						title={ __( 'Faster, more relevant and more powerful sitewide search with Jetpack Search.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
 						onClick={ () => trackBannerClick( feature ) }

--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -87,6 +87,7 @@ export const FEATURE_PRIORITY_SUPPORT_JETPACK = 'priority-support-jetpack';
 export const FEATURE_SEO_TOOLS_JETPACK = 'seo-tools-jetpack';
 export const FEATURE_WORDADS_JETPACK = 'wordads-jetpack';
 export const FEATURE_GOOGLE_ANALYTICS_JETPACK = 'google-analytics-jetpack';
+export const FEATURE_SEARCH_JETPACK = 'search-jetpack';
 
 export function isMonthly( plan ) {
 	return includes( JETPACK_MONTHLY_PLANS, plan );

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -8,6 +8,7 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { FEATURE_SEARCH_JETPACK } from 'lib/plans/constants';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -21,46 +22,36 @@ import { FormFieldset } from 'components/forms';
 const Search = moduleSettingsForm(
 	React.createClass( {
 		render() {
-			let planClass = null;
-
-			if ( this.props.sitePlan ) {
-				planClass = getPlanClass( this.props.sitePlan.product_slug );
-			}
-
-			if ( 'is-business-plan' === planClass ) {
-				return (
-					<SettingsCard
-						{ ...this.props }
-						module="search"
-						hideButton
-					>
-						<SettingsGroup module={ { module: 'search' } } hasChild support="https://jetpack.com/support/search">
-							<ModuleToggle
-								slug="search"
-								compact
-								activated={ this.props.getOptionValue( 'search' ) }
-								toggling={ this.props.isSavingAnyOption( 'search' ) }
-								toggleModule={ this.props.toggleModuleNow }>
-								{ __( 'Replace WordPress built-in search with an improved search experience (Beta)' ) }
-							</ModuleToggle>
-							{ this.props.getOptionValue( 'search' ) && (
-								<FormFieldset>
-									<p className="jp-form-setting-explanation">
-										{ __( 'To configure search filters add the {{link}}Jetpack Search widget to your sidebar{{/link}}.', {
-											components: {
-												link: <a href="widgets.php" />
-											}
-										} ) }
-									</p>
-									</FormFieldset>
-							) }
-						</SettingsGroup>
-					</SettingsCard>
-				);
-			} else {
-				// for now, no prompt to upgrade for missing search functionality
-				return null;
-			}
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="search"
+					feature={ FEATURE_SEARCH_JETPACK }
+					hideButton
+				>
+					<SettingsGroup module={ { module: 'search' } } hasChild support="https://jetpack.com/support/search">
+						<ModuleToggle
+							slug="search"
+							compact
+							activated={ this.props.getOptionValue( 'search' ) }
+							toggling={ this.props.isSavingAnyOption( 'search' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{ __( 'Replace WordPress built-in search with an improved search experience (Beta)' ) }
+						</ModuleToggle>
+						{ this.props.getOptionValue( 'search' ) && (
+							<FormFieldset>
+								<p className="jp-form-setting-explanation">
+									{ __( 'To configure search filters add the {{link}}Jetpack Search widget to your sidebar{{/link}}.', {
+										components: {
+											link: <a href="widgets.php" />
+										}
+									} ) }
+								</p>
+								</FormFieldset>
+						) }
+					</SettingsGroup>
+				</SettingsCard>
+			);
 		}
 	} )
 );

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -14,7 +14,6 @@ import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { getSiteAdminUrl } from 'state/initial-state';
-import { getPlanClass } from 'lib/plans/constants';
 import { getSitePlan } from 'state/site';
 import { isFetchingSiteData } from 'state/site';
 import { FormFieldset } from 'components/forms';

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -36,7 +36,7 @@ const Search = moduleSettingsForm(
 							activated={ this.props.getOptionValue( 'search' ) }
 							toggling={ this.props.isSavingAnyOption( 'search' ) }
 							toggleModule={ this.props.toggleModuleNow }>
-							{ __( 'Replace WordPress built-in search with an improved search experience (Beta)' ) }
+							{ __( 'Replace WordPress built-in search with an improved search experience' ) }
 						</ModuleToggle>
 						{ this.props.getOptionValue( 'search' ) && (
 							<FormFieldset>

--- a/modules/search.php
+++ b/modules/search.php
@@ -4,6 +4,7 @@
  * Module Name: Search
  * Module Description: Enhanced search, powered by Elasticsearch
  * First Introduced: 5.0
+ * Sort Order: 34
  * Free: false
  * Requires Connection: Yes
  * Auto Activate: No

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -169,27 +169,31 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		if ( $instance['use_filters'] ) {
 			$filters = array();
 			foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
+				$count = intval( $new_instance['num_filters'][ $index ] );
+				$count = min( 50, $count ); // Set max boundary at 20
+				$count = max( 1, $count );  // Set min boundary at 1
+
 				switch ( $type ) {
 					case 'taxonomy':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'taxonomy',
 							'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 						);
 						break;
 					case 'post_type':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'post_type',
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 						);
 						break;
 					case 'date_histogram':
 						$filters[] = array(
 							'name' => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
 							'type' => 'date_histogram',
-							'count' => intval( $new_instance['num_filters'][ $index ] ),
+							'count' => $count,
 							'field' => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
 							'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
 						);
@@ -366,12 +370,16 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 			<p>
 				<label>
-					<?php esc_html_e( 'Maximum number of filters:', 'jetpack' ); ?>
+					<?php esc_html_e( 'Maximum number of filters (1-50):', 'jetpack' ); ?>
 					<input
 						class="widefat"
 						name="<?php echo esc_attr( $this->get_field_name( 'num_filters' ) ); ?>[]"
 						type="number"
 						value="<?php echo intval( $args['count'] ); ?>"
+						min="1"
+						max="50"
+						step="1"
+						required
 					/>
 				</label>
 			</p>


### PR DESCRIPTION
Fixes #8468 

Adds a prompt for non-Professional sites to upgrade to get Jetpack Search.

<img width="665" alt="jetpack search prompt" src="https://user-images.githubusercontent.com/51896/34634446-ff6e43c6-f238-11e7-8a5f-977445e8c6d3.png">
