### PR TITLE
Admin Page: Omit onRequestClose prop from attributes forwarded to div element in modal component

### DIFF
--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -6,7 +6,8 @@
 var React = require( 'react' ),
 	ReactDOM = require( 'react-dom' ),
 	classNames = require( 'classnames' ),
-	assign = require( 'lodash/assign' );
+	assign = require( 'lodash/assign' ),
+	omit = require( 'lodash/omit' );
 
 var focusTrap = require( 'focus-trap' );
 
@@ -111,7 +112,7 @@ let Modal = React.createClass( {
 		var containerStyle, combinedStyle;
 
 		var { style, className, width, title, ...other } = this.props;
-
+		var { forwardedProps } = omit( other, 'onRequestClose' );
 		switch ( width ) {
 			case 'wide':
 				containerStyle = { maxWidth: 'inherit', width: 'inherit' };
@@ -133,7 +134,7 @@ let Modal = React.createClass( {
 					onMouseUp={this.handleMouseEventModal}
 					role="dialog"
 					aria-label={title}
-					{ ...other }>
+					{ ...forwardedProps }>
 					{this.props.children}
 				</div>
 			</div>


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Removes `onRequestClose` prop from the list of attributes forward to the div created by the `Modal` component

#### Testing instructions:

* check this branch
* build the admin page
* Visit the Jetpack dashboard
* Click the "Manage site connection" link
* Expect to see a modal/popup and no warnings like the following in the console:
   ```
   Warning: Unknown prop `onRequestClose` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop

   ```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
