### PR TITLE
Sync: Updates better to .com

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -112,26 +112,74 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 	}
 
-	public function get_update_checksum( $value ) {
-		// Create an new array so we don't modify the object passed in.
-		$a_value = (array) $value;
-		// ignore `last_checked`
-		unset( $a_value['last_checked'] );
-		unset( $a_value['checked'] );
-		unset( $a_value['version_checked'] );
-		if ( empty( $a_value['updates'] ) ) {
-			unset( $a_value['updates'] );
-		}
 
-		if ( empty( $a_value ) ) {
+	public function get_update_checksum( $update, $transient ) {
+		$updates = array();
+		$no_updated = array();
+		switch ( $transient ) {
+			case 'update_plugins':
+				if ( ! empty( $update->response ) ) {
+					foreach ( $update->response as $plugin_slug => $response ) {
+						if ( ! empty( $plugin_slug ) && isset( $response->new_version ) ) {
+							$updates[] = array( $plugin_slug => $response->new_version );
+						}
+					}
+				}
+				if ( ! empty( $update->no_update ) ) {
+					$no_updated = array_keys( $update->no_update );
+				}
+
+				if ( ! isset( $no_updated[ 'jetpack/jetpack.php' ] ) && isset( $updates[ 'jetpack/jetpack.php' ] ) ) {
+					return false;
+				}
+
+				break;
+			case 'update_themes':
+				if ( ! empty( $update->response ) ) {
+					foreach ( $update->response as $theme_slug => $response ) {
+						if ( ! empty( $theme_slug ) && isset( $response['new_version'] ) ) {
+							$updates[] = array( $theme_slug => $response['new_version'] );
+						}
+					}
+				}
+
+				if ( ! empty( $update->checked ) ) {
+					$no_updated = $update->checked;
+				}
+
+				break;
+			case 'update_core':
+				if ( ! empty( $update->updates ) ) {
+					foreach ( $update->updates as $response ) {
+						if( ! empty( $response->response ) && $response->response === 'latest' ) {
+							continue;
+						}
+						if ( ! empty( $response->response ) && isset( $response->packages->full ) ) {
+							$updates[] = array( $response->response => $response->packages->full );
+						}
+					}
+				}
+
+				if (  ! empty( $update->version_checked ) ) {
+					$no_updated = $update->version_checked;
+				}
+
+				if ( empty( $updates ) ) {
+					return false;
+				}
+				break;
+
+		}
+		if ( empty( $updates ) && empty( $no_updated ) ) {
 			return false;
 		}
-		return $this->get_check_sum( $a_value );
+		error_log( print_r( array( $no_updated, $updates ), 1 ) );
+		return $this->get_check_sum( array( $no_updated, $updates ) );
 	}
 
 	public function validate_update_change( $value, $expiration, $transient ) {
 
-		$new_checksum = $this->get_update_checksum( $value );
+		$new_checksum = $this->get_update_checksum( $value, $transient );
 		if ( false === $new_checksum  ) {
 			return;
 		}
@@ -146,6 +194,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		update_option( self::UPDATES_CHECKSUM_OPTION_NAME, $checksums );
 		// possible $transient value are update_plugins, update_themes, update_core
+		error_log( 'MARK TRNASIANT AS CHANGED :' . $transient );
+		error_log( print_r( $value,1 ) );
 		do_action( "jetpack_{$transient}_change", $value );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -37,7 +37,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
 		$theme = reset( $updates->response );
-		
+
 		$this->assertTrue( (bool) $theme['name'] );
 		$this->assertTrue( is_int( $updates->last_checked ) );
 	}
@@ -55,10 +55,12 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertTrue( is_int( $updates->last_checked ) );
-		
+
 		// Since the transient gets updates twice and we only care about the
 		// last update we only want to see 1 sync event.
 		$events = $this->server_event_storage->get_all_events( 'jetpack_update_core_change' );
+
+		var_dump( $events );
 		$this->assertEquals( count( $events ) , 1 );
 
 	}


### PR DESCRIPTION
Fixes improve how we detect what event should be synced. 

#### Changes proposed in this Pull Request:
* Figuring out if we should send plugin needs updating event by making sure that we have check some basic assumptions about the data.

#### Testing instructions:
* Do the unit tests pass? 

Track events on .com via listening to the data streaming into your .com sandbox. 

- Make a plugin updateable on your site by updating the version number.
? Does the plugin show up as needs updating in the activity log? 
Update the plugin. 
?. Does it show up that the plugin go updated. 

- Do the same for Core ( update `wp-includes/version.php`)
Does it show up that the core needs updating. 
Does it show up that  

Do the same things for a theme. 

Track the 



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
