### PR TITLE
Admin Page: Jetpack Banner - Make plan default to empty string instead of false

### DIFF
--- a/_inc/client/components/jetpack-banner/index.jsx
+++ b/_inc/client/components/jetpack-banner/index.jsx
@@ -32,7 +32,7 @@ class JetpackBanner extends Banner {
 
 	static defaultProps = {
 		onClick: noop,
-		plan: false,
+		plan: '',
 	};
 
 	render() {


### PR DESCRIPTION
So we don't get warnings about a boolean value for a string prop-type… a boolean value for a string prop-type

Fixes #8725

#### Changes proposed in this Pull Request:

* Updates the default value of `plan` to be `''` instead of `false` in JetpackBanner component.

#### Testing instructions:

* Check this branch
* Visit the Traffic tab
* Use the DevTools at the bottom of the page to emulate a **secondary admin**, that is **unlinked**:
   ![image](https://user-images.githubusercontent.com/746152/35740697-641876a2-0814-11e8-83e9-27f1f1eb3b79.png)
* Expect to see no error in the console mentioning an invalid boolean value

![image](https://user-images.githubusercontent.com/746152/35740741-871d00a0-0814-11e8-92a2-5c97c9b83447.png)


<!-- Add the following only if this is meant to be in changelog -->
