### PR TITLE
Search: Use checkboxes for filter ui and currently applied filters

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -135,7 +135,30 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		do_action( 'jetpack_search_render_filters_widget_title', esc_html( $title ), $args['before_title'], $args['after_title'] );
 
 		if ( ! empty( $instance['search_box_enabled'] ) ) {
-			get_search_form();
+			$form = get_search_form( false );
+
+			// If the widget has specified post types to search within and IF the post types differ
+			// from the default post types that would have been searched, set the selected post
+			// types via a hidden input.
+			if ( ! empty( $instance['post_types'] ) && is_array( $instance['post_types'] ) ) {
+				$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+				$diff_of_post_types = array_diff( $searchable_post_types, $instance['post_types'] );
+				if ( ! empty( $diff_of_post_types ) ) {
+					// The form should have a closing form tag, so let's add our hidden input before that
+					$form = str_replace(
+						'</form>',
+						sprintf(
+							'<input type="hidden" name="post_type" value="%s" /></form>',
+							esc_attr( implode( ',', $instance['post_types'] ) )
+						),
+						$form
+					);
+				}
+			}
+
+			// This shouldn't need to be escaped since we escaped above when we imploded the selected post types
+			echo $form;
+
 			echo '<br />';
 		}
 

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -337,6 +337,13 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		<?php
 	}
 
+	/**
+	 * Responsible for rendering a single filter in the customizer or the widget administration screen in wp-admin.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param array $filter
+	 */
 	function render_widget_filter( $filter ) {
 		$args = wp_parse_args( $filter, array(
 			'name' => '',
@@ -459,6 +466,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		</div>
 	<?php }
 
+	/**
+	 * Responsible for rendering the search box within our widget on the frontend.
+	 *
+	 * @param array $instance
+	 */
 	function render_widget_search_form( $instance ) {
 		$form = get_search_form( false );
 
@@ -485,6 +497,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		echo '<br />';
 	}
 
+	/**
+	 * Renders all available filters that can be used to filter down search results on the frontend.
+	 *
+	 * @param array $filters
+	 */
 	function render_available_filters( $filters ) {
 		foreach ( (array) $filters as $filter ) {
 			if ( count( $filter['buckets'] ) < 2 ) {
@@ -498,10 +515,29 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		echo $before_title . esc_html( $title ) . $after_title;
 	}
 
+	/**
+	 * Responsible for removing all active buckets with a type of post_type.
+	 *
+	 * If the current post type filters match the post type filters that the widget has restricted the
+	 * search too, then we don't want to show the post type buckets. Otherwise, when a user first search, we
+	 * would end up showing an active filters and a post types section that look very similar.
+	 *
+	 * See: https://github.com/Automattic/jetpack/pull/8471#issuecomment-355711814
+	 *
+	 * @param array $active_bucket
+	 */
 	function filter_post_types_from_active_buckets( $active_bucket ) {
 		return empty( $active_bucket['type'] ) || 'post_type' != $active_bucket['type'];
 	}
 
+	/**
+	 * Since we provide support for the widget restricting post types by adding the selected post types as
+	 * active filters, if removing a post type filter would result in there no longer be post_type args in the URL,
+	 * we need to be sure to add them back.
+	 *
+	 * @param array $active_buckets
+	 * @param array $post_types
+	 */
 	function ensure_post_types_on_remove_url( $active_buckets, $post_types ) {
 		$modified = array();
 
@@ -529,6 +565,12 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		return $modified;
 	}
 
+	/**
+	 * Given a url and an array of post types, will ensure that the post types are properly applied to the URL as args.
+	 *
+	 * @param string $url
+	 * @param array $post_types
+	 */
 	function add_post_types_to_url( $url, $post_types ) {
 		$url = remove_query_arg( 'post_type', $url );
 		foreach ( (array) $post_types as $post_type ) {
@@ -538,6 +580,12 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		return $url;
 	}
 
+	/**
+	 * Renders the current filters applied to the search.
+	 *
+	 * @param array $active_buckets
+	 * @param array $instance
+	 */
 	function render_current_filters( $active_buckets, $instance ) {
 		if ( ! $this->post_types_differ_query( $instance, true ) ) {
 			$active_buckets = array_filter( $active_buckets, array( $this, 'filter_post_types_from_active_buckets' ) );
@@ -580,6 +628,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		<br />
 	<?php }
 
+	/**
+	 * Renders a single filter that can be applied to the current search.
+	 *
+	 * @param array $filter
+	 */
 	function render_filter( $filter ) { ?>
 		<h4  class="widget-title"><?php echo esc_html( $filter['name'] ); ?></h4>
 		<ul>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -409,10 +409,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		</div>
 	<?php }
 
-	function post_type_to_input( $post_type ) {
-
-	}
-
 	function render_widget_search_form( $instance ) {
 		$form = get_search_form( false );
 

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -165,6 +165,9 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		$instance['use_filters'] = empty( $new_instance['use_filters'] ) ? '0' : '1';
 		$instance['search_box_enabled'] = empty( $new_instance['search_box_enabled'] ) ? '0' : '1';
+		$instance['post_types'] = empty( $new_instance['post_types'] )
+			? array()
+			: array_map( 'sanitize_key', $new_instance['post_types'] );
 
 		if ( $instance['use_filters'] ) {
 			$filters = array();
@@ -223,7 +226,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		$classes = sprintf(
 			'jetpack-search-filters-widget %s',
 			$use_filters ? '' : 'hide-filters'
-		 );
+		);
 		?>
 		<div class="<?php echo esc_attr( $classes ); ?>">
 			<p>
@@ -238,6 +241,21 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 					value="<?php echo esc_attr( $title ); ?>"
 				/>
 			</p>
+
+			<p>
+				<label><?php esc_html_e( 'Post types included in results:' ); ?></label>
+				<select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]" multiple="multiple">
+					<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
+						<option
+							value="<?php echo esc_attr( $post_type->name ); ?>"
+							<?php selected( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'] ) ); ?>
+						>
+							<?php echo esc_html( $post_type->label ); ?>
+						</option>
+					<?php endforeach; ?>
+				</select>
+			</p>
+
 			<p>
 				<label>
 					<input

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -135,31 +135,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		do_action( 'jetpack_search_render_filters_widget_title', esc_html( $title ), $args['before_title'], $args['after_title'] );
 
 		if ( ! empty( $instance['search_box_enabled'] ) ) {
-			$form = get_search_form( false );
-
-			// If the widget has specified post types to search within and IF the post types differ
-			// from the default post types that would have been searched, set the selected post
-			// types via a hidden input.
-			if ( ! empty( $instance['post_types'] ) && is_array( $instance['post_types'] ) ) {
-				$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
-				$diff_of_post_types = array_diff( $searchable_post_types, $instance['post_types'] );
-				if ( ! empty( $diff_of_post_types ) ) {
-					// The form should have a closing form tag, so let's add our hidden input before that
-					$form = str_replace(
-						'</form>',
-						sprintf(
-							'<input type="hidden" name="post_type" value="%s" /></form>',
-							esc_attr( implode( ',', $instance['post_types'] ) )
-						),
-						$form
-					);
-				}
-			}
-
-			// This shouldn't need to be escaped since we escaped above when we imploded the selected post types
-			echo $form;
-
-			echo '<br />';
+			$this->render_widget_search_form( $instance );
 		}
 
 		if ( $display_filters ) {
@@ -432,6 +408,41 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			</p>
 		</div>
 	<?php }
+
+	function post_type_to_input( $post_type ) {
+
+	}
+
+	function render_widget_search_form( $instance ) {
+		$form = get_search_form( false );
+
+		// If the widget has specified post types to search within and IF the post types differ
+		// from the default post types that would have been searched, set the selected post
+		// types via hidden inputs.
+		if ( ! empty( $instance['post_types'] ) && is_array( $instance['post_types'] ) ) {
+			$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+			$diff_of_post_types = array_diff( $searchable_post_types, $instance['post_types'] );
+
+			if ( ! empty( $diff_of_post_types ) ) {
+				$post_type_inputs = '';
+				foreach ( $instance['post_types'] as $post_type ) {
+					$post_type_inputs .= sprintf( '<input type="hidden" name="post_type[]" value="%s" />', esc_attr( $post_type ) );
+				}
+
+				// The form should have a closing form tag, so let's add our hidden inputs before that
+				$form = str_replace(
+					'</form>',
+					sprintf( '%s</form>', $post_type_inputs ),
+					$form
+				);
+			}
+		}
+
+		// This shouldn't need to be escaped since we escaped above when we imploded the selected post types
+		echo $form;
+
+		echo '<br />';
+	}
 
 	function render_widget_contents( $filters, $active_buckets ) {
 		if ( ! empty( $active_buckets ) ) {

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -100,6 +100,8 @@ class Jetpack_Search {
 			add_action( 'failed_jetpack_search_query', array( $this, 'store_query_failure' ) );
 
 			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
+
+			add_action( 'pre_get_posts', array( $this, 'maybe_add_post_type_as_var' ) );
 		}
 	}
 
@@ -197,6 +199,14 @@ class Jetpack_Search {
 
 		if ( ! empty( $filters ) ) {
 			$this->set_filters( $filters );
+		}
+	}
+
+	function maybe_add_post_type_as_var( $query ) {
+		if ( $query->is_main_query() && $query->is_search && ! empty( $_GET['post_type'] ) ) {
+			$post_type = explode( ',', $_GET['post_type'] );
+			$post_type = array_map( 'sanitize_key', $post_type );
+			$query->set('post_type', $post_type );
 		}
 	}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -204,9 +204,11 @@ class Jetpack_Search {
 
 	function maybe_add_post_type_as_var( $query ) {
 		if ( $query->is_main_query() && $query->is_search && ! empty( $_GET['post_type'] ) ) {
-			$post_type = explode( ',', $_GET['post_type'] );
-			$post_type = array_map( 'sanitize_key', $post_type );
-			$query->set('post_type', $post_type );
+			$post_types = ( is_string( $_GET['post_type'] ) && false !== strpos( $_GET['post_type'], ',' ) )
+				? $post_type = explode( ',', $_GET['post_type'] )
+				: (array) $_GET['post_type'];
+			$post_types = array_map( 'sanitize_key', $post_types );
+			$query->set('post_type', $post_types );
 		}
 	}
 


### PR DESCRIPTION
The current filters selected UI means that the selected set of filters are not in the same context of where they were clicked. Example:

![screen shot 2018-01-16 at 1 51 11 pm](https://user-images.githubusercontent.com/820871/35016176-ae405256-fad4-11e7-8df0-f7e6a8c16ca5.png)

By using checkboxes we can make it a little clearer what has been selected.

![screen shot 2018-01-16 at 3 35 15 pm](https://user-images.githubusercontent.com/820871/35016190-bed969cc-fad4-11e7-8145-e98a555095fc.png)

@MichaelArestad any feedback on this direction?
