### PR TITLE
REST API: Store JPO contact form page ID in an option

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1044,6 +1044,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				$error[] = 'form insert: 0';
 			} elseif ( is_wp_error( $form ) ) {
 				$error[] = 'form creation: '. $form->get_error_message();
+			} else {
+				update_option( 'jpo_contact_page', $form );
 			}
 		}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -534,6 +534,7 @@ class Jetpack_Options {
 			'jetpack_sso_remove_login_form',
 			'jetpack_last_connect_url_check',
 			'jpo_site_type',
+			'jpo_contact_page',
 		);
 	}
 


### PR DESCRIPTION
This PR updates the JPO contact form saving to store the ID of the contact page in an option. We'll need that in order to provide consistent experience to the user; also for knowing whether the user has already completed the contact form step.

We'll use this option when retrieving onboarding data for the GET onboarding endpoint.

To test:
* Checkout this branch.
* Use https://github.com/Automattic/wp-calypso/pull/21003 for step by step instructions.
* Verify the `jpo_contact_page` option is set (you can use `wp jetpack options get jpo_contact_page`)
  