### PR TITLE
Traffic: add missing siteRawUrl to props

### DIFF
--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -28,6 +28,7 @@ export const Traffic = React.createClass( {
 	render() {
 		const commonProps = {
 			settings: this.props.settings,
+			siteRawUrl: this.props.siteRawUrl,
 			getModule: this.props.module,
 			isDevMode: this.props.isDevMode,
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode


### PR DESCRIPTION
`commonProps` is passed on to `GoogleAnalytics` component which [expects to have `siteRawUrl`](https://github.com/Automattic/jetpack/blob/537309fd4a530257e4aa6ab5fa104e6496cda995/_inc/client/traffic/google-analytics.jsx#L33-L39).

Without it a link in the component will render with "undefined":

`https://wordpress.com/stats/day/undefined`

### Changes proposed in this Pull Request:

Add `siteRawUrl` to `commonProps` object in the Traffic class.

### Testing instructions:

- To see the copy you need **Professional plan**.
- Go to `/wordpress/wp-admin/admin.php?page=jetpack#/traffic`
- Scroll to **Google Analytics**

**Before:** "built-in stats"-link renders with `undefined`.
**After:** link renders with site URL. 👌 

![image](https://user-images.githubusercontent.com/87168/35569342-a2f9de16-05d4-11e8-9a28-19b60b3fc91f.png)
![image](https://user-images.githubusercontent.com/87168/35569351-a9a506be-05d4-11e8-8c16-1de4e7709afe.png)
