### PR TITLE
Site Settings: Source supporting files for changing the language setting

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -651,6 +651,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						return delete_option( 'WPLANG' );
 					}
 
+					if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+						require_once( ABSPATH . 'wp-admin/includes/file.php' );
+					}
+
+					if ( ! function_exists( 'wp_download_language_pack' ) ) {
+						require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+					}
+
 					// `wp_download_language_pack` only tries to download packs if they're not already available
 					$language = wp_download_language_pack( $value );
 					if ( $language === false ) {


### PR DESCRIPTION
Support for setting the site's language was added in #8568.

`wp_download_language_pack` & supporting functionality were previously defined in the context of the Site Settings API call.

That changed in [core](https://core.trac.wordpress.org/changeset/42606/trunk/src/wp-includes/capabilities.php) ([see also](https://core.trac.wordpress.org/ticket/42697
)) and now calls to change the language setting cause fatal errors.

This sources the files needed to continue calling `wp_download_language_pack`

#### Changes proposed in this Pull Request:

* Source required files in `wp-admin/includes` if `wp_download_language_pack` & `request_filesystem_credentials` are not defined.

#### Testing instructions:

* Apply this branch to your **connected** test site
* Run calypso at the version just prior to the language setting getting disabled:
  * `git checkout 1a0bad3550`
* Visit general site settings for your test site: http://calypso.localhost:3000/settings/general/<your-test-site-here>
* Change the language of the site
* Click save
  * It should save successfully
  * It should show as the new value on refresh
  * It should apply to the site's localization in wp-admin