### PR TITLE
Add new Social Icons widget and deprecate old Social Media Icons widget

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -123,8 +123,11 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			$social_icons  = $this->get_supported_icons();
 			$default_icon  = $this->get_svg_icon( array( 'icon' => 'chain' ) );
 
+			// Set target attribute for the link
 			if ( true === $instance['new-tab'] ) {
-				$new_tab = ' target="_blank"';
+				$target = '_blank';
+			} else {
+				$target = '_self';				
 			}
 		?>
 
@@ -134,7 +137,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 
 					<?php if ( ! empty( $icon['url'] ) ) : ?>
 						<li class="jetpack-social-widget-item">
-							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>"<?php echo $new_tab; ?>>
+							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>" target="<?php echo $target; ?>">
 								<?php
 									$found_icon = false;
 

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -1,0 +1,674 @@
+<?php
+class Jetpack_Widget_Social_Icons extends WP_Widget {
+	/**
+	 * @var array Default widget options.
+	 */
+	protected $defaults;
+
+	/**
+	 * Widget constructor.
+	 */
+	public function __construct() {
+		$widget_ops = array(
+			'classname'                   => 'jetpack_widget_social_icons',
+			'description'                 => __( 'Add social-media icons to your site.', 'jetpack' ),
+			'customize_selective_refresh' => true,
+		);
+
+		parent::__construct(
+			'jetpack_widget_social_icons',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Social Icons', 'jetpack' ) ),
+			$widget_ops
+		);
+
+		$this->defaults = array(
+			'title'     => __( 'Follow Us', 'jetpack' ),
+			'icon-size' => 'medium',
+			'new-tab'   => false,
+			'icons'     => array(
+				array(
+					'url' => '',
+				),
+			),
+		);
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'render_admin_js' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_icon_scripts' ) );
+		add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
+	}
+
+	/**
+	 * Script & styles for admin widget form.
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		global $wp_customize;
+
+		if ( isset( $wp_customize ) || 'widgets.php' === $hook ) {
+			wp_enqueue_script( 'jetpack-widget-social-icons-script', plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20170506' );
+			wp_enqueue_style( 'jetpack-widget-social-icons-admin', plugins_url( 'social-icons/social-icons-admin.css', __FILE__ ), array(), '20170506' );
+		}
+	}
+
+	/**
+	 * Styles for front-end widget.
+	 */
+	public function enqueue_icon_scripts() {
+		wp_enqueue_style( 'jetpack-widget-social-icons-styles', plugins_url( 'social-icons/social-icons.css', __FILE__ ), array(), '20170506' );
+	}
+
+	/**
+	 * JavaScript for admin widget form.
+	 */
+	public function render_admin_js() {
+		global $wp_customize;
+		global $pagenow;
+
+		if ( ! isset( $wp_customize ) && 'widgets.php' !== $pagenow ) {
+			return;
+		}
+	?>
+		<script type="text/html" id="tmpl-jetpack-widget-social-icons-template">
+			<?php self::render_icons_template(); ?>
+		</script>
+	<?php
+	}
+
+	/**
+	 * Add SVG definitions to the footer.
+	 */
+	public function include_svg_icons() {
+		if ( ! is_active_widget( false, $this->id, $this->id_base, true ) ) {
+			return;
+		}
+
+		// Define SVG sprite file in Jetpack
+		$svg_icons = dirname( dirname( __FILE__ ) ) . '/theme-tools/social-menu/social-menu.svg';
+
+		// Define SVG sprite file in WPCOM
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$svg_icons = dirname( dirname( __FILE__ ) ) . '/social-menu/social-menu.svg';
+		}
+
+		// If it exists, include it.
+		if ( is_file( $svg_icons ) ) {
+			require_once( $svg_icons );
+		}
+	}
+
+	/**
+	 * Front-end display of widget.
+	 *
+	 * @see WP_Widget::widget()
+	 *
+	 * @param array $args Widget arguments.
+	 * @param array $instance Saved values from database.
+	 */
+	public function widget( $args, $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults );
+
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
+		$title = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
+
+		echo $args['before_widget'];
+
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		}
+
+		if ( ! empty( $instance['icons'] ) ) :
+
+			// Get supported social icons.
+			$social_icons  = $this->get_supported_icons();
+			$default_icon  = $this->get_svg_icon( array( 'icon' => 'chain' ) );
+
+			if ( true === $instance['new-tab'] ) {
+				$new_tab = ' target="_blank"';
+			}
+		?>
+
+			<ul class="jetpack-social-widget-list size-<?php echo esc_attr( $instance['icon-size'] ); ?>">
+
+				<?php foreach ( $instance['icons'] as $icon ) : ?>
+
+					<?php if ( ! empty( $icon['url'] ) ) : ?>
+						<li class="jetpack-social-widget-item">
+							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>"<?php echo $new_tab; ?>>
+								<?php
+									$found_icon = false;
+
+									foreach( $social_icons as $social_icon ) {
+										if ( false !== stripos( $icon['url'], $social_icon['url'] ) ) {
+											echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
+											echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
+											$found_icon = true;
+											break;
+										}
+									}
+
+									if ( ! $found_icon ) {
+										echo $default_icon;
+									}
+								?>
+							</a>
+						</li>
+					<?php endif; ?>
+
+				<?php endforeach; ?>
+
+			</ul>
+
+		<?php
+		endif;
+
+		echo $args['after_widget'];
+
+		/** This action is documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'social_icons' );
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @see WP_Widget::update()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance['title']     = sanitize_text_field( $new_instance['title'] );
+		$instance['icon-size'] = $this->defaults['icon-size'];
+
+		if ( in_array( $new_instance['icon-size'], array( 'small', 'medium', 'large' ) ) ) {
+			$instance['icon-size'] = $new_instance['icon-size'];
+		}
+
+		$instance['new-tab'] = isset( $new_instance['new-tab'] ) ? (bool) $new_instance['new-tab'] : false;
+		$icon_count          = count( $new_instance['url-icons'] );
+		$instance['icons']   = array();
+
+		foreach( $new_instance['url-icons'] as $url ) {
+			$url = filter_var( $url, FILTER_SANITIZE_URL );
+
+			if ( ! empty( $url ) ) {
+				$instance['icons'][] = array(
+					'url' => $url,
+				);
+			}
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Back-end widget form.
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $instance Previously saved values from database.
+	 *
+	 * @return string|void
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults );
+		$title    = sanitize_text_field( $instance['title'] );
+		$sizes    = array(
+			'small'  => __( 'Small', 'jetpack' ),
+			'medium' => __( 'Medium', 'jetpack' ),
+			'large'  => __( 'Large', 'jetpack' ),
+		);
+		$new_tab  = isset( $instance['new-tab'] ) ? (bool) $instance['new-tab'] : false;
+		?>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+		</p>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'icon-size' ); ?>"><?php esc_html_e( 'Size:', 'jetpack' ); ?></label>
+			<select class="widefat" name="<?php echo $this->get_field_name( 'icon-size' ); ?>">
+				<?php foreach ( $sizes as $value => $label ) : ?>
+					<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $instance['icon-size'] ); ?>><?php echo esc_attr( $label ); ?></option>
+				<?php endforeach; ?>
+			</select>
+		</p>
+
+		<div class="jetpack-social-icons-widget-list"
+			data-url-icon-id="<?php echo $this->get_field_id( 'url-icons' ); ?>"
+			data-url-icon-name="<?php echo $this->get_field_name( 'url-icons' ); ?>"
+		>
+
+			<?php
+				foreach ( $instance['icons'] as $icon ) {
+					self::render_icons_template( array(
+						'url-icon-id'   => $this->get_field_id( 'url-icons' ),
+						'url-icon-name' => $this->get_field_name( 'url-icons' ),
+						'url-value'     => $icon['url'],
+					) );
+				}
+			?>
+
+		</div>
+
+		<p class="jetpack-social-icons-widget add-button">
+			<button type="button" class="button jetpack-social-icons-add-button">
+				<?php esc_html_e( 'Add an icon', 'jetpack' ); ?>
+			</button>
+		</p>
+
+		<?php
+			switch ( get_locale() ) {
+				case 'es':
+					$support = 'https://es.support.wordpress.com/social-media-icons-widget/#iconos-disponibles';
+					break;
+
+				case 'pt-br':
+					$support = 'https://br.support.wordpress.com/widgets/widget-de-icones-sociais/#ícones-disponíveis';
+					break;
+
+				default:
+					$support = 'https://en.support.wordpress.com/widgets/social-media-icons-widget/#available-icons';
+			}
+		?>
+
+		<p>
+			<em><a href="<?php echo esc_url( $support ); ?>" target="_blank">
+				<?php esc_html_e( 'View available icons', 'jetpack' ); ?>
+			</a></em>
+		</p>
+
+		<p>
+			<input type="checkbox" class="checkbox" id="<?php echo $this->get_field_id( 'new-tab' ); ?>" name="<?php echo $this->get_field_name( 'new-tab' ); ?>" <?php checked( $new_tab ); ?> />
+			<label for="<?php echo $this->get_field_id( 'new-tab' ); ?>"><?php esc_html_e( 'Open link in a new tab', 'jetpack' ); ?></label>
+		</p>
+
+	<?php
+	}
+
+	/**
+	 * Generates template to add icons.
+	 *
+	 * @param array $args Template arguments
+	 */
+	static function render_icons_template( $args = array() ) {
+		$defaults = array(
+			'url-icon-id'   => '',
+			'url-icon-name' => '',
+			'url-value'     => '',
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+		?>
+
+		<div class="jetpack-social-icons-widget-item">
+			<div class="jetpack-social-icons-widget-item-wrapper">
+				<div class="handle"></div>
+
+				<p class="jetpack-widget-social-icons-url">
+					<?php
+						printf( '<input class="widefat id="%1$s" name="%2$s[]" type="text" placeholder="%3$s" value="%4$s"/>',
+							esc_attr( $args['url-icon-id'] ),
+							esc_attr( $args['url-icon-name'] ),
+							esc_attr__( 'Account URL', 'jetpack' ),
+							esc_url( $args['url-value'], array( 'http', 'https', 'mailto', 'skype' ) )
+						);
+					?>
+				</p>
+
+				<p class="jetpack-widget-social-icons-remove-item">
+					<a class="jetpack-widget-social-icons-remove-item-button" href="javascript:;">
+						<?php esc_html_e( 'Remove', 'jetpack' ); ?>
+					</a>
+				</p>
+			</div>
+		</div>
+
+		<?php
+	}
+
+	/**
+	 * Return SVG markup.
+	 *
+	 * @param array $args {
+	 *     Parameters needed to display an SVG.
+	 *
+	 *     @type string $icon  Required SVG icon filename.
+	 * }
+	 * @return string SVG markup.
+	 */
+	public function get_svg_icon( $args = array() ) {
+		// Make sure $args are an array.
+		if ( empty( $args ) ) {
+			return esc_html__( 'Please define default parameters in the form of an array.', 'jetpack' );
+		}
+
+		// Set defaults.
+		$defaults = array(
+			'icon' => '',
+		);
+
+		// Parse args.
+		$args = wp_parse_args( $args, $defaults );
+
+		// Define an icon.
+		if ( false === array_key_exists( 'icon', $args ) ) {
+			return esc_html__( 'Please define an SVG icon filename.', 'jetpack' );
+		}
+
+		// Set aria hidden.
+		$aria_hidden = ' aria-hidden="true"';
+
+		// Begin SVG markup.
+		$svg = '<svg class="icon icon-' . esc_attr( $args['icon'] ) . '"' . $aria_hidden . ' role="img">';
+
+		/*
+		 * Display the icon.
+		 *
+		 * The whitespace around `<use>` is intentional - it is a work around to a keyboard navigation bug in Safari 10.
+		 *
+		 * See https://core.trac.wordpress.org/ticket/38387.
+		 */
+		$svg .= ' <use href="#icon-' . esc_html( $args['icon'] ) . '" xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use> ';
+
+		$svg .= '</svg>';
+
+		return $svg;
+	}
+
+	/**
+	 * Returns an array of supported social links (URL, icon, and label).
+	 *
+	 * @return array $social_links_icons
+	 */
+	public function get_supported_icons() {
+		$social_links_icons = array(
+			array(
+				'url'   => '500px.com',
+				'icon'  => '500px',
+				'label' => '500px',
+			),
+			array(
+				'url'   => 'amazon.cn',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.in',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.fr',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.de',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.it',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.nl',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.es',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.co',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.ca',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'amazon.com',
+				'icon'  => 'amazon',
+				'label' => 'Amazon',
+			),
+			array(
+				'url'   => 'apple.com',
+				'icon'  => 'apple',
+				'label' => 'Apple',
+			),
+			array(
+				'url'   => 'itunes.com',
+				'icon'  => 'apple',
+				'label' => 'iTunes',
+			),
+			array(
+				'url'   => 'bandcamp.com',
+				'icon'  => 'bandcamp',
+				'label' => 'Bandcamp',
+			),
+			array(
+				'url'   => 'behance.net',
+				'icon'  => 'behance',
+				'label' => 'Behance',
+			),
+			array(
+				'url'   => 'codepen.io',
+				'icon'  => 'codepen',
+				'label' => 'CodePen',
+			),
+			array(
+				'url'   => 'deviantart.com',
+				'icon'  => 'deviantart',
+				'label' => 'DeviantArt',
+			),
+			array(
+				'url'   => 'digg.com',
+				'icon'  => 'digg',
+				'label' => 'Digg',
+			),
+			array(
+				'url'   => 'dribbble.com',
+				'icon'  => 'dribbble',
+				'label' => 'Dribbble',
+			),
+			array(
+				'url'   => 'dropbox.com',
+				'icon'  => 'dropbox',
+				'label' => 'Dropbox',
+			),
+			array(
+				'url'   => 'etsy.com',
+				'icon'  => 'etsy',
+				'label' => 'Etsy',
+			),
+			array(
+				'url'   => 'facebook.com',
+				'icon'  => 'facebook',
+				'label' => 'Facebook',
+			),
+			array(
+				'url'   => '/feed/',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'flickr.com',
+				'icon'  => 'flickr',
+				'label' => 'Flickr',
+			),
+			array(
+				'url'   => 'foursquare.com',
+				'icon'  => 'foursquare',
+				'label' => 'Foursquare',
+			),
+			array(
+				'url'   => 'goodreads.com',
+				'icon'  => 'goodreads',
+				'label' => 'Goodreads',
+			),
+			array(
+				'url'   => 'google.com/+',
+				'icon'  => 'google-plus',
+				'label' => 'Google +',
+			),
+			array(
+				'url'   => 'plus.google.com',
+				'icon'  => 'google-plus',
+				'label' => 'Google +',
+			),
+			array(
+				'url'   => 'google.com',
+				'icon'  => 'google',
+				'label' => 'Google',
+			),
+			array(
+				'url'   => 'github.com',
+				'icon'  => 'github',
+				'label' => 'GitHub',
+			),
+			array(
+				'url'   => 'instagram.com',
+				'icon'  => 'instagram',
+				'label' => 'Instagram',
+			),
+			array(
+				'url'   => 'linkedin.com',
+				'icon'  => 'linkedin',
+				'label' => 'LinkedIn',
+			),
+			array(
+				'url'   => 'mailto:',
+				'icon'  => 'mail',
+				'label' => __( 'Email', 'jetpack' ),
+			),
+			array(
+				'url'   => 'meetup.com',
+				'icon'  => 'meetup',
+				'label' => 'Meetup',
+			),
+			array(
+				'url'   => 'medium.com',
+				'icon'  => 'medium',
+				'label' => 'Medium',
+			),
+			array(
+				'url'   => 'pinterest.com',
+				'icon'  => 'pinterest',
+				'label' => 'Pinterest',
+			),
+			array(
+				'url'   => 'getpocket.com',
+				'icon'  => 'pocket',
+				'label' => 'Pocket',
+			),
+			array(
+				'url'   => 'reddit.com',
+				'icon'  => 'reddit',
+				'label' => 'Reddit',
+			),
+			array(
+				'url'   => 'skype.com',
+				'icon'  => 'skype',
+				'label' => 'Skype',
+			),
+			array(
+				'url'   => 'skype:',
+				'icon'  => 'skype',
+				'label' => 'Skype',
+			),
+			array(
+				'url'   => 'slideshare.net',
+				'icon'  => 'slideshare',
+				'label' => 'SlideShare',
+			),
+			array(
+				'url'   => 'snapchat.com',
+				'icon'  => 'snapchat',
+				'label' => 'Snapchat',
+			),
+			array(
+				'url'   => 'soundcloud.com',
+				'icon'  => 'soundcloud',
+				'label' => 'SoundCloud',
+			),
+			array(
+				'url'   => 'spotify.com',
+				'icon'  => 'spotify',
+				'label' => 'Spotify',
+			),
+			array(
+				'url'   => 'stumbleupon.com',
+				'icon'  => 'stumbleupon',
+				'label' => 'StumbleUpon',
+			),
+			array(
+				'url'   => 'tumblr.com',
+				'icon'  => 'tumblr',
+				'label' => 'Tumblr',
+			),
+			array(
+				'url'   => 'twitch.tv',
+				'icon'  => 'twitch',
+				'label' => 'Twitch',
+			),
+			array(
+				'url'   => 'twitter.com',
+				'icon'  => 'twitter',
+				'label' => 'Twitter',
+			),
+			array(
+				'url'   => 'vimeo.com',
+				'icon'  => 'vimeo',
+				'label' => 'Vimeo',
+			),
+			array(
+				'url'   => 'vk.com',
+				'icon'  => 'vk',
+				'label' => 'VK',
+			),
+			array(
+				'url'   => 'wordpress.com',
+				'icon'  => 'wordpress',
+				'label' => 'WordPress.com',
+			),
+			array(
+				'url'   => 'wordpress.org',
+				'icon'  => 'wordpress',
+				'label' => 'WordPress',
+			),
+			array(
+				'url'   => 'yelp.com',
+				'icon'  => 'yelp',
+				'label' => 'Yelp',
+			),
+			array(
+				'url'   => 'youtube.com',
+				'icon'  => 'youtube',
+				'label' => 'YouTube',
+			),
+		);
+
+		return $social_links_icons;
+	}
+} // Jetpack_Widget_Social_Icons
+
+/**
+ * Register and load the widget.
+ *
+ * @access public
+ * @return void
+ */
+function jetpack_widget_social_icons_load() {
+	register_widget( 'Jetpack_Widget_Social_Icons' );
+}
+add_action( 'widgets_init', 'jetpack_widget_social_icons_load' );

--- a/modules/widgets/social-icons/social-icons-admin.css
+++ b/modules/widgets/social-icons/social-icons-admin.css
@@ -1,0 +1,94 @@
+.jetpack-social-icons-widget-item {
+	background: #fff;
+	border: 1px solid #e5e5e5;
+	cursor: move;
+	margin: 0;
+}
+
+html[class*='wordpress_com'] .jetpack-social-icons-widget-item,
+.in-calypso .jetpack-social-icons-widget-item {
+	border-color: #c8d7e1;
+}
+
+.jetpack-social-icons-widget-item:hover {
+	outline: 1px solid #999;
+	outline-offset: -1px;
+}
+
+html[class*='wordpress_com'] .jetpack-social-icons-widget-item:hover,
+.in-calypso .jetpack-social-icons-widget-item:hover {
+	outline-color: #a8bece;
+}
+
+.jetpack-social-icons-widget-item.ui-sortable-helper {
+	border-color: #999;
+}
+
+html[class*='wordpress_com'] .jetpack-social-icons-widget-item.ui-sortable-helper,
+.in-calypso .jetpack-social-icons-widget-item.ui-sortable-helper {
+	border-color: #a8bece;
+}
+
+.jetpack-social-icons-widget-item.ui-sortable-helper {
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.jetpack-social-icons-widget-item.ui-state-placeholder {
+	border-color: #a0a5aa;
+	border-style: dashed;
+	margin: 0 0 1px;
+}
+
+.jetpack-social-icons-widget-item + .jetpack-social-icons-widget-item:not(.ui-state-placeholder) {
+	margin-top: -1px;
+}
+
+.jetpack-social-icons-widget-item-wrapper {
+	padding: 1em;
+	position: relative;
+}
+
+.jetpack-social-icons-widget-item .handle {
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.jetpack-social-icons-widget-item p {
+	margin: 0;
+	position: relative;
+}
+
+.jetpack-social-icons-widget-item p + p {
+	margin-top: 1em;
+}
+
+.jetpack-widget-social-icons-remove-item {
+	display: inline-block;
+}
+
+.jetpack-widget-social-icons-remove-item-button {
+	color: #a00;
+	text-decoration: none;
+}
+
+.jetpack-widget-social-icons-remove-item-button:focus,
+.jetpack-widget-social-icons-remove-item-button:hover {
+	color: #f00;
+}
+
+.jetpack-social-icons-add-button:before {
+	content: "\f132";
+	display: inline-block;
+	position: relative;
+	left: -2px;
+	top: -1px;
+	font: 400 20px/1 dashicons;
+	vertical-align: middle;
+	transition: all 0.2s;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}

--- a/modules/widgets/social-icons/social-icons-admin.js
+++ b/modules/widgets/social-icons/social-icons-admin.js
@@ -1,0 +1,111 @@
+( function( $ ) {
+	var timeout = null;
+
+	// Make the list of items sortable.
+	function initWidget( widget ) {
+		widget.find( '.jetpack-social-icons-widget-list' ).sortable( {
+			items: '> .jetpack-social-icons-widget-item',
+			handle: '.handle',
+			cursor: 'move',
+			placeholder: 'jetpack-social-icons-widget-item ui-state-placeholder',
+			containment: widget,
+			forcePlaceholderSize: true,
+			update: function() {
+				livePreviewUpdate( $( this ).parents( '.form' ).find( '.widget-control-save' ) );
+			}
+		} );
+	}
+
+	// Live preview update.
+	function livePreviewUpdate( button ) {
+		if ( ! $( document.body ).hasClass( 'wp-customizer' ) || ! button.length  ) {
+			return;
+		}
+
+		button.trigger( 'click' ).hide();
+	}
+
+	$( document ).ready( function() {
+		// Add an item.
+		$( document ).on( 'click', '.jetpack-social-icons-widget.add-button button', function( event ) {
+			event.preventDefault();
+
+			var template, widgetContent, widgetList, widgetLastItem, urlId, urlName;
+
+			template      = $( $.trim( $( '#tmpl-jetpack-widget-social-icons-template' ).html() ) );
+			widgetContent = $( this ).parents( '.widget-content' );
+			widgetList    = widgetContent.find( '.jetpack-social-icons-widget-list' );
+			urlId         = widgetList.data( 'url-icon-id');
+			urlName       = widgetList.data( 'url-icon-name' );
+
+			template.find( '.jetpack-widget-social-icons-url input' ).attr( 'id', urlId ).attr( 'name', urlName + '[]' );
+
+			widgetList.append( template );
+
+			widgetLastItem = widgetContent.find( '.jetpack-social-icons-widget-item:last' );
+			widgetLastItem.find( 'input:first' ).trigger( 'focus' );
+		} );
+
+		// Remove an item.
+		$( document ).on( 'click', '.jetpack-widget-social-icons-remove-item-button', function( event ) {
+			event.preventDefault();
+
+			var button = $( this ).parents( '.form' ).find( '.widget-control-save' );
+
+			$( this ).parents( '.jetpack-social-icons-widget-item' ).remove();
+
+			livePreviewUpdate( button );
+		} );
+
+		// Event handler for widget open button.
+		$( document ).on( 'click', 'div.widget[id*="jetpack_widget_social_icons"] .widget-title, div.widget[id*="jetpack_widget_social_icons"] .widget-action', function() {
+			if ( $( this ).parents( '#available-widgets' ).length ) {
+				return;
+			}
+
+			initWidget( $( this ).parents( '.widget[id*="jetpack_widget_social_icons"]' ) );
+		} );
+
+		// Event handler for widget added.
+		$( document ).on( 'widget-added', function( event, widget ) {
+			if ( widget.is( '[id*="jetpack_widget_social_icons"]' ) ) {
+				event.preventDefault();
+				initWidget( widget );
+			}
+		} );
+
+		// Event handler for widget updated.
+		$( document ).on( 'widget-updated', function( event, widget ) {
+			if ( widget.is( '[id*="jetpack_widget_social_icons"]' ) ) {
+				event.preventDefault();
+				initWidget( widget );
+			}
+		} );
+
+		// Live preview update on input focus out.
+		$( document ).on( 'focusout', 'input[name*="jetpack_widget_social_icons"]', function() {
+			livePreviewUpdate( $( this ).parents( '.form' ).find( '.widget-control-save' ) );
+		} );
+
+		// Live preview update on input enter key.
+		$( document ).on( 'keydown', 'input[name*="jetpack_widget_social_icons"]', function( event ) {
+			if ( event.keyCode === 13 ) {
+				livePreviewUpdate( $( this ).parents( '.form' ).find( '.widget-control-save' ) );
+			}
+		} );
+
+		// Live preview update on input key up 1s.
+		$( document ).on( 'keyup', 'input[name*="jetpack_widget_social_icons"]', function() {
+			clearTimeout( timeout );
+
+			timeout = setTimeout( function() {
+				livePreviewUpdate( $( this ).parents( '.form' ).find( '.widget-control-save' ) );
+			}, 1000 );
+		} );
+
+		// Live preview update on select change.
+		$( document ).on( 'change', 'select[name*="jetpack_widget_social_icons"]', function() {
+			livePreviewUpdate( $( this ).parents( '.form' ).find( '.widget-control-save' ) );
+		} );
+	} );
+} )( jQuery );

--- a/modules/widgets/social-icons/social-icons.css
+++ b/modules/widgets/social-icons/social-icons.css
@@ -1,0 +1,57 @@
+.jetpack_widget_social_icons ul,
+.jetpack_widget_social_icons li {
+	list-style: none;
+}
+
+.jetpack_widget_social_icons ul {
+	display: block;
+	margin: 0 0 1.5em;
+	padding: 0;
+}
+
+.jetpack_widget_social_icons ul li {
+	border: 0;
+	display: inline-block;
+	line-height: 1;
+	margin: 0;
+	padding: 0;
+}
+
+.jetpack_widget_social_icons ul li:before,
+.jetpack_widget_social_icons ul li:after {
+	display: none;
+}
+
+.jetpack_widget_social_icons a {
+	border: 0;
+	box-shadow: none;
+	display: block;
+	height: 24px;
+	text-decoration: none;
+	width: 24px;
+}
+
+.jetpack_widget_social_icons svg {
+	color: inherit;
+	fill: currentColor;
+	height: inherit;
+	vertical-align: middle;
+	width: inherit;
+}
+
+/* Sizes */
+
+.jetpack_widget_social_icons ul.size-small a {
+	height: 24px;
+	width: 24px;
+}
+
+.jetpack_widget_social_icons ul.size-medium a {
+	height: 32px;
+	width: 32px;
+}
+
+.jetpack_widget_social_icons ul.size-large a {
+	height: 48px;
+	width: 48px;
+}

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -335,7 +335,7 @@ function wpcom_social_media_icons_widget_load_widget() {
 	}
 
 	// [DEPRECATION]: Only register widget if active widget exists already
-	if ( 1 === $has_widget ) {
+	if ( $has_widget ) {
 		register_widget( 'wpcom_social_media_icons_widget' );
 	}
 }

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -40,7 +40,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		parent::__construct(
 			'wpcom_social_media_icons_widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
-			apply_filters( 'jetpack_widget_name', esc_html__( 'Social Media Icons', 'jetpack' ) ),
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Social Media Icons (Deprecated)', 'jetpack' ) ),
 			array(
 				'description' => __( 'A simple widget that displays social media icons.', 'jetpack' ),
 				'customize_selective_refresh' => true,
@@ -325,6 +325,18 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
  * @return void
  */
 function wpcom_social_media_icons_widget_load_widget() {
-	register_widget( 'wpcom_social_media_icons_widget' );
+	$transient = 'wpcom_social_media_icons_widget::is_active';
+	$has_widget = get_transient( $transient );
+
+	if ( false === $has_widget ) {
+		$is_active_widget = is_active_widget( false, false, 'wpcom_social_media_icons_widget', false );
+		$has_widget       = (int) ! empty( $is_active_widget );
+		set_transient( $transient, $has_widget, 1 * HOUR_IN_SECONDS );
+	}
+
+	// [DEPRECATION]: Only register widget if active widget exists already
+	if ( 1 === $has_widget ) {
+		register_widget( 'wpcom_social_media_icons_widget' );
+	}
 }
 add_action( 'widgets_init', 'wpcom_social_media_icons_widget_load_widget' );


### PR DESCRIPTION
Fixes #3776
Fixes #7433
Fixes #7601 

Closing previous PR/branch (#7454) and opening a new one due to an issue with a rebase.

To keep in line with WPCOM, I’d like to add the new Social Icons
widget. You can add this widget to any site and you should have a new
widget as seen on its documentation page
(https://en.support.wordpress.com/widgets/social-media-icons-widget/).

The old widget should become unavailable to sites not using it. If they
do then we add a “(Deprecated)” to the label.

In `social-icons.php`, L72, we use the same `social-menu.svg` file as
the one used for the Social Menu.