### PR TITLE
Sync: Remove newly added plugin install failed event

### DIFF
--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -97,25 +97,6 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		}
 
 		if ( 'install' === $details['action'] ) {
-			$errors = $this->get_errors( $upgrader->skin );
-			if ( $errors ) {
-				foreach ( $plugins as $slug ) {
-					/**
-					 * Sync that a plugin update failed
-					 *
-					 * @since  5.8.0
-					 *
-					 * @module sync
-					 *
-					 * @param string $plugin , Plugin slug
-					 * @param        string  Error code
-					 * @param        string  Error message
-					 */
-					do_action( 'jetpack_plugin_install_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'] );
-				}
-
-				return;
-			}
 			/**
 			 * Signals to the sync listener that a plugin was installed and a sync action
 			 * reflecting the installation and the plugin info should be sent


### PR DESCRIPTION
It currentrly isn't even possible to reach this part of the code beacuse a failed intall event never calls the `upgrader_process_complete` do action.

Removing this event is find becasue we only included it very recently in https://github.com/Automattic/jetpack/pull/8654 and it never made it into a Jetpack version except master. 
