### PR TITLE
Don't show upsells for SEO and Google Analytics for Premium Plans

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -150,7 +150,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
-				if ( 'is-business-plan' === planClass ) {
+				if ( 'is-business-plan' === planClass || 'is-premium-plan' === planClass ) {
 					return '';
 				}
 				return (
@@ -164,7 +164,7 @@ export const SettingsCard = props => {
 					/>
 				);
 			case FEATURE_SEO_TOOLS_JETPACK:
-				if ( 'is-business-plan' === planClass ) {
+				if ( 'is-business-plan' === planClass || 'is-premium-plan' === planClass ) {
 					return '';
 				}
 
@@ -242,14 +242,14 @@ export const SettingsCard = props => {
 				break;
 
 			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
-				if ( 'is-business-plan' !== planClass ) {
+				if ( 'is-business-plan' !== planClass && 'is-premium-plan' !== planClass ) {
 					return false;
 				}
 
 				break;
 
 			case FEATURE_SEO_TOOLS_JETPACK:
-				if ( 'is-business-plan' !== planClass ) {
+				if ( 'is-business-plan' !== planClass && 'is-premium-plan' !== planClass ) {
 					return false;
 				}
 


### PR DESCRIPTION
The work started in #8584 did not address the upsells/setting links in the SEO Tools and Google Analytics cards for Premium Plans.

#### Testing instructions:

Load Jetpack's settings page in wp-admin for a site with a Premium plan, go to the **Traffic** section. Without this branch, you will see:

<img width="772" alt="seo-ga" src="https://user-images.githubusercontent.com/195089/35749000-a7c74544-0815-11e8-88dc-9305c7a20079.png">

With this branch, you should see:

![screen shot 2018-02-02 at 12 35 34](https://user-images.githubusercontent.com/195089/35749023-bf53f46e-0815-11e8-9b84-3bb5b5180ccb.png)
