### PR TITLE
Modified transient setter and getter calls to be object method calls.

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -37,7 +37,9 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$correct_ans = isset( $_POST[ 'jetpack_protect_answer' ] ) ? $_POST[ 'jetpack_protect_answer' ] : '' ;
 
 			if( isset( $_COOKIE[ 'jpp_math_pass' ] ) ) {
-				$transient = Jetpack_Protect_Module::get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+				$jetpack_protect = Jetpack_Protect_Module::instance();
+				$transient = $jetpack_protect->get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+
 				if( !$transient || $transient < 1 ) {
 					Jetpack_Protect_Math_Authenticate::generate_math_page();
 				}
@@ -100,7 +102,9 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				Jetpack_Protect_Math_Authenticate::generate_math_page(true);
 			} else {
 				$temp_pass = substr( sha1( rand( 1, 100000000 ) . get_site_option( 'jetpack_protect_key' ) ), 5, 25 );
-				Jetpack_Protect_Module::set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
+
+				$jetpack_protect = Jetpack_Protect_Module::instance();
+				$jetpack_protect->set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
 				setcookie('jpp_math_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
 				return true;
 			}


### PR DESCRIPTION
Before they were called as static methods and they fatalled on multisites because setter and getter methods require self object calls inside them.

Fixes #8507.

#### Testing instructions:
* Try to log into a multisite installation with Protect unavailable (mangle the API URL).
* Observe a fatal.
* Try to do it with this PR.
* Observe a math fallback instead.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed the math problem fallback for logging into Multisite installations.