### PR TITLE
Search: Update max offset and max posts per page

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -499,6 +499,6 @@ class Jetpack_Search_Helpers {
 	 * @return int
 	 */
 	public static function get_max_offset() {
-		return self::site_has_vip_index() ? 10000 : 1000;
+		return self::site_has_vip_index() ? 9000 : 1000;
 	}
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -460,4 +460,45 @@ class Jetpack_Search_Helpers {
 
 		return $no_post_types;
 	}
+
+	/**
+	 * Returns a boolen for whether the current site has a VIP index.
+	 *
+	 * @return bool
+	 */
+	public static function site_has_vip_index() {
+		$has_vip_index = (
+			Jetpack_Constants::is_defined( 'JETPACK_SEARCH_VIP_INDEX' ) &&
+			Jetpack_Constants::get_constant( 'JETPACK_SEARCH_VIP_INDEX' )
+		);
+
+		/**
+		 * Allows developers to filter whether the current site has a VIP index.
+		 *
+		 * @module search
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param bool $has_vip_index Whether the current site has a VIP index.
+		 */
+		return apply_filters( 'jetpack_search_has_vip_index', $has_vip_index );
+	}
+
+	/**
+	 * Returns the maximum posts per page for a search query
+	 *
+	 * @return int
+	 */
+	public static function get_max_posts_per_page() {
+		return self::site_has_vip_index() ? 1000 : 100;
+	}
+
+	/**
+	 * Returns the maximum offset for a search query
+	 *
+	 * @return int
+	 */
+	public static function get_max_offset() {
+		return self::site_has_vip_index() ? 10000 : 1000;
+	}
 }

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -1271,7 +1271,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 				false,
 			),
 			'has_vip_index' => array(
-				10000,
+				9000,
 				true,
 			),
 		);

--- a/tests/php/modules/search/test_class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test_class.jetpack-search-helpers.php
@@ -48,6 +48,9 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 		remove_filter( 'sidebars_widgets', array( $this, '_fake_out_search_widget' ) );
 
 		unset( $GLOBALS['wp_customize'] );
+
+		Jetpack_Constants::clear_constants();
+		remove_all_filters( 'jetpack_search_has_vip_index' );
 	}
 
 	function test_get_search_url_removes_page_when_no_query_s() {
@@ -523,6 +526,37 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * @dataProvider get_site_has_vip_index_data
+	 */
+	public function test_site_has_vip_index( $expected, $constant = null, $filter = false ) {
+		if ( ! is_null( $constant ) ) {
+			Jetpack_Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $constant );
+		}
+
+		if ( $filter ) {
+			add_filter( 'jetpack_search_has_vip_index', $filter );
+		}
+
+		$this->assertSame( $expected, Jetpack_Search_Helpers::site_has_vip_index() );
+	}
+
+	/**
+	 * @dataProvider get_max_posts_per_page_data
+	 */
+	public function test_get_max_posts_per_page( $expected, $has_vip_index ) {
+		Jetpack_Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
+		$this->assertSame( $expected, Jetpack_Search_Helpers::get_max_posts_per_page() );
+	}
+
+	/**
+	 * @dataProvider get_max_offset_data
+	 */
+	public function test_get_max_offset( $expected, $has_vip_index ) {
+		Jetpack_Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
+		$this->assertSame( $expected, Jetpack_Search_Helpers::get_max_offset() );
 	}
 
 	/**
@@ -1200,6 +1234,58 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 					),
 				),
 				array( 'post', 'page' ),
+			),
+		);
+	}
+
+	public function get_site_has_vip_index_data() {
+		return array(
+			'default_constants_filter' => array(
+				false,
+			),
+			'constant_false_no_filter' => array(
+				false,
+				false,
+			),
+			'constant_true_no_filter' => array(
+				true,
+				true,
+			),
+			'constant_false_filter_true' => array(
+				true,
+				false,
+				'__return_true',
+			),
+			'constant_true_filter_false' => array(
+				false,
+				true,
+				'__return_false',
+			),
+		);
+	}
+
+	public function get_max_offset_data() {
+		return array (
+			'not_vip_index' => array(
+				1000,
+				false,
+			),
+			'has_vip_index' => array(
+				10000,
+				true,
+			),
+		);
+	}
+
+	public function get_max_posts_per_page_data() {
+		return array (
+			'not_vip_index' => array(
+				100,
+				false,
+			),
+			'has_vip_index' => array(
+				1000,
+				true,
 			),
 		);
 	}


### PR DESCRIPTION
Fixes #8560

We've changed the maximum values for `size` and `from` in the API, so now we need to apply those changes here.

To test:

- Checkout branch on site with Jetpack Professional
- Run `phpunit --testsuite=search`
- Test that search continues to work as expected