### PR TITLE
Search: Fixes issue where filters did not always properly save

### DIFF
--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -370,9 +370,10 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		$user_sort_enabled = ! empty( $instance['user_sort_enabled'] );
 		$sort = isset( $instance['sort'] ) ? $instance['sort'] : self::DEFAULT_SORT;
 		$classes = sprintf(
-			'jetpack-search-filters-widget %s %s',
+			'jetpack-search-filters-widget %s %s %s',
 			$hide_filters ? 'hide-filters' : '',
-			$search_box_enabled ? '' : 'hide-post-types'
+			$search_box_enabled ? '' : 'hide-post-types',
+			$this->id
 		);
 		?>
 		<div class="<?php echo esc_attr( $classes ); ?>">
@@ -592,11 +593,19 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		$args['name_placeholder'] = Jetpack_Search_Helpers::generate_widget_filter_name( $args );
 
+		$filter_selector = sprintf(
+			'.jetpack-search-filters-widget.%s .jetpack-search-filters-widget__filters',
+			sanitize_key( $this->id )
+		);
+
 		?>
 		<script type="text/javascript">
 			// output as JSON and render
 			jQuery( document ).ready( function( $ ) {
-				window.JetpackSearch.addFilter( $('.jetpack-search-filters-widget__filters'), <?php echo json_encode($args) ?> );
+				window.JetpackSearch.addFilter(
+					$( '<?php echo esc_js( $filter_selector ); ?>' ),
+					<?php echo json_encode($args) ?>
+				);
 			});
 		</script>
 	<?php }

--- a/modules/search/js/search-widget-filters-admin.js
+++ b/modules/search/js/search-widget-filters-admin.js
@@ -37,8 +37,12 @@
 	}
 
 	var addFilter = function( filtersContainer, args ) {
-		// render using underscore
-		var template = _.template( $('.jetpack-search-filters-widget__filter-template').html() );
+		var template = _.template(
+			filtersContainer
+				.closest( '.jetpack-search-filters-widget' )
+				.find( '.jetpack-search-filters-widget__filter-template' )
+				.html()
+		);
 		var filter = $('<div></div>');
 
 		filter.html( template( args ) );
@@ -211,7 +215,12 @@
 		// add filter button
 		widget.on( 'click', '.jetpack-search-filters-widget__add-filter', function( e ) {
 			e.preventDefault();
-			addFilter( widget.find('.jetpack-search-filters-widget__filters'), {
+
+			var filtersContainer = $( this )
+				.closest( '.jetpack-search-filters-widget' )
+				.find( '.jetpack-search-filters-widget__filters' );
+
+			addFilter( filtersContainer, {
 				type: 'taxonomy',
 				taxonomy: '',
 				post_type: '',
@@ -224,6 +233,12 @@
 			if ( wp && wp.customize ) {
 				wp.customize.state( 'saved' ).set( false );
 			}
+
+			// Trigger change event to let legacy widget admin know the widget state is "dirty"
+			filtersContainer
+				.find( '.jetpack-search-filters-widget__filter' )
+				.find( 'input, textarea, select' )
+				.change();
 
 			trackAndBumpMCStats( 'added_filter', args.tracksEventData );
 		} );


### PR DESCRIPTION
Fixes #8667 as well as an issue where filters didn't properly save.

The root issue behind #8667 was that we had removed a `.change()` event which had previously told the legacy widget UI that it was in a "dirty" state. To fix that, we now fire a change event on form fields within the new widget that was added.

There was also an issue where filters were not always properly saving. After looking into this, it was because the filters had an incorrect name. I described some about that here: https://github.com/Automattic/jetpack/pull/8637#issuecomment-361421715

@gravityrail and I paired to nail that down. The root issue was that I had multiple instance of the widget on the page. For example, some were inactive. To fix this, we simply needed to find the template for our specific widget. So, I updated some selectors so we got the correct filters container.

To test:

- Checkout branch on site with Jetpack Professional
- Go to legacy widget UI and add widget if not already there
- Add/remove filters and ensure everything saves properly
- Do the same in the customizer