### PR TITLE
Search: Ensure adding or removing filters allows customizer to save

### DIFF
--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -30,11 +30,14 @@
 			clone.find( 'select option:first-child' ).prop( 'selected', true );
 
 			clone.insertAfter( closest );
+			clone.find( 'input, textarea, select' ).change();
 		} );
 
 		widget.on( 'click', '.jetpack-search-filters-widget__controls .delete', function( e ) {
 			e.preventDefault();
-			$( this ).closest( '.jetpack-search-filters-widget__filter' ).remove();
+			var filter = $( this ).closest( '.jetpack-search-filters-widget__filter' );
+			filter.find( 'input, textarea, select' ).change();
+			filter.remove();
 		} );
 
 		widget.on( 'change', '.jetpack-search-filters-widget__use-filters', function() {


### PR DESCRIPTION
Fixes #8475

In #8475, @Viper007Bond pointed out that removing filters didn't always allow the customizer to save the filter removal. After testing, I found that the customizer would not allow a save if ONLY a filter had been removed. If any other form field had changed, the customizer would allow saving.

It appears the the root issue is that we're dynamically inserting/removing content to our widget and the customizer wasn't receiving change events when we added or removed those values.

The fix here was to fire some change events when we added or removed a filter.

To test:

- Checkout branch on a site with Jetpack Professional
- Add Jetpack Search widget
- Add filter
- Ensure that customizer button changes to "Save & Publish"
- Click that "Save & Publish" button
- Ensure that button text changes to "Saved
- Remove a filter
- Ensure that button again changes to "Save & Publish"