### PR TITLE
Lazy Images: Update module description to match marketing

### DIFF
--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Lazy Images
- * Module Description: "Lazy-load" images
+ * Module Description: Lazy load images
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -82,7 +82,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'lazy-images' => array(
 				'name' => _x( 'Lazy Images', 'Module Name', 'jetpack' ),
-				'description' => _x( '"Lazy-load" images', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Lazy load images', 'Module Description', 'jetpack' ),
 			),
 
 			'likes' => array(


### PR DESCRIPTION
For the Jetpack 5.8 release, our marketing is going to be using the phrase "Lazy load images".

See: p9mQOq-hy-ps

This PR updates the module description to match what marketing is using.

@ballio2000 said these changes are important, so I've added the blocker label.

Screenshot:

<img width="761" alt="screen shot 2018-02-02 at 1 48 44 pm" src="https://user-images.githubusercontent.com/1126811/35752128-64ead14a-0820-11e8-90ac-ad0a55bd4794.png">
