### PR TITLE
Search: Enable the sort selector even if no query

### DIFF
--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -264,8 +264,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 				jQuery( document ).ready( function( $ ) {
 					var orderByDefault = <?php echo json_encode( $orderby ); ?>,
 						orderDefault   = <?php echo json_encode( $order ); ?>,
-						widgetId       = <?php echo json_encode( $this->id ); ?>,
-						currentSearch  = <?php echo json_encode( isset( $_GET['s'] ) ? $_GET['s'] : '' ); ?>;
+						widgetId       = <?php echo json_encode( $this->id ); ?>;
 
 					var container = $('#' + widgetId);
 					var form = container.find('.jetpack-search-form form');
@@ -279,13 +278,12 @@ class Jetpack_Search_Widget extends WP_Widget {
 						orderBy.val( values[0] );
 						order.val( values[1] );
 
-						if ( currentSearch ) {
-							form.submit();
-						}
+						form.submit();
 					});
 				} );
 			</script>
-		<?php endif;
+		<?php
+		endif;
 	}
 
 	private function sorting_to_wp_query_param( $sort ) {


### PR DESCRIPTION
While testing the beta, I realized that if I attempted a search without a query that the sort selector didn't work.

For example, if you go to `$site.com?s=&orderby=relevance&order=DESC&post_type=post%2Cpage%2Cjetpack-testimonial` with the current master, the sort select won't work.

The issue was that we were short-circuiting the sort selector functionality if there was not a current search query. I can't think of a reason to leave that in, so I went ahead and pulled it out.

I considered not showing the sort selector when there's no query, but decided to leave it in since it's possible for a user to sort oldest to newest in order to see older posts.

To test:

- Checkout branch on site with Jetpack Professional
- Ensure Jetpack Search is on and a widget is added to your sidebar with the search box and sort controls enabled
- Go to `$site.com/?s=`
- Ensure that the relevance sort option doesn't show
- Perform a search with a phrase
- Ensure that the relevance option shows (and that you don't see "recommended" in the label)
- Go to customize or the legacy wp-admin widgets UI, find the search widget, and ensure that "recommended" shows on the relevance label