### PR TITLE
Search: Force labels to be shown in widget. Fixes Twenty Ten.

### DIFF
--- a/modules/search/css/search-widget-frontend.css
+++ b/modules/search/css/search-widget-frontend.css
@@ -21,6 +21,10 @@
 	margin-bottom: 1.5em;
 }
 
+.jetpack-search-sort-wrapper label {
+	display: inherit;
+}
+
 .widget_search .jetpack-search-filters-widget__filter-list input[type="checkbox"] {
 	height: auto;
 }
@@ -41,6 +45,7 @@ ul.jetpack-search-filters-widget__filter-list li a:hover {
 
 ul.jetpack-search-filters-widget__filter-list li label {
 	font-weight: inherit;
+	display: inherit;
 }
 
 .jetpack-search-filters-widget__filter-list {


### PR DESCRIPTION
Twenty Ten hides labels in the search widget: https://core.trac.wordpress.org/browser/tags/4.9.2/src/wp-content/themes/twentyten/style.css#L1154

This forces them to be shown within our search widget.

**Before:**

![firefox_2018-02-02_16-51-55](https://user-images.githubusercontent.com/406254/35761053-6d6158a8-0839-11e8-8861-fd9acec0b036.png)

**After:**

![firefox_2018-02-02_16-51-17](https://user-images.githubusercontent.com/406254/35761057-7270bf00-0839-11e8-9d50-fcc5231eb655.png)

See #8742.

