### PR TITLE
REST API: JPO: Disable WooCommerce Wizard

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1113,6 +1113,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		if ( ! empty( $data['installWooCommerce'] ) ) {
+			add_filter( 'woocommerce_prevent_automatic_wizard_redirect', '__return_true' );
 			jetpack_require_lib( 'plugins' );
 			$wc_install_result = Jetpack_Plugins::install_and_activate_plugin( 'woocommerce' );
 			if ( is_wp_error( $wc_install_result ) ) {


### PR DESCRIPTION
WIP, testing instructions coming soon.

Fixes an issue reported by @rachelmcr on the JPO Call-for-Testing: (p1HpG7-4O1-p2 #comment-24230):

> <strong>WooCommerce abrupt transition</strong>
> 
> In step 2 ("Let's shape your new site.") I selected "Business site," which led me to step 6 ("Are you looking to sell online?"). There's I said I was interested and WooCommerce was installed for me. However, there's no connection from there to any sort of WooCommerce intro.
> 
> On the final onboarding screen, I selected "Visit your site" which took me to the front end of my site. I wanted to get back to site setup, so I returned to my site's WP Admin and was immediately taken to the WooCommerce setup wizard at <code>/wp-admin/index.php?page=wc-setup</code>. That was really abrupt and it would have been smoother for me to have some kind of prompt from the onboarding flow to finish setting up my store in that scenario, rather than run into the wizard unexpectedly.