### PR TITLE
Build: warn about incompatible yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "webpack-dev-server": "2.9.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8",
+    "yarn": "^1.3.2"
   }
 }


### PR DESCRIPTION
Add `yarn` version to `engines` in `package.json`

---
**Before https://github.com/Automattic/jetpack/pull/8630#issuecomment-361237331 Issue description was:**

Warn about Node or Yarn versions we don't guarantee to work on build/watch. Gives smoother developer experience when Node/Yarn updates happen.

Calypso [uses the same module](https://github.com/Automattic/wp-calypso/blob/c9a6a98cf90a7d0bfea600a2e5663183a9038c65/package.json#L215), although over there it's a bit more important because Node/NPM versions are [locked down precisely](https://github.com/Automattic/wp-calypso/blob/c28274a4214a1eaec3131ddfefbc0cc491303e0c/package.json#L164-L167).

Instead of just warning, this could also exit on failure.

#### Changes proposed in this Pull Request:
- Add Yarn to `engines` in `package.json` (version from [docs/development-environment.md](https://github.com/Automattic/jetpack/blob/1ae23f5636cad3f8dc3e20e8fd30fb673b28d0a0/docs/development-environment.md))
- Use [`check-node-version`](https://www.npmjs.com/package/check-node-version) to warn about incorrect Node or Yarn versions.

#### Testing instructions:
Affecting commands: `yarn build`, `yarn watch`, `npm start` and `npm build`

- Run affected command and observe no warning when on Node.js 8
- Switch to Node.js v6 and observe warning and build to keep rolling:
![screen shot 2018-01-25 at 13 54 14](https://user-images.githubusercontent.com/87168/35440526-76934ef4-02a8-11e8-9ff1-2c01eb097225.png)
