### PR TITLE
Switch e2e tests to Jurassic.Ninja infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           command: ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: xvfb-run ./run.sh -R -j -H CI -p
+          command: xvfb-run ./run.sh -R -j -H JN -p
       - store_test_results:
           path: reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ defaults: &defaults
     docker:
       - image: automattic/wp-e2e-tests:0.0.7
         environment:
-                JETPACKHOST: CI
+                JETPACKHOST: JN
                 NODE_ENV: test
 version: 2
 jobs:
   build:
-    <<: *defaults          
+    <<: *defaults
     steps:
       - run:
           name: Clone wp-e2e-tests repo
@@ -16,7 +16,7 @@ jobs:
                   cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
                   cd /wp-e2e-tests
-                  git checkout origin/${E2E_BRANCH-master}
+                  git checkout try/switch-jetpack-tests-to-jn
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install
@@ -29,18 +29,8 @@ jobs:
           paths:
             - .
       - run:
-          name: Initialize site on Digital Ocean via ServerPilot
-          command: |
-                  source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js # In case of a rebuild
-                  source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
-      - run:
-          name: Install Jetpack from master
-          command: |
-                  scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
-                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-${CIRCLE_SHA1:0:20}
-      - run:
-          name: Run Jetpack activation spec
-          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
+          name: Run Jetpack JN activation spec
+          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - store_test_results:
           path: reports/
       - store_artifacts:
@@ -48,7 +38,7 @@ jobs:
       - store_artifacts:
           path: screenshots/
   test:
-    <<: *defaults          
+    <<: *defaults
     parallelism: 2
     steps:
       - attach_workspace:
@@ -65,29 +55,6 @@ jobs:
           path: screenshots/
       - store_artifacts:
           path: reports/
-  destroy:
-    <<: *defaults          
-    steps:
-      - attach_workspace:
-          at: /wp-e2e-tests
-      - run:
-          name: Run Jetpack deactivation spec
-          command: |
-                  if [ "$E2E_DEBUG" == "true" ]; then
-                    echo "Skipping deactivation step for DEBUG purposes"
-                  else
-                    source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
-                  fi
-          when: always
-      - run:
-          name: Delete site from Digital Ocean via ServerPilot
-          command: |
-                  if [ "$E2E_DEBUG" == "true" ]; then
-                    echo "Skipping delete step for DEBUG purposes"
-                  else
-                    source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
-                  fi
-          when: always 
 workflows:
   version: 2
   build_test_destroy:
@@ -101,6 +68,3 @@ workflows:
       - test:
           requires:
             - build
-      - destroy:
-          requires:
-            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,16 @@ jobs:
       - run:
           name: Run Jetpack JN activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
+      - persist_to_workspace:
+          root: /wp-e2e-tests
+          paths:
+            - .
+      - store_test_results:
+          path: reports/
+      - store_artifacts:
+          path: reports/
+      - store_artifacts:
+          path: screenshots/
   test:
     <<: *defaults
     parallelism: 2
@@ -45,3 +55,16 @@ jobs:
           path: screenshots/
       - store_artifacts:
           path: reports/
+workflows:
+  version: 2
+  build_test_destroy:
+    jobs:
+      - build:
+          filters:
+             branches:
+                only:
+                  - master
+                  - /.*e2e.*/
+      - test:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,6 @@ jobs:
       - run:
           name: Run Jetpack JN activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
-      - persist_to_workspace:
-          root: /wp-e2e-tests
-          paths:
-            - .
-      - store_test_results:
-          path: reports/
-      - store_artifacts:
-          path: reports/
-      - store_artifacts:
-          path: screenshots/
   test:
     <<: *defaults
     parallelism: 2
@@ -55,16 +45,3 @@ jobs:
           path: screenshots/
       - store_artifacts:
           path: reports/
-workflows:
-  version: 2
-  build_test_destroy:
-    jobs:
-      - build:
-          filters:
-             branches:
-                only:
-                  - master
-                  - /.*e2e.*/
-      - test:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
                   cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
                   cd /wp-e2e-tests
-                  git checkout try/switch-jetpack-tests-to-jn
+                  git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ jobs:
           paths:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
+      - run:
+          name: Run Jetpack JN activation spec
+          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - persist_to_workspace:
           root: /wp-e2e-tests
           paths:
             - .
-      - run:
-          name: Run Jetpack JN activation spec
-          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - store_test_results:
           path: reports/
       - store_artifacts:


### PR DESCRIPTION
Relies on https://github.com/Automattic/wp-e2e-tests/pull/911

#### Changes proposed in this Pull Request:

* Use Jurassic.ninja as platform for e2e tests
* Get rid of `destroy` step which was dependant on `test` step and was not always successful

#### Testing instructions:

* re-run CircleCI job: https://circleci.com/gh/Automattic/workflows/jetpack/tree/master