### PR TITLE
Prevent linked pages from using window.opener

### DIFF
--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -36,6 +36,7 @@
 			var target = $( this ).get( 0 ).target;
 			if ( url && target && '_self' !== target ) {
 				var newTabWindow = window.open( '', target );
+				newTabWindow.opener = null;
 			}
 
 			event.preventDefault();


### PR DESCRIPTION
Fixes #8517

#### Changes proposed in this Pull Request:

* Prevents window.opener from being set with new tabs opened via tracks lib

#### Testing instructions:

* Open a jitm link, `window.opener` should be null

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
