### PR TITLE
Tests: Add info about slow tests.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -113,4 +113,15 @@
 			</exclude>
 		</whitelist>
 	</filter>
+	<listeners>
+		<listener class="SpeedTrapListener">
+			<arguments>
+				<array>
+					<element key="slowThreshold">
+						<integer>150</integer>
+					</element>
+				</array>
+			</arguments>
+		</listener>
+	</listeners>
 </phpunit>

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -111,3 +111,5 @@ function in_running_uninstall_group() {
 	global  $argv;
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
 }
+
+require $test_root . '/includes/speed-trap-listener.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -112,4 +112,6 @@ function in_running_uninstall_group() {
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
 }
 
+// Using the Speed Trap Listener provided by WordPress Core testing suite to expose
+// slowest running tests. See the configuration in phpunit.xml.dist
 require $test_root . '/includes/speed-trap-listener.php';


### PR DESCRIPTION
Now when running phpunit you should see the following enriched output:

```
You should really fix these slow tests (>150ms)...
 1. 17859ms to run WP_Test_Jetpack_PHP_Lint:test_php_lint
 2. 15209ms to run WP_Test_Jetpack_Heartbeat:test_cron_exec
 3. 15177ms to run WP_Test_Jetpack_Sync_Module_Stats:test_dont_send_expensive_data_on_heartbeat
 4. 15003ms to run WP_Test_Jetpack_Sync_Module_Stats:test_sends_stats_data_on_heartbeat
 5. 9366ms to run WP_Test_Jetpack_Sync_Themes:test_install_edit_delete_theme_sync
 6. 8812ms to run WP_Test_Jetpack_Sync_Plugins:test_installing_and_removing_plugin_is_synced
 7. 6037ms to run WP_Test_Jetpack_Sync_Sender:test_rate_limit_how_often_sync_runs_with_option
 8. 6023ms to run WP_Test_Jetpack_Sync_Sender:test_limits_execution_time_of_do_sync
 9. 6006ms to run WP_Test_Jetpack_Sync_Queue:test_queue_lag
 10. 4164ms to run WP_Test_Jetpack_Sync_Functions:test_force_sync_callabled_on_plugin_update
...and there are 68 more above your threshold hidden from view

Time: 3.44 minutes, Memory: 138.25MB
```