### PR TITLE
Use correct widget name in Search setting explanation

### DIFF
--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -30,6 +30,10 @@
 		+ .dops-card {
 			margin-top: rem( 16px );
 		}
+
+		a {
+			text-decoration: underline;
+		}
 	}
 	.dops-foldable-card & {
 		padding-bottom: 16px;

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -39,7 +39,7 @@ class Search extends React.Component {
 					{ this.props.getOptionValue( 'search' ) && (
 						<FormFieldset>
 							<p className="jp-form-setting-explanation">
-								{ __( 'To configure search filters add the {{link}}Jetpack Search widget to your sidebar{{/link}}.', {
+								{ __( 'To configure search filters add the {{link}}"Search (Jetpack)" widget to your sidebar{{/link}}.', {
 									components: {
 										link: <a href="widgets.php" />
 									}


### PR DESCRIPTION
Fixes #8712

Use correct widget name in settings panel.

Also adds an underline to link styles in the "settings explanation" panels, since it was hard to distinguish links from non-linked text.

<img width="655" alt="search-explanation-link-with-underline" src="https://user-images.githubusercontent.com/51896/35743605-ef747128-07f2-11e8-8510-f8e78c6e46a9.png">
