### PR TITLE
Tests: Fix unit tests after change to REST API authentication error code

### DIFF
--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -68,7 +68,9 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 		$response = $this->server->dispatch( $this->request );
 		// Starting with https://core.trac.wordpress.org/ticket/42828, Core uses rest_authorization_required_code()
 		// to get the appropriate status code instead of a hardcoded 403.
-		$expected_status_code = version_compare( $wp_version, '5.0-alpha', '>=' ) ? rest_authorization_required_code() : 403;
+		$expected_status_code = version_compare( $wp_version, '4.9.1', '>=' )
+			? rest_authorization_required_code() :
+			403;
 		// From https://github.com/WordPress/WordPress/blob/4.7/wp-includes/rest-api/class-wp-rest-server.php#L902
 		$this->assertErrorResponse( 'rest_forbidden', $response, $expected_status_code );
 		$this->assertEquals( 0, get_current_user_id() );


### PR DESCRIPTION
I've noticed several failing Travis CI tests with the following:

```
1) WP_Test_Jetpack_REST_API_Authentication::test_jetpack_rest_api_authentication_fail_no_token_or_signature
Failed asserting that 401 matches expected 403.
```

I believe this PR fixes the issue by moving the version check back to `4.9.1`. That version is chosen because the WordPress version when https://core.trac.wordpress.org/changeset/42422 is applied is `4.9.1-src`.