### PR TITLE
Shortcodes: Check if Brightcove shortcode attributes are an array before assuming they can be counted

### DIFF
--- a/modules/shortcodes/brightcove.php
+++ b/modules/shortcodes/brightcove.php
@@ -56,7 +56,7 @@ class Jetpack_Brightcove_Shortcode {
 	 * @return array
 	 */
 	static public function normalize_attributes( $atts ) {
-		if ( 1 == count( $atts ) ) { // this is the case we need to take care of.
+		if ( is_array( $atts ) && 1 == count( $atts ) ) { // this is the case we need to take care of.
 			$parsed_atts = array();
 			$params = shortcode_new_to_old_params( $atts );
 			$params = apply_filters( 'brightcove_dimensions', $params );


### PR DESCRIPTION
Fixes error being shown when used under PHP 7.2.

Part of #8156.

#### Changes proposed in this Pull Request:

* Updates `shortcodes/brightcove.php` to check attributes with `is_array()` before assuming we can use `count()` on the argument passed to `normalize_attributes()`.

#### Testing instructions:

* Run `phpunit --testsuite infinite-scroll` under PHP 7.1, PHP 7.0 or PHP 5.6
* Expect test to pass.

#### Proposed changelog entry for your changes:

* Updated Brightcove shortcodes to be compatible with PHP 7.2.
  