### PR TITLE
Site Settings: Add support for the language setting to the API

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1889,7 +1889,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			'WPLANG' => array(
+			'lang_id' => array(
 				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
 				'type' => 'string',
 				'default' => '',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1889,10 +1889,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			'lang_id' => array(
+			'WPLANG' => array(
 				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
-				'type' => 'integer',
-				'default' => 0,
+				'type' => 'string',
+				'default' => '',
 				'jp_group' => 'settings',
 			),
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1889,6 +1889,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			'lang_id' => array(
+				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
+				'type' => 'integer',
+				'default' => 0,
+				'jp_group' => 'settings',
+			),
+
 			'onboarding' => array(
 				'description'       => '',
 				'type'              => 'object',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1892,7 +1892,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'lang_id' => array(
 				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
 				'type' => 'string',
-				'default' => '',
+				'default' => 'en_US',
 				'jp_group' => 'settings',
 			),
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -409,13 +409,22 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
 				case 'lang_id':
-					if ( defined( 'WPLANG' ) || ! current_user_can( 'install_languages' ) ) {
-						// We can't affect this setting, so don't include it in the response
+					if ( defined( 'WPLANG' ) && ! empty( WPLANG ) ) {
+						// We can't affect this setting, so warn the client
+						$response[ $setting ] = 'error_const';
 						break;
 					}
+
+					if ( ! current_user_can( 'install_languages' ) ) {
+						// The user doesn't have caps to install language packs, so warn the client
+						$response[ $setting ] = 'error_cap';
+						break;
+					}
+
 					$value = get_option( 'WPLANG' );
 					$response[ $setting ] = empty( $value ) ? 'en_US' : $value;
 					break;
+
 				case $holiday_snow_option_name:
 					$response[ $setting ] = get_option( $holiday_snow_option_name ) === 'letitsnow';
 					break;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -409,7 +409,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
 				case 'lang_id':
-					if ( defined( 'WPLANG' ) && ! empty( WPLANG ) ) {
+					if ( defined( 'WPLANG' ) ) {
 						// We can't affect this setting, so warn the client
 						$response[ $setting ] = 'error_const';
 						break;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -408,6 +408,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
+				case 'WPLANG':
+					if ( defined( 'WPLANG' ) ) {
+						// We can't affect this setting, so don't include it in the response
+						// @TODO maybe also bail if:
+						//   the user has no capabilities to install language files &
+						//   they already have the only available locale selected
+						break;
+					}
 				case $holiday_snow_option_name:
 					$response[ $setting ] = get_option( $holiday_snow_option_name ) === 'letitsnow';
 					break;
@@ -594,6 +602,20 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			$value = Jetpack_Core_Json_Api_Endpoints::cast_value( $value, $option_attrs );
 
 			switch ( $option ) {
+				case 'WPLANG':
+					if ( defined( 'WPLANG' ) ) {
+						// We can't affect this setting
+						$updated = false;
+						break;
+					}
+
+					$language = current_user_can( 'install_languages' )
+						? wp_download_language_pack( $value )
+						: $value;
+
+					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;
+					break;
+
 				case 'monitor_receive_notifications':
 					$monitor = new Jetpack_Monitor();
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -624,6 +624,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 					// `wp_download_language_pack` only tries to download packs if they're not already available
 					$language = wp_download_language_pack( $value );
+					if ( $language === false ) {
+						// The language pack download failed.
+						$updated = false;
+						break;
+					}
 					$updated = get_option( 'WPLANG' ) === $language ? true : update_option( 'WPLANG', $language );
 					break;
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -413,7 +413,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						// We can't affect this setting, so don't include it in the response
 						break;
 					}
-					$response[ $setting ] = get_option( 'WPLANG' );
+					$value = get_option( 'WPLANG' );
+					$response[ $setting ] = empty( $value ) ? 'en_US' : $value;
 					break;
 				case $holiday_snow_option_name:
 					$response[ $setting ] = get_option( $holiday_snow_option_name ) === 'letitsnow';


### PR DESCRIPTION
Provide API support for users to manage site / blog language from their WordPress.com Site Settings page.

See: https://github.com/Automattic/wp-calypso/issues/11316

#### Changes proposed in this Pull Request:

* Declare support for `lang_id`
* Prevent modification & return an error code if the client cannot change the setting
* Download language packs if needed & available
* Broker access to the `WPLANG` option

#### Testing instructions:

* Run this branch on your connected Jetpack site
* Run the Calypso branch in https://github.com/Automattic/wp-calypso/pull/21482 & follow testing instructions there

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Added support for changing site language via WordPress.com
