### PR TITLE
Work Around Trim() Parameter Error

### DIFF
--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -332,7 +332,9 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 		$defaults 		= $this->defaults();
 
 		foreach ( $instance as $key => $value ) {
-			$value = trim( $value );
+			implode(" ", $value); //since value was extracted from instance which is an array, value is still an array
+			$value = trim( $value ); //error occurs on this line because value is not a string
+			explode(" ", $value); //since the later conditions compare array elements, I would need to convert the string back to array. 
 
 			if ( isset( $allowed_values[ $key ] ) && $allowed_values[ $key ] && ! array_key_exists( $value, $allowed_values[ $key ] ) ) {
 				$instance[ $key ] = $defaults[ $key ];


### PR DESCRIPTION
Following this issue : https://github.com/Automattic/jetpack/issues/6563
One of the poster has isolated the bug to line 335 where trim() expects a string as an argument. The message specified that the array was given as the argument. To work around this issue, I convert $value to an array for the sole purpose of this function. I have no way of compiling this myself but I hope this works.

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
