### PR TITLE
Admin Page: Fix settingsPath prop passed to DashSectionHeader from Main component

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -58,7 +58,7 @@ class AtAGlance extends Component {
 		const trackSecurityClick = () => analytics.tracks.recordJetpackClick( 'aag_manage_security_wpcom' );
 		const securityHeader = <DashSectionHeader
 					label={ __( 'Security' ) }
-					settingsPath={ this.props.userCanManageModules && '#security' }
+					settingsPath={ this.props.userCanManageModules ? '#security' : undefined }
 					externalLink={ this.props.isDevMode || ! this.props.userCanManageModules
 						? ''
 						: __( 'Manage security on WordPress.com' )


### PR DESCRIPTION
Avoids a warning being thrown when visiting the Jetpack dashboard as an Editor or Subscriber

#### Changes proposed in this Pull Request:

* Updates the check for ability to manage modules that results in a boolean attribute passed if user can't manage modules.

#### Testing instructions:

* check this branch
* build the admin page
* Visit the Jetpack dashboard.
* Using the Dev Tools at the bottom of the page, switch roles to `Editor`.
* Expect to see no warning being thrown in the console about `Invalid prop `settingsPath` of type `boolean` supplied to `DashSectionHeader`

![image](https://user-images.githubusercontent.com/746152/35742636-d06e694c-0819-11e8-9e59-faadeb79a32a.png)
