### PR TITLE
Admin page: Better error message in notice when the error is a WP_Error coming from the API

### DIFF
--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -87,7 +87,10 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 		let messages = {
 				progress: __( 'Updating settings…' ),
 				success: __( 'Updated settings.' ),
-				error: error => __( 'Error updating settings. (%(error)s)', { args: { error: error.name || error } } )
+				// We try to get a message or an error code if this is an unexpected WP_Error coming from the API.
+				// Otherwise we try to show error.name (coming from the custom errors defined in rest-api/index.js and if that's not useful
+				// then we try to let Javascript stringify the error object.
+				error: error => __( 'Error updating settings. %(error)s', { args: { error: error.message || error.code || error.name || error } } )
 			},
 			updatedOptionsSuccess = () => newOptionValues;
 


### PR DESCRIPTION
Helps debugging issues when users see vague messages like: 
`Error updating settings. (Error)`

We're currently handling some errors that come from rogue web server setups (404 status, or 404 after a redirection) and also problems with JSON parsing (In case the REST API is redirected or turned off for the site). 

But we have a bunch of custom messages (already translated) that come from the API related to possible problems around Jetpack innerworkings. This PR adds more support for them.

#### Changes proposed in this Pull Request:

* Tries to show `error.message` or `error.code` (provided by the WP REST API response when creafted based on an `WP_Error`) before falling back to `error.code` or `error` (which are custom JS errors we implement to detect network errors..

#### Before

![image](https://user-images.githubusercontent.com/746152/35738537-e8ff7976-080d-11e8-90e3-3db95bc3f483.png)


#### After

![image](https://user-images.githubusercontent.com/746152/35734183-00515c8e-07ff-11e8-8c01-4ad698fece20.png)


#### Testing instructions:

* Check this branch
* build the admin page
* Add this minor change to generate a custom `WP_Error` coming from the API.
*  Update `_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php` to include this as the first line in  the body of the function `update_data`:
   ```
   return new WP_Error( 'some_updated', esc_html( 'Some options were updated' ), array( 'status' => 400 ) );
   ```
* Expect to see the custom WP_Error message shown in the red notice. This example here is not translated but all other errors already implemented as API responses, are. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

We improved the way errors are described in notices when updating Jetpack settings does not work properly.