### PR TITLE
Admin Page: Only query Rewind status from Jetpack Dashboard if the site is connected 

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -253,7 +253,7 @@ const Main = React.createClass( {
 			<div>
 				<Masthead route={ this.props.route } />
 					<div className="jp-lower">
-						<QueryRewindStatus />
+						{ this.props.isSiteConnected && <QueryRewindStatus /> }
 						<AdminNotices />
 						<JetpackNotices />
 						{ this.renderMainContent( this.props.route.path ) }


### PR DESCRIPTION
Avoid an unnecessary query to .com if the site is not yet connected when visisting the Jetpack Admin Page.


#### Changes proposed in this Pull Request:

* Checks if site is connected before rendering the `QueryRewindStatus` component.

#### Testing instructions:

* Check this PR on a disconnected site.
* Build the admin page
* Visit the Jetpack Dashboard
* Expect to see no failed request (404 status if the site is brand new. 400 if the site has been connected before being disconnected now) to get rewind status on the network panel.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

  