### PR TITLE
Fix Hemingway checkbox height in search filters

### DIFF
--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -20,6 +20,10 @@
 	margin-bottom: 1.5em;
 }
 
+.widget_search input[type="checkbox"] {
+	height: auto;
+}
+
 ul.jetpack-search-filters-widget__filter-list li {
 	border: none;
 	padding: 0;

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -20,7 +20,7 @@
 	margin-bottom: 1.5em;
 }
 
-.widget_search input[type="checkbox"] {
+.widget_search .jetpack-search-filters-widget__filter-list input[type="checkbox"] {
 	height: auto;
 }
 


### PR DESCRIPTION
Fixes a visual issue on the Hemingway theme which would affect others that set height on input controls.

Before:

<img width="282" alt="hemingway-ugh" src="https://user-images.githubusercontent.com/51896/35740464-bcfaa4e6-07e9-11e8-8228-e221d2b1e836.png">

After:

<img width="280" alt="hemingway-yay" src="https://user-images.githubusercontent.com/51896/35740482-cdf10222-07e9-11e8-98a6-13aa04d21153.png">
