### PR TITLE
Indent 'show sort controls' checkbox

### DIFF
--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -9,8 +9,8 @@
 	text-align: right;
 }
 
-.jetpack-search-filters-widget__sort-controls-enabled {
-	margin-left: 20px !important;
+.jetpack-search-filters-widget .jetpack-search-filters-widget__sort-controls-enabled {
+	margin-left: 24px;
 }
 
 .jetpack-search-filters-widget__controls .delete {

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -9,6 +9,10 @@
 	text-align: right;
 }
 
+.jetpack-search-filters-widget__sort-controls-enabled {
+	margin-left: 20px !important;
+}
+
 .jetpack-search-filters-widget__controls .delete {
 	color: #a00;
 }


### PR DESCRIPTION
Addresses a UI issue raised by @jeffgolenski in https://github.com/Automattic/jetpack/pull/8542

Indents the checkbox for enabling sort controls since it is dependent on the search box being enabled.

<img width="292" alt="sort-control-indent" src="https://user-images.githubusercontent.com/51896/35236612-c7b0734c-ff5c-11e7-8c42-19d47a9bcc82.png">
