### PR TITLE
Prevent actorless Plugin Updated activity log entry

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -52,24 +52,24 @@ class Jetpack_Sync_Sender {
 		}
 	}
 
-	public function maybe_set_user_from_token() {
+	public function maybe_set_user_from_token( ) {
 		$jetpack = Jetpack::init();
+		$verified_user = $jetpack->verify_xml_rpc_signature();
 		if ( Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) &&
-		     $jetpack->verify_xml_rpc_signature()
+			! is_wp_error( $verified_user )
+			&& $verified_user
 		) {
-			$verified_user = $jetpack->verify_xml_rpc_signature();
 			$old_user = wp_get_current_user();
 			$this->old_user = isset( $old_user->ID ) ? $old_user->ID : 0;
-			$this->old_user = wp_set_current_user( $verified_user['user_id'] );
+			wp_set_current_user( $verified_user['user_id'] );
 		}
-
 	}
 
 	public function maybe_clear_user_from_token() {
 		if ( isset( $this->old_user ) ) {
 			wp_set_current_user( $this->old_user );
 		}
- 	}
+	}
 
 	public function get_next_sync_time( $queue_name ) {
 		return (double) get_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name, 0 );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -45,7 +45,6 @@ class Jetpack_Sync_Sender {
 	}
 
 	private function init() {
-		//
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -59,8 +58,7 @@ class Jetpack_Sync_Sender {
 			$verified_user = $jetpack->verify_xml_rpc_signature();
 			$old_user = wp_get_current_user();
 			$this->old_user = isset( $old_user->ID ) ? $old_user->ID : 0;
-			$this->old_user =
-			wp_set_current_user( $verified_user['user_id'] );
+			$this->old_user = wp_set_current_user( $verified_user['user_id'] );
 		}
 	}
 

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -54,12 +54,16 @@ class Jetpack_Sync_Sender {
 
 	public function maybe_set_user_from_token() {
 		$jetpack = Jetpack::init();
-		if ( $jetpack->verify_xml_rpc_signature() ) {
+		if ( defined( 'XMLRPC_REQUEST' ) &&
+		     XMLRPC_REQUEST &&
+		     $jetpack->verify_xml_rpc_signature()
+		) {
 			$verified_user = $jetpack->verify_xml_rpc_signature();
 			$old_user = wp_get_current_user();
 			$this->old_user = isset( $old_user->ID ) ? $old_user->ID : 0;
 			$this->old_user = wp_set_current_user( $verified_user['user_id'] );
 		}
+
 	}
 
 	public function maybe_clear_user_from_token() {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -54,8 +54,7 @@ class Jetpack_Sync_Sender {
 
 	public function maybe_set_user_from_token() {
 		$jetpack = Jetpack::init();
-		if ( defined( 'XMLRPC_REQUEST' ) &&
-		     XMLRPC_REQUEST &&
+		if ( Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) &&
 		     $jetpack->verify_xml_rpc_signature()
 		) {
 			$verified_user = $jetpack->verify_xml_rpc_signature();

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -879,7 +879,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$_SERVER['REQUEST_URI'] = '/xmlrpc.php';
 		$_GET['body'] = 'abc';
-		$_GET['body-hash'] = jetpack_sha1_base64( 'abc' );
+		$_GET['body-hash'] = base64_encode( sha1( 'abc', true ) );
 		$GLOBALS['HTTP_RAW_POST_DATA'] = 'abc';
 		$_SERVER['REQUEST_METHOD']  = 'POST';
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -857,17 +857,17 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $event->user_id, 0, ' Callables user_id is null' );
 
 		$this->resetCallableAndConstantTimeouts();
-		$this->mock_authenicated_xml_rpc(); // mock requet
+		$this->mock_authenticated_xml_rpc(); // mock requet
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_callable' );
-		// clean up
-		$this->mock_autehicated_xml_rpc_cleanup( $user->ID );
+		// clean up by unsetting globals, etc. set previously by $this->mock_authenticated_xml_rpc()
+		$this->mock_authenticated_xml_rpc_cleanup( $user->ID );
 
 		$this->assertEquals( $event->user_id, self::$admin_id, ' Callables XMLRPC_Reqeust not equal to event user_id' );
 	}
 
-	function mock_authenicated_xml_rpc() {
+	function mock_authenticated_xml_rpc() {
 		self::$admin_id = $this->factory->user->create( array(
 			'role' => 'administrator',
 		) );
@@ -897,7 +897,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', $normalize , 'secret', true ) );
 
-		// call one of the autheticad endpoints
+		// call one of the authenticated endpoints
 		Jetpack_Constants::set_constant( 'XMLRPC_REQUEST', true );
 		$jetpack = Jetpack::init();
 		$jetpack->xmlrpc_methods( array() );
@@ -905,7 +905,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$jetpack->verify_xml_rpc_signature();
 	}
 
-	function mock_autehicated_xml_rpc_cleanup( $user_id ) {
+	function mock_authenticated_xml_rpc_cleanup( $user_id ) {
 		Jetpack_Constants::clear_constants();
 		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10 );
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -15,6 +15,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
 	protected $callable_module;
 
+	protected static $admin_id; // used in mock_xml_rpc_request
+
 	public function setUp() {
 		parent::setUp();
 
@@ -846,6 +848,89 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNotEmpty( $synced_value3, 'value is empty!' );
 
 	}
+
+	function test_xml_rpc_request_callables_has_() {
+		$this->server_event_storage->reset();
+		$user = wp_get_current_user();
+		wp_set_current_user( 0 ); //
+		$this->mock_authenicated_xml_rpc(); // mock requet
+		$this->sender->do_sync();
+		$events = $this->server_event_storage->get_all_events();
+		foreach( $events as $e ) {
+			var_dump( $e->action );
+		}
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_callable' );
+		$this->mock_autehicated_xml_rpc_cleanup( $user->ID );
+		$this->assertEquals( $event->user_id, self::$admin_id, ' Callables XMLRPC_Reqeust not equal to event user_id' );
+	}
+
+	function mock_authenicated_xml_rpc() {
+		self::$admin_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+
+		var_dump( 'mock_reques');
+
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+		$_GET['token'] = 'pretend_this_is_valid:1:' . self::$admin_id;
+		$_GET['timestamp'] = (string) time();
+		$_GET['nonce'] = 'testing123';
+		var_dump( $_SERVER['REQUEST_URI'] );
+		$_SERVER['REQUEST_URI'] = '/xmlrpc.php';
+		$_GET['body'] = 'abc';
+		$_GET['body-hash'] = jetpack_sha1_base64( 'abc' );
+		$GLOBALS['HTTP_RAW_POST_DATA'] = 'abc';
+		$_SERVER['REQUEST_METHOD']  = 'POST';
+
+		$normalized_request_pieces = array(
+			$_GET['token'],
+			$_GET['timestamp'],
+			$_GET['nonce'],
+			$_GET['body-hash'],
+			'POST',
+			'example.org',
+			'80',
+			'/xmlrpc.php',
+		);
+		$normalize = join( "\n", $normalized_request_pieces ) . "\n";
+
+		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', $normalize , 'secret', true ) );
+
+		// call one of the autheticad endpoints
+		Jetpack_Constants::set_constant( 'XMLRPC_REQUEST', true );
+		$jetpack = Jetpack::init();
+		$jetpack->xmlrpc_methods( array() );
+		$jetpack->require_jetpack_authentication();
+		$jetpack->verify_xml_rpc_signature();
+	}
+
+	function mock_autehicated_xml_rpc_cleanup( $user_id ) {
+		Jetpack_Constants::clear_constants();
+		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10 );
+
+		unset( $_GET['token'] );
+		unset( $_GET['timestamp'] );
+		unset( $_GET['nonce'] );
+		$_SERVER['REQUEST_URI'] = '';
+		unset( $_GET['body'] );
+		unset( $_GET['body-hash'] ) ;
+		unset( $GLOBALS['HTTP_RAW_POST_DATA'] );
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$jetpack = Jetpack::init();
+		$jetpack->reset_saved_auth_state();
+		wp_set_current_user( $user_id );
+		self::$admin_id = null;
+	}
+
+	function mock_jetpack_private_options() {
+		$user_tokens = array();
+		$user_tokens[ self::$admin_id ] = 'pretend_this_is_valid.secret.' . self::$admin_id;
+		return array(
+			'user_tokens' => $user_tokens,
+		);
+	}
+
 }
 
 function jetpack_foo_is_callable_random() {


### PR DESCRIPTION
This PR prevents the actorless Plugin Updated activity log entry. 

#### Changes proposed in this Pull Request:

Previously, certain wpcom api requests to Jetpack sites resulted in the syncing of callables without a user set. This code ensures that the user is determined from the token and sent along in the Jetpack sync action.

#### Testing instructions:

Update a plugin via Calypso and ensure that you don't have an actorless Plugin Update activity in your activity log.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
