### PR TITLE
Update links to point to correct "manage plugin" path

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -20,7 +20,7 @@ class DashPluginUpdates extends Component {
 	activateAndRedirect( e ) {
 		e.preventDefault();
 		this.props.activateManage()
-			.then( window.location = 'https://wordpress.com/plugins/' + this.props.siteRawUrl );
+			.then( window.location = 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl );
 	}
 
 	getContent() {
@@ -69,7 +69,7 @@ class DashPluginUpdates extends Component {
 						{
 							this.props.isDevMode
 								? ''
-								: __( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ 'https://wordpress.com/plugins/' + this.props.siteRawUrl } /> } } )
+								: __( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
 						}
 					</p>
 				</DashItem>

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -89,7 +89,7 @@ export class DashItem extends Component {
 					toggle = (
 						<a href={ this.props.isDevMode
 							? this.props.siteAdminUrl + 'update-core.php'
-							: 'https://wordpress.com/plugins/' + this.props.siteRawUrl
+							: 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl
 						} >
 							<SimpleNotice
 								showDismiss={ false }

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -179,7 +179,7 @@ describe( 'DashItem', () => {
 		} );
 
 		it( 'when it is activated, the warning badge is linked to Plugins screen in WordPress.com', () => {
-			expect( wrapper.find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( 'https://wordpress.com/plugins/' + manageProps.siteRawUrl );
+			expect( wrapper.find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( 'https://wordpress.com/plugins/manage/' + manageProps.siteRawUrl );
 		} );
 
 		it( "when status is 'is-working', the warning badge has an 'active' label", () => {

--- a/modules/manage/confirm-admin.php
+++ b/modules/manage/confirm-admin.php
@@ -18,7 +18,7 @@ $description = __( 'Well that was easy. You can now manage all of your sites in 
 
 switch( $section ) {
 	case 'plugins':
-		$link = 'https://wordpress.com/plugins/' . $normalized_site_url;
+		$link = 'https://wordpress.com/plugins/manage/' . $normalized_site_url;
 		$link_title = __( 'Manage Your Plugins', 'jetpack' );
 		break;
 


### PR DESCRIPTION
Fixes #8669

This updates the relevant links to manage your plugins to the correct path.  

To Test: 
- Trigger some plugin update notices by updating the plugin's version manually 
- See the notices in the dashboard card as shown in the linked issue
- Clicking them should take you to the correct path described in the linked issue 
