### PR TITLE
Allow enabling lazy images from the upgrade screen

### DIFF
--- a/_inc/client/components/jetpack-dialogue/style.scss
+++ b/_inc/client/components/jetpack-dialogue/style.scss
@@ -87,3 +87,20 @@
 .jp-dialogue__cta-container {
 	padding: rem( 8px ) 0 0;
 }
+
+.jp-upgrade-notice__enable-module {
+	.jp-form-settings-group {
+		margin: 0px auto;
+		max-width: 300px;
+		text-align: left;
+	}
+
+	.jp-form-has-child {
+		padding: 10px;
+	}
+
+	.jp-module-settings__learn-more {
+		top: rem( 15px );
+		right: rem( 15px );
+	}
+}

--- a/_inc/client/components/jetpack-dialogue/style.scss
+++ b/_inc/client/components/jetpack-dialogue/style.scss
@@ -89,6 +89,8 @@
 }
 
 .jp-upgrade-notice__enable-module {
+	margin-bottom: calc(1em + 8px);
+
 	.jp-form-settings-group {
 		margin: 0px auto;
 		max-width: 300px;

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -18,7 +18,6 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import { getModule } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsGroup from 'components/settings-group';
-import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
 const UpgradeNoticeContent = moduleSettingsForm(
 	class extends Component {
 		toggleModule = ( name, value ) => {

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -47,7 +47,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 						{ __( 'If this sounds like a great improvement (and it is) you can enable it now by clicking the toggle below.' ) }
 					</p>
 
-					<p>
+					<p className="jp-upgrade-notice__enable-module">
 
 						<SettingsGroup
 							hasChild

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -46,7 +46,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 						{ __( 'If this sounds like a great improvement (and it is) you can enable it now by clicking the toggle below.' ) }
 					</p>
 
-					<p className="jp-upgrade-notice__enable-module">
+					<div className="jp-upgrade-notice__enable-module">
 
 						<SettingsGroup
 							hasChild
@@ -65,7 +65,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 								</span>
 							</ModuleToggle>
 						</SettingsGroup>
-					</p>
+					</div>
 
 					<p>
 						{ __( 'We have also upgraded all our Premium plan customers to unlimited high-speed video storage ' +

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -6,79 +6,123 @@ import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import JetpackDialogue from 'components/jetpack-dialogue';
+import decodeEntities from 'lib/decode-entities';
 import { imagePath } from 'constants/urls';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { getModule } from 'state/modules';
+import { ModuleToggle } from 'components/module-toggle';
+import SettingsGroup from 'components/settings-group';
+import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
+const UpgradeNoticeContent = moduleSettingsForm(
+	class extends Component {
+		toggleModule = ( name, value ) => {
+			this.props.updateOptions( { [ name ]: ! value } );
+		};
 
-class UpgradeNoticeContent extends Component {
-	renderInnerContent() {
-		return (
-			<div>
-				<p>
-					{ __( 'This release of Jetpack brings major new features and big improvements to your WordPress site.' ) }
-				</p>
-
-				<h2>
-					{ __( 'Speed up your site and its content' ) }
-				</h2>
-
-				<p>
-					{ __( 'Sites with large numbers of images can now activate the Lazy Loading Images feature, which significantly ' +
-						"speeds up loading times for visitors. Instead of waiting for the entire page to load, " +
-						'Jetpack will instead show pages instantly, and only download additional images when they are about to come into view.' ) }
-				</p>
-
-				<p>
-					{ __( 'We have also upgraded all our Premium plan customers to unlimited high-speed video storage ' +
-						"(up from 13GB), and significantly reduced the CSS and JavaScript assets that Jetpack downloads " +
-						'when using features like infinite scroll and embedding rich content.' ) }
-				</p>
-
-				<h2>
-					{ __( 'Faster, more relevant search results' ) }
-				</h2>
-
-				<img src={ imagePath + 'Jetpack-Search-Placeholder.png' } alt={ __( 'Elasticsearch' ) } />
-
-				<p>
-					{ __( 'Our faster site search is now available to all Professional' +
-						" plan customers. This replaces the default WordPress search with an Elasticsearch-powered infrastructure that returns faster, more " +
-						'relevant results to users.' ) }
-				</p>
-
-				<div className="jp-dialogue__cta-container">
-					<Button
-						primary={ true }
-						href="https://jetpack.com/?p=27095"
-					>
-						{ __( 'Read the full announcement!' ) }
-					</Button>
-
-					<p className="jp-dialogue__note">
-						<a href="https://jetpack.com/pricing">{ __( 'Compare paid plans' ) }</a>
+		renderInnerContent() {
+			const lazyImages = this.props.module( 'lazy-images' );
+			return (
+				<div>
+					<p>
+						{ __( 'This release of Jetpack brings major new features and big improvements to your WordPress site.' ) }
 					</p>
-				</div>
-			</div>
-		);
-	}
 
-	render() {
-		return (
-			<JetpackDialogue
-				svg={ <img src={ imagePath + 'jetpack-search.svg' } width="250" alt={ __( 'Jetpack Search' ) } /> }
-				title={ __( 'Major new features from Jetpack' ) }
-				content={ this.renderInnerContent() }
-				dismiss={ this.props.dismiss }
-			/>
-		);
+					<h2>
+						{ __( 'Speed up your site and its content' ) }
+					</h2>
+
+					<p>
+						{ __( 'Sites with large numbers of images can now activate the Lazy Loading Images feature, which significantly ' +
+							"speeds up loading times for visitors. Instead of waiting for the entire page to load, " +
+							'Jetpack will instead show pages instantly, and only download additional images when they are about to come into view.' ) }
+					</p>
+
+					<p>
+						{ __( 'If this sounds like a great improvement (and it is) you can enable it now by clicking the toggle below.' ) }
+					</p>
+
+					<p>
+
+						<SettingsGroup
+							hasChild
+							disableInDevMode
+							module={ lazyImages }>
+
+							<ModuleToggle
+								slug="lazy-images"
+								disabled={ false }
+								activated={ this.props.getOptionValue( 'lazy-images' ) }
+								toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
+								toggleModule={ this.toggleModule }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ decodeEntities( lazyImages.description ) }
+								</span>
+							</ModuleToggle>
+						</SettingsGroup>
+					</p>
+
+					<p>
+						{ __( 'We have also upgraded all our Premium plan customers to unlimited high-speed video storage ' +
+							"(up from 13GB), and significantly reduced the CSS and JavaScript assets that Jetpack downloads " +
+							'when using features like infinite scroll and embedding rich content.' ) }
+					</p>
+
+					<h2>
+						{ __( 'Faster, more relevant search results' ) }
+					</h2>
+
+					<img src={ imagePath + 'Jetpack-Search-Placeholder.png' } alt={ __( 'Elasticsearch' ) } />
+
+					<p>
+						{ __( 'Our faster site search is now available to all Professional' +
+							" plan customers. This replaces the default WordPress search with an Elasticsearch-powered infrastructure that returns faster, more " +
+							'relevant results to users.' ) }
+					</p>
+
+					<div className="jp-dialogue__cta-container">
+						<Button
+							primary={ true }
+							href="https://jetpack.com/?p=27095"
+						>
+							{ __( 'Read the full announcement!' ) }
+						</Button>
+
+						<p className="jp-dialogue__note">
+							<a href="https://jetpack.com/pricing">{ __( 'Compare paid plans' ) }</a>
+						</p>
+					</div>
+				</div>
+			);
+		}
+
+		render() {
+			return (
+				<JetpackDialogue
+					svg={ <img src={ imagePath + 'jetpack-search.svg' } width="250" alt={ __( 'Jetpack Search' ) } /> }
+					title={ __( 'Major new features from Jetpack' ) }
+					content={ this.renderInnerContent() }
+					dismiss={ this.props.dismiss }
+				/>
+			);
+		}
 	}
-}
+);
 
 JetpackDialogue.propTypes = {
 	dismiss: PropTypes.func
 };
 
-export default UpgradeNoticeContent;
+export default connect(
+	( state ) => {
+		return {
+			module: ( module_name ) => getModule( state, module_name ),
+		};
+	}
+)(UpgradeNoticeContent);


### PR DESCRIPTION
A suggestion from @beaulebens, it's handy for users to be able to enable a new feature when we add a UI for it. 

So I added the module toggle right into the upgrade notice.

<img width="568" alt="enable-lazy-images" src="https://user-images.githubusercontent.com/51896/35654222-ef1a2ab8-06a0-11e8-8d71-f989b99c2432.png">

#### Testing instructions:

* Upgrade Jetpack, or force showing the upgrade prompt by using the following micro-plugin:

```php
add_action( 'plugins_loaded', function() {
    Jetpack::state( 'message', 'modules_activated' );
});
```

* Use the toggle in the screen to enable Lazy Images
* Close the prompt and confirm that Lazy Images is enabled in the Jetpack settings and that images on the front-end are being lazy loaded (i.e. they have the `data-lazy-loaded="1"` attribute)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Allow enabling new features from upgrade screen