### PR TITLE
Comments: edit link without predefined action

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -702,7 +702,7 @@ class Jetpack {
 	function point_edit_comment_links_to_calypso( $url ) {
 		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
 		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
-		return esc_url( sprintf( 'https://wordpress.com/comment/%s/%d?action=edit',
+		return esc_url( sprintf( 'https://wordpress.com/comment/%s/%d',
 			Jetpack::build_raw_urls( get_home_url() ),
 			$query_args['amp;c']
 		) );


### PR DESCRIPTION
The "edit" link on a site's frontend no longer redirects the user to the comments management interface with a predefined action

Fixes https://github.com/Automattic/wp-calypso/issues/21931 for Jetpack

#### Changes proposed in this Pull Request:

* 

#### Testing instructions:

* Force `edit_links_calypso_redirect` option to `true`.
* Logged in as Admin or Editor, navigate to a site's frontend.
* View a post with comments
* click the _Edit_ link.

The link should redirect the user to Calypso's comment management single comment view without a preselected action.