### PR TITLE
Search: Open filters help link in filters widget in a new tab to avoid leaving customizer

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -411,7 +411,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 					<?php $this->render_widget_filter( $filter ); ?>
 				<?php endforeach; ?>
 				<div class="jetpack-search-filters-help">
-					<a href="https://jetpack.com/support/search/#filters-not-showing-up"><?php esc_html_e( 'Why aren\'t my filters appearing?', 'jetpack' ); ?></a>
+					<a href="https://jetpack.com/support/search/#filters-not-showing-up" target="_blank"><?php esc_html_e( "Why aren't my filters appearing?", 'jetpack' ); ?></a>
 				</div>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
Makes the "Why aren't my filters appearing?" link at the bottom of the search filters widget open in a new tab so that you don't navigate away from the customizer in the process. Changes likely wouldn't be lost due to auto-save but this improves the user experience since presumably the user isn't finished with the customizer yet.

Also a minor string change to avoid having to escape a single quote.