### PR TITLE
Jetpack Start: Allow hosts to pass a tracking ID when provisioning or cancelling a plan

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -3,7 +3,7 @@
 # cancel a the plan provided for the current site using the given partner keys
 
 usage () {
-	echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com] [--allow-root]"
+	echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com] [--allow-root] [--host_tracking_id]"
 }
 
 GLOBAL_ARGS=""
@@ -17,6 +17,9 @@ for i in "$@"; do
 			shift
 			;;
 		-u=* | --url=* )            SITE_URL="${i#*=}"
+			shift
+			;;
+		--host_tracking_id=* )      HOST_TRACKING_ID="${i#*=}"
 			shift
 			;;
 		--allow-root )              GLOBAL_ARGS="--allow-root"
@@ -48,6 +51,11 @@ if [ ! -z "$SITE_URL" ]; then
 	GLOBAL_ARGS=" --url=$SITE_URL"
 fi
 
+ADDITIONAL_ARGS=""
+if [ ! -z "$HOST_TRACKING_ID" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --host_tracking_id=$HOST_TRACKING_ID"
+fi
+
 # Remove leading whitespace
 GLOBAL_ARGS=$(echo "$GLOBAL_ARGS" | xargs echo)
 
@@ -57,4 +65,4 @@ GLOBAL_ARGS=$(echo "$GLOBAL_ARGS" | xargs echo)
 wp $GLOBAL_ARGS plugin activate jetpack >/dev/null 2>&1
 
 # cancel the partner plan
-wp $GLOBAL_ARGS jetpack partner_cancel "$ACCESS_TOKEN_JSON"
+wp $GLOBAL_ARGS jetpack partner_cancel "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS

--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -3,7 +3,7 @@
 # cancel a the plan provided for the current site using the given partner keys
 
 usage () {
-	echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com] [--allow-root] [--host_tracking_id]"
+	echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com] [--allow-root] [--partner-tracking-id]"
 }
 
 GLOBAL_ARGS=""
@@ -19,7 +19,7 @@ for i in "$@"; do
 		-u=* | --url=* )            SITE_URL="${i#*=}"
 			shift
 			;;
-		--host_tracking_id=* )      HOST_TRACKING_ID="${i#*=}"
+		--partner-tracking-id=* )   PARTNER_TRACKING_ID="${i#*=}"
 			shift
 			;;
 		--allow-root )              GLOBAL_ARGS="--allow-root"
@@ -52,8 +52,8 @@ if [ ! -z "$SITE_URL" ]; then
 fi
 
 ADDITIONAL_ARGS=""
-if [ ! -z "$HOST_TRACKING_ID" ]; then
-	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --host_tracking_id=$HOST_TRACKING_ID"
+if [ ! -z "$PARTNER_TRACKING_ID" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --partner-tracking-id=$PARTNER_TRACKING_ID"
 fi
 
 # Remove leading whitespace

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -4,7 +4,7 @@
 # executes wp-cli command to provision Jetpack site for given partner
 
 usage () {
-	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--wpcom_user_email=wpcom_user_email] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url]"
+	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--wpcom_user_email=wpcom_user_email] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url] [--host_tracking_id]"
 }
 
 GLOBAL_ARGS=""
@@ -45,6 +45,9 @@ for i in "$@"; do
 			shift
 			;;
 		--home_url=* )              WP_HOME="${i#*=}"
+			shift
+			;;
+		--host_tracking_id=* )      HOST_TRACKING_ID="${i#*=}"
 			shift
 			;;
 		--allow-root )              GLOBAL_ARGS="--allow-root"
@@ -119,6 +122,10 @@ fi
 
 if [ ! -z "$WP_HOME" ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --home_url=$WP_HOME"
+fi
+
+if [ ! -z "$HOST_TRACKING_ID" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --host_tracking_id=$HOST_TRACKING_ID"
 fi
 
 # Remove leading whitespace

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -4,7 +4,7 @@
 # executes wp-cli command to provision Jetpack site for given partner
 
 usage () {
-	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--wpcom_user_email=wpcom_user_email] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url] [--host_tracking_id]"
+	echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--wpcom_user_email=wpcom_user_email] [--url=http://example.com] [--force_connect=1] [--force_register=1] [--allow-root] [--home_url] [--site_url] [--partner-tracking-id]"
 }
 
 GLOBAL_ARGS=""
@@ -47,7 +47,7 @@ for i in "$@"; do
 		--home_url=* )              WP_HOME="${i#*=}"
 			shift
 			;;
-		--host_tracking_id=* )      HOST_TRACKING_ID="${i#*=}"
+		--partner-tracking-id=* )   PARTNER_TRACKING_ID="${i#*=}"
 			shift
 			;;
 		--allow-root )              GLOBAL_ARGS="--allow-root"
@@ -124,8 +124,8 @@ if [ ! -z "$WP_HOME" ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --home_url=$WP_HOME"
 fi
 
-if [ ! -z "$HOST_TRACKING_ID" ]; then
-	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --host_tracking_id=$HOST_TRACKING_ID"
+if [ ! -z "$PARTNER_TRACKING_ID" ]; then
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --partner-tracking-id=$PARTNER_TRACKING_ID"
 fi
 
 # Remove leading whitespace

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -823,6 +823,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * <token_json>
 	 * : JSON blob of WPCOM API token
+	 *  [--host_tracking_id=<host_tracking_id>]
+	 * : This is an optional ID that a host can pass to help identify a site in logs on WordPress.com
+	 *
+	 *  * @synopsis <token_json> [--host_tracking_id=<host_tracking_id>]
 	 */
 	public function partner_cancel( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -855,6 +859,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%s/partner-cancel', $this->get_api_host(), $site_identifier );
+		if ( ! empty( $named_args ) && ! empty( $named_args['host_tracking_id'] ) ) {
+			$url = esc_url_raw( add_query_arg( 'host_source_id', $named_args, $url ) );
+		}
 
 		$result = Jetpack_Client::_wp_remote_request( $url, $request );
 
@@ -894,13 +901,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : Overrides the home option via the home_url filter, or the WP_HOME constant
 	 * [--site_url=<site_url>]
 	 * : Overrides the siteurl option via the site_url filter, or the WP_SITEURL constant
+	 * [--host_tracking_id=<host_tracking_id>]
+	 * : This is an optional ID that a host can pass to help identify a site in logs on WordPress.com
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>] [--wpcom_user_email=<wpcom_user_email>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>] [--wpcom_user_email=<wpcom_user_email>] [--host_tracking_id=<host_tracking_id>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -1045,6 +1054,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%d/partner-provision', $this->get_api_host(), $blog_id );
+		if ( ! empty( $named_args['host_tracking_id'] ) ) {
+			$url = esc_url_raw( add_query_arg( 'host_source_id', $named_args, $url ) );
+		}
 
 		// add calypso env if set
 		if ( getenv( 'CALYPSO_ENV' ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -823,10 +823,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * <token_json>
 	 * : JSON blob of WPCOM API token
-	 *  [--host_tracking_id=<host_tracking_id>]
+	 *  [--partner-tracking-id=<partner_tracking_id>]
 	 * : This is an optional ID that a host can pass to help identify a site in logs on WordPress.com
 	 *
-	 *  * @synopsis <token_json> [--host_tracking_id=<host_tracking_id>]
+	 *  * @synopsis <token_json> [--partner-tracking-id=<partner_tracking_id>]
 	 */
 	public function partner_cancel( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -859,8 +859,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%s/partner-cancel', $this->get_api_host(), $site_identifier );
-		if ( ! empty( $named_args ) && ! empty( $named_args['host_tracking_id'] ) ) {
-			$url = esc_url_raw( add_query_arg( 'host_source_id', $named_args, $url ) );
+		if ( ! empty( $named_args ) && ! empty( $named_args['partner-tracking-id'] ) ) {
+			$url = esc_url_raw( add_query_arg( 'partner_tracking_id', $named_args['partner-tracking-id'], $url ) );
 		}
 
 		$result = Jetpack_Client::_wp_remote_request( $url, $request );
@@ -901,7 +901,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : Overrides the home option via the home_url filter, or the WP_HOME constant
 	 * [--site_url=<site_url>]
 	 * : Overrides the siteurl option via the site_url filter, or the WP_SITEURL constant
-	 * [--host_tracking_id=<host_tracking_id>]
+	 * [--partner-tracking-id=<partner_tracking_id>]
 	 * : This is an optional ID that a host can pass to help identify a site in logs on WordPress.com
 	 *
 	 * ## EXAMPLES
@@ -909,7 +909,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>] [--wpcom_user_email=<wpcom_user_email>] [--host_tracking_id=<host_tracking_id>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>] [--home_url=<home_url>] [--site_url=<site_url>] [--wpcom_user_email=<wpcom_user_email>] [--partner-tracking-id=<partner_tracking_id>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -1054,8 +1054,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%d/partner-provision', $this->get_api_host(), $blog_id );
-		if ( ! empty( $named_args['host_tracking_id'] ) ) {
-			$url = esc_url_raw( add_query_arg( 'host_source_id', $named_args, $url ) );
+		if ( ! empty( $named_args['partner-tracking-id'] ) ) {
+			$url = esc_url_raw( add_query_arg( 'partner_tracking_id', $named_args['partner-tracking-id'], $url ) );
 		}
 
 		// add calypso env if set


### PR DESCRIPTION
While debugging plan provisions and cancellations, I've noticed that users will often create various clones of sites and will move a domain name around those sites.

This sometimes results in the plan for a given site being cancelled when it probably shouldn't.

We have logs in place on WordPress.com to track when a partner provisions or cancels a plan, but it sure would be nice if we could tell exactly which site the partner intended on provisioning or cancelling the plan for. After this PR, hosts will be allowed to pass in a `--host_tracking_id` argument which will help in debugging.

To test:

For instructions on setting up a partner ID and secret, see: PCYsg-eDL-p2

- Checkout branch
- Use the following command, replacing partner the arguments :
    - `sh jetpack/bin/partner-provision.sh --partner_id={PARTNER_ID} --partner_secret={PARTNER_SECRET} --user={LOCAL_WP_USER_ID} --plan=professional --host_tracking_id=$some_numeric_value`
- Check logstash and ensure that `id` has the value that was sent via `host_tracking_id`