### PR TITLE
Allow rendering of JITM's on Jetpack admin page

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -8,7 +8,6 @@ const AdminNotices = React.createClass( {
 		const $adminNotices = jQuery( this.refs.adminNotices );
 
 		const $vpNotice = jQuery( '.vp-notice' );
-
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function() {
 				const $success = jQuery( this ).hasClass( 'vp-registered' );
@@ -47,7 +46,7 @@ const AdminNotices = React.createClass( {
 	},
 
 	render() {
-		return ( <div ref="adminNotices" aria-live="polite"></div> );
+		return ( <div id="jp-admin-notices" ref="adminNotices" aria-live="polite"></div> );
 	}
 } );
 

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -56,6 +56,9 @@ jQuery( document ).ready( function( $ ) {
 		$template.find( '.jitm-banner__dismiss' ).click( render( $template ) );
 
 		$el.replaceWith( $template );
+
+		// Add to Jetpack notices within the Jetpack settings app.
+		$template.prependTo( $( '#jp-admin-notices' ) );
 	};
 
 	$( '.jetpack-jitm-message' ).each( function() {

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -67,7 +67,6 @@ class Jetpack_JITM {
 	 */
 	function prepare_jitms( $screen ) {
 		if ( ! in_array( $screen->id, array(
-			'toplevel_page_jetpack',
 			'jetpack_page_stats',
 			'jetpack_page_akismet-key-config',
 			'admin_page_jetpack_modules'

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7021,7 +7021,7 @@ p {
 			$rewind_data = (array) Jetpack_Core_Json_Api_Endpoints::rewind_data();
 			$rewind_enabled = ( ! is_wp_error( $rewind_data )
 				&& ! empty( $rewind_data['state'] )
-				&& 'unavailable' !== $rewind_data['state'] )
+				&& 'active' === $rewind_data['state'] )
 				? 1
 				: 0;
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7021,7 +7021,7 @@ p {
 			$rewind_data = (array) Jetpack_Core_Json_Api_Endpoints::rewind_data();
 			$rewind_enabled = ( ! is_wp_error( $rewind_data )
 				&& ! empty( $rewind_data['state'] )
-				&& 'active' === $rewind_data['state'] )
+				&& 'unavailable' !== $rewind_data['state'] )
 				? 1
 				: 0;
 


### PR DESCRIPTION
This will allow JITM's to load on the Jetpack settings/dashboard page.  It modifies the jitm script to add the JITM to a div within the Jetpack UI, so that it's not rendered ugly above.  

To Test: 
- Test with D9355-code
- Change `JETPACK__WPCOM_JSON_API_HOST` to point to your sandbox
- If the site is connected by an a11n, you should see this notice on the Jetpack admin page. 
- You should also be seeing it in your wp-admin dashboard page.  If you're not seeing it in either places, something else is wrong. 

![screen shot 2018-01-17 at 4 03 34 pm 1](https://user-images.githubusercontent.com/7129409/35066954-4fbdc692-fba0-11e7-8cee-f54c14819b39.png)
