### PR TITLE
JITM: Add noopener noreferrer to jitm button link

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -14,7 +14,7 @@ jQuery( document ).ready( function( $ ) {
 			html += '</div>';
 			if ( envelope.CTA.message ) {
 				html += '<div class="jitm-banner__action">';
-				html += '<a href="' + envelope.url + '" target="_blank" title="' + envelope.CTA.message + '" data-module="' + envelope.feature_class + '" type="button" class="jitm-button is-compact ' + ( envelope.CTA.primary ? 'is-primary' : '' ) + ' jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '">' + envelope.CTA.message + '</a>';
+				html += '<a href="' + envelope.url + '" target="_blank" rel="noopener noreferrer" title="' + envelope.CTA.message + '" data-module="' + envelope.feature_class + '" type="button" class="jitm-button is-compact ' + ( envelope.CTA.primary ? 'is-primary' : '' ) + ' jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '">' + envelope.CTA.message + '</a>';
 				html += '</div>';
 			}
 			html += '<a href="#" data-module="' + envelope.feature_class + '" class="jitm-banner__dismiss"></a>';


### PR DESCRIPTION

* Makes the button link in JITM open a new window without sharing control of the current window to the destination site.

#### Changes proposed in this Pull Request:

* Adds attribute `rel="noopener noreferrer"` to JITM button link in `_inc/jetpack-jitm.js`.

#### Testing instructions:

* Checkout this branch.
* Confirm that the JITM setup link contains the `rel` attribute.


