### PR TITLE
Add/sync widget title

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -40,6 +40,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		$widget = array(
 			'name' => $widget_object->name,
 			'id' => $widget_object->id,
+			'title' => isset( $new_instance['title'] ) ? $new_instance['title'] : '',
 		);
 		/**
 		 * Trigger action to alert $callable sync listener that a widget was edited

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -391,13 +391,14 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		/**
 		 * This filter is already documented in wp-includes/class-wp-widget.php
 		 */
-		do_action( 'widget_update_callback', array(), array(), array( 'dummy' => 'data' ), $object);
+		do_action( 'widget_update_callback', array(), array( 'title' => 'My Widget' ), array( 'dummy' => 'data' ), $object);
 
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_edited' );
 		$this->assertEquals( $event->args[0]['name'], 'Search' );
 		$this->assertEquals( $event->args[0]['id'], 'search-1' );
+		$this->assertEquals( $event->args[0]['title'], 'My Widget' );
 	}
 
 	private function install_theme( $slug ) {


### PR DESCRIPTION
This PR sync the widget's title (if it has one) when a widget is modified/edited.

#### Changes proposed in this Pull Request:

This PR sync the widget's title (if it has one) when a widget is modified/edited.

#### Testing instructions:

phpunit makes additional assertion to check for the title

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
