### PR TITLE
API: Allow posts_per_rss and rss_use_excerpt to be updated/read from API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -100,6 +100,8 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'site_icon'                    => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                    => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'               => '(int) Number of posts to show on blog pages',
+		'posts_per_rss'                => '(int) Number of posts to show in the RSS feed',
+		'rss_use_excerpt'              => '(bool) Whether the RSS feed will use post excerpts',
 	),
 
 	'response_format' => array(
@@ -348,6 +350,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'amp_is_enabled'          => (bool) function_exists( 'wpcom_is_amp_enabled' ) && wpcom_is_amp_enabled( $blog_id ),
 					'api_cache'               => $api_cache,
 					'posts_per_page'          => (int) get_option( 'posts_per_page' ),
+					'posts_per_rss'           => (int) get_option( 'posts_per_rss' ),
+					'rss_use_excerpt'         => (bool) get_option( 'rss_use_excerpt' ),
 				);
 
 				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -97,6 +97,8 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
+		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
+		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -104,6 +104,8 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
+		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
+		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -104,6 +104,8 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
+		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
+		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),
 
 	'response_format' => array(


### PR DESCRIPTION
This Diff updates the site settings endpoints to allow `posts_per_rss` and `rss_use_excerpt` to be updated and read from the API.

See p3Ex-32f-p2.

Differential Revision: D9173-code

This commit syncs r168133-wpcom.


#### Testing instructions:

* Apply this PR to a Jetpack site managed in Calypso
* In Calypso, visit Site-Settings for this site and select "Writing" (https://wordpress.com/settings/writing/)
* A section for "Feed Settings" should appear (it wouldn't have appeared prior to applying this PR).
* Any changes made to feed settings should persist to your site.
