### PR TITLE
Admin Page: Remove invalid props forwarded from ClipboardButtonInput to input element

### DIFF
--- a/_inc/client/components/text-input/index.jsx
+++ b/_inc/client/components/text-input/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import omit from 'lodash/omit';
 
 require( './style.scss' );
 
@@ -30,10 +31,10 @@ export default React.createClass( {
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid
 		} );
-
+		const forwardedProps = omit( this.props, 'selectOnFocus', 'isError', 'isValid' );
 		return (
 			<input
-				{ ...this.props }
+				{ ...forwardedProps }
 				ref="textField"
 				className={ classes }
 				onClick={ selectOnFocus ? this.selectOnFocus : null } />


### PR DESCRIPTION
ClipboardButtonInput was forwarding non-standar attributes to the input element (like `isError`, `isValid`, etc).

#### Changes proposed in this Pull Request:

* Updates clipboard-button-input to not forward own props.

#### Testing instructions:

1. Check this branch
2. Build the admin page
3. Visit the Settings page and confirm you don't see a warning like:
  ```
   Warning: Unknown props `selectOnFocus`, `isError`, `isValid` on <input> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
   ```


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
