### PR TITLE
Search: First pass at debug bar support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 _inc/client/**/test/*.js
 modules/lazy-images/js/lazy-images.js
 modules/search/js/search-widget-filters-admin.js
+3rd-party/debug-bar/debug-bar.js

--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -14,6 +14,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/vaultpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/beaverbuilder.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/debug-bar.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * Placeholder to load 3rd party plugin tweaks until a legit system
  * is architected
  */

--- a/3rd-party/debug-bar.php
+++ b/3rd-party/debug-bar.php
@@ -2,6 +2,10 @@
 
 add_filter( 'debug_bar_panels', 'init_jetpack_search_debug_bar' );
 function init_jetpack_search_debug_bar( $panels ) {
+	if ( ! Jetpack::is_module_active( 'search' ) ) {
+		return $panels;
+	}
+
 	require_once( dirname( __FILE__ ) . '/debug-bar/class.jetpack-search-debug-bar.php' );
 	$panels[] = Jetpack_Search_Debug_Bar::instance();
 	return $panels;

--- a/3rd-party/debug-bar.php
+++ b/3rd-party/debug-bar.php
@@ -1,12 +1,19 @@
 <?php
 
-add_filter( 'debug_bar_panels', 'init_jetpack_search_debug_bar' );
+/**
+ * Checks if the search module is active, and if so, will initialize the singleton instance
+ * of Jetpack_Search_Debug_Bar and add it to the array of debug bar panels.
+ *
+ * @param array $panels The array of debug bar panels.
+ * @return array $panel The array of debug bar panels with our added panel.
+ */
 function init_jetpack_search_debug_bar( $panels ) {
 	if ( ! Jetpack::is_module_active( 'search' ) ) {
 		return $panels;
 	}
 
-	require_once( dirname( __FILE__ ) . '/debug-bar/class.jetpack-search-debug-bar.php' );
+	require_once dirname( __FILE__ ) . '/debug-bar/class.jetpack-search-debug-bar.php';
 	$panels[] = Jetpack_Search_Debug_Bar::instance();
 	return $panels;
 }
+add_filter( 'debug_bar_panels', 'init_jetpack_search_debug_bar' );

--- a/3rd-party/debug-bar.php
+++ b/3rd-party/debug-bar.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'debug_bar_panels', 'init_jetpack_search_debug_bar' );
+function init_jetpack_search_debug_bar( $panels ) {
+	require_once( dirname( __FILE__ ) . '/debug-bar/class.jetpack-search-debug-bar.php' );
+	$panels[] = Jetpack_Search_Debug_Bar::instance();
+	return $panels;
+}

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -53,7 +53,15 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
-		wp_enqueue_style( 'jetpack-search-debug-bar', plugins_url( '3rd-party/debug-bar/debug-bar.css', JETPACK__PLUGIN_FILE ) );
+		wp_enqueue_style(
+			'jetpack-search-debug-bar',
+			plugins_url( '3rd-party/debug-bar/debug-bar.css', JETPACK__PLUGIN_FILE )
+		);
+		wp_enqueue_script(
+			'jetpack-search-debug-bar',
+			plugins_url( '3rd-party/debug-bar/debug-bar.js', JETPACK__PLUGIN_FILE ),
+			array( 'jquery' )
+		);
 	}
 
 	/**
@@ -110,7 +118,21 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 					foreach ( $last_query_info as $key => $info ) :
 					?>
 						<h3><?php echo esc_html( $key ); ?></h3>
+					<?php
+					if ( 'response' !== $key && 'args' !== $key ) :
+					?>
 						<pre><?php print_r( $info ); ?></pre>
+					<?php
+					else :
+					?>
+						<div class="json-toggle-wrap">
+							<pre class="json"><?php echo wp_json_encode( $info ); ?></pre>
+							<span class="pretty toggle"><?php echo esc_html_x( 'Pretty', 'label for formatting JSON', 'jetpack' ); ?></span>
+							<span class="ugly toggle"><?php echo esc_html_x( 'Minify', 'label for formatting JSON', 'jetpack' ); ?></span>
+						</div>
+					<?php
+					endif;
+					?>
 					<?php
 					endforeach;
 			endif;

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -101,12 +101,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 				<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
 			<?php
 				else :
-					foreach ( $last_query_failure_info as $key => $info ) :
-					?>
-						<h3><?php echo esc_html( $key ); ?></h3>
-						<pre><?php print_r( $info ); ?></pre>
-					<?php
-					endforeach;
+					$this->render_json_toggle( $last_query_failure_info );
 			endif;
 			?>
 
@@ -124,13 +119,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 						<pre><?php print_r( $info ); ?></pre>
 					<?php
 					else :
-					?>
-						<div class="json-toggle-wrap">
-							<pre class="json"><?php echo wp_json_encode( $info ); ?></pre>
-							<span class="pretty toggle"><?php echo esc_html_x( 'Pretty', 'label for formatting JSON', 'jetpack' ); ?></span>
-							<span class="ugly toggle"><?php echo esc_html_x( 'Minify', 'label for formatting JSON', 'jetpack' ); ?></span>
-						</div>
-					<?php
+						$this->render_json_toggle( $info );
 					endif;
 					?>
 					<?php
@@ -139,5 +128,21 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			?>
 		</div><!-- Closes .jetpack-search-debug-bar -->
 		<?php
+	}
+
+	/**
+	 * Responsible for rendering the HTML necessary for the JSON toggle
+	 *
+	 * @param array $value The resonse from the API as an array.
+	 * @return void
+	 */
+	public function render_json_toggle( $value ) {
+	?>
+		<div class="json-toggle-wrap">
+			<pre class="json"><?php echo wp_json_encode( $value ); ?></pre>
+			<span class="pretty toggle"><?php echo esc_html_x( 'Pretty', 'label for formatting JSON', 'jetpack' ); ?></span>
+			<span class="ugly toggle"><?php echo esc_html_x( 'Minify', 'label for formatting JSON', 'jetpack' ); ?></span>
+		</div>
+	<?php
 	}
 }

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -1,33 +1,73 @@
 <?php
 
+/**
+ * Singleton class instantiated by Jetpack_Searc_Debug_Bar::instance() that handles
+ * rendering the Jetpack Search debug bar menu item and panel.
+ */
 class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
-	static $instance = null;
+	/**
+	 * Holds singleton instance
+	 *
+	 * @var Jetpack_Search_Debug_Bar
+	 */
+	protected static $instance = null;
 
+	/**
+	 * Holds an instance of Jetpack_Search
+	 *
+	 * @var Jetpack_Search
+	 */
 	private $jetpack_search;
 
+	/**
+	 * The title to use in the debug bar navigation
+	 *
+	 * @var string
+	 */
 	public $title;
 
+	/**
+	 * Constructor
+	 */
 	public function __construct() {
 		$this->title( esc_html__( 'Jetpack Search', 'jetpack' ) );
 		$this->jetpack_search = Jetpack_Search::instance();
 	}
 
-	static function instance() {
+	/**
+	 * Returns the singleton instance of Jetpack_Search_Debug_Bar
+	 *
+	 * @return Jetpack_Search_Debug_Bar
+	 */
+	public static function instance() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_Search_Debug_Bar();
 		}
 		return self::$instance;
 	}
 
+	/**
+	 * Should the Jetpack Search Debug Bar show?
+	 *
+	 * Since we've previously done a check for the search module being activated, let's just return true.
+	 * Later on, we can update this to only show when `is_search()` is true.
+	 *
+	 * @return boolean
+	 */
 	public function is_visible() {
 		return true;
 	}
 
+	/**
+	 * Renders the panel content
+	 *
+	 * @return void
+	 */
 	public function render() {
-		$last_query_failure_info =  $this->jetpack_search->get_last_query_failure_info();
+		$last_query_failure_info = $this->jetpack_search->get_last_query_failure_info();
 		$last_query_info = $this->jetpack_search->get_last_query_info();
 
-		// If not empty, let's reshuffle the order of some things
+		// If not empty, let's reshuffle the order of some things.
 		if ( ! empty( $last_query_info ) ) {
 			$args = $last_query_info['args'];
 			$response = $last_query_info['response'];
@@ -40,21 +80,28 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 		<h3><?php esc_html_e( 'Last query failure information:', 'jetpack' ); ?></h3>
 		<?php if ( empty( $last_query_failure_info ) ) : ?>
 			<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
-		<?php else:
-			foreach ( $last_query_failure_info as $key => $info ) : ?>
-				<h4><?php echo esc_html( $key ); ?></h4>
-				<pre><?php print_r( $info ); ?></pre>
-			<?php endforeach;
-		endif; ?>
+		<?php
+			else :
+				foreach ( $last_query_failure_info as $key => $info ) :
+				?>
+					<h4><?php echo esc_html( $key ); ?></h4>
+					<pre><?php print_r( $info ); ?></pre>
+				<?php
+				endforeach;
+		endif;
+		?>
 
 		<h3><?php esc_html_e( 'Last query information:', 'jetpack' ); ?></h3>
 		<?php if ( empty( $last_query_info ) ) : ?>
 				<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
-		<?php else:
- 			foreach ( $last_query_info as $key => $info ) : ?>
-				<h4><?php echo esc_html( $key ); ?></h4>
-				<pre><?php print_r( $info ); ?></pre>
-			<?php endforeach;
-		endif; ?>
-	<?php }
+		<?php
+			else :
+				foreach ( $last_query_info as $key => $info ) :
+				?>
+					<h4><?php echo esc_html( $key ); ?></h4>
+					<pre><?php print_r( $info ); ?></pre>
+				<?php
+				endforeach;
+		endif;
+	}
 }

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -32,6 +32,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	public function __construct() {
 		$this->title( esc_html__( 'Jetpack Search', 'jetpack' ) );
 		$this->jetpack_search = Jetpack_Search::instance();
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -44,6 +45,15 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			self::$instance = new Jetpack_Search_Debug_Bar();
 		}
 		return self::$instance;
+	}
+
+	/**
+	 * Enqueues styles for our panel in the debug bar
+	 *
+	 * @return void
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_style( 'jetpack-search-debug-bar', plugins_url( '3rd-party/debug-bar/debug-bar.css', JETPACK__PLUGIN_FILE ) );
 	}
 
 	/**
@@ -77,31 +87,35 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			$last_query_info['args'] = $args;
 		}
 		?>
-		<h3><?php esc_html_e( 'Last query failure information:', 'jetpack' ); ?></h3>
-		<?php if ( empty( $last_query_failure_info ) ) : ?>
-			<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
-		<?php
-			else :
-				foreach ( $last_query_failure_info as $key => $info ) :
-				?>
-					<h4><?php echo esc_html( $key ); ?></h4>
-					<pre><?php print_r( $info ); ?></pre>
-				<?php
-				endforeach;
-		endif;
-		?>
-
-		<h3><?php esc_html_e( 'Last query information:', 'jetpack' ); ?></h3>
-		<?php if ( empty( $last_query_info ) ) : ?>
+		<div class="jetpack-search-debug-bar">
+			<h2><?php esc_html_e( 'Last query failure information:', 'jetpack' ); ?></h2>
+			<?php if ( empty( $last_query_failure_info ) ) : ?>
 				<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
+			<?php
+				else :
+					foreach ( $last_query_failure_info as $key => $info ) :
+					?>
+						<h3><?php echo esc_html( $key ); ?></h3>
+						<pre><?php print_r( $info ); ?></pre>
+					<?php
+					endforeach;
+			endif;
+			?>
+
+			<h2><?php esc_html_e( 'Last query information:', 'jetpack' ); ?></h2>
+			<?php if ( empty( $last_query_info ) ) : ?>
+					<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
+			<?php
+				else :
+					foreach ( $last_query_info as $key => $info ) :
+					?>
+						<h3><?php echo esc_html( $key ); ?></h3>
+						<pre><?php print_r( $info ); ?></pre>
+					<?php
+					endforeach;
+			endif;
+			?>
+		</div><!-- Closes .jetpack-search-debug-bar -->
 		<?php
-			else :
-				foreach ( $last_query_info as $key => $info ) :
-				?>
-					<h4><?php echo esc_html( $key ); ?></h4>
-					<pre><?php print_r( $info ); ?></pre>
-				<?php
-				endforeach;
-		endif;
 	}
 }

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -1,0 +1,60 @@
+<?php
+
+class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
+	static $instance = null;
+
+	private $jetpack_search;
+
+	public $title;
+
+	public function __construct() {
+		$this->title( esc_html__( 'Jetpack Search', 'jetpack' ) );
+		$this->jetpack_search = Jetpack_Search::instance();
+	}
+
+	static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Jetpack_Search_Debug_Bar();
+		}
+		return self::$instance;
+	}
+
+	public function is_visible() {
+		return true;
+	}
+
+	public function render() {
+		$last_query_failure_info =  $this->jetpack_search->get_last_query_failure_info();
+		$last_query_info = $this->jetpack_search->get_last_query_info();
+
+		// If not empty, let's reshuffle the order of some things
+		if ( ! empty( $last_query_info ) ) {
+			$args = $last_query_info['args'];
+			$response = $last_query_info['response'];
+			unset( $last_query_info['args'] );
+			unset( $last_query_info['response'] );
+			$last_query_info['response'] = $response;
+			$last_query_info['args'] = $args;
+		}
+		?>
+		<h3><?php esc_html_e( 'Last query failure information:', 'jetpack' ); ?></h3>
+		<?php if ( empty( $last_query_failure_info ) ) : ?>
+			<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
+		<?php else:
+			foreach ( $last_query_failure_info as $key => $info ) : ?>
+				<h4><?php echo esc_html( $key ); ?></h4>
+				<pre><?php print_r( $info ); ?></pre>
+			<?php endforeach;
+		endif; ?>
+
+		<h3><?php esc_html_e( 'Last query information:', 'jetpack' ); ?></h3>
+		<?php if ( empty( $last_query_info ) ) : ?>
+				<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
+		<?php else:
+ 			foreach ( $last_query_info as $key => $info ) : ?>
+				<h4><?php echo esc_html( $key ); ?></h4>
+				<pre><?php print_r( $info ); ?></pre>
+			<?php endforeach;
+		endif; ?>
+	<?php }
+}

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -82,29 +82,29 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function render() {
-		$last_query_failure_info = $this->jetpack_search->get_last_query_failure_info();
 		$last_query_info = $this->jetpack_search->get_last_query_info();
 
 		// If not empty, let's reshuffle the order of some things.
 		if ( ! empty( $last_query_info ) ) {
-			$args = $last_query_info['args'];
+			$args     = $last_query_info['args'];
 			$response = $last_query_info['response'];
+			$response_code = $last_query_info['response_code'];
+
 			unset( $last_query_info['args'] );
 			unset( $last_query_info['response'] );
-			$last_query_info['response'] = $response;
-			$last_query_info['args'] = $args;
+			unset( $last_query_info['response_code'] );
+
+			$temp = array_merge(
+				array( 'response_code' => $response_code ),
+				array( 'args' => $args ),
+				$last_query_info,
+				array( 'response' => $response )
+			);
+
+			$last_query_info = $temp;
 		}
 		?>
 		<div class="jetpack-search-debug-bar">
-			<h2><?php esc_html_e( 'Last query failure information:', 'jetpack' ); ?></h2>
-			<?php if ( empty( $last_query_failure_info ) ) : ?>
-				<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>
-			<?php
-				else :
-					$this->render_json_toggle( $last_query_failure_info );
-			endif;
-			?>
-
 			<h2><?php esc_html_e( 'Last query information:', 'jetpack' ); ?></h2>
 			<?php if ( empty( $last_query_info ) ) : ?>
 					<?php echo esc_html_x( 'None', 'Text displayed when there is no information', 'jetpack' ); ?>

--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -94,6 +94,14 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			unset( $last_query_info['response'] );
 			unset( $last_query_info['response_code'] );
 
+			if ( is_null( $last_query_info['es_time'] ) ) {
+				$last_query_info['es_time'] = esc_html_x(
+					'cache hit',
+					'displayed in search results when results are cached',
+					'jetpack'
+				);
+			}
+
 			$temp = array_merge(
 				array( 'response_code' => $response_code ),
 				array( 'args' => $args ),
@@ -116,7 +124,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 					<?php
 					if ( 'response' !== $key && 'args' !== $key ) :
 					?>
-						<pre><?php print_r( $info ); ?></pre>
+						<pre><?php print_r( esc_html( $info ) ); ?></pre>
 					<?php
 					else :
 						$this->render_json_toggle( $info );

--- a/3rd-party/debug-bar/debug-bar.css
+++ b/3rd-party/debug-bar/debug-bar.css
@@ -1,10 +1,52 @@
-.jetpack-search-debug-bar h2 {
+.jetpack-search-debug-bar h2,
+.qm-debug-bar-output .jetpack-search-debug-bar h2 {
 	float: none !important;
 	padding: 0 !important;
 	text-align: left !important;
+}
+
+.qm-debug-bar-output .jetpack-search-debug-bar h2 {
 	margin-top: 1em !important;
 }
 
-.jetpack-search-debug-bar h2:first-child {
-	margin-top: .5 !important;
+.qm-debug-bar-output .jetpack-search-debug-bar h2:first-child {
+	margin-top: .5em !important;
+}
+
+.jetpack-search-debug-output-toggle .print-r {
+	display: none;
+}
+
+.json-toggle-wrap {
+	position: relative;
+}
+
+.json-toggle-wrap .toggle {
+	position: absolute;
+		bottom: 10px;
+		right: 10px;
+	background: #fff;
+	border: 1px solid #000;
+	cursor: pointer;
+	padding: 2px 4px;
+}
+
+.json-toggle-wrap .ugly {
+	display: none;
+}
+
+.json-toggle-wrap.pretty .pretty {
+	display: none;
+}
+
+.json-toggle-wrap.pretty .ugly {
+	display: inline;
+}
+
+.jetpack-search-debug-bar pre {
+	white-space: pre-wrap;
+	white-space: -moz-pre-wrap;
+	white-space: -pre-wrap;
+	white-space: -o-pre-wrap;
+	word-wrap: break-word;
 }

--- a/3rd-party/debug-bar/debug-bar.css
+++ b/3rd-party/debug-bar/debug-bar.css
@@ -1,0 +1,10 @@
+.jetpack-search-debug-bar h2 {
+	float: none !important;
+	padding: 0 !important;
+	text-align: left !important;
+	margin-top: 1em !important;
+}
+
+.jetpack-search-debug-bar h2:first-child {
+	margin-top: .5 !important;
+}

--- a/3rd-party/debug-bar/debug-bar.css
+++ b/3rd-party/debug-bar/debug-bar.css
@@ -13,6 +13,10 @@
 	margin-top: .5em !important;
 }
 
+.debug-menu-target h3 {
+	padding-top: 0
+}
+
 .jetpack-search-debug-output-toggle .print-r {
 	display: none;
 }

--- a/3rd-party/debug-bar/debug-bar.js
+++ b/3rd-party/debug-bar/debug-bar.js
@@ -10,9 +10,9 @@
 				isPretty = wrap.hasClass( 'pretty' );
 
 			if ( ! isPretty ) {
-				pre.text( JSON.stringify( JSON.parse( content ), null, '\t' ) );
+				pre.text( JSON.stringify( JSON.parse( content ), null, 2 ) );
 			} else {
-				content.replace( '\t', '' ).replace( '\n', '' );
+				content.replace( '\t', '' ).replace( '\n', '' ).replace( ' ', '' );
 				pre.text( JSON.stringify( JSON.parse( content ) ) );
 			}
 

--- a/3rd-party/debug-bar/debug-bar.js
+++ b/3rd-party/debug-bar/debug-bar.js
@@ -1,4 +1,4 @@
-/* global jQuery */
+/* global jQuery, JSON */
 
 ( function( $ ) {
 	$( document ).ready( function() {

--- a/3rd-party/debug-bar/debug-bar.js
+++ b/3rd-party/debug-bar/debug-bar.js
@@ -1,0 +1,22 @@
+/* global jQuery */
+
+( function( $ ) {
+	$( document ).ready( function() {
+		$( '.jetpack-search-debug-bar .json-toggle-wrap .toggle' ).click( function() {
+			var t = $( this ),
+				wrap = t.closest( '.json-toggle-wrap' ),
+				pre = wrap.find( 'pre' ),
+				content = pre.text(),
+				isPretty = wrap.hasClass( 'pretty' );
+
+			if ( ! isPretty ) {
+				pre.text( JSON.stringify( JSON.parse( content ), null, '\t' ) );
+			} else {
+				content.replace( '\t', '' ).replace( '\n', '' );
+				pre.text( JSON.stringify( JSON.parse( content ) ) );
+			}
+
+			wrap.toggleClass( 'pretty' );
+		} );
+	} );
+} )( jQuery );

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -142,10 +142,20 @@ class Jetpack_Search {
 		}
 	}
 
+	/**
+	 * Returns the last query information, or false if no information was stored.
+	 *
+	 * @return bool|array
+	 */
 	public function get_last_query_info() {
 		return empty( $this->last_query_info ) ? false : $this->last_query_info;
 	}
 
+	/**
+	 * Returns the last query failure information, or false if no failure information was stored.
+	 *
+	 * @return bool|array
+	 */
 	public function get_last_query_failure_info() {
 		return empty( $this->last_query_failure_info ) ? false : $this->last_query_failure_info;
 	}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -142,6 +142,14 @@ class Jetpack_Search {
 		}
 	}
 
+	public function get_last_query_info() {
+		return empty( $this->last_query_info ) ? false : $this->last_query_info;
+	}
+
+	public function get_last_query_failure_info() {
+		return empty( $this->last_query_failure_info ) ? false : $this->last_query_failure_info;
+	}
+
 	function are_filters_by_widget_disabled() {
 		/**
 		 * Allows developers to disable filters being set by widget, in favor of manually


### PR DESCRIPTION
Addresses part of #8564

In Progress

This PR is a first pass at adding debug bar support for Jetpack Search.

To test:

- Checkout branch on site with Jetpack Professional
- Add a search widget to your sidebar and add filters
- Ensure Debug Bar plugin is not activated
- Run a search on the frontend and ensure that no errors occur in the error log
- Install and activate the [Debug Bar](https://wordpress.org/plugins/debug-bar/) plugin
- Install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/)
- Run a query on the front end and ensure you get debug bar output
- Force an error and ensure error information shows up in debug bar. One way I found was to add the following in an integration plugin:
    ```php
    function jp_search_setup_filters() {
    	if ( class_exists( 'Jetpack_Search' ) ) {
    		Jetpack_Search::instance()->set_filters(array(
    			'0' => array(
    				'type'     => 'taxonomy',
    				'taxonomy' => 'category',
    				'count'    => 10,
    				'name' => '',
    			),
    			'0' => array(
    				'type'     => 'taxonomy',
    				'taxonomy' => 'post_tag',
    				'count'    => 10,
    				'name' => '',
    			),
    			'0' => array(
    				'type'     => 'date_histogram',
    				'field'    => 'post_date',
    				'interval' => 'month',
    				'count'    => 10,
    				'name' => '',
    			),
    		) );
    	}
    }
    add_action( 'init', 'jp_search_setup_filters', 10 );
    add_filter( 'jetpack_search_disable_widget_filters', '__return_true' );
    ```
- Deactivate the Debug Bar plugin and check that Query Monitor begins to show the Jetpack Search panel

Screenshots:
<img width="1344" alt="screen shot 2018-01-25 at 11 23 11 am" src="https://user-images.githubusercontent.com/1126811/35402459-49060b20-01c2-11e8-83a9-0fb8034b2854.png">
<img width="1344" alt="screen shot 2018-01-25 at 11 23 09 am" src="https://user-images.githubusercontent.com/1126811/35402460-49188eb2-01c2-11e8-8c4f-9fd07168c92d.png">
<img width="1344" alt="screen shot 2018-01-25 at 11 22 32 am" src="https://user-images.githubusercontent.com/1126811/35402461-492c0dde-01c2-11e8-8b4a-927b419bd2b5.png">
<img width="1344" alt="screen shot 2018-01-25 at 11 22 13 am" src="https://user-images.githubusercontent.com/1126811/35402462-493e36b2-01c2-11e8-81f8-647e6cf9dd7e.png">
<img width="1344" alt="screen shot 2018-01-25 at 11 22 10 am" src="https://user-images.githubusercontent.com/1126811/35402463-49506850-01c2-11e8-9b89-5288563d698d.png">

Note how Query Monitor shows its menu item in red. That's because the search API returned a `400` status code:

<img width="1221" alt="screen shot 2018-01-25 at 11 27 52 am" src="https://user-images.githubusercontent.com/1126811/35402680-f16405ec-01c2-11e8-8593-55466948a05e.png">

