### PR TITLE
Allow re-ordering of filters via drag and drop

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -61,7 +61,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		wp_register_script(
 			'widget-jetpack-search-filters',
 			plugins_url( 'js/search-widget-filters-admin.js', __FILE__ ),
-			array( 'jquery', 'jp-tracks', 'jp-tracks-functions' )
+			array( 'jquery', 'jquery-ui-sortable', 'jp-tracks', 'jp-tracks-functions' )
 
 		);
 
@@ -442,9 +442,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 						<?php esc_html_e( 'Show extra filtering options', 'jetpack' ); ?>
 					</label>
 				</p>
-				<?php foreach ( (array) $instance['filters'] as $filter ) : ?>
-					<?php $this->render_widget_filter( $filter ); ?>
-				<?php endforeach; ?>
+				<div class="jetpack-search-filters-widget__filters">
+					<?php foreach ( (array) $instance['filters'] as $filter ) : ?>
+						<?php $this->render_widget_filter( $filter ); ?>
+					<?php endforeach; ?>
+				</div>
 				<div class="jetpack-search-filters-help">
 					<a href="https://jetpack.com/support/search/#filters-not-showing-up" target="_blank"><?php esc_html_e( "Why aren't my filters appearing?", 'jetpack' ); ?></a>
 				</div>

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -3,6 +3,7 @@
 	border: 1px solid #dfdfdf;
 	padding: 0 12px;
 	margin-bottom: 12px;
+	cursor: move;
 }
 
 .jetpack-search-filters-widget__controls {
@@ -37,6 +38,13 @@
 
 .jetpack-search-filters-widget__date-histogram-select {
 	display: none;
+}
+
+.jetpack-search-filters-widget__filter-placeholder {
+	border: 1px #555 dashed;
+	background-color: #eee;
+	height: 150px;
+	margin-bottom: 12px;
 }
 
 /* When post type is selected, remove the other controls */

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -182,6 +182,20 @@
 
 			selector.toggleClass( 'hide-filters' );
 		} );
+
+		// make the filters sortable
+		$( '.jetpack-search-filters-widget__filters' ).sortable({
+			placeholder: 'jetpack-search-filters-widget__filter-placeholder',
+			axis: 'y',
+			revert: true,
+			// containment: 'parent',
+			// forceHelperSize: true,
+			// forceContainerSize: true,
+			change: function( ev ) {
+				wp.customize.state( 'saved' ).set( false );
+			}
+		})
+		.disableSelection();
 	};
 
 	// When widgets are updated, remove and re-add listeners


### PR DESCRIPTION
Allows Search filters to be reordered via drag and drop in the widget configuration UI.

To test:

- add more than one filter
- rearrange as you like
- "Publish" button should become enabled (code marks state as dirty)
- Filters in widget should reflect reordered state
