### PR TITLE
JPO: do not add a Contact Us form when one exists already.

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1069,8 +1069,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 		// Setup contact page and add a form and/or business info
 		$contact_page = '';
-
-		if ( isset( $data['addContactForm'] ) && $data['addContactForm'] ) {
+		if ( isset( $data['addContactForm'] ) && $data['addContactForm'] &&
+			! get_option( 'jpo_contact_page' ) ) {
 			$contact_form_module_active = Jetpack::is_module_active( 'contact-form' );
 			if ( ! $contact_form_module_active ) {
 				$contact_form_module_active = Jetpack::activate_module( 'contact-form', false, false );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1069,8 +1069,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 		// Setup contact page and add a form and/or business info
 		$contact_page = '';
-		if ( isset( $data['addContactForm'] ) && $data['addContactForm'] &&
-			! get_option( 'jpo_contact_page' ) ) {
+		if ( ! empty( $data['addContactForm'] ) && ! get_option( 'jpo_contact_page' ) ) {
 			$contact_form_module_active = Jetpack::is_module_active( 'contact-form' );
 			if ( ! $contact_form_module_active ) {
 				$contact_form_module_active = Jetpack::activate_module( 'contact-form', false, false );


### PR DESCRIPTION
Currently we insert a Contact Us form every time the `Add a contact form` tile is clicked in the JPO flow. 

Fixes: adding multiple Contact Us forms.

#### Changes proposed in this Pull Request:

* Adds a check to not set the form when one already exists.

#### Testing instructions:
* Checkout this branch on your JP sandbox,
* Follow the instructions on #8426,
* Skip to the contact form step and select `Add a Contact Form`,
* Check that the contact us page was inserted,
`yourJPsandbox.com/wp-admin/edit.php?post_type=page`
* Go back and add click the tile again
* Confirm that there is only one contact form on your sandbox.



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
