### PR TITLE
Use tag.name/category.name instead of tag/category for search field

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -668,7 +668,7 @@ class Jetpack_Search {
 			'blog_id'        => get_current_blog_id(),
 
 			'query'          => null,    // Search phrase
-			'query_fields'   => array( 'title', 'content', 'author', 'tag', 'category' ),
+			'query_fields'   => array( 'title', 'content', 'author', 'tag.name', 'category' ),
 
 			'post_type'      => null,  // string or an array
 			'terms'          => array(), // ex: array( 'taxonomy-1' => array( 'slug' ), 'taxonomy-2' => array( 'slug-a', 'slug-b' ) )

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -668,7 +668,7 @@ class Jetpack_Search {
 			'blog_id'        => get_current_blog_id(),
 
 			'query'          => null,    // Search phrase
-			'query_fields'   => array( 'title', 'content', 'author', 'tag.name', 'category' ),
+			'query_fields'   => array( 'title', 'content', 'author', 'tag.name', 'category.name' ),
 
 			'post_type'      => null,  // string or an array
 			'terms'          => array(), // ex: array( 'taxonomy-1' => array( 'slug' ), 'taxonomy-2' => array( 'slug-a', 'slug-b' ) )


### PR DESCRIPTION
Fixes #8114

We were searching by tag before, but tag is an object with a `tag.name.*` property (in the global index) so we weren't matching any records.

This fixes the issue, when combined with r168666-wpcom

To test:
- tag some content with a unique tag that doesn't match any text, e.g. `customtag1234`
- search by that tag alone
- results should match the tagged posts
- do the same for a category