### PR TITLE
Search: Remove unnecessary .off in widget JS after changing classes

### DIFF
--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -292,7 +292,6 @@
 		// seem noisy in the customizer. We'll track those via PHP.
 
 		widget.off( 'change', '.filter-select' );
-		widget.off( 'click', '.jetpack-search-filters-widget__controls .add' );
 		widget.off( 'click', '.jetpack-search-filters-widget__controls .delete' );
 		widget.off( 'change', '.jetpack-search-filters-widget__use-filters' );
 		widget.off( 'change', '.jetpack-search-filters-widget__search-box-enabled' );


### PR DESCRIPTION
In #8637, we changed the `.on` listener for adding a filter here:

https://github.com/Automattic/jetpack/pull/8637/files#diff-937926921eb40702b21d1b8e21d7f3cdL143

But, we didn't remove the `.off` call for that.

To test:

- Checkout branch on site with Jetpack Professional
- Add Jetpack Search widget
- Ensure that you can manipulate filters without JS errors