### PR TITLE
Sync: Send updates to transients only once

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -141,7 +141,14 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 				continue;
 			}
 			/**
-			 * 'jetpack_update_core_change', 'jetpack_update_plugins_change', jetpack_update_themes_change
+			 * Fires any time one of the following transients changes:
+			 * 'update_core', 'update_plugins', 'update_themes'
+			 *
+			 * @module sync
+			 *
+			 * @since 5.8
+			 *
+			 * @param array The transient value.
 			 */
 			do_action( "jetpack_{$transient_name}_change", $value );
 		}
@@ -176,6 +183,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all updates to the server
+		 *
+		 * @module sync
 		 *
 		 * @since 4.2.0
 		 *


### PR DESCRIPTION
This would make it so that we only send the transient data once and if plugins or theme modify it somehow that we only track the changes at one point.

#### Changes proposed in this Pull Request:
* Plugin can modify the transient that has what needs updating at any point. This helps to make sure that the data only gets set once. 

#### Testing instructions:
* Do the test pass? 
* Set a plugin to update, by modifying wp-includes/version.php file
* Set wp core to update by modifying the plugin file
* Set a theme to update by modifying style.css file

Do you see the events show up in the activity log?
