### PR TITLE
Search: Fix PHP warnings introduced in #8655

### DIFF
--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -35,7 +35,7 @@ class Jetpack_Search_Template_Tags {
 			// remove any post_type filters from display if the current query
 			// already specifies to match all post types
 			if ( ! $post_types_differ_query ) {
-				$active_buckets = array_filter( $active_buckets, array( 'Jetpack_Search_Helpers', 'is_not_post_type_filter' ) );
+				$active_buckets = array_filter( $active_buckets, array( __CLASS__, 'is_not_post_type_filter' ) );
 			}
 
 			$active_post_types = Jetpack_Search_Helpers::get_active_post_types( $active_buckets, $post_types );


### PR DESCRIPTION
After #8655, I noticed that there were some PHP warnings:

```
[30-Jan-2018 21:41:37 UTC] PHP Warning:  array_filter() expects parameter 2 to be a valid callback, class 'Jetpack_Search_Helpers' does not have a method 'is_not_post_type_filter' in wp-content/plugins/jetpack/modules/search/class.jetpack-search-template-tags.php on line 38
[30-Jan-2018 21:41:37 UTC] PHP Warning:  Invalid argument supplied for foreach() in /wp-content/plugins/jetpack/modules/search/class.jetpack-search-helpers.php on line 365
```

The issue was that `is_not_post_type_filter` is a static method on the `Jetpack_Search_Template_Tags` class and not `Jetpack_Search_Helpers`.

To test:

- Checkout branch on site with Jetpack Professional
- Add a search widget 
- Do a search
- Ensure there are no PHP warnings
