### PR TITLE
Search: Begin using helper for adding and removing query args

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -1,0 +1,31 @@
+<?php
+
+class Jetpack_Search_Helpers {
+	static function get_search_url() {
+		$query_args = $_GET;
+
+		// Handle the case where a permastruct is being used, such as /search/{$query}
+		if ( ! isset( $query_args['s'] ) ) {
+			$query_args['s'] = get_search_query();
+		}
+
+		if ( isset( $query_args['paged'] ) ) {
+			unset( $query_args['paged'] );
+		}
+
+		$query = http_build_query( $query_args );
+		return home_url( "?{$query}" );
+	}
+
+	static function add_query_arg( $key, $value = false ) {
+		if ( is_array( $key ) ) {
+			return add_query_arg( $key, self::get_search_url() );
+		}
+
+		return add_query_arg( $key, $value, self::get_search_url() );
+	}
+
+	static function remove_query_arg( $key ) {
+		return remove_query_arg( $key, self::get_search_url() );
+	}
+}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -80,6 +80,8 @@ class Jetpack_Search {
 			return;
 		}
 
+		require_once( dirname( __FILE__ ) . '/class.jetpack-search-helpers.php' );
+
 		$this->init_hooks();
 	}
 
@@ -1247,9 +1249,12 @@ class Jetpack_Search {
 							$slug_count = count( $existing_term_slugs );
 
 							if ( $slug_count > 1 ) {
-								$remove_url = add_query_arg( $tax_query_var, urlencode( implode( '+', array_diff( $existing_term_slugs, array( $item['key'] ) ) ) ) );
+								$remove_url = Jetpack_Search_Helpers::add_query_arg(
+									$tax_query_var,
+									urlencode( implode( '+', array_diff( $existing_term_slugs, array( $item['key'] ) ) ) )
+								);
 							} else {
-								$remove_url = remove_query_arg( $tax_query_var );
+								$remove_url = Jetpack_Search_Helpers::remove_query_arg( $tax_query_var );
 							}
 						}
 
@@ -1282,9 +1287,12 @@ class Jetpack_Search {
 
 							// For the right 'remove filter' url, we need to remove the post type from the array, or remove the param entirely if it's the only one
 							if ( $post_type_count > 1 ) {
-								$remove_url = add_query_arg( 'post_type', urlencode_deep( array_diff( $post_types, array( $item['key'] ) ) ) );
+								$remove_url = Jetpack_Search_Helpers::add_query_arg(
+									'post_type',
+									urlencode_deep( array_diff( $post_types, array( $item['key'] ) ) )
+								);
 							} else {
-								$remove_url = remove_query_arg( 'post_type' );
+								$remove_url = Jetpack_Search_Helpers::remove_query_arg( 'post_type' );
 							}
 						}
 
@@ -1313,7 +1321,7 @@ class Jetpack_Search {
 								if ( ! empty( $current_year ) && (int) $current_year === $year ) {
 									$active = true;
 
-									$remove_url = remove_query_arg( array( 'year', 'monthnum', 'day' ) );
+									$remove_url = Jetpack_Search_Helpers::remove_query_arg( array( 'year', 'monthnum', 'day' ) );
 								}
 
 								break;
@@ -1335,7 +1343,7 @@ class Jetpack_Search {
 								     ! empty( $current_month ) && (int) $current_month === $month ) {
 									$active = true;
 
-									$remove_url = remove_query_arg( array( 'year', 'monthnum' ) );
+									$remove_url = Jetpack_Search_Helpers::remove_query_arg( array( 'year', 'monthnum' ) );
 								}
 
 								break;
@@ -1359,7 +1367,7 @@ class Jetpack_Search {
 								     ! empty( $current_day ) && (int) $current_day === $day ) {
 									$active = true;
 
-									$remove_url = remove_query_arg( array( 'day' ) );
+									$remove_url = Jetpack_Search_Helpers::remove_query_arg( array( 'day' ) );
 								}
 
 								break;
@@ -1378,7 +1386,7 @@ class Jetpack_Search {
 				$url_params = urlencode_deep( $query_vars );
 
 				$aggregation_data[ $label ]['buckets'][] = array(
-					'url'        => add_query_arg( $url_params ),
+					'url'        => Jetpack_Search_Helpers::add_query_arg( $url_params ),
 					'query_vars' => $query_vars,
 					'name'       => $name,
 					'count'      => $item['doc_count'],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -95,6 +95,9 @@
 		<testsuite name="lazy-images">
 			<directory prefix="test_" suffix=".php">tests/php/modules/lazy-images</directory>
 		</testsuite>
+		<testsuite name="search">
+			<directory prefix="test_" suffix=".php">tests/php/modules/search</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -1,0 +1,86 @@
+<?php
+
+
+require dirname( __FILE__ ) . '/../../../../modules/search/class.jetpack-search-helpers.php';
+
+class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
+	protected $request_uri;
+	protected $get;
+
+	function setup() {
+		$this->request_uri = $_SERVER['REQUEST_URI'];
+		$this->get = $_GET;
+	}
+
+	function tearDown() {
+		$_SERVER['REQUEST_URI'] = $this->request_uri;
+		$_GET = $this->get;
+	}
+
+	function test_get_search_url_removes_page_when_no_query_s() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/search/test/page/2/";
+		set_query_var( 's', 'test' );
+
+		$url = Jetpack_Search_Helpers::get_search_url();
+
+		$this->assertNotContains( '/search/test/', $url );
+		$this->assertNotContains( '/page/', $url );
+		$this->assertContains( 's=test', $url );
+	}
+
+	function test_get_search_url_removes_page() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/page/2/?s=test";
+		$_GET['s'] = 'test';
+
+		$url = Jetpack_Search_Helpers::get_search_url();
+
+		$this->assertNotContains( '/page/', $url );
+		$this->assertContains( 's=test', $url );
+	}
+
+	function test_get_search_url_removes_paged_query_arg() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/page/2/?s=test&paged=2";
+		$_GET['s'] = 'test';
+		$_GET['paged'] = '2';
+
+		$url = Jetpack_Search_Helpers::get_search_url();
+
+		$this->assertNotContains( 'paged=', $url );
+		$this->assertContains( 's=test', $url );
+	}
+
+	function test_add_query_arg_works_when_sending_array_of_args() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/page/2/?s=test&post_type=page";
+		$_GET['s'] = 'test';
+
+		$url = Jetpack_Search_Helpers::add_query_arg( array(
+			'post_type' => 'page',
+			'category' => 'uncategorized',
+		) );
+
+		$this->assertContains( 's=test', $url );
+		$this->assertContains( 'post_type=page', $url );
+		$this->assertContains( 'category=uncategorized', $url );
+	}
+
+	function test_add_query_arg_does_not_persist_page() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/page/2/?s=test&post_type=page";
+		$_GET['s'] = 'test';
+
+		$url = Jetpack_Search_Helpers::add_query_arg( 'post_type', 'page' );
+
+		$this->assertNotContains( '/page/', $url );
+		$this->assertContains( 's=test', $url );
+	}
+
+	function test_remove_query_arg_does_not_persist_page() {
+		$_SERVER['REQUEST_URI'] = "http://example.com/page/2/?s=test";
+		$_GET['s'] = 'test';
+
+		$url = Jetpack_Search_Helpers::remove_query_arg( 'post_type' );
+
+		$this->assertNotContains( '/page/', $url );
+		$this->assertContains( 's=test', $url );
+		$this->assertNotContains( 'post_type=', $url );
+	}
+}


### PR DESCRIPTION
Fixes #8532

In #8532, I noticed an issue where we were building URLs for filters that sometimes resulted in 404s. The root cause of this is that we were simply adding/removing query args to the current URL which included the page of the search results.

So, if the user was on, say, page 4 of search results, and then selected a filter that reduced results to a single page, then the user would end up getting a 404.

To fix this, I created a class named `Jetpack_Search_Helpers` with some functions that add the query args to the result of `home_url()`. 

As a note, this PR also adds some boilerplate for unit testing the search module. 👍 

To test:

- Checkout branch on site with Jetpack Professional
- Search for term with many results
- Go past page 1 of results
- Select a filter, and ensure that the page is removed from the URL