### PR TITLE
Better checks for active Jetpack in Tracks

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -53,6 +53,10 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	static function record_event( $event ) {
+		if ( ! Jetpack::is_active() ) {
+			return false;
+		}
+		
 		if ( ! $event instanceof Jetpack_Tracks_Event ) {
 			$event = new Jetpack_Tracks_Event( $event );
 		}


### PR DESCRIPTION
Blocks sending a tracks event (if Jetpack is not connected) late enough to catch all instances of sending an event.  