### PR TITLE
Fix array->string conversion notice in carousel

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -441,7 +441,7 @@ class Jetpack_Carousel {
 			unset( $img_meta['keywords'] );
 		}
 
-		$img_meta = json_encode( array_map( 'strval', $img_meta ) );
+		$img_meta = json_encode( array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ) );
 
 		$attr['data-attachment-id']     = $attachment_id;
 		$attr['data-permalink']         = esc_attr( get_permalink( $attachment->ID ) );


### PR DESCRIPTION
Fixes an issue in Jetpack Carousel that printed an Array to string conversion notice on the screen.

Reported in https://wordpress.org/support/topic/php-notice-array-to-string-conversion-in-jetpack-carousel/ and 892311-zen.

To reproduce the issue:

- add meta to an image, where that meta is an array
- add that image to a gallery
- output that gallery as a Jetpack carousel
- you will see a notice like "Notice: Array to string conversion in 
`/home/user/public_html/wp-content/plugins/jetpack/modules/carousel/jetpack-carousel.php 
on line 444`

This PR removes non-scalar values from the array before applying strval.