### PR TITLE
REST API: Allow empty site description in onboarding requests

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1022,7 +1022,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
-		if ( ! empty( $data['siteDescription'] ) ) {
+		if ( isset( $data['siteDescription'] ) ) {
 			// If option value was the same, consider it done.
 			if ( ! ( update_option( 'blogdescription', $data['siteDescription'] ) || get_option( 'blogdescription' ) == $data['siteDescription'] ) ) {
 				$error[] = 'siteDescription';


### PR DESCRIPTION
This PR updates the settings save endpoint to allow onboarding requests to contain an empty site description. It seems that right now we were specifically allowing only non-empty site descriptions, and empty descriptions are also a valid case.

Fixes part of https://github.com/Automattic/wp-calypso/issues/21868

To test:
* Checkout this branch
* Make sure the site already has a tagline.
* Start the onboarding flow
* Empty the site description field.
* Click the save button.
* Verify the site description is properly updated to an empty string in the remote site.