### PR TITLE
REST API: Include business address in the JPO GET endpoint

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -437,7 +437,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						'siteType' => get_option( 'jpo_site_type' ),
 						'homepageFormat' => get_option( 'jpo_homepage_format' ),
 						'addContactForm' => intval( get_option( 'jpo_contact_page' ) ),
-						'businessAddress' => array(), // TODO
+						'businessAddress' => get_option( 'jpo_business_address' ),
 						'installWooCommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
 					);
 					break;


### PR DESCRIPTION
This PR updates the settings endpoint to contain the business address within the onboarding setting. 

Requires #8523 to have landed first - it takes care of saving the business address in the option that we're using here.

To test right now:
* Checkout #8523 and follow its instructions.
* After you've saved the business address, make a GET request to the `/jetpack/v4/settings` endpoint.
* Verify the business address is returned in the response.
* Delete the option (`wp option delete jpo_business_address` using WP CLI)
* Hit the endpoint again and verify that the business address returned is `false`.