### PR TITLE
Sync: Add user password syncing as an event

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -63,7 +63,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_register_user', array( $this, 'expand_user' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_save_user' ) );
 		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 
@@ -134,13 +134,22 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function expand_user( $args ) {
 		list( $user ) = $args;
 		if ( $user ) {
-			if ( isset( $args[1] ) ) { // if state is available also send state.
-				return array( $this->add_to_user( $user ), $args[1] );
-			}
 			return array( $this->add_to_user( $user ) );
 		}
 
 		return false;
+	}
+
+	public function expand_save_user( $args ) {
+		list( $user, $flags ) = $args;
+
+		$expanded_user = $this->expand_user( $args );
+
+		if ( $expanded_user ) {
+			$expanded_user[] = $flags;
+		}
+
+		return $expanded_user;
 	}
 
 	public function expand_login_username( $args ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -209,26 +209,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 		$role_changed = isset( $this->previous_role[ $user_id ] ) ? $this->previous_role[ $user_id ] : false;
 
-		if ( $old_user !== null ) {
-			if ( $raw_user->user_pass !== $old_user->user_pass ) {
-				$user_password_changed = true;
-			}
-			unset( $old_user->user_pass );
-			if ( serialize( $old_user ) === serialize( $user->data ) ) {
-				if ( $user_password_changed ) {
-					/**
-					 * Documented already in this file
-					 * @param array state - New since 5.8.0
-					 */
-					do_action( 'jetpack_sync_save_user', $user, array(
-						'password_changed' => true,
-						'user_data_changed' => false,
-						'role_changed' => (bool) $role_changed,
-						'previous_role' => $role_changed,
-					) );
-				}
-				return;
-			}
+		if ( $old_user !== null && $raw_user->user_pass !== $old_user->user_pass ) {
+			$user_password_changed = true;
 		}
 
 		if ( 'user_register' === current_filter() ) {
@@ -257,8 +239,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-
-
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *
@@ -269,7 +249,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_sync_save_user', $user, array(
 			'password_changed' => $user_password_changed,
-			'user_data_changed' => true,
 			'role_changed' => (bool) $role_changed,
 			'previous_role' => $role_changed,
 			) );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -26,7 +26,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'jetpack_sync_add_user', $callable, 10, 2 );
 		add_action( 'jetpack_sync_register_user', $callable, 10, 2 );
 		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
-		add_action( 'jetpack_updated_user_password', $callable );
 
 		//Edit user info, see https://github.com/WordPress/WordPress/blob/c05f1dc805bddcc0e76fd90c4aaf2d9ea76dc0fb/wp-admin/user-edit.php#L126
 		add_action( 'personal_options_update', array( $this, 'edited_user_handler' ) );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -141,11 +141,17 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_save_user( $args ) {
-		list( $user, $flags ) = $args;
+		$default_flags = array(
+			'password_changed' => false,
+			'role_changed'     => false,
+			'previous_role'    => false,
+		);
 
+		$flags         = ( isset( $args[1] ) && is_array( $args[1] ) ) ? $args[1] : array();
 		$expanded_user = $this->expand_user( $args );
 
 		if ( $expanded_user ) {
+			$flags           = wp_parse_args( $flags, $default_flags );
 			$expanded_user[] = $flags;
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -76,7 +76,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		// Don't sync the password changes since we don't track passwords
 		$events = $this->server_event_storage->get_all_events( 'jetpack_sync_save_user' );
 		$this->assertTrue( $events[0]->args[1]['password_changed'] );
-		$this->assertFalse( $events[0]->args[1]['user_data_changed'] );
 		$this->assertEquals( $this->user_id, $events[0]->args[0]->ID );
 
 		// Only the sync save user event should be present.
@@ -100,7 +99,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 		$events = $this->server_event_storage->get_all_events( 'jetpack_sync_save_user' );
 		$this->assertTrue( $events[0]->args[1]['password_changed'] );
-		$this->assertTrue( $events[0]->args[1]['user_data_changed'] );
 
 		// Only the sync save user event should be present.
 		$this->assertFalse( isset( $events[1] ) );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -13,7 +13,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		// create a user
 		$this->user_id = $this->factory->user->create();
 		$this->sender->do_sync();
-		var_dump( 'RUNing...' );
 	}
 
 	public function test_insert_user_is_synced() {


### PR DESCRIPTION

Add state of the jetpack_sync_save_user event so that we know a bit more information as to why it was triggered in the first place. This will make it easier to provide info to the user as to what was changed.

- Did the role change? Did the capabilities change. Did we also change the password? Did all those things change at once? 

Fixes issue where we didn't record that we a password was changed. 

#### Changes proposed in this Pull Request:
* Add a state to the jetpack_save_user sync event that provides more info as to why the event happened. 

#### Testing instructions:
* Do the tests pass? 
* Does everything still work as before? 
* Test changing password, Role, and user data at once. 
* Test adding a new user. Do we get the right info? 
* Test Removing a user? 
* Does multisite still work as expected? 


  