### PR TITLE
Inline label with search widget sort control

### DIFF
--- a/modules/search/class.jetpack-search-widget.php
+++ b/modules/search/class.jetpack-search-widget.php
@@ -269,15 +269,17 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		if ( ! empty( $instance['search_box_enabled'] ) && ! empty( $instance['user_sort_enabled'] ) ): ?>
-			<h4 class="jetpack-search-filters-widget__sub-heading"><?php esc_html_e( 'Sort by', 'jetpack' ); ?></h4>
 			<div class="jetpack-search-sort-wrapper">
-				<select class="jetpack-search-sort">
-					<?php foreach ( $this->get_sort_types() as $sort => $label ) { ?>
-						<option value="<?php echo esc_attr( $sort ); ?>" <?php selected( $current_sort, $sort ); ?>>
-							<?php echo esc_html( $label ); ?>
-						</option>
-					<?php } ?>
-				</select>
+				<label>
+					<?php esc_html_e( 'Sort by', 'jetpack' ); ?>
+					<select class="jetpack-search-sort">
+						<?php foreach ( $this->get_sort_types() as $sort => $label ) { ?>
+							<option value="<?php echo esc_attr( $sort ); ?>" <?php selected( $current_sort, $sort ); ?>>
+								<?php echo esc_html( $label ); ?>
+							</option>
+						<?php } ?>
+					</select>
+				</label>
 			</div>
 		<?php endif;
 

--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -17,6 +17,7 @@
 }
 
 .jetpack-search-sort-wrapper {
+	margin-top: 1em;
 	margin-bottom: 1.5em;
 }
 


### PR DESCRIPTION
Fixes #8690 

We currently put the label for the sort control in a `<h4>` right above it, similar to the headings for filter sections.

<img width="283" alt="sort-label-above" src="https://user-images.githubusercontent.com/51896/35741236-218e1418-07ec-11e8-9ac0-1b8041a122f2.png">

As per @gibrown 's suggestion, this PR turns it into a less obtrusive inline label.

<img width="280" alt="sort-inline-label" src="https://user-images.githubusercontent.com/51896/35743727-4362fdfe-07f3-11e8-9057-6959062c1a5b.png">

(theme pictured is Hemingway)

By adopting this HTML structure, I also feel like it's a little closer to how forms are typically rendered (including the form elements in our widget admin area)