### PR TITLE
 Search: Disable widget sorting control if search box not checked

### DIFF
--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -491,6 +491,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 						class="jetpack-search-filters-widget__sort-controls-enabled"
 						name="<?php echo esc_attr( $this->get_field_name( 'user_sort_enabled' ) ); ?>"
 						<?php checked( $user_sort_enabled ); ?>
+						<?php disabled( ! $search_box_enabled ); ?>
 					/>
 					<?php esc_html_e( 'Show sort selection dropdown', 'jetpack' ); ?>
 				</label>

--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -391,36 +391,38 @@ class Jetpack_Search_Widget extends WP_Widget {
 			: array_map( 'sanitize_key', $new_instance['post_types'] );
 
 		$filters = array();
-		foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
-			$count = intval( $new_instance['num_filters'][ $index ] );
-			$count = min( 50, $count ); // Set max boundary at 20
-			$count = max( 1, $count );  // Set min boundary at 1
+		if ( isset( $new_instance['filter_type'] ) ) {
+			foreach ( (array) $new_instance['filter_type'] as $index => $type ) {
+				$count = intval( $new_instance['num_filters'][ $index ] );
+				$count = min( 50, $count ); // Set max boundary at 20.
+				$count = max( 1, $count );  // Set min boundary at 1.
 
-			switch ( $type ) {
-				case 'taxonomy':
-					$filters[] = array(
-						'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type'     => 'taxonomy',
-						'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
-						'count'    => $count,
-					);
-					break;
-				case 'post_type':
-					$filters[] = array(
-						'name'  => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type'  => 'post_type',
-						'count' => $count,
-					);
-					break;
-				case 'date_histogram':
-					$filters[] = array(
-						'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
-						'type'     => 'date_histogram',
-						'count'    => $count,
-						'field'    => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
-						'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
-					);
-					break;
+				switch ( $type ) {
+					case 'taxonomy':
+						$filters[] = array(
+							'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type'     => 'taxonomy',
+							'taxonomy' => sanitize_key( $new_instance['taxonomy_type'][ $index ] ),
+							'count'    => $count,
+						);
+						break;
+					case 'post_type':
+						$filters[] = array(
+							'name'  => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type'  => 'post_type',
+							'count' => $count,
+						);
+						break;
+					case 'date_histogram':
+						$filters[] = array(
+							'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type'     => 'date_histogram',
+							'count'    => $count,
+							'field'    => sanitize_key( $new_instance['date_histogram_field'][ $index ] ),
+							'interval' => sanitize_key( $new_instance['date_histogram_interval'][ $index ] ),
+						);
+						break;
+				}
 			}
 		}
 


### PR DESCRIPTION
@rachelmcr reported a bug with how the sort controls checkbox is disabled or not:

@gibrown asks:
> The sort selection dropdown checkbox should be disabled when “show search box” is unchecked. Was that not the case?

@rachelmcr responds:
> Nope, that wasn’t the case for me. I tried again, watching more closely, and I see now what’s happening:
>
> When I first add the widget, the sort selection checkbox is disabled when “show search box” is unchecked.
>
>After I save the widget settings (either under Appearance > Widgets or in the customizer) even if “show search box” is unchecked the sort selection checkbox is enabled.
>
>If I check and then uncheck “show search box,” the sort selection checkbox is disabled again.

At first I was not able to reproduce with my existing widget. But, once I deleted that widget and added a new one it was quite easy to reproduce.

The issue was that we didn't have any logic in the `form` method to disable the sort control checkbox for the first render of the page. After that first render, the JavaScript would handle disabling the sort control when the show search box checkbox was unchecked, but we still needed to handle the render before JavaScript kicked in.

This PR also addresses an undefined index notice that can happen when the widget has no filters.

To test:

- Checkout branch on site with Jetpack Professional
- Add a new search widget
- Ensure that "Show search box" is unchecked
- Save the widget
- Ensure that when the widget saves, the "Show sort selection dropdown" checkbox is disabled
- Try toggling the "Show search box" checkbox and check that the "Show sort selection dropdown" checkbox is disabled any time the "Show search box" checkbox is not checked
- Check both legacy wp-admin widget UI and customizer

cc @zinigor as release lead so that we can get this in.
