### PR TITLE
REST API: Decode special chars in onboarding data

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -449,7 +449,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case 'onboarding':
 					$business_address = get_option( 'jpo_business_address' );
-					$business_address = ! empty( $business_address ) ? array_map( array( $this, 'decode_special_characters' ), $business_address ) : $business_address;
+					$business_address = is_array( $business_address ) ? array_map( array( $this, 'decode_special_characters' ), $business_address ) : $business_address;
 
 					$response[ $setting ] = array(
 						'siteTitle' => $this->decode_special_characters( get_option( 'blogname' ) ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -473,6 +473,15 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		return rest_ensure_response( $response );
 	}
 
+	/**
+	 * Decode the special HTML characters in a certain value.
+	 *
+	 * @since 5.8
+	 *
+	 * @param string $value Value to decode.
+	 *
+	 * @return string Value with decoded HTML characters.
+	 */
 	private function decode_special_characters( $value ) {
 		return (string) htmlspecialchars_decode( $value, ENT_QUOTES );
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -449,7 +449,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case 'onboarding':
 					$business_address = get_option( 'jpo_business_address' );
-					$business_address = $business_address ? array_map( array( $this, 'decode_special_characters' ), $business_address ) : $business_address;
+					$business_address = ! empty( $business_address ) ? array_map( array( $this, 'decode_special_characters' ), $business_address ) : $business_address;
 
 					$response[ $setting ] = array(
 						'siteTitle' => $this->decode_special_characters( get_option( 'blogname' ) ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -448,13 +448,16 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'onboarding':
+					$business_address = get_option( 'jpo_business_address' );
+					$business_address = $business_address ? array_map( array( $this, 'decode_special_characters' ), $business_address ) : $business_address;
+
 					$response[ $setting ] = array(
-						'siteTitle' => get_option( 'blogname' ),
-						'siteDescription' => get_option( 'blogdescription' ),
+						'siteTitle' => $this->decode_special_characters( get_option( 'blogname' ) ),
+						'siteDescription' => $this->decode_special_characters( get_option( 'blogdescription' ) ),
 						'siteType' => get_option( 'jpo_site_type' ),
 						'homepageFormat' => get_option( 'jpo_homepage_format' ),
 						'addContactForm' => intval( get_option( 'jpo_contact_page' ) ),
-						'businessAddress' => get_option( 'jpo_business_address' ),
+						'businessAddress' => $business_address,
 						'installWooCommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
 					);
 					break;
@@ -468,6 +471,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		$response['akismet'] = is_plugin_active( 'akismet/akismet.php' );
 
 		return rest_ensure_response( $response );
+	}
+
+	public function decode_special_characters( $value ) {
+		return (string) htmlspecialchars_decode( $value, ENT_QUOTES );
 	}
 
 	/**

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -473,7 +473,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		return rest_ensure_response( $response );
 	}
 
-	public function decode_special_characters( $value ) {
+	private function decode_special_characters( $value ) {
 		return (string) htmlspecialchars_decode( $value, ENT_QUOTES );
 	}
 


### PR DESCRIPTION
This PR fixes https://github.com/Automattic/wp-calypso/issues/21923

To test:
1. Checkout this branch.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. For site title and description, use some HTML entities, like single quote or ampersand.
1. During the JPO flow, when asked whether you want a personal or business site, select business.
1. Skip to the Business Address step.
1. For each business address field, use some HTML entities, like single quote or ampersand.
1. Re-run the onboarding flow (step 3).
1. Go through the site title step and the business address step and verify that the special characters appear properly and are not encoded.