### PR TITLE
Remove usage of create_function so PHP 7.2 does not complain

### DIFF
--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -559,12 +559,32 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		);
 	}
 
+	function object_id( $o ) {
+		return $o->ID;
+	}
+
+	function is_comment( $m ) {
+		return 'comment' === $m->type;
+	}
+
+	function is_post( $m ) {
+		return 'post' === $m->type;
+	}
+
+	function comment_id( $o ) {
+		return $o->comment_ID;
+	}
+
+	function meta_id( $o ) {
+		return $o->meta_id;
+	}
+
 	function checksum_histogram( $object_type, $buckets, $start_id = null, $end_id = null, $fields = null ) {
 		// divide all IDs into the number of buckets
 		switch ( $object_type ) {
 			case 'posts':
 				$posts         = $this->get_posts( null, $start_id, $end_id );
-				$all_ids      = array_map( create_function( '$o', 'return $o->ID;' ), $posts );
+				$all_ids      = array_map( array( $this, 'object_id' ), $posts );
 				$id_field      = 'ID';
 				$get_function  = 'get_post';
 
@@ -574,8 +594,8 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 				break;
 			case 'post_meta':
-				$post_meta = array_filter( $this->meta[ get_current_blog_id() ][ 'post' ], create_function( '$m', 'return $m->type === \'post\';' ) );
-				$all_ids  = array_values( array_map( create_function( '$o', 'return $o->meta_id;' ), $post_meta ) );
+				$post_meta = array_filter( $this->meta[ get_current_blog_id() ]['post'], array( $this, 'is_post' ) );
+				$all_ids  = array_values( array_map( array( $this, 'meta_id' ), $post_meta ) );
 				$id_field     = 'meta_id';
 				$get_function = 'get_post_meta_by_id';
 
@@ -585,7 +605,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 				break;
 			case 'comments':
 				$comments     = $this->get_comments( null, $start_id, $end_id );
-				$all_ids  = array_map( create_function( '$o', 'return $o->comment_ID;' ), $comments );
+				$all_ids  = array_map( array( $this, 'comment_id' ), $comments );
 				$id_field     = 'comment_ID';
 				$get_function = 'get_comment';
 
@@ -594,8 +614,8 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 				}
 				break;
 			case 'comment_meta':
-				$comment_meta = array_filter( $this->meta[ get_current_blog_id() ][ 'comment' ], create_function( '$m', 'return $m->type === \'comment\';' ) );
-				$all_ids  = array_values( array_map( create_function( '$o', 'return $o->meta_id;' ), $comment_meta ) );
+				$comment_meta = array_filter( $this->meta[ get_current_blog_id() ]['comment'], array( $this, 'is_comment' ) );
+				$all_ids  = array_values( array_map( array( $this, 'meta_id' ), $comment_meta ) );
 				$id_field     = 'meta_id';
 				$get_function = 'get_comment_meta_by_id';
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -259,13 +259,25 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	// this is just here to support checksum histograms
 	function get_post_meta_by_id( $meta_id ) {
-		$matching_metas = array_filter( $this->meta[ get_current_blog_id() ][ 'post' ], create_function( '$m', 'return $m->meta_id == '.$meta_id.';' ) );
+		$matching_metas = array();
+		$metas = $this->meta[ get_current_blog_id() ]['post'];
+		foreach ( $metas as $m ) {
+			if ( $m->meta_id === $meta_id ) {
+				$matching_metas[] = $m;
+			}
+		}
 		return reset( $matching_metas );
 	}
 
 	// this is just here to support checksum histograms
 	function get_comment_meta_by_id( $meta_id ) {
-		$matching_metas = array_filter( $this->meta[ get_current_blog_id() ][ 'comment' ], create_function( '$m', 'return $m->meta_id == '.$meta_id.';' ) );
+		$matching_metas = array();
+		$metas = $this->meta[ get_current_blog_id() ]['comment'];
+		foreach ( $metas as $m ) {
+			if ( $m->meta_id === $meta_id ) {
+				$matching_metas[] = $m;
+			}
+		}
 		return reset( $matching_metas );
 	}
 


### PR DESCRIPTION
Part of #8156.

#### Changes proposed in this Pull Request:

* Replaces usage of `create_function` in `class.jetpack-sync-test-replicastore.php` for regular foreach loops and a set of new class methods that serve as callback to `array_map`.

#### Testing instructions:

* Run tests on PHP 7.0, PHP 7.1 or PHP 5.6 and confirm they pass. 

<!-- Add the following only if this is meant to be in changelog -->

Updated code to be compatible with PHP 7.2

  