### PR TITLE
Search: Refactor logic into Jetpack_Search_Helpers and add tests

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -1,6 +1,8 @@
 <?php
 
 class Jetpack_Search_Helpers {
+	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
+
 	static function get_search_url() {
 		$query_args = $_GET;
 
@@ -27,5 +29,56 @@ class Jetpack_Search_Helpers {
 
 	static function remove_query_arg( $key ) {
 		return remove_query_arg( $key, self::get_search_url() );
+	}
+
+	static function get_widget_option_name() {
+		return sprintf( 'widget_%s', self::FILTER_WIDGET_BASE );
+	}
+
+	static function get_widgets_from_option() {
+		$widget_options = get_option( self::get_widget_option_name(), array() );
+
+		// We don't need this
+		if ( ! empty( $widget_options ) && isset( $widget_options['_multiwidget'] ) ) {
+			unset( $widget_options['_multiwidget'] );
+		}
+
+		return $widget_options;
+	}
+
+	static function build_widget_id( $number ) {
+		return sprintf( '%s-%d', self::FILTER_WIDGET_BASE, $number );
+	}
+
+	static function is_active_widget( $widget_id ) {
+		return (bool) is_active_widget( false, $widget_id, self::FILTER_WIDGET_BASE );
+	}
+
+	static function get_filters_from_widgets() {
+		$filters = array();
+
+		$widget_options = self::get_widgets_from_option();
+		if ( empty( $widget_options ) ) {
+			return $filters;
+		}
+
+		foreach ( (array) $widget_options as $number => $settings ) {
+			$widget_id = self::build_widget_id( $number );
+			if ( ! self::is_active_widget( $widget_id ) || empty( $settings['filters'] ) ) {
+				continue;
+			}
+
+			if ( empty( $settings['use_filters'] ) ) {
+				continue;
+			}
+
+			foreach ( (array) $settings['filters'] as $widget_filter ) {
+				$widget_filter['widget_id'] = $widget_id;
+				$key = sprintf( '%s_%d', $widget_filter['type'], count( $filters ) );
+				$filters[ $key ] = $widget_filter;
+			}
+		}
+
+		return $filters;
 	}
 }

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -29,8 +29,6 @@ class Jetpack_Search {
 	// but are analyzed with the default analyzer.
 	public static $analyzed_langs = array( 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'eu', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh' );
 
-	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
-
 	protected function __construct() {
 		/* Don't do anything, needs to be initialized via instance() method */
 	}
@@ -169,35 +167,7 @@ class Jetpack_Search {
 			return;
 		}
 
-		$widget_options = get_option( sprintf( 'widget_%s', self::FILTER_WIDGET_BASE ) );
-
-		if ( empty( $widget_options ) ) {
-			return;
-		}
-
-		// We don't need this
-		if ( isset( $widget_options['_multiwidget'] ) ) {
-			unset( $widget_options['_multiwidget'] );
-		}
-
-		$filters = array();
-
-		foreach ( (array) $widget_options as $number => $settings ) {
-			$widget_id = sprintf( '%s-%d', self::FILTER_WIDGET_BASE, $number );
-			if ( ! is_active_widget( false, $widget_id, self::FILTER_WIDGET_BASE ) || empty( $settings['filters'] ) ) {
-				continue;
-			}
-
-			if ( empty( $settings['use_filters'] ) ) {
-				continue;
-			}
-
-			foreach ( (array) $settings['filters'] as $widget_filter ) {
-				$widget_filter['widget_id'] = $widget_id;
-				$key = sprintf( '%s_%d', $widget_filter['type'], count( $filters ) );
-				$filters[ $key ] = $widget_filter;
-			}
-		}
+		$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
 
 		if ( ! empty( $filters ) ) {
 			$this->set_filters( $filters );

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -1,20 +1,25 @@
 <?php
 
-
+require dirname( __FILE__ ) . '/../../../../modules/search/class.jetpack-search.php';
 require dirname( __FILE__ ) . '/../../../../modules/search/class.jetpack-search-helpers.php';
 
 class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	protected $request_uri;
 	protected $get;
+	protected $registered_widgets;
 
 	function setup() {
 		$this->request_uri = $_SERVER['REQUEST_URI'];
 		$this->get = $_GET;
+		$this->registered_widgets = $GLOBALS['wp_registered_widgets'];
+		delete_option( Jetpack_Search_Helpers::get_widget_option_name() );
 	}
 
 	function tearDown() {
 		$_SERVER['REQUEST_URI'] = $this->request_uri;
 		$_GET = $this->get;
+		$GLOBALS['wp_registered_widgets'] = $this->registered_widgets;
+		remove_filter( 'sidebars_widgets', array( $this, '_fake_out_search_widget' ) );
 	}
 
 	function test_get_search_url_removes_page_when_no_query_s() {
@@ -82,5 +87,171 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 		$this->assertNotContains( '/page/', $url );
 		$this->assertContains( 's=test', $url );
 		$this->assertNotContains( 'post_type=', $url );
+	}
+
+	function test_get_widget_option_name() {
+		$this->assertSame( 'widget_jetpack-search-filters', Jetpack_Search_Helpers::get_widget_option_name() );
+	}
+
+	function test_get_widgets_from_option_empty_widget_option() {
+		$this->assertSame( array(), Jetpack_Search_Helpers::get_widgets_from_option() );
+	}
+
+	function test_get_widgets_from_option_with_widgets_saved() {
+		update_option( Jetpack_Search_Helpers::get_widget_option_name(), $this->get_sample_widgets_option() );
+
+		$filters = Jetpack_Search_Helpers::get_widgets_from_option();
+
+		$expected = $this->get_sample_widgets_option();
+		unset( $expected['_multiwidget'] );
+
+		$this->assertSame( $expected, $filters );
+	}
+	/**
+	 * @dataProvider get_build_widget_id_data
+	 */
+	function test_build_widget_id( $number, $expected ) {
+		$this->assertSame( $expected, Jetpack_Search_Helpers::build_widget_id( $number ) );
+	}
+
+	/**
+	 * @dataProvider get_test_is_active_widget_data
+	 */
+	function test_is_active_widget( $number, $expected ) {
+		$this->register_fake_widgets();
+
+		$widget_id = Jetpack_Search_Helpers::build_widget_id( $number );
+
+		$this->assertSame( $expected, Jetpack_Search_Helpers::is_active_widget( $widget_id ) );
+
+	}
+
+	function test_get_filters_from_widgets() {
+		$raw_option = $this->get_sample_widgets_option();
+		update_option( Jetpack_Search_Helpers::get_widget_option_name(), $raw_option );
+		$this->register_fake_widgets();
+
+		$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
+
+		$this->assertCount( count( $raw_option['22']['filters'] ), $filters );
+
+		$this->assertArrayHasKey( 'taxonomy_0', $filters );
+		foreach ( array( 'name', 'type', 'taxonomy', 'count', 'widget_id'  ) as $key ) {
+			$this->assertArrayHasKey( $key, $filters['taxonomy_0'], sprintf( 'Could not find %s key in taxonomy_0', $key ) );
+		}
+
+		$this->assertSame( 'taxonomy', $filters['taxonomy_0']['type'] );
+		$this->assertSame( 'category', $filters['taxonomy_0']['taxonomy'] );
+		$this->assertSame( 4, (int) $filters['taxonomy_0']['count'] );
+		$this->assertSame( 'jetpack-search-filters-22', $filters['taxonomy_0']['widget_id'] );
+
+		$this->assertArrayHasKey( 'post_type_1', $filters );
+		foreach ( array( 'name', 'type', 'count', 'widget_id'  ) as $key ) {
+			$this->assertArrayHasKey( $key, $filters['post_type_1'], sprintf( 'Could not find %s key in post_type_1', $key ) );
+		}
+
+		$this->assertSame( 'post_type', $filters['post_type_1']['type'] );
+		$this->assertSame( 5, (int) $filters['post_type_1']['count'] );
+		$this->assertSame( 'jetpack-search-filters-22', $filters['post_type_1']['widget_id'] );
+	}
+
+	/**
+	 * Data providers
+	 */
+	function get_build_widget_id_data() {
+		return array(
+			'jetpack-search-filters-22' => array(
+				22,
+				'jetpack-search-filters-22'
+			),
+			'jetpack-search-filters-10' => array(
+				10,
+				'jetpack-search-filters-10'
+			)
+		);
+	}
+
+	function get_test_is_active_widget_data() {
+		return array(
+			'jetpack-search-filters-22' => array(
+				22,
+				true
+			),
+			'jetpack-search-filters-10' => array(
+				10,
+				false
+			)
+		);
+	}
+
+	/**
+	 * Helpers
+	 */
+	function _fake_out_search_widget( $widgets ) {
+		$widgets['wp_inactive_widgets'][] = 'jetpack-search-filters-10';
+
+		$override = array();
+		foreach ( $widgets as $key => $sidebar ) {
+			if ( 'wp_inactive_widgets' == $key ) {
+				continue;
+			}
+
+			$widgets[ $key ][] = 'jetpack-search-filters-22';
+			return $widgets;
+		}
+
+		return $widgets;
+	}
+
+	function register_fake_widgets() {
+		add_filter( 'sidebars_widgets', array( $this, '_fake_out_search_widget' ) );
+
+		$widget_ids = array(
+			'jetpack-search-filters-10',
+			'jetpack-search-filters-22',
+		);
+
+		foreach( $widget_ids as $id ) {
+			$GLOBALS['wp_registered_widgets'][ $id ] = array(
+				'id' => $id,
+			);
+		}
+	}
+
+	function get_sample_widgets_option() {
+		return array(
+			'15' => array(
+				'title' => 'Search',
+				'use_filters' => 1,
+				'search_box_enabled' => 0,
+				'filters' => array(
+					array(
+						'name' => 'Categories',
+						'type' => 'taxonomy',
+						'taxonomy' => 'category',
+						'count' => 4
+					)
+				)
+			),
+			'22' => array(
+				'title' => 'Search',
+				'use_filters' => 1,
+				'search_box_enabled' => 1,
+				'filters' => array(
+					array(
+						'name' => 'Categories',
+						'type' => 'taxonomy',
+						'taxonomy' => 'category',
+						'count' => 4
+					),
+					array(
+						'name' => 'Post Type',
+						'type' => 'post_type',
+						'count' => 5,
+					)
+				)
+			),
+			'_multiwidget' => 1
+		);
 	}
 }


### PR DESCRIPTION
This factors some logic from the `Jetpack_Search` class into the `Jetpack_Search_Helpers` and adds tests. 

This will help keep things DRY as I continue to work on customizer preview in #8552. There shouldn't be any functionality changes here. The existing functionality that we're factoring out is in the `set_filters_from_widgets()` method in `Jetpack_Search`.

To test:

- Checkout branch on a site with Jetpack Professional
- Setup search widget with several filters and with post types
- Ensure search widget works