### PR TITLE
Tweak "add" label for search filters

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -588,7 +588,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			<p class="jetpack-search-filters-widget__controls">
 				<a href="#" class="delete"><?php esc_html_e( 'Remove', 'jetpack' ); ?></a>
 				<span class="control-separator">|</span>
-				<a href="#" class="add"><?php esc_html_e( 'Add', 'jetpack' ); ?></a>
+				<a href="#" class="add"><?php esc_html_e( 'Add another', 'jetpack' ); ?></a>
 			</p>
 		</div>
 	<?php }


### PR DESCRIPTION
Make 'add another' filter label clearer - it was just "Add" before and I wasn't sure if it meant "add this one" or "add another one of these"

<img width="256" alt="add-another-link" src="https://user-images.githubusercontent.com/51896/35417953-7fe19ba6-01e4-11e8-9e19-f2e681bd0f6f.png">


