### PR TITLE
 Search: Ensure that the search query is set in the widget search box

### DIFF
--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -345,6 +345,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 						searchInput.val( searchQuery );
 					}
 
+					searchInput.addClass( 'show-placeholder' );
+
 					container.find( '.jetpack-search-sort' ).change( function( event ) {
 						var values  = event.target.value.split( '|' );
 						orderBy.val( values[0] );

--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -325,14 +325,25 @@ class Jetpack_Search_Widget extends WP_Widget {
 				jQuery( document ).ready( function( $ ) {
 					var orderByDefault = <?php echo wp_json_encode( $orderby ); ?>,
 						orderDefault   = <?php echo wp_json_encode( $order ); ?>,
-						widgetId       = <?php echo wp_json_encode( $this->id ); ?>;
+						widgetId       = <?php echo wp_json_encode( $this->id ); ?>,
+						searchQuery    = <?php echo wp_json_encode( get_query_var( 's', '' ) ); ?>,
+						isSearch       = <?php echo wp_json_encode( is_search() ); ?>;
 
-					var container = $('#' + widgetId);
-					var form = container.find('.jetpack-search-form form');
-					var orderBy = form.find( 'input[name=orderby]');
-					var order = form.find( 'input[name=order]');
-					orderBy.val(orderByDefault);
-					order.val(orderDefault);
+					var container = $( '#' + widgetId ),
+						form = container.find('.jetpack-search-form form'),
+						orderBy = form.find( 'input[name=orderby]'),
+						order = form.find( 'input[name=order]'),
+						searchInput = form.find( 'input[name="s"]' );
+
+					orderBy.val( orderByDefault );
+					order.val( orderDefault );
+
+					// Some themes don't set the search query, which results in the query being lost
+					// when doing a sort selection. So, if the query isn't set, let's set it now. This approach
+					// is chosen over running a regex over HTML for every search query performed.
+					if ( isSearch && ! searchInput.val() ) {
+						searchInput.val( searchQuery );
+					}
 
 					container.find( '.jetpack-search-sort' ).change( function( event ) {
 						var values  = event.target.value.split( '|' );

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -45,3 +45,11 @@ ul.jetpack-search-filters-widget__filter-list li label {
 ul.jetpack-search-filters-widget__filter-list {
 	margin-bottom: 1.5em;
 }
+
+body.search .jetpack-search-form input[name="s"]::placeholder {
+	color: transparent;
+}
+
+body.search .jetpack-search-form input[name="s"].show-placeholder::placeholder {
+	color: inherit;
+}


### PR DESCRIPTION
While working on #8689, we realized that there was another issue where the search query wasn't set in the search input for some themes. This would result in the query not being set when changing the sort.

For example, in the ColorMag theme, the search input looks a bit like this:

```html
<input name="s" placeholder="Search" />
```

But, since it doesn't have the `value=""` attribute, it'll never persist the search query for subsequent searches.

To fix this, I decided to always set the search query in the input with JavaScript. One alternative approach was to run a regex over the HTML for the search form, but I'd rather not go that route for the moment. 

The biggest issue I could think of with this JavaScript approach is that there could be flash of the placeholder text until the document was ready and our JavaScript replaced the value with the current search query. To address this, I decided to hide the placeholder text of our search input by default and then apply a class to the input to show the placeholder text after JavaScript has loaded.

To test:

- Checkout branch on a site with Jetpack Professional
- Install a default theme
- Add a search widget and ensure that the "Show search box" and "Show sort selection dropdown" checkboxes are checked
- Go to the frontend and search for something
- Ensure that you see the search phrase in the search input
- Change the sort
- Ensure that the search query persists
- Change themes to ColorMag
- Perform a search
- Ensure that search query shows in the search input
- Change the sort selection
- Ensure that the search query persists
