### PR TITLE
Add wrapper div for more reliable targeting of search form

### DIFF
--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -242,7 +242,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		?><div id="jetpack-search__<?php echo esc_attr( $this->id ); ?>"><?php
+		?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper"><?php
 
 		if ( ! empty( $title ) ) {
 			/**
@@ -331,7 +331,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 						searchQuery    = <?php echo wp_json_encode( get_query_var( 's', '' ) ); ?>,
 						isSearch       = <?php echo wp_json_encode( is_search() ); ?>;
 
-					var container = $( '#jetpack-search__' + widgetId ),
+					var container = $( '#' + widgetId + '-wrapper' ),
 						form = container.find('.jetpack-search-form form'),
 						orderBy = form.find( 'input[name=orderby]'),
 						order = form.find( 'input[name=order]'),

--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -242,6 +242,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
+		?><div id="jetpack-search__<?php echo esc_attr( $this->id ); ?>"><?php
 
 		if ( ! empty( $title ) ) {
 			/**
@@ -301,6 +302,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		$this->maybe_render_sort_javascript( $instance, $order, $orderby );
 
+		echo "</div>";
 		echo $args['after_widget'];
 	}
 
@@ -329,7 +331,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 						searchQuery    = <?php echo wp_json_encode( get_query_var( 's', '' ) ); ?>,
 						isSearch       = <?php echo wp_json_encode( is_search() ); ?>;
 
-					var container = $( '#' + widgetId ),
+					var container = $( '#jetpack-search__' + widgetId ),
 						form = container.find('.jetpack-search-form form'),
 						orderBy = form.find( 'input[name=orderby]'),
 						order = form.find( 'input[name=order]'),


### PR DESCRIPTION
Fixes #8724

#### Changes proposed in this Pull Request:

* Add a wrapper div with a unique ID, so that our JS which updates the search form works with themes that don't output the widget ID into the before_widget HTML.

#### Testing instructions:

* Install and activate the Hemingway theme
* Add a widget to any widget area with a search box and sorting controls 
* Do a search
* Changing the sort dropdown value should reload the search results with the new sort order
