### PR TITLE
Widget housekeeping: extend functionality and add check for existing data upon update

### DIFF
--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -388,6 +388,10 @@ class Jetpack_Widgets {
 		$widget_settings = get_option( $widget_option_name );
 		$instance_key = self::get_widget_instance_key( $widget_id );
 
+		if ( ! $widget = self::get_registered_widget_object( self::get_widget_id_base( $widget_id ) ) ) {
+			return new WP_Error( 'invalid_data', 'Invalid ID base.', 400 );
+		}
+
 		// if the widget's content already exists
 		if ( isset( $widget_settings[ $instance_key ] ) ) {
 			$old_settings = $widget_settings[ $instance_key ];
@@ -507,7 +511,7 @@ class Jetpack_Widgets {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Deletes a widget entirely including all its settings. Returns a WP_Error if
 	 * the widget could not be found. Otherwise returns an empty array.

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -390,16 +390,19 @@ class Jetpack_Widgets {
 		$widget_option_name = self::get_widget_option_name( $widget_id );
 		$widget_settings = get_option( $widget_option_name );
 		$instance_key = self::get_widget_instance_key( $widget_id );
-		$old_settings = $widget_settings[ $instance_key ];
 
-		if ( ! $settings = self::sanitize_widget_settings( $widget_id, $settings, $old_settings ) ) {
-			return new WP_Error( 'invalid_data', 'Update failed.', 500 );
-		}
-		if ( is_array( $old_settings ) ) {
-			// array_filter prevents empty arguments from replacing existing ones
-			$settings = wp_parse_args( array_filter( $settings ), $old_settings );
-		}
+		// if the widget's content already exists
+		if ( isset( $widget_settings[ $instance_key ] ) ) {
+			$old_settings = $widget_settings[ $instance_key ];
 
+			if ( ! $settings = self::sanitize_widget_settings( $widget_id, $settings, $old_settings ) ) {
+				return new WP_Error( 'invalid_data', 'Update failed.', 500 );
+			}
+			if ( is_array( $old_settings ) ) {
+				// array_filter prevents empty arguments from replacing existing ones
+				$settings = wp_parse_args( array_filter( $settings ), $old_settings );
+			}
+		}
 		$widget_settings[ $instance_key ] = $settings;
 
 		return update_option( $widget_option_name, $widget_settings );

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -494,6 +494,22 @@ class Jetpack_Widgets {
 	}
 
 	/**
+	 * Retrieve the first active sidebar
+	 *
+	 * @return array|false Active sidebar or false if none exists
+	 */
+	public function get_first_sidebar() {
+		$active_sidebars = Jetpack_Widgets::get_active_sidebars();
+
+		unset( $active_sidebars[ 'array_version' ] );
+
+		if ( empty( $active_sidebars ) ) {
+			return false;
+		}
+		return array_shift( array_keys( $active_sidebars ) );
+	}
+
+	/**
 	 * Find a widget in a list of all widgets retrieved from a sidebar
 	 * using get_widgets_in_sidebar()
 	 * @param string $widget The widget we want to look up in the sidebar
@@ -502,7 +518,6 @@ class Jetpack_Widgets {
 	 *
 	 * @return bool Whether present.
 	 */
-
 	public static function is_widget_in_sidebar( $widgets_all, $widget_id ) {
 		foreach ( $widgets_all as $widget_el_id ) {
 			if ( $widget_el_id  === $widget_id ) {

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -121,6 +121,23 @@ class Jetpack_Widgets {
 	}
 
 	/**
+	 * Return a widget by base ID or null if nothing is found.
+	 *
+	 * @param string $id_base The id of a widget to look for.
+	 *
+	 * @return array|null The matching formatted widget (see format_widget).
+	 */
+	public static function get_widget_by_id_base( $id_base ) {
+		$found = null;
+		foreach ( self::get_all_widgets() as $widget ) {
+			if ( $widget['id_base'] === $id_base ) {
+				$found = $widget;
+			}
+		}
+		return $found;
+	}
+
+	/**
 	 * Return an array of all widgets (active and inactive) formatted for output.
 	 *
 	 * @return array An array of all widgets (see format_widget).

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -458,7 +458,6 @@ class Jetpack_Widgets {
 		if ( ! isset( $widgets_in_sidebar ) ) {
 			return new WP_Error( 'invalid_data', 'No such sidebar exists', 400 );
 		}
-		self::move_widget_to_sidebar( $widget, $sidebar, $position );
 		$widget_save_status = self::set_widget_settings( $widget_id, $settings );
 		if ( is_wp_error( $widget_save_status ) ) {
 			return $widget_save_status;


### PR DESCRIPTION
Side effect of the JPO work on extending the endpoint to inject Business Address widget. 


#### Changes proposed in this Pull Request: 

* ~remove redundant sidebar placement when updating the widget~ when updating a widget, it adds a check of whether a widget is in a sidebar before calling a function that moves it there
* a helper method to query widget in a sidebar by `id_base`, not only by `widget_id`
* a helper method to query first active sidebar
* a helper method to check if a widget is present in a given sidebar
* when updating widget's content we need to check whether such content exists. Currently, the corresponding function (`set_widget_settings`) is called both when activating a new and updating an existing widget with no checks in place.

#### Testing instructions:
 `Jetpack_Widgets` have not been used elsewhere, so we do not introduce regression with these changes.  UPDATE: outside of  https://github.com/Automattic/jetpack/blob/master/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php 😄 
* follow the instructions in https://github.com/Automattic/jetpack/pull/8426

 *Q:* Should those changes include separate JP tests?
  
  
  
  