### PR TITLE
Tests: Try to gain speed on tests execution time

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -105,5 +105,9 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	function serverReceive( $data, $codec, $sent_timestamp, $queue_id ) {
 		return $this->server->receive( $data, null, $sent_timestamp, $queue_id );
 	}
+
+	function pre_http_request_success() {
+		return array( 'body' => json_encode( array( 'success' => true ) ) );
+	}
 }
 

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -5,16 +5,23 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_stats_data_on_heartbeat() {
 		$heartbeat = Jetpack_Heartbeat::init();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$heartbeat->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+
 		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
+
 		$this->assertEquals( JETPACK__VERSION, $action->args[0]['version'] );
 	}
 
 	function test_dont_send_expensive_data_on_heartbeat() {
 		$heartbeat = Jetpack_Heartbeat::init();
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$heartbeat->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
@@ -42,7 +49,10 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		add_user_to_blog( $other_blog_id, $mu_blog_user_id, 'administrator' );
 
 		$heartbeat = Jetpack_Heartbeat::init();
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$heartbeat->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+
 		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -322,7 +322,10 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->set_sync_wait_threshold( 2 ); // wait no matter what
 
 		$this->factory->post->create();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$this->sender->do_sync();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
 		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );
 	}

--- a/tests/php/test_class.jetpack-heartbeat.php
+++ b/tests/php/test_class.jetpack-heartbeat.php
@@ -22,9 +22,15 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 		$this->heartbeat_action = false;
 		add_action( 'jetpack_heartbeat', array( $this, 'jetpack_heartbeat' ) );
 
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		Jetpack_Heartbeat::init()->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
 		$this->assertTrue( $this->heartbeat_action );
+	}
+
+	function pre_http_request_success() {
+		return array( 'body' => json_encode( array( 'success' => true ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Improvements on execution time for the following tests:

test_sends_stats_data_on_heartbeat
test_dont_send_expensive_data_on_heartbeat
test_delays_next_send_if_exceeded_sync_wait_threshold
test_cron_exec

#### Changes proposed in this Pull Request:
* adds a prefilter to `wp_remote_request` 

#### Testing instructions:
phpunit --filter=<your favorite test name>

* Do the test pass. Are they faster than currently?

Thanks for your help @zinigor :)