### PR TITLE
Lint PHP files only for older PHP versions.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,9 @@
 			<file>tests/php/test_class.jetpack-constants.php</file>
 			<file>tests/php/test_class.jetpack-connection-banner.php</file>
 			<file>tests/php/test_class.jetpack-options.php</file>
-			<file>tests/php/test_php-lint.php</file>
+		</testsuite>
+		<testsuite name="php-lint">
+			<file phpVersion="5.3.0" phpVersionOperator="lte">tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>


### PR DESCRIPTION
The logic behind this is that we check the syntax only on PHP versions that are older than 5.4 to avoid unnecessarily spent time on these tests. It's the same code, so the lowest versions will serve as the lowest common denominator of sorts.
