### PR TITLE
Jetpack Sync Actor: only include IP address after running checks

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -259,7 +259,7 @@ class Jetpack_Sync_Listener {
 			'is_wp_admin'      => is_admin(),
 		);
 
-		if ( $this->should_send_ip_address_with_actor() ) {
+		if ( $this->should_send_ip_address_with_actor( $current_filter ) ) {
 			require_once( JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php' );
 			$actor['ip'] = jetpack_protect_get_ip();
 		}
@@ -267,8 +267,23 @@ class Jetpack_Sync_Listener {
 		return $actor;
 	}
 
-	function should_send_ip_address_with_actor() {
-		return false;
+	function should_send_ip_address_with_actor( $current_filter ) {
+		if ( ! in_array( $current_filter, array( 'wp_login', 'wp_logout', 'jetpack_valid_failed_login_attempt' ) ) ) {
+			// Only send IP Address with login-related events
+			return false;
+		}
+
+		/**
+		 * Allow or deny sending actor's IP Address during a sync event
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param bool True if we should send the IP Address
+		 */
+		if ( ! apply_filters( 'jetpack_sync_actor_ip_address', true ) ) {
+			return false;
+		}
+		return true;
 	}
 
 	function set_defaults() {

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -256,11 +256,19 @@ class Jetpack_Sync_Listener {
 			'is_xmlrpc'        => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
-			'ip'               => isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null,
 			'is_wp_admin'      => is_admin(),
 		);
 
+		if ( $this->should_send_ip_address_with_actor() ) {
+			require_once( JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php' );
+			$actor['ip'] = jetpack_protect_get_ip();
+		}
+
 		return $actor;
+	}
+
+	function should_send_ip_address_with_actor() {
+		return false;
 	}
 
 	function set_defaults() {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -108,6 +108,71 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		}
 	}
 
+	function test_does_listener_add_actor_ip_for_login_events() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$this->listener->get_sync_queue()->reset();
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+		$current_user = wp_get_current_user();
+		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
+
+		$example_actor = array(
+			'wpcom_user_id'    => null,
+			'external_user_id' => $current_user->ID,
+			'display_name'     => $current_user->display_name,
+			'user_email'       => $current_user->user_email,
+			'user_roles'       => $current_user->roles,
+			'translated_role'  => Jetpack::translate_current_user_to_role(),
+			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
+			'is_wp_admin'      => is_admin(),
+			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,
+			'is_xmlrpc'        => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
+			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
+			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
+			'ip'               => jetpack_protect_get_ip()
+		);
+
+		$all = $queue->get_all();
+		foreach ( $all as $queue_item ) {
+			list( $current_filter, $args, $current_user_id, $microtime, $is_importing, $actor ) = $queue_item->value;
+			$this->assertEquals( $actor, $example_actor );
+		}
+	}
+
+	function test_does_listener_exclude_actor_ip_if_filter_is_present() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$this->listener->get_sync_queue()->reset();
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+		$current_user = wp_get_current_user();
+		add_filter( 'jetpack_sync_actor_ip_address', '__return_false' );
+		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
+		remove_filter( 'jetpack_sync_actor_ip_address', '__return_false' );
+		$example_actor = array(
+			'wpcom_user_id'    => null,
+			'external_user_id' => $current_user->ID,
+			'display_name'     => $current_user->display_name,
+			'user_email'       => $current_user->user_email,
+			'user_roles'       => $current_user->roles,
+			'translated_role'  => Jetpack::translate_current_user_to_role(),
+			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
+			'is_wp_admin'      => is_admin(),
+			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,
+			'is_xmlrpc'        => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
+			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
+			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false
+		);
+
+		$all = $queue->get_all();
+		foreach ( $all as $queue_item ) {
+			list( $current_filter, $args, $current_user_id, $microtime, $is_importing, $actor ) = $queue_item->value;
+			$this->assertEquals( $actor, $example_actor );
+		}
+
+	}
+
 	function test_does_set_silent_flag_true_while_importing() {
 		Jetpack_Sync_Settings::set_importing( true );
 

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -93,7 +93,6 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'user_email'       => $current_user->user_email,
 			'user_roles'       => $current_user->roles,
 			'translated_role'  => Jetpack::translate_current_user_to_role(),
-			'ip'               => $_SERVER['REMOTE_ADDR'],
 			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
 			'is_wp_admin'      => is_admin(),
 			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,


### PR DESCRIPTION
If applied this PR will:

- only send IP address to the server during login related events
- allow site administrators to completely opt out of sending IP address
- use `jetpack_protect_get_ip` instead of relying on $_SERVER global

To test:
- try logging in, logging out, and a failed login attempt and ensure IP is sent upstream
- try filtering `jetpack_sync_actor_ip_address` to `false` and ensure IP is not sent upstream
- any other event, writing a post for example, should not send IP upstream regardless of filter