### PR TITLE
Search: Force at least one post type to be selected

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -435,7 +435,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			</p>
 
 			<p class="jetpack-search-filters-widget__post-types-select">
-				<label><?php esc_html_e( 'Post types included in results:', 'jetpack' ); ?></label>
+				<label><?php esc_html_e( 'Post types to search (minimum of 1):', 'jetpack' ); ?></label>
 				<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
 					<label>
 						<input

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -63,6 +63,19 @@
 			}
 		} );
 
+		widget.on( 'click', '.jetpack-search-filters-widget__post-types-select input[type="checkbox"]', function( e ) {
+			var t = $( this );
+			var siblingsChecked = t.closest( '.jetpack-search-filters-widget' )
+				.find( '.jetpack-search-filters-widget__post-types-select input[type="checkbox"]:checked' );
+
+			if ( 0 === siblingsChecked.length ) {
+				e.preventDefault();
+				e.stopPropagation();
+
+				trackAndBumpMCStats( 'attempted_no_post_types', args.tracksEventData );
+			}
+		} );
+
 		widget.on( 'change', '.jetpack-search-filters-widget__post-types-select input[type="checkbox"]', function() {
 			var t = $( this );
 			var eventArgs = {

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -223,6 +223,7 @@
 		widget.off( 'change', '.jetpack-search-filters-widget__taxonomy-select' );
 		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:first select' );
 		widget.off( 'change', '.jetpack-search-filters-widget__date-histogram-select:eq(1) select' );
+		widget.off( 'click', '.jetpack-search-filters-widget__post-types-select input[type="checkbox"]' );
 
 		setListeners( widget );
 	} );


### PR DESCRIPTION
Fixes #8616 

A user can not deselect all post types, or else what would we search? But, the way we handled this previously was to validate on the backend and just select all of the posts.

This PR updates the label to to mention that at least one post type is required and then doesn't allow deselecting all post types via JavaScript. As a note, we can't just disabled that last checkbox, because disabled checkboxes don't get sent in the request to save the widget. TIL.

To test:

- Checkout branch on site with Jetpack Professional
- Add search widget
- Ensure "Show search box" is toggled on
- Try deselecting all post types

Screenshot:

<img width="299" alt="screen shot 2018-01-26 at 12 33 56 pm" src="https://user-images.githubusercontent.com/1126811/35454825-3788df7a-0295-11e8-968b-c6ff51d4a75e.png">
