### PR TITLE
Added suppress_filters param to get_posts / get_children function calls.

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -174,6 +174,7 @@ class Jetpack_PostImages {
 			'numberposts' => 5,          // No more than 5
 			'post_type' => 'attachment', // Must be attachments
 			'post_mime_type' => 'image', // Must be images
+			'suppress_filters' => false,
 		) );
 
 		if ( ! $post_images ) {

--- a/json-endpoints/class.wpcom-json-api-list-media-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-media-endpoint.php
@@ -60,7 +60,8 @@ class WPCOM_JSON_API_List_Media_Endpoint extends WPCOM_JSON_API_Endpoint {
 			'post_parent' => $args['parent_id'],
 			'offset' => $args['offset'],
 			'numberposts' => $args['number'],
-			'post_mime_type' => $args['mime_type']
+			'post_mime_type' => $args['mime_type'],
+			'suppress_filters' => false,
 		) );
 
 		$response = array();

--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -556,16 +556,16 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		if ( !empty( $include ) ) {
 			$include      = preg_replace( '/[^0-9,]+/', '', $include );
-			$_attachments = get_posts( array( 'include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$_attachments = get_posts( array( 'include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 			$attachments  = array();
 			foreach ( $_attachments as $key => $val ) {
 				$attachments[$val->ID] = $_attachments[$key];
 			}
 		} elseif ( !empty( $exclude ) ) {
 			$exclude     = preg_replace( '/[^0-9,]+/', '', $exclude );
-			$attachments = get_children( array( 'post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$attachments = get_children( array( 'post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 		} else {
-			$attachments = get_children( array( 'post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$attachments = get_children( array( 'post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 		}
 
 		if ( ! empty( $attachments ) ) {

--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -324,16 +324,16 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 
 		if ( !empty( $include ) ) {
 			$include      = preg_replace( '/[^0-9,]+/', '', $include );
-			$_attachments = get_posts( array( 'include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$_attachments = get_posts( array( 'include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 			$attachments  = array();
 			foreach ( $_attachments as $key => $val ) {
 				$attachments[$val->ID] = $_attachments[$key];
 			}
 		} elseif ( !empty( $exclude ) ) {
 			$exclude     = preg_replace( '/[^0-9,]+/', '', $exclude );
-			$attachments = get_children( array( 'post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$attachments = get_children( array( 'post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 		} else {
-			$attachments = get_children( array( 'post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$attachments = get_children( array( 'post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 		}
 
 		if ( ! empty( $attachments ) ) {

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -374,7 +374,8 @@ class Jetpack_Carousel {
 		$attachments = get_posts( array(
 			'include' => array_keys( $selected_images ),
 			'post_type' => 'any',
-			'post_status' => 'any'
+			'post_status' => 'any',
+			'suppress_filters' => false,
 		) );
 
 		foreach ( $attachments as $attachment ) {

--- a/modules/minileven/theme/pub/minileven/functions.php
+++ b/modules/minileven/theme/pub/minileven/functions.php
@@ -232,13 +232,14 @@ function minileven_get_gallery_images() {
 
 	if ( ! $images ) {
 		$images = get_posts( array(
-			'fields'         => 'ids',
-			'numberposts'    => 999,
-			'order'          => 'ASC',
-			'orderby'        => 'menu_order',
-			'post_mime_type' => 'image',
-			'post_parent'    => get_the_ID(),
-			'post_type'      => 'attachment',
+			'fields'           => 'ids',
+			'numberposts'      => 999,
+			'order'            => 'ASC',
+			'orderby'          => 'menu_order',
+			'post_mime_type'   => 'image',
+			'post_parent'      => get_the_ID(),
+			'post_type'        => 'attachment',
+			'suppress_filters' => false,
 		) );
 	}
 

--- a/modules/minileven/theme/pub/minileven/image.php
+++ b/modules/minileven/theme/pub/minileven/image.php
@@ -26,7 +26,7 @@ get_header(); ?>
 	 * Grab the IDs of all the image attachments in a gallery so we can get the URL of the next adjacent image in a gallery,
 	 * or the first image (if we're looking at the last image in a gallery), or, in a gallery of one, just the link to that image file
 	 */
-	$attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => 'ASC', 'orderby' => 'menu_order ID' ) ) );
+	$attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => 'ASC', 'orderby' => 'menu_order ID', 'suppress_filters' => false ) ) );
 	foreach ( $attachments as $k => $attachment ) {
 		if ( $attachment->ID == $post->ID )
 			break;

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -140,15 +140,16 @@ class Jetpack_Slideshow_Shortcode {
 
 		$attachments = get_posts(
 			array(
-				'post_status'    => 'inherit',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image',
-				'posts_per_page' => - 1,
-				'post_parent'    => $post_parent,
-				'order'          => $attr['order'],
-				'orderby'        => $attr['orderby'],
-				'include'        => $attr['include'],
-				'exclude'        => $attr['exclude'],
+				'post_status'      => 'inherit',
+				'post_type'        => 'attachment',
+				'post_mime_type'   => 'image',
+				'posts_per_page'   => - 1,
+				'post_parent'      => $post_parent,
+				'order'            => $attr['order'],
+				'orderby'          => $attr['orderby'],
+				'include'          => $attr['include'],
+				'exclude'          => $attr['exclude'],
+				'suppress_filters' => false,
 			)
 		);
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -702,6 +702,7 @@ function stats_convert_post_titles( $html ) {
 			'post_type' => 'any',
 			'post_status' => 'any',
 			'numberposts' => -1,
+			'suppress_filters' => false,
 		)
 	);
 	foreach ( $posts as $post ) {

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -172,9 +172,10 @@ class Featured_Content {
 		}
 
 		$featured_posts = get_posts( array(
-			'include'        => $post_ids,
-			'posts_per_page' => count( $post_ids ),
-			'post_type'      => self::$post_types,
+			'include'          => $post_ids,
+			'posts_per_page'   => count( $post_ids ),
+			'post_type'        => self::$post_types,
+			'suppress_filters' => false,
 		) );
 
 		return $featured_posts;
@@ -230,6 +231,7 @@ class Featured_Content {
 		$featured = get_posts( array(
 			'numberposts' => $quantity,
 			'post_type'   => self::$post_types,
+			'suppress_filters' => false,
 			'tax_query'   => array(
 				array(
 					'field'    => 'term_id',

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -70,7 +70,7 @@ class Jetpack_Tiled_Gallery {
 
 		if ( !empty( $include ) ) {
 			$include = preg_replace( '/[^0-9,]+/', '', $include );
-			$_attachments = get_posts( array('include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby) );
+			$_attachments = get_posts( array('include' => $include, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false) );
 
 			$attachments = array();
 			foreach ( $_attachments as $key => $val ) {
@@ -83,9 +83,9 @@ class Jetpack_Tiled_Gallery {
 			$attachments = array();
 		} elseif ( !empty( $exclude ) ) {
 			$exclude = preg_replace( '/[^0-9,]+/', '', $exclude );
-			$attachments = get_children( array('post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby) );
+			$attachments = get_children( array('post_parent' => $id, 'exclude' => $exclude, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false) );
 		} else {
-			$attachments = get_children( array('post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby ) );
+			$attachments = get_children( array('post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $order, 'orderby' => $orderby, 'suppress_filters' => false ) );
 		}
 		return $attachments;
 	}

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -130,6 +130,7 @@ function jetpack_migrate_image_widget() {
 			),
 			'post_status' => 'inherit',
 			'post_type'   => 'attachment',
+			'suppress_filters' => false,
 		) );
 
 		foreach ( $attachment_ids as $attachment_id ) {

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -295,6 +295,7 @@ abstract class SAL_Site {
 			'name' => $name,
 			'numberposts' => 1,
 			'post_type' => $this->get_whitelisted_post_types(),
+		    'suppress_filters' => false,
 		) );
 
 		if ( ! $posts || ! isset( $posts[0]->ID ) || ! $posts[0]->ID ) {


### PR DESCRIPTION
Fixes #8624

#### Changes proposed in this Pull Request:

* Pass suppress_filters to all public facing calls to get_posts / get_children

#### Testing instructions:

* This is hard to test. There should be no noticeable difference it it works. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Added suppress_filters param to get_posts / get_children function calls.
