### PR TITLE
Lazy Images: Ensure lazy image attributes are not filtered out

### DIFF
--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -180,6 +180,36 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 		$this->assertSame( Jetpack_Lazy_Images::process_image_attributes( $input ), $expected_output );
 	}
 
+	function test_compat_with_wp_kses_post() {
+		$instance = Jetpack_Lazy_Images::instance();
+		remove_filter( 'wp_kses_allowed_html', array( $instance, 'allow_lazy_attributes' ) );
+
+		$sample_image_srcset = '<img src="placeholder.jpg" data-lazy-src="image.jpg" data-lazy-srcset="medium.jpg 1000w, large.jpg 2000w">';
+		$sample_img_sizes    = '<img src="placeholder.jpg" data-lazy-src="image.jpg" data-lazy-sizes="(min-width: 36em) 33.3vw, 100vw">';
+
+		$allowed = wp_kses_allowed_html();
+
+		// First, test existence of issue if we don't filter.
+		$no_lazy_srcset = wp_kses_post( $sample_image_srcset );
+		$no_lazy_sizes  = wp_kses_post( $sample_img_sizes );
+
+		$this->assertNotContains( 'data-lazy-src', $no_lazy_srcset );
+		$this->assertNotContains( 'data-lazy-src', $no_lazy_sizes );
+		$this->assertNotContains( 'data-lazy-srcset', $no_lazy_srcset );
+		$this->assertNotContains( 'data-lazy-size', $no_lazy_sizes );
+
+		add_filter( 'wp_kses_allowed_html', array( $instance, 'allow_lazy_attributes' ) );
+
+		// Second, test that the issue is fixed when we filter.
+		$with_lazy_srcset = wp_kses_post( $sample_image_srcset );
+		$with_lazy_sizes  = wp_kses_post( $sample_img_sizes );
+
+		$this->assertContains( 'data-lazy-src', $with_lazy_srcset );
+		$this->assertContains( 'data-lazy-src', $with_lazy_sizes );
+		$this->assertContains( 'data-lazy-srcset', $with_lazy_srcset );
+		$this->assertContains( 'data-lazy-size', $with_lazy_sizes );
+	}
+
 	/*
 	 * Helpers
 	 */


### PR DESCRIPTION
Fixes #8490

In #8490, @StefMattana reported an issue where featured images weren't working for a theme. After looking into it, the issue was that our "lazy" attributes were being filtered out by `wp_kses_post()`. 😱 

This meant that the src was getting swapped to the transparent GIF, but then we had no record in the HTML of what the src should be. Further, the JS didn't even know which images were lazy loaded since they didn't have the `data-lazy-src` attribute that the JavaScript looks for.

This PR ensures that our lazy attributes are allowed for images.

To test:

- Check out branch
- Ensure lazy images is enabled
- Run tests `phpunit --testsuite=lazy-images`
    - Note that there's a test there without any assertions... Let's fix that in a follow-up PR
- Install the Apostrophe 2 theme and ensure featured images work