### PR TITLE
JPO: skip Business Address widget instance and option update if the content has not changed.

### DIFF
--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -743,12 +743,17 @@ class Jetpack_Widgets {
 			return new WP_Error( 'invalid_data', 'No such widget.', 400 );
 		}
 
-		// Update the widget instance with the new data
-		$widget_instances[ $widget_key ] = array_merge( $widget_instances[ $widget_key ], $widget_options );
+		// Update the widget instance and option if the data has changed
+		if ( $widget_instances[ $widget_key ]['title'] !== $widget_options['title']
+			|| $widget_instances[ $widget_key ]['address'] !== $widget_options['address']
+		) {
 
-		// Store updated widget instances and return Error when not successful
-		if ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) {
-			return new WP_Error( 'widget_update_failed', 'Failed to update widget.', 400 );
+			$widget_instances[ $widget_key ] = array_merge( $widget_instances[ $widget_key ], $widget_options );
+
+			// Store updated widget instances and return Error when not successful
+			if ( ! ( update_option( 'widget_' . $widget_id, $widget_instances ) ) ) {
+				return new WP_Error( 'widget_update_failed', 'Failed to update widget.', 400 );
+			};
 		};
 		return true;
 	}


### PR DESCRIPTION
Fixes: redundant error thrown when updating the Business Address widget.

Currently we update the widget 's content and option containing the Business Address details even if no changes were introduced to the form. `update_option` returns `false` at attempts to update unchanged content resulting in throwing a WP error as an indication of an unsuccessful update. We want to keep an error on unsuccessful update, but do not need to throw it in this scenario.

#### Changes proposed in this Pull Request:

* adds a check to the updating function of whether the widget's content has changed, prior to updating its instance and option with any new data.

#### Testing instructions:

* Follow the instructions on https://github.com/Automattic/jetpack/pull/8426 with a Business site ( or temporarily set `isBusiness` to `true`/remove from the definition of steps in jetpack-onboarding/main.jsx in Calypso). 
* Verify that there are no error when moving back and forth between the Business Address and WooCommerce steps, both when changing the content of the Business Address form and leaving it unchanged.

* Verify that the `jpo_business_address` option is set ( `wp option get jpo_business_address` ) whenever the content has changed and remains unchanged when it did not.

