### PR TITLE
Load active modules when onboarding

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1746,6 +1746,7 @@ class Jetpack {
 		if (
 			! self::is_active()
 			&& ! self::is_development_mode()
+			&& ! self::is_onboarding()
 			&& (
 				! is_multisite()
 				|| ! get_site_option( 'jetpack_protect_active' )


### PR DESCRIPTION
This PR allows active modules to be loaded while onboarding. We need to handle this special case because we might be in a state where we're not connected and not in development mode in the same time, but we still need to load the active modules.

Fixes https://github.com/Automattic/wp-calypso/issues/21930

To test:
1. Create a fresh Jurassic Ninja site.
1. Install JP beta, switch on bleeding edge.
1. SSH into the JN site and apply this branch manually.
1. Go to https://JNsite.com/wp-admin/admin.php?page=jetpack&action=onboard where `JNsite.com` is a fresh Jurassic Ninja site.
1. On the site type step, select Business.
1. On the Business address step, input your business address and submit the step.
1. Go to wp-admin and verify that the contact info widget is active and is properly inserted in your sidebar with all the business address inside.