### PR TITLE
Search: adjust query boosting, add recency filter, and minor refactoring

### DIFF
--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -23,28 +23,28 @@
 
 class Jetpack_WPES_Query_Builder {
 
-	public $es_filters = array();
+	protected $es_filters = array();
 
 	// Custom boosting with function_score
-	public $functions = array();
-	public $decays    = array();
-	public $scripts   = array();
-	public $functions_max_boost  = 2.0;
-	public $functions_score_mode = 'multiply';
-	public $query_bool_boost     = null;
+	protected $functions = array();
+	protected $decays    = array();
+	protected $scripts   = array();
+	protected $functions_max_boost  = 2.0;
+	protected $functions_score_mode = 'multiply';
+	protected $query_bool_boost     = null;
 
 	// General aggregations for buckets and metrics
-	public $aggs_query = false;
-	public $aggs       = array();
+	protected $aggs_query = false;
+	protected $aggs       = array();
 
 	// The set of top level text queries to combine
-	public $must_queries    = array();
-	public $should_queries  = array();
-	public $dis_max_queries = array();
+	protected $must_queries    = array();
+	protected $should_queries  = array();
+	protected $dis_max_queries = array();
 
-	public $diverse_buckets_query = false;
-	public $bucket_filters        = array();
-	public $bucket_sub_aggs       = array();
+	protected $diverse_buckets_query = false;
+	protected $bucket_filters        = array();
+	protected $bucket_sub_aggs       = array();
 
 	////////////////////////////////////
 	// Methods for building a query
@@ -169,7 +169,7 @@ class Jetpack_WPES_Query_Builder {
 		$this->bucket_sub_aggs = array_merge( $this->bucket_sub_aggs, $agg );
 	}
 
-	public function _add_bucket_filter( $name, $filter ) {
+	protected function _add_bucket_filter( $name, $filter ) {
 		$this->diverse_buckets_query   = true;
 		$this->bucket_filters[ $name ] = $filter;
 	}
@@ -306,7 +306,7 @@ class Jetpack_WPES_Query_Builder {
 	 *
 	 * @return array An aggregation query as an array of topics, filters, and bucket names
 	 */
-	function build_aggregation() {
+	public function build_aggregation() {
 		if ( empty( $this->bucket_sub_aggs ) && empty( $this->aggs_query ) ) {
 			return array();
 		}

--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
@@ -111,18 +111,18 @@ jetpack_require_lib( 'jetpack-wpes-query-builder' );
 
 class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 
-	var $orig_query = '';
-	var $current_query = '';
-	var $langs;
-	var $avail_langs = array( 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'eu', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh' );
+	protected $orig_query = '';
+	protected $current_query = '';
+	protected $langs;
+	protected $avail_langs = array( 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'eu', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh' );
 
-	function __construct( $user_query, $langs ) {
+	public function __construct( $user_query, $langs ) {
 		$this->orig_query = $user_query;
 		$this->current_query = $this->orig_query;
 		$this->langs = $this->norm_langs( $langs );
 	}
 
-	var $extracted_phrases = array();
+	protected $extracted_phrases = array();
 
 	///////////////////////////////////////////////////////
 	// Methods for Building arrays of multilingual fields
@@ -130,7 +130,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	/*
 	 * Normalize language codes
 	 */
-	function norm_langs( $langs ) {
+	public function norm_langs( $langs ) {
 		$lst = array();
 		foreach( $langs as $l ) {
 			$l = strtok( $l, '-_' );
@@ -147,7 +147,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 * Take a list of field prefixes and expand them for multi-lingual
 	 * with the provided boostings.
 	 */
-	function merge_ml_fields( $fields2boosts, $additional_fields ) {
+	public function merge_ml_fields( $fields2boosts, $additional_fields ) {
 		$flds = array();
 		foreach( $fields2boosts as $f => $b ) {
 			foreach( $this->langs as $l ) {
@@ -178,7 +178,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *
 	 * See also: https://github.com/twitter/twitter-text/blob/master/java/src/com/twitter/Regex.java
 	 */
-	function author_field_filter( $args ) {
+	public function author_field_filter( $args ) {
 		$defaults = array(
 			'wpcom_id_field' => 'author_id',
 			'must_query_fields' => null,
@@ -281,7 +281,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *  returns true/false of whether any were found
 	 *
 	 */
-	function text_field_filter( $args ) {
+	public function text_field_filter( $args ) {
 		$defaults = array(
 			'must_query_fields' => array( 'tag.name' ),
 			'boost_query_fields' => array( 'tag.name' ),
@@ -364,7 +364,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *  returns true/false of whether any were found
 	 *
 	 */
-	function phrase_filter( $args ) {
+	public function phrase_filter( $args ) {
 		$defaults = array(
 			'must_query_fields' => array( 'all_content' ),
 			'boost_query_fields' => array( 'title' ),
@@ -435,7 +435,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *    boost_query_fields: array of fields to boost the remaining terms on (optional)
 	 *
 	 */
-	function remaining_query( $args ) {
+	public function remaining_query( $args ) {
 		$defaults = array(
 			'must_query_fields' => null,
 			'boost_query_fields' => null,
@@ -480,7 +480,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *    boost_query_fields: array of fields to boost the remaining terms on (optional)
 	 *
 	 */
-	function remaining_prefix_query( $args ) {
+	public function remaining_prefix_query( $args ) {
 		$defaults = array(
 			'must_query_fields' => array( 'all_content' ),
 			'boost_query_fields' => array( 'title' ),
@@ -628,7 +628,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	 *  args:
 	 *    langs2prob: list of languages to search in with associated boosts
 	 */
-	function boost_lang_probs( $langs2prob ) {
+	public function boost_lang_probs( $langs2prob ) {
 		foreach( $langs2prob as $l => $p ) {
 			$this->add_function( 'field_value_factor', array(
 				'modifier' => 'none',
@@ -657,7 +657,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	}
 
 	//Best effort string truncation that splits on word breaks
-	function truncate_string( $string, $limit, $break=" " ) {
+	protected function truncate_string( $string, $limit, $break=" " ) {
 		if ( mb_strwidth( $string ) <= $limit ) {
 			return $string;
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1,34 +1,5 @@
 <?php
 
-define( 'JETPACK_SEARCH_VIP_INDEX', true );
-
-add_filter( 'jetpack_search_es_query_args', function( $es_query_args, $query ) {
-	if ( ! is_user_logged_in() ) {
-		//return $es_query_args;
-	}
-
-	echo '<div style="background-color:white;padding:10px;">';
-	var_dump( $es_query_args );
-	echo '</div>';
-
-	return $es_query_args;
-}, 10, 2 );
-
-
-//add_filter( 'jetpack_search_es_wp_query_args', function ( $args ) {
-//
-//	// set of default query fields
-//	$args[ 'query_fields' ] = [
-//		'title',
-//		'content',
-//		'author',
-//		'tag',
-//		'category',
-//	];
-//
-//	return $args;
-//}, 10, 2 );
-
 class Jetpack_Search {
 
 	protected $found_posts = 0;


### PR DESCRIPTION
Fixes #8590 

- Adjusts what fields we boost on when running our queries (now I really want an all_content field)
- Adds separate groups of fields for boosting on. All of the boosting is very ad-hoc. Needs more data and testing rather than this hand tuned mess
- Fixes a bug where the default search query was not working if the site had a VIP index (requires adding `define( 'JETPACK_SEARCH_VIP_INDEX', true )` as proposed in #8560 )
- Added a filter for adjusting the recency scoring as discussed in #7975 cc @jeherve 
- I looked at adding other filters, but feels like the other parts of the alg are likely to change too much.
- Cleaned up some code, and made some vars and functions protected

@mdbitz @nickdaugherty the VIP index bug was pretty big here. Also, I think we had broken any cases where query_fields was used to over ride the fields. If you have any real sites set up, looking at the actual query results quality with and without this would be good too.
