### PR TITLE
Sync: Refactor test so it's able to pass on PHP 5.2

### DIFF
--- a/tests/install-php-phpunit.sh
+++ b/tests/install-php-phpunit.sh
@@ -88,8 +88,8 @@ if [[ ${SWITCH_TO_PHP:0:3} == "5.2" ]]; then
     export PHPBREW_RC_ENABLE=1
     source $HOME/.phpbrew/bashrc
     phpbrew use 5.2.17
-    pear channel-discover pear.symfony-project.com
-    pear install pear.symfony-project.com/YAML-1.0.2
+    pear channel-discover pear.symfony.com
+    pear install symfony2/YAML-2.0.0
 
     # manually go back to the system php, we can't use `phpbrew switch-off`
     # because we're running a version of php that phpbrew doesn't work with at this point

--- a/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
+++ b/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
@@ -1,3 +1,9 @@
 <?php
 
+/**
+ * This code is used by the test test_register_post_types_callback_error() present in the file tests/php/sync/test_class.jetpack-sync-callables.php
+ * This test attempts to sync an anonymous callable but anonymous functions are not present in PHP 5.2 which we still support.
+ * So, this file is conditionally included by that test if being run on PHP >=5.4
+ */
 register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
+

--- a/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
+++ b/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
@@ -1,0 +1,3 @@
+<?php
+
+register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -624,8 +624,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	function test_register_post_types_callback_error() {
 		if ( version_compare(PHP_VERSION, '5.4', '<' ) ) {
 			$this->markTestSkipped( 'Callbacks are only available in PHP 5.4 and greater' );
+			return;
 		}
-		register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
+		// This file needs to be included conditionally so PHP 5.2 does not error due to static analysis of this file.
+		require_once dirname( __FILE__ ) . '/anonymous_function_test_for_register_post_types_callback_error.php';
 		$this->sender->do_sync();
 
 		$post_types =  $this->server_replica_storage->get_callable( 'post_types' );


### PR DESCRIPTION
Fixes #8458

The PHP 5.2 job was failing due to static analysis of this test file even when the test was marked as skipped for PHP >= 5.4.

#### Changes introduced by this PR

* Replaces a current test code for one that includes a file that will define an anonymouns function for testing when PHP >= 5.4.
* Updates the way we install the yaml dependency for phpunit.

#### Testing instructions

* Checking that the tests run by Travis in this PR pass is a good way to test. Otherwise setting all of the environments locally is complicated.
* Particularly, confirm that the job for PHP 5.2 (The last one in the list and currently allowed to fail) passes the tests.

