### PR TITLE
Docs: update link to community issues in contributing guide.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Once your development environment is ready, you can get started and [create your
 If you'd like to contribute but don't know where to get started, you can take a look at existing issues:
 
 - ["Good First Bug"](https://github.com/Automattic/jetpack/labels/%5BType%5D%20Good%20First%20Bug) issues are a good entry point to get familiar with Jetpack's codebase.
-- All issues labeled with [the "Community" milestone](https://github.com/Automattic/jetpack/issues?q=is%3Aopen+is%3Aissue+milestone%3ACommunity) are fair game. That's a great way to contribute new features and fix small issues within Jetpack.
+- All issues labeled with [the "Good For Community" label](https://github.com/Automattic/Jetpack/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Good+For+Community%22) are fair game. That's a great way to contribute new features and fix small issues within Jetpack.
 - ["Whisky"](https://github.com/Automattic/jetpack/labels/Whisky%20Ticket) issues are important bugs or enhancements. Take a crack at it if you feel adventurous! :)
 
 Are you new to Git? You can [follow these detailed steps to find out how to submit your first patch.](/docs/guides/submit-patch.md)


### PR DESCRIPTION
We do not use the Community milestone anymore. Instead we use a label.

