### PR TITLE
JPO: Remove sanitize key on registration URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3986,7 +3986,7 @@ p {
 				$url = $this->build_connect_url( true, $redirect, $from );
 
 				if ( ! empty( $_GET['onboarding'] ) ) {
-					$url = add_query_arg( 'onboarding', sanitize_key( $_GET['onboarding'] ), $url );
+					$url = add_query_arg( 'onboarding', $_GET['onboarding'], $url );
 				}
 
 				wp_redirect( $url );


### PR DESCRIPTION
Seems like in #8449 we introduced `sanitize_key` over the registration URL onboarding token. This was a mistake, because it caused (only) fresh Jetpack sites onboarding tokens to be passed to Calypso as lowercase instead of uppercase 🤦‍♂️ And then, when comparing the lowercase tokens to the original ones, comparison failed and signature was different, thus we received the "The request is not signed correctly." error.

So, we don't need the `sanitize_key` and we can remove it safely.

To test:
* Start a new JN site with the latest JP master (to do that, start the site from here https://jurassic.ninja/create/?shortlived&nojetpack and use ssh to install Jetpack master)
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where YourJetpackSandbox.com is the domain of your Jetpack sandbox.
* When you land in the JPO flow, try saving the site title step.
* Verify you get a success message in the network request, and that your site title/description are properly saved.

Kudos to @oskosk for finding this issue, and for helping diagnose it.