### PR TITLE
REST API: Store JPO homepage format in an option

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1012,7 +1012,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				}
 			}
 
-			update_option( 'jpo_homepage_format_set', 1 );
+			update_option( 'jpo_homepage_format', $data['homepageFormat'] );
 		}
 
 		// Setup contact page and add a form and/or business info

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -970,45 +970,49 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
-		// If $data['homepageFormat'] is 'posts', we have nothing to do since it's WordPress' default
-		if ( isset( $data['homepageFormat'] ) && 'page' === $data['homepageFormat'] ) {
-			if ( ! ( update_option( 'show_on_front', 'page' ) || get_option( 'show_on_front' ) == 'page' ) ) {
-				$error[] = 'homepageFormat';
+		if ( isset( $data['homepageFormat'] ) ) {
+			// If $data['homepageFormat'] is 'posts', we have nothing to do since it's WordPress' default
+			if ( 'page' === $data['homepageFormat'] ) {
+				if ( ! ( update_option( 'show_on_front', 'page' ) || get_option( 'show_on_front' ) == 'page' ) ) {
+					$error[] = 'homepageFormat';
+				}
+
+				$home = wp_insert_post( array(
+					'post_type'     => 'page',
+					/* translators: this references the home page of a site, also called front page. */
+					'post_title'    => esc_html_x( 'Home Page', 'The home page of a website.', 'jetpack' ),
+					'post_content'  => sprintf( esc_html__( 'Welcome to %s.', 'jetpack' ), $site_title ),
+					'post_status'   => 'publish',
+					'post_author'   => $author,
+				) );
+				if ( 0 == $home ) {
+					$error[] = 'home insert: 0';
+				} elseif ( is_wp_error( $home ) ) {
+					$error[] = 'home creation: '. $home->get_error_message();
+				}
+				if ( ! ( update_option( 'page_on_front', $home ) || get_option( 'page_on_front' ) == $home ) ) {
+					$error[] = 'home set';
+				}
+
+				$blog = wp_insert_post( array(
+					'post_type'     => 'page',
+					/* translators: this references the page where blog posts are listed. */
+					'post_title'    => esc_html_x( 'Blog', 'The blog of a website.', 'jetpack' ),
+					'post_content'  => sprintf( esc_html__( 'These are the latest posts in %s.', 'jetpack' ), $site_title ),
+					'post_status'   => 'publish',
+					'post_author'   => $author,
+				) );
+				if ( 0 == $blog ) {
+					$error[] = 'blog insert: 0';
+				} elseif ( is_wp_error( $blog ) ) {
+					$error[] = 'blog creation: '. $blog->get_error_message();
+				}
+				if ( ! ( update_option( 'page_for_posts', $blog ) || get_option( 'page_for_posts' ) == $blog ) ) {
+					$error[] = 'blog set';
+				}
 			}
 
-			$home = wp_insert_post( array(
-				'post_type'     => 'page',
-				/* translators: this references the home page of a site, also called front page. */
-				'post_title'    => esc_html_x( 'Home Page', 'The home page of a website.', 'jetpack' ),
-				'post_content'  => sprintf( esc_html__( 'Welcome to %s.', 'jetpack' ), $site_title ),
-				'post_status'   => 'publish',
-				'post_author'   => $author,
-			) );
-			if ( 0 == $home ) {
-				$error[] = 'home insert: 0';
-			} elseif ( is_wp_error( $home ) ) {
-				$error[] = 'home creation: '. $home->get_error_message();
-			}
-			if ( ! ( update_option( 'page_on_front', $home ) || get_option( 'page_on_front' ) == $home ) ) {
-				$error[] = 'home set';
-			}
-
-			$blog = wp_insert_post( array(
-				'post_type'     => 'page',
-				/* translators: this references the page where blog posts are listed. */
-				'post_title'    => esc_html_x( 'Blog', 'The blog of a website.', 'jetpack' ),
-				'post_content'  => sprintf( esc_html__( 'These are the latest posts in %s.', 'jetpack' ), $site_title ),
-				'post_status'   => 'publish',
-				'post_author'   => $author,
-			) );
-			if ( 0 == $blog ) {
-				$error[] = 'blog insert: 0';
-			} elseif ( is_wp_error( $blog ) ) {
-				$error[] = 'blog creation: '. $blog->get_error_message();
-			}
-			if ( ! ( update_option( 'page_for_posts', $blog ) || get_option( 'page_for_posts' ) == $blog ) ) {
-				$error[] = 'blog set';
-			}
+			update_option( 'jpo_homepage_format_set', 1 );
 		}
 
 		// Setup contact page and add a form and/or business info

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -535,6 +535,7 @@ class Jetpack_Options {
 			'jetpack_last_connect_url_check',
 			'jpo_site_type',
 			'jpo_contact_page',
+			'jpo_homepage_format_set',
 		);
 	}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -534,8 +534,8 @@ class Jetpack_Options {
 			'jetpack_sso_remove_login_form',
 			'jetpack_last_connect_url_check',
 			'jpo_site_type',
+			'jpo_homepage_format',
 			'jpo_contact_page',
-			'jpo_homepage_format_set',
 		);
 	}
 


### PR DESCRIPTION
This PR updates the JPO homepage saving to store the format of the homepage in an option. We'll need that in order to provide consistent experience to the user; also for knowing whether the user has already completed the homepage format step.

We'll use this option when retrieving onboarding data for the GET onboarding endpoint.

To test:
* Checkout this branch.
* Use https://github.com/Automattic/wp-calypso/pull/21003 for step by step instructions.
* Verify the `jpo_homepage_format` option is set (you can use `wp option get jpo_homepage_format`)