### PR TITLE
Convert dropdown to radio buttons in tiled gallaries

### DIFF
--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -90,7 +90,7 @@ class Jetpack_Gallery_Settings {
 				<span><?php _e( 'Type', 'jetpack' ); ?></span>
 				<select class="type" name="type" data-setting="type">
 					<?php foreach ( $this->gallery_types as $value => $caption ) : ?>
-						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></option>
+						<input type="radio" value="<?php echo esc_attr( $value ); ?>" <?php checked( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></input>
 					<?php endforeach; ?>
 				</select>
 			</label>


### PR DESCRIPTION
Fixes #6886

#### Changes proposed in this Pull Request:

* Convert the drop-down menu for _Tiled Galleries_ to _radio_ buttons
