### PR TITLE
Search: Add tracks events

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -196,14 +196,15 @@ class Jetpack_Search_Helpers {
 				: $new_value[ $diff[0] ];
 		} else if ( count( $old_keys ) > count( $new_keys ) ) { // This is the case for a widget being deleted
 			$diff = self::array_diff( $old_keys, $new_keys );
-
 			$action = 'widget_deleted';
 			$widget = empty( $diff ) || ! isset( $old_value[ $diff[0] ] )
 				? false
 				: $old_value[ $diff[0] ];
+		} else {
+			$action = 'widget_updated';
 		}
 
-		if ( empty( $action ) || empty( $diff ) || empty( $widget ) ) {
+		if ( empty( $action ) || empty( $widget ) ) {
 			return false;
 		}
 

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -172,4 +172,90 @@ class Jetpack_Search_Helpers {
 		$diff_query = self::array_diff( (array) $instance['post_types'], $post_types_from_query );
 		return ! empty( $diff_query );
 	}
+
+	static function get_widget_tracks_value( $old_value, $new_value ) {
+		$old_value = (array) $old_value;
+		if ( isset( $old_value['_multiwidget'] ) ) {
+			unset( $old_value['_multiwidget'] );
+		}
+
+		$new_value = (array) $new_value;
+		if ( isset( $new_value['_multiwidget'] ) ) {
+			unset( $new_value['_multiwidget'] );
+		}
+
+		$action = '';
+		$old_keys = array_keys( $old_value );
+		$new_keys = array_keys( $new_value );
+
+		if ( count( $new_keys ) > count( $old_keys ) ) { // This is the case for a widget being added
+			$diff = self::array_diff( $new_keys, $old_keys );
+			$action = 'widget_added';
+			$widget = empty( $diff ) || ! isset( $new_value[ $diff[0] ] )
+				? false
+				: $new_value[ $diff[0] ];
+		} else if ( count( $old_keys ) > count( $new_keys ) ) { // This is the case for a widget being deleted
+			$diff = self::array_diff( $old_keys, $new_keys );
+
+			$action = 'widget_deleted';
+			$widget = empty( $diff ) || ! isset( $old_value[ $diff[0] ] )
+				? false
+				: $old_value[ $diff[0] ];
+		}
+
+		if ( empty( $action ) || empty( $diff ) || empty( $widget ) ) {
+			return false;
+		}
+
+		return array(
+			'action' => $action,
+			'widget' => self::get_widget_properties_for_tracks( $widget ),
+		);
+	}
+
+	static function get_widget_properties_for_tracks( $widget ) {
+		$sanitized = array();
+
+		foreach ( (array) $widget as $key => $value ) {
+			if ( '_multiwidget' == $key ) {
+				continue;
+			}
+			if ( is_scalar( $value ) ) {
+				$key = str_replace( '-', '_', sanitize_key( $key ) );
+				$key = "widget_{$key}";
+				$sanitized[ $key ] = $value;
+			}
+		}
+
+		$filters_properties = ! empty( $widget['filters'] )
+			? self::get_filter_properties_for_tracks( $widget['filters'] )
+			: array();
+
+		return array_merge( $sanitized, $filters_properties );
+	}
+
+	static function get_filter_properties_for_tracks( $filters ) {
+		if ( empty( $filters ) ) {
+			return $filters;
+		}
+
+		$filters_properties = array(
+			'widget_filter_count' => count( $filters ),
+		);
+
+		foreach ( $filters as $filter ) {
+			if ( empty( $filter['type'] ) ) {
+				continue;
+			}
+
+			$key = sprintf( 'widget_filter_type_%s', $filter['type'] );
+			if ( isset( $filters_properties[ $key ] ) ) {
+				$filters_properties[ $key ]++;
+			} else {
+				$filters_properties[ $key ] = 1;
+			}
+		}
+
+		return $filters_properties;
+	}
 }

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -312,8 +312,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	function update( $new_instance, $old_instance ) {
 		$instance = array();
 
-		error_log( print_r( array( $_GET, $_POST ), true ) );
-
 		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		$instance['use_filters'] = empty( $new_instance['use_filters'] ) ? '0' : '1';
 		$instance['search_box_enabled'] = empty( $new_instance['search_box_enabled'] ) ? '0' : '1';

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -102,6 +102,8 @@ class Jetpack_Search {
 			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
 
 			add_action( 'pre_get_posts', array( $this, 'maybe_add_post_type_as_var' ) );
+		} else {
+			add_action( 'update_option', array( $this, 'track_widget_updates' ), 10, 3 );
 		}
 	}
 
@@ -1533,5 +1535,22 @@ class Jetpack_Search {
 		}
 
 		return $reordered;
+	}
+
+	public function track_widget_updates( $option, $old_value, $new_value ) {
+		if ( 'widget_jetpack-search-filters' !== $option ) {
+			return;
+		}
+
+		$event = Jetpack_Search_Helpers::get_widget_tracks_value( $old_value, $new_value );
+		if ( ! $event ) {
+			return;
+		}
+
+		jetpack_tracks_record_event(
+			wp_get_current_user(),
+			sprintf( 'jetpack_search_widget_%s', $event['action'] ),
+			$event['widget']
+		);
 	}
 }

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -1,4 +1,4 @@
-/* globals jetpack_search_filter_admin, jQuery */
+/* globals jetpack_search_filter_admin, jQuery, analytics */
 
 ( function( $, args ) {
 	var defaultFilterCount = ( 'undefined' !== typeof args && args.defaultFilterCount ) ?
@@ -15,9 +15,9 @@
 	} );
 
 	var setListeners = function( widget ) {
-		widget = ( 'undefined' === typeof widget )
-			? $( '.jetpack-search-filters-widget' )
-			: widget;
+		widget = ( 'undefined' === typeof widget ) ?
+			$( '.jetpack-search-filters-widget' ):
+			widget;
 
 		widget.on( 'change', '.filter-select', function() {
 			var select = $( this ),
@@ -205,7 +205,7 @@
 		widget.off( 'change', '.jetpack-search-filters-widget__sort-order' );
 		widget.off( 'change', '.jetpack-search-filters-widget__taxonomy-select' );
 		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:first select' );
-		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:eq(1) select' )
+		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:eq(1) select' );
 
 		setListeners( widget );
 	} );

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -5,32 +5,122 @@
 		args.defaultFilterCount :
 		5; // Just in case we couldn't find the defaultFiltercount arg
 
-	var setListeners = function() {
-		var widget = $( '.jetpack-search-filters-widget' );
+	$( document ).ready( function() {
+		setListeners();
+
+		// Initialize Tracks
+		if ( 'undefined' !== typeof analytics && args.tracksUserData ) {
+			analytics.initialize( args.tracksUserData.userid, args.tracksUserData.username );
+		}
+	} );
+
+	var setListeners = function( widget ) {
+		widget = ( 'undefined' === typeof widget )
+			? $( '.jetpack-search-filters-widget' )
+			: widget;
 
 		widget.on( 'change', '.filter-select', function() {
 			var select = $( this ),
-				selectVal = select.val();
+				selectVal = select.val(),
+				eventArgs = {
+					is_customizer: args.tracksEventData.is_customizer
+				};
+
+			eventArgs.type = selectVal;
 
 			select
 				.closest( '.jetpack-search-filters-widget__filter' )
 				.attr( 'class', 'jetpack-search-filters-widget__filter' )
 				.addClass( 'is-' + selectVal );
+
+			trackAndBumpMCStats( 'changed_filter_type', eventArgs );
 		} );
 
 		// enable showing sort controls only if showing search box is enabled
 		widget.on( 'change', '.jetpack-search-filters-widget__search-box-enabled', function() {
 			var checkbox = $( this ),
-				checkboxVal = checkbox.is(':checked');
+				checkboxVal = checkbox.is(':checked'),
+				filterParent = checkbox.closest( '.jetpack-search-filters-widget' ),
+				sortControl = filterParent.find( '.jetpack-search-filters-widget__sort-controls-enabled' );
 
-			var sortControl = checkbox.closest( '.jetpack-search-filters-widget' ).find( '.jetpack-search-filters-widget__sort-controls-enabled' );
+			filterParent.toggleClass( 'hide-post-types' );
 
 			if ( checkboxVal ) {
 				sortControl.removeAttr( 'disabled' );
+				trackAndBumpMCStats( 'enabled_search_box', args.tracksEventData );
 			} else {
 				sortControl.prop( 'checked', false );
 				sortControl.prop( 'disabled', true );
+				trackAndBumpMCStats( 'disabled_search_box', args.tracksEventData );
 			}
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__sort-controls-enabled', function() {
+			if ( $( this ).is( ':checked' ) ) {
+				trackAndBumpMCStats( 'enabled_sort_controls', args.tracksEventData );
+			} else {
+				trackAndBumpMCStats( 'disabled_sort_controls', args.tracksEventData );
+			}
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__post-type-selector', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.post_types = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_post_types', eventArgs );
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__sort-order', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.order = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_sort_order', eventArgs );
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__taxonomy-select select', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.taxonomy = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_taxonomy', eventArgs );
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__date-histogram-select:first select', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.field = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_date_field', eventArgs );
+		} );
+
+		widget.on( 'change', '.jetpack-search-filters-widget__date-histogram-select:eq(1) select', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.interval = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_date_interval', eventArgs );
+		} );
+
+		widget.on( 'change', '.filter-count', function() {
+			var eventArgs = {
+				is_customizer: args.tracksEventData.is_customizer
+			};
+
+			eventArgs.count = $( this ).val();
+
+			trackAndBumpMCStats( 'changed_filter_count', eventArgs );
 		} );
 
 		widget.on( 'click', '.jetpack-search-filters-widget__controls .add', function( e ) {
@@ -46,36 +136,106 @@
 
 			clone.insertAfter( closest );
 			clone.find( 'input, textarea, select' ).change();
+
+			trackAndBumpMCStats( 'added_filter', args.tracksEventData );
 		} );
 
 		widget.on( 'click', '.jetpack-search-filters-widget__controls .delete', function( e ) {
 			e.preventDefault();
-			var filter = $( this ).closest( '.jetpack-search-filters-widget__filter' );
+			var filter = $( this ).closest( '.jetpack-search-filters-widget__filter' ),
+				eventArgs = {
+					is_customizer: args.tracksEventData.is_customizer
+				};
+
+			eventArgs.type = filter.find( '.filter-select' ).val();
+
+			switch ( eventArgs.type ) {
+				case 'taxonomy':
+					eventArgs.taxonomy = filter.find( '.jetpack-search-filters-widget__taxonomy-select select' ).val();
+					break;
+				case 'date_histogram':
+					eventArgs.dateField = filter.find( '.jetpack-search-filters-widget__date-histogram-select:first select' ).val();
+					eventArgs.dateInterval = filter.find( '.jetpack-search-filters-widget__date-histogram-select:nth-child( 2 ) select' ).val();
+					break;
+			}
+
+			eventArgs.filterCount = filter.find( '.filter-count' ).val();
+
+			trackAndBumpMCStats( 'deleted_filter', eventArgs );
+
 			filter.find( 'input, textarea, select' ).change();
 			filter.remove();
 		} );
 
 		widget.on( 'change', '.jetpack-search-filters-widget__use-filters', function() {
-			$( this ).closest( '.jetpack-search-filters-widget' ).toggleClass( 'hide-filters' );
-		} );
+			var selector = $( this ).closest( '.jetpack-search-filters-widget' );
 
-		widget.on( 'change', '.jetpack-search-filters-widget__search-box-enabled', function() {
-			$( this ).closest( '.jetpack-search-filters-widget' ).toggleClass( 'hide-post-types' );
+			if ( $( this ).is(':checked') ) {
+				trackAndBumpMCStats( 'enabled_filters', args.tracksEventData );
+			} else {
+				trackAndBumpMCStats( 'disabled_filters', args.tracksEventData );
+			}
+
+			selector.toggleClass( 'hide-filters' );
 		} );
 	};
 
-	$( document ).ready( function() {
-		setListeners();
-	} );
-
 	// When widgets are updated, remove and re-add listeners
-	$( document ).on( 'widget-updated widget-added', function() {
-		var widget = $( '.jetpack-search-filters-widget' );
+	$( document ).on( 'widget-updated widget-added', function( e, widget ) {
+		widget = $( widget );
+
+		var id = widget.attr( 'id' ),
+			isJetpackSearch = ( id && ( -1 !== id.indexOf( 'jetpack-search-filters' ) ) );
+
+		if ( ! isJetpackSearch ) {
+			 return;
+		}
+
+		// Intentionally not tracking widget additions and updates here as these events
+		// seem noisy in the customizer. We'll track those via PHP.
+
 		widget.off( 'change', '.filter-select' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .delete' );
 		widget.off( 'change', '.jetpack-search-filters-widget__use-filters' );
 		widget.off( 'change', '.jetpack-search-filters-widget__search-box-enabled' );
-		setListeners();
+		widget.off( 'change', '.jetpack-search-filters-widget__sort-controls-enabled' );
+		widget.off( 'change', '.jetpack-search-filters-widget__sort-controls-enabled' );
+		widget.off( 'change', '.jetpack-search-filters-widget__post-type-selector' );
+		widget.off( 'change', '.jetpack-search-filters-widget__sort-order' );
+		widget.off( 'change', '.jetpack-search-filters-widget__taxonomy-select' );
+		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:first select' );
+		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:eq(1) select' )
+
+		setListeners( widget );
 	} );
+
+	/**
+	 * This function will fire both a Tracks and MC stat.
+	 *
+	 * Tracks: Will be prefixed by 'jetpack_widget_search_' and use underscores.
+	 * MC: Will not be prefixed, and will use dashes.
+	 *
+	 * Logic borrowed from `idc-notice.js`.
+	 *
+	 * @param eventName string
+	 * @param extraProps object
+	 */
+	function trackAndBumpMCStats( eventName, extraProps ) {
+		if ( 'undefined' === typeof extraProps || 'object' !== typeof extraProps ) {
+			extraProps = {};
+		}
+
+		if ( eventName && eventName.length && 'undefined' !== typeof analytics && analytics.tracks && analytics.mc ) {
+			// Format for Tracks
+			eventName = eventName.replace( /-/g, '_' );
+			eventName = eventName.indexOf( 'jetpack_widget_search_' ) !== 0 ? 'jetpack_widget_search_' + eventName : eventName;
+			analytics.tracks.recordEvent( eventName, extraProps );
+
+			// Now format for MC stats
+			eventName = eventName.replace( 'jetpack_widget_search_', '' );
+			eventName = eventName.replace( /_/g, '-' );
+			analytics.mc.bumpStat( 'jetpack-search-widget', eventName );
+		}
+	}
 } )( jQuery, jetpack_search_filter_admin );

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -485,10 +485,13 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	}
 
 	function get_widget_tracks_value_data() {
+		$instance_with_filter_updated = $this->get_sample_widget_instance();
+		$instance_with_filter_updated['filters'][1] = $this->get_tag_filter();
+
 		return array(
 			'widget_updated_added_filters' => array(
 				array(
-					'action' => 'widget_added',
+					'action' => 'widget_updated',
 					'widget' => array(
 						'widget_title' => 'Search',
 						'widget_use_filters' => 1,
@@ -502,13 +505,14 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 			),
 			'widget_updated_title_changed' => array(
 				array(
-					'action' => 'widget_added',
+					'action' => 'widget_updated',
 					'widget' => array(
 						'widget_title' => 'changed',
 						'widget_use_filters' => 1,
 						'widget_search_box_enabled' => 1,
-						'widget_filter_count' => 1,
+						'widget_filter_count' => 2,
 						'widget_filter_type_taxonomy' => 1,
+						'widget_filter_type_post_type' => 1
 					)
 				),
 				array( $this->get_sample_widget_instance() ),
@@ -516,7 +520,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 			),
 			'widget_update_removed_filters' => array(
 				array(
-					'action' => 'widget_added',
+					'action' => 'widget_updated',
 					'widget' => array(
 						'widget_title' => 'Search',
 						'widget_use_filters' => 0,
@@ -525,6 +529,86 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 				),
 				array( $this->get_sample_widget_instance( 2 ) ),
 				array( $this->get_sample_widget_instance( 0 ) ),
+			),
+			'multiple_widgets_one_title_changed' => array(
+				array(
+					'action' => 'widget_updated',
+					'widget' => array(
+						'widget_title' => 'updated',
+						'widget_use_filters' => 0,
+						'widget_search_box_enabled' => 1,
+					)
+				),
+				array(
+					'0' => $this->get_sample_widget_instance( 0 ),
+					'1' => $this->get_sample_widget_instance( 1 ),
+					'2' => $this->get_sample_widget_instance( 2 ),
+					'_multiwidget' => 1
+				),
+				array(
+					'0' => array_merge( $this->get_sample_widget_instance( 0 ), array( 'title' => 'updated' ) ),
+					'1' => $this->get_sample_widget_instance( 1 ),
+					'2' => $this->get_sample_widget_instance( 2 ),
+					'_multiwidget' => 1
+				),
+				array(
+					'_multiwidget' => 1
+				)
+			),
+			'multiple_widgets_filter_added' => array(
+				array(
+					'action' => 'widget_updated',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 2,
+						'widget_filter_type_taxonomy' => 1,
+						'widget_filter_type_post_type' => 1
+					)
+				),
+				array(
+					'0' => $this->get_sample_widget_instance( 0 ),
+					'1' => $this->get_sample_widget_instance( 1 ),
+					'2' => $this->get_sample_widget_instance( 2 ),
+					'_multiwidget' => 1
+				),
+				array(
+					'0' => $this->get_sample_widget_instance( 0 ),
+					'1' => $this->get_sample_widget_instance( 2 ),
+					'2' => $this->get_sample_widget_instance( 2 ),
+					'_multiwidget' => 1
+				),
+				array(
+					'_multiwidget' => 1
+				)
+			),
+			'multiple_widgets_filter_updated' => array(
+				array(
+					'action' => 'widget_updated',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 2,
+						'widget_filter_type_taxonomy' => 2,
+					)
+				),
+				array(
+					'0' => $this->get_sample_widget_instance( 0 ),
+					'1' => $this->get_sample_widget_instance( 1 ),
+					'2' => $this->get_sample_widget_instance( 2 ),
+					'_multiwidget' => 1
+				),
+				array(
+					'0' => $this->get_sample_widget_instance( 0 ),
+					'1' => $this->get_sample_widget_instance( 1 ),
+					'2' => $instance_with_filter_updated,
+					'_multiwidget' => 1
+				),
+				array(
+					'_multiwidget' => 1
+				)
 			),
 			'widget_added_from_empty' => array(
 				array(
@@ -540,7 +624,8 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 				),
 				array( '_multiwidget' => 1 ),
 				array(
-					array_merge( $this->get_sample_widget_instance(), array( '_multiwidget' => 1 ) )
+					'0' => $this->get_sample_widget_instance(),
+					'_multiwidget' => 1,
 				),
 			),
 			'widget_removed_none_to_empty' => array(
@@ -556,7 +641,8 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 					)
 				),
 				array(
-					array_merge( $this->get_sample_widget_instance(), array( '_multiwidget' => 1 ) )
+					'0' => $this->get_sample_widget_instance(),
+					'_multiwidget' => 1
 				),
 				array( '_multiwidget' => 1 ),
 			),

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -487,17 +487,42 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	function get_widget_tracks_value_data() {
 		return array(
 			'widget_updated_added_filters' => array(
-				false,
+				array(
+					'action' => 'widget_added',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 1,
+						'widget_filter_type_taxonomy' => 1,
+					)
+				),
 				array( $this->get_sample_widget_instance( 0 ) ),
 				array( $this->get_sample_widget_instance( 1 ) ),
 			),
 			'widget_updated_title_changed' => array(
-				false,
+				array(
+					'action' => 'widget_added',
+					'widget' => array(
+						'widget_title' => 'changed',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 1,
+						'widget_filter_type_taxonomy' => 1,
+					)
+				),
 				array( $this->get_sample_widget_instance() ),
 				array( array_merge( $this->get_sample_widget_instance(), array( 'title' => 'changed' ) ) ),
 			),
 			'widget_update_removed_filters' => array(
-				false,
+				array(
+					'action' => 'widget_added',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 0,
+						'widget_search_box_enabled' => 1,
+					)
+				),
 				array( $this->get_sample_widget_instance( 2 ) ),
 				array( $this->get_sample_widget_instance( 0 ) ),
 			),

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -225,6 +225,27 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider get_filter_properties_for_tracks_data
+	 */
+	function test_get_filter_properties_for_tracks( $expected, $filters ) {
+		$this->assertSame( $expected, Jetpack_Search_Helpers::get_filter_properties_for_tracks( $filters ) );
+	}
+
+	/**
+	 * @dataProvider get_widget_properties_for_tracks_data
+	 */
+	function test_get_widget_properties_for_tracks( $expected, $widget ) {
+		$this->assertSame( $expected, Jetpack_Search_Helpers::get_widget_properties_for_tracks( $widget ) );
+	}
+
+	/**
+	 * @dataProvider get_widget_tracks_value_data
+	 */
+	function test_get_widget_tracks_value( $expected, $old_value, $new_value ) {
+		$this->assertSame( $expected, Jetpack_Search_Helpers::get_widget_tracks_value( $old_value, $new_value ) );
+	}
+
+	/**
 	 * Data providers
 	 */
 	function get_build_widget_id_data() {
@@ -400,6 +421,163 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 		);
 	}
 
+	function get_filter_properties_for_tracks_data() {
+		return array(
+			'empty_filters' => array(
+				array(),
+				array()
+			),
+			'single_filter' => array(
+				array(
+					'widget_filter_count' => 1,
+					'widget_filter_type_taxonomy' => 1,
+				),
+				array(
+					$this->get_cat_filter()
+				)
+			),
+			'multiple_filters' => array(
+				array(
+					'widget_filter_count' => 3,
+					'widget_filter_type_taxonomy' => 2,
+					'widget_filter_type_post_type' => 1,
+				),
+				array(
+					$this->get_cat_filter(),
+					$this->get_post_type_filter(),
+					$this->get_tag_filter()
+				)
+			)
+		);
+	}
+
+	function get_widget_properties_for_tracks_data() {
+		return array(
+			'empty_instance' => array(
+				array(),
+				array()
+			),
+			'instance_with_only_multiwidet' => array(
+				array(),
+				array(
+					'_multiwidget' => 1,
+				),
+			),
+			'instance_with_no_filters' => array(
+				array(
+					'widget_title' => 'Search',
+					'widget_use_filters' => 0,
+					'widget_search_box_enabled' => 1,
+				),
+				$this->get_sample_widget_instance( 0 )
+			),
+			'instance_with_filters' => array(
+				array(
+					'widget_title' => 'Search',
+					'widget_use_filters' => 1,
+					'widget_search_box_enabled' => 1,
+					'widget_filter_count' => 1,
+					'widget_filter_type_taxonomy' => 1,
+				),
+				$this->get_sample_widget_instance( 1 )
+			),
+		);
+	}
+
+	function get_widget_tracks_value_data() {
+		return array(
+			'widget_updated_added_filters' => array(
+				false,
+				array( $this->get_sample_widget_instance( 0 ) ),
+				array( $this->get_sample_widget_instance( 1 ) ),
+			),
+			'widget_updated_title_changed' => array(
+				false,
+				array( $this->get_sample_widget_instance() ),
+				array( array_merge( $this->get_sample_widget_instance(), array( 'title' => 'changed' ) ) ),
+			),
+			'widget_update_removed_filters' => array(
+				false,
+				array( $this->get_sample_widget_instance( 2 ) ),
+				array( $this->get_sample_widget_instance( 0 ) ),
+			),
+			'widget_added_from_empty' => array(
+				array(
+					'action' => 'widget_added',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 2,
+						'widget_filter_type_taxonomy' => 1,
+						'widget_filter_type_post_type' => 1,
+					)
+				),
+				array( '_multiwidget' => 1 ),
+				array(
+					array_merge( $this->get_sample_widget_instance(), array( '_multiwidget' => 1 ) )
+				),
+			),
+			'widget_removed_none_to_empty' => array(
+				array(
+					'action' => 'widget_deleted',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 2,
+						'widget_filter_type_taxonomy' => 1,
+						'widget_filter_type_post_type' => 1,
+					)
+				),
+				array(
+					array_merge( $this->get_sample_widget_instance(), array( '_multiwidget' => 1 ) )
+				),
+				array( '_multiwidget' => 1 ),
+			),
+			'widget_added_one_to_two' => array(
+				array(
+					'action' => 'widget_added',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 1,
+						'widget_search_box_enabled' => 1,
+						'widget_filter_count' => 1,
+						'widget_filter_type_taxonomy' => 1,
+					)
+				),
+				array(
+					$this->get_sample_widget_instance(),
+					'_multiwidget' => 1,
+				),
+				array(
+					$this->get_sample_widget_instance(),
+					$this->get_sample_widget_instance( 1 ),
+					'_multiwidget' => 1,
+				)
+			),
+			'widget_added_two_to_one' => array(
+				array(
+					'action' => 'widget_deleted',
+					'widget' => array(
+						'widget_title' => 'Search',
+						'widget_use_filters' => 0,
+						'widget_search_box_enabled' => 1,
+					)
+				),
+				array(
+					'1' => $this->get_sample_widget_instance( 0 ),
+					'2' => $this->get_sample_widget_instance( 1 ),
+					'_multiwidget' => 1,
+				),
+				array(
+					'2' => $this->get_sample_widget_instance( 1 ),
+					'_multiwidget' => 1,
+				),
+			),
+		);
+	}
+
 	/**
 	 * Helpers
 	 */
@@ -469,12 +647,19 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	}
 
 	function get_sample_widget_instance( $count_filters = 2, $count_cat = 4 ) {
-		return array(
+		$instance = array(
 			'title' => 'Search',
-			'use_filters' => 1,
+			'use_filters' => 0,
 			'search_box_enabled' => 1,
-			'filters' => $this->get_sample_filters( $count_filters, $count_cat )
+
 		);
+
+		if ( $count_filters > 0 ) {
+			$instance['use_filters'] = 1;
+			$instance['filters'] = $this->get_sample_filters( $count_filters, $count_cat );
+		}
+
+		return $instance;
 	}
 
 	function get_cat_filter( $count = 4 ) {
@@ -483,6 +668,15 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 			'type' => 'taxonomy',
 			'taxonomy' => 'category',
 			'count' => $count,
+		);
+	}
+
+	function get_tag_filter() {
+		return array(
+			'name' => 'Tags',
+			'type' => 'taxonomy',
+			'taxonomy' => 'tag',
+			'count' => 2,
 		);
 	}
 


### PR DESCRIPTION
Fixes #8571

This PR adds analytics to the Jetpack Search feature. At the moment, specifically in the widget UI.

I'd still like to figure out a way to track when a widget is added or updated that way we can understand how many widgets are being added to each site, which filters are most used, etc.

To test:

- Checkout branch on a site with a Jetpack Professional plan
- Add a Jetpack Search widget
- Make changes to widget
- Delete widget
- Check and ensure events were logged in tracks