### PR TITLE
Fix ugly "VP deactivated" notice

### DIFF
--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -5,7 +5,7 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 
 	deactivate_plugins( $plugin_file );
 	?>
-	<div class="notice notice-success">
+	<div class="notice notice-success vp-deactivated">
 		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>
 		<p><?php _e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
 	</div>

--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -6,6 +6,21 @@ import React from 'react';
 class AdminNotices extends React.Component {
 	componentDidMount() {
 		const $adminNotices = jQuery( this.refs.adminNotices );
+		const dismiss = '<span role="button" tabindex="0" class="dops-notice__dismiss"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path></g></svg><span class="screen-reader-text"></span></span>';
+
+		const $vpDeactivationNotice = jQuery( '.vp-deactivated' );
+		if ( $vpDeactivationNotice.length > 0 ) {
+			$vpDeactivationNotice.each( function() {
+				const $notice = jQuery( this ).addClass( 'dops-notice is-success is-dismissable' ).removeClass( 'wrap vp-notice notice notice-success' );
+				const icon = '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>';
+				$notice.wrapInner( '<span class="dops-notice__content">' );
+				$notice.find( '.dops-notice__content' ).before( icon ).css( 'display', 'block' );
+				$notice.find( '.dops-notice__content' ).after( dismiss );
+				$notice.find( 'h2' ).replaceWith( function() { return jQuery( '<strong />', { html: this.innerHTML } ); } );
+				$notice.find( 'p' ).replaceWith( function() { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+				$notice.prependTo( $adminNotices ).css( 'display', 'flex' );
+			} );
+		}
 
 		const $vpNotice = jQuery( '.vp-notice' );
 		if ( $vpNotice.length > 0 ) {
@@ -41,6 +56,12 @@ class AdminNotices extends React.Component {
 				$notice.wrapInner( '<span class="dops-notice__content">' ).prependTo( $adminNotices ).css( 'display', 'flex' );
 				$notice.find( '.dops-notice__action' ).not( ':first' ).removeClass( 'dops-notice__action' ).detach().appendTo( $notice.find( '.dops-notice__text' ) );
 				$notice.find( '.dops-notice__action:first' ).detach().appendTo( $notice );
+			} );
+		}
+
+		if ( $adminNotices.length > 0 ) {
+			jQuery( '.dops-notice__dismiss' ).click( function() {
+				jQuery( this ).parent().closest( 'div' ).hide();
 			} );
 		}
 	}


### PR DESCRIPTION
Fixes #8679

To Test: 
- Add this in a functionality plugin or anywhere `add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );`
- See the notice in the correct place
- Make sure it's dismissible 

Before: 
![screen shot 2018-01-31 at 4 06 06 pm](https://user-images.githubusercontent.com/7129409/35647475-abb5d600-06a0-11e8-9c87-472ceb004f76.png)

After: 
![screen shot 2018-01-31 at 4 05 17 pm](https://user-images.githubusercontent.com/7129409/35647452-944369e2-06a0-11e8-95b9-3b1733c52c79.png)
