### PR TITLE
Rely on data rather than fetching state to determine loading

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -21,11 +21,9 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import {
 	getVaultPressData,
-	isFetchingVaultPressData,
 	getVaultPressScanThreatCount,
 } from 'state/at-a-glance';
-import { getSitePlan, isFetchingSiteData } from 'state/site';
-import { isFetchingRewindStatus } from 'state/rewind';
+import { getSitePlan } from 'state/site';
 import includes from 'lodash/includes';
 
 class LoadingCard extends Component {
@@ -34,6 +32,7 @@ class LoadingCard extends Component {
 			<SettingsCard
 				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 				hideButton
+				action="scan"
 			>
 				<SettingsGroup
 					disableInDevMode
@@ -149,9 +148,9 @@ export const BackupsScan = moduleSettingsForm(
 		render() {
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
 			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
-			const isFetchingData = false !== get( this.props.rewindStatus, [ 'state' ], false ) && false !== get( this.props.vaultPressData, [ 'data' ], false );
+			const hasVpRewindData = false !== get( this.props.rewindStatus, [ 'state' ], false ) && false !== get( this.props.vaultPressData, [ 'data' ], false );
 
-			if ( isFetchingData ) {
+			if ( ! hasVpRewindData ) {
 				return <LoadingCard />;
 			}
 
@@ -188,10 +187,7 @@ export const BackupsScan = moduleSettingsForm(
 export default connect( state => {
 	return {
 		sitePlan: getSitePlan( state ),
-		isFetchingSiteData: isFetchingSiteData( state ),
 		vaultPressData: getVaultPressData( state ),
-		isFetchingVaultPressData: isFetchingVaultPressData( state ),
 		hasThreats: getVaultPressScanThreatCount( state ),
-		isFetchingRewindData: isFetchingRewindStatus( state ),
 	};
 } )( BackupsScan );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -149,7 +149,7 @@ export const BackupsScan = moduleSettingsForm(
 		render() {
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
 			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
-			const isFetchingData = this.props.isFetchingSiteData || this.props.isFetchingVaultPressData || this.props.isFetchingRewindData;
+			const isFetchingData = false !== get( this.props.rewindStatus, [ 'state' ], false ) && false !== get( this.props.vaultPressData, [ 'data' ], false );
 
 			if ( isFetchingData ) {
 				return <LoadingCard />;

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -25,6 +25,7 @@ import {
 } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
 import includes from 'lodash/includes';
+import { isModuleActivated } from 'state/modules';
 
 class LoadingCard extends Component {
 	render() {
@@ -148,9 +149,10 @@ export const BackupsScan = moduleSettingsForm(
 		render() {
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
 			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
-			const hasVpRewindData = false !== get( this.props.rewindStatus, [ 'state' ], false ) && false !== get( this.props.vaultPressData, [ 'data' ], false );
+			const hasRewindData = false !== get( this.props.rewindStatus, [ 'state' ], false );
+			const hasVpData = this.props.vaultPressData !== 'N/A' && false !== get( this.props.vaultPressData, [ 'data' ], false );
 
-			if ( ! hasVpRewindData ) {
+			if ( ! hasRewindData || ( this.props.vaultPressActive && ! hasVpData ) ) {
 				return <LoadingCard />;
 			}
 
@@ -189,5 +191,6 @@ export default connect( state => {
 		sitePlan: getSitePlan( state ),
 		vaultPressData: getVaultPressData( state ),
 		hasThreats: getVaultPressScanThreatCount( state ),
+		vaultPressActive: isModuleActivated( state, 'vaultpress' ),
 	};
 } )( BackupsScan );


### PR DESCRIPTION
Reported by @Viper007Bond in Slack, the `/security` tab was repeatedly requesting endpoints.  This was introduced in #8382 where we were rendering a loading card if we were fetching data, and when the data was fetched it was calling a sub-component `ProStatus` which would request again, etc... 

To Test: 
- Activate VP plugin
- Make sure there are no multiple requests being made in /security tab. 