### PR TITLE
Search: Style sub-heading on front-end of search widget

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -58,6 +58,7 @@ class Jetpack {
 		'wordads',
 		'eu-cookie-law-style',
 		'flickr-widget-style',
+		'jetpack-search-widget'
 	);
 
 	/**

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -29,6 +29,8 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		if ( is_admin() ) {
 			add_action( 'sidebar_admin_setup', array( $this, 'widget_admin_setup' ) );
+		} else {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 		}
 
 		add_action( 'jetpack_search_render_filters_widget_title', array( $this, 'render_widget_title' ), 10, 3 );
@@ -72,6 +74,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		) );
 
 		wp_enqueue_script( 'widget-jetpack-search-filters' );
+	}
+
+	function enqueue_frontend_scripts() {
+		wp_enqueue_style( 'jetpack-search-widget', plugins_url( 'modules/search/css/search-widget-frontend.css', JETPACK__PLUGIN_FILE ) );
 	}
 
 	private function get_sort_types() {
@@ -186,54 +192,19 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			$this->render_widget_search_form( $instance, $orderby, $order );
 		}
 
-		if ( ! empty( $instance['search_box_enabled'] ) && ! empty( $instance['user_sort_enabled'] ) ) {
-			?>
-			<label class="jetpack-search-sort-wrapper">
-				<?php esc_html_e( 'Sort by', 'jetpack' ); ?>
-				<select name="<?php echo esc_attr( $this->get_field_name( 'sort' ) ); ?>" class="jetpack-search-sort">
+		if ( ! empty( $instance['search_box_enabled'] ) && ! empty( $instance['user_sort_enabled'] ) ): ?>
+			<h4 class="jetpack-search-filters-widget__sub-heading"><?php esc_html_e( 'Sort by', 'jetpack' ); ?></h4>
+			<div class="jetpack-search-sort-wrapper">
+				<select class="jetpack-search-sort">
 					<?php foreach( $this->get_sort_types() as $sort => $label ) { ?>
 						<option value="<?php echo esc_attr( $sort ); ?>" <?php selected( $current_sort, $sort ); ?>>
 							<?php echo esc_html( $label ); ?>
 						</option>
 					<?php } ?>
 				</select>
-			</label> <?php
-		}
+			</div>
+		<?php endif;
 
-		/*
-		 * this JS is a bit complicated, but here's what it's trying to do:
-		 * - find or create a search form
-		 * - find or create the orderby/order fields with default values
-		 * - detect changes to the sort field, if it exists, and use it to set the order field values
-		 */
-		?>
-		<script type="text/javascript">
-			jQuery( document ).ready( function( $ ) {
-				var actionUrl      = <?php echo json_encode( home_url( '/' ) ); ?>,
-					orderByDefault = <?php echo json_encode( $orderby ); ?>,
-					orderDefault   = <?php echo json_encode( $order ); ?>,
-					widgetId       = <?php echo json_encode( $this->id ); ?>,
-					currentSearch  = <?php echo json_encode( isset( $_GET['s'] ) ? $_GET['s'] : '' ); ?>
-
-				var container = $('#' + widgetId);
-				var form = container.find('.jetpack-search-form form');
-				var orderBy = form.find( 'input[name=orderby]');
-				var order = form.find( 'input[name=order]');
-				orderBy.val(orderByDefault);
-				order.val(orderDefault);
-
-				container.find( '.jetpack-search-sort' ).change( function( event ) {
-					var values  = event.target.value.split( '|' );
-					orderBy.val( values[0] );
-					order.val( values[1] );
-
-					if ( currentSearch ) {
-						form.submit();
-					}
-				});
-			} );
-		</script>
-		<?php
 		if ( $display_filters ) {
 
 			/**
@@ -263,7 +234,46 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			do_action( 'jetpack_search_render_filters', $filters, $instance, $this->jetpack_search );
 		}
 
+		$this->maybe_render_javascript( $instance, $order, $orderby );
+
 		echo $args['after_widget'];
+	}
+
+	private function maybe_render_javascript( $instance, $order, $orderby ) {
+		if ( ! empty( $instance['user_sort_enabled'] ) ): ?>
+		<!--
+		This JS is a bit complicated, but here's what it's trying to do:
+		- find or create a search form
+		- find or create the orderby/order fields with default values
+		- detect changes to the sort field, if it exists, and use it to set the order field values
+		-->
+		<script type="text/javascript">
+				jQuery( document ).ready( function( $ ) {
+					var actionUrl      = <?php echo json_encode( home_url( '/' ) ); ?>,
+						orderByDefault = <?php echo json_encode( $orderby ); ?>,
+						orderDefault   = <?php echo json_encode( $order ); ?>,
+						widgetId       = <?php echo json_encode( $this->id ); ?>,
+						currentSearch  = <?php echo json_encode( isset( $_GET['s'] ) ? $_GET['s'] : '' ); ?>
+
+					var container = $('#' + widgetId);
+					var form = container.find('.jetpack-search-form form');
+					var orderBy = form.find( 'input[name=orderby]');
+					var order = form.find( 'input[name=order]');
+					orderBy.val(orderByDefault);
+					order.val(orderDefault);
+
+					container.find( '.jetpack-search-sort' ).change( function( event ) {
+						var values  = event.target.value.split( '|' );
+						orderBy.val( values[0] );
+						order.val( values[1] );
+
+						if ( currentSearch ) {
+							form.submit();
+						}
+					});
+				} );
+			</script>
+		<?php endif;
 	}
 
 	private function sorting_to_wp_query_param( $sort ) {
@@ -742,8 +752,9 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		}
 
 		?>
-		<h4 class="widget-title"><?php esc_html_e( 'Current Filters', 'jetpack' ); ?></h4>
-		<ul>
+
+		<h4 class="jetpack-search-filters-widget__sub-heading"><?php esc_html_e( 'Current Filters', 'jetpack' ); ?></h4>
+		<ul class="jetpack-search-filters-widget__filer-list">
 			<?php foreach ( $active_buckets as $item ) : ?>
 				<li>
 					<a href="<?php echo esc_url( $item['remove_url'] ); ?>">
@@ -765,7 +776,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				</li>
 			<?php endif; ?>
 		</ul>
-		<br />
 	<?php }
 
 	/**
@@ -774,8 +784,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	 * @param array $filter
 	 */
 	function render_filter( $filter ) { ?>
-		<h4  class="widget-title"><?php echo esc_html( $filter['name'] ); ?></h4>
-		<ul>
+		<h4 class="jetpack-search-filters-widget__sub-heading">
+			<?php echo esc_html( $filter['name'] ); ?>
+		</h4>
+		<ul class="jetpack-search-filters-widget__filer-list">
 			<?php foreach ( $filter['buckets'] as $item ) : ?>
 				<li>
 					<a href="<?php echo esc_url( $item['url'] ); ?>">
@@ -786,6 +798,5 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				</li>
 			<?php endforeach;?>
 		</ul>
-		<br />
 	<?php }
 }

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -1,0 +1,19 @@
+.jetpack-search-filters-widget__sub-heading {
+	font-size: inherit;
+	font-weight: bold;
+	margin: 0 0 .5em;
+	padding: 0;
+}
+
+/* The first heading after the form */
+.jetpack-search-form + .jetpack-search-filters-widget__sub-heading {
+	margin-top: 1.5em;
+}
+
+.jetpack-search-sort-wrapper {
+	margin-bottom: 1.5em;
+}
+
+ul.jetpack-search-filters-widget__filer-list {
+	margin-bottom: 1.5em;
+}

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -43,7 +43,8 @@ const concat_list = [
 	'css/jetpack-idc-admin-bar.css',
 	'modules/wordads/css/style.css',
 	'modules/widgets/eu-cookie-law/style.css',
-	'modules/widgets/flickr/style.css'
+	'modules/widgets/flickr/style.css',
+	'modules/search/css/search-widget-frontend.css'
 ];
 
 /**


### PR DESCRIPTION
Fixes #8553

Previously, since we were hard-coding in an `h4` and not changing styles, our sub-heading could look out-of-place. This was definitely the case in the TwentySeventeen theme. See #8553 for an example.

To test:

- Checkout branch on site with Jetpack Professional
- `yarn build` to build the `jetpack.css`
- Add search widget
- Add various filters
- Try with sorting controls on/off
- Try selecting a filter to see current filters
- test with/without `define( 'SCRIPT_DEBUG', true );` in `wp-config.php`

Some notes:

- I moved the JavaScript we were outputting to the end of the widget
- I also replaced the label for the sort control with an `h4` to match the other sections in the widget

Here are some current screenshots of the TwentySeventeen theme after this PR:

<img width="408" alt="screen shot 2018-01-24 at 7 22 30 pm" src="https://user-images.githubusercontent.com/1126811/35365803-f7d782aa-013b-11e8-80e6-ef04c7c270e1.png">


<img width="382" alt="screen shot 2018-01-24 at 7 18 20 pm" src="https://user-images.githubusercontent.com/1126811/35365734-ba972b84-013b-11e8-8584-a473f9738081.png">
<img width="407" alt="screen shot 2018-01-24 at 7 18 35 pm" src="https://user-images.githubusercontent.com/1126811/35365736-baafe5f2-013b-11e8-990c-52d20f44dfaa.png">

On TwentySixteen:

<img width="331" alt="screen shot 2018-01-24 at 7 19 28 pm" src="https://user-images.githubusercontent.com/1126811/35365745-c165077e-013b-11e8-9e04-43ec11f841cc.png">
<img width="331" alt="screen shot 2018-01-24 at 7 19 06 pm" src="https://user-images.githubusercontent.com/1126811/35365746-c17b2f04-013b-11e8-8038-2cf256b44dba.png">

On TwentyFifteen:

<img width="323" alt="screen shot 2018-01-24 at 7 19 58 pm" src="https://user-images.githubusercontent.com/1126811/35365755-c98d1270-013b-11e8-87a3-306809f08f48.png">
<img width="303" alt="screen shot 2018-01-24 at 7 20 16 pm" src="https://user-images.githubusercontent.com/1126811/35365756-c99ff412-013b-11e8-87c8-de64b06af826.png">
