### PR TITLE
Search: Emit change event after sorting filters

### DIFF
--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -206,6 +206,9 @@
 				if ( wp && wp.customize ) {
 					wp.customize.state( 'saved' ).set( false );
 				}
+			},
+			update: function( e, ui ) {
+				$( ui.item ).find( 'input, textarea, select' ).change();
 			}
 		} )
 		.disableSelection();


### PR DESCRIPTION
Fixes #8649

In #8649, @gibrown reported an issue where the filter order wasn't updated after changing the order of filters. After looking into it, this seems to be because we weren't firing a change event which the customizer picks up on.

This PR ensures that we fire a change event after moving a filter.

To test:

- Checkout branch on a site with Jetpack Professional
- Go to customizer
- Add a widget if you don't already have one, with multiple filters, and save
- Reload customizer
- Change the order of the filters
- Publish
- Ensure order changes on the frontend
- Do the same above, this time testing the legacy widgets admin at `$site.com/wp-admin/widgets.php`