### PR TITLE
REST API: add functionality for saving Business Address widget in JPO (alternative)

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1109,12 +1109,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		if ( $first_sidebar ) {
-			$title = $address['name'];
+			$title = sanitize_text_field( $address['name'] );
 			$business_address =
-				$address['city'] . ' ' .
-				$address['state'] . ' ' .
-				$address['street'] . ' ' .
-				$address['zip'];
+				sanitize_text_field( $address['street'] ). ' ',
+				sanitize_text_field( $address['city'] ). ' ' .
+				sanitize_text_field( $address['state'] ). ' ' .
+				sanitize_text_field( $address['zip'] ). ' ';
 			$widget_options = array(
 				'title'   => $title,
 				'address' => $business_address,
@@ -1146,9 +1146,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	/**
 	 * Check whether "Contact Info & Map" widget is present in a given sidebar.
 	 *
- 	 * @param string  $sidebar ID of the sidebar to which the widget will be added.
- 	 *
- 	 * @return bool Whether the widget is present in a given sidebar.
+	 * @param string  $sidebar ID of the sidebar to which the widget will be added.
+	 *
+	 * @return bool Whether the widget is present in a given sidebar.
 	*/
 	static function has_business_address_widget( $sidebar ) {
 		$sidebars_widgets = get_option( 'sidebars_widgets', array() );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1093,15 +1093,18 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		if ( $first_sidebar ) {
-			$title = sanitize_text_field( $address['name'] );
-			$business_address =
-				sanitize_text_field( $address['street'] ). ' ',
-				sanitize_text_field( $address['city'] ). ' ' .
-				sanitize_text_field( $address['state'] ). ' ' .
-				sanitize_text_field( $address['zip'] ). ' ';
+			$title = isset( $address['name'] ) ? sanitize_text_field( $address['name'] ) : '';
+			$street = isset( $address['street'] ) ? sanitize_text_field( $address['street'] )
+			: '';
+			$city = isset( $address['city'] ) ? sanitize_text_field( $address['city'] ) : '';
+			$state = isset( $address['state'] ) ? sanitize_text_field( $address['state'] ) : '';
+			$zip = isset( $address['zip'] ) ? sanitize_text_field( $address['zip'] ) : '';
+
+			$full_address = implode( ' ', array_filter( array( $street, $city, $state, $zip ) ) );
+
 			$widget_options = array(
 				'title'   => $title,
-				'address' => $business_address,
+				'address' => $full_address,
 				'phone'   => '',
 				'hours'   => '',
 				'showmap' => false,
@@ -1119,7 +1122,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				return new WP_Error( 'widget_update_failed', 'Widget could not be updated.', 400 );
 			}
 
-			update_option( 'jpo_business_address', $address );
+			$address_save = array(
+				'name' => $title,
+				'street' => $street,
+				'city' => $city,
+				'state' => $state,
+				'zip' => $zip
+			);
+			update_option( 'jpo_business_address', $address_save );
 			return true;
 		}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1084,7 +1084,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		unset( $active_sidebars[ 'wp_inactive_widgets' ], $active_sidebars[ 'array_version' ] );
 
 		if ( empty( $active_sidebars ) ) {
-			return new WP_Error( 'invalid_data', 'Invalid data.', 400 );
+			return false;
 		}
 		$active_sidebars_keys = array_keys( $active_sidebars );
 		return array_shift( $active_sidebars_keys );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1102,6 +1102,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	static function handle_business_address( $business_address_content ) {
 		$first_sidebar = self::get_first_sidebar();
 
+		$widgets_module_active = Jetpack::is_module_active( 'widgets' );
+		if ( ! $widgets_module_active ) {
+			$widgets_module_active = Jetpack::activate_module( 'widgets', false, false );
+		}	
+		if ( ! $widgets_module_active ) {
+			return new WP_Error( 'invalid_data', 'Failed to activate module.', 400 );
+		}
+
 		if ( $first_sidebar ) {
 			$title = $business_address_content['name'];
 			$address =

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1058,6 +1058,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			if ( is_wp_error( $handled_business_address ) ) {
 				$error[] = 'BusinessAddress';
 			}
+			update_option( 'jpo_business_address', $data['businessAddress'] );
 		}
 
 		if ( ! empty( $data['installWooCommerce'] ) ) {
@@ -1127,6 +1128,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			if ( is_wp_error( $widget_inserted ) || is_wp_error( $widget_updated ) ) {
 				return new WP_Error( 'invalid_data', 'Invalid update.', 400 );
 			}
+
 			return true;
 		}
 		// No sidebar to place the widget

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1089,13 +1089,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			$widgets_module_active = Jetpack::activate_module( 'widgets', false, false );
 		}
 		if ( ! $widgets_module_active ) {
-			return new WP_Error( 'module_activation_failed', 'Failed to activate module.', 400 );
+			return new WP_Error( 'module_activation_failed', 'Failed to activate the widgets module.', 400 );
 		}
 
 		if ( $first_sidebar ) {
 			$title = isset( $address['name'] ) ? sanitize_text_field( $address['name'] ) : '';
-			$street = isset( $address['street'] ) ? sanitize_text_field( $address['street'] )
-			: '';
+			$street = isset( $address['street'] ) ? sanitize_text_field( $address['street'] ) : '';
 			$city = isset( $address['city'] ) ? sanitize_text_field( $address['city'] ) : '';
 			$state = isset( $address['state'] ) ? sanitize_text_field( $address['state'] ) : '';
 			$zip = isset( $address['zip'] ) ? sanitize_text_field( $address['zip'] ) : '';
@@ -1111,14 +1110,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				'email' => ''
 			);
 
-			$widget_inserted = '';
 			$widget_updated = '';
 			if ( ! self::has_business_address_widget( $first_sidebar ) ) {
-				$widget_inserted = Jetpack_Widgets::insert_widget_in_sidebar( 'widget_contact_info', $widget_options, $first_sidebar );
+				$widget_updated  = Jetpack_Widgets::insert_widget_in_sidebar( 'widget_contact_info', $widget_options, $first_sidebar );
 			} else {
 				$widget_updated = Jetpack_Widgets::update_widget_in_sidebar( 'widget_contact_info', $widget_options, $first_sidebar );
 			}
-			if ( is_wp_error( $widget_inserted ) || is_wp_error( $widget_updated ) ) {
+			if ( is_wp_error( $widget_updated ) ) {
 				return new WP_Error( 'widget_update_failed', 'Widget could not be updated.', 400 );
 			}
 
@@ -1134,7 +1132,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		// No sidebar to place the widget
-		return new WP_Error( 'sidebar_failed', 'No sidebar.', 400 );
+		return new WP_Error( 'sidebar_not_found', 'No sidebar.', 400 );
 	}
 
 	/**

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1075,22 +1075,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	}
 
 	/**
-	 * Retrieve the first active sidebar.
-	 *
-	 * @return string|WP_Error First active sidebar, error if none exists.
-	*/
-	static function get_first_sidebar() {
-		$active_sidebars = get_option( 'sidebars_widgets', array() );
-		unset( $active_sidebars[ 'wp_inactive_widgets' ], $active_sidebars[ 'array_version' ] );
-
-		if ( empty( $active_sidebars ) ) {
-			return false;
-		}
-		$active_sidebars_keys = array_keys( $active_sidebars );
-		return array_shift( $active_sidebars_keys );
-	}
-
-	/**
 	 * Add or update Business Address widget.
 	 *
 	 * @param array $address Array of business address fields.
@@ -1098,7 +1082,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * @return WP_Error|true True if the data was saved correctly.
 	*/
 	static function handle_business_address( $address ) {
-		$first_sidebar = self::get_first_sidebar();
+		$first_sidebar = Jetpack_Widgets::get_first_sidebar();
 
 		$widgets_module_active = Jetpack::is_module_active( 'widgets' );
 		if ( ! $widgets_module_active ) {

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -676,4 +676,86 @@ class Jetpack_Widgets {
 	public static function validate_id_base( $id_base ) {
 		return ( false !== self::get_registered_widget_object( $id_base ) );
 	}
+
+	/**
+	 * Insert a new widget in a given sidebar.
+	 *
+	 * @param string $widget_id ID of the widget.
+	 *
+	 * @param array $widget_options Content of the widget.
+ 	 *
+ 	 * @param string $sidebar ID of the sidebar to which the widget will be added.
+ 	 *
+ 	 * @return WP_Error|true True when data has been saved correctly,
+ 	 * error otherwise.
+	*/
+	static function insert_widget_in_sidebar( $widget_id, $widget_options, $sidebar ) {
+		// Retrieve sidebars, widgets and their instances
+		$sidebars_widgets = get_option( 'sidebars_widgets', array() );
+		$widget_instances = get_option( 'widget_' . $widget_id, array() );
+
+		// Retrieve the key of the next widget instance
+		$numeric_keys = array_filter( array_keys( $widget_instances ), 'is_int' );
+		$next_key = $numeric_keys ? max( $numeric_keys ) + 1 : 2;
+
+		// Add this widget to the sidebar
+		if ( ! isset( $sidebars_widgets[ $sidebar ] ) ) {
+			$sidebars_widgets[ $sidebar ] = array();
+		}
+		$sidebars_widgets[ $sidebar ][] = $widget_id . '-' . $next_key;
+
+		// Add the new widget instance
+		$widget_instances[ $next_key ] = $widget_options;
+
+		// Store updated sidebars, widgets and their instances
+		if ( ! ( update_option( 'blogname', $data['siteTitle'] ) || get_option( 'blogname' ) == $data['siteTitle'] )
+		|| ( ! ( update_option( 'sidebars_widgets', $sidebars_widgets ) ) )
+		|| ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) ) {
+			return new WP_Error( 'invalid_data', 'Invalid update.', 400 );
+		};
+
+		return true;
+	}
+
+	/**
+	 * Update the content of an exisitng widget in a given sidebar.
+	 *
+	 * @param string $widget_id ID of the widget.
+	 *
+	 * @param array $widget_options New content for the update.
+ 	 *
+ 	 * @param string $sidebar ID of the sidebar to which the widget will be added.
+ 	 *
+ 	 * @return WP_Error|true True when data has been updated correctly,
+ 	 * error otherwise.
+	*/
+	static function update_widget_in_sidebar( $widget_id, $widget_options, $sidebar ) {
+		// Retrieve sidebars, widgets and their instances
+		$sidebars_widgets = get_option( 'sidebars_widgets', array() );
+		$widget_instances = get_option( 'widget_' . $widget_id, array() );
+
+		// Retrieve index of first widget instance in that sidebar
+		$widget_key = false;
+		foreach ( $sidebars_widgets[ $sidebar ] as $widget ) {
+			if ( strpos( $widget, 'widget_contact_info' ) !== false ) {
+				$widget_key = absint( str_replace( 'widget_contact_info-', '', $widget ) );
+				break;
+			}
+		}
+
+		// There is no widget instance
+		if ( ! $widget_key ) {
+			return new WP_Error( 'invalid_data', 'No such widget.', 400 );
+		}
+
+		// Update the widget instance with the new data
+		$widget_instances[ $widget_key ] = array_merge( $widget_instances[ $widget_key ], $widget_options );
+
+		// Store updated widget instances and return Error when not successful
+		if ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) {
+			return new WP_Error( 'invalid_data', 'Invalid update.', 400 );
+		};
+		return true;
+	}
+
 }

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -714,7 +714,7 @@ class Jetpack_Widgets {
 	}
 
 	/**
-	 * Update the content of an exisiting widget in a given sidebar.
+	 * Update the content of an existing widget in a given sidebar.
 	 *
 	 * @param string $widget_id ID of the widget.
 	 * @param array $widget_options New content for the update.

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -684,8 +684,7 @@ class Jetpack_Widgets {
 	 * @param array $widget_options Content of the widget.
  	 * @param string $sidebar ID of the sidebar to which the widget will be added.
  	 *
- 	 * @return WP_Error|true True when data has been saved correctly,
- 	 * error otherwise.
+ 	 * @return WP_Error|true True when data has been saved correctly, error otherwise.
 	*/
 	static function insert_widget_in_sidebar( $widget_id, $widget_options, $sidebar ) {
 		// Retrieve sidebars, widgets and their instances
@@ -715,14 +714,13 @@ class Jetpack_Widgets {
 	}
 
 	/**
-	 * Update the content of an exisitng widget in a given sidebar.
+	 * Update the content of an exisiting widget in a given sidebar.
 	 *
 	 * @param string $widget_id ID of the widget.
 	 * @param array $widget_options New content for the update.
  	 * @param string $sidebar ID of the sidebar to which the widget will be added.
  	 *
- 	 * @return WP_Error|true True when data has been updated correctly,
- 	 * error otherwise.
+ 	 * @return WP_Error|true True when data has been updated correctly, error otherwise.
 	*/
 	static function update_widget_in_sidebar( $widget_id, $widget_options, $sidebar ) {
 		// Retrieve sidebars, widgets and their instances
@@ -732,8 +730,8 @@ class Jetpack_Widgets {
 		// Retrieve index of first widget instance in that sidebar
 		$widget_key = false;
 		foreach ( $sidebars_widgets[ $sidebar ] as $widget ) {
-			if ( strpos( $widget, 'widget_contact_info' ) !== false ) {
-				$widget_key = absint( str_replace( 'widget_contact_info-', '', $widget ) );
+			if ( strpos( $widget, $widget_id ) !== false ) {
+				$widget_key = absint( str_replace( $widget_id . '-', '', $widget ) );
 				break;
 			}
 		}

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -681,9 +681,7 @@ class Jetpack_Widgets {
 	 * Insert a new widget in a given sidebar.
 	 *
 	 * @param string $widget_id ID of the widget.
-	 *
 	 * @param array $widget_options Content of the widget.
- 	 *
  	 * @param string $sidebar ID of the sidebar to which the widget will be added.
  	 *
  	 * @return WP_Error|true True when data has been saved correctly,
@@ -708,10 +706,9 @@ class Jetpack_Widgets {
 		$widget_instances[ $next_key ] = $widget_options;
 
 		// Store updated sidebars, widgets and their instances
-		if ( ! ( update_option( 'blogname', $data['siteTitle'] ) || get_option( 'blogname' ) == $data['siteTitle'] )
-		|| ( ! ( update_option( 'sidebars_widgets', $sidebars_widgets ) ) )
-		|| ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) ) {
-			return new WP_Error( 'invalid_data', 'Invalid update.', 400 );
+		if ( ! ( update_option( 'sidebars_widgets', $sidebars_widgets ) )
+		|| ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) )  {
+			return new WP_Error( 'widget_update_failed', 'Failed to update widget or sidebar.', 400 );
 		};
 
 		return true;
@@ -721,9 +718,7 @@ class Jetpack_Widgets {
 	 * Update the content of an exisitng widget in a given sidebar.
 	 *
 	 * @param string $widget_id ID of the widget.
-	 *
 	 * @param array $widget_options New content for the update.
- 	 *
  	 * @param string $sidebar ID of the sidebar to which the widget will be added.
  	 *
  	 * @return WP_Error|true True when data has been updated correctly,
@@ -753,7 +748,7 @@ class Jetpack_Widgets {
 
 		// Store updated widget instances and return Error when not successful
 		if ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) {
-			return new WP_Error( 'invalid_data', 'Invalid update.', 400 );
+			return new WP_Error( 'widget_update_failed', 'Failed to update widget.', 400 );
 		};
 		return true;
 	}

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -753,4 +753,19 @@ class Jetpack_Widgets {
 		return true;
 	}
 
+	/**
+	 * Retrieve the first active sidebar.
+	 *
+	 * @return string|WP_Error First active sidebar, error if none exists.
+	*/
+	static function get_first_sidebar() {
+		$active_sidebars = get_option( 'sidebars_widgets', array() );
+		unset( $active_sidebars[ 'wp_inactive_widgets' ], $active_sidebars[ 'array_version' ] );
+
+		if ( empty( $active_sidebars ) ) {
+			return false;
+		}
+		$active_sidebars_keys = array_keys( $active_sidebars );
+		return array_shift( $active_sidebars_keys );
+	}
 }

--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -705,8 +705,10 @@ class Jetpack_Widgets {
 		$widget_instances[ $next_key ] = $widget_options;
 
 		// Store updated sidebars, widgets and their instances
-		if ( ! ( update_option( 'sidebars_widgets', $sidebars_widgets ) )
-		|| ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) )  {
+		if (
+			! ( update_option( 'sidebars_widgets', $sidebars_widgets ) )
+			|| ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) )
+		) {
 			return new WP_Error( 'widget_update_failed', 'Failed to update widget or sidebar.', 400 );
 		};
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -533,6 +533,7 @@ class Jetpack_Options {
 			'jetpack_sso_require_two_step',
 			'jetpack_sso_remove_login_form',
 			'jetpack_last_connect_url_check',
+			'jpo_business_address',
 			'jpo_site_type',
 			'jpo_homepage_format',
 			'jpo_contact_page',


### PR DESCRIPTION
An alternative approach to #8480  and #8426. 

#### Changes proposed in this Pull Request:
* adds functions required to inject a Business Address widget or update an existing one,
* saves Business Address data in an option,
* enables widget module if inactive ( throws an error on failure ).

#### Testing instructions:

* Follow the instructions https://github.com/Automattic/jetpack/pull/8426 tested on a site with a Business Plan ( or temporarily set `isBusiness` to `true` in main.jsx). 
* To test that it works for the initially inactive `widgets` module: 
 use `wp jetpack module deactivate` to deactivate the module and follow the previous instructions. After, verify that the module is listed as active in `wp jetpack module list` and that the widget has been set correctly. 
* Verify that the `jpo_business_address` option is set i.e. using `wp option get jpo_business_address`.
