### PR TITLE
Ads: January Ads Tweaks

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1731,7 +1731,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'enable_header_ad' => array(
 				'description'        => esc_html__( 'Display an ad unit at the top of each page.', 'jetpack' ),
 				'type'               => 'boolean',
-				'default'            => 0,
+				'default'            => 1,
 				'validate_callback'  => __CLASS__ . '::validate_boolean',
 				'jp_group'           => 'wordads',
 			),

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -13,7 +13,7 @@ class WordAds_Params {
 			'wordads_approved'           => false,
 			'wordads_active'             => false,
 			'wordads_house'              => true,
-			'enable_header_ad'           => false,
+			'enable_header_ad'           => true,
 			'wordads_second_belowpost'   => true,
 			'wordads_display_front_page' => true,
 			'wordads_display_post'       => true,

--- a/modules/wordads/php/widgets.php
+++ b/modules/wordads/php/widgets.php
@@ -8,6 +8,7 @@
 class WordAds_Sidebar_Widget extends WP_Widget {
 
 	private static $allowed_tags = array( 'mrec', 'wideskyscraper' );
+	private static $num_widgets = 0;
 
 	function __construct() {
 		parent::__construct(
@@ -31,9 +32,14 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 			$instance['unit'] = 'mrec';
 		}
 
+		self::$num_widgets++;
 		$about = __( 'Advertisements', 'jetpack' );
 		$width = WordAds::$ad_tag_ids[$instance['unit']]['width'];
 		$height = WordAds::$ad_tag_ids[$instance['unit']]['height'];
+		$unit_id = 1 == self::$num_widgets ? 3 : self::$num_widgets + 3; // 2nd belowpost is '4'
+		$section_id = 0 === $wordads->params->blog_id ?
+			WORDADS_API_TEST_ID :
+			$wordads->params->blog_id . $unit_id;
 
 		$snippet = '';
 		if ( $wordads->option( 'wordads_house', true ) ) {
@@ -46,7 +52,6 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 
 			$snippet = $wordads->get_house_ad( $unit );
 		} else {
-			$section_id = 0 === $wordads->params->blog_id ? WORDADS_API_TEST_ID : $wordads->params->blog_id . '3';
 			$snippet = $wordads->get_ad_snippet( $section_id, $height, $width );
 		}
 

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -114,10 +114,32 @@ class WordAds {
 		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
+		/**
+		 * Filters enabling ads in `the_content` filter
+		 *
+		 * @see https://jetpack.com/support/ads/
+		 *
+		 * @module wordads
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param bool True to disable ads in `the_content`
+		 */
 		if ( ! apply_filters( 'wordads_content_disable', false ) ) {
 			add_filter( 'the_content', array( $this, 'insert_ad' ) );
 		}
 
+		/**
+		 * Filters enabling ads in `the_excerpt` filter
+		 *
+		 * @see https://jetpack.com/support/ads/
+		 *
+		 * @module wordads
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param bool True to disable ads in `the_excerpt`
+		 */
 		if ( ! apply_filters( 'wordads_excerpt_disable', false ) ) {
 			add_filter( 'the_excerpt', array( $this, 'insert_ad' ) );
 		}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -113,10 +113,16 @@ class WordAds {
 		add_action( 'wp_head', array( $this, 'insert_head_meta' ), 20 );
 		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_filter( 'the_content', array( $this, 'insert_ad' ) );
-		add_filter( 'the_excerpt', array( $this, 'insert_ad' ) );
 
-		if ( $this->option( 'enable_header_ad' ) ) {
+		if ( ! apply_filters( 'wordads_content_disable', false ) ) {
+			add_filter( 'the_content', array( $this, 'insert_ad' ) );
+		}
+
+		if ( ! apply_filters( 'wordads_excerpt_disable', false ) ) {
+			add_filter( 'the_excerpt', array( $this, 'insert_ad' ) );
+		}
+
+		if ( $this->option( 'enable_header_ad', true ) ) {
 			switch ( get_stylesheet() ) {
 				case 'twentyseventeen':
 				case 'twentyfifteen':


### PR DESCRIPTION
A handful of small updates to bring Jetpack Ads on par w/ .com.

Notably:
1. Default header unit to on.
2. Increment widget unit section ids so they’re unique.
3. Ensure belowpost unit(s) only gets displayed once per page.

**To Test**
1. Enable Jetpack Ads module on a fresh install
    1. Check that header unit is defaulted on
1. Enable `Display second ad below post`
    1. Check to see that 2nd unit appears below post.
    1. Check to see that below post units only appear once in front page.
1. Add two Ads widgets under `Appearance -> Widgets`, check both load.