### PR TITLE
Masterbar: Fix compatibility with BeaverBuilder plugin.

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -13,6 +13,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/vaultpress.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/beaverbuilder.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/beaverbuilder.php
+++ b/3rd-party/beaverbuilder.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Beaverbuilder Compatibility.
+ */
+class BeaverBuilderCompat {
+
+	function __construct() {
+		add_action( 'init', array( $this, 'masterbar_refresh' ) );
+	}
+
+	/**
+	 * If masterbar module is active force BeaverBuilder to refresh when publishing a layout.
+	 */
+	function masterbar_refresh() {
+		if ( Jetpack::is_module_active( 'masterbar' ) ) {
+			add_filter( 'fl_builder_should_refresh_on_publish', '__return_true' );
+		}
+	}
+}
+new BeaverBuilderCompat();

--- a/3rd-party/beaverbuilder.php
+++ b/3rd-party/beaverbuilder.php
@@ -5,13 +5,13 @@
 class BeaverBuilderCompat {
 
 	function __construct() {
-		add_action( 'init', array( $this, 'masterbar_refresh' ) );
+		add_action( 'init', array( $this, 'beaverbuilder_refresh' ) );
 	}
 
 	/**
 	 * If masterbar module is active force BeaverBuilder to refresh when publishing a layout.
 	 */
-	function masterbar_refresh() {
+	function beaverbuilder_refresh() {
 		if ( Jetpack::is_module_active( 'masterbar' ) ) {
 			add_filter( 'fl_builder_should_refresh_on_publish', '__return_true' );
 		}


### PR DESCRIPTION
Fixes #8594 

#### Changes proposed in this Pull Request:

* Add filter provided by BeaverBuilder which forces a page refresh on save.

#### Testing instructions:

* Install BeaverBuilder from https://wordpress.org/plugins/beaver-builder-lite-version/
* Make sure WordPress.com toolbar (masterbar) module is active.
* Edit a page with BeaverBuilder, add a module to the page anything you like.
* Click 'Done', then 'Publish'.
* The 'My Sites' link will now be unclickable.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
