### PR TITLE
Search: Fix remove all filters link when multiple filters selected

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -19,16 +19,18 @@ class Jetpack_Search_Helpers {
 		return home_url( "?{$query}" );
 	}
 
-	static function add_query_arg( $key, $value = false ) {
+	static function add_query_arg( $key, $value = false, $url = false ) {
+		$url = empty( $url ) ? self::get_search_url() : $url;
 		if ( is_array( $key ) ) {
-			return add_query_arg( $key, self::get_search_url() );
+			return add_query_arg( $key, $url );
 		}
 
-		return add_query_arg( $key, $value, self::get_search_url() );
+		return add_query_arg( $key, $value, $url );
 	}
 
-	static function remove_query_arg( $key ) {
-		return remove_query_arg( $key, self::get_search_url() );
+	static function remove_query_arg( $key, $url = false ) {
+		$url = empty( $url ) ? self::get_search_url() : $url;
+		return remove_query_arg( $key, $url );
 	}
 
 	static function get_widget_option_name() {

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -721,7 +721,8 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		$url = Jetpack_Search_Helpers::add_query_arg(
 			'post_type',
-			implode( ',', $post_types )
+			implode( ',', $post_types ),
+			$url
 		);
 
 		return $url;
@@ -734,7 +735,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	 * @param array $instance
 	 */
 	function render_current_filters( $active_buckets, $instance ) {
-		if ( ! Jetpack_Search_Helpers::post_types_differ_query( $instance, true ) ) {
+		if ( ! Jetpack_Search_Helpers::post_types_differ_query( $instance ) ) {
 			$active_buckets = array_filter( $active_buckets, array( $this, 'filter_post_types_from_active_buckets' ) );
 		}
 

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -117,6 +117,25 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 		$this->assertNotContains( 'post_type=', $url );
 	}
 
+	function test_add_query_arg_respects_url_passed() {
+		$input_url = 'http://example.com/page/2/?s=test';
+		$_SERVER['REQUEST_URI'] = $input_url;
+		$_GET['s'] = 'test';
+
+		$url = Jetpack_Search_Helpers::add_query_arg( 'post_type', 'page', $input_url );
+		$this->assertSame( 'http://example.com/page/2/?s=test&post_type=page', $url );
+	}
+
+	function test_remove_query_arg_respects_url_passed() {
+		$input_url = 'http://example.com/page/2/?s=test&post_type=post,page';
+		$_SERVER['REQUEST_URI'] = $input_url;
+		$_GET['s'] = 'test';
+		$_GET['post_type'] = 'post,page';
+
+		$url = Jetpack_Search_Helpers::remove_query_arg( 'post_type', $input_url );
+		$this->assertSame( 'http://example.com/page/2/?s=test', $url );
+	}
+
 	function test_get_widget_option_name() {
 		$this->assertSame( 'widget_jetpack-search-filters', Jetpack_Search_Helpers::get_widget_option_name() );
 	}


### PR DESCRIPTION
Fixes #8604 
Alternative to #8605


Testing instructions:

1. In the search filters widget configuration in the customizer, exclude one or more post types.
2. Search for something.
3. Limit results to a particular post type.
4. Limit results by something else so that "Remove All Filters" shows up.
5. Verify that "Remove All Filters" link only contains the search term and the limited post types.