### PR TITLE
Move 'Search' to top of a Search for Search

### DIFF
--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -71,6 +71,13 @@ export class Traffic extends React.Component {
 					)
 				}
 				{
+					foundSearch && (
+						<Search
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
 					foundAds && (
 						<Ads
 							{ ...commonProps }
@@ -115,13 +122,6 @@ export class Traffic extends React.Component {
 				{
 					foundVerification && (
 						<VerificationServices
-							{ ...commonProps }
-						/>
-					)
-				}
-				{
-					foundSearch && (
-						<Search
 							{ ...commonProps }
 						/>
 					)


### PR DESCRIPTION
Currently when you type "Search" into the search UI of the Jetpack Settings, the actual "Search" _module_ is way down the list, below modules of dubious relevance like SItemaps.

Given the simplistic nature of our feature search (just lists matching modules in their current UI order), this change hacks Search into the top spot by moving it closer to the top of the Traffic tab, right below stats.

#### Testing instructions:

* Search for "Search" in Jetpack Settings
* Should be at top of list.

New Search results:

<img width="662" alt="search-for-search" src="https://user-images.githubusercontent.com/51896/35747510-5972c1b8-07ff-11e8-8680-cee0d960befe.png">

Reordered UI in Traffic tab:

<img width="658" alt="search-traffic-tab" src="https://user-images.githubusercontent.com/51896/35747516-5eff28ce-07ff-11e8-8e3d-1b8a480c4505.png">


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
