### PR TITLE
Admin Page: Run class codemod on the admin page codebase

### DIFF
--- a/_inc/client/components/button-group/docs/example.jsx
+++ b/_inc/client/components/button-group/docs/example.jsx
@@ -6,7 +6,7 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ const ButtonGroup = require( 'components/button-group' ),
 	Card = require( 'components/card' ),
 	Gridicon = require( 'components/gridicon' );
 
-const Buttons = createReactClass({
+const Buttons = createReactClass( {
 	displayName: 'ButtonGroup',
 
 	mixins: [ PureRenderMixin ],
@@ -69,6 +69,6 @@ const Buttons = createReactClass({
 			</div>
 		);
 	},
-});
+} );
 
 module.exports = Buttons;

--- a/_inc/client/components/button-group/docs/example.jsx
+++ b/_inc/client/components/button-group/docs/example.jsx
@@ -6,6 +6,8 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
@@ -14,7 +16,7 @@ const ButtonGroup = require( 'components/button-group' ),
 	Card = require( 'components/card' ),
 	Gridicon = require( 'components/gridicon' );
 
-const Buttons = React.createClass( {
+const Buttons = createReactClass({
 	displayName: 'ButtonGroup',
 
 	mixins: [ PureRenderMixin ],
@@ -67,6 +69,6 @@ const Buttons = React.createClass( {
 			</div>
 		);
 	},
-} );
+});
 
 module.exports = Buttons;

--- a/_inc/client/components/button-group/index.jsx
+++ b/_inc/client/components/button-group/index.jsx
@@ -6,11 +6,10 @@ import classNames from 'classnames';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default class extends React.Component {
+    static displayName = 'ButtonGroup';
 
-	displayName: 'ButtonGroup',
-
-	propTypes: {
+    static propTypes = {
 		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
@@ -20,13 +19,13 @@ export default React.createClass( {
 			} );
 			return error;
 		}
-	},
+	};
 
-	render() {
+    render() {
 		const buttonGroupClasses = classNames( 'dops-button-group', this.props.className );
 
 		return (
 			<span className={ buttonGroupClasses }>{ this.props.children }</span>
 		);
 	}
-} );
+}

--- a/_inc/client/components/button-group/index.jsx
+++ b/_inc/client/components/button-group/index.jsx
@@ -7,9 +7,9 @@ import classNames from 'classnames';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'ButtonGroup';
+	static displayName = 'ButtonGroup';
 
-    static propTypes = {
+	static propTypes = {
 		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
@@ -21,7 +21,7 @@ export default class extends React.Component {
 		}
 	};
 
-    render() {
+	render() {
 		const buttonGroupClasses = classNames( 'dops-button-group', this.props.className );
 
 		return (

--- a/_inc/client/components/button-group/index.jsx
+++ b/_inc/client/components/button-group/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class ButtonGroup extends React.Component {
 	static displayName = 'ButtonGroup';
 
 	static propTypes = {

--- a/_inc/client/components/button/index.jsx
+++ b/_inc/client/components/button/index.jsx
@@ -9,9 +9,9 @@ import noop from 'lodash/noop';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'Button';
+	static displayName = 'Button';
 
-    static propTypes = {
+	static propTypes = {
 		disabled: PropTypes.bool,
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
@@ -23,14 +23,14 @@ export default class extends React.Component {
 		className: PropTypes.string
 	};
 
-    static defaultProps = {
-        disabled: false,
-        type: 'button',
-        onClick: noop,
-        borderless: false
-    };
+	static defaultProps = {
+		disabled: false,
+		type: 'button',
+		onClick: noop,
+		borderless: false
+	};
 
-    render() {
+	render() {
 		const element = this.props.href ? 'a' : 'button';
 		const { primary, compact, scary, borderless, className, ...props } = this.props;
 

--- a/_inc/client/components/button/index.jsx
+++ b/_inc/client/components/button/index.jsx
@@ -8,11 +8,10 @@ import noop from 'lodash/noop';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default class extends React.Component {
+    static displayName = 'Button';
 
-	displayName: 'Button',
-
-	propTypes: {
+    static propTypes = {
 		disabled: PropTypes.bool,
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
@@ -22,18 +21,16 @@ export default React.createClass( {
 		onClick: PropTypes.func,
 		borderless: PropTypes.bool,
 		className: PropTypes.string
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			disabled: false,
-			type: 'button',
-			onClick: noop,
-			borderless: false
-		};
-	},
+    static defaultProps = {
+        disabled: false,
+        type: 'button',
+        onClick: noop,
+        borderless: false
+    };
 
-	render() {
+    render() {
 		const element = this.props.href ? 'a' : 'button';
 		const { primary, compact, scary, borderless, className, ...props } = this.props;
 
@@ -49,4 +46,4 @@ export default React.createClass( {
 
 		return React.createElement( element, props, this.props.children );
 	}
-} );
+}

--- a/_inc/client/components/button/index.jsx
+++ b/_inc/client/components/button/index.jsx
@@ -8,7 +8,7 @@ import noop from 'lodash/noop';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class Button extends React.Component {
 	static displayName = 'Button';
 
 	static propTypes = {

--- a/_inc/client/components/card/compact.jsx
+++ b/_inc/client/components/card/compact.jsx
@@ -11,9 +11,9 @@ const React = require( 'react' ),
 const Card = require( 'components/card' );
 
 module.exports = class extends React.Component {
-    static displayName = 'CompactCard';
+	static displayName = 'CompactCard';
 
-    render() {
+	render() {
 		const props = assign( {}, this.props, { className: classnames( this.props.className, 'is-compact' ) } );
 
 		return (

--- a/_inc/client/components/card/compact.jsx
+++ b/_inc/client/components/card/compact.jsx
@@ -10,10 +10,10 @@ const React = require( 'react' ),
  */
 const Card = require( 'components/card' );
 
-module.exports = React.createClass( {
-	displayName: 'CompactCard',
+module.exports = class extends React.Component {
+    static displayName = 'CompactCard';
 
-	render: function() {
+    render() {
 		const props = assign( {}, this.props, { className: classnames( this.props.className, 'is-compact' ) } );
 
 		return (
@@ -22,4 +22,4 @@ module.exports = React.createClass( {
 			</Card>
 		);
 	}
-} );
+};

--- a/_inc/client/components/card/compact.jsx
+++ b/_inc/client/components/card/compact.jsx
@@ -10,7 +10,7 @@ const React = require( 'react' ),
  */
 const Card = require( 'components/card' );
 
-module.exports = class extends React.Component {
+export default class CompactCard extends React.Component {
 	static displayName = 'CompactCard';
 
 	render() {
@@ -22,4 +22,4 @@ module.exports = class extends React.Component {
 			</Card>
 		);
 	}
-};
+}

--- a/_inc/client/components/card/index.jsx
+++ b/_inc/client/components/card/index.jsx
@@ -14,7 +14,7 @@ const Gridicon = require( '../gridicon' );
 require( './style.scss' );
 
 class CardSection extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		title: PropTypes.any,
 		vertical: PropTypes.any,
 		style: PropTypes.object,
@@ -22,9 +22,9 @@ class CardSection extends React.Component {
 		device: PropTypes.oneOf( [ 'desktop', 'tablet', 'phone' ] )
 	};
 
-    static defaultProps = { vertical: null };
+	static defaultProps = { vertical: null };
 
-    render() {
+	render() {
 		return (
 			<div className={ classnames( 'dops-card-section', this.props.className ) } style={ this.props.style }>
 				{this.props.title
@@ -35,7 +35,7 @@ class CardSection extends React.Component {
 		);
 	}
 
-    _renderWithTitle = () => {
+	_renderWithTitle = () => {
 		const orientation = this.props.vertical ? 'vertical' : 'horizontal';
 		const wrapperClassName = 'dops-card-section-orient-' + orientation;
 
@@ -53,7 +53,7 @@ class CardSection extends React.Component {
 }
 
 class CardFooter extends React.Component {
-    render() {
+	render() {
 		return (
 			<div className="dops-card-footer">
 				{this.props.children}
@@ -63,7 +63,7 @@ class CardFooter extends React.Component {
 }
 
 class Card extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		meta: PropTypes.any,
 		icon: PropTypes.string,
 		iconLabel: PropTypes.any,
@@ -78,13 +78,13 @@ class Card extends React.Component {
 		children: PropTypes.node
 	};
 
-    static defaultProps = {
-        iconColor: '#787878',
-        className: '',
-        tagName: 'div'
-    };
+	static defaultProps = {
+		iconColor: '#787878',
+		className: '',
+		tagName: 'div'
+	};
 
-    render() {
+	render() {
 		const className = classnames( 'dops-card', this.props.className, {
 			'is-card-link': !! this.props.href,
 			'is-compact': this.props.compact
@@ -123,7 +123,7 @@ class Card extends React.Component {
 		);
 	}
 
-    _renderIcon = () => {
+	_renderIcon = () => {
 		return (
 			<span className="dops-card-icon" style={ { color: this.props.iconColor } }>
 				{ this.props.icon && <Gridicon icon={ this.props.icon } style={ { backgroundColor: this.props.iconColor } } />}

--- a/_inc/client/components/card/index.jsx
+++ b/_inc/client/components/card/index.jsx
@@ -13,21 +13,18 @@ const Gridicon = require( '../gridicon' );
 
 require( './style.scss' );
 
-const CardSection = React.createClass( {
-
-	propTypes: {
+class CardSection extends React.Component {
+    static propTypes = {
 		title: PropTypes.any,
 		vertical: PropTypes.any,
 		style: PropTypes.object,
 		className: PropTypes.string,
 		device: PropTypes.oneOf( [ 'desktop', 'tablet', 'phone' ] )
-	},
+	};
 
-	getDefaultProps: function() {
-		return { vertical: null };
-	},
+    static defaultProps = { vertical: null };
 
-	render: function() {
+    render() {
 		return (
 			<div className={ classnames( 'dops-card-section', this.props.className ) } style={ this.props.style }>
 				{this.props.title
@@ -36,9 +33,9 @@ const CardSection = React.createClass( {
 				}
 			</div>
 		);
-	},
+	}
 
-	_renderWithTitle: function() {
+    _renderWithTitle = () => {
 		const orientation = this.props.vertical ? 'vertical' : 'horizontal';
 		const wrapperClassName = 'dops-card-section-orient-' + orientation;
 
@@ -52,23 +49,21 @@ const CardSection = React.createClass( {
 				</div>
 			</div>
 		);
-	}
-} );
+	};
+}
 
-const CardFooter = React.createClass( {
-
-	render: function() {
+class CardFooter extends React.Component {
+    render() {
 		return (
 			<div className="dops-card-footer">
 				{this.props.children}
 			</div>
 		);
 	}
-} );
+}
 
-const Card = React.createClass( {
-
-	propTypes: {
+class Card extends React.Component {
+    static propTypes = {
 		meta: PropTypes.any,
 		icon: PropTypes.string,
 		iconLabel: PropTypes.any,
@@ -81,17 +76,15 @@ const Card = React.createClass( {
 		target: PropTypes.string,
 		compact: PropTypes.bool,
 		children: PropTypes.node
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			iconColor: '#787878',
-			className: '',
-			tagName: 'div'
-		};
-	},
+    static defaultProps = {
+        iconColor: '#787878',
+        className: '',
+        tagName: 'div'
+    };
 
-	render: function() {
+    render() {
 		const className = classnames( 'dops-card', this.props.className, {
 			'is-card-link': !! this.props.href,
 			'is-compact': this.props.compact
@@ -128,17 +121,17 @@ const Card = React.createClass( {
 			fancyTitle,
 			this.props.children
 		);
-	},
+	}
 
-	_renderIcon: function() {
+    _renderIcon = () => {
 		return (
 			<span className="dops-card-icon" style={ { color: this.props.iconColor } }>
 				{ this.props.icon && <Gridicon icon={ this.props.icon } style={ { backgroundColor: this.props.iconColor } } />}
 				{ this.props.iconLabel }
 			</span>
 		);
-	}
-} );
+	};
+}
 
 Card.Section = CardSection;
 Card.Footer = CardFooter;

--- a/_inc/client/components/chart/bar-container.jsx
+++ b/_inc/client/components/chart/bar-container.jsx
@@ -11,9 +11,9 @@ const Bar = require( './bar' ),
 	XAxis = require( './x-axis' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ModuleChartBarContainer';
+	static displayName = 'ModuleChartBarContainer';
 
-    static propTypes = {
+	static propTypes = {
 		isTouch: PropTypes.bool,
 		data: PropTypes.array,
 		yAxisMax: PropTypes.number,
@@ -21,7 +21,7 @@ module.exports = class extends React.Component {
 		barClick: PropTypes.func
 	};
 
-    buildBars = (max) => {
+	buildBars = ( max ) => {
 		const numberBars = this.props.data.length,
 			width = this.props.chartWidth,
 			barWidth = ( width / numberBars );
@@ -50,7 +50,7 @@ module.exports = class extends React.Component {
 		return bars;
 	};
 
-    render() {
+	render() {
 		return (
 			<div>
 				<div className="dops-chart__bars">

--- a/_inc/client/components/chart/bar-container.jsx
+++ b/_inc/client/components/chart/bar-container.jsx
@@ -10,18 +10,18 @@ const React = require( 'react' );
 const Bar = require( './bar' ),
 	XAxis = require( './x-axis' );
 
-module.exports = React.createClass( {
-	displayName: 'ModuleChartBarContainer',
+module.exports = class extends React.Component {
+    static displayName = 'ModuleChartBarContainer';
 
-	propTypes: {
+    static propTypes = {
 		isTouch: PropTypes.bool,
 		data: PropTypes.array,
 		yAxisMax: PropTypes.number,
 		width: PropTypes.number,
 		barClick: PropTypes.func
-	},
+	};
 
-	buildBars: function( max ) {
+    buildBars = (max) => {
 		const numberBars = this.props.data.length,
 			width = this.props.chartWidth,
 			barWidth = ( width / numberBars );
@@ -48,9 +48,9 @@ module.exports = React.createClass( {
 		}, this );
 
 		return bars;
-	},
+	};
 
-	render: function() {
+    render() {
 		return (
 			<div>
 				<div className="dops-chart__bars">
@@ -60,4 +60,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/chart/bar-container.jsx
+++ b/_inc/client/components/chart/bar-container.jsx
@@ -10,7 +10,7 @@ const React = require( 'react' );
 const Bar = require( './bar' ),
 	XAxis = require( './x-axis' );
 
-module.exports = class extends React.Component {
+export default class ModuleChartBarContainer extends React.Component {
 	static displayName = 'ModuleChartBarContainer';
 
 	static propTypes = {
@@ -60,4 +60,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/chart/bar.jsx
+++ b/_inc/client/components/chart/bar.jsx
@@ -14,9 +14,9 @@ const Tooltip = require( 'components/tooltip' ),
 	Gridicon = require( 'components/gridicon' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ModuleChartBar';
+	static displayName = 'ModuleChartBar';
 
-    static propTypes = {
+	static propTypes = {
 		isTouch: PropTypes.bool,
 		tooltipPosition: PropTypes.string,
 		className: PropTypes.string,
@@ -26,9 +26,9 @@ module.exports = class extends React.Component {
 		count: PropTypes.number
 	};
 
-    state = { showPopover: false };
+	state = { showPopover: false };
 
-    buildSections = () => {
+	buildSections = () => {
 		const value = this.props.data.value,
 			max = this.props.max,
 			percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
@@ -70,21 +70,21 @@ module.exports = class extends React.Component {
 		return sections;
 	};
 
-    clickHandler = () => {
+	clickHandler = () => {
 		if ( 'function' === typeof( this.props.clickHandler ) ) {
 			this.props.clickHandler( this.props.data );
 		}
 	};
 
-    mouseEnter = () => {
+	mouseEnter = () => {
 		this.setState( { showPopover: true } );
 	};
 
-    mouseLeave = () => {
+	mouseLeave = () => {
 		this.setState( { showPopover: false } );
 	};
 
-    renderTooltip = () => {
+	renderTooltip = () => {
 		if (
 			! this.props.data.tooltipData ||
 			! this.props.data.tooltipData.length ||
@@ -131,7 +131,7 @@ module.exports = class extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		const count = this.props.count || 1;
 		const barClass = { 'dops-chart__bar': true };
 

--- a/_inc/client/components/chart/bar.jsx
+++ b/_inc/client/components/chart/bar.jsx
@@ -13,10 +13,10 @@ const React = require( 'react' ),
 const Tooltip = require( 'components/tooltip' ),
 	Gridicon = require( 'components/gridicon' );
 
-module.exports = React.createClass( {
-	displayName: 'ModuleChartBar',
+module.exports = class extends React.Component {
+    static displayName = 'ModuleChartBar';
 
-	propTypes: {
+    static propTypes = {
 		isTouch: PropTypes.bool,
 		tooltipPosition: PropTypes.string,
 		className: PropTypes.string,
@@ -24,13 +24,11 @@ module.exports = React.createClass( {
 		data: PropTypes.object.isRequired,
 		max: PropTypes.number,
 		count: PropTypes.number
-	},
+	};
 
-	getInitialState: function() {
-		return { showPopover: false };
-	},
+    state = { showPopover: false };
 
-	buildSections: function() {
+    buildSections = () => {
 		const value = this.props.data.value,
 			max = this.props.max,
 			percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
@@ -70,23 +68,23 @@ module.exports = React.createClass( {
 		sections.push( <div key="label" className="dops-chart__bar-label">{ this.props.label }</div> );
 
 		return sections;
-	},
+	};
 
-	clickHandler: function() {
+    clickHandler = () => {
 		if ( 'function' === typeof( this.props.clickHandler ) ) {
 			this.props.clickHandler( this.props.data );
 		}
-	},
+	};
 
-	mouseEnter: function() {
+    mouseEnter = () => {
 		this.setState( { showPopover: true } );
-	},
+	};
 
-	mouseLeave: function() {
+    mouseLeave = () => {
 		this.setState( { showPopover: false } );
-	},
+	};
 
-	renderTooltip() {
+    renderTooltip = () => {
 		if (
 			! this.props.data.tooltipData ||
 			! this.props.data.tooltipData.length ||
@@ -131,9 +129,9 @@ module.exports = React.createClass( {
 				</ul>
 			</Tooltip>
 		);
-	},
+	};
 
-	render: function() {
+    render() {
 		const count = this.props.count || 1;
 		const barClass = { 'dops-chart__bar': true };
 
@@ -159,4 +157,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/chart/bar.jsx
+++ b/_inc/client/components/chart/bar.jsx
@@ -13,7 +13,7 @@ const React = require( 'react' ),
 const Tooltip = require( 'components/tooltip' ),
 	Gridicon = require( 'components/gridicon' );
 
-module.exports = class extends React.Component {
+export default class ModuleChartBar extends React.Component {
 	static displayName = 'ModuleChartBar';
 
 	static propTypes = {
@@ -157,4 +157,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -14,7 +14,7 @@ const BarContainer = require( './bar-container' ),
 
 require( './style.scss' );
 
-module.exports = class extends React.Component {
+export default class ModuleChart extends React.Component {
 	static displayName = 'ModuleChart';
 
 	static propTypes = {
@@ -147,4 +147,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -15,9 +15,9 @@ const BarContainer = require( './bar-container' ),
 require( './style.scss' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ModuleChart';
+	static displayName = 'ModuleChart';
 
-    static propTypes = {
+	static propTypes = {
 		loading: PropTypes.bool,
 		data: PropTypes.array,
 		minTouchBarWidth: PropTypes.number,
@@ -25,36 +25,36 @@ module.exports = class extends React.Component {
 		barClick: PropTypes.func
 	};
 
-    static defaultProps = {
-        minTouchBarWidth: 42,
-        minBarWidth: 15,
-        barClick: noop
-    };
+	static defaultProps = {
+		minTouchBarWidth: 42,
+		minBarWidth: 15,
+		barClick: noop
+	};
 
-    state = {
-        maxBars: 100, // arbitrarily high number. This will be calculated by resize method
-        width: 650
-    };
+	state = {
+		maxBars: 100, // arbitrarily high number. This will be calculated by resize method
+		width: 650
+	};
 
     // Add listener for window resize
-    componentDidMount() {
+	componentDidMount() {
 		this.resize = throttle( this.resize, 400 );
 		window.addEventListener( 'resize', this.resize );
 		this.resize();
 	}
 
     // Remove listener
-    componentWillUnmount() {
+	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resize );
 	}
 
-    componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps( nextProps ) {
 		if ( this.props.loading && ! nextProps.loading ) {
 			this.resize();
 		}
 	}
 
-    resize = () => {
+	resize = () => {
 		const node = this.refs.chart;
 		let width = node.clientWidth - 82,
 			maxBars;
@@ -72,7 +72,7 @@ module.exports = class extends React.Component {
 		} );
 	};
 
-    getYAxisMax = (values) => {
+	getYAxisMax = ( values ) => {
 		const max = Math.max.apply( null, values ),
 			operand = Math.pow( 10, ( max.toString().length - 1 ) );
 		let rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
@@ -84,7 +84,7 @@ module.exports = class extends React.Component {
 		return rounded;
 	};
 
-    getData = () => {
+	getData = () => {
 		let data = this.props.data;
 
 		data = data.slice( 0 - this.state.maxBars );
@@ -92,7 +92,7 @@ module.exports = class extends React.Component {
 		return data;
 	};
 
-    getValues = () => {
+	getValues = () => {
 		let data = this.getData();
 
 		data = data.map( function( item ) {
@@ -102,7 +102,7 @@ module.exports = class extends React.Component {
 		return data;
 	};
 
-    isEmptyChart = (values) => {
+	isEmptyChart = ( values ) => {
 		values = values.filter( function( value ) {
 			return value > 0;
 		}, this );
@@ -110,7 +110,7 @@ module.exports = class extends React.Component {
 		return values.length === 0;
 	};
 
-    render() {
+	render() {
 		const values = this.getValues(),
 			yAxisMax = this.getYAxisMax( values ),
 			data = this.getData();

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -14,51 +14,47 @@ const BarContainer = require( './bar-container' ),
 
 require( './style.scss' );
 
-module.exports = React.createClass( {
-	displayName: 'ModuleChart',
+module.exports = class extends React.Component {
+    static displayName = 'ModuleChart';
 
-	propTypes: {
+    static propTypes = {
 		loading: PropTypes.bool,
 		data: PropTypes.array,
 		minTouchBarWidth: PropTypes.number,
 		minBarWidth: PropTypes.number,
 		barClick: PropTypes.func
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			maxBars: 100, // arbitrarily high number. This will be calculated by resize method
-			width: 650
-		};
-	},
+    static defaultProps = {
+        minTouchBarWidth: 42,
+        minBarWidth: 15,
+        barClick: noop
+    };
 
-	getDefaultProps: function() {
-		return {
-			minTouchBarWidth: 42,
-			minBarWidth: 15,
-			barClick: noop
-		};
-	},
+    state = {
+        maxBars: 100, // arbitrarily high number. This will be calculated by resize method
+        width: 650
+    };
 
-	// Add listener for window resize
-	componentDidMount: function() {
+    // Add listener for window resize
+    componentDidMount() {
 		this.resize = throttle( this.resize, 400 );
 		window.addEventListener( 'resize', this.resize );
 		this.resize();
-	},
+	}
 
-	// Remove listener
-	componentWillUnmount: function() {
+    // Remove listener
+    componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resize );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps(nextProps) {
 		if ( this.props.loading && ! nextProps.loading ) {
 			this.resize();
 		}
-	},
+	}
 
-	resize: function() {
+    resize = () => {
 		const node = this.refs.chart;
 		let width = node.clientWidth - 82,
 			maxBars;
@@ -74,9 +70,9 @@ module.exports = React.createClass( {
 			maxBars: maxBars,
 			width: width
 		} );
-	},
+	};
 
-	getYAxisMax: function( values ) {
+    getYAxisMax = (values) => {
 		const max = Math.max.apply( null, values ),
 			operand = Math.pow( 10, ( max.toString().length - 1 ) );
 		let rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
@@ -86,17 +82,17 @@ module.exports = React.createClass( {
 		}
 
 		return rounded;
-	},
+	};
 
-	getData: function() {
+    getData = () => {
 		let data = this.props.data;
 
 		data = data.slice( 0 - this.state.maxBars );
 
 		return data;
-	},
+	};
 
-	getValues: function() {
+    getValues = () => {
 		let data = this.getData();
 
 		data = data.map( function( item ) {
@@ -104,17 +100,17 @@ module.exports = React.createClass( {
 		}, this );
 
 		return data;
-	},
+	};
 
-	isEmptyChart: function( values ) {
+    isEmptyChart = (values) => {
 		values = values.filter( function( value ) {
 			return value > 0;
 		}, this );
 
 		return values.length === 0;
-	},
+	};
 
-	render: function() {
+    render() {
 		const values = this.getValues(),
 			yAxisMax = this.getYAxisMax( values ),
 			data = this.getData();
@@ -151,4 +147,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/chart/label.jsx
+++ b/_inc/client/components/chart/label.jsx
@@ -4,16 +4,16 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'ModuleChartLabel',
+module.exports = class extends React.Component {
+    static displayName = 'ModuleChartLabel';
 
-	propTypes: {
+    static propTypes = {
 		width: PropTypes.number.isRequired,
 		x: PropTypes.number.isRequired,
 		label: PropTypes.string.isRequired
-	},
+	};
 
-	render: function() {
+    render() {
 		const dir = 'left';
 		const labelStyle = {
 			width: this.props.width + 'px'
@@ -23,4 +23,4 @@ module.exports = React.createClass( {
 
 		return <div className="dops-chart__x-axis-label" style={ labelStyle }>{ this.props.label }</div>;
 	}
-} );
+};

--- a/_inc/client/components/chart/label.jsx
+++ b/_inc/client/components/chart/label.jsx
@@ -4,7 +4,7 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = class extends React.Component {
+export default class ModuleChartLabel extends React.Component {
 	static displayName = 'ModuleChartLabel';
 
 	static propTypes = {
@@ -23,4 +23,4 @@ module.exports = class extends React.Component {
 
 		return <div className="dops-chart__x-axis-label" style={ labelStyle }>{ this.props.label }</div>;
 	}
-};
+}

--- a/_inc/client/components/chart/label.jsx
+++ b/_inc/client/components/chart/label.jsx
@@ -5,15 +5,15 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ModuleChartLabel';
+	static displayName = 'ModuleChartLabel';
 
-    static propTypes = {
+	static propTypes = {
 		width: PropTypes.number.isRequired,
 		x: PropTypes.number.isRequired,
 		label: PropTypes.string.isRequired
 	};
 
-    render() {
+	render() {
 		const dir = 'left';
 		const labelStyle = {
 			width: this.props.width + 'px'

--- a/_inc/client/components/chart/legend.jsx
+++ b/_inc/client/components/chart/legend.jsx
@@ -7,13 +7,13 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
  */
 
-const LegendItem = createReactClass({
+const LegendItem = createReactClass( {
 	displayName: 'ModuleChartLegendItem',
 
 	mixins: [ PureRenderMixin ],
@@ -40,12 +40,12 @@ const LegendItem = createReactClass({
 		);
 	}
 
-});
+} );
 
 class Legend extends React.Component {
-    static displayName = 'ModuleChartLegend';
+	static displayName = 'ModuleChartLegend';
 
-    static propTypes = {
+	static propTypes = {
 		activeTab: PropTypes.object.isRequired,
 		tabs: PropTypes.array.isRequired,
 		activeCharts: PropTypes.array.isRequired,
@@ -53,11 +53,11 @@ class Legend extends React.Component {
 		clickHandler: PropTypes.func.isRequired
 	};
 
-    onFilterChange = (chartItem) => {
+	onFilterChange = ( chartItem ) => {
 		this.props.clickHandler( chartItem );
 	};
 
-    render() {
+	render() {
 		const legendColors = [ 'dops-chart__legend-color is-dark-blue' ],
 			activeTab = this.props.activeTab;
 		const legendItems = this.props.availableCharts.map( function( legendItem, index ) {

--- a/_inc/client/components/chart/legend.jsx
+++ b/_inc/client/components/chart/legend.jsx
@@ -7,11 +7,13 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
 
-const LegendItem = React.createClass( {
+const LegendItem = createReactClass({
 	displayName: 'ModuleChartLegendItem',
 
 	mixins: [ PureRenderMixin ],
@@ -38,24 +40,24 @@ const LegendItem = React.createClass( {
 		);
 	}
 
-} );
+});
 
-const Legend = React.createClass( {
-	displayName: 'ModuleChartLegend',
+class Legend extends React.Component {
+    static displayName = 'ModuleChartLegend';
 
-	propTypes: {
+    static propTypes = {
 		activeTab: PropTypes.object.isRequired,
 		tabs: PropTypes.array.isRequired,
 		activeCharts: PropTypes.array.isRequired,
 		availableCharts: PropTypes.array.isRequired,
 		clickHandler: PropTypes.func.isRequired
-	},
+	};
 
-	onFilterChange: function( chartItem ) {
+    onFilterChange = (chartItem) => {
 		this.props.clickHandler( chartItem );
-	},
+	};
 
-	render: function() {
+    render() {
 		const legendColors = [ 'dops-chart__legend-color is-dark-blue' ],
 			activeTab = this.props.activeTab;
 		const legendItems = this.props.availableCharts.map( function( legendItem, index ) {
@@ -77,6 +79,6 @@ const Legend = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 module.exports = Legend;

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -10,41 +10,39 @@ const React = require( 'react' ),
  */
 const Label = require( './label' );
 
-module.exports = React.createClass( {
-	displayName: 'ModuleChartXAxis',
+module.exports = class extends React.Component {
+    static displayName = 'ModuleChartXAxis';
 
-	propTypes: {
+    static propTypes = {
 		labelWidth: PropTypes.number.isRequired,
 		data: PropTypes.array.isRequired
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			divisor: 1,
-			spacing: this.props.labelWidth
-		};
-	},
+    state = {
+        divisor: 1,
+        spacing: this.props.labelWidth
+    };
 
-	// Add listener for window resize
-	componentDidMount: function() {
+    // Add listener for window resize
+    componentDidMount() {
 		this.resizeThrottled = throttle( this.resize, 400 );
 		window.addEventListener( 'resize', this.resizeThrottled );
 		this.resize();
-	},
+	}
 
-	// Remove listener
-	componentWillUnmount: function() {
+    // Remove listener
+    componentWillUnmount() {
 		if ( this.resizeThrottled.cancel ) {
 			this.resizeThrottled.cancel();
 		}
 		window.removeEventListener( 'resize', this.resizeThrottled );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps(nextProps) {
 		this.resize( nextProps );
-	},
+	}
 
-	resize: function( nextProps ) {
+    resize = (nextProps) => {
 		let props = this.props;
 
 		const node = this.refs.axis;
@@ -71,9 +69,9 @@ module.exports = React.createClass( {
 			divisor: divisor,
 			spacing: spacing
 		} );
-	},
+	};
 
-	render: function() {
+    render() {
 		const data = this.props.data;
 
 		const labels = data.map( function( item, index ) {
@@ -92,4 +90,4 @@ module.exports = React.createClass( {
 			<div ref="axis" className="dops-chart__x-axis">{ labels }</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -10,7 +10,7 @@ const React = require( 'react' ),
  */
 const Label = require( './label' );
 
-module.exports = class extends React.Component {
+export default class ModuleChartXAxis extends React.Component {
 	static displayName = 'ModuleChartXAxis';
 
 	static propTypes = {
@@ -90,4 +90,4 @@ module.exports = class extends React.Component {
 			<div ref="axis" className="dops-chart__x-axis">{ labels }</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -11,38 +11,38 @@ const React = require( 'react' ),
 const Label = require( './label' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ModuleChartXAxis';
+	static displayName = 'ModuleChartXAxis';
 
-    static propTypes = {
+	static propTypes = {
 		labelWidth: PropTypes.number.isRequired,
 		data: PropTypes.array.isRequired
 	};
 
-    state = {
-        divisor: 1,
-        spacing: this.props.labelWidth
-    };
+	state = {
+		divisor: 1,
+		spacing: this.props.labelWidth
+	};
 
     // Add listener for window resize
-    componentDidMount() {
+	componentDidMount() {
 		this.resizeThrottled = throttle( this.resize, 400 );
 		window.addEventListener( 'resize', this.resizeThrottled );
 		this.resize();
 	}
 
     // Remove listener
-    componentWillUnmount() {
+	componentWillUnmount() {
 		if ( this.resizeThrottled.cancel ) {
 			this.resizeThrottled.cancel();
 		}
 		window.removeEventListener( 'resize', this.resizeThrottled );
 	}
 
-    componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps( nextProps ) {
 		this.resize( nextProps );
 	}
 
-    resize = (nextProps) => {
+	resize = ( nextProps ) => {
 		let props = this.props;
 
 		const node = this.refs.axis;
@@ -71,7 +71,7 @@ module.exports = class extends React.Component {
 		} );
 	};
 
-    render() {
+	render() {
 		const data = this.props.data;
 
 		const labels = data.map( function( item, index ) {

--- a/_inc/client/components/clipboard-button-input/index.jsx
+++ b/_inc/client/components/clipboard-button-input/index.jsx
@@ -14,37 +14,33 @@ import TextInput from 'components/text-input';
 
 require( './style.scss' );
 
-export default React.createClass( {
-	displayName: 'ClipboardButtonInput',
+export default class extends React.Component {
+    static displayName = 'ClipboardButtonInput';
 
-	propTypes: {
+    static propTypes = {
 		value: PropTypes.string,
 		disabled: PropTypes.bool,
 		className: PropTypes.string,
 		copied: PropTypes.string,
 		copy: PropTypes.string,
 		prompt: PropTypes.string
-	},
+	};
 
-	getInitialState() {
-		return {
-			isCopied: false,
-			disabled: false
-		};
-	},
+    static defaultProps = {
+        value: ''
+    };
 
-	getDefaultProps() {
-		return {
-			value: ''
-		};
-	},
+    state = {
+        isCopied: false,
+        disabled: false
+    };
 
-	componentWillUnmount() {
+    componentWillUnmount() {
 		clearTimeout( this.confirmationTimeout );
 		delete this.confirmationTimeout;
-	},
+	}
 
-	showConfirmation() {
+    showConfirmation = () => {
 		this.setState( {
 			isCopied: true
 		} );
@@ -54,9 +50,9 @@ export default React.createClass( {
 				isCopied: false
 			} );
 		}, 4000 );
-	},
+	};
 
-	render() {
+    render() {
 		const forwardedProps = omit( this.props,
 			'className',
 			'copied',
@@ -87,4 +83,4 @@ export default React.createClass( {
 			</span>
 		);
 	}
-} );
+}

--- a/_inc/client/components/clipboard-button-input/index.jsx
+++ b/_inc/client/components/clipboard-button-input/index.jsx
@@ -15,9 +15,9 @@ import TextInput from 'components/text-input';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'ClipboardButtonInput';
+	static displayName = 'ClipboardButtonInput';
 
-    static propTypes = {
+	static propTypes = {
 		value: PropTypes.string,
 		disabled: PropTypes.bool,
 		className: PropTypes.string,
@@ -26,21 +26,21 @@ export default class extends React.Component {
 		prompt: PropTypes.string
 	};
 
-    static defaultProps = {
-        value: ''
-    };
+	static defaultProps = {
+		value: ''
+	};
 
-    state = {
-        isCopied: false,
-        disabled: false
-    };
+	state = {
+		isCopied: false,
+		disabled: false
+	};
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		clearTimeout( this.confirmationTimeout );
 		delete this.confirmationTimeout;
 	}
 
-    showConfirmation = () => {
+	showConfirmation = () => {
 		this.setState( {
 			isCopied: true
 		} );
@@ -52,7 +52,7 @@ export default class extends React.Component {
 		}, 4000 );
 	};
 
-    render() {
+	render() {
 		const forwardedProps = omit( this.props,
 			'className',
 			'copied',

--- a/_inc/client/components/clipboard-button-input/index.jsx
+++ b/_inc/client/components/clipboard-button-input/index.jsx
@@ -14,7 +14,7 @@ import TextInput from 'components/text-input';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class ClipboardButtonInput extends React.Component {
 	static displayName = 'ClipboardButtonInput';
 
 	static propTypes = {

--- a/_inc/client/components/count/docs/example.jsx
+++ b/_inc/client/components/count/docs/example.jsx
@@ -4,14 +4,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
  */
 const Count = require( 'components/count' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'Count',
 
 	mixins: [ PureRenderMixin ],
@@ -28,4 +28,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/count/docs/example.jsx
+++ b/_inc/client/components/count/docs/example.jsx
@@ -4,12 +4,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
 const Count = require( 'components/count' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'Count',
 
 	mixins: [ PureRenderMixin ],
@@ -26,4 +28,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/count/index.jsx
+++ b/_inc/client/components/count/index.jsx
@@ -10,7 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 
 require( './style.scss' );
 
-export default createReactClass({
+export default createReactClass( {
 
 	displayName: 'Count',
 
@@ -25,4 +25,4 @@ export default createReactClass({
 			<span className="dops-count">{ this.numberFormat( this.props.count ) }</span>
 		);
 	}
-});
+} );

--- a/_inc/client/components/count/index.jsx
+++ b/_inc/client/components/count/index.jsx
@@ -5,11 +5,12 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default createReactClass({
 
 	displayName: 'Count',
 
@@ -24,4 +25,4 @@ export default React.createClass( {
 			<span className="dops-count">{ this.numberFormat( this.props.count ) }</span>
 		);
 	}
-} );
+});

--- a/_inc/client/components/external-link/index.jsx
+++ b/_inc/client/components/external-link/index.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 import assign from 'lodash/assign';
@@ -15,7 +16,7 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default createReactClass({
 
 	displayName: 'ExternalLink',
 
@@ -52,4 +53,4 @@ export default React.createClass( {
 			</a>
 		);
 	}
-} );
+});

--- a/_inc/client/components/external-link/index.jsx
+++ b/_inc/client/components/external-link/index.jsx
@@ -16,7 +16,7 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default createReactClass({
+export default createReactClass( {
 
 	displayName: 'ExternalLink',
 
@@ -53,4 +53,4 @@ export default createReactClass({
 			</a>
 		);
 	}
-});
+} );

--- a/_inc/client/components/foldable-card/index.jsx
+++ b/_inc/client/components/foldable-card/index.jsx
@@ -17,7 +17,7 @@ const Card = require( 'components/card' ),
 require( './style.scss' );
 
 class FoldableCard extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		actionButton: PropTypes.element,
 		actionButtonExpanded: PropTypes.element,
 		cardKey: PropTypes.string,
@@ -34,21 +34,21 @@ class FoldableCard extends React.Component {
 		clickableHeaderText: PropTypes.bool
 	};
 
-    static defaultProps = {
-        onOpen: noop,
-        onClose: noop,
-        cardKey: '',
-        icon: 'chevron-down',
-        isExpanded: false,
-        clickableHeader: false,
-        clickableHeaderText: false
-    };
+	static defaultProps = {
+		onOpen: noop,
+		onClose: noop,
+		cardKey: '',
+		icon: 'chevron-down',
+		isExpanded: false,
+		clickableHeader: false,
+		clickableHeaderText: false
+	};
 
-    state = {
-        expanded: this.props.expanded
-    };
+	state = {
+		expanded: this.props.expanded
+	};
 
-    onClick = () => {
+	onClick = () => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
 		}
@@ -64,21 +64,21 @@ class FoldableCard extends React.Component {
 		}
 	};
 
-    getClickAction = () => {
+	getClickAction = () => {
 		if ( this.props.disabled ) {
 			return;
 		}
 		return this.onClick;
 	};
 
-    getActionButton = () => {
+	getActionButton = () => {
 		if ( this.state.expanded ) {
 			return this.props.actionButtonExpanded || this.props.actionButton;
 		}
 		return this.props.actionButton;
 	};
 
-    renderActionButton = () => {
+	renderActionButton = () => {
 		const clickAction = ! this.props.clickableHeader ? this.getClickAction() : null;
 		if ( this.props.actionButton ) {
 			return (
@@ -98,7 +98,7 @@ class FoldableCard extends React.Component {
 		}
 	};
 
-    renderContent = () => {
+	renderContent = () => {
 		return (
 			<div className="dops-foldable-card__content">
 				{ this.props.children }
@@ -106,7 +106,7 @@ class FoldableCard extends React.Component {
 		);
 	};
 
-    renderHeader = () => {
+	renderHeader = () => {
 		const summary = this.props.summary ? <span className="dops-foldable-card__summary">{ this.props.summary } </span> : null,
 			expandedSummary = this.props.expandedSummary ? <span className="dops-foldable-card__summary_expanded">{ this.props.expandedSummary } </span> : null,
 			header = this.props.header ? <div className="dops-foldable-card__header-text">{ this.props.header }</div> : null,
@@ -141,7 +141,7 @@ class FoldableCard extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		const Container = this.props.compact ? CompactCard : Card,
 			itemSiteClasses = classNames(
 				'dops-foldable-card',

--- a/_inc/client/components/foldable-card/index.jsx
+++ b/_inc/client/components/foldable-card/index.jsx
@@ -16,9 +16,8 @@ const Card = require( 'components/card' ),
 
 require( './style.scss' );
 
-const FoldableCard = React.createClass( {
-
-	propTypes: {
+class FoldableCard extends React.Component {
+    static propTypes = {
 		actionButton: PropTypes.element,
 		actionButtonExpanded: PropTypes.element,
 		cardKey: PropTypes.string,
@@ -33,27 +32,23 @@ const FoldableCard = React.createClass( {
 		summary: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		clickableHeader: PropTypes.bool,
 		clickableHeaderText: PropTypes.bool
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			expanded: this.props.expanded
-		};
-	},
+    static defaultProps = {
+        onOpen: noop,
+        onClose: noop,
+        cardKey: '',
+        icon: 'chevron-down',
+        isExpanded: false,
+        clickableHeader: false,
+        clickableHeaderText: false
+    };
 
-	getDefaultProps: function() {
-		return {
-			onOpen: noop,
-			onClose: noop,
-			cardKey: '',
-			icon: 'chevron-down',
-			isExpanded: false,
-			clickableHeader: false,
-			clickableHeaderText: false
-		};
-	},
+    state = {
+        expanded: this.props.expanded
+    };
 
-	onClick: function() {
+    onClick = () => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
 		}
@@ -67,23 +62,23 @@ const FoldableCard = React.createClass( {
 		} else {
 			this.props.onOpen( this.props.cardKey );
 		}
-	},
+	};
 
-	getClickAction: function() {
+    getClickAction = () => {
 		if ( this.props.disabled ) {
 			return;
 		}
 		return this.onClick;
-	},
+	};
 
-	getActionButton: function() {
+    getActionButton = () => {
 		if ( this.state.expanded ) {
 			return this.props.actionButtonExpanded || this.props.actionButton;
 		}
 		return this.props.actionButton;
-	},
+	};
 
-	renderActionButton: function() {
+    renderActionButton = () => {
 		const clickAction = ! this.props.clickableHeader ? this.getClickAction() : null;
 		if ( this.props.actionButton ) {
 			return (
@@ -101,17 +96,17 @@ const FoldableCard = React.createClass( {
 				</button>
 			);
 		}
-	},
+	};
 
-	renderContent: function() {
+    renderContent = () => {
 		return (
 			<div className="dops-foldable-card__content">
 				{ this.props.children }
 			</div>
 		);
-	},
+	};
 
-	renderHeader: function() {
+    renderHeader = () => {
 		const summary = this.props.summary ? <span className="dops-foldable-card__summary">{ this.props.summary } </span> : null,
 			expandedSummary = this.props.expandedSummary ? <span className="dops-foldable-card__summary_expanded">{ this.props.expandedSummary } </span> : null,
 			header = this.props.header ? <div className="dops-foldable-card__header-text">{ this.props.header }</div> : null,
@@ -144,9 +139,9 @@ const FoldableCard = React.createClass( {
 				</span>
 			</div>
 		);
-	},
+	};
 
-	render: function() {
+    render() {
 		const Container = this.props.compact ? CompactCard : Card,
 			itemSiteClasses = classNames(
 				'dops-foldable-card',
@@ -165,6 +160,6 @@ const FoldableCard = React.createClass( {
 			</Container>
 		);
 	}
-} );
+}
 
 module.exports = FoldableCard;

--- a/_inc/client/components/form-input-validation/index.jsx
+++ b/_inc/client/components/form-input-validation/index.jsx
@@ -9,18 +9,18 @@ const React = require( 'react' ),
 require( './style.scss' );
 
 module.exports = class extends React.Component {
-    static displayName = 'FormInputValidation';
+	static displayName = 'FormInputValidation';
 
-    static propTypes = {
+	static propTypes = {
 		isError: PropTypes.bool,
 		isWarning: PropTypes.bool,
 		text: PropTypes.node,
 		icon: PropTypes.string
 	};
 
-    static defaultProps = { isError: false };
+	static defaultProps = { isError: false };
 
-    render() {
+	render() {
 		const classes = classNames( {
 			'form-input-validation': true,
 			'is-warning': this.props.isWarning,

--- a/_inc/client/components/form-input-validation/index.jsx
+++ b/_inc/client/components/form-input-validation/index.jsx
@@ -8,22 +8,19 @@ const React = require( 'react' ),
 
 require( './style.scss' );
 
-module.exports = React.createClass( {
+module.exports = class extends React.Component {
+    static displayName = 'FormInputValidation';
 
-	displayName: 'FormInputValidation',
-
-	propTypes: {
+    static propTypes = {
 		isError: PropTypes.bool,
 		isWarning: PropTypes.bool,
 		text: PropTypes.node,
 		icon: PropTypes.string
-	},
+	};
 
-	getDefaultProps: function() {
-		return { isError: false };
-	},
+    static defaultProps = { isError: false };
 
-	render: function() {
+    render() {
 		const classes = classNames( {
 			'form-input-validation': true,
 			'is-warning': this.props.isWarning,
@@ -38,4 +35,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form-input-validation/index.jsx
+++ b/_inc/client/components/form-input-validation/index.jsx
@@ -8,7 +8,7 @@ const React = require( 'react' ),
 
 require( './style.scss' );
 
-module.exports = class extends React.Component {
+export default class FormInputValidation extends React.Component {
 	static displayName = 'FormInputValidation';
 
 	static propTypes = {
@@ -35,4 +35,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/action-bar.jsx
+++ b/_inc/client/components/form/action-bar.jsx
@@ -2,18 +2,18 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'ActionBar',
+module.exports = class extends React.Component {
+    static displayName = 'ActionBar';
 
-	propTypes: {
+    static propTypes = {
 		style: PropTypes.object
-	},
+	};
 
-	render: function() {
+    render() {
 		return (
 			<div className="dops-form-actionbar" style={ this.props.style }>
 				{this.props.children}
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/action-bar.jsx
+++ b/_inc/client/components/form/action-bar.jsx
@@ -2,7 +2,7 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = class extends React.Component {
+export default class ActionBar extends React.Component {
 	static displayName = 'ActionBar';
 
 	static propTypes = {
@@ -16,4 +16,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/action-bar.jsx
+++ b/_inc/client/components/form/action-bar.jsx
@@ -3,13 +3,13 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
 module.exports = class extends React.Component {
-    static displayName = 'ActionBar';
+	static displayName = 'ActionBar';
 
-    static propTypes = {
+	static propTypes = {
 		style: PropTypes.object
 	};
 
-    render() {
+	render() {
 		return (
 			<div className="dops-form-actionbar" style={ this.props.style }>
 				{this.props.children}

--- a/_inc/client/components/form/clipboard-button/index.jsx
+++ b/_inc/client/components/form/clipboard-button/index.jsx
@@ -15,20 +15,20 @@ const ReactDom = require( 'react-dom' ),
 import Button from 'components/button';
 
 module.exports = class extends React.Component {
-    static displayName = 'ClipboardButton';
+	static displayName = 'ClipboardButton';
 
-    static propTypes = {
+	static propTypes = {
 		className: PropTypes.string,
 		text: PropTypes.string,
 		prompt: PropTypes.string,
 		onCopy: PropTypes.func
 	};
 
-    static defaultProps = {
-        onCopy: noop
-    };
+	static defaultProps = {
+		onCopy: noop
+	};
 
-    componentDidMount() {
+	componentDidMount() {
 		const button = ReactDom.findDOMNode( this.refs.button );
 		this.clipboard = new Clipboard( button, {
 			text: () => this.props.text
@@ -37,16 +37,16 @@ module.exports = class extends React.Component {
 		this.clipboard.on( 'error', this.displayPrompt );
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		this.clipboard.destroy();
 		delete this.clipboard;
 	}
 
-    displayPrompt = () => {
+	displayPrompt = () => {
 		window.prompt( this.props.prompt, this.props.text );
 	};
 
-    render() {
+	render() {
 		const classes = classNames( 'dops-clipboard-button', this.props.className );
 		return (
 			<Button

--- a/_inc/client/components/form/clipboard-button/index.jsx
+++ b/_inc/client/components/form/clipboard-button/index.jsx
@@ -14,7 +14,7 @@ const ReactDom = require( 'react-dom' ),
  */
 import Button from 'components/button';
 
-module.exports = class extends React.Component {
+export default class ClipboardButton extends React.Component {
 	static displayName = 'ClipboardButton';
 
 	static propTypes = {
@@ -55,4 +55,4 @@ module.exports = class extends React.Component {
 				className={ classes } />
 		);
 	}
-};
+}

--- a/_inc/client/components/form/clipboard-button/index.jsx
+++ b/_inc/client/components/form/clipboard-button/index.jsx
@@ -14,41 +14,39 @@ const ReactDom = require( 'react-dom' ),
  */
 import Button from 'components/button';
 
-module.exports = React.createClass( {
-	displayName: 'ClipboardButton',
+module.exports = class extends React.Component {
+    static displayName = 'ClipboardButton';
 
-	propTypes: {
+    static propTypes = {
 		className: PropTypes.string,
 		text: PropTypes.string,
 		prompt: PropTypes.string,
 		onCopy: PropTypes.func
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			onCopy: noop
-		};
-	},
+    static defaultProps = {
+        onCopy: noop
+    };
 
-	componentDidMount: function() {
+    componentDidMount() {
 		const button = ReactDom.findDOMNode( this.refs.button );
 		this.clipboard = new Clipboard( button, {
 			text: () => this.props.text
 		} );
 		this.clipboard.on( 'success', this.props.onCopy );
 		this.clipboard.on( 'error', this.displayPrompt );
-	},
+	}
 
-	componentWillUnmount: function() {
+    componentWillUnmount() {
 		this.clipboard.destroy();
 		delete this.clipboard;
-	},
+	}
 
-	displayPrompt: function() {
+    displayPrompt = () => {
 		window.prompt( this.props.prompt, this.props.text );
-	},
+	};
 
-	render: function() {
+    render() {
 		const classes = classNames( 'dops-clipboard-button', this.props.className );
 		return (
 			<Button
@@ -57,4 +55,4 @@ module.exports = React.createClass( {
 				className={ classes } />
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/form-toggle/compact.jsx
+++ b/_inc/client/components/form/form-toggle/compact.jsx
@@ -10,11 +10,10 @@ const React = require( 'react' ),
  */
 const Toggle = require( 'components/form/form-toggle' );
 
-module.exports = React.createClass( {
+module.exports = class extends React.Component {
+    static displayName = 'CompactFormToggle';
 
-	displayName: 'CompactFormToggle',
-
-	render: function() {
+    render() {
 		return (
 			<Toggle
 				{ ...omit( this.props, 'className' ) }
@@ -24,4 +23,4 @@ module.exports = React.createClass( {
 			</Toggle>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/form-toggle/compact.jsx
+++ b/_inc/client/components/form/form-toggle/compact.jsx
@@ -11,9 +11,9 @@ const React = require( 'react' ),
 const Toggle = require( 'components/form/form-toggle' );
 
 module.exports = class extends React.Component {
-    static displayName = 'CompactFormToggle';
+	static displayName = 'CompactFormToggle';
 
-    render() {
+	render() {
 		return (
 			<Toggle
 				{ ...omit( this.props, 'className' ) }

--- a/_inc/client/components/form/form-toggle/compact.jsx
+++ b/_inc/client/components/form/form-toggle/compact.jsx
@@ -10,7 +10,7 @@ const React = require( 'react' ),
  */
 const Toggle = require( 'components/form/form-toggle' );
 
-module.exports = class extends React.Component {
+export default class CompactFormToggle extends React.Component {
 	static displayName = 'CompactFormToggle';
 
 	render() {
@@ -23,4 +23,4 @@ module.exports = class extends React.Component {
 			</Toggle>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/index.jsx
+++ b/_inc/client/components/form/index.jsx
@@ -21,34 +21,31 @@ const ActionBar = require( './action-bar' ),
 require( './style.scss' );
 
 // very thin wrapper for Formsy.Form
-const Form = React.createClass( {
-
-	propTypes: {
+class Form extends React.Component {
+    static propTypes = {
 		style: PropTypes.object,
 		onValidSubmit: PropTypes.func,
 		onInvalidSubmit: PropTypes.func,
 		onValid: PropTypes.func,
 		onInvalid: PropTypes.func,
 		validationErrors: PropTypes.object
-	},
+	};
 
-	getInitialState: function() {
-		return {};
-	},
+    state = {};
 
-	isValid: function() {
+    isValid = () => {
 		return this.refs.form.state.isValid;
-	},
+	};
 
-	getCurrentValues: function() {
+    getCurrentValues = () => {
 		return this.refs.form.getCurrentValues();
-	},
+	};
 
-	submit: function() {
+    submit = () => {
 		this.refs.form.submit();
-	},
+	};
 
-	render: function() {
+    render() {
 		const { style, ...other } = this.props;
 		return (
 			<div className="dops-form" style={ style }>
@@ -58,7 +55,7 @@ const Form = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 // from: https://gist.github.com/ShirtlessKirk/2134376
 /**

--- a/_inc/client/components/form/index.jsx
+++ b/_inc/client/components/form/index.jsx
@@ -22,7 +22,7 @@ require( './style.scss' );
 
 // very thin wrapper for Formsy.Form
 class Form extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		style: PropTypes.object,
 		onValidSubmit: PropTypes.func,
 		onInvalidSubmit: PropTypes.func,
@@ -31,21 +31,21 @@ class Form extends React.Component {
 		validationErrors: PropTypes.object
 	};
 
-    state = {};
+	state = {};
 
-    isValid = () => {
+	isValid = () => {
 		return this.refs.form.state.isValid;
 	};
 
-    getCurrentValues = () => {
+	getCurrentValues = () => {
 		return this.refs.form.getCurrentValues();
 	};
 
-    submit = () => {
+	submit = () => {
 		this.refs.form.submit();
 	};
 
-    render() {
+	render() {
 		const { style, ...other } = this.props;
 		return (
 			<div className="dops-form" style={ style }>

--- a/_inc/client/components/form/input-checkbox-multiple.jsx
+++ b/_inc/client/components/form/input-checkbox-multiple.jsx
@@ -5,13 +5,15 @@ const React = require( 'react' ),
 	map = require( 'lodash/map' ),
 	Formsy = require( 'formsy-react' );
 
+const createReactClass = require('create-react-class');
+
 /** Internal Dependencies **/
 const Label = require( './label' ),
 	getUniqueId = require( './counter' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'MultiCheckboxInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -119,4 +121,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/input-checkbox-multiple.jsx
+++ b/_inc/client/components/form/input-checkbox-multiple.jsx
@@ -5,7 +5,7 @@ const React = require( 'react' ),
 	map = require( 'lodash/map' ),
 	Formsy = require( 'formsy-react' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -13,7 +13,7 @@ const Label = require( './label' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'MultiCheckboxInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -121,4 +121,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-checkbox.jsx
+++ b/_inc/client/components/form/input-checkbox.jsx
@@ -4,7 +4,7 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -12,7 +12,7 @@ const Label = require( './label' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'CheckboxInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -76,4 +76,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-checkbox.jsx
+++ b/_inc/client/components/form/input-checkbox.jsx
@@ -4,13 +4,15 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
+const createReactClass = require('create-react-class');
+
 /** Internal Dependencies **/
 const Label = require( './label' ),
 	getUniqueId = require( './counter' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'CheckboxInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -74,4 +76,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/input-hidden.jsx
+++ b/_inc/client/components/form/input-hidden.jsx
@@ -3,7 +3,9 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	Formsy = require( 'formsy-react' );
 
-module.exports = React.createClass( {
+const createReactClass = require('create-react-class');
+
+module.exports = createReactClass({
 	displayName: 'HiddenInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -17,4 +19,4 @@ module.exports = React.createClass( {
 			<input type="hidden" value={ this.getValue() } />
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/input-hidden.jsx
+++ b/_inc/client/components/form/input-hidden.jsx
@@ -3,9 +3,9 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	Formsy = require( 'formsy-react' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'HiddenInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -19,4 +19,4 @@ module.exports = createReactClass({
 			<input type="hidden" value={ this.getValue() } />
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-radio.jsx
+++ b/_inc/client/components/form/input-radio.jsx
@@ -4,33 +4,32 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
+const createReactClass = require('create-react-class');
+
 /** Internal Dependencies **/
 const Label = require( './label' ),
 	getUniqueId = require( './counter' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-const Radios = React.createClass( {
-
-	propTypes: {
+class Radios extends React.Component {
+    static propTypes = {
 		name: PropTypes.string,
 		choices: PropTypes.array,
 		selected: PropTypes.any,
 		uniqueId: PropTypes.string,
 		changeValue: PropTypes.func,
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			choices: [],
-		};
-	},
+    static defaultProps = {
+        choices: [],
+    };
 
-	onChange: function( event ) {
+    onChange = (event) => {
 		this.props.changeValue( event );
-	},
+	};
 
-	render: function() {
+    render() {
 		const uniqueId = this.props.uniqueId,
 			choices = this.props.choices.map( function( choice, i ) {
 				const checked = this.props.selected === choice.value;
@@ -49,9 +48,9 @@ const Radios = React.createClass( {
 			</fieldset>
 		);
 	}
-} );
+}
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'RadioInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -111,4 +110,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/input-radio.jsx
+++ b/_inc/client/components/form/input-radio.jsx
@@ -4,7 +4,7 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -13,7 +13,7 @@ const Label = require( './label' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
 class Radios extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		name: PropTypes.string,
 		choices: PropTypes.array,
 		selected: PropTypes.any,
@@ -21,15 +21,15 @@ class Radios extends React.Component {
 		changeValue: PropTypes.func,
 	};
 
-    static defaultProps = {
-        choices: [],
-    };
+	static defaultProps = {
+		choices: [],
+	};
 
-    onChange = (event) => {
+	onChange = ( event ) => {
 		this.props.changeValue( event );
 	};
 
-    render() {
+	render() {
 		const uniqueId = this.props.uniqueId,
 			choices = this.props.choices.map( function( choice, i ) {
 				const checked = this.props.selected === choice.value;
@@ -50,7 +50,7 @@ class Radios extends React.Component {
 	}
 }
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'RadioInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -110,4 +110,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-select-country-2.jsx
+++ b/_inc/client/components/form/input-select-country-2.jsx
@@ -5,9 +5,9 @@ const React = require( 'react' );
 const SelectInput = require( './input-select' );
 
 module.exports = class extends React.Component {
-    static displayName = 'CountrySelectInput2';
+	static displayName = 'CountrySelectInput2';
 
-    render() {
+	render() {
 		return (
 			<SelectInput { ...this.props }>
 				<option value="AF">Afghanistan</option>

--- a/_inc/client/components/form/input-select-country-2.jsx
+++ b/_inc/client/components/form/input-select-country-2.jsx
@@ -4,7 +4,7 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const SelectInput = require( './input-select' );
 
-module.exports = class extends React.Component {
+export default class CountrySelectInput2 extends React.Component {
 	static displayName = 'CountrySelectInput2';
 
 	render() {
@@ -262,4 +262,4 @@ module.exports = class extends React.Component {
 			</SelectInput>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/input-select-country-2.jsx
+++ b/_inc/client/components/form/input-select-country-2.jsx
@@ -4,10 +4,10 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const SelectInput = require( './input-select' );
 
-module.exports = React.createClass( {
-	displayName: 'CountrySelectInput2',
+module.exports = class extends React.Component {
+    static displayName = 'CountrySelectInput2';
 
-	render: function() {
+    render() {
 		return (
 			<SelectInput { ...this.props }>
 				<option value="AF">Afghanistan</option>
@@ -262,4 +262,4 @@ module.exports = React.createClass( {
 			</SelectInput>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/input-select-country.jsx
+++ b/_inc/client/components/form/input-select-country.jsx
@@ -5,9 +5,9 @@ const React = require( 'react' );
 const SelectInput = require( './input-select' );
 
 module.exports = class extends React.Component {
-    static displayName = 'CountrySelectInput';
+	static displayName = 'CountrySelectInput';
 
-    render() {
+	render() {
 		return (
 			<SelectInput { ...this.props }>
 				<option value="AFG">Afghanistan</option>

--- a/_inc/client/components/form/input-select-country.jsx
+++ b/_inc/client/components/form/input-select-country.jsx
@@ -4,10 +4,10 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const SelectInput = require( './input-select' );
 
-module.exports = React.createClass( {
-	displayName: 'CountrySelectInput',
+module.exports = class extends React.Component {
+    static displayName = 'CountrySelectInput';
 
-	render: function() {
+    render() {
 		return (
 			<SelectInput { ...this.props }>
 				<option value="AFG">Afghanistan</option>
@@ -262,4 +262,4 @@ module.exports = React.createClass( {
 			</SelectInput>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/input-select-country.jsx
+++ b/_inc/client/components/form/input-select-country.jsx
@@ -4,7 +4,7 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const SelectInput = require( './input-select' );
 
-module.exports = class extends React.Component {
+export default class CountrySelectInput extends React.Component {
 	static displayName = 'CountrySelectInput';
 
 	render() {
@@ -262,4 +262,4 @@ module.exports = class extends React.Component {
 			</SelectInput>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/input-select.jsx
+++ b/_inc/client/components/form/input-select.jsx
@@ -6,13 +6,15 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
+const createReactClass = require('create-react-class');
+
 /** Internal Dependencies **/
 const Label = require( './label' ),
 	getUniqueId = require( './counter' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'SelectInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -81,4 +83,4 @@ module.exports = React.createClass( {
 			</Label>
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/input-select.jsx
+++ b/_inc/client/components/form/input-select.jsx
@@ -6,7 +6,7 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	Formsy = require( 'formsy-react' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -14,7 +14,7 @@ const Label = require( './label' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'SelectInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -83,4 +83,4 @@ module.exports = createReactClass({
 			</Label>
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-text.js
+++ b/_inc/client/components/form/input-text.js
@@ -3,7 +3,7 @@ const React = require( 'react' ),
 	Formsy = require( 'formsy-react' ),
 	classNames = require( 'classnames' ),
 	Payment = require( 'payment' );
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 const PropTypes = require( 'prop-types' );
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -11,7 +11,7 @@ const Label = require( './label' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'TextInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -152,4 +152,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/form/input-text.js
+++ b/_inc/client/components/form/input-text.js
@@ -3,6 +3,7 @@ const React = require( 'react' ),
 	Formsy = require( 'formsy-react' ),
 	classNames = require( 'classnames' ),
 	Payment = require( 'payment' );
+const createReactClass = require('create-react-class');
 const PropTypes = require( 'prop-types' );
 /** Internal Dependencies **/
 const Label = require( './label' ),
@@ -10,7 +11,7 @@ const Label = require( './label' ),
 	FormInputValidation = require( '../form-input-validation' ),
 	requiredFieldErrorFormatter = require( './required-error-label' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'TextInput',
 
 	mixins: [ Formsy.Mixin ],
@@ -151,4 +152,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/form/label.jsx
+++ b/_inc/client/components/form/label.jsx
@@ -3,10 +3,10 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	classNames = require( 'classnames' );
 
-module.exports = React.createClass( {
-	displayName: 'Label',
+module.exports = class extends React.Component {
+    static displayName = 'Label';
 
-	propTypes: {
+    static propTypes = {
 		style: PropTypes.any,
 		label: PropTypes.any,
 		labelSuffix: PropTypes.any,
@@ -15,9 +15,9 @@ module.exports = React.createClass( {
 		htmlFor: PropTypes.string,
 		required: PropTypes.any,
 		inline: PropTypes.any
-	},
+	};
 
-	render: function() {
+    render() {
 		const label = this.props.label,
 			className = classNames( {
 				'dops-form-label': true,
@@ -41,4 +41,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/label.jsx
+++ b/_inc/client/components/form/label.jsx
@@ -4,9 +4,9 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 module.exports = class extends React.Component {
-    static displayName = 'Label';
+	static displayName = 'Label';
 
-    static propTypes = {
+	static propTypes = {
 		style: PropTypes.any,
 		label: PropTypes.any,
 		labelSuffix: PropTypes.any,
@@ -17,7 +17,7 @@ module.exports = class extends React.Component {
 		inline: PropTypes.any
 	};
 
-    render() {
+	render() {
 		const label = this.props.label,
 			className = classNames( {
 				'dops-form-label': true,

--- a/_inc/client/components/form/label.jsx
+++ b/_inc/client/components/form/label.jsx
@@ -3,7 +3,7 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' ),
 	classNames = require( 'classnames' );
 
-module.exports = class extends React.Component {
+export default class Label extends React.Component {
 	static displayName = 'Label';
 
 	static propTypes = {
@@ -41,4 +41,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/row.jsx
+++ b/_inc/client/components/form/row.jsx
@@ -2,9 +2,9 @@
 const React = require( 'react' );
 
 module.exports = class extends React.Component {
-    static displayName = 'Row';
+	static displayName = 'Row';
 
-    render() {
+	render() {
 		return (
 			<div className="dops-form-row">
 				{this.props.children}

--- a/_inc/client/components/form/row.jsx
+++ b/_inc/client/components/form/row.jsx
@@ -1,7 +1,7 @@
 /** External Dependencies **/
 const React = require( 'react' );
 
-module.exports = class extends React.Component {
+export default class Row extends React.Component {
 	static displayName = 'Row';
 
 	render() {
@@ -11,4 +11,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/row.jsx
+++ b/_inc/client/components/form/row.jsx
@@ -1,14 +1,14 @@
 /** External Dependencies **/
 const React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'Row',
+module.exports = class extends React.Component {
+    static displayName = 'Row';
 
-	render: function() {
+    render() {
 		return (
 			<div className="dops-form-row">
 				{this.props.children}
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/section.jsx
+++ b/_inc/client/components/form/section.jsx
@@ -2,7 +2,7 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = class extends React.Component {
+export default class Section extends React.Component {
 	static displayName = 'Section';
 
 	static propTypes = {
@@ -27,4 +27,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/components/form/section.jsx
+++ b/_inc/client/components/form/section.jsx
@@ -3,14 +3,14 @@ const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
 module.exports = class extends React.Component {
-    static displayName = 'Section';
+	static displayName = 'Section';
 
-    static propTypes = {
+	static propTypes = {
 		title: PropTypes.any,
 		id: PropTypes.string
 	};
 
-    render() {
+	render() {
 		return (
 			<div id={ this.props.id }>
 				{this.props.title

--- a/_inc/client/components/form/section.jsx
+++ b/_inc/client/components/form/section.jsx
@@ -2,15 +2,15 @@
 const PropTypes = require( 'prop-types' );
 const React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'Section',
+module.exports = class extends React.Component {
+    static displayName = 'Section';
 
-	propTypes: {
+    static propTypes = {
 		title: PropTypes.any,
 		id: PropTypes.string
-	},
+	};
 
-	render: function() {
+    render() {
 		return (
 			<div id={ this.props.id }>
 				{this.props.title
@@ -27,4 +27,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/submit.jsx
+++ b/_inc/client/components/form/submit.jsx
@@ -4,14 +4,14 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const Button = require( '../button' );
 
-module.exports = React.createClass( {
-	displayName: 'Submit',
+module.exports = class extends React.Component {
+    static displayName = 'Submit';
 
-	render: function() {
+    render() {
 		let { ...other } = this.props;
 
 		return (
 			<Button { ...other } type="submit">{this.props.children}</Button>
 		);
 	}
-} );
+};

--- a/_inc/client/components/form/submit.jsx
+++ b/_inc/client/components/form/submit.jsx
@@ -5,9 +5,9 @@ const React = require( 'react' );
 const Button = require( '../button' );
 
 module.exports = class extends React.Component {
-    static displayName = 'Submit';
+	static displayName = 'Submit';
 
-    render() {
+	render() {
 		let { ...other } = this.props;
 
 		return (

--- a/_inc/client/components/form/submit.jsx
+++ b/_inc/client/components/form/submit.jsx
@@ -4,7 +4,7 @@ const React = require( 'react' );
 /** Internal Dependencies **/
 const Button = require( '../button' );
 
-module.exports = class extends React.Component {
+export default class Submit extends React.Component {
 	static displayName = 'Submit';
 
 	render() {
@@ -14,4 +14,4 @@ module.exports = class extends React.Component {
 			<Button { ...other } type="submit">{this.props.children}</Button>
 		);
 	}
-};
+}

--- a/_inc/client/components/global-notices/index.jsx
+++ b/_inc/client/components/global-notices/index.jsx
@@ -19,36 +19,33 @@ const debug = debugModule( 'calypso:notices' );
 
 require( './style.scss' );
 
-const NoticesList = React.createClass( {
+class NoticesList extends React.Component {
+    static displayName = 'NoticesList';
 
-	displayName: 'NoticesList',
-
-	propTypes: {
+    static propTypes = {
 		id: PropTypes.string,
 		notices: PropTypes.oneOfType( [
 			PropTypes.object,
 			PropTypes.array
 		] )
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			id: 'overlay-notices',
-			notices: Object.freeze( [] )
-		};
-	},
+    static defaultProps = {
+        id: 'overlay-notices',
+        notices: Object.freeze( [] )
+    };
 
-	componentWillMount() {
+    componentWillMount() {
 		debug( 'Mounting Global Notices React component.' );
-	},
+	}
 
-	removeNotice( notice ) {
+    removeNotice = (notice) => {
 		if ( notice ) {
 			notices.removeNotice( notice );
 		}
-	},
+	};
 
-	render() {
+    render() {
 		const noticesRaw = this.props.notices[ this.props.id ] || [];
 		let noticesList = noticesRaw.map( function( notice, index ) {
 			return (
@@ -98,7 +95,7 @@ const NoticesList = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {

--- a/_inc/client/components/global-notices/index.jsx
+++ b/_inc/client/components/global-notices/index.jsx
@@ -20,9 +20,9 @@ const debug = debugModule( 'calypso:notices' );
 require( './style.scss' );
 
 class NoticesList extends React.Component {
-    static displayName = 'NoticesList';
+	static displayName = 'NoticesList';
 
-    static propTypes = {
+	static propTypes = {
 		id: PropTypes.string,
 		notices: PropTypes.oneOfType( [
 			PropTypes.object,
@@ -30,22 +30,22 @@ class NoticesList extends React.Component {
 		] )
 	};
 
-    static defaultProps = {
-        id: 'overlay-notices',
-        notices: Object.freeze( [] )
-    };
+	static defaultProps = {
+		id: 'overlay-notices',
+		notices: Object.freeze( [] )
+	};
 
-    componentWillMount() {
+	componentWillMount() {
 		debug( 'Mounting Global Notices React component.' );
 	}
 
-    removeNotice = (notice) => {
+	removeNotice = ( notice ) => {
 		if ( notice ) {
 			notices.removeNotice( notice );
 		}
 	};
 
-    render() {
+	render() {
 		const noticesRaw = this.props.notices[ this.props.id ] || [];
 		let noticesList = noticesRaw.map( function( notice, index ) {
 			return (

--- a/_inc/client/components/gridicon/index.jsx
+++ b/_inc/client/components/gridicon/index.jsx
@@ -15,27 +15,29 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
+const createReactClass = require('create-react-class');
+
 require( './style.scss' );
 
-const Gridicon = React.createClass( {
+const Gridicon = createReactClass({
+    displayName: 'Gridicon',
+    mixins: [ PureRenderMixin ],
 
-	mixins: [ PureRenderMixin ],
-
-	getDefaultProps: function() {
+    getDefaultProps: function() {
 		return {
 			className: '',
 			size: 24
 		};
 	},
 
-	propTypes: {
+    propTypes: {
 		icon: PropTypes.string.isRequired,
 		size: PropTypes.number,
 		onClick: PropTypes.func,
 		className: PropTypes.string
 	},
 
-	needsOffset: function( icon, size ) {
+    needsOffset: function( icon, size ) {
 		const iconNeedsOffset = [
 			'gridicons-add-outline',
 			'gridicons-add',
@@ -95,7 +97,7 @@ const Gridicon = React.createClass( {
 		return false;
 	},
 
-	needsOffsetX: function( icon, size ) {
+    needsOffsetX: function( icon, size ) {
 		const iconNeedsOffsetX = [
 			'gridicons-arrow-down',
 			'gridicons-arrow-up',
@@ -113,7 +115,7 @@ const Gridicon = React.createClass( {
 		return false;
 	},
 
-	needsOffsetY: function( icon, size ) {
+    needsOffsetY: function( icon, size ) {
 		const iconNeedsOffsetY = [
 			'gridicons-align-center',
 			'gridicons-align-justify',
@@ -139,7 +141,7 @@ const Gridicon = React.createClass( {
 		return false;
 	},
 
-	render: function() {
+    render: function() {
 		const icon = 'gridicons-' + this.props.icon,
 			needsOffset = this.needsOffset( icon, this.props.size ),
 			needsOffsetX = this.needsOffsetX( icon, this.props.size ),
@@ -601,7 +603,7 @@ const Gridicon = React.createClass( {
 		}
 
 		return ( svg );
-	}
-} );
+	},
+});
 
 module.exports = Gridicon;

--- a/_inc/client/components/gridicon/index.jsx
+++ b/_inc/client/components/gridicon/index.jsx
@@ -15,29 +15,29 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 require( './style.scss' );
 
-const Gridicon = createReactClass({
-    displayName: 'Gridicon',
-    mixins: [ PureRenderMixin ],
+const Gridicon = createReactClass( {
+	displayName: 'Gridicon',
+	mixins: [ PureRenderMixin ],
 
-    getDefaultProps: function() {
+	getDefaultProps: function() {
 		return {
 			className: '',
 			size: 24
 		};
 	},
 
-    propTypes: {
+	propTypes: {
 		icon: PropTypes.string.isRequired,
 		size: PropTypes.number,
 		onClick: PropTypes.func,
 		className: PropTypes.string
 	},
 
-    needsOffset: function( icon, size ) {
+	needsOffset: function( icon, size ) {
 		const iconNeedsOffset = [
 			'gridicons-add-outline',
 			'gridicons-add',
@@ -97,7 +97,7 @@ const Gridicon = createReactClass({
 		return false;
 	},
 
-    needsOffsetX: function( icon, size ) {
+	needsOffsetX: function( icon, size ) {
 		const iconNeedsOffsetX = [
 			'gridicons-arrow-down',
 			'gridicons-arrow-up',
@@ -115,7 +115,7 @@ const Gridicon = createReactClass({
 		return false;
 	},
 
-    needsOffsetY: function( icon, size ) {
+	needsOffsetY: function( icon, size ) {
 		const iconNeedsOffsetY = [
 			'gridicons-align-center',
 			'gridicons-align-justify',
@@ -141,7 +141,7 @@ const Gridicon = createReactClass({
 		return false;
 	},
 
-    render: function() {
+	render: function() {
 		const icon = 'gridicons-' + this.props.icon,
 			needsOffset = this.needsOffset( icon, this.props.size ),
 			needsOffsetX = this.needsOffsetX( icon, this.props.size ),
@@ -604,6 +604,6 @@ const Gridicon = createReactClass({
 
 		return ( svg );
 	},
-});
+} );
 
 module.exports = Gridicon;

--- a/_inc/client/components/info-popover/docs/example.jsx
+++ b/_inc/client/components/info-popover/docs/example.jsx
@@ -5,12 +5,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
 * Internal dependencies
 */
 const InfoPopover = require( 'components/info-popover' );
 
-const InfoPopoverExample = React.createClass( {
+const InfoPopoverExample = createReactClass({
 	displayName: 'InfoPopover',
 
 	mixins: [ PureRenderMixin ],
@@ -54,6 +56,6 @@ const InfoPopoverExample = React.createClass( {
 		this.setState( { popoverPosition: event.target.value } );
 	}
 
-} );
+});
 
 module.exports = InfoPopoverExample;

--- a/_inc/client/components/info-popover/docs/example.jsx
+++ b/_inc/client/components/info-popover/docs/example.jsx
@@ -5,14 +5,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
 * Internal dependencies
 */
 const InfoPopover = require( 'components/info-popover' );
 
-const InfoPopoverExample = createReactClass({
+const InfoPopoverExample = createReactClass( {
 	displayName: 'InfoPopover',
 
 	mixins: [ PureRenderMixin ],
@@ -56,6 +56,6 @@ const InfoPopoverExample = createReactClass({
 		this.setState( { popoverPosition: event.target.value } );
 	}
 
-});
+} );
 
 module.exports = InfoPopoverExample;

--- a/_inc/client/components/info-popover/index.jsx
+++ b/_inc/client/components/info-popover/index.jsx
@@ -16,7 +16,7 @@ import analytics from 'lib/analytics';
 
 require( './style.scss' );
 
-export default createReactClass({
+export default createReactClass( {
 
 	displayName: 'InfoPopover',
 
@@ -101,4 +101,4 @@ export default createReactClass({
 			analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + dialogState );
 		}
 	}
-});
+} );

--- a/_inc/client/components/info-popover/index.jsx
+++ b/_inc/client/components/info-popover/index.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import noop from 'lodash/noop';
 
 /**
@@ -15,7 +16,7 @@ import analytics from 'lib/analytics';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default createReactClass({
 
 	displayName: 'InfoPopover',
 
@@ -100,4 +101,4 @@ export default React.createClass( {
 			analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + dialogState );
 		}
 	}
-} );
+});

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -13,10 +13,10 @@ import ConnectButton from 'components/connect-button';
 import { getConnectUrl as getConnectUrl } from 'state/connection';
 import { imagePath } from 'constants/urls';
 
-const JetpackConnect = React.createClass( {
-	displayName: 'JetpackConnect',
+class JetpackConnect extends React.Component {
+    static displayName = 'JetpackConnect';
 
-	render: function() {
+    render() {
 		const newAccountUrl = this.props.connectUrl + '&from=new-account-button';
 
 		return (
@@ -228,7 +228,7 @@ const JetpackConnect = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -14,9 +14,9 @@ import { getConnectUrl as getConnectUrl } from 'state/connection';
 import { imagePath } from 'constants/urls';
 
 class JetpackConnect extends React.Component {
-    static displayName = 'JetpackConnect';
+	static displayName = 'JetpackConnect';
 
-    render() {
+	render() {
 		const newAccountUrl = this.props.connectUrl + '&from=new-account-button';
 
 		return (

--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -30,7 +30,7 @@ function allowClose() {
 }
 
 class Modal extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		style: PropTypes.object,
 		width: PropTypes.oneOf( [ 'wide', 'medium', 'narrow' ] ),
 		className: PropTypes.string,
@@ -39,15 +39,15 @@ class Modal extends React.Component {
 		onRequestClose: PropTypes.func
 	};
 
-    static defaultProps = {
-        style: {}
-    };
+	static defaultProps = {
+		style: {}
+	};
 
-    state = {
-        overlayMouseDown: false
-    };
+	state = {
+		overlayMouseDown: false
+	};
 
-    componentDidMount() {
+	componentDidMount() {
 		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.dopsmodal', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
@@ -60,7 +60,7 @@ class Modal extends React.Component {
 		}
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		jQuery( 'body' ).removeClass( 'dops-modal-showing' ).off( 'touchmove.dopsmodal', false );
 		jQuery( document ).unbind( 'keyup', this.handleEscapeKey );
 		try {
@@ -70,13 +70,13 @@ class Modal extends React.Component {
 		}
 	}
 
-    handleEscapeKey = (e) => {
+	handleEscapeKey = ( e ) => {
 		if ( e.keyCode === 27 ) { // escape key maps to keycode `27`
 			this.maybeClose();
 		}
 	};
 
-    maybeClose = () => {
+	maybeClose = () => {
 		if ( this.props.onRequestClose && ! preventCloseFlag ) {
 			this.props.onRequestClose();
 		}
@@ -84,13 +84,13 @@ class Modal extends React.Component {
 
     // this exists so we can differentiate between click events on the background
     // which initiated there vs. drags that ended there (most notably from the slider in a modal)
-    handleMouseDownOverlay = (e) => {
+	handleMouseDownOverlay = ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
 		this.setState( { overlayMouseDown: true } );
 	};
 
-    handleClickOverlay = (e) => {
+	handleClickOverlay = ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
 		if ( this.state.overlayMouseDown && this.props.onRequestClose && ! preventCloseFlag ) {
@@ -100,11 +100,11 @@ class Modal extends React.Component {
 	};
 
     // prevent clicks from propagating to background
-    handleMouseEventModal = (e) => {
+	handleMouseEventModal = ( e ) => {
 		e.stopPropagation();
 	};
 
-    render() {
+	render() {
 		let containerStyle;
 
 		const { style, className, width, title, ...other } = this.props;

--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -29,30 +29,25 @@ function allowClose() {
 	preventCloseFlag = false;
 }
 
-const Modal = React.createClass( {
-
-	propTypes: {
+class Modal extends React.Component {
+    static propTypes = {
 		style: PropTypes.object,
 		width: PropTypes.oneOf( [ 'wide', 'medium', 'narrow' ] ),
 		className: PropTypes.string,
 		title: PropTypes.string,
 		initialFocus: PropTypes.string,
 		onRequestClose: PropTypes.func
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			overlayMouseDown: false
-		};
-	},
+    static defaultProps = {
+        style: {}
+    };
 
-	getDefaultProps: function() {
-		return {
-			style: {}
-		};
-	},
+    state = {
+        overlayMouseDown: false
+    };
 
-	componentDidMount: function() {
+    componentDidMount() {
 		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.dopsmodal', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
@@ -63,9 +58,9 @@ const Modal = React.createClass( {
 		} catch ( e ) {
 			//noop
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
+    componentWillUnmount() {
 		jQuery( 'body' ).removeClass( 'dops-modal-showing' ).off( 'touchmove.dopsmodal', false );
 		jQuery( document ).unbind( 'keyup', this.handleEscapeKey );
 		try {
@@ -73,43 +68,43 @@ const Modal = React.createClass( {
 		} catch ( e ) {
 			//noop
 		}
-	},
+	}
 
-	handleEscapeKey: function( e ) {
+    handleEscapeKey = (e) => {
 		if ( e.keyCode === 27 ) { // escape key maps to keycode `27`
 			this.maybeClose();
 		}
-	},
+	};
 
-	maybeClose: function() {
+    maybeClose = () => {
 		if ( this.props.onRequestClose && ! preventCloseFlag ) {
 			this.props.onRequestClose();
 		}
-	},
+	};
 
-	// this exists so we can differentiate between click events on the background
-	// which initiated there vs. drags that ended there (most notably from the slider in a modal)
-	handleMouseDownOverlay: function( e ) {
+    // this exists so we can differentiate between click events on the background
+    // which initiated there vs. drags that ended there (most notably from the slider in a modal)
+    handleMouseDownOverlay = (e) => {
 		e.preventDefault();
 		e.stopPropagation();
 		this.setState( { overlayMouseDown: true } );
-	},
+	};
 
-	handleClickOverlay: function( e ) {
+    handleClickOverlay = (e) => {
 		e.preventDefault();
 		e.stopPropagation();
 		if ( this.state.overlayMouseDown && this.props.onRequestClose && ! preventCloseFlag ) {
 			this.setState( { overlayMouseDown: false } );
 			this.props.onRequestClose();
 		}
-	},
+	};
 
-	// prevent clicks from propagating to background
-	handleMouseEventModal: function( e ) {
+    // prevent clicks from propagating to background
+    handleMouseEventModal = (e) => {
 		e.stopPropagation();
-	},
+	};
 
-	render: function() {
+    render() {
 		let containerStyle;
 
 		const { style, className, width, title, ...other } = this.props;
@@ -141,7 +136,7 @@ const Modal = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 Modal.preventClose = preventClose;
 Modal.allowClose = allowClose;

--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -82,8 +82,8 @@ class Modal extends React.Component {
 		}
 	};
 
-    // this exists so we can differentiate between click events on the background
-    // which initiated there vs. drags that ended there (most notably from the slider in a modal)
+	// this exists so we can differentiate between click events on the background
+	// which initiated there vs. drags that ended there (most notably from the slider in a modal)
 	handleMouseDownOverlay = ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -99,7 +99,7 @@ class Modal extends React.Component {
 		}
 	};
 
-    // prevent clicks from propagating to background
+	// prevent clicks from propagating to background
 	handleMouseEventModal = ( e ) => {
 		e.stopPropagation();
 	};

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -14,21 +14,18 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default React.createClass( {
-	displayName: 'SimpleNotice',
-	dismissTimeout: null,
+export default class extends React.Component {
+    static displayName = 'SimpleNotice';
 
-	getDefaultProps() {
-		return {
-			duration: 0,
-			status: null,
-			showDismiss: true,
-			className: '',
-			onDismissClick: noop
-		};
-	},
+    static defaultProps = {
+        duration: 0,
+        status: null,
+        showDismiss: true,
+        className: '',
+        onDismissClick: noop
+    };
 
-	propTypes: {
+    static propTypes = {
 		// we should validate the allowed statuses
 		status: PropTypes.string,
 		showDismiss: PropTypes.bool,
@@ -40,21 +37,23 @@ export default React.createClass( {
 		] ),
 		icon: PropTypes.string,
 		className: PropTypes.string
-	},
+	};
 
-	componentDidMount() {
+    dismissTimeout = null;
+
+    componentDidMount() {
 		if ( this.props.duration > 0 ) {
 			this.dismissTimeout = setTimeout( this.props.onDismissClick, this.props.duration );
 		}
-	},
+	}
 
-	componentWillUnmount() {
+    componentWillUnmount() {
 		if ( this.dismissTimeout ) {
 			clearTimeout( this.dismissTimeout );
 		}
-	},
+	}
 
-	getIcon() {
+    getIcon = () => {
 		let icon;
 
 		switch ( this.props.status ) {
@@ -76,9 +75,9 @@ export default React.createClass( {
 		}
 
 		return icon;
-	},
+	};
 
-	render() {
+    render() {
 		const { status, className, isCompact, showDismiss } = this.props;
 		const classes = classnames( 'dops-notice', status, className, {
 			'is-compact': isCompact,
@@ -110,4 +109,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -15,17 +15,17 @@ import Gridicon from 'components/gridicon';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'SimpleNotice';
+	static displayName = 'SimpleNotice';
 
-    static defaultProps = {
-        duration: 0,
-        status: null,
-        showDismiss: true,
-        className: '',
-        onDismissClick: noop
-    };
+	static defaultProps = {
+		duration: 0,
+		status: null,
+		showDismiss: true,
+		className: '',
+		onDismissClick: noop
+	};
 
-    static propTypes = {
+	static propTypes = {
 		// we should validate the allowed statuses
 		status: PropTypes.string,
 		showDismiss: PropTypes.bool,
@@ -39,21 +39,21 @@ export default class extends React.Component {
 		className: PropTypes.string
 	};
 
-    dismissTimeout = null;
+	dismissTimeout = null;
 
-    componentDidMount() {
+	componentDidMount() {
 		if ( this.props.duration > 0 ) {
 			this.dismissTimeout = setTimeout( this.props.onDismissClick, this.props.duration );
 		}
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		if ( this.dismissTimeout ) {
 			clearTimeout( this.dismissTimeout );
 		}
 	}
 
-    getIcon = () => {
+	getIcon = () => {
 		let icon;
 
 		switch ( this.props.status ) {
@@ -77,7 +77,7 @@ export default class extends React.Component {
 		return icon;
 	};
 
-    render() {
+	render() {
 		const { status, className, isCompact, showDismiss } = this.props;
 		const classes = classnames( 'dops-notice', status, className, {
 			'is-compact': isCompact,

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -14,7 +14,7 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class SimpleNotice extends React.Component {
 	static displayName = 'SimpleNotice';
 
 	static defaultProps = {

--- a/_inc/client/components/notice/notice-action.jsx
+++ b/_inc/client/components/notice/notice-action.jsx
@@ -11,23 +11,21 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default React.createClass( {
-	displayName: 'NoticeAction',
+export default class extends React.Component {
+    static displayName = 'NoticeAction';
 
-	propTypes: {
+    static propTypes = {
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		external: PropTypes.bool,
 		icon: PropTypes.string
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			external: false
-		};
-	},
+    static defaultProps = {
+        external: false
+    };
 
-	render() {
+    render() {
 		const attributes = {
 			className: 'dops-notice__action',
 			href: this.props.href,
@@ -46,4 +44,4 @@ export default React.createClass( {
 			</a>
 		);
 	}
-} );
+}

--- a/_inc/client/components/notice/notice-action.jsx
+++ b/_inc/client/components/notice/notice-action.jsx
@@ -12,20 +12,20 @@ import Gridicon from 'components/gridicon';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'NoticeAction';
+	static displayName = 'NoticeAction';
 
-    static propTypes = {
+	static propTypes = {
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		external: PropTypes.bool,
 		icon: PropTypes.string
 	};
 
-    static defaultProps = {
-        external: false
-    };
+	static defaultProps = {
+		external: false
+	};
 
-    render() {
+	render() {
 		const attributes = {
 			className: 'dops-notice__action',
 			href: this.props.href,

--- a/_inc/client/components/notice/notice-action.jsx
+++ b/_inc/client/components/notice/notice-action.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'components/gridicon';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class NoticeAction extends React.Component {
 	static displayName = 'NoticeAction';
 
 	static propTypes = {

--- a/_inc/client/components/popover/docs/example.jsx
+++ b/_inc/client/components/popover/docs/example.jsx
@@ -15,11 +15,11 @@ import Popover from 'components/popover';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 
-const Popovers = createReactClass({
-    displayName: 'Popovers',
-    mixins: [ PureRenderMixin ],
+const Popovers = createReactClass( {
+	displayName: 'Popovers',
+	mixins: [ PureRenderMixin ],
 
-    getInitialState: function() {
+	getInitialState: function() {
 		return {
 			popoverPosition: 'bottom left',
 
@@ -33,47 +33,47 @@ const Popovers = createReactClass({
 	},
 
     // set position for all popovers
-    changePopoverPosition( event ) {
+	changePopoverPosition( event ) {
 		this.setState( { popoverPosition: event.target.value } );
 	},
 
-    swapPopoverVisibility() {
+	swapPopoverVisibility() {
 		this.setState( { showPopover: ! this.state.showPopover } );
 	},
 
-    closePopover() {
+	closePopover() {
 		this.setState( { showPopover: false } );
 	},
 
-    showPopoverMenu() {
+	showPopoverMenu() {
 		this.setState( {
 			showPopoverMenu: ! this.state.showPopoverMenu
 		} );
 	},
 
-    closePopoverMenu() {
+	closePopoverMenu() {
 		this.setState( { showPopoverMenu: false } );
 	},
 
-    onPopoverMenuItemBClick( closePopover ) {
+	onPopoverMenuItemBClick( closePopover ) {
 		closePopover();
 	},
 
-    updateMultiplePopover( event ) {
+	updateMultiplePopover( event ) {
 		this.setState( {
 			currentTarget: event.currentTarget,
 			showMultiplePopover: true
 		} );
 	},
 
-    closeMultiplePopover() {
+	closeMultiplePopover() {
 		this.setState( {
 			showMultiplePopover: false,
 			currentTarget: null
 		} );
 	},
 
-    movePopovertoRandomTarget( event ) {
+	movePopovertoRandomTarget( event ) {
 		event.preventDefault();
 		const random = parseInt( Math.random() * 1 * 256 );
 		const ref = this.refs && this.refs[ `target-${ random }` ];
@@ -87,7 +87,7 @@ const Popovers = createReactClass({
 		} );
 	},
 
-    renderPopover() {
+	renderPopover() {
 		return (
 			<div>
 				<button
@@ -115,7 +115,7 @@ const Popovers = createReactClass({
 		);
 	},
 
-    renderMenuPopover() {
+	renderMenuPopover() {
 		return (
 			<div>
 				<button
@@ -143,7 +143,7 @@ const Popovers = createReactClass({
 		);
 	},
 
-    renderPopoverRubic() {
+	renderPopoverRubic() {
 		const squares = [];
 		const width = 150;
 		const positions = [
@@ -229,7 +229,7 @@ const Popovers = createReactClass({
 		);
 	},
 
-    renderMultipleTargetsPopover() {
+	renderMultipleTargetsPopover() {
 		const targets = [];
 		const targetsCount = 256;
 		for ( let n = 0; n < targetsCount; n++ ) {
@@ -280,7 +280,7 @@ const Popovers = createReactClass({
 		);
 	},
 
-    renderPopoverContent() {
+	renderPopoverContent() {
 		const { currentTarget } = this.state;
 		const targetId = currentTarget ? currentTarget.innerText : null;
 
@@ -298,7 +298,7 @@ const Popovers = createReactClass({
 		);
 	},
 
-    render() {
+	render() {
 		const id = 'example-select';
 		return (
 			<div className="docs__design-assets-group">
@@ -341,6 +341,6 @@ const Popovers = createReactClass({
 			</div>
 		);
 	},
-});
+} );
 
 export default Popovers;

--- a/_inc/client/components/popover/docs/example.jsx
+++ b/_inc/client/components/popover/docs/example.jsx
@@ -5,6 +5,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
@@ -14,10 +15,11 @@ import Popover from 'components/popover';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 
-const Popovers = React.createClass( {
-	mixins: [ PureRenderMixin ],
+const Popovers = createReactClass({
+    displayName: 'Popovers',
+    mixins: [ PureRenderMixin ],
 
-	getInitialState: function() {
+    getInitialState: function() {
 		return {
 			popoverPosition: 'bottom left',
 
@@ -30,48 +32,48 @@ const Popovers = React.createClass( {
 		};
 	},
 
-	// set position for all popovers
-	changePopoverPosition( event ) {
+    // set position for all popovers
+    changePopoverPosition( event ) {
 		this.setState( { popoverPosition: event.target.value } );
 	},
 
-	swapPopoverVisibility() {
+    swapPopoverVisibility() {
 		this.setState( { showPopover: ! this.state.showPopover } );
 	},
 
-	closePopover() {
+    closePopover() {
 		this.setState( { showPopover: false } );
 	},
 
-	showPopoverMenu() {
+    showPopoverMenu() {
 		this.setState( {
 			showPopoverMenu: ! this.state.showPopoverMenu
 		} );
 	},
 
-	closePopoverMenu() {
+    closePopoverMenu() {
 		this.setState( { showPopoverMenu: false } );
 	},
 
-	onPopoverMenuItemBClick( closePopover ) {
+    onPopoverMenuItemBClick( closePopover ) {
 		closePopover();
 	},
 
-	updateMultiplePopover( event ) {
+    updateMultiplePopover( event ) {
 		this.setState( {
 			currentTarget: event.currentTarget,
 			showMultiplePopover: true
 		} );
 	},
 
-	closeMultiplePopover() {
+    closeMultiplePopover() {
 		this.setState( {
 			showMultiplePopover: false,
 			currentTarget: null
 		} );
 	},
 
-	movePopovertoRandomTarget( event ) {
+    movePopovertoRandomTarget( event ) {
 		event.preventDefault();
 		const random = parseInt( Math.random() * 1 * 256 );
 		const ref = this.refs && this.refs[ `target-${ random }` ];
@@ -85,7 +87,7 @@ const Popovers = React.createClass( {
 		} );
 	},
 
-	renderPopover() {
+    renderPopover() {
 		return (
 			<div>
 				<button
@@ -113,7 +115,7 @@ const Popovers = React.createClass( {
 		);
 	},
 
-	renderMenuPopover() {
+    renderMenuPopover() {
 		return (
 			<div>
 				<button
@@ -141,7 +143,7 @@ const Popovers = React.createClass( {
 		);
 	},
 
-	renderPopoverRubic() {
+    renderPopoverRubic() {
 		const squares = [];
 		const width = 150;
 		const positions = [
@@ -227,7 +229,7 @@ const Popovers = React.createClass( {
 		);
 	},
 
-	renderMultipleTargetsPopover() {
+    renderMultipleTargetsPopover() {
 		const targets = [];
 		const targetsCount = 256;
 		for ( let n = 0; n < targetsCount; n++ ) {
@@ -278,7 +280,7 @@ const Popovers = React.createClass( {
 		);
 	},
 
-	renderPopoverContent() {
+    renderPopoverContent() {
 		const { currentTarget } = this.state;
 		const targetId = currentTarget ? currentTarget.innerText : null;
 
@@ -296,7 +298,7 @@ const Popovers = React.createClass( {
 		);
 	},
 
-	render() {
+    render() {
 		const id = 'example-select';
 		return (
 			<div className="docs__design-assets-group">
@@ -338,7 +340,7 @@ const Popovers = React.createClass( {
 				{ this.renderMultipleTargetsPopover() }
 			</div>
 		);
-	}
-} );
+	},
+});
 
 export default Popovers;

--- a/_inc/client/components/popover/docs/example.jsx
+++ b/_inc/client/components/popover/docs/example.jsx
@@ -32,7 +32,7 @@ const Popovers = createReactClass( {
 		};
 	},
 
-    // set position for all popovers
+	// set position for all popovers
 	changePopoverPosition( event ) {
 		this.setState( { popoverPosition: event.target.value } );
 	},

--- a/_inc/client/components/popover/menu-item.jsx
+++ b/_inc/client/components/popover/menu-item.jsx
@@ -5,16 +5,14 @@ const React = require( 'react' ),
 	noop = require( 'lodash/noop' ),
 	classnames = require( 'classnames' );
 
-const MenuItem = React.createClass( {
-	getDefaultProps: function() {
-		return {
-			isVisible: false,
-			className: '',
-			focusOnHover: true
-		};
-	},
+class MenuItem extends React.Component {
+    static defaultProps = {
+        isVisible: false,
+        className: '',
+        focusOnHover: true
+    };
 
-	render: function() {
+    render() {
 		const onMouseOver = this.props.focusOnHover ? this._onMouseOver : null;
 		return (
 			<button className={ classnames( 'dops-popover__menu-item', this.props.className ) }
@@ -27,11 +25,11 @@ const MenuItem = React.createClass( {
 				{ this.props.children }
 			</button>
 		);
-	},
-
-	_onMouseOver: function( event ) {
-		event.target.focus();
 	}
-} );
+
+    _onMouseOver = (event) => {
+		event.target.focus();
+	};
+}
 
 module.exports = MenuItem;

--- a/_inc/client/components/popover/menu-item.jsx
+++ b/_inc/client/components/popover/menu-item.jsx
@@ -6,13 +6,13 @@ const React = require( 'react' ),
 	classnames = require( 'classnames' );
 
 class MenuItem extends React.Component {
-    static defaultProps = {
-        isVisible: false,
-        className: '',
-        focusOnHover: true
-    };
+	static defaultProps = {
+		isVisible: false,
+		className: '',
+		focusOnHover: true
+	};
 
-    render() {
+	render() {
 		const onMouseOver = this.props.focusOnHover ? this._onMouseOver : null;
 		return (
 			<button className={ classnames( 'dops-popover__menu-item', this.props.className ) }
@@ -27,7 +27,7 @@ class MenuItem extends React.Component {
 		);
 	}
 
-    _onMouseOver = (event) => {
+	_onMouseOver = ( event ) => {
 		event.target.focus();
 	};
 }

--- a/_inc/client/components/popover/menu.jsx
+++ b/_inc/client/components/popover/menu.jsx
@@ -10,26 +10,24 @@ const ReactDom = require( 'react-dom' ),
 */
 const Popover = require( 'components/popover' );
 
-const PopoverMenu = React.createClass( {
-	propTypes: {
+class PopoverMenu extends React.Component {
+    static propTypes = {
 		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		position: PropTypes.string,
 		className: PropTypes.string
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			position: 'top'
-		};
-	},
+    static defaultProps = {
+        position: 'top'
+    };
 
-	componentWillUnmount: function() {
+    componentWillUnmount() {
 		// Make sure we don't hold on to reference to the DOM reference
 		this._previouslyFocusedElement = null;
-	},
+	}
 
-	render: function() {
+    render() {
 		const children = React.Children.map( this.props.children, this._setPropsOnChild, this );
 
 		return (
@@ -45,9 +43,9 @@ const PopoverMenu = React.createClass( {
 				</div>
 			</Popover>
 		);
-	},
+	}
 
-	_setPropsOnChild: function( child ) {
+    _setPropsOnChild = (child) => {
 		if ( child == null ) {
 			return child;
 		}
@@ -62,9 +60,9 @@ const PopoverMenu = React.createClass( {
 		return React.cloneElement( child, {
 			onClick: onClick
 		} );
-	},
+	};
 
-	_onShow: function() {
+    _onShow = () => {
 		const elementToFocus = ReactDom.findDOMNode( this.refs.menu );
 
 		this._previouslyFocusedElement = document.activeElement;
@@ -72,19 +70,19 @@ const PopoverMenu = React.createClass( {
 		if ( elementToFocus ) {
 			elementToFocus.focus();
 		}
-	},
+	};
 
-	_isInvalidTarget: function( target ) {
+    _isInvalidTarget = (target) => {
 		return target.tagName === 'HR';
-	},
+	};
 
-	/*
+    /*
 	 * Warning:
 	 *
 	 * This doesn't cover crazy things like a separator at the very top or
 	 * bottom.
 	 */
-	_getClosestSibling: function( target, isDownwardMotion = true ) {
+    _getClosestSibling = (target, isDownwardMotion = true) => {
 		const menu = ReactDom.findDOMNode( this.refs.menu );
 
 		let first = menu.firstChild,
@@ -106,9 +104,9 @@ const PopoverMenu = React.createClass( {
 		return this._isInvalidTarget( sibling )
 			? this._getClosestSibling( sibling, isDownwardMotion )
 			: sibling;
-	},
+	};
 
-	_onKeyDown: function( event ) {
+    _onKeyDown = (event) => {
 		const target = event.target;
 		let handled = false,
 			elementToFocus;
@@ -137,9 +135,9 @@ const PopoverMenu = React.createClass( {
 		if ( handled ) {
 			event.preventDefault();
 		}
-	},
+	};
 
-	_onClose: function( action ) {
+    _onClose = (action) => {
 		if ( this._previouslyFocusedElement ) {
 			this._previouslyFocusedElement.focus();
 			this._previouslyFocusedElement = null;
@@ -148,7 +146,7 @@ const PopoverMenu = React.createClass( {
 		if ( this.props.onClose ) {
 			this.props.onClose( action );
 		}
-	}
-} );
+	};
+}
 
 module.exports = PopoverMenu;

--- a/_inc/client/components/popover/menu.jsx
+++ b/_inc/client/components/popover/menu.jsx
@@ -76,7 +76,7 @@ class PopoverMenu extends React.Component {
 		return target.tagName === 'HR';
 	};
 
-    /*
+	/*
 	 * Warning:
 	 *
 	 * This doesn't cover crazy things like a separator at the very top or

--- a/_inc/client/components/popover/menu.jsx
+++ b/_inc/client/components/popover/menu.jsx
@@ -11,23 +11,23 @@ const ReactDom = require( 'react-dom' ),
 const Popover = require( 'components/popover' );
 
 class PopoverMenu extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		position: PropTypes.string,
 		className: PropTypes.string
 	};
 
-    static defaultProps = {
-        position: 'top'
-    };
+	static defaultProps = {
+		position: 'top'
+	};
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		// Make sure we don't hold on to reference to the DOM reference
 		this._previouslyFocusedElement = null;
 	}
 
-    render() {
+	render() {
 		const children = React.Children.map( this.props.children, this._setPropsOnChild, this );
 
 		return (
@@ -45,7 +45,7 @@ class PopoverMenu extends React.Component {
 		);
 	}
 
-    _setPropsOnChild = (child) => {
+	_setPropsOnChild = ( child ) => {
 		if ( child == null ) {
 			return child;
 		}
@@ -62,7 +62,7 @@ class PopoverMenu extends React.Component {
 		} );
 	};
 
-    _onShow = () => {
+	_onShow = () => {
 		const elementToFocus = ReactDom.findDOMNode( this.refs.menu );
 
 		this._previouslyFocusedElement = document.activeElement;
@@ -72,7 +72,7 @@ class PopoverMenu extends React.Component {
 		}
 	};
 
-    _isInvalidTarget = (target) => {
+	_isInvalidTarget = ( target ) => {
 		return target.tagName === 'HR';
 	};
 
@@ -82,7 +82,7 @@ class PopoverMenu extends React.Component {
 	 * This doesn't cover crazy things like a separator at the very top or
 	 * bottom.
 	 */
-    _getClosestSibling = (target, isDownwardMotion = true) => {
+	_getClosestSibling = ( target, isDownwardMotion = true ) => {
 		const menu = ReactDom.findDOMNode( this.refs.menu );
 
 		let first = menu.firstChild,
@@ -106,7 +106,7 @@ class PopoverMenu extends React.Component {
 			: sibling;
 	};
 
-    _onKeyDown = (event) => {
+	_onKeyDown = ( event ) => {
 		const target = event.target;
 		let handled = false,
 			elementToFocus;
@@ -137,7 +137,7 @@ class PopoverMenu extends React.Component {
 		}
 	};
 
-    _onClose = (action) => {
+	_onClose = ( action ) => {
 		if ( this._previouslyFocusedElement ) {
 			this._previouslyFocusedElement.focus();
 			this._previouslyFocusedElement = null;

--- a/_inc/client/components/root-child/index.jsx
+++ b/_inc/client/components/root-child/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-export default class extends React.Component {
+export default class RootChild extends React.Component {
 	static displayName = 'RootChild';
 
 	static propTypes = {

--- a/_inc/client/components/root-child/index.jsx
+++ b/_inc/client/components/root-child/index.jsx
@@ -8,28 +8,28 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-export default React.createClass( {
-	displayName: 'RootChild',
+export default class extends React.Component {
+    static displayName = 'RootChild';
 
-	propTypes: {
+    static propTypes = {
 		children: PropTypes.node
-	},
+	};
 
-	contextTypes: {
+    static contextTypes = {
 		store: PropTypes.object
-	},
+	};
 
-	componentDidMount: function() {
+    componentDidMount() {
 		this.container = document.createElement( 'div' );
 		document.body.appendChild( this.container );
 		this.renderChildren();
-	},
+	}
 
-	componentDidUpdate: function() {
+    componentDidUpdate() {
 		this.renderChildren();
-	},
+	}
 
-	componentWillUnmount: function() {
+    componentWillUnmount() {
 		if ( ! this.container ) {
 			return;
 		}
@@ -37,9 +37,9 @@ export default React.createClass( {
 		ReactDom.unmountComponentAtNode( this.container );
 		document.body.removeChild( this.container );
 		delete this.container;
-	},
+	}
 
-	renderChildren: function() {
+    renderChildren = () => {
 		let content;
 
 		if ( this.props &&
@@ -61,9 +61,9 @@ export default React.createClass( {
 		}
 
 		ReactDom.render( content, this.container );
-	},
+	};
 
-	render: function() {
+    render() {
 		return null;
 	}
-} );
+}

--- a/_inc/client/components/root-child/index.jsx
+++ b/_inc/client/components/root-child/index.jsx
@@ -9,27 +9,27 @@ import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
 export default class extends React.Component {
-    static displayName = 'RootChild';
+	static displayName = 'RootChild';
 
-    static propTypes = {
+	static propTypes = {
 		children: PropTypes.node
 	};
 
-    static contextTypes = {
+	static contextTypes = {
 		store: PropTypes.object
 	};
 
-    componentDidMount() {
+	componentDidMount() {
 		this.container = document.createElement( 'div' );
 		document.body.appendChild( this.container );
 		this.renderChildren();
 	}
 
-    componentDidUpdate() {
+	componentDidUpdate() {
 		this.renderChildren();
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		if ( ! this.container ) {
 			return;
 		}
@@ -39,7 +39,7 @@ export default class extends React.Component {
 		delete this.container;
 	}
 
-    renderChildren = () => {
+	renderChildren = () => {
 		let content;
 
 		if ( this.props &&
@@ -63,7 +63,7 @@ export default class extends React.Component {
 		ReactDom.render( content, this.container );
 	};
 
-    render() {
+	render() {
 		return null;
 	}
 }

--- a/_inc/client/components/search/docs/example.jsx
+++ b/_inc/client/components/search/docs/example.jsx
@@ -4,6 +4,8 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
@@ -15,7 +17,7 @@ const Search = require( 'components/search' ),
  */
 const noop = () => {};
 
-const SearchDemo = React.createClass( {
+const SearchDemo = createReactClass({
 	displayName: 'Search',
 
 	mixins: [ PureRenderMixin ],
@@ -38,6 +40,6 @@ const SearchDemo = React.createClass( {
 			</div>
 		);
 	}
-} );
+});
 
 module.exports = SearchDemo;

--- a/_inc/client/components/search/docs/example.jsx
+++ b/_inc/client/components/search/docs/example.jsx
@@ -4,7 +4,7 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ const Search = require( 'components/search' ),
  */
 const noop = () => {};
 
-const SearchDemo = createReactClass({
+const SearchDemo = createReactClass( {
 	displayName: 'Search',
 
 	mixins: [ PureRenderMixin ],
@@ -40,6 +40,6 @@ const SearchDemo = createReactClass({
 			</div>
 		);
 	}
-});
+} );
 
 module.exports = SearchDemo;

--- a/_inc/client/components/search/index.jsx
+++ b/_inc/client/components/search/index.jsx
@@ -34,10 +34,10 @@ function keyListener( methodToCall, event ) {
 }
 
 class Search extends React.Component {
-    static displayName = 'Search';
-    static instances = 0;
+	static displayName = 'Search';
+	static instances = 0;
 
-    static propTypes = {
+	static propTypes = {
 		additionalClasses: PropTypes.string,
 		initialValue: PropTypes.string,
 		placeholder: PropTypes.string,
@@ -64,35 +64,35 @@ class Search extends React.Component {
 		hideClose: PropTypes.bool
 	};
 
-    static defaultProps = {
-        pinned: false,
-        delaySearch: false,
-        delayTimeout: SEARCH_DEBOUNCE_MS,
-        autoFocus: false,
-        disabled: false,
-        onSearchChange: noop,
-        onSearchOpen: noop,
-        onSearchClose: noop,
-        onKeyDown: noop,
-        onClick: noop,
+	static defaultProps = {
+		pinned: false,
+		delaySearch: false,
+		delayTimeout: SEARCH_DEBOUNCE_MS,
+		autoFocus: false,
+		disabled: false,
+		onSearchChange: noop,
+		onSearchOpen: noop,
+		onSearchClose: noop,
+		onKeyDown: noop,
+		onClick: noop,
         //undefined value for overlayStyling is an optimization that will
         //disable overlay scrolling calculation when no overlay is provided.
-        overlayStyling: undefined,
-        disableAutocorrect: false,
-        searching: false,
-        isOpen: false,
-        dir: undefined,
-        fitsContainer: false,
-        hideClose: false
-    };
+		overlayStyling: undefined,
+		disableAutocorrect: false,
+		searching: false,
+		isOpen: false,
+		dir: undefined,
+		fitsContainer: false,
+		hideClose: false
+	};
 
-    state = {
-        keyword: this.props.initialValue || '',
-        isOpen: !! this.props.isOpen,
-        hasFocus: false
-    };
+	state = {
+		keyword: this.props.initialValue || '',
+		isOpen: !! this.props.isOpen,
+		hasFocus: false
+	};
 
-    componentWillMount() {
+	componentWillMount() {
 		this.setState( {
 			instanceId: ++Search.instances
 		} );
@@ -101,7 +101,7 @@ class Search extends React.Component {
 		this.openListener = keyListener.bind( this, 'openSearch' );
 	}
 
-    componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.onSearch !== this.props.onSearch ||
 			nextProps.delaySearch !== this.props.delaySearch
@@ -121,7 +121,7 @@ class Search extends React.Component {
 		}
 	}
 
-    componentDidUpdate(prevProps, prevState) {
+	componentDidUpdate( prevProps, prevState ) {
 		this.scrollOverlay();
 		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
@@ -151,7 +151,7 @@ class Search extends React.Component {
 		this.props.onSearchChange( this.state.keyword );
 	}
 
-    componentDidMount() {
+	componentDidMount() {
 		this.onSearch = this.props.delaySearch
 			? debounce( this.props.onSearch, this.props.delayTimeout )
 			: this.props.onSearch;
@@ -162,7 +162,7 @@ class Search extends React.Component {
 		}
 	}
 
-    scrollOverlay = () => {
+	scrollOverlay = () => {
 		this.refs.overlay && window.requestAnimationFrame( () => {
 			if ( this.refs.overlay && this.refs.searchInput ) {
 				this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
@@ -173,7 +173,7 @@ class Search extends React.Component {
     //This is fix for IE11. Does not work on Edge.
     //On IE11 scrollLeft value for input is always 0.
     //We are calculating it manually using TextRange object.
-    getScrollLeft = (inputElement) => {
+	getScrollLeft = ( inputElement ) => {
 		//TextRange is IE11 specific so this checks if we are not on IE11.
 		if ( ! inputElement.createTextRange ) {
 			return inputElement.scrollLeft;
@@ -187,25 +187,25 @@ class Search extends React.Component {
 		return scrollLeft;
 	};
 
-    focus = () => {
+	focus = () => {
 		// if we call focus before the element has been entirely synced up with the DOM, we stand a decent chance of
 		// causing the browser to scroll somewhere odd. Instead, defer the focus until a future turn of the event loop.
 		setTimeout( () => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(), 0 );
 	};
 
-    blur = () => {
+	blur = () => {
 		ReactDom.findDOMNode( this.refs.searchInput ).blur();
 	};
 
-    getCurrentSearchValue = () => {
+	getCurrentSearchValue = () => {
 		return ReactDom.findDOMNode( this.refs.searchInput ).value;
 	};
 
-    clear = () => {
+	clear = () => {
 		this.setState( { keyword: '' } );
 	};
 
-    onBlur = (event) => {
+	onBlur = ( event ) => {
 		if ( this.props.onBlur ) {
 			this.props.onBlur( event );
 		}
@@ -213,13 +213,13 @@ class Search extends React.Component {
 		this.setState( { hasFocus: false } );
 	};
 
-    onChange = () => {
+	onChange = () => {
 		this.setState( {
 			keyword: this.getCurrentSearchValue()
 		} );
 	};
 
-    openSearch = (event) => {
+	openSearch = ( event ) => {
 		this.props.onClick();
 		event.preventDefault();
 		this.setState( {
@@ -230,7 +230,7 @@ class Search extends React.Component {
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
 	};
 
-    closeSearch = (event) => {
+	closeSearch = ( event ) => {
 		event.preventDefault();
 
 		if ( this.props.disabled ) {
@@ -256,7 +256,7 @@ class Search extends React.Component {
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
 	};
 
-    keyUp = (event) => {
+	keyUp = ( event ) => {
 		if ( event.key === 'Enter' && isMobile() ) {
 			//dismiss soft keyboards
 			this.blur();
@@ -272,7 +272,7 @@ class Search extends React.Component {
 		this.scrollOverlay();
 	};
 
-    keyDown = (event) => {
+	keyDown = ( event ) => {
 		this.scrollOverlay();
 		if ( event.key === 'Escape' && event.target.value === '' ) {
 			this.closeSearch( event );
@@ -282,7 +282,7 @@ class Search extends React.Component {
 
     // Puts the cursor at end of the text when starting
     // with `initialValue` set.
-    onFocus = () => {
+	onFocus = () => {
 		const input = ReactDom.findDOMNode( this.refs.searchInput ),
 			setValue = input.value;
 
@@ -296,7 +296,7 @@ class Search extends React.Component {
 		this.props.onSearchOpen( );
 	};
 
-    render() {
+	render() {
 		const searchValue = this.state.keyword;
 		const placeholder = this.props.placeholder || 'Search…';
 
@@ -368,7 +368,7 @@ class Search extends React.Component {
 		);
 	}
 
-    renderStylingDiv = () => {
+	renderStylingDiv = () => {
 		return (
 			<div className="dops-search__text-overlay" ref="overlay">
 				{ this.props.overlayStyling( this.state.keyword ) }
@@ -376,7 +376,7 @@ class Search extends React.Component {
 		);
 	};
 
-    closeButton = () => {
+	closeButton = () => {
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div

--- a/_inc/client/components/search/index.jsx
+++ b/_inc/client/components/search/index.jsx
@@ -33,15 +33,11 @@ function keyListener( methodToCall, event ) {
 	}
 }
 
-const Search = React.createClass( {
+class Search extends React.Component {
+    static displayName = 'Search';
+    static instances = 0;
 
-	displayName: 'Search',
-
-	statics: {
-		instances: 0
-	},
-
-	propTypes: {
+    static propTypes = {
 		additionalClasses: PropTypes.string,
 		initialValue: PropTypes.string,
 		placeholder: PropTypes.string,
@@ -66,50 +62,46 @@ const Search = React.createClass( {
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
 		hideClose: PropTypes.bool
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			keyword: this.props.initialValue || '',
-			isOpen: !! this.props.isOpen,
-			hasFocus: false
-		};
-	},
+    static defaultProps = {
+        pinned: false,
+        delaySearch: false,
+        delayTimeout: SEARCH_DEBOUNCE_MS,
+        autoFocus: false,
+        disabled: false,
+        onSearchChange: noop,
+        onSearchOpen: noop,
+        onSearchClose: noop,
+        onKeyDown: noop,
+        onClick: noop,
+        //undefined value for overlayStyling is an optimization that will
+        //disable overlay scrolling calculation when no overlay is provided.
+        overlayStyling: undefined,
+        disableAutocorrect: false,
+        searching: false,
+        isOpen: false,
+        dir: undefined,
+        fitsContainer: false,
+        hideClose: false
+    };
 
-	getDefaultProps: function() {
-		return {
-			pinned: false,
-			delaySearch: false,
-			delayTimeout: SEARCH_DEBOUNCE_MS,
-			autoFocus: false,
-			disabled: false,
-			onSearchChange: noop,
-			onSearchOpen: noop,
-			onSearchClose: noop,
-			onKeyDown: noop,
-			onClick: noop,
-			//undefined value for overlayStyling is an optimization that will
-			//disable overlay scrolling calculation when no overlay is provided.
-			overlayStyling: undefined,
-			disableAutocorrect: false,
-			searching: false,
-			isOpen: false,
-			dir: undefined,
-			fitsContainer: false,
-			hideClose: false
-		};
-	},
+    state = {
+        keyword: this.props.initialValue || '',
+        isOpen: !! this.props.isOpen,
+        hasFocus: false
+    };
 
-	componentWillMount: function() {
+    componentWillMount() {
 		this.setState( {
 			instanceId: ++Search.instances
 		} );
 
 		this.closeListener = keyListener.bind( this, 'closeSearch' );
 		this.openListener = keyListener.bind( this, 'openSearch' );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps(nextProps) {
 		if (
 			nextProps.onSearch !== this.props.onSearch ||
 			nextProps.delaySearch !== this.props.delaySearch
@@ -127,9 +119,9 @@ const Search = React.createClass( {
 				( this.state.keyword === this.props.initialValue || this.state.keyword === '' ) ) {
 			this.setState( { keyword: nextProps.initialValue || '' } );
 		}
-	},
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
+    componentDidUpdate(prevProps, prevState) {
 		this.scrollOverlay();
 		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
@@ -157,9 +149,9 @@ const Search = React.createClass( {
 			this.props.onSearch( this.state.keyword );
 		}
 		this.props.onSearchChange( this.state.keyword );
-	},
+	}
 
-	componentDidMount: function() {
+    componentDidMount() {
 		this.onSearch = this.props.delaySearch
 			? debounce( this.props.onSearch, this.props.delayTimeout )
 			: this.props.onSearch;
@@ -168,20 +160,20 @@ const Search = React.createClass( {
 			// this hack makes autoFocus work correctly in Dropdown
 			setTimeout( () => this.focus(), 0 );
 		}
-	},
+	}
 
-	scrollOverlay: function() {
+    scrollOverlay = () => {
 		this.refs.overlay && window.requestAnimationFrame( () => {
 			if ( this.refs.overlay && this.refs.searchInput ) {
 				this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
 			}
 		} );
-	},
+	};
 
-	//This is fix for IE11. Does not work on Edge.
-	//On IE11 scrollLeft value for input is always 0.
-	//We are calculating it manually using TextRange object.
-	getScrollLeft: function( inputElement ) {
+    //This is fix for IE11. Does not work on Edge.
+    //On IE11 scrollLeft value for input is always 0.
+    //We are calculating it manually using TextRange object.
+    getScrollLeft = (inputElement) => {
 		//TextRange is IE11 specific so this checks if we are not on IE11.
 		if ( ! inputElement.createTextRange ) {
 			return inputElement.scrollLeft;
@@ -193,41 +185,41 @@ const Search = React.createClass( {
 		const rangeRect = range.getBoundingClientRect();
 		const scrollLeft = inputElement.getBoundingClientRect().left + inputElement.clientLeft + paddingLeft - rangeRect.left;
 		return scrollLeft;
-	},
+	};
 
-	focus: function() {
+    focus = () => {
 		// if we call focus before the element has been entirely synced up with the DOM, we stand a decent chance of
 		// causing the browser to scroll somewhere odd. Instead, defer the focus until a future turn of the event loop.
 		setTimeout( () => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(), 0 );
-	},
+	};
 
-	blur: function() {
+    blur = () => {
 		ReactDom.findDOMNode( this.refs.searchInput ).blur();
-	},
+	};
 
-	getCurrentSearchValue: function() {
+    getCurrentSearchValue = () => {
 		return ReactDom.findDOMNode( this.refs.searchInput ).value;
-	},
+	};
 
-	clear: function() {
+    clear = () => {
 		this.setState( { keyword: '' } );
-	},
+	};
 
-	onBlur: function( event ) {
+    onBlur = (event) => {
 		if ( this.props.onBlur ) {
 			this.props.onBlur( event );
 		}
 
 		this.setState( { hasFocus: false } );
-	},
+	};
 
-	onChange: function() {
+    onChange = () => {
 		this.setState( {
 			keyword: this.getCurrentSearchValue()
 		} );
-	},
+	};
 
-	openSearch: function( event ) {
+    openSearch = (event) => {
 		this.props.onClick();
 		event.preventDefault();
 		this.setState( {
@@ -236,9 +228,9 @@ const Search = React.createClass( {
 		} );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
-	},
+	};
 
-	closeSearch: function( event ) {
+    closeSearch = (event) => {
 		event.preventDefault();
 
 		if ( this.props.disabled ) {
@@ -262,9 +254,9 @@ const Search = React.createClass( {
 		this.props.onSearchClose( event );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
-	},
+	};
 
-	keyUp: function( event ) {
+    keyUp = (event) => {
 		if ( event.key === 'Enter' && isMobile() ) {
 			//dismiss soft keyboards
 			this.blur();
@@ -278,19 +270,19 @@ const Search = React.createClass( {
 			this.closeSearch( event );
 		}
 		this.scrollOverlay();
-	},
+	};
 
-	keyDown: function( event ) {
+    keyDown = (event) => {
 		this.scrollOverlay();
 		if ( event.key === 'Escape' && event.target.value === '' ) {
 			this.closeSearch( event );
 		}
 		this.props.onKeyDown( event );
-	},
+	};
 
-	// Puts the cursor at end of the text when starting
-	// with `initialValue` set.
-	onFocus: function() {
+    // Puts the cursor at end of the text when starting
+    // with `initialValue` set.
+    onFocus = () => {
 		const input = ReactDom.findDOMNode( this.refs.searchInput ),
 			setValue = input.value;
 
@@ -302,9 +294,9 @@ const Search = React.createClass( {
 
 		this.setState( { hasFocus: true } );
 		this.props.onSearchOpen( );
-	},
+	};
 
-	render: function() {
+    render() {
 		const searchValue = this.state.keyword;
 		const placeholder = this.props.placeholder || 'Search…';
 
@@ -374,17 +366,17 @@ const Search = React.createClass( {
 				{ this.closeButton() }
 			</div>
 		);
-	},
+	}
 
-	renderStylingDiv: function() {
+    renderStylingDiv = () => {
 		return (
 			<div className="dops-search__text-overlay" ref="overlay">
 				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);
-	},
+	};
 
-	closeButton: function() {
+    closeButton = () => {
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
@@ -401,7 +393,7 @@ const Search = React.createClass( {
 		}
 
 		return null;
-	}
-} );
+	};
+}
 
 module.exports = Search;

--- a/_inc/client/components/search/index.jsx
+++ b/_inc/client/components/search/index.jsx
@@ -75,8 +75,8 @@ class Search extends React.Component {
 		onSearchClose: noop,
 		onKeyDown: noop,
 		onClick: noop,
-        //undefined value for overlayStyling is an optimization that will
-        //disable overlay scrolling calculation when no overlay is provided.
+		//undefined value for overlayStyling is an optimization that will
+		//disable overlay scrolling calculation when no overlay is provided.
 		overlayStyling: undefined,
 		disableAutocorrect: false,
 		searching: false,
@@ -170,9 +170,9 @@ class Search extends React.Component {
 		} );
 	};
 
-    //This is fix for IE11. Does not work on Edge.
-    //On IE11 scrollLeft value for input is always 0.
-    //We are calculating it manually using TextRange object.
+	//This is fix for IE11. Does not work on Edge.
+	//On IE11 scrollLeft value for input is always 0.
+	//We are calculating it manually using TextRange object.
 	getScrollLeft = ( inputElement ) => {
 		//TextRange is IE11 specific so this checks if we are not on IE11.
 		if ( ! inputElement.createTextRange ) {
@@ -280,8 +280,8 @@ class Search extends React.Component {
 		this.props.onKeyDown( event );
 	};
 
-    // Puts the cursor at end of the text when starting
-    // with `initialValue` set.
+	// Puts the cursor at end of the text when starting
+	// with `initialValue` set.
 	onFocus = () => {
 		const input = ReactDom.findDOMNode( this.refs.searchInput ),
 			setValue = input.value;

--- a/_inc/client/components/search/search-collection.jsx
+++ b/_inc/client/components/search/search-collection.jsx
@@ -40,7 +40,7 @@ class FilterSummary extends React.Component {
 	}
 }
 
-export default class extends React.Component {
+export default class Collection extends React.Component {
 	static displayName = 'Collection';
 
 	shouldWeHide = ( example ) => {

--- a/_inc/client/components/search/search-collection.jsx
+++ b/_inc/client/components/search/search-collection.jsx
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class Hider extends React.Component {
-    static displayName = 'Hider';
+	static displayName = 'Hider';
 
-    static propTypes = {
+	static propTypes = {
 		hide: PropTypes.bool,
 	};
 
-    render() {
+	render() {
 		return (
 			<div
 				className={ 'design-assets__group' }
@@ -24,15 +24,15 @@ class Hider extends React.Component {
 }
 
 class FilterSummary extends React.Component {
-    static defaultProps = {
-        noResultsText: 'No Results Found'
-    };
+	static defaultProps = {
+		noResultsText: 'No Results Found'
+	};
 
-    static propTypes = {
+	static propTypes = {
 		noResultsText: PropTypes.string
 	};
 
-    render() {
+	render() {
 		if ( this.props.items.length === 0 ) {
 			return ( <p>{ this.props.noResultsText }</p> );
 		}
@@ -41,9 +41,9 @@ class FilterSummary extends React.Component {
 }
 
 export default class extends React.Component {
-    static displayName = 'Collection';
+	static displayName = 'Collection';
 
-    shouldWeHide = (example) => {
+	shouldWeHide = ( example ) => {
 		const filter = this.props.filter || '';
 		let searchString = example.props.searchTerms;
 
@@ -58,13 +58,13 @@ export default class extends React.Component {
 		return ! ( ! filter || searchString.toLowerCase().indexOf( filter ) > -1 );
 	};
 
-    visibleExamples = (examples) => {
+	visibleExamples = ( examples ) => {
 		return examples.filter( ( child ) => {
 			return ! child.props.hide;
 		} );
 	};
 
-    render() {
+	render() {
 		const examples = React.Children.map( this.props.children, ( example ) => {
 			return (
 				<Hider hide={ this.shouldWeHide( example ) } key={ 'example-' + example.type.displayName }>

--- a/_inc/client/components/search/search-collection.jsx
+++ b/_inc/client/components/search/search-collection.jsx
@@ -4,14 +4,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const Hider = React.createClass( {
-	displayName: 'Hider',
+class Hider extends React.Component {
+    static displayName = 'Hider';
 
-	propTypes: {
+    static propTypes = {
 		hide: PropTypes.bool,
-	},
+	};
 
-	render() {
+    render() {
 		return (
 			<div
 				className={ 'design-assets__group' }
@@ -21,31 +21,29 @@ const Hider = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-const FilterSummary = React.createClass( {
-	getDefaultProps: function() {
-		return {
-			noResultsText: 'No Results Found'
-		};
-	},
+class FilterSummary extends React.Component {
+    static defaultProps = {
+        noResultsText: 'No Results Found'
+    };
 
-	propTypes: {
+    static propTypes = {
 		noResultsText: PropTypes.string
-	},
+	};
 
-	render() {
+    render() {
 		if ( this.props.items.length === 0 ) {
 			return ( <p>{ this.props.noResultsText }</p> );
 		}
 		return null;
 	}
-} );
+}
 
-export default React.createClass( {
-	displayName: 'Collection',
+export default class extends React.Component {
+    static displayName = 'Collection';
 
-	shouldWeHide: function( example ) {
+    shouldWeHide = (example) => {
 		const filter = this.props.filter || '';
 		let searchString = example.props.searchTerms;
 
@@ -58,15 +56,15 @@ export default React.createClass( {
 		}
 
 		return ! ( ! filter || searchString.toLowerCase().indexOf( filter ) > -1 );
-	},
+	};
 
-	visibleExamples: function( examples ) {
+    visibleExamples = (examples) => {
 		return examples.filter( ( child ) => {
 			return ! child.props.hide;
 		} );
-	},
+	};
 
-	render: function() {
+    render() {
 		const examples = React.Children.map( this.props.children, ( example ) => {
 			return (
 				<Hider hide={ this.shouldWeHide( example ) } key={ 'example-' + example.type.displayName }>
@@ -93,4 +91,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -13,9 +13,9 @@ import Card from 'components/card';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'SectionHeader';
+	static displayName = 'SectionHeader';
 
-    static propTypes = {
+	static propTypes = {
 		label: PropTypes.string,
 		cardBadge: PropTypes.oneOfType( [
 			PropTypes.string,
@@ -24,12 +24,12 @@ export default class extends React.Component {
 		] )
 	};
 
-    static defaultProps = {
-        label: '',
-        cardBadge: ''
-    };
+	static defaultProps = {
+		label: '',
+		cardBadge: ''
+	};
 
-    render() {
+	render() {
 		const classes = classNames(
 			this.props.className,
 			'dops-section-header'

--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -12,26 +12,24 @@ import Card from 'components/card';
 
 require( './style.scss' );
 
-export default React.createClass( {
-	displayName: 'SectionHeader',
+export default class extends React.Component {
+    static displayName = 'SectionHeader';
 
-	propTypes: {
+    static propTypes = {
 		label: PropTypes.string,
 		cardBadge: PropTypes.oneOfType( [
 			PropTypes.string,
 			PropTypes.element,
 			PropTypes.object
 		] )
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			label: '',
-			cardBadge: ''
-		};
-	},
+    static defaultProps = {
+        label: '',
+        cardBadge: ''
+    };
 
-	render() {
+    render() {
 		const classes = classNames(
 			this.props.className,
 			'dops-section-header'
@@ -53,4 +51,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}

--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -12,7 +12,7 @@ import Card from 'components/card';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class SectionHeader extends React.Component {
 	static displayName = 'SectionHeader';
 
 	static propTypes = {

--- a/_inc/client/components/section-nav/docs/example.jsx
+++ b/_inc/client/components/section-nav/docs/example.jsx
@@ -5,7 +5,7 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	forEach = require( 'lodash/forEach' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ const SectionNav = require( 'components/section-nav' ),
 /**
  * Main
  */
-const SectionNavigation = createReactClass({
+const SectionNavigation = createReactClass( {
 	displayName: 'SectionNav',
 
 	mixins: [ PureRenderMixin ],
@@ -187,6 +187,6 @@ const SectionNavigation = createReactClass({
 	},
 
 	demoSearch: function() {}
-});
+} );
 
 module.exports = SectionNavigation;

--- a/_inc/client/components/section-nav/docs/example.jsx
+++ b/_inc/client/components/section-nav/docs/example.jsx
@@ -5,6 +5,8 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	forEach = require( 'lodash/forEach' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
@@ -17,7 +19,7 @@ const SectionNav = require( 'components/section-nav' ),
 /**
  * Main
  */
-const SectionNavigation = React.createClass( {
+const SectionNavigation = createReactClass({
 	displayName: 'SectionNav',
 
 	mixins: [ PureRenderMixin ],
@@ -185,6 +187,6 @@ const SectionNavigation = React.createClass( {
 	},
 
 	demoSearch: function() {}
-} );
+});
 
 module.exports = SectionNavigation;

--- a/_inc/client/components/section-nav/index.jsx
+++ b/_inc/client/components/section-nav/index.jsx
@@ -8,7 +8,7 @@ const React = require( 'react' ),
 	isEqual = require( 'lodash/isEqual' ),
 	classNames = require( 'classnames' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal Dependencies
@@ -22,10 +22,10 @@ require( './style.scss' );
 /**
  * Main
  */
-const SectionNav = createReactClass({
-    displayName: 'SectionNav',
+const SectionNav = createReactClass( {
+	displayName: 'SectionNav',
 
-    propTypes: {
+	propTypes: {
 		children: PropTypes.node,
 		selectedText: PropTypes.node,
 		selectedCount: PropTypes.number,
@@ -33,23 +33,23 @@ const SectionNav = createReactClass({
 		onMobileNavPanelOpen: PropTypes.func
 	},
 
-    getInitialState: function() {
+	getInitialState: function() {
 		return {
 			mobileOpen: false
 		};
 	},
 
-    getDefaultProps: function() {
+	getDefaultProps: function() {
 		return {
 			onMobileNavPanelOpen: () => {}
 		};
 	},
 
-    componentWillMount: function() {
+	componentWillMount: function() {
 		this.checkForSiblingControls( this.props.children );
 	},
 
-    componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps: function( nextProps ) {
 		if ( isEqual( this.props, nextProps ) ) {
 			return;
 		}
@@ -61,7 +61,7 @@ const SectionNav = createReactClass({
 		}
 	},
 
-    render: function() {
+	render: function() {
 		const children = this.getChildren();
 		let className;
 
@@ -104,7 +104,7 @@ const SectionNav = createReactClass({
 		);
 	},
 
-    getChildren: function() {
+	getChildren: function() {
 		return React.Children.map( this.props.children, function( child ) {
 			const extraProps = {
 				hasSiblingControls: this.hasSiblingControls,
@@ -141,7 +141,7 @@ const SectionNav = createReactClass({
 		}.bind( this ) );
 	},
 
-    closeMobilePanel: function() {
+	closeMobilePanel: function() {
 		if ( window.innerWidth < 480 && this.state.mobileOpen ) {
 			this.setState( {
 				mobileOpen: false
@@ -149,7 +149,7 @@ const SectionNav = createReactClass({
 		}
 	},
 
-    toggleMobileOpenState: function() {
+	toggleMobileOpenState: function() {
 		const mobileOpen = ! this.state.mobileOpen;
 
 		this.setState( {
@@ -161,14 +161,14 @@ const SectionNav = createReactClass({
 		}
 	},
 
-    generateOnSearch: function( existingOnSearch ) {
+	generateOnSearch: function( existingOnSearch ) {
 		return function() {
 			existingOnSearch.apply( this, arguments );
 			this.closeMobilePanel();
 		}.bind( this );
 	},
 
-    checkForSiblingControls: function( children ) {
+	checkForSiblingControls: function( children ) {
 		this.hasSiblingControls = false;
 
 		React.Children.forEach( children, function( child, index ) {
@@ -178,6 +178,6 @@ const SectionNav = createReactClass({
 			}
 		}.bind( this ) );
 	},
-});
+} );
 
 module.exports = SectionNav;

--- a/_inc/client/components/section-nav/index.jsx
+++ b/_inc/client/components/section-nav/index.jsx
@@ -8,6 +8,8 @@ const React = require( 'react' ),
 	isEqual = require( 'lodash/isEqual' ),
 	classNames = require( 'classnames' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal Dependencies
  */
@@ -20,9 +22,10 @@ require( './style.scss' );
 /**
  * Main
  */
-const SectionNav = React.createClass( {
+const SectionNav = createReactClass({
+    displayName: 'SectionNav',
 
-	propTypes: {
+    propTypes: {
 		children: PropTypes.node,
 		selectedText: PropTypes.node,
 		selectedCount: PropTypes.number,
@@ -30,23 +33,23 @@ const SectionNav = React.createClass( {
 		onMobileNavPanelOpen: PropTypes.func
 	},
 
-	getInitialState: function() {
+    getInitialState: function() {
 		return {
 			mobileOpen: false
 		};
 	},
 
-	getDefaultProps: function() {
+    getDefaultProps: function() {
 		return {
 			onMobileNavPanelOpen: () => {}
 		};
 	},
 
-	componentWillMount: function() {
+    componentWillMount: function() {
 		this.checkForSiblingControls( this.props.children );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps: function( nextProps ) {
 		if ( isEqual( this.props, nextProps ) ) {
 			return;
 		}
@@ -58,7 +61,7 @@ const SectionNav = React.createClass( {
 		}
 	},
 
-	render: function() {
+    render: function() {
 		const children = this.getChildren();
 		let className;
 
@@ -101,7 +104,7 @@ const SectionNav = React.createClass( {
 		);
 	},
 
-	getChildren: function() {
+    getChildren: function() {
 		return React.Children.map( this.props.children, function( child ) {
 			const extraProps = {
 				hasSiblingControls: this.hasSiblingControls,
@@ -138,7 +141,7 @@ const SectionNav = React.createClass( {
 		}.bind( this ) );
 	},
 
-	closeMobilePanel: function() {
+    closeMobilePanel: function() {
 		if ( window.innerWidth < 480 && this.state.mobileOpen ) {
 			this.setState( {
 				mobileOpen: false
@@ -146,7 +149,7 @@ const SectionNav = React.createClass( {
 		}
 	},
 
-	toggleMobileOpenState: function() {
+    toggleMobileOpenState: function() {
 		const mobileOpen = ! this.state.mobileOpen;
 
 		this.setState( {
@@ -158,14 +161,14 @@ const SectionNav = React.createClass( {
 		}
 	},
 
-	generateOnSearch: function( existingOnSearch ) {
+    generateOnSearch: function( existingOnSearch ) {
 		return function() {
 			existingOnSearch.apply( this, arguments );
 			this.closeMobilePanel();
 		}.bind( this );
 	},
 
-	checkForSiblingControls: function( children ) {
+    checkForSiblingControls: function( children ) {
 		this.hasSiblingControls = false;
 
 		React.Children.forEach( children, function( child, index ) {
@@ -174,7 +177,7 @@ const SectionNav = React.createClass( {
 				this.hasSiblingControls = true;
 			}
 		}.bind( this ) );
-	}
-} );
+	},
+});
 
 module.exports = SectionNav;

--- a/_inc/client/components/section-nav/item.jsx
+++ b/_inc/client/components/section-nav/item.jsx
@@ -8,6 +8,8 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal Dependencies
  */
@@ -16,11 +18,11 @@ const Count = require( 'components/count' );
 /**
  * Main
  */
-const NavItem = React.createClass( {
+const NavItem = createReactClass({
+    displayName: 'NavItem',
+    mixins: [ PureRenderMixin ],
 
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+    propTypes: {
 		itemType: PropTypes.string,
 		path: PropTypes.string,
 		selected: PropTypes.bool,
@@ -31,7 +33,7 @@ const NavItem = React.createClass( {
 		count: PropTypes.number
 	},
 
-	render: function() {
+    render: function() {
 		const itemClassPrefix = this.props.itemType
 			? this.props.itemType
 			: 'tab';
@@ -72,7 +74,7 @@ const NavItem = React.createClass( {
 				</a>
 			</li>
 		);
-	}
-} );
+	},
+});
 
 module.exports = NavItem;

--- a/_inc/client/components/section-nav/item.jsx
+++ b/_inc/client/components/section-nav/item.jsx
@@ -8,7 +8,7 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal Dependencies
@@ -18,11 +18,11 @@ const Count = require( 'components/count' );
 /**
  * Main
  */
-const NavItem = createReactClass({
-    displayName: 'NavItem',
-    mixins: [ PureRenderMixin ],
+const NavItem = createReactClass( {
+	displayName: 'NavItem',
+	mixins: [ PureRenderMixin ],
 
-    propTypes: {
+	propTypes: {
 		itemType: PropTypes.string,
 		path: PropTypes.string,
 		selected: PropTypes.bool,
@@ -33,7 +33,7 @@ const NavItem = createReactClass({
 		count: PropTypes.number
 	},
 
-    render: function() {
+	render: function() {
 		const itemClassPrefix = this.props.itemType
 			? this.props.itemType
 			: 'tab';
@@ -75,6 +75,6 @@ const NavItem = createReactClass({
 			</li>
 		);
 	},
-});
+} );
 
 module.exports = NavItem;

--- a/_inc/client/components/section-nav/segmented.jsx
+++ b/_inc/client/components/section-nav/segmented.jsx
@@ -19,25 +19,22 @@ let _instance = 1;
 /**
  * Main
  */
-const NavSegmented = React.createClass( {
-
-	propTypes: {
+class NavSegmented extends React.Component {
+    static propTypes = {
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasSiblingControls: false
-		};
-	},
+    static defaultProps = {
+        hasSiblingControls: false
+    };
 
-	componentWillMount: function() {
+    componentWillMount() {
 		this.id = _instance;
 		_instance++;
-	},
+	}
 
-	render: function() {
+    render() {
 		const segmentedClassName = classNames( {
 			'dops-section-nav-group': true,
 			'dops-section-nav__segmented': true,
@@ -56,9 +53,9 @@ const NavSegmented = React.createClass( {
 				</SegmentedControl>
 			</div>
 		);
-	},
+	}
 
-	getControlItems: function() {
+    getControlItems = () => {
 		return React.Children.map( this.props.children, function( child, index ) {
 			return (
 				<ControlItem
@@ -69,7 +66,7 @@ const NavSegmented = React.createClass( {
 				</ControlItem>
 			);
 		}, this );
-	}
-} );
+	};
+}
 
 module.exports = NavSegmented;

--- a/_inc/client/components/section-nav/segmented.jsx
+++ b/_inc/client/components/section-nav/segmented.jsx
@@ -16,25 +16,22 @@ const SegmentedControl = require( 'components/segmented-control' ),
  */
 let _instance = 1;
 
-/**
- * Main
- */
 class NavSegmented extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool
 	};
 
-    static defaultProps = {
-        hasSiblingControls: false
-    };
+	static defaultProps = {
+		hasSiblingControls: false
+	};
 
-    componentWillMount() {
+	componentWillMount() {
 		this.id = _instance;
 		_instance++;
 	}
 
-    render() {
+	render() {
 		const segmentedClassName = classNames( {
 			'dops-section-nav-group': true,
 			'dops-section-nav__segmented': true,
@@ -55,7 +52,7 @@ class NavSegmented extends React.Component {
 		);
 	}
 
-    getControlItems = () => {
+	getControlItems = () => {
 		return React.Children.map( this.props.children, function( child, index ) {
 			return (
 				<ControlItem

--- a/_inc/client/components/section-nav/tabs.jsx
+++ b/_inc/client/components/section-nav/tabs.jsx
@@ -24,43 +24,38 @@ const MOBILE_PANEL_THRESHOLD = 480;
 /**
  * Main
  */
-const NavTabs = React.createClass( {
-
-	propTypes: {
+class NavTabs extends React.Component {
+    static propTypes = {
 		selectedText: PropTypes.string,
 		selectedCount: PropTypes.number,
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasSiblingControls: false
-		};
-	},
+    static defaultProps = {
+        hasSiblingControls: false
+    };
 
-	getInitialState: function() {
-		return {
-			isDropdown: false
-		};
-	},
+    state = {
+        isDropdown: false
+    };
 
-	componentDidMount: function() {
+    componentDidMount() {
 		this.setDropdown();
 		this.debouncedAfterResize = debounce( this.setDropdown, 300 );
 
 		window.addEventListener( 'resize', this.debouncedAfterResize );
-	},
+	}
 
-	componentWillReceiveProps: function() {
+    componentWillReceiveProps() {
 		this.setDropdown();
-	},
+	}
 
-	componentWillUnmount: function() {
+    componentWillUnmount() {
 		window.removeEventListener( 'resize', this.debouncedAfterResize );
-	},
+	}
 
-	render: function() {
+    render() {
 		const tabs = React.Children.map( this.props.children, function( child, index ) {
 			return child && React.cloneElement( child, { ref: 'tab-' + index } );
 		} );
@@ -98,9 +93,9 @@ const NavTabs = React.createClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
-	getTabWidths: function() {
+    getTabWidths = () => {
 		let totalWidth = 0;
 
 		React.Children.forEach( this.props.children, function( child, index ) {
@@ -112,9 +107,9 @@ const NavTabs = React.createClass( {
 		}.bind( this ) );
 
 		this.tabsWidth = totalWidth;
-	},
+	};
 
-	getDropdown: function() {
+    getDropdown = () => {
 		const dropdownOptions = React.Children.map(
 		this.props.children, function( child, index ) {
 			if ( ! child ) {
@@ -136,9 +131,9 @@ const NavTabs = React.createClass( {
 				{ dropdownOptions }
 			</SelectDropdown>
 		);
-	},
+	};
 
-	setDropdown: function() {
+    setDropdown = () => {
 		let navGroupWidth;
 
 		if ( window.innerWidth > MOBILE_PANEL_THRESHOLD ) {
@@ -166,9 +161,9 @@ const NavTabs = React.createClass( {
 				isDropdown: false
 			} );
 		}
-	},
+	};
 
-	keyHandler: function( event ) {
+    keyHandler = (event) => {
 		switch ( event.keyCode ) {
 			case 32: // space
 			case 13: // enter
@@ -176,7 +171,7 @@ const NavTabs = React.createClass( {
 				document.activeElement.click();
 				break;
 		}
-	}
-} );
+	};
+}
 
 module.exports = NavTabs;

--- a/_inc/client/components/section-nav/tabs.jsx
+++ b/_inc/client/components/section-nav/tabs.jsx
@@ -21,41 +21,38 @@ const SelectDropdown = require( 'components/select-dropdown' ),
  */
 const MOBILE_PANEL_THRESHOLD = 480;
 
-/**
- * Main
- */
 class NavTabs extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		selectedText: PropTypes.string,
 		selectedCount: PropTypes.number,
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool
 	};
 
-    static defaultProps = {
-        hasSiblingControls: false
-    };
+	static defaultProps = {
+		hasSiblingControls: false
+	};
 
-    state = {
-        isDropdown: false
-    };
+	state = {
+		isDropdown: false
+	};
 
-    componentDidMount() {
+	componentDidMount() {
 		this.setDropdown();
 		this.debouncedAfterResize = debounce( this.setDropdown, 300 );
 
 		window.addEventListener( 'resize', this.debouncedAfterResize );
 	}
 
-    componentWillReceiveProps() {
+	componentWillReceiveProps() {
 		this.setDropdown();
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.debouncedAfterResize );
 	}
 
-    render() {
+	render() {
 		const tabs = React.Children.map( this.props.children, function( child, index ) {
 			return child && React.cloneElement( child, { ref: 'tab-' + index } );
 		} );
@@ -95,7 +92,7 @@ class NavTabs extends React.Component {
 		);
 	}
 
-    getTabWidths = () => {
+	getTabWidths = () => {
 		let totalWidth = 0;
 
 		React.Children.forEach( this.props.children, function( child, index ) {
@@ -109,7 +106,7 @@ class NavTabs extends React.Component {
 		this.tabsWidth = totalWidth;
 	};
 
-    getDropdown = () => {
+	getDropdown = () => {
 		const dropdownOptions = React.Children.map(
 		this.props.children, function( child, index ) {
 			if ( ! child ) {
@@ -133,7 +130,7 @@ class NavTabs extends React.Component {
 		);
 	};
 
-    setDropdown = () => {
+	setDropdown = () => {
 		let navGroupWidth;
 
 		if ( window.innerWidth > MOBILE_PANEL_THRESHOLD ) {
@@ -163,7 +160,7 @@ class NavTabs extends React.Component {
 		}
 	};
 
-    keyHandler = (event) => {
+	keyHandler = ( event ) => {
 		switch ( event.keyCode ) {
 			case 32: // space
 			case 13: // enter

--- a/_inc/client/components/select-dropdown/docs/example.jsx
+++ b/_inc/client/components/select-dropdown/docs/example.jsx
@@ -6,7 +6,7 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ const SelectDropdown = require( 'components/select-dropdown' ),
 	DropdownLabel = require( 'components/select-dropdown/label' ),
 	DropdownSeparator = require( 'components/select-dropdown/separator' );
 
-const SelectDropdownDemo = createReactClass({
+const SelectDropdownDemo = createReactClass( {
 	displayName: 'SelectDropdown',
 
 	mixins: [ PureRenderMixin ],
@@ -119,6 +119,6 @@ const SelectDropdownDemo = createReactClass({
 	},
 
 	onDropdownSelect: function() {}
-});
+} );
 
 module.exports = SelectDropdownDemo;

--- a/_inc/client/components/select-dropdown/docs/example.jsx
+++ b/_inc/client/components/select-dropdown/docs/example.jsx
@@ -6,6 +6,8 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
@@ -14,7 +16,7 @@ const SelectDropdown = require( 'components/select-dropdown' ),
 	DropdownLabel = require( 'components/select-dropdown/label' ),
 	DropdownSeparator = require( 'components/select-dropdown/separator' );
 
-const SelectDropdownDemo = React.createClass( {
+const SelectDropdownDemo = createReactClass({
 	displayName: 'SelectDropdown',
 
 	mixins: [ PureRenderMixin ],
@@ -117,6 +119,6 @@ const SelectDropdownDemo = React.createClass( {
 	},
 
 	onDropdownSelect: function() {}
-} );
+});
 
 module.exports = SelectDropdownDemo;

--- a/_inc/client/components/select-dropdown/item.jsx
+++ b/_inc/client/components/select-dropdown/item.jsx
@@ -12,22 +12,20 @@ const React = require( 'react' ),
  */
 const Count = require( 'components/count' );
 
-const SelectDropdownItem = React.createClass( {
-	propTypes: {
+class SelectDropdownItem extends React.Component {
+    static propTypes = {
 		children: PropTypes.string.isRequired,
 		path: PropTypes.string,
 		selected: PropTypes.bool,
 		onClick: PropTypes.func,
 		count: PropTypes.number
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			selected: false
-		};
-	},
+    static defaultProps = {
+        selected: false
+    };
 
-	render: function() {
+    render() {
 		const optionClassName = classNames( this.props.className, {
 			'dops-select-dropdown__item': true,
 			'is-selected': this.props.selected,
@@ -56,6 +54,6 @@ const SelectDropdownItem = React.createClass( {
 			</li>
 		);
 	}
-} );
+}
 
 module.exports = SelectDropdownItem;

--- a/_inc/client/components/select-dropdown/item.jsx
+++ b/_inc/client/components/select-dropdown/item.jsx
@@ -13,7 +13,7 @@ const React = require( 'react' ),
 const Count = require( 'components/count' );
 
 class SelectDropdownItem extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		children: PropTypes.string.isRequired,
 		path: PropTypes.string,
 		selected: PropTypes.bool,
@@ -21,11 +21,11 @@ class SelectDropdownItem extends React.Component {
 		count: PropTypes.number
 	};
 
-    static defaultProps = {
-        selected: false
-    };
+	static defaultProps = {
+		selected: false
+	};
 
-    render() {
+	render() {
 		const optionClassName = classNames( this.props.className, {
 			'dops-select-dropdown__item': true,
 			'is-selected': this.props.selected,

--- a/_inc/client/components/select-dropdown/separator.jsx
+++ b/_inc/client/components/select-dropdown/separator.jsx
@@ -5,13 +5,12 @@
  */
 const React = require( 'react' );
 
-const SelectDropdownSeparator = React.createClass( {
-
-	render: function() {
+class SelectDropdownSeparator extends React.Component {
+    render() {
 		return (
 			<li className="dops-select-dropdown__separator" />
 		);
 	}
-} );
+}
 
 module.exports = SelectDropdownSeparator;

--- a/_inc/client/components/select-dropdown/separator.jsx
+++ b/_inc/client/components/select-dropdown/separator.jsx
@@ -6,7 +6,7 @@
 const React = require( 'react' );
 
 class SelectDropdownSeparator extends React.Component {
-    render() {
+	render() {
 		return (
 			<li className="dops-select-dropdown__separator" />
 		);

--- a/_inc/client/components/spinner/docs/example.jsx
+++ b/_inc/client/components/spinner/docs/example.jsx
@@ -4,14 +4,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const createReactClass = require('create-react-class');
+const createReactClass = require( 'create-react-class' );
 
 /**
  * Internal dependencies
  */
 const Spinner = require( 'components/spinner' );
 
-module.exports = createReactClass({
+module.exports = createReactClass( {
 	displayName: 'Spinner',
 
 	mixins: [ PureRenderMixin ],
@@ -29,4 +29,4 @@ module.exports = createReactClass({
 			</div>
 		);
 	}
-});
+} );

--- a/_inc/client/components/spinner/docs/example.jsx
+++ b/_inc/client/components/spinner/docs/example.jsx
@@ -4,12 +4,14 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+const createReactClass = require('create-react-class');
+
 /**
  * Internal dependencies
  */
 const Spinner = require( 'components/spinner' );
 
-module.exports = React.createClass( {
+module.exports = createReactClass({
 	displayName: 'Spinner',
 
 	mixins: [ PureRenderMixin ],
@@ -27,4 +29,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+});

--- a/_inc/client/components/spinner/index.jsx
+++ b/_inc/client/components/spinner/index.jsx
@@ -12,31 +12,27 @@ require( './style.scss' );
 /**
  * Module variables
  */
-const Spinner = React.createClass( {
-	propTypes: {
+class Spinner extends React.Component {
+    static propTypes = {
 		className: PropTypes.string,
 		size: PropTypes.number,
 		duration: PropTypes.number
-	},
+	};
 
-	statics: {
-		instances: 0
-	},
+    static instances = 0;
 
-	getDefaultProps: function() {
-		return {
-			size: 20,
-			duration: 3000
-		};
-	},
+    static defaultProps = {
+        size: 20,
+        duration: 3000
+    };
 
-	componentWillMount: function() {
+    componentWillMount() {
 		this.setState( {
 			instanceId: ++Spinner.instances
 		} );
-	},
+	}
 
-	/**
+    /**
 	 * Returns whether the current browser supports CSS animations for SVG
 	 * elements. Specifically, this returns false for Internet Explorer
 	 * versions 11 and below.
@@ -45,18 +41,18 @@ const Spinner = React.createClass( {
 	 * @return {Boolean} True if the browser supports CSS animations for SVG
 	 *                   elements, or false otherwise.
 	 */
-	isSVGCSSAnimationSupported: function() {
+    isSVGCSSAnimationSupported = () => {
 		const navigator = global.window ? global.window.navigator.userAgent : ''; // FIXME: replace with UA from server
 		return ! /(MSIE |Trident\/)/.test( navigator );
-	},
+	};
 
-	getClassName: function() {
+    getClassName = () => {
 		return classNames( 'dops-spinner', this.props.className, {
 			'is-fallback': ! this.isSVGCSSAnimationSupported()
 		} );
-	},
+	};
 
-	renderFallback: function() {
+    renderFallback = () => {
 		const style = {
 			width: this.props.size,
 			height: this.props.size
@@ -68,9 +64,9 @@ const Spinner = React.createClass( {
 				<span className="dops-spinner__progress is-right"></span>
 			</div>
 		);
-	},
+	};
 
-	render: function() {
+    render() {
 		const instanceId = parseInt( this.state.instanceId, 10 );
 
 		if ( ! this.isSVGCSSAnimationSupported() ) {
@@ -120,6 +116,6 @@ const Spinner = React.createClass( {
 		);
 		/*eslint-enable react/no-danger*/
 	}
-} );
+}
 
 module.exports = Spinner;

--- a/_inc/client/components/spinner/index.jsx
+++ b/_inc/client/components/spinner/index.jsx
@@ -9,24 +9,21 @@ const React = require( 'react' ),
 
 require( './style.scss' );
 
-/**
- * Module variables
- */
 class Spinner extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		className: PropTypes.string,
 		size: PropTypes.number,
 		duration: PropTypes.number
 	};
 
-    static instances = 0;
+	static instances = 0;
 
-    static defaultProps = {
-        size: 20,
-        duration: 3000
-    };
+	static defaultProps = {
+		size: 20,
+		duration: 3000
+	};
 
-    componentWillMount() {
+	componentWillMount() {
 		this.setState( {
 			instanceId: ++Spinner.instances
 		} );
@@ -41,18 +38,18 @@ class Spinner extends React.Component {
 	 * @return {Boolean} True if the browser supports CSS animations for SVG
 	 *                   elements, or false otherwise.
 	 */
-    isSVGCSSAnimationSupported = () => {
+	isSVGCSSAnimationSupported = () => {
 		const navigator = global.window ? global.window.navigator.userAgent : ''; // FIXME: replace with UA from server
 		return ! /(MSIE |Trident\/)/.test( navigator );
 	};
 
-    getClassName = () => {
+	getClassName = () => {
 		return classNames( 'dops-spinner', this.props.className, {
 			'is-fallback': ! this.isSVGCSSAnimationSupported()
 		} );
 	};
 
-    renderFallback = () => {
+	renderFallback = () => {
 		const style = {
 			width: this.props.size,
 			height: this.props.size
@@ -66,7 +63,7 @@ class Spinner extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		const instanceId = parseInt( this.state.instanceId, 10 );
 
 		if ( ! this.isSVGCSSAnimationSupported() ) {

--- a/_inc/client/components/spinner/index.jsx
+++ b/_inc/client/components/spinner/index.jsx
@@ -29,7 +29,7 @@ class Spinner extends React.Component {
 		} );
 	}
 
-    /**
+	/**
 	 * Returns whether the current browser supports CSS animations for SVG
 	 * elements. Specifically, this returns false for Internet Explorer
 	 * versions 11 and below.

--- a/_inc/client/components/text-input/index.jsx
+++ b/_inc/client/components/text-input/index.jsx
@@ -8,20 +8,20 @@ import omit from 'lodash/omit';
 require( './style.scss' );
 
 export default class extends React.Component {
-    static displayName = 'TextInput';
+	static displayName = 'TextInput';
 
-    static defaultProps = {
-        isError: false,
-        isValid: false,
-        selectOnFocus: false,
-        type: 'text'
-    };
+	static defaultProps = {
+		isError: false,
+		isValid: false,
+		selectOnFocus: false,
+		type: 'text'
+	};
 
-    focus = () => {
+	focus = () => {
 		this.refs.textField.focus();
 	};
 
-    render() {
+	render() {
 		const { className, selectOnFocus } = this.props;
 		const classes = classNames( className, {
 			'dops-text-input': true,
@@ -38,7 +38,7 @@ export default class extends React.Component {
 		);
 	}
 
-    selectOnFocus = (event) => {
+	selectOnFocus = ( event ) => {
 		event.target.select();
 	};
 }

--- a/_inc/client/components/text-input/index.jsx
+++ b/_inc/client/components/text-input/index.jsx
@@ -7,24 +7,21 @@ import omit from 'lodash/omit';
 
 require( './style.scss' );
 
-export default React.createClass( {
+export default class extends React.Component {
+    static displayName = 'TextInput';
 
-	displayName: 'TextInput',
+    static defaultProps = {
+        isError: false,
+        isValid: false,
+        selectOnFocus: false,
+        type: 'text'
+    };
 
-	getDefaultProps() {
-		return {
-			isError: false,
-			isValid: false,
-			selectOnFocus: false,
-			type: 'text'
-		};
-	},
-
-	focus() {
+    focus = () => {
 		this.refs.textField.focus();
-	},
+	};
 
-	render() {
+    render() {
 		const { className, selectOnFocus } = this.props;
 		const classes = classNames( className, {
 			'dops-text-input': true,
@@ -39,10 +36,9 @@ export default React.createClass( {
 				className={ classes }
 				onClick={ selectOnFocus ? this.selectOnFocus : null } />
 		);
-	},
-
-	selectOnFocus( event ) {
-		event.target.select();
 	}
 
-} );
+    selectOnFocus = (event) => {
+		event.target.select();
+	};
+}

--- a/_inc/client/components/text-input/index.jsx
+++ b/_inc/client/components/text-input/index.jsx
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
 
 require( './style.scss' );
 
-export default class extends React.Component {
+export default class TextInput extends React.Component {
 	static displayName = 'TextInput';
 
 	static defaultProps = {

--- a/_inc/client/components/textarea/index.jsx
+++ b/_inc/client/components/textarea/index.jsx
@@ -7,15 +7,14 @@ const React = require( 'react' ),
 
 require( './style.scss' );
 
-module.exports = React.createClass( {
+module.exports = class extends React.Component {
+    static displayName = 'Textarea';
 
-	displayName: 'Textarea',
-
-	render: function() {
+    render() {
 		return (
 			<textarea { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'dops-textarea' ) } >
 				{ this.props.children }
 			</textarea>
 		);
 	}
-} );
+};

--- a/_inc/client/components/textarea/index.jsx
+++ b/_inc/client/components/textarea/index.jsx
@@ -8,9 +8,9 @@ const React = require( 'react' ),
 require( './style.scss' );
 
 module.exports = class extends React.Component {
-    static displayName = 'Textarea';
+	static displayName = 'Textarea';
 
-    render() {
+	render() {
 		return (
 			<textarea { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'dops-textarea' ) } >
 				{ this.props.children }

--- a/_inc/client/components/textarea/index.jsx
+++ b/_inc/client/components/textarea/index.jsx
@@ -7,7 +7,7 @@ const React = require( 'react' ),
 
 require( './style.scss' );
 
-module.exports = class extends React.Component {
+export default class Textarea extends React.Component {
 	static displayName = 'Textarea';
 
 	render() {
@@ -17,4 +17,4 @@ module.exports = class extends React.Component {
 			</textarea>
 		);
 	}
-};
+}

--- a/_inc/client/notices/validation-error-list.jsx
+++ b/_inc/client/notices/validation-error-list.jsx
@@ -7,13 +7,13 @@ const React = require( 'react' ),
 import { translate as __ } from 'i18n-calypso';
 
 module.exports = class extends React.Component {
-    static displayName = 'ValidationErrorList';
+	static displayName = 'ValidationErrorList';
 
-    static propTypes = {
+	static propTypes = {
 		messages: PropTypes.array.isRequired
 	};
 
-    render() {
+	render() {
 		return (
 			<div>
 				<p>

--- a/_inc/client/notices/validation-error-list.jsx
+++ b/_inc/client/notices/validation-error-list.jsx
@@ -6,7 +6,7 @@ const React = require( 'react' ),
 	map = require( 'lodash/map' );
 import { translate as __ } from 'i18n-calypso';
 
-module.exports = class extends React.Component {
+export default class ValidationErrorList extends React.Component {
 	static displayName = 'ValidationErrorList';
 
 	static propTypes = {
@@ -33,4 +33,4 @@ module.exports = class extends React.Component {
 			</div>
 		);
 	}
-};
+}

--- a/_inc/client/notices/validation-error-list.jsx
+++ b/_inc/client/notices/validation-error-list.jsx
@@ -6,14 +6,14 @@ const React = require( 'react' ),
 	map = require( 'lodash/map' );
 import { translate as __ } from 'i18n-calypso';
 
-module.exports = React.createClass( {
-	displayName: 'ValidationErrorList',
+module.exports = class extends React.Component {
+    static displayName = 'ValidationErrorList';
 
-	propTypes: {
+    static propTypes = {
 		messages: PropTypes.array.isRequired
-	},
+	};
 
-	render: function() {
+    render() {
 		return (
 			<div>
 				<p>
@@ -33,4 +33,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+};

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -28,123 +28,118 @@ import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSitePlan } from 'state/site';
 
-const Media = moduleSettingsForm(
-	React.createClass( {
+const Media = moduleSettingsForm(class extends React.Component {
+    /**
+     * Get options for initial state.
+     *
+     * @returns {Object} {{carousel_display_exif: Boolean}}
+     */
+    state = {
+        carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
+    };
 
-		/**
-		 * Get options for initial state.
-		 *
-		 * @returns {Object} {{carousel_display_exif: Boolean}}
-		 */
-		getInitialState() {
-			return {
-				carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
-			};
-		},
+    /**
+     * Update state so toggles are updated.
+     *
+     * @param {string} optionName option slug
+     */
+    updateOptions = (optionName) => {
+        this.setState(
+            {
+                [ optionName ]: ! this.state[ optionName ]
+            },
+            this.props.updateFormStateModuleOption( 'carousel', optionName )
+        );
+    };
 
-		/**
-		 * Update state so toggles are updated.
-		 *
-		 * @param {string} optionName option slug
-		 */
-		updateOptions( optionName ) {
-			this.setState(
-				{
-					[ optionName ]: ! this.state[ optionName ]
-				},
-				this.props.updateFormStateModuleOption( 'carousel', optionName )
-			);
-		},
+    render() {
+        const foundCarousel = this.props.isModuleFound( 'carousel' ),
+            foundVideoPress = this.props.isModuleFound( 'videopress' );
 
-		render() {
-			const foundCarousel = this.props.isModuleFound( 'carousel' ),
-				foundVideoPress = this.props.isModuleFound( 'videopress' );
+        if ( ! foundCarousel && ! foundVideoPress ) {
+            return null;
+        }
 
-			if ( ! foundCarousel && ! foundVideoPress ) {
-				return null;
-			}
+        const carousel = this.props.module( 'carousel' ),
+            isCarouselActive = this.props.getOptionValue( 'carousel' ),
+            videoPress = this.props.module( 'videopress' ),
+            planClass = getPlanClass( this.props.sitePlan.product_slug );
 
-			const carousel = this.props.module( 'carousel' ),
-				isCarouselActive = this.props.getOptionValue( 'carousel' ),
-				videoPress = this.props.module( 'videopress' ),
-				planClass = getPlanClass( this.props.sitePlan.product_slug );
+        const carouselSettings = (
+            <SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
+                <ModuleToggle
+                    slug="carousel"
+                    activated={ isCarouselActive }
+                    toggling={ this.props.isSavingAnyOption( 'carousel' ) }
+                    toggleModule={ this.props.toggleModuleNow }
+                >
+                    <span className="jp-form-toggle-explanation">
+                        {
+                            carousel.description
+                        }
+                    </span>
+                </ModuleToggle>
+                <FormFieldset>
+                    <CompactFormToggle
+                        checked={ this.state.carousel_display_exif }
+                        disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
+                        onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
+                        <span className="jp-form-toggle-explanation">
+                            {
+                                __( 'Show photo metadata (Exif) in carousel, when available' )
+                            }
+                        </span>
+                    </CompactFormToggle>
+                    <FormLabel>
+                        <FormLegend className="jp-form-label-wide">
+                            { __( 'Color scheme' ) }
+                        </FormLegend>
+                        <FormSelect
+                            name={ 'carousel_background_color' }
+                            value={ this.props.getOptionValue( 'carousel_background_color' ) }
+                            disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] ) }
+                            { ...this.props }
+                            validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
+                    </FormLabel>
+                </FormFieldset>
+            </SettingsGroup>
+        );
 
-			const carouselSettings = (
-				<SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
-					<ModuleToggle
-						slug="carousel"
-						activated={ isCarouselActive }
-						toggling={ this.props.isSavingAnyOption( 'carousel' ) }
-						toggleModule={ this.props.toggleModuleNow }
-					>
-						<span className="jp-form-toggle-explanation">
-							{
-								carousel.description
-							}
-						</span>
-					</ModuleToggle>
-					<FormFieldset>
-						<CompactFormToggle
-							checked={ this.state.carousel_display_exif }
-							disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
-							onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
-							<span className="jp-form-toggle-explanation">
-								{
-									__( 'Show photo metadata (Exif) in carousel, when available' )
-								}
-							</span>
-						</CompactFormToggle>
-						<FormLabel>
-							<FormLegend className="jp-form-label-wide">
-								{ __( 'Color scheme' ) }
-							</FormLegend>
-							<FormSelect
-								name={ 'carousel_background_color' }
-								value={ this.props.getOptionValue( 'carousel_background_color' ) }
-								disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] ) }
-								{ ...this.props }
-								validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
-						</FormLabel>
-					</FormFieldset>
-				</SettingsGroup>
-			);
+        const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
+            <SettingsGroup
+                hasChild
+                disableInDevMode
+                module={ videoPress }>
+                <ModuleToggle
+                    slug="videopress"
+                    disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+                    activated={ this.props.getOptionValue( 'videopress' ) }
+                    toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+                    toggleModule={ this.props.toggleModuleNow }
+                >
+                    <span className="jp-form-toggle-explanation">
+                        {
+                            videoPress.description
+                        }
+                    </span>
+                </ModuleToggle>
+            </SettingsGroup>
+        );
 
-			const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
-				<SettingsGroup
-					hasChild
-					disableInDevMode
-					module={ videoPress }>
-					<ModuleToggle
-						slug="videopress"
-						disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
-						activated={ this.props.getOptionValue( 'videopress' ) }
-						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-						toggleModule={ this.props.toggleModuleNow }
-					>
-						<span className="jp-form-toggle-explanation">
-							{
-								videoPress.description
-							}
-						</span>
-					</ModuleToggle>
-				</SettingsGroup>
-			);
-
-			return (
-				<SettingsCard
-					{ ...this.props }
-					header={ __( 'Media' ) }
-					hideButton={ ! foundCarousel }
-					feature={ FEATURE_VIDEO_HOSTING_JETPACK }
-					saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
-				>
-					{ foundCarousel && carouselSettings }
-					{ foundVideoPress && videoPressSettings }
-				</SettingsCard>
-			);
-		}
-	} )
-);
+        return (
+            <SettingsCard
+                { ...this.props }
+                header={ __( 'Media' ) }
+                hideButton={ ! foundCarousel }
+                feature={ FEATURE_VIDEO_HOSTING_JETPACK }
+                saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
+            >
+                { foundCarousel && carouselSettings }
+                { foundVideoPress && videoPressSettings }
+            </SettingsCard>
+        );
+    }
+});
 
 export default connect(
 	( state ) => {

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -28,44 +28,44 @@ import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSitePlan } from 'state/site';
 
-const Media = moduleSettingsForm(class extends React.Component {
+const Media = moduleSettingsForm( class extends React.Component {
     /**
      * Get options for initial state.
      *
      * @returns {Object} {{carousel_display_exif: Boolean}}
      */
-    state = {
-        carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
-    };
+	state = {
+		carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
+	};
 
     /**
      * Update state so toggles are updated.
      *
      * @param {string} optionName option slug
      */
-    updateOptions = (optionName) => {
-        this.setState(
-            {
-                [ optionName ]: ! this.state[ optionName ]
-            },
+	updateOptions = ( optionName ) => {
+		this.setState(
+			{
+				[ optionName ]: ! this.state[ optionName ]
+			},
             this.props.updateFormStateModuleOption( 'carousel', optionName )
         );
-    };
+	};
 
-    render() {
-        const foundCarousel = this.props.isModuleFound( 'carousel' ),
-            foundVideoPress = this.props.isModuleFound( 'videopress' );
+	render() {
+		const foundCarousel = this.props.isModuleFound( 'carousel' ),
+			foundVideoPress = this.props.isModuleFound( 'videopress' );
 
-        if ( ! foundCarousel && ! foundVideoPress ) {
-            return null;
-        }
+		if ( ! foundCarousel && ! foundVideoPress ) {
+			return null;
+		}
 
-        const carousel = this.props.module( 'carousel' ),
-            isCarouselActive = this.props.getOptionValue( 'carousel' ),
-            videoPress = this.props.module( 'videopress' ),
-            planClass = getPlanClass( this.props.sitePlan.product_slug );
+		const carousel = this.props.module( 'carousel' ),
+			isCarouselActive = this.props.getOptionValue( 'carousel' ),
+			videoPress = this.props.module( 'videopress' ),
+			planClass = getPlanClass( this.props.sitePlan.product_slug );
 
-        const carouselSettings = (
+		const carouselSettings = (
             <SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
                 <ModuleToggle
                     slug="carousel"
@@ -105,7 +105,7 @@ const Media = moduleSettingsForm(class extends React.Component {
             </SettingsGroup>
         );
 
-        const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
+		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
             <SettingsGroup
                 hasChild
                 disableInDevMode
@@ -126,7 +126,7 @@ const Media = moduleSettingsForm(class extends React.Component {
             </SettingsGroup>
         );
 
-        return (
+		return (
             <SettingsCard
                 { ...this.props }
                 header={ __( 'Media' ) }
@@ -138,8 +138,8 @@ const Media = moduleSettingsForm(class extends React.Component {
                 { foundVideoPress && videoPressSettings }
             </SettingsCard>
         );
-    }
-});
+	}
+} );
 
 export default connect(
 	( state ) => {

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -28,28 +28,28 @@ import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSitePlan } from 'state/site';
 
-const Media = moduleSettingsForm( class extends React.Component {
-    /**
-     * Get options for initial state.
-     *
-     * @returns {Object} {{carousel_display_exif: Boolean}}
-     */
+class Media extends React.Component {
+	/**
+ 	* Get options for initial state.
+ 	*
+ 	* @returns {Object} {{carousel_display_exif: Boolean}}
+ 	*/
 	state = {
 		carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
 	};
 
-    /**
-     * Update state so toggles are updated.
-     *
-     * @param {string} optionName option slug
-     */
+	/**
+ 	* Update state so toggles are updated.
+ 	*
+ 	* @param {string} optionName option slug
+ 	*/
 	updateOptions = ( optionName ) => {
 		this.setState(
 			{
 				[ optionName ]: ! this.state[ optionName ]
 			},
-            this.props.updateFormStateModuleOption( 'carousel', optionName )
-        );
+			this.props.updateFormStateModuleOption( 'carousel', optionName )
+		);
 	};
 
 	render() {
@@ -66,80 +66,80 @@ const Media = moduleSettingsForm( class extends React.Component {
 			planClass = getPlanClass( this.props.sitePlan.product_slug );
 
 		const carouselSettings = (
-            <SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
-                <ModuleToggle
-                    slug="carousel"
-                    activated={ isCarouselActive }
-                    toggling={ this.props.isSavingAnyOption( 'carousel' ) }
-                    toggleModule={ this.props.toggleModuleNow }
-                >
-                    <span className="jp-form-toggle-explanation">
-                        {
-                            carousel.description
-                        }
-                    </span>
-                </ModuleToggle>
-                <FormFieldset>
-                    <CompactFormToggle
-                        checked={ this.state.carousel_display_exif }
-                        disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
-                        onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
-                        <span className="jp-form-toggle-explanation">
-                            {
-                                __( 'Show photo metadata (Exif) in carousel, when available' )
-                            }
-                        </span>
-                    </CompactFormToggle>
-                    <FormLabel>
-                        <FormLegend className="jp-form-label-wide">
-                            { __( 'Color scheme' ) }
-                        </FormLegend>
-                        <FormSelect
-                            name={ 'carousel_background_color' }
-                            value={ this.props.getOptionValue( 'carousel_background_color' ) }
-                            disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] ) }
-                            { ...this.props }
-                            validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
-                    </FormLabel>
-                </FormFieldset>
-            </SettingsGroup>
-        );
+			<SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
+				<ModuleToggle
+					slug="carousel"
+					activated={ isCarouselActive }
+					toggling={ this.props.isSavingAnyOption( 'carousel' ) }
+					toggleModule={ this.props.toggleModuleNow }
+					>
+					<span className="jp-form-toggle-explanation">
+						{
+							carousel.description
+						}
+					</span>
+				</ModuleToggle>
+				<FormFieldset>
+					<CompactFormToggle
+						checked={ this.state.carousel_display_exif }
+						disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
+						onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
+						<span className="jp-form-toggle-explanation">
+							{
+								__( 'Show photo metadata (Exif) in carousel, when available' )
+							}
+						</span>
+					</CompactFormToggle>
+					<FormLabel>
+						<FormLegend className="jp-form-label-wide">
+							{ __( 'Color scheme' ) }
+						</FormLegend>
+						<FormSelect
+							name={ 'carousel_background_color' }
+							value={ this.props.getOptionValue( 'carousel_background_color' ) }
+							disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] ) }
+							{ ...this.props }
+							validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
+					</FormLabel>
+				</FormFieldset>
+			</SettingsGroup>
+		);
 
 		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
-            <SettingsGroup
-                hasChild
-                disableInDevMode
-                module={ videoPress }>
-                <ModuleToggle
-                    slug="videopress"
-                    disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
-                    activated={ this.props.getOptionValue( 'videopress' ) }
-                    toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-                    toggleModule={ this.props.toggleModuleNow }
-                >
-                    <span className="jp-form-toggle-explanation">
-                        {
-                            videoPress.description
-                        }
-                    </span>
-                </ModuleToggle>
-            </SettingsGroup>
-        );
+			<SettingsGroup
+				hasChild
+				disableInDevMode
+				module={ videoPress }>
+				<ModuleToggle
+					slug="videopress"
+					disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+					activated={ this.props.getOptionValue( 'videopress' ) }
+					toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+					toggleModule={ this.props.toggleModuleNow }
+					>
+					<span className="jp-form-toggle-explanation">
+						{
+							videoPress.description
+						}
+					</span>
+				</ModuleToggle>
+			</SettingsGroup>
+		);
 
 		return (
-            <SettingsCard
-                { ...this.props }
-                header={ __( 'Media' ) }
-                hideButton={ ! foundCarousel }
-                feature={ FEATURE_VIDEO_HOSTING_JETPACK }
-                saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
-            >
-                { foundCarousel && carouselSettings }
-                { foundVideoPress && videoPressSettings }
-            </SettingsCard>
-        );
+			<SettingsCard
+				{ ...this.props }
+				header={ __( 'Media' ) }
+				hideButton={ ! foundCarousel }
+				feature={ FEATURE_VIDEO_HOSTING_JETPACK }
+				saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
+				>
+				{ foundCarousel && carouselSettings }
+				{ foundVideoPress && videoPressSettings }
+			</SettingsCard>
+		);
 	}
-} );
+}
 
 export default connect(
 	( state ) => {
@@ -149,4 +149,4 @@ export default connect(
 			sitePlan: getSitePlan( state )
 		};
 	}
-)( Media );
+)( moduleSettingsForm( Media ) );


### PR DESCRIPTION
Fixes more warnings about createclass usage.

#### Changes proposed in this Pull Request:

* Runs the `class` codemod over `_inc/client` making 63 components not depend on `React.createClass`
* Runs `eslint --fix` on the files

For simplicity, files unprocessed will be addressed by another PR.

#### Testing instructions:

1. Check this branch
2. Build the Admin Page (`yarn build`)
3. Expect it to build properly.
4. Visit the Admin Page. Expect to see no warnings about using createClass from the main `React` package. ` Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement`

#### Skipped files
```
_inc/client/components/gridicon/index.jsx: `Gridicon` was skipped because of inconvertible mixins.
_inc/client/components/info-popover/index.jsx: `` was skipped because of deprecated API calls. Remove calls to getDOMNode, isMounted, replaceProps, replaceState, setProps in your React component and re-run this script.
_inc/client/components/chart/legend.jsx: `LegendItem` was skipped because of inconvertible mixins.
_inc/client/components/count/index.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/external-link/index.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-checkbox-multiple.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-checkbox.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-hidden.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-radio.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-select.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/form/input-text.js: `` was skipped because of inconvertible mixins.
_inc/client/components/section-nav/index.jsx: `SectionNav` was skipped because `arguments` was found in your functions. Arrow functions do not expose an `arguments` object; consider changing to use ES6 spread operator and re-run this script.
_inc/client/components/button-group/docs/example.jsx: `Buttons` was skipped because of inconvertible mixins.
_inc/client/components/count/docs/example.jsx: `` was skipped because of inconvertible mixins.
_inc/client/components/section-nav/item.jsx: `NavItem` was skipped because of inconvertible mixins.
_inc/client/components/info-popover/docs/example.jsx: `InfoPopoverExample` was skipped because of inconvertible mixins.
_inc/client/components/popover/docs/example.jsx: `Popovers` was skipped because of inconvertible mixins.
_inc/client/components/search/docs/example.jsx: `SearchDemo` was skipped because of inconvertible mixins.
_inc/client/components/select-dropdown/docs/example.jsx: `SelectDropdownDemo` was skipped because of inconvertible mixins.
_inc/client/components/section-nav/docs/example.jsx: `SectionNavigation` was skipped because of inconvertible mixins.
_inc/client/components/spinner/docs/example.jsx: `` was skipped because of inconvertible mixins.
```