### PR TITLE
Search: Widget minor UI/UX tweaks

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -559,7 +559,11 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 						<?php $this->render_widget_filter( $filter ); ?>
 					<?php endforeach; ?>
 				</div>
-				<a class="button jetpack-search-filters-widget__add-filter" href="#"><?php esc_html_e( 'Add a filter', 'jetpack' ); ?></a>
+				<p>
+					<a class="button jetpack-search-filters-widget__add-filter" href="#">
+						<?php esc_html_e( 'Add a filter', 'jetpack' ); ?>
+					</a>
+				</p>
 				<?php if ( is_customize_preview() ) : ?>
 					<div class="jetpack-search-filters-help">
 						<a href="https://jetpack.com/support/search/#filters-not-showing-up" target="_blank">

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -559,17 +559,22 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 						<?php $this->render_widget_filter( $filter ); ?>
 					<?php endforeach; ?>
 				</div>
-				<p>
+				<p class="jetpack-search-filters-widget__add-filter-wrapper">
 					<a class="button jetpack-search-filters-widget__add-filter" href="#">
 						<?php esc_html_e( 'Add a filter', 'jetpack' ); ?>
 					</a>
 				</p>
+				<noscript>
+					<p class="jetpack-search-filters-help">
+						<?php echo esc_html_e( 'Adding filters requires JavaScript!', 'jetpack' ); ?>
+					</p>
+				</noscript>
 				<?php if ( is_customize_preview() ) : ?>
-					<div class="jetpack-search-filters-help">
+					<p class="jetpack-search-filters-help">
 						<a href="https://jetpack.com/support/search/#filters-not-showing-up" target="_blank">
 							<?php esc_html_e( "Why aren't my filters appearing?", 'jetpack' ); ?>
 						</a>
-					</div>
+					</p>
 				<?php endif; ?>
 			<?php endif; ?>
 		</div>

--- a/modules/search/css/search-widget-filters-admin-ui.css
+++ b/modules/search/css/search-widget-filters-admin-ui.css
@@ -70,8 +70,7 @@
 	content:"\f223";
 }
 .jetpack-search-filters-help {
-	padding: 5px;
-	padding-bottom: 15px;
+	padding: 5px 5px 15px 0;
 }
 
 .jetpack-search-filters-widget__post-types-select label {
@@ -81,4 +80,8 @@
 
 .jetpack-search-filters-widget__post-types-select input[type="checkbox"] {
 	margin-left: 24px;
+}
+
+body.no-js .jetpack-search-filters-widget__add-filter-wrapper {
+	display: none;
 }


### PR DESCRIPTION
This PR makes a few simple UI tweaks:

- Surrounds the "Add a filter" button with a `<p`> tag to give it some vertical space
- Changes the "Where are my filters?" link to use a `<p>` to give it some vertical space
- Adds a notice to tell users that adding filters requires JS support
- Removes the left padding for the widget notices

Screenshots after:

<img width="275" alt="screen shot 2018-01-30 at 10 24 14 am" src="https://user-images.githubusercontent.com/1126811/35577912-4d1bd19c-05a8-11e8-98f8-013e45d623d9.png">
<img width="402" alt="screen shot 2018-01-30 at 10 20 06 am" src="https://user-images.githubusercontent.com/1126811/35577913-4d358470-05a8-11e8-8618-321ada06bc4c.png">
<img width="285" alt="screen shot 2018-01-30 at 10 26 35 am" src="https://user-images.githubusercontent.com/1126811/35577914-4d4ebff8-05a8-11e8-9840-36b51342ab7b.png">

Screenshots before:

<img width="296" alt="screen shot 2018-01-30 at 10 28 05 am" src="https://user-images.githubusercontent.com/1126811/35577907-479ff7e8-05a8-11e8-9909-f144713712e5.png">
<img width="287" alt="screen shot 2018-01-30 at 10 27 01 am" src="https://user-images.githubusercontent.com/1126811/35577908-47b84eba-05a8-11e8-82e5-60d29bf50b39.png">

<img width="410" alt="screen shot 2018-01-30 at 10 28 39 am" src="https://user-images.githubusercontent.com/1126811/35577950-5d401dd0-05a8-11e8-82a9-562ef6ad4148.png">
