### PR TITLE
Update CODEOWNERS for search

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@
 * @automattic/jetpack
 
 # Individual Modules:
-modules/contact-form/    @georgestephanis
-modules/custom-css/      @georgestephanis
-modules/search/          @Automattic/jetpack-search
+/modules/contact-form/    @georgestephanis
+/modules/custom-css/      @georgestephanis
+/modules/search/          @Automattic/jetpack-search
 
 # Other bits of the Codebase
-class.jetpack-debugger.php @kraftbj
+/class.jetpack-debugger.php @kraftbj
 docs/ @jeherve
-_inc/lib/jetpack-wpes-query-builder/ @gibrown
+/_inc/lib/jetpack-wpes-query-builder/ @gibrown

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,11 @@
 * @automattic/jetpack
 
 # Individual Modules:
-modules/contact-form*    @georgestephanis
-modules/custom-css*      @georgestephanis
+modules/contact-form/    @georgestephanis
+modules/custom-css/      @georgestephanis
+modules/search/          @Automattic/jetpack-search
 
 # Other bits of the Codebase
 class.jetpack-debugger.php @kraftbj
-docs/* @jeherve
+docs/ @jeherve
+_inc/lib/jetpack-wpes-query-builder/ @gibrown


### PR DESCRIPTION
* Adds @Automattic/jetpack-search team as reviewers to any changes to the Search module.
* Adds @gibrown to any changes to the ES Query Builder library.

Also swaps out `*` for `/` so that files in subdirectories get included too. See https://help.github.com/articles/about-codeowners/#codeowners-syntax