### PR TITLE
Add: Sync  Plugin Updated event.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6467,6 +6467,7 @@ p {
 			'jetpack_has_identity_crisis'                            => 'jetpack_sync_error_idc_validation',
 			'jetpack_is_post_mailable'                               => null,
 			'jetpack_seo_site_host'                                  => null,
+			'jetpack_installed_plugin'								 => 'jetpack_plugin_installed',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6467,7 +6467,7 @@ p {
 			'jetpack_has_identity_crisis'                            => 'jetpack_sync_error_idc_validation',
 			'jetpack_is_post_mailable'                               => null,
 			'jetpack_seo_site_host'                                  => null,
-			'jetpack_installed_plugin'								 => 'jetpack_plugin_installed',
+			'jetpack_installed_plugin'                               => 'jetpack_plugin_installed',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -351,7 +351,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$errors = $upgrader->skin->get_errors();
 			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
 
-			if ( is_wp_error( $errors ) ) {
+			if ( is_wp_error( $errors ) && $errors->get_error_code() ) {
 				return $errors;
 			}
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -17,6 +17,9 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 		),
+		'query_parameters' => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
+		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
 		'example_request_data' => array(
 			'headers' => array(
@@ -47,6 +50,9 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 			'plugins'      => '(array) A list of plugin ids to modify',
+		),
+		'query_parameters' => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => array(
 			'plugins'     => '(array:plugin) An array of plugin objects.',
@@ -81,6 +87,9 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 		'path_labels'          => array(
 			'$site'   => '(int|string) The site ID, The site domain',
 			'$plugin' => '(string) The plugin ID',
+		),
+		'query_parameters' => array(
+			'invite_accepted' => '(bool=false) If the user is being created in the invite context',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
 		'example_request_data' => array(
@@ -283,7 +292,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	}
 
 	protected function update() {
-
+		$query_args = $this->query_args();
+		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] ) {
+			Jetpack_Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
+		}
 		wp_clean_plugins_cache();
 		ob_start();
 		wp_update_plugins(); // Check for Plugin updates

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -17,7 +17,7 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
@@ -51,7 +51,7 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 			'plugins'      => '(array) A list of plugin ids to modify',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => array(
@@ -88,7 +88,7 @@ new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 			'$site'   => '(int|string) The site ID, The site domain',
 			'$plugin' => '(string) The plugin ID',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'invite_accepted' => '(bool=false) If the user is being created in the invite context',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
@@ -195,20 +195,20 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		foreach ( $this->plugins as $plugin ) {
 
 			if ( ! $this->current_user_can( 'activate_plugin', $plugin ) ) {
-				$this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
+				$this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to activate this plugin.' );
 				$has_errors                  = true;
 				$permission_error            = true;
 				continue;
 			}
 
 			if ( ( ! $this->network_wide && Jetpack::is_plugin_active( $plugin ) ) || is_plugin_active_for_network( $plugin ) ) {
-				$this->log[ $plugin ]['error'] = __( 'The Plugin is already active.', 'jetpack' );
+				$this->log[$plugin]['error'] = __( 'The Plugin is already active.', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
 
 			if ( ! $this->network_wide && is_network_only_plugin( $plugin ) && is_multisite() ) {
-				$this->log[ $plugin ]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
+				$this->log[$plugin]['error'] = __( 'Plugin can only be Network Activated', 'jetpack' );
 				$has_errors                  = true;
 				continue;
 			}
@@ -216,7 +216,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$result = activate_plugin( $plugin, '', $this->network_wide );
 
 			if ( is_wp_error( $result ) ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages();
+				$this->log[$plugin]['error'] = $result->get_error_messages();
 				$has_errors                  = true;
 				continue;
 			}
@@ -227,19 +227,20 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			if ( ! $success ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages;
+				$this->log[$plugin]['error'] = $result->get_error_messages;
 				$has_errors                  = true;
 				continue;
 			}
-			$this->log[ $plugin ][] = __( 'Plugin activated.', 'jetpack' );
+			$this->log[$plugin][] = __( 'Plugin activated.', 'jetpack' );
 		}
 
-		if ( ! $this->bulk && isset( $has_errors )  ) {
+		if ( ! $this->bulk && isset( $has_errors ) ) {
 			$plugin = $this->plugins[0];
 			if ( $permission_error ) {
-				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );
+				return new WP_Error( 'unauthorized_error', $this->log[$plugin]['error'], 403 );
 			}
-			return new WP_Error( 'activation_error', $this->log[ $plugin ]['error'] );
+
+			return new WP_Error( 'activation_error', $this->log[$plugin]['error'] );
 		}
 	}
 
@@ -249,8 +250,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			if ( $plugin ) {
 				return current_user_can( $capability, $plugin );
 			}
+
 			return current_user_can( $capability );
 		}
+
 		// Assume that the user has the activate plugins capability.
 		return current_user_can( 'activate_plugins' );
 
@@ -259,14 +262,14 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	protected function deactivate() {
 		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
-			if ( ! $this->current_user_can('deactivate_plugin', $plugin ) ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
-				$permission_error = true;
+			if ( ! $this->current_user_can( 'deactivate_plugin', $plugin ) ) {
+				$error = $this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
+				$permission_error                     = true;
 				continue;
 			}
 
 			if ( ! Jetpack::is_plugin_active( $plugin ) ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'The Plugin is already deactivated.', 'jetpack' );
+				$error = $this->log[$plugin]['error'] = __( 'The Plugin is already deactivated.', 'jetpack' );
 				continue;
 			}
 
@@ -278,15 +281,16 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			if ( ! $success ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'There was an error deactivating your plugin', 'jetpack' );
+				$error = $this->log[$plugin]['error'] = __( 'There was an error deactivating your plugin', 'jetpack' );
 				continue;
 			}
-			$this->log[ $plugin ][] = __( 'Plugin deactivated.', 'jetpack' );
+			$this->log[$plugin][] = __( 'Plugin deactivated.', 'jetpack' );
 		}
 		if ( ! $this->bulk && isset( $error ) ) {
 			if ( $permission_error ) {
 				return new WP_Error( 'unauthorized_error', $error, 403 );
 			}
+
 			return new WP_Error( 'deactivation_error', $error );
 		}
 	}
@@ -323,7 +327,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		foreach ( $this->plugins as $plugin ) {
 
 			if ( ! in_array( $plugin, $plugin_updates_needed ) ) {
-				$this->log[ $plugin ][] = __( 'No update needed', 'jetpack' );
+				$this->log[$plugin][] = __( 'No update needed', 'jetpack' );
 				continue;
 			}
 
@@ -347,9 +351,9 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$upgrader->init();
 			// This avoids the plugin to be deactivated.
 			// Using bulk upgrade puts the site into maintenance mode during the upgrades
-			$result = $upgrader->bulk_upgrade( array( $plugin ) );
-			$errors = $upgrader->skin->get_errors();
-			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
+			$result             = $upgrader->bulk_upgrade( array( $plugin ) );
+			$errors             = $upgrader->skin->get_errors();
+			$this->log[$plugin] = $upgrader->skin->get_upgrade_messages();
 
 			if ( is_wp_error( $errors ) && $errors->get_error_code() ) {
 				return $errors;
@@ -384,7 +388,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$translation = array_filter( $available_updates->translations, array( $this, 'get_translation' ) );
 
 			if ( empty( $translation ) ) {
-				$this->log[ $plugin ][] = __( 'No update needed', 'jetpack' );
+				$this->log[$plugin][] = __( 'No update needed', 'jetpack' );
 				continue;
 			}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -329,15 +329,19 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$update_attempted = true;
 
 			// Object created inside the for loop to clean the messages for each plugin
-			$skin = new Automatic_Upgrader_Skin();
+			$skin = new WP_Ajax_Upgrader_Skin();
 			// The Automatic_Upgrader_Skin skin shouldn't output anything.
 			$upgrader = new Plugin_Upgrader( $skin );
 			$upgrader->init();
 			// This avoids the plugin to be deactivated.
 			// Using bulk upgrade puts the site into maintenance mode during the upgrades
 			$result = $upgrader->bulk_upgrade( array( $plugin ) );
-
+			$errors = $upgrader->skin->get_errors();
 			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
+
+			if ( is_wp_error( $errors ) ) {
+				return $errors;
+			}
 		}
 
 		if ( ! $this->bulk && ! $result && $update_attempted ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -16,7 +16,7 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format_v1_2,
@@ -49,7 +49,7 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 			'plugins'      => '(array) A list of plugin ids to modify',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => array(
@@ -85,7 +85,7 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 			'$site'   => '(int|string) The site ID, The site domain',
 			'$plugin' => '(string) The plugin ID',
 		),
-		'query_parameters' => array(
+		'query_parameters'     => array(
 			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format_v1_2,
@@ -102,7 +102,7 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 
 	protected function activate() {
 		$permission_error = false;
-		$has_errors = false;
+		$has_errors       = false;
 		foreach ( $this->plugins as $plugin ) {
 
 			if ( ! $this->current_user_can( 'activate_plugin', $plugin ) ) {
@@ -125,8 +125,8 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			$result = activate_plugin( $plugin, '', $this->network_wide );
 
 			if ( is_wp_error( $result ) ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages();
-				$has_errors = true;
+				$this->log[$plugin]['error'] = $result->get_error_messages();
+				$has_errors                  = true;
 				continue;
 			}
 
@@ -136,18 +136,19 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			}
 
 			if ( ! $success ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages;
-				$has_errors = true;
+				$this->log[$plugin]['error'] = $result->get_error_messages;
+				$has_errors                  = true;
 				continue;
 			}
-			$this->log[ $plugin ][] = __( 'Plugin activated.', 'jetpack' );
+			$this->log[$plugin][] = __( 'Plugin activated.', 'jetpack' );
 		}
 
 		if ( ! $this->bulk && $has_errors ) {
 			$plugin = $this->plugins[0];
 			if ( $permission_error ) {
-				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );
+				return new WP_Error( 'unauthorized_error', $this->log[$plugin]['error'], 403 );
 			}
+
 			return new WP_Error( 'activation_error', $this->log[$plugin]['error'] );
 		}
 	}
@@ -156,9 +157,9 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 	protected function deactivate() {
 		$permission_error = false;
 		foreach ( $this->plugins as $plugin ) {
-			if ( ! $this->current_user_can('deactivate_plugin', $plugin ) ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
-				$permission_error = true;
+			if ( ! $this->current_user_can( 'deactivate_plugin', $plugin ) ) {
+				$error = $this->log[$plugin]['error'] = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
+				$permission_error                     = true;
 				continue;
 			}
 
@@ -174,15 +175,16 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			}
 
 			if ( ! $success ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'There was an error deactivating your plugin', 'jetpack' );
+				$error = $this->log[$plugin]['error'] = __( 'There was an error deactivating your plugin', 'jetpack' );
 				continue;
 			}
-			$this->log[ $plugin ][] = __( 'Plugin deactivated.', 'jetpack' );
+			$this->log[$plugin][] = __( 'Plugin deactivated.', 'jetpack' );
 		}
 		if ( ! $this->bulk && isset( $error ) ) {
 			if ( $permission_error ) {
 				return new WP_Error( 'unauthorized_error', $error, 403 );
 			}
+
 			return new WP_Error( 'deactivation_error', $error );
 		}
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -16,6 +16,9 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 		),
+		'query_parameters' => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
+		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format_v1_2,
 		'example_request_data' => array(
 			'headers' => array(
@@ -45,6 +48,9 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 			'active'       => '(bool) Activate or deactivate the plugin',
 			'network_wide' => '(bool) Do action network wide (default value: false)',
 			'plugins'      => '(array) A list of plugin ids to modify',
+		),
+		'query_parameters' => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => array(
 			'plugins'     => '(array:plugin_v1_2) An array of plugin objects.',
@@ -78,6 +84,9 @@ new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 		'path_labels'          => array(
 			'$site'   => '(int|string) The site ID, The site domain',
 			'$plugin' => '(string) The plugin ID',
+		),
+		'query_parameters' => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
 		),
 		'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format_v1_2,
 		'example_request_data' => array(

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -16,9 +16,10 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		add_action( 'activated_plugin', $callable, 10, 2 );
 		add_action( 'deactivated_plugin', $callable, 10, 2 );
 		add_action( 'delete_plugin',  array( $this, 'delete_plugin') );
-		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader' ), 10, 2 );
-		add_action( 'jetpack_installed_plugin', $callable, 10, 2 );
+		add_action( 'upgrader_process_complete', array( $this, 'on_upgrader_completion' ), 10, 2 );
+		add_action( 'jetpack_plugin_installed', $callable, 10, 1 );
 		add_action( 'jetpack_plugin_update_failed', $callable, 10, 3 );
+		add_action( 'jetpack_plugins_updated', $callable, 10, 1 );
 		add_action( 'admin_action_update', array( $this, 'check_plugin_edit') );
 		add_action( 'jetpack_edited_plugin', $callable, 10, 2 );
 		add_action( 'wp_ajax_edit-theme-plugin-file', array( $this, 'plugin_edit_ajax' ), 0 );
@@ -30,68 +31,127 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		//Note that we don't simply 'expand_plugin_data' on the 'delete_plugin' action here because the plugin file is deleted when that action finishes
 	}
 
-	public function check_upgrader( $upgrader, $details) {
-		/*
-		 * Handle plugin update errors
-		 */
-		if (
-			'Plugin_Upgrader' == get_class( $upgrader ) &&
-			isset( $details['type'] ) &&
-			'plugin' == $details['type'] &&
-			(
-				'WP_Ajax_Upgrader_Skin' == get_class( $upgrader->skin ) ||
-			    'Bulk_Plugin_Upgrader_Skin' == get_class( $upgrader->skin )
-			)
-		) {
-			if ( 'WP_Ajax_Upgrader_Skin' == get_class( $upgrader->skin ) ) {
-				$errors = $upgrader->skin->get_errors();
-			} else {
-				$errors = $upgrader->skin->result;
-			}
+	public function on_upgrader_completion( $upgrader, $details ) {
+		if ( ! isset( $details['type'] ) ) {
+			return;
+		}
+		if ( 'plugin' != $details['type'] ) {
+			return;
+		}
 
-			if ( is_wp_error( $errors) ) {
-				foreach ( $details['plugins'] as $slug ) {
+		if ( ! isset( $details['action'] ) ) {
+			return;
+		}
+
+		$plugins =  ( isset( $details['plugins'] ) ? $details['plugins'] : null );
+		if ( empty( $plugins ) ) {
+			$plugins = ( isset( $details['plugin'] ) ? array( $details['plugin'] ) : null );
+		}
+
+		// for plugin installer
+		if ( empty( $plugins ) && method_exists( $upgrader, 'plugin_info' ) ) {
+			$plugins = array( $upgrader->plugin_info() );
+		}
+
+		if ( empty( $plugins ) ) {
+			return; // We shouldn't be here
+		}
+
+		switch ( $details['action'] ) {
+			case 'update':
+				$errors = $this->get_errors( $upgrader->skin );
+				var_dump( $plugins );
+				if ( $errors ) {
+					foreach ( $plugins as $slug ) {
+						/**
+						 * Sync that a plugin update failed
+						 *
+						 * @since 5.8.0
+						 *
+						 * @module sync
+						 *
+						 * @param string $plugin, Plugin slug
+						 * @param string Error code
+						 * @param string Error message
+						 */
+						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'] );
+					}
+					return;
+				}
+				/**
+				 * Sync that a plugin update
+				 *
+				 * @since 5.8.0
+				 *
+				 * @module sync
+				 *
+				 * @param array() $plugin, Plugin Data
+				 */
+				do_action( 'jetpack_plugins_updated', array_map( array( $this, 'get_plugin_info' ), $plugins ) );
+				break;
+			case 'install':
+
+		}
+
+		if ( 'install' === $details['action'] ) {
+			$errors = $this->get_errors( $upgrader->skin );
+			if ( $errors ) {
+				foreach ( $plugins as $slug ) {
 					/**
 					 * Sync that a plugin update failed
 					 *
 					 * @since 5.8.0
-					 * 
+					 *
 					 * @module sync
 					 *
 					 * @param string $plugin, Plugin slug
 					 * @param string Error code
 					 * @param string Error message
 					 */
-					do_action( 'jetpack_plugin_update_failed', $slug, $errors->get_error_code(), $errors->get_error_message() );
+					do_action( 'jetpack_plugin_install_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'] );
 				}
 				return;
 			}
-		}
-
-		if ( ! isset( $details['type'] ) ||
-			'plugin' !== $details['type'] ||
-			is_wp_error( $upgrader->skin->result ) ||
-			! method_exists( $upgrader, 'plugin_info' )
-		) {
-			return;
-		}
-
-		if ( 'install' === $details['action'] ) {
-			$plugin_path = $upgrader->plugin_info();
-			$plugins = get_plugins();
-			$plugin_info = $plugins[ $plugin_path ];
-
 			/**
 			 * Signals to the sync listener that a plugin was installed and a sync action
 			 * reflecting the installation and the plugin info should be sent
 			 *
-			 * @since 4.9.0
+			 * @since 5.8.0
 			 *
-			 * @param string $plugin_path Path of plugin installed
-			 * @param mixed $plugin_info Array of info describing plugin installed
+			 * @module sync
+			 *
+			 * @param array() $plugin, Plugin Data
 			 */
-			do_action( 'jetpack_installed_plugin', $plugin_path, $plugin_info );
+			do_action( 'jetpack_plugin_installed',  array_map( array( $this, 'get_plugin_info' ), $plugins ) );
+			return;
 		}
+	}
+
+	private function get_plugin_info( $slug ) {
+		$plugins = get_plugins();
+		return isset( $plugins[ $slug ] ) ? array_merge( array( 'slug' => $slug), $plugins[ $slug ] ): array( 'slug' => $slug );
+	}
+
+	private function get_errors( $skin ) {
+		$errors = method_exists( $skin, 'get_errors' ) ? $skin->get_errors() : null;
+		if ( is_wp_error( $errors ) ) {
+
+			if ( ! empty( $errors->get_error_code() ) ) {
+				return array( 'code' => $errors->get_error_code(), 'message' => $errors->get_error_message() );
+			}
+		}
+
+		if ( isset( $skin->result ) ) {
+			$errors = $skin->result;
+			if ( is_wp_error( $errors ) ) {
+				return array( 'code' => $errors->get_error_code(), 'message' => $errors->get_error_message() );
+			}
+
+			if ( false == $skin->result ) {
+				return array( 'code' => 'unknown', 'message' => __( 'Unknown Plugin Update Failure', 'jetpack' ) );
+			}
+		}
+		return false;
 	}
 
 	public function check_plugin_edit() {

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -43,7 +43,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$plugins =  ( isset( $details['plugins'] ) ? $details['plugins'] : null );
+		$plugins = ( isset( $details['plugins'] ) ? $details['plugins'] : null );
 		if ( empty( $plugins ) ) {
 			$plugins = ( isset( $details['plugin'] ) ? array( $details['plugin'] ) : null );
 		}
@@ -59,7 +59,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 
 		switch ( $details['action'] ) {
 			case 'update':
-				$state = array(
+				$state  = array(
 					'is_autoupdate' => Jetpack_Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
 				);
 				$errors = $this->get_errors( $upgrader->skin );
@@ -68,26 +68,27 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 						/**
 						 * Sync that a plugin update failed
 						 *
-						 * @since 5.8.0
+						 * @since  5.8.0
 						 *
 						 * @module sync
 						 *
-						 * @param string $plugin, Plugin slug
-						 * @param string Error code
-						 * @param string Error message
+						 * @param string $plugin , Plugin slug
+						 * @param        string  Error code
+						 * @param        string  Error message
 						 */
 						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'], $state );
 					}
+
 					return;
 				}
 				/**
 				 * Sync that a plugin update
 				 *
-				 * @since 5.8.0
+				 * @since  5.8.0
 				 *
 				 * @module sync
 				 *
-				 * @param array() $plugin, Plugin Data
+				 * @param array () $plugin, Plugin Data
 				 */
 				do_action( 'jetpack_plugins_updated', array_map( array( $this, 'get_plugin_info' ), $plugins ), $state );
 				break;
@@ -102,29 +103,31 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 					/**
 					 * Sync that a plugin update failed
 					 *
-					 * @since 5.8.0
+					 * @since  5.8.0
 					 *
 					 * @module sync
 					 *
-					 * @param string $plugin, Plugin slug
-					 * @param string Error code
-					 * @param string Error message
+					 * @param string $plugin , Plugin slug
+					 * @param        string  Error code
+					 * @param        string  Error message
 					 */
 					do_action( 'jetpack_plugin_install_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'] );
 				}
+
 				return;
 			}
 			/**
 			 * Signals to the sync listener that a plugin was installed and a sync action
 			 * reflecting the installation and the plugin info should be sent
 			 *
-			 * @since 5.8.0
+			 * @since  5.8.0
 			 *
 			 * @module sync
 			 *
-			 * @param array() $plugin, Plugin Data
+			 * @param array () $plugin, Plugin Data
 			 */
-			do_action( 'jetpack_plugin_installed',  array_map( array( $this, 'get_plugin_info' ), $plugins ) );
+			do_action( 'jetpack_plugin_installed', array_map( array( $this, 'get_plugin_info' ), $plugins ) );
+
 			return;
 		}
 	}

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -60,7 +60,6 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		switch ( $details['action'] ) {
 			case 'update':
 				$errors = $this->get_errors( $upgrader->skin );
-				var_dump( $plugins );
 				if ( $errors ) {
 					foreach ( $plugins as $slug ) {
 						/**

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -138,7 +138,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		$errors = method_exists( $skin, 'get_errors' ) ? $skin->get_errors() : null;
 		if ( is_wp_error( $errors ) ) {
 
-			if ( ! empty( $errors->get_error_code() ) ) {
+			if ( $errors->get_error_code() ) {
 				return array( 'code' => $errors->get_error_code(), 'message' => $errors->get_error_message() );
 			}
 		}

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -137,9 +137,9 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 	private function get_errors( $skin ) {
 		$errors = method_exists( $skin, 'get_errors' ) ? $skin->get_errors() : null;
 		if ( is_wp_error( $errors ) ) {
-
-			if ( $errors->get_error_code() ) {
-				return array( 'code' => $errors->get_error_code(), 'message' => $errors->get_error_message() );
+			$error_code = $errors->get_error_code();
+			if ( ! empty( $error_code ) ) {
+				return array( 'code' => $error_code, 'message' => $errors->get_error_message() );
 			}
 		}
 

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -18,8 +18,8 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		add_action( 'delete_plugin',  array( $this, 'delete_plugin') );
 		add_action( 'upgrader_process_complete', array( $this, 'on_upgrader_completion' ), 10, 2 );
 		add_action( 'jetpack_plugin_installed', $callable, 10, 1 );
-		add_action( 'jetpack_plugin_update_failed', $callable, 10, 3 );
-		add_action( 'jetpack_plugins_updated', $callable, 10, 1 );
+		add_action( 'jetpack_plugin_update_failed', $callable, 10, 4 );
+		add_action( 'jetpack_plugins_updated', $callable, 10, 2 );
 		add_action( 'admin_action_update', array( $this, 'check_plugin_edit') );
 		add_action( 'jetpack_edited_plugin', $callable, 10, 2 );
 		add_action( 'wp_ajax_edit-theme-plugin-file', array( $this, 'plugin_edit_ajax' ), 0 );
@@ -59,6 +59,9 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 
 		switch ( $details['action'] ) {
 			case 'update':
+				$state = array(
+					'is_autoupdate' => Jetpack_Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
+				);
 				$errors = $this->get_errors( $upgrader->skin );
 				if ( $errors ) {
 					foreach ( $plugins as $slug ) {
@@ -73,7 +76,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 						 * @param string Error code
 						 * @param string Error message
 						 */
-						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'] );
+						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'], $state );
 					}
 					return;
 				}
@@ -86,7 +89,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 				 *
 				 * @param array() $plugin, Plugin Data
 				 */
-				do_action( 'jetpack_plugins_updated', array_map( array( $this, 'get_plugin_info' ), $plugins ) );
+				do_action( 'jetpack_plugins_updated', array_map( array( $this, 'get_plugin_info' ), $plugins ), $state );
 				break;
 			case 'install':
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -830,7 +830,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$upgrader = (object) array(
 			'skin' => (object) array(
-				'result' => new WP_Error( 'fail' )
+				'result' => new WP_Error( 'fail', 'Fail' )
 			)
 		);
 
@@ -838,7 +838,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'action' => 'update',
 			'type' => 'plugin',
 			'bulk' => true,
-			'plugins' => 'the/the.php',
+			'plugins' => array( 'the/the.php' ),
 		) );
 
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -1,0 +1,169 @@
+<?php
+
+if ( ! class_exists( 'WP_Test_Jetpack_Sync_Plugins' ) ) {
+	$sync_dir        = dirname( __FILE__ );
+	require_once $sync_dir . '/test_class.jetpack-sync-plugins.php';
+}
+/**
+ * Testing CRUD on Plugins
+ */
+class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
+
+	public function setUp() {
+		parent::setUp();
+
+
+		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
+			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");
+		}
+
+		$this->server_event_storage->reset();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		if ( ! file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
+			WP_Test_Jetpack_Sync_Plugins::install_the_plugin();
+		}
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		if ( file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
+			WP_Test_Jetpack_Sync_Plugins::remove_plugin();
+		}
+	}
+
+	public function test_updating_a_plugin_is_synced() {
+		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
+			$this->markTestIncomplete( "Right now this doesn't work on PHP 5.2");
+		}
+		$skins = array(
+			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+		);
+		foreach( $skins as $skin ) {
+			$this->update_the_plugin( $skin );
+			$this->sender->do_sync();
+			$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
+
+			$this->assertEquals( 'the/the.php', $updated_plugin->args[0][0]['slug'] );
+			$this->server_event_storage->reset();
+		}
+	}
+
+	public function test_updating_plugin_in_bulk_is_synced() {
+		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
+			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");
+		}
+		$skins = array(
+			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+			new Bulk_Plugin_Upgrader_Skin( compact( 'nonce', 'url' ) ),
+		);
+		foreach ( $skins as $skin ) {
+			$this->update_bulk_plugins( $skin );
+			$this->sender->do_sync();
+			$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
+			$this->assertEquals(  'the/the.php', $updated_plugin->args[0][0]['slug'] );
+			$this->server_event_storage->reset();
+		}
+	}
+
+	public function test_updating_a_plugin_error_is_synced() {
+		/**
+		 * in WP Plugin_Upgrader->update() doesn't fire the upgrader_process_complete action
+		 * when it encounters an error so right now we do not have a way to hook into why a plugin failed.
+		 */
+		$this->markTestIncomplete( "Right now this doesn't work on PHP 5.2" );
+
+		$this->server_event_storage->reset();
+		$skins = array(
+			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+		);
+		foreach( $skins as $skin ) {
+			$this->set_error();
+			$this->update_the_plugin( $skin );
+			$this->remove_error();
+			$this->sender->do_sync();
+			$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugin_update_failed' );
+			$this->assertEquals( array( 'the/the.php' ), $updated_plugin->args[0]['slug'] );
+			$this->server_event_storage->reset();
+		}
+	}
+
+	public function test_updating_plugin_error_in_bulk_is_synced() {
+		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
+			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");
+		}
+		$skins = array(
+			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
+			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+			new Bulk_Plugin_Upgrader_Skin( compact( 'nonce', 'url' ) ),
+		);
+		foreach ( $skins as $skin ) {
+			$this->set_error();
+			$this->update_bulk_plugins( $skin );
+			$this->remove_error();
+			$this->sender->do_sync();
+			$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugin_update_failed' );
+			$this->assertEquals(  'the/the.php', $updated_plugin->args[0]['slug'], get_class( $skin ) . ' Wasn\'t able to sync failed login attempt' );
+			$this->server_event_storage->reset();
+		}
+	}
+
+	function update_the_plugin( $skin ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		add_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient' ) );
+		$upgrader = new Plugin_Upgrader( $skin );
+		// 'https://downloads.wordpress.org/plugin/the.1.1.zip' Install it from local disk
+		$upgrader->upgrade( 'the/the.php' );
+		remove_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient' ) );
+	}
+
+	function update_bulk_plugins( $skin ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		add_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient' ) );
+		$upgrader = new Plugin_Upgrader( $skin );
+		$upgrader->bulk_upgrade( array( 'the/the.php' ) );
+		remove_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient' ) );
+	}
+
+	function set_update_plugin_transient( $transient ) {
+		return (object) array(
+			'response' => array(
+				'the/the.php' => (object) array(
+					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP
+				)
+			)
+		);
+	}
+
+	public function set_error() {
+		add_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient_with_error' ), 11 );
+	}
+
+	public function remove_error() {
+		remove_filter( 'site_transient_update_plugins' , array( $this, 'set_update_plugin_transient_with_error' ), 11 );
+	}
+	function set_update_plugin_transient_with_error( $transient ) {
+		return (object) array(
+			'response' => array(
+				'the/the.php' => (object) array(
+					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP . '-doesnotexitst.zip'
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
This PR adds test for plugin updates and plugin update failures.

#### Changes proposed in this Pull Request:

- Fix API for plugin updates so that it returns an error as expected. 
- Adds 
  - syncing of plugin updates on success fully plugin update and failure.
  - updates the ....wait for it....
 

#### Testing instructions:
* Do the tests pass? 
* make it so that plugin updates fail ( use a plugin like something below) 
```
<?php
/*
 * Plugin Name: Break Plugin Updates
*/

add_filter( 'upgrader_package_options', 'eb_break_plugin_updated' );
function eb_break_plugin_updated( $options ) {
        $options['package'] = 'http://example.com';
        return $options;
}
```
- try updating a plugin via the api (in calyspo) Do you notice an error? 
- try updating the plugin via the wp-admin interface, plugin.php and core-updates.php UI.
- try updating the plugin via the wp cli interface. `wp plugin update jetpack`
Do you get the expected failure event on .com? 

- Try updating the plugin do you get the event as expected on .com that tells you that a plugin updated? 

- Do you still get a plugin install event as expected? 

