### PR TITLE
Search: Only allow adding filters for public taxonomies

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -533,7 +533,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 				<label>
 					<?php esc_html_e( 'Choose a taxonomy:', 'jetpack' ); $seen_taxonomy_labels = array(); ?>
 					<select name="<?php echo esc_attr( $this->get_field_name( 'taxonomy_type' ) ); ?>[]" class="widefat">
-						<?php foreach ( get_taxonomies( false, 'objects' ) as $taxonomy ) : ?>
+						<?php foreach ( get_taxonomies( array( 'public' => true ), 'objects' ) as $taxonomy ) : ?>
 							<option value="<?php echo esc_attr( $taxonomy->name ); ?>" <?php selected( $taxonomy->name, $args['taxonomy'] ); ?>>
 								<?php
 									$label = in_array( $taxonomy->label, $seen_taxonomy_labels )


### PR DESCRIPTION
After walking through Jetpack Search, @kellychoffman pointed out that there were some awkward taxonomies that admins could choose to filter on. For example

- Navigation menus
- Link categories
- Format

The issue is that were calling `get_taxonomies( false, 'objects' )` without an array of args for the first argument. This meant we were getting all taxonomies and not just public ones. 🤦‍♂️ 

After making this change, link categories and navigation menus no longer show up by default. Format does, which makes sense since post formats are public.

To test:

- Checkout branch on site with Jetpack Professional
- Add Jetpack Search Widget
- Ensure that non-public taxonomies are not listed