### PR TITLE
REST API: JPO: Enable WooCommerce installation

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1047,6 +1047,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
+		if ( ! empty( $data['installWooCommerce'] ) ) {
+			jetpack_require_lib( 'plugins' );
+			$wc_install_result = Jetpack_Plugins::install_and_activate_plugin( 'woocommerce' );
+			if ( is_wp_error( $wc_install_result ) ) {
+				$error[] = 'woocommerce installation';
+			}
+		}
+
 		return empty( $error )
 			? ''
 			: join( ', ', $error );

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -23,12 +23,6 @@ class Jetpack_Plugins {
 	 * @return bool|WP_Error True if installation succeeded, error object otherwise.
 	 */
 	public static function install_and_activate_plugin( $slug ) {
-		// Check if get_plugins() function exists. This is required on the front end of the
-		// site, since it is in a file that is normally only loaded in the admin.
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		$plugin_id = self::get_plugin_id_by_slug( $slug );
 
 		if ( ! $plugin_id ) {
@@ -102,6 +96,12 @@ class Jetpack_Plugins {
 	 }
 
 	 public static function get_plugin_id_by_slug( $slug ) {
+		// Check if get_plugins() function exists. This is required on the front end of the
+		// site, since it is in a file that is normally only loaded in the admin.
+		if ( ! function_exists( 'get_plugins' ) ) {
+		 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
 		$plugins = apply_filters( 'all_plugins', get_plugins() );
 		if ( ! is_array( $plugins ) ) {

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -32,7 +32,7 @@ class Jetpack_Plugins {
 			}
 			$plugin_id = self::get_plugin_id_by_slug( $slug );
 		} else if ( is_plugin_active( $plugin_id ) ) {
-			return true;
+			return true; // Already installed and active
 		}
 
 		if ( ! current_user_can( 'activate_plugins' ) ) {
@@ -44,7 +44,7 @@ class Jetpack_Plugins {
 			return $activated;
 		}
 
-		return true; // Already installed and active
+		return true;
 	}
 
 	/**

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -29,14 +29,14 @@ class Jetpack_Plugins {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_id = get_plugin_id_by_slug( $slug );
+		$plugin_id = self::get_plugin_id_by_slug( $slug );
 
 		if ( ! $plugin_id ) {
 			$installed = self::install_plugin( $slug );
 			if ( is_wp_error( $installed ) ) {
 				return $installed;
 			}
-			$plugin_id = get_plugin_id_by_slug( $slug );
+			$plugin_id = self::get_plugin_id_by_slug( $slug );
 			return activate_plugin( $plugin_id );
 		} else if ( ! is_plugin_active( $plugin_id ) ) {
 			return activate_plugin( $plugin_id );

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -103,7 +103,7 @@ class Jetpack_Plugins {
 		// Check if get_plugins() function exists. This is required on the front end of the
 		// site, since it is in a file that is normally only loaded in the admin.
 		if ( ! function_exists( 'get_plugins' ) ) {
-		 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -32,7 +32,7 @@ class Jetpack_Plugins {
 			}
 			$plugin_id = self::get_plugin_id_by_slug( $slug );
 		} else if ( is_plugin_active( $plugin_id ) ) {
-				return true;
+			return true;
 		}
 
 		if ( ! current_user_can( 'activate_plugins' ) ) {

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -37,10 +37,15 @@ class Jetpack_Plugins {
 				return $installed;
 			}
 			$plugin_id = self::get_plugin_id_by_slug( $slug );
-			return activate_plugin( $plugin_id );
-		} else if ( ! is_plugin_active( $plugin_id ) ) {
-			return activate_plugin( $plugin_id );
+		} else if ( is_plugin_active( $plugin_id ) ) {
+				return true;
 		}
+
+		$activated = activate_plugin( $plugin_id );
+		if ( is_wp_error( $activated ) ) {
+			return $activated;
+		}
+
 		return true; // Already installed and active
 	}
 

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -35,6 +35,10 @@ class Jetpack_Plugins {
 				return true;
 		}
 
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return new WP_Error( 'not_allowed', __( 'You are not allowed to activate plugins on this site.', 'jetpack' ) );
+		}
+
 		$activated = activate_plugin( $plugin_id );
 		if ( is_wp_error( $activated ) ) {
 			return $activated;

--- a/_inc/lib/plugins.php
+++ b/_inc/lib/plugins.php
@@ -14,6 +14,37 @@ include_once( 'class.jetpack-automatic-install-skin.php' );
 class Jetpack_Plugins {
 
 	/**
+	 * Install and activate a plugin.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param string $slug Plugin slug.
+	 *
+	 * @return bool|WP_Error True if installation succeeded, error object otherwise.
+	 */
+	public static function install_and_activate_plugin( $slug ) {
+		// Check if get_plugins() function exists. This is required on the front end of the
+		// site, since it is in a file that is normally only loaded in the admin.
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_id = get_plugin_id_by_slug( $slug );
+
+		if ( ! $plugin_id ) {
+			$installed = self::install_plugin( $slug );
+			if ( is_wp_error( $installed ) ) {
+				return $installed;
+			}
+			$plugin_id = get_plugin_id_by_slug( $slug );
+			return activate_plugin( $plugin_id );
+		} else if ( ! is_plugin_active( $plugin_id ) ) {
+			return activate_plugin( $plugin_id );
+		}
+		return true; // Already installed and active
+	}
+
+	/**
 	 * Install a plugin.
 	 *
 	 * @since 5.8.0


### PR DESCRIPTION
Add `install_and_activate_plugins()` to the Plugins Helper class, and use that to install WooCommerce from the JP Onboarding endpoint.

Counterpart to Automattic/wp-calypso#21237 -- find testing instructions there.
  
  
  
  