### PR TITLE
Connection Banner: Fix path calculation for svg images

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -226,7 +226,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Jetpack simplifies site security, customization, and management.', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/jetpack-welcome.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/jetpack-welcome.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it',
 									'jetpack'
@@ -288,7 +288,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Detailed stats and traffic tools to help your site grow', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/stats-people.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/stats-people.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 								esc_attr_e(
 									'Get clear and concise stats and analytics about your visitors',
 								 'jetpack'
@@ -340,7 +340,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Multiple security tools to give you peace of mind', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/security.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/security.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Your site is automatically protected from brute force attacks, plus you can use single sign-on for extra security',
 									'jetpack'
@@ -394,7 +394,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Hundreds of beautiful themes to choose from', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/customize-theme.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/customize-theme.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Choosing a design for your site is essential. It defines your brand, your layout, and your visitors’ reading experience',
 									'jetpack'
@@ -449,7 +449,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Faster site speeds through the WordPress.com CDN', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/cloud-based.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/cloud-based.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Jetpack automatically optimizes and speeds up images using the global WordPress.com Content Delivery Network (CDN)',
 									'jetpack'
@@ -492,7 +492,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Free WordPress apps to manage your site(s) from any device', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/apps.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/apps.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Our mobile and desktop apps are free and available to you on Apple or Android devices once Jetpack is connected to WordPress.com',
 									'jetpack'
@@ -535,7 +535,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'More Jetpack features our users love', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/customize-theme-2.svg', dirname( __FILE__ ) ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/customize-theme-2.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
 										'Jetpack includes other features that help you customize your site',
 									'jetpack'
@@ -626,7 +626,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Welcome to Jetpack', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/jetpack-welcome.svg', dirname( __FILE__ ) ); ?>" alt="Your site is automatically protected from brute force attacks, plus you can use single sign-on for extra security." height="auto" width="250" />
+							<img src="<?php echo plugins_url( 'images/jetpack-welcome.svg', JETPACK__PLUGIN_FILE ); ?>" alt="Your site is automatically protected from brute force attacks, plus you can use single sign-on for extra security." height="auto" width="250" />
 						</div>
 
 						<p>
@@ -684,7 +684,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Code-Free Design and Publishing', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/customize-theme.svg', dirname( __FILE__ ) ); ?>" alt="Customization tools and widgets help you make your site look great without writing any code" height="auto" width="225" />
+							<img src="<?php echo plugins_url( 'images/customize-theme.svg', JETPACK__PLUGIN_FILE ); ?>" alt="Customization tools and widgets help you make your site look great without writing any code" height="auto" width="225" />
 						</div>
 
 						<p>
@@ -732,7 +732,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Get The Traffic You Deserve', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/stats-people.svg', dirname( __FILE__ ) ); ?>" alt="Get clear and concise stats and analytics about your visitors." height="auto" width="265" />
+							<img src="<?php echo plugins_url( 'images/stats-people.svg', JETPACK__PLUGIN_FILE ); ?>" alt="Get clear and concise stats and analytics about your visitors." height="auto" width="265" />
 						</div>
 
 						<p>
@@ -782,7 +782,7 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Make Sure Your Site Is Always Online', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'jetpack/images/security.svg', dirname( __FILE__ ) ); ?>" alt="Your site is automatically protected from brute force attacks, plus you can use single sign-on for extra security." height="auto" width="250" />
+							<img src="<?php echo plugins_url( 'images/security.svg', JETPACK__PLUGIN_FILE ); ?>" alt="Your site is automatically protected from brute force attacks, plus you can use single sign-on for extra security." height="auto" width="250" />
 						</div>
 
 						<p>


### PR DESCRIPTION
Fixes connection banner images when Jetpack is run from a directory named other than `jetpack`.

#### Changes proposed in this Pull Request:

* Replaces usage of `dirname( __FILE__)` for `JETPACK__PLUGIN_FILE` when calculating the URL path to some images in the connection banner shown in WordPress dashboard.

#### Testing instructions:

* Check this PR using the Jetpack Beta plugin.
* Visit WordPress' dashboard. 
* Confirm that images are not broken in all tabs.

**Before**

![image](https://user-images.githubusercontent.com/746152/34684556-37b9148e-f484-11e7-8156-3a513cabc408.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixed images shown in the dashboard when Jetpack is installed in a directory naed different than `jetpack`