### PR TITLE
No longer hide backup & scan cards if Rewind is available

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -76,7 +76,6 @@ class AtAGlance extends Component {
 				</div>
 			);
 		const isRewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
-		const hideVaultPressCards = ! isRewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
 		const securityCards = [
 			<DashProtect { ...settingsProps } />,
 			<DashScan
@@ -94,9 +93,9 @@ class AtAGlance extends Component {
 			<DashPluginUpdates { ...settingsProps } { ...urls } />
 		];
 
-		// Hack to remove VP cards if rewind is in a weird state; not active but available.
+		// Hack to remove VP cards if rewind is active.
 		// @todo we need some actual messaging here.
-		hideVaultPressCards && securityCards.splice( 1, 2 );
+		isRewindActive && securityCards.splice( 1, 2 );
 
 		// Maybe add the rewind card
 		isRewindActive && securityCards.unshift( <DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -93,10 +93,6 @@ class AtAGlance extends Component {
 			<DashPluginUpdates { ...settingsProps } { ...urls } />
 		];
 
-		// Hack to remove VP cards if rewind is active.
-		// @todo we need some actual messaging here.
-		isRewindActive && securityCards.splice( 1, 2 );
-
 		// Maybe add the rewind card
 		isRewindActive && securityCards.unshift( <DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
 

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -80,7 +80,7 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ foundBackups && ! rewindActive && <BackupsScan { ...commonProps } /> }
+				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundAkismet &&
 					<div>
 						<Antispam { ...commonProps } />

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -67,8 +67,7 @@ export class Security extends Component {
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
-			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
-			hideVaultPressCards = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
+			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive;
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
@@ -81,7 +80,7 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ foundBackups && ! hideVaultPressCards && <BackupsScan { ...commonProps } /> }
+				{ foundBackups && ! rewindActive && <BackupsScan { ...commonProps } /> }
 				{ foundAkismet &&
 					<div>
 						<Antispam { ...commonProps } />


### PR DESCRIPTION
**New! Use the `dev tools` link to mock rewind state for testing!**

Compliments #8581 nicely.  

This PR updates the logic that decides whether or not to hide the backup & scan cards.  The new logic is to NOT hide them if rewind is `available`.  Instead, we show these cards, including the new `<DashActivity />` card: 

![screen shot 2018-01-29 at 1 35 35 pm](https://user-images.githubusercontent.com/7129409/35527694-98068f08-04f9-11e8-8771-cc16c3c1bcb9.png)

To Test: 
- You should see no changes to the UI in any state unless the /rewind endpoint is returning an `active` state. 
- With rewind `active`, you should see the cards in the state shown in the screenshot for ANY level of paid plan.
- With rewind `active`, you should see this as the backup/scan card in `/security` tab: 
![screen shot 2018-01-29 at 1 42 23 pm](https://user-images.githubusercontent.com/7129409/35527941-578a4e6e-04fa-11e8-9eb6-4b8912662415.png)
