### PR TITLE
Rewind: when displaying a JITM for Rewind, add a redirect parameter

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -25,7 +25,7 @@ jQuery( document ).ready( function( $ ) {
 		}
 	};
 
-	var setJITMContent = function( $el, response ) {
+	var setJITMContent = function( $el, response, redirect ) {
 		var template;
 
 		var render = function( $my_template ) {
@@ -52,6 +52,8 @@ jQuery( document ).ready( function( $ ) {
 			template = 'default';
 		}
 
+		response.url = response.url + '&redirect=' + redirect;
+
 		var $template = templates[ template ]( response );
 		$template.find( '.jitm-banner__dismiss' ).click( render( $template ) );
 
@@ -66,6 +68,7 @@ jQuery( document ).ready( function( $ ) {
 
 		var message_path = $el.data( 'message-path' );
 		var query = $el.data( 'query' );
+		var redirect = $el.data( 'redirect' );
 
 		$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
 			message_path: message_path,
@@ -82,7 +85,7 @@ jQuery( document ).ready( function( $ ) {
 			}
 
 			// for now, always take the first response
-			setJITMContent( $el, response[ 0 ] );
+			setJITMContent( $el, response[ 0 ], redirect );
 		} );
 	} );
 } );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -137,12 +137,13 @@ class Jetpack_JITM {
 	function ajax_message() {
 		$message_path = $this->get_message_path();
 		$query_string = _http_build_query( $_GET, '', ',' );
-
+		$current_screen = wp_unslash( $_SERVER['REQUEST_URI'] );
 		?>
 		<div class="jetpack-jitm-message"
 		     data-nonce="<?php echo wp_create_nonce( 'wp_rest' ) ?>"
 		     data-message-path="<?php echo esc_attr( $message_path ) ?>"
 		     data-query="<?php echo urlencode_deep( $query_string ) ?>"
+		     data-redirect="<?php echo urlencode_deep( $current_screen ) ?>"
 		></div>
 		<?php
 	}


### PR DESCRIPTION
This PR introduces a `redirect` parameter in the URL of a JITM pointed to the current screen URL where the JITM was displayed.
This is handled in D9909-code to apply it to Rewind JITMs and sent to Calypso as `rewind-redirect`. This query param triggers the flow to activate Rewind.

#### Testing instructions:

- use this PR with D9909-code and https://github.com/Automattic/wp-calypso/pull/22141
- check the WP Admin of a site that doesn't have Rewind active (but available). It should show a JITM. When clicked, it should go to Calypso and display the Rewind activation flow