### PR TITLE
Display taxonomy name in parentheses if we detect a duplicate taxonomy label

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -478,11 +478,15 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 			<p class="jetpack-search-filters-widget__taxonomy-select">
 				<label>
-					<?php esc_html_e( 'Choose a taxonomy:', 'jetpack' ); ?>
+					<?php esc_html_e( 'Choose a taxonomy:', 'jetpack' ); $seen_taxonomy_labels = array(); ?>
 					<select name="<?php echo esc_attr( $this->get_field_name( 'taxonomy_type' ) ); ?>[]" class="widefat">
 						<?php foreach ( get_taxonomies( false, 'objects' ) as $taxonomy ) : ?>
 							<option value="<?php echo esc_attr( $taxonomy->name ); ?>" <?php selected( $taxonomy->name, $args['taxonomy'] ); ?>>
-								<?php echo esc_html( $taxonomy->label ); ?>
+								<?php
+									$label = in_array( $taxonomy->label, $seen_taxonomy_labels ) ? "{$taxonomy->label} ({$taxonomy->name})" : $taxonomy->label;
+									echo esc_html( $label );
+									$seen_taxonomy_labels[] = $taxonomy->label;
+								?>
 							</option>
 						<?php endforeach; ?>
 					</select>


### PR DESCRIPTION
Fixes #8597

Some plugins define taxonomies with common names, like "Tag" (I'm looking at you, WooCommerce ;) ). In order to disambiguate these taxonomies in the Jetpack Search widget taxonomy drop-down, we add the taxonomy name (i.e. slug) in parentheses, since this is required to be unique.

Before:

<img width="399" alt="multiple-tag-instances" src="https://user-images.githubusercontent.com/51896/35297658-894c9e7c-0034-11e8-9e72-b8b1b0884d9a.png">

After:

<img width="414" alt="dupe-tax-label-disambiguation" src="https://user-images.githubusercontent.com/51896/35297615-6653236e-0034-11e8-9425-88a673fbd8c4.png">
