### PR TITLE
Search: Enqueue debug bar styles in admin

### DIFF
--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -25,6 +25,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	public function __construct() {
 		$this->title( esc_html__( 'Jetpack Search', 'jetpack' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes a minor issue where the Jetpack Search debug bar styles weren't including in wp-admin. This led to some weird styling like this in wp-admin:

<img width="706" alt="screen shot 2018-01-31 at 2 11 12 pm" src="https://user-images.githubusercontent.com/1126811/35645209-c6cdb788-0690-11e8-959b-41dd79c267a3.png">

This PR ensures that we enqueue the debug bar styles in wp-admin as well, which makes things look like this:

<img width="665" alt="screen shot 2018-01-31 at 2 10 51 pm" src="https://user-images.githubusercontent.com/1126811/35645253-e283229c-0690-11e8-8652-91a2ae7556bb.png">

To test:

- Checkout branch on a site with Jetpack Professional
- Ensure debug bar or query monitor are installed
- Load wp-admin
- Check that the Jetpack Search debug bar panel looks more like the second screenshot than the first

Note: styles are a tad different with the query monitor plugin. So, the screenshots will not be exact. The big thing to look out for is that the header is not floated and that the "none" is displayed below the header.

Another note: we don't currently use Jetpack Search in the backend. So another approach might be to not show the panel in the admin. We have discussed the possibility of supporting Elasticsearch in the admin though, so i'd rather fix the issue by enqueueing the CSS in the admin.