### PR TITLE
Replace p with div to allow child paragraphs in bio

### DIFF
--- a/modules/theme-tools/content-options/author-bio.php
+++ b/modules/theme-tools/content-options/author-bio.php
@@ -49,12 +49,12 @@ function jetpack_author_bio() {
 			<h2 class="author-title"><?php printf( esc_html__( 'Published by %s', 'jetpack' ), '<span class="author-name">' . get_the_author() . '</span>' ); ?></h2>
 		</div><!-- .author-heading -->
 
-		<p class="author-bio">
+		<div class="author-bio">
 			<?php the_author_meta( 'description' ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php printf( esc_html__( 'View all posts by %s', 'jetpack' ), get_the_author() ); ?>
 			</a>
-		</p><!-- .author-bio -->
+		</div><!-- .author-bio -->
 	</div><!-- .entry-auhtor -->
 <?php
 }


### PR DESCRIPTION
Fixes #8255

#### Changes proposed in this Pull Request:

* Replace `<p>` with `<div>` to allow child paragraphs in author bio.

#### Testing instructions:

* Try adding multiline bio in author profile. Here's how it actually ends up:
![image](https://user-images.githubusercontent.com/1505631/34983448-9d88a22a-fad3-11e7-94bf-6b33716d1f73.png)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fix multiline author bio HTML tag output