### PR TITLE
Add in description text from Lazy Images dash controls

### DIFF
--- a/_inc/client/components/jetpack-dialogue/style.scss
+++ b/_inc/client/components/jetpack-dialogue/style.scss
@@ -93,7 +93,7 @@
 
 	.jp-form-settings-group {
 		margin: 0px auto;
-		max-width: 300px;
+		max-width: 500px;
 		text-align: left;
 	}
 

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import JetpackDialogue from 'components/jetpack-dialogue';
 import decodeEntities from 'lib/decode-entities';
+import { FormFieldset } from 'components/forms';
 import { imagePath } from 'constants/urls';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { getModule } from 'state/modules';
@@ -64,6 +65,11 @@ const UpgradeNoticeContent = moduleSettingsForm(
 									{ decodeEntities( lazyImages.description ) }
 								</span>
 							</ModuleToggle>
+							<FormFieldset>
+								<span className="jp-form-setting-explanation">
+									{ decodeEntities( lazyImages.long_description ) }
+								</span>
+							</FormFieldset>
 						</SettingsGroup>
 					</div>
 


### PR DESCRIPTION
Builds on #8700 by including the module description with the toggle button.

<img width="557" alt="module-desc-enable-lazy-images" src="https://user-images.githubusercontent.com/51896/35708047-10dc582c-0761-11e8-8615-d49c7cc94ca0.png">

