### PR TITLE
Remove :visited rule from dops-button

### DIFF
--- a/_inc/client/components/button/style.scss
+++ b/_inc/client/components/button/style.scss
@@ -36,9 +36,6 @@
 	&:active {
 		border-width: 2px 1px 1px;
 	}
-	&:visited {
-		color: $gray-dark;
-	}
 	&[disabled],
 	&:disabled {
 		color: lighten( $gray, 30% );


### PR DESCRIPTION
Fixes #8688

#### Changes proposed in this Pull Request:

* Remove :visited rule from .dops-button which sets inner text to gray

#### Testing instructions:

* In Chrome debugger, set state of a dops-button to :visited. Text should stay white.

