### PR TITLE
REST API: Introduce onboarding option in GET settings endpoint

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -406,6 +406,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$settings = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'settings' );
 		$holiday_snow_option_name = Jetpack_Core_Json_Api_Endpoints::holiday_snow_option_name();
 
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
 				case $holiday_snow_option_name:
@@ -426,15 +430,24 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					}
 					break;
 
+				case 'onboarding':
+					$response[ $setting ] = array(
+						'siteTitle' => get_option( 'blogname' ),
+						'siteDescription' => get_option( 'blogdescription' ),
+						'siteType' => get_option( 'jpo_site_type' ),
+						'homepageFormat' => get_option( 'jpo_homepage_format' ),
+						'contactForm' => get_option( 'jpo_contact_page' ),
+						'businessAddress' => array(), // TODO
+						'woocommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
+					);
+					break;
+
 				default:
 					$response[ $setting ] = Jetpack_Core_Json_Api_Endpoints::cast_value( get_option( $setting ), $settings[ $setting ] );
 					break;
 			}
 		}
 
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
 		$response['akismet'] = is_plugin_active( 'akismet/akismet.php' );
 
 		return rest_ensure_response( $response );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -436,7 +436,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						'siteDescription' => get_option( 'blogdescription' ),
 						'siteType' => get_option( 'jpo_site_type' ),
 						'homepageFormat' => get_option( 'jpo_homepage_format' ),
-						'addContactForm' => get_option( 'jpo_contact_page' ),
+						'addContactForm' => intval( get_option( 'jpo_contact_page' ) ),
 						'businessAddress' => array(), // TODO
 						'installWooCommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
 					);

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -436,9 +436,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						'siteDescription' => get_option( 'blogdescription' ),
 						'siteType' => get_option( 'jpo_site_type' ),
 						'homepageFormat' => get_option( 'jpo_homepage_format' ),
-						'contactForm' => get_option( 'jpo_contact_page' ),
+						'addContactForm' => get_option( 'jpo_contact_page' ),
 						'businessAddress' => array(), // TODO
-						'woocommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
+						'installWooCommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
 					);
 					break;
 


### PR DESCRIPTION
This PR introduces an `onboarding` option in the GET settings endpoint, in order to allow us to retrieve the state of onboarding of a site. 

To test:

* Checkout this branch
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=wpcalypso where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* In the JPO flow, fill all the steps in a certain way until you reach the Summary step.
* Hit the `GET` `/jetpack/v4/settings` endpoint and verify the `onboarding` option returns data as expected.

Note: storing business address is currently in progress, so it's not expected to work in this PR - it'll always return an empty array right now.
