### PR TITLE
Deactivate VP only if Rewind is active

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7021,7 +7021,7 @@ p {
 			$rewind_data = (array) Jetpack_Core_Json_Api_Endpoints::rewind_data();
 			$rewind_enabled = ( ! is_wp_error( $rewind_data )
 				&& ! empty( $rewind_data['state'] )
-				&& 'unavailable' !== $rewind_data['state'] )
+				&& 'active' === $rewind_data['state'] )
 				? 1
 				: 0;
 


### PR DESCRIPTION
This PR modifies the `is_rewind_enabled` method to only return `true` if rewind is ACTIVE, rather than AVAILABLE as it was for the Pressable release, since all of the migration paths require user intervention/confirmation before migration.  This affects the behavior of "auto-deactivating" VP which was added in #8378. 

p9rlnk-3T-p2