### PR TITLE
Mailchimp Widget: avoid conflicts with jQuery UI

### DIFF
--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -199,6 +199,6 @@ class MailChimp_Subscriber_Popup {
 
 		$displayed_once = true;
 
-		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); window.require = window.define = undefined; } );</script>' . "\n\n";
+		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); window.define.amd = undefined; } );</script>' . "\n\n";
 	}
 }

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -199,6 +199,6 @@ class MailChimp_Subscriber_Popup {
 
 		$displayed_once = true;
 
-		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); } );</script>' . "\n\n";
+		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); window.require = window.define = undefined; } );</script>' . "\n\n";
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.mailchimp.php
+++ b/tests/php/modules/shortcodes/test_class.mailchimp.php
@@ -37,6 +37,6 @@ class WP_Test_Jetpack_Shortcodes_MailChimp extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( '<script type="text/javascript" data-dojo-config="usePlainJson: true, isDebug: false">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"' . $uuid . '","lid":"' . $lid . '"}) }); } );</script>', $shortcode_content );
+		$this->assertContains( '<script type="text/javascript" data-dojo-config="usePlainJson: true, isDebug: false">jQuery.getScript( "//downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"' . $uuid . '","lid":"' . $lid . '"}) }); window.define.amd = undefined; } );</script>', $shortcode_content );
 	}
 }


### PR DESCRIPTION
Fixes #8546

#### Changes proposed in this Pull Request:

* Set window.define.amd to undefined after window.define is set by MailChimp script

#### Testing instructions:

* Create a mailchimp popup window widget, and open any page where it should work kick in. It should work, and both window.define and window.require should be null.

#### Proposed changelog entry for your changes:

* Ideally we would set `window.require` and `window.define` to undefined after using them in MailChimp shortcode, but MailChimp script needs `require` and `define` functions to remain in the global scope. Scripts like jquery will not use `define` if `window.define.amd` is undefined so we can at least do that.