### PR TITLE
Properly handle display of Lazy Images setting.

### DIFF
--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -49,48 +49,52 @@ const SpeedUpSite = moduleSettingsForm(
 					header={ __( 'Speed up your site' ) }
 					hideButton>
 
-					<SettingsGroup
-						hasChild
-						disableInDevMode
-						module={ photon }>
-						<ModuleToggle
-							slug="photon"
-							disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
-							activated={ this.props.getOptionValue( 'photon' ) }
-							toggling={ this.props.isSavingAnyOption( 'photon' ) }
-							toggleModule={ this.toggleModule }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ decodeEntities( photon.description ) }
-							</span>
-						</ModuleToggle>
-						<FormFieldset>
-							<span className="jp-form-setting-explanation">
-								{ decodeEntities( photon.long_description ) }
-							</span>
-						</FormFieldset>
-					</SettingsGroup>
+					{ foundPhoton &&
+						<SettingsGroup
+							hasChild
+							disableInDevMode
+							module={ photon }>
+							<ModuleToggle
+								slug="photon"
+								disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+								activated={ this.props.getOptionValue( 'photon' ) }
+								toggling={ this.props.isSavingAnyOption( 'photon' ) }
+								toggleModule={ this.toggleModule }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ decodeEntities( photon.description ) }
+								</span>
+							</ModuleToggle>
+							<FormFieldset>
+								<span className="jp-form-setting-explanation">
+									{ decodeEntities( photon.long_description ) }
+								</span>
+							</FormFieldset>
+						</SettingsGroup>
+					}
 
-					<SettingsGroup
-						hasChild
-						module={ lazyImages }>
-						<ModuleToggle
-							slug="lazy-images"
-							disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
-							activated={ this.props.getOptionValue( 'lazy-images' ) }
-							toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
-							toggleModule={ this.toggleModule }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ decodeEntities( lazyImages.description ) }
-							</span>
-						</ModuleToggle>
-						<FormFieldset>
-							<span className="jp-form-setting-explanation">
-								{ decodeEntities( lazyImages.long_description ) }
-							</span>
-						</FormFieldset>
-					</SettingsGroup>
+					{ foundLazyImages &&
+						<SettingsGroup
+							hasChild
+							module={ lazyImages }>
+							<ModuleToggle
+								slug="lazy-images"
+								disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
+								activated={ this.props.getOptionValue( 'lazy-images' ) }
+								toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
+								toggleModule={ this.toggleModule }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ decodeEntities( lazyImages.description ) }
+								</span>
+							</ModuleToggle>
+							<FormFieldset>
+								<span className="jp-form-setting-explanation">
+									{ decodeEntities( lazyImages.long_description ) }
+								</span>
+							</FormFieldset>
+						</SettingsGroup>
+					}
 				</SettingsCard>
 			);
 		}


### PR DESCRIPTION
This allows the setting UI to hide Lazy Images individually when they are filtered out, plus properly display search results.

Fixes #8778. 

#### Changes proposed in this Pull Request:
* Fixed Lazy Images setting display in Settings for search results and special cases like filter usage.

#### Testing instructions:
* Try to filter out lazy images as a module using this snippet:
```
add_filter( 'jetpack_get_available_modules', function( $active ) {
	return array_diff_key( $active, array( 'lazy-images' => 'Does not matter' ) );
} );
```
* Make sure you don't see the module at all when you open the Writing tab, or search for something like `lazy`.