### PR TITLE
Added i18n to search widget admin UI taxonomy selector.

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -515,7 +515,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 									$label = in_array( $taxonomy->label, $seen_taxonomy_labels )
 										? sprintf(
 											/* translators: %1$s is the taxonomy name, %2s is the name of its type to help distinguish between several taxonomies with the same name, e.g. category and tag. */
-											__( '%1$s (%2$s)', 'jetpack' ),
+											_x( '%1$s (%2$s)', 'A label for a taxonomy selector option', 'jetpack' ),
 											$taxonomy->label,
 											$taxonomy->name
 										)

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -512,7 +512,14 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 						<?php foreach ( get_taxonomies( false, 'objects' ) as $taxonomy ) : ?>
 							<option value="<?php echo esc_attr( $taxonomy->name ); ?>" <?php selected( $taxonomy->name, $args['taxonomy'] ); ?>>
 								<?php
-									$label = in_array( $taxonomy->label, $seen_taxonomy_labels ) ? "{$taxonomy->label} ({$taxonomy->name})" : $taxonomy->label;
+									$label = in_array( $taxonomy->label, $seen_taxonomy_labels )
+										? sprintf(
+											/* translators: %1$s is the taxonomy name, %2s is the name of its type to help distinguish between several taxonomies with the same name, e.g. category and tag. */
+											__( '%1$s (%2$s)', 'jetpack' ),
+											$taxonomy->label,
+											$taxonomy->name
+										)
+										: $taxonomy->label;
 									echo esc_html( $label );
 									$seen_taxonomy_labels[] = $taxonomy->label;
 								?>


### PR DESCRIPTION
As suggested by @Viper007Bond, labels in the taxonomy selector may need to be adapted to each language, so we need to use a translated string and sprintf values into it.