### PR TITLE
Lazy Images: Allow filtering out images via class and attributes

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -168,30 +168,14 @@ class Jetpack_Lazy_Images {
 			return $matches[0];
 		}
 
-		if (
-			! empty( $old_attributes_kses_hair['class'] ) &&
-			! empty( $old_attributes_kses_hair['class']['value'] ) &&
-			self::should_skip_image_with_blacklisted_class( $old_attributes_kses_hair['class']['value'] )
-		) {
-			return $matches[0];
-		}
-
-		/**
-		 * Allow plugins and themes to conditionally skip processing an image via its attributes.
-		 *
-		 * @module-lazy-images
-		 *
-		 * @since 5.9.0
-		 *
-		 * @param bool  Default to not skip processing the current image.
-		 * @param array An array of attributes via wp_kses_hair() for the current image.
-		 */
-		if ( apply_filters( 'jetpack_lazy_images_skip_image_with_atttributes', false, $old_attributes_kses_hair ) ) {
-			return $matches[0];
-		}
-
 		$old_attributes = self::flatten_kses_hair_data( $old_attributes_kses_hair );
 		$new_attributes = self::process_image_attributes( $old_attributes );
+
+		// If we didn't add lazy attributes, just return the original image source.
+		if ( empty( $new_attributes['data-lazy-src'] ) ) {
+			return $matches[0];
+		}
+
 		$new_attributes_str = self::build_attributes_string( $new_attributes );
 
 		return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );
@@ -209,6 +193,24 @@ class Jetpack_Lazy_Images {
 	 */
 	static function process_image_attributes( $attributes ) {
 		if ( empty( $attributes['src'] ) ) {
+			return $attributes;
+		}
+
+		if ( ! empty( $attributes['class'] ) && self::should_skip_image_with_blacklisted_class( $attributes['class'] ) ) {
+			return $attributes;
+		}
+
+		/**
+		 * Allow plugins and themes to conditionally skip processing an image via its attributes.
+		 *
+		 * @module-lazy-images
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param bool  Default to not skip processing the current image.
+		 * @param array An array of attributes via wp_kses_hair() for the current image.
+		 */
+		if ( apply_filters( 'jetpack_lazy_images_skip_image_with_atttributes', false, $attributes ) ) {
 			return $attributes;
 		}
 

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -176,6 +176,20 @@ class Jetpack_Lazy_Images {
 			return $matches[0];
 		}
 
+		/**
+		 * Allow plugins and themes to conditionally skip processing an image via its attributes.
+		 *
+		 * @module-lazy-images
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param bool  Default to not skip processing the current image.
+		 * @param array An array of attributes via wp_kses_hair() for the current image.
+		 */
+		if ( apply_filters( 'jetpack_lazy_images_skip_image_with_atttributes', false, $old_attributes_kses_hair ) ) {
+			return $matches[0];
+		}
+
 		$old_attributes = self::flatten_kses_hair_data( $old_attributes_kses_hair );
 		$new_attributes = self::process_image_attributes( $old_attributes );
 		$new_attributes_str = self::build_attributes_string( $new_attributes );

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -115,6 +115,21 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 					'data-lazy-sizes' => '(min-width: 36em) 33.3vw, 100vw'
 				)
 			),
+			'gazette_theme_featured_image' => array(
+				array(
+					'src' => 'image.jpg',
+					'width' => 10,
+					'height' => 10,
+					'class' => 'attachment-gazette-featured-content-thumbnail wp-post-image'
+				),
+				// should be unmodified
+				array(
+					'src' => 'image.jpg',
+					'width' => 10,
+					'height' => 10,
+					'class' => 'attachment-gazette-featured-content-thumbnail wp-post-image'
+				)
+			),
 		);
 	}
 

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -278,6 +278,22 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 		);
 	}
 
+	function test_jetpack_lazy_images_skip_image_with_atttributes_filter() {
+		$instance = Jetpack_Lazy_Images::instance();
+		$src = '<img src="image.jpg" srcset="medium.jpg 1000w, large.jpg 2000w" class="wp-post-image"/>';
+
+		$this->assertContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
+
+		add_filter( 'jetpack_lazy_images_skip_image_with_atttributes', '__return_true' );
+		$this->assertNotContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
+		remove_filter( 'jetpack_lazy_images_skip_image_with_atttributes', '__return_true' );
+
+		add_filter( 'jetpack_lazy_images_skip_image_with_atttributes', array( $this, '__skip_if_srcset' ), 10, 2 );
+		$this->assertNotContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
+		$this->assertContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( '<img src="image.jpg" />' ) );
+		remove_filter( 'jetpack_lazy_images_skip_image_with_atttributes', array( $this, '__skip_if_srcset' ), 10, 2 );
+	}
+
 	/*
 	 * Helpers
 	 */
@@ -313,5 +329,9 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 		ob_end_clean();
 
 		return trim( $contents );
+	}
+
+	public function __skip_if_srcset( $should_skip, $attributes ) {
+		return isset( $attributes['srcset'] );
 	}
 }


### PR DESCRIPTION
Closes #8785
Closes #8641 

In #8641, a user requests the ability to skip processing images with a given class.

In #8745, a user reports a compatibility issue with another plugin where we shouldn't be processing an image so that it's lazy. After looking at the plugin's code, I don't see any specific classes that we can hook on. 

These two issues go pretty well together. :smile:

This PR will begin skipping images where the `skip-lazy` class is applied. Further, a user can filter `jetpack_lazy_images_blacklisted_classes` to add or remove classes to the list of classes that we'll skip.

I've also added a filter that will allow skipping an image via its attributes. The `jetpack_lazy_images_skip_image_with_atttributes` receives an array of the current image's attributes as its second argument. Filters can hook on this, examine the attributes, and decide whether to skip the image or not.

These two methods of skipping images should provide a good amount of flexibility for plugins and themes.

To test:

- Run tests `phpunit --testsuite=lazy-images`
    - ~Note: there is currently a test that does not assert anything. That is not related to this PR. #8788 fixes that test.~ (Merged already)
- Ensure lazy images is on
- Install and activate gazette theme
- Go to customizer, the "Featured Content" section, then select a tag to show featured posts
- Ensure that some posts have featured images and the tag from the previous step
- Load frontend and ensure that the featured image thumbnails up to are displaying correctly