### PR TITLE
Admin Page: Post By Email Address - Handle null value properly

### DIFF
--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -34,8 +34,9 @@ class PostByEmail extends React.Component {
 	address = () => {
 		const currentValue = this.props.getOptionValue( 'post_by_email_address' );
 		// If the module Post-by-email is enabled BUT it's configured as disabled
-		// Its value is set to false
-		if ( false === currentValue || '1' === currentValue ) {
+		// the post_by_email_address value is set to false.
+		// If there's no address generated yet, post_by_email_address is null.
+		if ( false === currentValue || '1' === currentValue || null === currentValue ) {
 			return '';
 		}
 		return currentValue;


### PR DESCRIPTION
Fixes a warning being shown in the console for development builds of the admin page, due to a `null` value forward as an attribute of an `input` tag when everything is enabled, but the user hasn't generated an address yet.

#### Changes proposed in this Pull Request:

* Updates the `PostByEmail` component `address()` method to return `''` if there's a value of `null` currently.

#### Testing instructions:

* Start with a fresh site.
* Checkout this branch
* Build the admin page.
* Connect Jetpack
* Activate recommended features.
* Visit the Settings page
* Confirm there's now warning about an `<input>` receiving a value of `null`.

![image](https://user-images.githubusercontent.com/746152/35737977-2bb163da-080c-11e8-9dd6-ecaea7aefd42.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
