### PR TITLE
Search: Use checkboxes instead of select for post type selection

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -400,6 +400,21 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				</label>
 			</p>
 
+			<p class="jetpack-search-filters-widget__post-types-select">
+				<label><?php esc_html_e( 'Post types included in results:', 'jetpack' ); ?></label>
+				<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
+					<label>
+						<input
+							type="checkbox"
+							value="<?php echo esc_attr( $post_type->name ); ?>"
+							name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]"
+							<?php checked( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'] ) ); ?>
+						/>&nbsp;
+						<?php echo esc_html( $post_type->label ); ?>
+					</label>
+				<?php endforeach; ?>
+			</p>
+
 			<p>
 				<label>
 					<?php esc_html_e( 'Default sort order:', 'jetpack' ); ?>
@@ -414,25 +429,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 					</select>
 				</label>
 			</p>
-
-			<div class="jetpack-search-filters-widget__post-types-select">
-				<p class="jetpack-search">
-					<label><?php esc_html_e( 'Post types included in results:', 'jetpack' ); ?></label>
-					<select
-						class="widefat jetpack-search-filters-widget__post-type-selector"
-						name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]"
-						multiple="multiple">
-						<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
-							<option
-								value="<?php echo esc_attr( $post_type->name ); ?>"
-								<?php selected( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'] ) ); ?>
-							>
-								<?php echo esc_html( $post_type->label ); ?>
-							</option>
-						<?php endforeach; ?>
-					</select>
-				</p>
-			</div>
 
 			<?php if ( ! $hide_filters ): ?>
 				<p>

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -70,3 +70,12 @@
 	padding: 5px;
 	padding-bottom: 15px;
 }
+
+.jetpack-search-filters-widget__post-types-select label {
+	display: block;
+	margin-bottom: 4px;
+}
+
+.jetpack-search-filters-widget__post-types-select input[type="checkbox"] {
+	margin-left: 24px;
+}

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -63,14 +63,18 @@
 			}
 		} );
 
-		widget.on( 'change', '.jetpack-search-filters-widget__post-type-selector', function() {
+		widget.on( 'change', '.jetpack-search-filters-widget__post-types-select input[type="checkbox"]', function() {
+			var t = $( this );
 			var eventArgs = {
-				is_customizer: args.tracksEventData.is_customizer
+				is_customizer: args.tracksEventData.is_customizer,
+				post_type:  t.val()
 			};
 
-			eventArgs.post_types = $( this ).val();
-
-			trackAndBumpMCStats( 'changed_post_types', eventArgs );
+			if ( t.is( ':checked' ) ) {
+				trackAndBumpMCStats( 'added_post_type', eventArgs );
+			} else {
+				trackAndBumpMCStats( 'removed_post_type', eventArgs );
+			}
 		} );
 
 		widget.on( 'change', '.jetpack-search-filters-widget__sort-order', function() {


### PR DESCRIPTION
Fixes #8537 

Previously we used a multiple select to allow an admin to restrict a search widget to certain post types. We were given some feedback that a list of checkboxes would be better. This Pr does that.

To test:

- Checkout branch on site with Jetpack Professional
- Add Jetpack search widget
- Ensure when "Show search box" is not checked that the list of post type checkboxes does not show
- Ensure when the "Show search box" is checked that the post type checkboxes appear and you are able to select and save post types
- Once selecting post type, perform a search on the frontend and ensure that something like `&post_type=post,page` is added to the URL after entering a value in the widget
- Ensure that tracks events are triggered and are properly recorded

Screenshots:
<img width="435" alt="screen shot 2018-01-24 at 8 42 33 pm" src="https://user-images.githubusercontent.com/1126811/35368180-a0c4791c-0147-11e8-959e-6a940519d60f.png">
<img width="432" alt="screen shot 2018-01-24 at 8 42 28 pm" src="https://user-images.githubusercontent.com/1126811/35368181-a0ddf090-0147-11e8-89af-a57feb9d2d95.png">

