### PR TITLE
Search: Fix undefined index when all searchable post types selected

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -83,7 +83,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			return false;
 		}
 
-		$diff_query = array_diff( (array) $instance['post_types'], (array) $_GET['post_type'] );
+		$post_types_from_query = isset( $_GET['post_type' ] )
+			? (array) $_GET['post_type']
+			: array();
+
+		$diff_query = array_diff( (array) $instance['post_types'], $post_types_from_query );
 		return ! empty( $diff_query );
 	}
 


### PR DESCRIPTION
When all post types are selected, we don't send `&post_type=` with all search queries. This caused an undefined index notice:

```
PHP Notice:  Undefined index: post_type[...]
```

This PR fixes that.

I didn't catch this before, because I didn't have ALL post types selected.

To test:

- Checkout branch on a site with Jetpack Professional
- Ensure `WP_DEBUG` is defined and true
- Add a Jetpack Search widget to a sidebar
- Ensure all post types are selected
- Search for something on the frontend of your site
- Ensure there are no notices