### PR TITLE
Update/invite user sync events

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -112,7 +112,6 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'profile_URL'  => '(url) Gravatar Profile URL',
 		'site_ID'      => '(int) ID of the user\'s primary blog',
 		'roles'        => '(array|string) The role or roles of the user',
-		'invite_accepted' => '(bool:false) Is the user accepting an invite',
 	);
 
 	// /sites/%s/users/%d -> $blog_id, $user_id

--- a/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -112,6 +112,7 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'profile_URL'  => '(url) Gravatar Profile URL',
 		'site_ID'      => '(int) ID of the user\'s primary blog',
 		'roles'        => '(array|string) The role or roles of the user',
+		'invite_accepted' => '(bool:false) Is the user accepting an invite',
 	);
 
 	// /sites/%s/users/%d -> $blog_id, $user_id

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -26,10 +26,13 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	function create_or_get_user() {
 		require_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php';
-
 		// Check for an existing user
 		$user = get_user_by( 'email', $this->user_data['email'] );
-
+		/**
+		 * Fires after a user accepts an invitation and before a user gets created.
+		 * @return WP_User|false WP_User object on success, false on failure.
+		 */
+		do_action( 'jetpack_invitation_accepted', $user );
 		if ( ! $user ) {
 			// We modify the input here to mimick the same call structure of the update user endpoint.
 			$this->user_data = (object) $this->user_data;

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -35,7 +35,7 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$this->user_data = (object) $this->user_data;
 			$roles = (array) $this->user_data->roles;
 			$this->user_data->role = array_pop( $roles );
-			$this->user_data->url = $this->user_data->roles;
+			$this->user_data->url = isset( $this->user_data->url ) ? $this->user_data->url : '';
 			$this->user_data->display_name = $this->user_data->name;
 			$this->user_data->description = '';
 			$user = Jetpack_SSO_Helpers::generate_user( $this->user_data );

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -12,6 +12,7 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	function validate_input( $object ) {
 		$this->user_data = $this->input();
+
 		if ( empty( $this->user_data ) ) {
 			return new WP_Error( 'input_error', __( 'user_data is required', 'jetpack' ) );
 		}
@@ -28,11 +29,21 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 		require_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php';
 		// Check for an existing user
 		$user = get_user_by( 'email', $this->user_data['email'] );
-		/**
-		 * Fires after a user accepts an invitation and before a user gets created.
-		 * @return WP_User|false WP_User object on success, false on failure.
-		 */
-		do_action( 'jetpack_invitation_accepted', $user );
+
+		$query_args = $this->query_args();
+		if ( isset( $query_args['invite_accepted'] ) && $query_args['invite_accepted'] ) {
+			/**
+			 * Fires after a user accepts an invitation and before a user gets created.
+			 *
+			 * @module sync
+			 *
+			 * @since  5.8.0
+			 *
+			 * @props  WP_User|false WP_User object on success, false on failure.
+			 */
+			do_action( 'jetpack_invitation_accepted', $user );
+		}
+
 		if ( ! $user ) {
 			// We modify the input here to mimick the same call structure of the update user endpoint.
 			$this->user_data = (object) $this->user_data;

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -31,6 +31,12 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 		$user = get_user_by( 'email', $this->user_data['email'] );
 		$roles = (array) $this->user_data['roles'];
 		$role = array_pop( $roles );
+
+		$query_args = $this->query_args();
+		if ( isset( $query_args['invite_accepted'] ) && $query_args['invite_accepted'] ) {
+			Jetpack_Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
+		}
+
 		if ( ! $user ) {
 			// We modify the input here to mimick the same call structure of the update user endpoint.
 			$this->user_data = (object) $this->user_data;

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1130,6 +1130,9 @@ new Jetpack_JSON_API_User_Create_Endpoint( array(
 	'path_labels'    => array(
 		'$site' => '(int|string) The site ID, The site domain',
 	),
+	'query_parameters' => array(
+		'invite_accepted' => '(bool=false) If the user is being created in the invite context',
+	),
 	'request_format'  => WPCOM_JSON_API_Site_User_Endpoint::$user_format,
 	'response_format' => WPCOM_JSON_API_Site_User_Endpoint::$user_format,
 	'example_request_data' => array(

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1130,9 +1130,6 @@ new Jetpack_JSON_API_User_Create_Endpoint( array(
 	'path_labels'    => array(
 		'$site' => '(int|string) The site ID, The site domain',
 	),
-	'query_parameters' => array(
-		'invite_accepted' => '(bool=false) If the user is being created in the invite context',
-	),
 	'request_format'  => WPCOM_JSON_API_Site_User_Endpoint::$user_format,
 	'response_format' => WPCOM_JSON_API_Site_User_Endpoint::$user_format,
 	'example_request_data' => array(

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -203,11 +203,6 @@ class Jetpack_SSO_Helpers {
 
 	static function generate_user( $user_data ) {
 		$username = $user_data->login;
-		// .com user ID
-		/**
-		 * User to figure out if we are in the context of adding a new user
-		 */
-
 		/**
 		 * Determines how many times the SSO module can attempt to randomly generate a user.
 		 *

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -58,7 +58,7 @@ class Jetpack_SSO_Helpers {
 		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
 
 		/**
-		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations. 
+		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations.
 		 * If you return a string that corresponds to a user role, the user will be given that role.
 		 *
 		 * @module sso
@@ -203,6 +203,10 @@ class Jetpack_SSO_Helpers {
 
 	static function generate_user( $user_data ) {
 		$username = $user_data->login;
+		// .com user ID
+		/**
+		 * User to figure out if we are in the context of adding a new user
+		 */
 
 		/**
 		 * Determines how many times the SSO module can attempt to randomly generate a user.
@@ -224,10 +228,10 @@ class Jetpack_SSO_Helpers {
 			return false;
 		}
 
-		$password = wp_generate_password( 20 );
-		$user_id  = wp_create_user( $username, $password, $user_data->email );
-		$user     = get_userdata( $user_id );
-
+		$user = (object) array();
+		$user->user_pass    = wp_generate_password( 20 );
+		$user->user_login   = wp_slash( $username );
+		$user->user_email   = wp_slash( $user_data->email );
 		$user->display_name = $user_data->display_name;
 		$user->first_name   = $user_data->first_name;
 		$user->last_name    = $user_data->last_name;
@@ -238,11 +242,10 @@ class Jetpack_SSO_Helpers {
 			$user->role     = $user_data->role;
 		}
 
-		wp_update_user( $user );
+		$created_user_id = wp_insert_user( $user );
 
-		update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
-		
-		return $user;
+		update_user_meta( $created_user_id, 'wpcom_user_id', $user_data->ID );
+		return get_userdata( $created_user_id );
 	}
 
 	static function extend_auth_cookie_expiration_for_sso() {

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -223,10 +223,6 @@ class Jetpack_SSO_Helpers {
 			return false;
 		}
 
-		if ( $user_data->invite_accepted ) {
-			do_action( 'jetpack_invite_accepted' );
-		}
-
 		$user = (object) array();
 		$user->user_pass    = wp_generate_password( 20 );
 		$user->user_login   = wp_slash( $username );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -223,6 +223,10 @@ class Jetpack_SSO_Helpers {
 			return false;
 		}
 
+		if ( $user_data->invite_accepted ) {
+			do_action( 'jetpack_invite_accepted' );
+		}
+
 		$user = (object) array();
 		$user->user_pass    = wp_generate_password( 20 );
 		$user->user_login   = wp_slash( $username );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -189,7 +189,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
+		if ( Jetpack_Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -209,7 +209,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
+		if ( Jetpack_Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -4,7 +4,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;
 
 	protected $flags = array();
-	protected $is_accepting_invitation = false;
 
 	function name() {
 		return 'users';
@@ -42,9 +41,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'jetpack_deleted_user', $callable, 10, 3 );
 		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
 		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
-
-		// invitations
-		add_action( 'jetpack_invite_accepted', array( $this, 'invite_accepted_handler' ) );
 
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
@@ -89,10 +85,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return $user;
 		}
 		return null;
-	}
-
-	public function invite_accepted_handler() {
-		$this->is_accepting_invitation = true;
 	}
 
 	public function sanitize_user( $user ) {
@@ -197,7 +189,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( $this->is_accepting_invitation ) {
+		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -217,7 +209,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( $this->is_accepting_invitation ) {
+		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -4,6 +4,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;
 
 	protected $flags = array();
+	protected $is_accepting_invitation = false;
 
 	function name() {
 		return 'users';
@@ -41,6 +42,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'jetpack_deleted_user', $callable, 10, 3 );
 		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
 		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
+
+		// invitations
+		add_action( 'jetpack_invite_accepted', array( $this, 'invite_accepted_handler' ) );
 
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
@@ -85,6 +89,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return $user;
 		}
 		return null;
+	}
+
+	public function invite_accepted_handler() {
+		$this->is_accepting_invitation = true;
 	}
 
 	public function sanitize_user( $user ) {
@@ -189,7 +197,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
+		if ( $this->is_accepting_invitation ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -209,7 +217,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( isset( $_GET['invite_accepted'] ) && 'true' === $_GET['invite_accepted'] ) {
+		if ( $this->is_accepting_invitation ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -685,7 +685,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_invite_user_sync_invite_event() {
 		$this->server_event_storage->reset();
 		// Fake it till you make it
-		do_action( 'jetpack_invitation_accepted', false );
+		$_GET['invite_accepted'] = 'true';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		$user_data = (object) array();
 		$user_data->ID = 1234;
@@ -700,22 +700,43 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$user = Jetpack_SSO_Helpers::generate_user( $user_data );
 		$this->sender->do_sync();
 
+		unset( $_GET['invite_accepted'] );
+
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );
+
 		$this->assertTrue( $event->args[1]['invitation_accepted'] );
 		$this->assertEquals( 'editor' , $event->args[0]->roles[0] );
 	}
 
-	public function test_invite_user_sync_invite_event_user_already_exists() {
+	public function test_invite_user_sync_invite_event_false() {
 		$this->server_event_storage->reset();
-
-		// invite events
-		do_action( 'jetpack_invitation_accepted', get_user_by( 'id', $this->user_id ) );
+		// Fake it till we make it
+		$_GET['invite_accepted'] = 'false';
+		// We modify the input here to mimick the same call structure of the update user endpoint.
+		$user_data = (object) array();
+		$user_data->ID = 1234;
+		$user_data->first_name = '';
+		$user_data->last_name = '';
+		$user_data->url = '';
+		$user_data->login = 'test_user_invite';
+		$user_data->email = 'test_user_invite@example.com';
+		$user_data->role = 'editor';
+		$user_data->display_name = 'Gill';
+		$user_data->description = '';
+		$user = Jetpack_SSO_Helpers::generate_user( $user_data );
 		$this->sender->do_sync();
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_invitation_accepted' );
-		$this->assertEquals( $this->user_id, $event->args[0]->ID );
+
+		unset( $_GET['invite_accepted'] );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
+		$this->assertFalse( $event );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );
+		$this->assertFalse( isset( $event->args[1]['invitation_accepted'] ) );
+		$this->assertEquals( 'editor' , $event->args[0]->roles[0] );
 	}
 
 	protected function assertUsersEqual( $user1, $user2 ) {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -684,13 +684,9 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_invite_user_sync_invite_event() {
 		$this->server_event_storage->reset();
-		// Fake it till you make it
-		$_GET['invite_accepted'] = 'true';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
-
-		unset( $_GET['invite_accepted'] );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -703,13 +699,11 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_invite_user_sync_invite_event_false() {
 		$this->server_event_storage->reset();
-		// Fake it till we make it
-		$_GET['invite_accepted'] = 'false';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
-		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
+		$data = $this->get_invite_user_data();
+		$data->invite_accepted = false;
+		Jetpack_SSO_Helpers::generate_user( $data );
 		$this->sender->do_sync();
-
-		unset( $_GET['invite_accepted'] );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -742,6 +736,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 			'role'         => 'editor',
 			'display_name' => 'Gill',
 			'description'  => '',
+			'invite_accepted' => true
 		);
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -685,12 +685,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_invite_user_sync_invite_event() {
 		$this->server_event_storage->reset();
 		// Fake it till you make it
-		$_GET['invite_accepted'] = 'true';
+		Jetpack_Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
-		unset( $_GET['invite_accepted'] );
+		Jetpack_Constants::clear_constants();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -704,12 +704,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_invite_user_sync_invite_event_false() {
 		$this->server_event_storage->reset();
 		// Fake it till we make it
-		$_GET['invite_accepted'] = 'false';
+		Jetpack_Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', false );
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
-		unset( $_GET['invite_accepted'] );
+		Jetpack_Constants::clear_constants();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -687,17 +687,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		// Fake it till you make it
 		$_GET['invite_accepted'] = 'true';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
-		$user_data = (object) array();
-		$user_data->ID = 1234;
-		$user_data->first_name = '';
-		$user_data->last_name = '';
-		$user_data->url = '';
-		$user_data->login = 'test_user_invite';
-		$user_data->email = 'test_user_invite@example.com';
-		$user_data->role = 'editor';
-		$user_data->display_name = 'Gill';
-		$user_data->description = '';
-		$user = Jetpack_SSO_Helpers::generate_user( $user_data );
+		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
 		unset( $_GET['invite_accepted'] );
@@ -716,17 +706,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		// Fake it till we make it
 		$_GET['invite_accepted'] = 'false';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
-		$user_data = (object) array();
-		$user_data->ID = 1234;
-		$user_data->first_name = '';
-		$user_data->last_name = '';
-		$user_data->url = '';
-		$user_data->login = 'test_user_invite';
-		$user_data->email = 'test_user_invite@example.com';
-		$user_data->role = 'editor';
-		$user_data->display_name = 'Gill';
-		$user_data->description = '';
-		$user = Jetpack_SSO_Helpers::generate_user( $user_data );
+		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
 		unset( $_GET['invite_accepted'] );
@@ -749,6 +729,20 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		unset( $user2_array['user_pass'] );
 
 		$this->assertTrue( array_diff( $user1_array, $user2_array ) == array_diff( $user2_array, $user1_array ) );
+	}
+
+	private function get_invite_user_data() {
+		return (object) array(
+			'ID'           => 1234,
+			'first_name'   => '',
+			'last_name'    => '',
+			'url'          => '',
+			'login'        => 'test_user_invite',
+			'email'        => 'test_user_invite@example.com',
+			'role'         => 'editor',
+			'display_name' => 'Gill',
+			'description'  => '',
+		);
 	}
 
 }

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -684,9 +684,13 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_invite_user_sync_invite_event() {
 		$this->server_event_storage->reset();
+		// Fake it till you make it
+		$_GET['invite_accepted'] = 'true';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
+
+		unset( $_GET['invite_accepted'] );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -699,11 +703,13 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_invite_user_sync_invite_event_false() {
 		$this->server_event_storage->reset();
+		// Fake it till we make it
+		$_GET['invite_accepted'] = 'false';
 		// We modify the input here to mimick the same call structure of the update user endpoint.
-		$data = $this->get_invite_user_data();
-		$data->invite_accepted = false;
-		Jetpack_SSO_Helpers::generate_user( $data );
+		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
+
+		unset( $_GET['invite_accepted'] );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -736,7 +742,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 			'role'         => 'editor',
 			'display_name' => 'Gill',
 			'description'  => '',
-			'invite_accepted' => true
 		);
 	}
 


### PR DESCRIPTION
- only send 1 event when user accepts the invite via the .com invites. 
Add the flag when a user registes so that we know when a user is invited. 

#### Changes proposed in this Pull Request:
* 

#### Testing instructions:
* Do the test pass? 
* user .com to invite a user? Do we just get one event in the activity log as expected? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
