### PR TITLE
Search: After updating the widget, rerun search to get lastest filters

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -81,4 +81,95 @@ class Jetpack_Search_Helpers {
 
 		return $filters;
 	}
+
+	/**
+	 * Whether we should rerun a search in the customizer preview or not.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @return bool
+	 */
+	static function should_rerun_search_in_customizer_preview() {
+		// Only update when in a customizer preview and data is being posted.
+		// Check for $_POST removes an extra update when the customizer loads.
+		//
+		// Note: We use $GLOBALS['wp_customize'] here instead of is_customize_preview() to support unit tests.
+		if ( ! isset( $GLOBALS['wp_customize'] ) || ! $GLOBALS['wp_customize']->is_preview() || empty( $_POST ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Since PHP's built-in array_diff() works by comparing the values that are in array 1 to the other arrays,
+	 * if there are less values in array 1, it's possible to get an empty diff where one might be expected.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param array $array_1
+	 * @param array $array_2
+	 *
+	 * @return array
+	 */
+	static function array_diff( $array_1, $array_2 ) {
+		// If the array counts are the same, then the order doesn't matter. If the count of
+		// $array_1 is higher than $array_2, that's also fine. If the count of $array_2 is higher,
+		// we need to swap the array order though.
+		if ( count( $array_1 ) != count( $array_2 ) && count( $array_2 ) > count( $array_1 ) ) {
+			$temp = $array_1;
+			$array_1 = $array_2;
+			$array_2 = $temp;
+		}
+
+		// Disregard keys
+		return array_values( array_diff( $array_1, $array_2 ) );
+	}
+
+	/**
+	 * Given the widget instance, will return true when selected post types differ from searchable post types.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param array $instance
+	 * @return bool
+	 */
+	static function post_types_differ_searchable( $instance ) {
+		if ( empty( $instance['post_types'] ) ) {
+			return false;
+		}
+
+		$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+		$diff_of_searchable = self::array_diff( $searchable_post_types, (array) $instance['post_types'] );
+
+		return ! empty( $diff_of_searchable );
+	}
+
+	/**
+	 * Given the widget instance, will return true when selected post types differ from the post type filters
+	 * applied to the search.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param array $instance
+	 * @return bool
+	 */
+	static function post_types_differ_query( $instance ) {
+		if ( empty( $instance['post_types'] ) ) {
+			return false;
+		}
+
+		if ( empty( $_GET['post_type'] ) ) {
+			$post_types_from_query = array();
+		} else if ( is_array( $_GET['post_type'] ) ) {
+			$post_types_from_query = $_GET['post_type'];
+		} else {
+			$post_types_from_query = (array) explode( ',',  $_GET['post_type'] );
+		}
+
+		$post_types_from_query = array_map( 'trim', $post_types_from_query );
+
+		$diff_query = self::array_diff( (array) $instance['post_types'], $post_types_from_query );
+		return ! empty( $diff_query );
+	}
 }

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -48,3 +48,7 @@
 .jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__taxonomy-select {
 	display: none;
 }
+
+.jetpack-search-filters-widget.hide-post-types .jetpack-search-filters-widget__post-types-select {
+	display: none;
+}

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -43,6 +43,10 @@
 		widget.on( 'change', '.jetpack-search-filters-widget__use-filters', function() {
 			$( this ).closest( '.jetpack-search-filters-widget' ).toggleClass( 'hide-filters' );
 		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__search-box-enabled', function() {
+			$( this ).closest( '.jetpack-search-filters-widget' ).toggleClass( 'hide-post-types' );
+		} );
 	};
 
 	$( document ).ready( function() {
@@ -56,6 +60,7 @@
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .delete' );
 		widget.off( 'change', '.jetpack-search-filters-widget__use-filters' );
+		widget.off( 'change', '.jetpack-search-filters-widget__search-box-enabled' );
 		setListeners();
 	} );
 } )( jQuery, jetpack_search_filter_admin );


### PR DESCRIPTION
Fixes #8535, Fixes #8536, Fixes #8466

Previously, managing the Jetpack Search filters widget was pretty frustrating via the customizer since the preview didn't work very well. 😞 

The main issue was that when filters were added, we didn't update and redo the query to WPCOM to get update buckets back.

This PR also addresses #8536, which was to start using a comma separated string of post types in the URL instead of using `&post_type[]=post&post_type[]=page`. Normally, I would've addressed this in a separate, smaller PR. But, I noticed that the customizer doesn't play nicely when multiple values are passed like this `&post_type[]=post&post_type[]=page`.

Lastly, this PR also addresses #8466 by not rendering a header for the title when the title is empty.

The only known issue with preview is that search results don't automatically repopulated when the user changes the allowed post types for the widget. I attempted to add notices to have the user refresh the page, but have failed miserably so far. I'd like to pull that out into a separate issue so that we can at least get this preview work in.

To test:

- Checkout PR on a site with Jetpack Professional
- Ensure search module is on
- Open customizer
- Add Jetpack Search widget
- Add and remove filters and ensure that widget updates