### PR TITLE
Search: Use checkboxes for frontend filters

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -408,7 +408,7 @@ class Jetpack_Search_Helpers {
 
 		foreach ( (array) $filters as $filter_key => $filter ) {
 			if ( 'post_type' !== $filter['type'] || empty( $filter['buckets'] ) ) {
-				$modified[] = $filter;
+				$modified[ $filter_key ] = $filter;
 				continue;
 			}
 
@@ -423,7 +423,9 @@ class Jetpack_Search_Helpers {
 				}
 
 				$query = array();
-				wp_parse_str( $parsed['query'], $query );
+				if ( ! empty( $parsed['query'] ) ) {
+					wp_parse_str( $parsed['query'], $query );
+				}
 
 				if ( empty( $query['post_type'] ) ) {
 					$modified[ $filter_key ]['buckets'][ $bucket_key ]['remove_url'] = self::add_post_types_to_url(

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -348,4 +348,92 @@ class Jetpack_Search_Helpers {
 
 		return $filters_properties;
 	}
+
+	/**
+	 * Sets active to false on all post type buckets.
+	 *
+	 * @param array $filters The available filters for the current query.
+	 *
+	 * @return array $modified The filters for the current query with modified active field.
+	 */
+	public static function remove_active_from_post_type_buckets( $filters ) {
+		$modified = $filters;
+		foreach ( $filters as $key => $filter ) {
+			if ( 'post_type' === $filter['type'] && ! empty( $filter['buckets'] ) ) {
+				foreach ( $filter['buckets'] as $k => $bucket ) {
+					$bucket['active']                  = false;
+					$modified[ $key ]['buckets'][ $k ] = $bucket;
+				}
+			}
+		}
+
+		return $modified;
+	}
+
+	/**
+	 * Given a url and an array of post types, will ensure that the post types are properly applied to the URL as args.
+	 *
+	 * @param string $url        The URL to add post types to.
+	 * @param array  $post_types An array of post types that should be added to the URL.
+	 *
+	 * @return string $url The URL with added post types.
+	 */
+	public static function add_post_types_to_url( $url, $post_types ) {
+		$url = Jetpack_Search_Helpers::remove_query_arg( 'post_type', $url );
+		if ( empty( $post_types ) ) {
+			return $url;
+		}
+
+		$url = Jetpack_Search_Helpers::add_query_arg(
+			'post_type',
+			implode( ',', $post_types ),
+			$url
+		);
+
+		return $url;
+	}
+
+	/**
+	 * Since we provide support for the widget restricting post types by adding the selected post types as
+	 * active filters, if removing a post type filter would result in there no longer be post_type args in the URL,
+	 * we need to be sure to add them back.
+	 *
+	 * @param array $filters    An array of possible filters for the current query.
+	 * @param array $post_types The post types to ensure are on the link.
+	 *
+	 * @return array $modified The updated array of filters with post typed added to the remove URLs.
+	 */
+	public static function ensure_post_types_on_remove_url( $filters, $post_types ) {
+		$modified = $filters;
+
+		foreach ( (array) $filters as $filter_key => $filter ) {
+			if ( 'post_type' !== $filter['type'] || empty( $filter['buckets'] ) ) {
+				$modified[] = $filter;
+				continue;
+			}
+
+			foreach ( (array) $filter['buckets'] as $bucket_key => $bucket ) {
+				if ( empty( $bucket['remove_url'] ) ) {
+					continue;
+				}
+
+				$parsed = wp_parse_url( $bucket['remove_url'] );
+				if ( ! $parsed ) {
+					continue;
+				}
+
+				$query = array();
+				wp_parse_str( $parsed['query'], $query );
+
+				if ( empty( $query['post_type'] ) ) {
+					$modified[ $filter_key ]['buckets'][ $bucket_key ]['remove_url'] = self::add_post_types_to_url(
+						$bucket['remove_url'],
+						$post_types
+					);
+				}
+			}
+		}
+
+		return $modified;
+	}
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -438,4 +438,26 @@ class Jetpack_Search_Helpers {
 
 		return $modified;
 	}
+
+	/**
+	 * Given an array of filters or active buckets, will filter out any that are post types.
+	 *
+	 * @param array $filters The array of filters or active buckets.
+	 * @return array
+	 */
+	public static function filter_post_types( $filters ) {
+		$no_post_types = array();
+
+		foreach ( (array) $filters as $key => $filter ) {
+			if ( empty( $filter['type'] ) || 'post_type' !== $filter['type'] ) {
+				if ( is_int( $key ) ) {
+					$no_post_types[] = $filter;
+				} else {
+					$no_post_types[ $key ] = $filter;
+				}
+			}
+		}
+
+		return $no_post_types;
+	}
 }

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -295,7 +295,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				var checkboxSelector = '.jetpack-search-filters-widget__filter-list input[type="checkbox"]',
 					checkboxes = jQuery( checkboxSelector );
 
-				jQuery( checkboxSelector ) .prop( 'disabled', false );
+				jQuery( checkboxSelector ).prop( 'disabled', false ).css( 'cursor', 'inherit' );
 				jQuery( checkboxSelector ).on( 'click change', function( e ) {
 					var anchor;
 					e.preventDefault();

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -738,6 +738,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	 * @param array $filter The filter to render.
 	 */
 	public function render_filter( $filter ) {
+		if ( empty( $filter ) || empty( $filter['buckets'] ) ) {
+			return;
+		}
+
 		?>
 		<h4 class="jetpack-search-filters-widget__sub-heading">
 			<?php echo esc_html( $filter['name'] ); ?>

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -34,8 +34,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		}
 
 		add_action( 'jetpack_search_render_filters_widget_title', array( $this, 'render_widget_title' ), 10, 3 );
-		add_action( 'jetpack_search_render_active_filters', array( $this, 'render_current_filters' ), 10, 2 );
-		add_action( 'jetpack_search_render_filters', array( $this, 'render_available_filters' ), 10, 1 );
+		add_action( 'jetpack_search_render_filters', array( $this, 'render_available_filters' ), 10, 2 );
 	}
 
 	function widget_admin_setup() {
@@ -76,7 +75,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		wp_enqueue_script( 'widget-jetpack-search-filters' );
 	}
 
-	function enqueue_frontend_scripts() {
+	/**
+	 * Enqueue scripts and styles for the frontend
+	 */
+	public function enqueue_frontend_scripts() {
+		wp_enqueue_script( 'jquery' );
 		wp_enqueue_style( 'jetpack-search-widget', plugins_url( 'modules/search/css/search-widget-frontend.css', JETPACK__PLUGIN_FILE ) );
 	}
 
@@ -121,7 +124,15 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		return true;
 	}
 
-	function widget( $args, $instance ) {
+	/**
+	 * Responsible for rendering the widget on the frontend
+	 *
+	 * @param array $args     Widgets args supplied by the theme.
+	 * @param array $instance The current widget instance.
+	 *
+	 * @return void
+	 */
+	public function widget( $args, $instance ) {
 		$display_filters = false;
 
 		if ( is_search() ) {
@@ -129,13 +140,12 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				$this->jetpack_search->update_search_results_aggregations();
 			}
 			$filters = $this->jetpack_search->get_filters();
-			$active_buckets = $this->jetpack_search->get_active_filter_buckets();
 
-			if ( ! empty( $filters ) || ! empty( $active_buckets ) ) {
+			if ( ! empty( $filters ) ) {
+				$display_filters = true;
 
 				if ( ! $this->jetpack_search->are_filters_by_widget_disabled() && ! $this->should_display_sitewide_filters() ) {
 					$filters = array_filter( $filters, array( $this, 'is_for_current_widget' ) );
-					$active_buckets = array_filter( $active_buckets, array( $this, 'is_for_current_widget' ) );
 				}
 
 				foreach ( $filters as $filter ) {
@@ -144,10 +154,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 						break;
 					}
-				}
-
-				if ( ! empty( $active_buckets ) ) {
-					$display_filters = true;
 				}
 			}
 		}
@@ -206,20 +212,6 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		<?php endif;
 
 		if ( $display_filters ) {
-
-			/**
-			 * Responsible for rendering the widget's active filters that are applied to the search.
-			 *
-			 * @module search
-			 *
-			 * @since 5.8.0
-			 *
-			 * @param $active_bucket                       The selected filters for the currenet query
-			 * @param $instance                            The current widget instance
-			 * @param Jetpack_Search $this->jetpack_search The Jetpack_Search instance
-			 */
-			do_action( 'jetpack_search_render_active_filters', $active_buckets, $instance, $this->jetpack_search );
-
 			/**
 			 * Responsible for rendering filters to narrow down search results.
 			 *
@@ -227,20 +219,35 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			 *
 			 * @since 5.8.0
 			 *
-			 * @param array $filters                       The possible filters for the current query
-			 * @param $instance                            The current widget instance
-			 * @param Jetpack_Search $this->jetpack_search The Jetpack_Search instance
+			 * @param array $filters                       The possible filters for the current query.
+			 * @param $instance                            The current widget instance.
+			 * @param Jetpack_Search $this->jetpack_search The Jetpack_Search instance.
 			 */
-			do_action( 'jetpack_search_render_filters', $filters, $instance, $this->jetpack_search );
+			do_action(
+				'jetpack_search_render_filters',
+				$filters,
+				$instance,
+				$this->jetpack_search
+			);
 		}
 
-		$this->maybe_render_javascript( $instance, $order, $orderby );
+		$this->maybe_render_sort_javascript( $instance, $order, $orderby );
+		$this->render_filter_interaction_javascript();
 
 		echo $args['after_widget'];
 	}
 
-	private function maybe_render_javascript( $instance, $order, $orderby ) {
-		if ( ! empty( $instance['user_sort_enabled'] ) ): ?>
+	/**
+	 * Renders JavaScript for the sorting controls on the frontend
+	 *
+	 * @param array  $instance The current widget instance.
+	 * @param string $order   The order to initialize the select with.
+	 * @param string $orderby The orderby to initialize the select with.
+	 * @return void
+	 */
+	private function maybe_render_sort_javascript( $instance, $order, $orderby ) {
+		if ( ! empty( $instance['user_sort_enabled'] ) ) :
+		?>
 		<!--
 		This JS is a bit complicated, but here's what it's trying to do:
 		- find or create a search form
@@ -274,6 +281,33 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				} );
 			</script>
 		<?php endif;
+	}
+
+	/**
+	 * Renders JavaScript to support checkbox filters.
+	 *
+	 * @return void
+	 */
+	private function render_filter_interaction_javascript() {
+		?>
+		<script type="text/javascript">
+			jQuery( document ).ready( function() {
+				var checkboxSelector = '.jetpack-search-filters-widget__filter-list input[type="checkbox"]',
+					checkboxes = jQuery( checkboxSelector );
+
+				jQuery( checkboxSelector ) .prop( 'disabled', false );
+				jQuery( checkboxSelector ).on( 'click change', function( e ) {
+					var anchor;
+					e.preventDefault();
+
+					anchor = jQuery( this ).closest( 'a' );
+					if ( anchor.length ) {
+						window.location.href = anchor.prop( 'href' );
+					}
+				} );
+			} );
+		</script>
+		<?php
 	}
 
 	private function sorting_to_wp_query_param( $sort ) {
@@ -648,13 +682,40 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	/**
 	 * Renders all available filters that can be used to filter down search results on the frontend.
 	 *
-	 * @param array $filters
+	 * @param array $filters  The available filters for the current query.
+	 * @param array $instance The current widget instance.
+	 *
+	 * @return void
 	 */
-	function render_available_filters( $filters ) {
-		foreach ( (array) $filters as $filter ) {
-			if ( count( $filter['buckets'] ) < 2 ) {
-				continue;
+	public function render_available_filters( $filters, $instance ) {
+		$active_buckets               = $this->jetpack_search->get_active_filter_buckets();
+		$post_types_differ_searchable = Jetpack_Search_Helpers::post_types_differ_searchable( $instance );
+		$post_types_differ_query      = Jetpack_Search_Helpers::post_types_differ_query( $instance );
+		$remove_all_filters           = ( count( $active_buckets ) > 1 )
+			? add_query_arg( 's', get_query_var( 's' ), home_url() )
+			: '';
+
+		if ( $post_types_differ_searchable ) {
+			$remove_all_filters = empty( $remove_all_filters ) ? '' : Jetpack_Search_Helpers::add_post_types_to_url( $remove_all_filters, $instance['post_types'] );
+
+			if ( $post_types_differ_query ) {
+				$filters = Jetpack_Search_Helpers::ensure_post_types_on_remove_url( $filters, $instance['post_types'] );
+			} else {
+				$filters = Jetpack_Search_Helpers::remove_active_from_post_type_buckets( $filters );
 			}
+		}
+
+		if ( $remove_all_filters ) :
+		?>
+			<p>
+				<a href="<?php echo esc_url( $remove_all_filters ); ?>">
+					<?php esc_html_e( 'Remove All Filters', 'jetpack' ); ?>
+				</a>
+			</p>
+		<?php
+		endif;
+
+		foreach ( (array) $filters as $filter ) {
 			$this->render_filter( $filter );
 		}
 	}
@@ -664,143 +725,41 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	}
 
 	/**
-	 * Responsible for removing all active buckets with a type of post_type.
-	 *
-	 * If the current post type filters match the post type filters that the widget has restricted the
-	 * search too, then we don't want to show the post type buckets. Otherwise, when a user first search, we
-	 * would end up showing an active filters and a post types section that look very similar.
-	 *
-	 * See: https://github.com/Automattic/jetpack/pull/8471#issuecomment-355711814
-	 *
-	 * @param array $active_bucket
-	 */
-	function filter_post_types_from_active_buckets( $active_bucket ) {
-		return empty( $active_bucket['type'] ) || 'post_type' != $active_bucket['type'];
-	}
-
-	/**
-	 * Since we provide support for the widget restricting post types by adding the selected post types as
-	 * active filters, if removing a post type filter would result in there no longer be post_type args in the URL,
-	 * we need to be sure to add them back.
-	 *
-	 * @param array $active_buckets
-	 * @param array $post_types
-	 */
-	function ensure_post_types_on_remove_url( $active_buckets, $post_types ) {
-		$modified = array();
-
-		foreach ( (array) $active_buckets as $active_bucket ) {
-			if ( 'post_type' != $active_bucket['type'] ) {
-				$modified[] = $active_bucket;
-				continue;
-			}
-
-			$parsed = wp_parse_url( $active_bucket['remove_url'] );
-			if ( ! $parsed ) {
-				$modified[] = $active_bucket;
-			}
-
-			$query = array();
-			wp_parse_str( $parsed['query'], $query );
-
-			if ( empty( $query['post_type'] ) ) {
-				$active_bucket['remove_url'] = $this->add_post_types_to_url( $active_bucket['remove_url'], $post_types );
-			}
-
-			$modified[] = $active_bucket;
-		}
-
-		return $modified;
-	}
-
-	/**
-	 * Given a url and an array of post types, will ensure that the post types are properly applied to the URL as args.
-	 *
-	 * @param string $url
-	 * @param array $post_types
-	 */
-	function add_post_types_to_url( $url, $post_types ) {
-		$url = Jetpack_Search_Helpers::remove_query_arg( 'post_type', $url );
-		if ( empty( $post_types ) ) {
-			return $url;
-		}
-
-		$url = Jetpack_Search_Helpers::add_query_arg(
-			'post_type',
-			implode( ',', $post_types ),
-			$url
-		);
-
-		return $url;
-	}
-
-	/**
-	 * Renders the current filters applied to the search.
-	 *
-	 * @param array $active_buckets
-	 * @param array $instance
-	 */
-	function render_current_filters( $active_buckets, $instance ) {
-		if ( ! Jetpack_Search_Helpers::post_types_differ_query( $instance ) ) {
-			$active_buckets = array_filter( $active_buckets, array( $this, 'filter_post_types_from_active_buckets' ) );
-		}
-
-		if ( empty( $active_buckets ) ) {
-			return;
-		}
-
-		$remove_all_filters = add_query_arg( 's', get_query_var( 's' ), home_url() );
-		if ( Jetpack_Search_Helpers::post_types_differ_searchable( $instance ) ) {
-			$remove_all_filters = $this->add_post_types_to_url( $remove_all_filters, $instance['post_types'] );
-			$active_buckets = $this->ensure_post_types_on_remove_url( $active_buckets, $instance['post_types'] );
-		}
-
-		?>
-
-		<h4 class="jetpack-search-filters-widget__sub-heading"><?php esc_html_e( 'Current Filters', 'jetpack' ); ?></h4>
-		<ul class="jetpack-search-filters-widget__filer-list">
-			<?php foreach ( $active_buckets as $item ) : ?>
-				<li>
-					<a href="<?php echo esc_url( $item['remove_url'] ); ?>">
-						<?php
-							echo sprintf(
-								_x( '&larr; %1$s: %2$s', 'aggregation widget: active filter type and name', 'jetpack' ),
-								esc_html( $item['type_label'] ),
-								esc_html( $item['name'] )
-							);
-						?>
-					</a>
-				</li>
-			<?php endforeach; ?>
-			<?php if ( count( $active_buckets ) > 1 ) : ?>
-				<li>
-					<a href="<?php echo esc_url( $remove_all_filters ); ?>">
-						<?php esc_html_e( 'Remove All Filters', 'jetpack' ); ?>
-					</a>
-				</li>
-			<?php endif; ?>
-		</ul>
-	<?php }
-
-	/**
 	 * Renders a single filter that can be applied to the current search.
 	 *
-	 * @param array $filter
+	 * @param array $filter The filter to render.
 	 */
-	function render_filter( $filter ) { ?>
+	public function render_filter( $filter ) {
+		?>
 		<h4 class="jetpack-search-filters-widget__sub-heading">
 			<?php echo esc_html( $filter['name'] ); ?>
 		</h4>
-		<ul class="jetpack-search-filters-widget__filer-list">
+		<ul class="jetpack-search-filters-widget__filter-list">
 			<?php foreach ( $filter['buckets'] as $item ) : ?>
 				<li>
-					<a href="<?php echo esc_url( $item['url'] ); ?>">
-						<?php echo esc_html( $item['name'] ); ?>
-					</a>
-
-					(<?php echo number_format_i18n( absint( $item['count'] ) ); ?>)
+					<label>
+					<?php if ( empty( $item['active'] ) ) : ?>
+						<a href="<?php echo esc_url( $item['url'] ); ?>">
+					<?php else : ?>
+						<a href="<?php echo esc_url( $item['remove_url'] ); ?>">
+					<?php endif; ?>
+							<input
+								type="checkbox"
+								<?php checked( ! empty( $item['active'] ) ); ?>
+								disabled
+							/>&nbsp;
+							<?php echo esc_html( $item['name'] ); ?>&nbsp;
+							<?php
+								echo esc_html( sprintf(
+									'(%s)',
+									number_format_i18n( absint( $item['count'] ) )
+								) );
+							?>
+						</a>
+					</label>
 				</li>
-			<?php endforeach;?>
+			<?php endforeach; ?>
 		</ul>
-	<?php }
+	<?php
+	}
 }

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -688,15 +688,23 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 	 * @return void
 	 */
 	public function render_available_filters( $filters, $instance ) {
-		$active_buckets               = $this->jetpack_search->get_active_filter_buckets();
 		$post_types_differ_searchable = Jetpack_Search_Helpers::post_types_differ_searchable( $instance );
 		$post_types_differ_query      = Jetpack_Search_Helpers::post_types_differ_query( $instance );
+		$this->jetpack_search->get_active_filter_buckets();
+		$active_buckets               = $this->jetpack_search->get_active_filter_buckets();
+
+		if ( ! $post_types_differ_query ) {
+			$active_buckets = Jetpack_Search_Helpers::filter_post_types( $active_buckets );
+		}
+
 		$remove_all_filters           = ( count( $active_buckets ) > 1 )
 			? add_query_arg( 's', get_query_var( 's' ), home_url() )
 			: '';
 
 		if ( $post_types_differ_searchable ) {
-			$remove_all_filters = empty( $remove_all_filters ) ? '' : Jetpack_Search_Helpers::add_post_types_to_url( $remove_all_filters, $instance['post_types'] );
+			$remove_all_filters = empty( $remove_all_filters )
+				? ''
+				: Jetpack_Search_Helpers::add_post_types_to_url( $remove_all_filters, $instance['post_types'] );
 
 			if ( $post_types_differ_query ) {
 				$filters = Jetpack_Search_Helpers::ensure_post_types_on_remove_url( $filters, $instance['post_types'] );

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -14,6 +14,31 @@
 	margin-bottom: 1.5em;
 }
 
-ul.jetpack-search-filters-widget__filer-list {
+ul.jetpack-search-filters-widget__filter-list li {
+	border: none;
+	padding: 0;
+}
+
+ul.jetpack-search-filters-widget__filter-list li a {
+	text-decoration: none;
+}
+
+ul.jetpack-search-filters-widget__filter-list li a:hover {
+	box-shadow: none;
+}
+
+ul.jetpack-search-filters-widget__filter-list li label {
+	font-weight: inherit;
+}
+
+ul.jetpack-search-filters-widget__filter-list li input[type="checkbox"] {
+	cursor: inherit;
+}
+
+.jetpack-search-filters-widget__filter-list {
+	list-style: none;
+}
+
+ul.jetpack-search-filters-widget__filter-list {
 	margin-bottom: 1.5em;
 }

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -31,10 +31,6 @@ ul.jetpack-search-filters-widget__filter-list li label {
 	font-weight: inherit;
 }
 
-ul.jetpack-search-filters-widget__filter-list li input[type="checkbox"] {
-	cursor: inherit;
-}
-
 .jetpack-search-filters-widget__filter-list {
 	list-style: none;
 }

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -399,111 +399,58 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 		);
 	}
 
-	function get_ensure_post_types_on_remove_url_data() {
+	/**
+	 * @dataProvider get_filter_post_types_data
+	 */
+	function test_filter_post_types( $expected, $filters ) {
+		$this->assertSame( $expected, Jetpack_Search_Helpers::filter_post_types( $filters ) );
+	}
+
+	function get_filter_post_types_data() {
 		return array(
-			'unmodified_if_no_post_types' => array(
+			'unchanged_active_buckets_no_post_types' => array(
 				array(
-					'taxonomy_0' => array(
+					array(
+						'type' => 'date_histogram',
+					),
+					array(
 						'type' => 'taxonomy',
 					),
 				),
 				array(
-					'taxonomy_0' => array(
+					array(
+						'type' => 'date_histogram',
+					),
+					array(
 						'type' => 'taxonomy',
 					),
 				),
-				array(),
 			),
-			'unmodified_if_post_type_no_buckets' => array(
+			'active_bucket_no_post_types' => array(
 				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
+					array(
+						'type' => 'date_histogram',
+					),
+					array(
+						'type' => 'taxonomy',
 					),
 				),
 				array(
-					'post_type_0' => array(
+					array(
+						'type' => 'date_histogram',
+					),
+					array(
 						'type' => 'post_type',
 					),
+					array(
+						'type' => 'taxonomy',
+					),
 				),
-				array(),
 			),
-			'unmodified_if_remove_url_not_on_bucket' => array(
+			'unchaged_filters_no_post_type' => array(
 				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-							),
-						),
-					),
-				),
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-							),
-						),
-					),
-				),
-				array(),
-			),
-			'unmodified_if_remove_url_bad' => array(
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-								'remove_url' => 'http://:80',
-							),
-						),
-					),
-				),
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-								'remove_url' => 'http://:80',
-							),
-						),
-					),
-				),
-				array(),
-			),
-			'unmodified_if_no_query' => array(
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-								'remove_url' => 'http://jetpack.com',
-							),
-						),
-					),
-				),
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
-						'buckets' => array(
-							array(
-								'name' => 'test',
-								'remove_url' => 'http://jetpack.com',
-							),
-						),
-					),
-				),
-				array(),
-			),
-			'unmodified_if_query_has_post_type' => array(
-				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
 						'buckets' => array(
 							array(
 								'name' => 'test',
@@ -513,8 +460,8 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 					),
 				),
 				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
 						'buckets' => array(
 							array(
 								'name' => 'test',
@@ -523,12 +470,20 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 						),
 					),
 				),
-				array(),
 			),
-			'adds_post_types_if_no_post_types_on_remove_url' => array(
+			'filters_no_post_type' => array(
 				array(
-					'post_type_0' => array(
-						'type' => 'post_type',
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+					'date_histogram_2' => array(
+						'type' => 'date_histogram',
 						'buckets' => array(
 							array(
 								'name' => 'test',
@@ -538,17 +493,34 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 					),
 				),
 				array(
-					'post_type_0' => array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+					'post_type_1' => array(
 						'type' => 'post_type',
 						'buckets' => array(
 							array(
 								'name' => 'test',
-								'remove_url' => 'http://jetpack.com',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+					'date_histogram_2' => array(
+						'type' => 'date_histogram',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
 							),
 						),
 					),
 				),
-				array( 'post', 'page' ),
 			),
 		);
 	}
@@ -1073,6 +1045,160 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 			'overwrite_existing_post_types' => array(
 				'http://jetpack.com?s=test&post_type=post,page',
 				'http://jetpack.com?s=test&post_type=jetpack-testimonial',
+				array( 'post', 'page' ),
+			),
+		);
+	}
+
+	function get_ensure_post_types_on_remove_url_data() {
+		return array(
+			'unmodified_if_no_post_types' => array(
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+				array(),
+			),
+			'unmodified_if_post_type_no_buckets' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+				array(),
+			),
+			'unmodified_if_remove_url_not_on_bucket' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_remove_url_bad' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://:80',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://:80',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_no_query' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_query_has_post_type' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'adds_post_types_if_no_post_types_on_remove_url' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
 				array( 'post', 'page' ),
 			),
 		);

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -380,7 +380,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider  get_add_post_types_to_url_data(
+	 * @dataProvider get_add_post_types_to_url_data
 	 */
 	function test_add_post_types_to_url( $expected, $url, $post_types ) {
 		$this->assertSame(

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -370,6 +370,190 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider get_remove_active_from_post_type_buckets_data
+	 */
+	public function test_remove_active_from_post_type_buckets( $expected, $input ) {
+		$this->assertSame(
+			$expected,
+			Jetpack_Search_Helpers::remove_active_from_post_type_buckets( $input )
+		);
+	}
+
+	/**
+	 * @dataProvider  get_add_post_types_to_url_data(
+	 */
+	function test_add_post_types_to_url( $expected, $url, $post_types ) {
+		$this->assertSame(
+			$expected,
+			Jetpack_Search_Helpers::add_post_types_to_url( $url, $post_types )
+		);
+	}
+
+	/**
+	 * @dataProvider get_ensure_post_types_on_remove_url_data
+	 */
+	function test_ensure_post_types_on_remove_url( $expected, $filters, $post_types ) {
+		$this->assertSame(
+			$expected,
+			Jetpack_Search_Helpers::ensure_post_types_on_remove_url( $filters, $post_types )
+		);
+	}
+
+	function get_ensure_post_types_on_remove_url_data() {
+		return array(
+			'unmodified_if_no_post_types' => array(
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+				array(),
+			),
+			'unmodified_if_post_type_no_buckets' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+				array(),
+			),
+			'unmodified_if_remove_url_not_on_bucket' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_remove_url_bad' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://:80',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://:80',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_no_query' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'unmodified_if_query_has_post_type' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(),
+			),
+			'adds_post_types_if_no_post_types_on_remove_url' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com?post_type=post,page',
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'name' => 'test',
+								'remove_url' => 'http://jetpack.com',
+							),
+						),
+					),
+				),
+				array( 'post', 'page' ),
+			),
+		);
+	}
+
+	/**
 	 * Data providers
 	 */
 	function get_build_widget_id_data() {
@@ -809,6 +993,87 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 					'2' => $this->get_sample_widget_instance( 1 ),
 					'_multiwidget' => 1,
 				),
+			),
+		);
+	}
+
+	public function get_remove_active_from_post_type_buckets_data() {
+		return array(
+			'empty_array' => array(
+				array(),
+				array(),
+			),
+			'unchanged_if_not_post_type_filter' => array(
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+				array(
+					'taxonomy_0' => array(
+						'type' => 'taxonomy',
+					),
+				),
+			),
+			'unchanged_if_post_type_but_no_buckets' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+					),
+				),
+			),
+			'active_false_on_post_type_buckets' => array(
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'active' => false,
+							),
+							array(
+								'active' => false,
+							),
+						),
+					),
+				),
+				array(
+					'post_type_0' => array(
+						'type' => 'post_type',
+						'buckets' => array(
+							array(
+								'active' => true,
+							),
+							array(
+								'active' => true,
+							),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	function get_add_post_types_to_url_data() {
+		return array(
+			'same_url_empty_post_types' => array(
+				'http://jetpack.com?s=test',
+				'http://jetpack.com?s=test',
+				array(),
+			),
+			'no_post_types_on_url' => array(
+				'http://jetpack.com?s=test&post_type=post,page',
+				'http://jetpack.com?s=test',
+				array( 'post', 'page' ),
+			),
+			'overwrite_existing_post_types' => array(
+				'http://jetpack.com?s=test&post_type=post,page',
+				'http://jetpack.com?s=test&post_type=jetpack-testimonial',
+				array( 'post', 'page' ),
 			),
 		);
 	}


### PR DESCRIPTION
Alternative to #8540 

This PR begins to use checkboxes for the filters in the hopes that it's a bit clearer to the user which filters are applied and which are not.

As part of this, the active buckets are now displayed in line with other buckets for a given filter. Because of this, the "Current Filters" section is now gone. 👋 🚶 

To test:

- Checkout branch on site with Jetpack Professional
- Add a Jetpack search widget with multiple filters
- Ensure all post types are selected
- Select/deselect filter on the frontend and ensure they act as expected
- Go back to widget admin and make sure at least one post type is NOT selected
- Select/deselect filters on the frontend and ensure:
    - When you remove a post type filter, or when you click "Remove all filters", that you end up on a URL 
    - On that URL, also ensure that the available post type filters are not checked
- Clear all filters
- Select one post type filter and some other filter
- Click "Remove all filters" and ensure that all filters are in fact removed
- Disable JavaScript and test that it's still functional
    - Note: When JS is disabled the checkboxes are disabled and the user will need to click the link. Because of this, the checkbox does not inherit the cursor pointer unless JS is enabled.

Screenshots:
TwentySeventeen
<img width="378" alt="screen shot 2018-01-25 at 7 36 50 pm" src="https://user-images.githubusercontent.com/1126811/35421154-34c406ae-0207-11e8-8f4b-34cb366c66bb.png">
<img width="381" alt="screen shot 2018-01-25 at 7 36 42 pm" src="https://user-images.githubusercontent.com/1126811/35421155-34d34fe2-0207-11e8-92b7-200790fe7728.png">

TwentySixteen
<img width="346" alt="screen shot 2018-01-25 at 7 36 29 pm" src="https://user-images.githubusercontent.com/1126811/35421156-34e238b8-0207-11e8-8bb0-b5b3d4a8ed4f.png">
<img width="366" alt="screen shot 2018-01-25 at 7 36 21 pm" src="https://user-images.githubusercontent.com/1126811/35421157-34f21404-0207-11e8-9e0e-cfa909cdecd8.png">

TwentyFifteen
<img width="334" alt="screen shot 2018-01-25 at 7 37 26 pm" src="https://user-images.githubusercontent.com/1126811/35421152-349fb2cc-0207-11e8-9c0f-df64738df685.png">
<img width="319" alt="screen shot 2018-01-25 at 7 37 03 pm" src="https://user-images.githubusercontent.com/1126811/35421153-34af4dcc-0207-11e8-8970-82adffee3f23.png">
