### PR TITLE
Search: Force checkboxes in the search width to have normal width.

### DIFF
--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -22,6 +22,7 @@
 }
 
 .widget_search .jetpack-search-filters-widget__filter-list input[type="checkbox"] {
+	width: auto;
 	height: auto;
 }
 


### PR DESCRIPTION
Fixes themes that set a width to inputs, such as Zerif Lite.

**Before:**

![firefox_2018-02-02_16-24-59](https://user-images.githubusercontent.com/406254/35760547-da52ae34-0835-11e8-8fde-1d34ee82adf5.png)

**After:**

![firefox_2018-02-02_16-27-23](https://user-images.githubusercontent.com/406254/35760576-f91808a0-0835-11e8-9cf3-7b5efbf1fcb4.png)

See #8742