### PR TITLE
Migrate from parse_url to wp_parse_url()

### DIFF
--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -206,7 +206,7 @@ class Jetpack_Media_Meta_Extractor {
 			if ( preg_match_all( '#(?:^|\s|"|\')(https?://([^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/))))#', $content, $matches ) ) {
 
 				foreach ( $matches[1] as $link_raw ) {
-					$url = parse_url( $link_raw );
+					$url = wp_parse_url( $link_raw );
 
 					// Data URI links
 					if ( isset( $url['scheme'] ) && 'data' === $url['scheme'] )
@@ -286,7 +286,7 @@ class Jetpack_Media_Meta_Extractor {
 				$embeds = array();
 
 				foreach ( $matches[1] as $link_raw ) {
-					$url = parse_url( $link_raw );
+					$url = wp_parse_url( $link_raw );
 
 					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw );
 
@@ -402,11 +402,11 @@ class Jetpack_Media_Meta_Extractor {
 		if ( !empty( $from_html ) ) {
 			$srcs = wp_list_pluck( $from_html, 'src' );
 			foreach( $srcs as $image_url ) {
-				if ( ( $src = parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
+				if ( ( $src = wp_parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
 					// Rebuild the URL without the query string
 					$queryless = $src['scheme'] . '://' . $src['host'] . $src['path'];
 				} elseif ( $length = strpos( $image_url, '?' ) ) {
-					// If parse_url() didn't work, strip off the query string the old fashioned way
+					// If wp_parse_url() didn't work, strip off the query string the old fashioned way
 					$queryless = substr( $image_url, 0, $length );
 				} else {
 					// Failing that, there was no spoon! Err ... query string!

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -127,7 +127,7 @@ class Jetpack_Media_Summary {
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
 							if ( !empty( $poster_image ) ) {
 								$return['image'] = $poster_image;
-								$poster_url_parts = parse_url( $poster_image );
+								$poster_url_parts = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
 						}
@@ -158,12 +158,12 @@ class Jetpack_Media_Summary {
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
 							if ( !empty( $poster_image ) ) {
 								$return['image'] = $poster_image;
-								$poster_url_parts = parse_url( $poster_image );
+								$poster_url_parts = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
 						} else if ( false !== strpos( $embed, 'dailymotion' ) ) {
 							$return['image'] = str_replace( 'dailymotion.com/video/','dailymotion.com/thumbnail/video/', $embed );
-							$return['image'] = parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
+							$return['image'] = wp_parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
 							$return['secure']['image'] = self::https( $return['image'] );
 						}
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -131,7 +131,7 @@ class Jetpack_Client_Server {
 		}
 
 		// If redirect_uri is SSO, ensure SSO module is enabled
-		parse_str( parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
+		parse_str( wp_parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
 
 		/** This filter is documented in class.jetpack-cli.php */
 		$jetpack_start_enable_sso = apply_filters( 'jetpack_start_enable_sso', true );

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -132,7 +132,7 @@ class Jetpack_Client {
 			'Authorization' => "X_JETPACK " . join( ' ', $header_pieces ),
 		) );
 
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 
 		// If we have a JETPACK__WPCOM_JSON_API_HOST_HEADER set, then let's use
 		// that, otherwise, let's fallback to the standard.

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -211,7 +211,7 @@ class Jetpack_PostImages {
 		$inserted_images = array();
 
 		foreach( $html_images as $html_image ) {
-			$src = parse_url( $html_image['src'] );
+			$src = wp_parse_url( $html_image['src'] );
 			// strip off any query strings from src
 			if( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
 				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
@@ -619,7 +619,7 @@ class Jetpack_PostImages {
 		}
 
 		// If WPCOM hosted image use native transformations
-		$img_host = parse_url( $src, PHP_URL_HOST );
+		$img_host = wp_parse_url( $src, PHP_URL_HOST );
 		if ( '.files.wordpress.com' == substr( $img_host, -20 ) ) {
 			return add_query_arg( array( 'w' => $width, 'h' => $height, 'crop' => 1 ), set_url_scheme( $src ) );
 		}

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -157,7 +157,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		$parsed = parse_url( $url );
+		$parsed = wp_parse_url( $url );
 		if ( !isset( $parsed['host'] ) ) {
 			return new Jetpack_Error( 'invalid_signature', sprintf( 'The required "%s" parameter is malformed.', 'url' ) );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -707,7 +707,7 @@ class Jetpack {
 
 	function point_edit_comment_links_to_calypso( $url ) {
 		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
-		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+		wp_parse_str( wp_wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
 		return esc_url( sprintf( 'https://wordpress.com/comment/%s/%d',
 			Jetpack::build_raw_urls( get_home_url() ),
 			$query_args['amp;c']
@@ -3008,7 +3008,7 @@ p {
 			return array( 'wp-cli', null );
 		}
 
-		$referer = parse_url( $referer_url );
+		$referer = wp_parse_url( $referer_url );
 
 		$source_type = 'unknown';
 		$source_query = null;
@@ -3017,8 +3017,8 @@ p {
 			return array( $source_type, $source_query );
 		}
 
-		$plugins_path = parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
-		$plugins_install_path = parse_url( admin_url( 'plugin-install.php' ), PHP_URL_PATH );// /wp-admin/plugin-install.php
+		$plugins_path = wp_parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
+		$plugins_install_path = wp_parse_url( admin_url( 'plugin-install.php' ), PHP_URL_PATH );// /wp-admin/plugin-install.php
 
 		if ( isset( $referer['query'] ) ) {
 			parse_str( $referer['query'], $query_parts );
@@ -3212,8 +3212,8 @@ p {
 		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
 			// Before attempting to connect, let's make sure that the domains are viable.
 			$domains_to_check = array_unique( array(
-				'siteurl' => parse_url( get_site_url(), PHP_URL_HOST ),
-				'homeurl' => parse_url( get_home_url(), PHP_URL_HOST ),
+				'siteurl' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+				'homeurl' => wp_parse_url( get_home_url(), PHP_URL_HOST ),
 			) );
 			foreach ( $domains_to_check as $domain ) {
 				$result = Jetpack_Data::is_usable_domain( $domain );
@@ -4628,7 +4628,7 @@ p {
 					remove_action( 'jetpack_pre_activate_module',   array( Jetpack_Admin::init(), 'fix_redirect' ) );
 
 					// Don't redirect form the Jetpack Setting Page
-					$referer_parsed = parse_url ( wp_get_referer() );
+					$referer_parsed = wp_parse_url ( wp_get_referer() );
 					// check that we do have a wp_get_referer and the query paramater is set orderwise go to the Jetpack Home
 					if ( isset( $referer_parsed['query'] ) && false !== strpos( $referer_parsed['query'], 'page=jetpack_modules' ) ) {
 						// Take the user to Jetpack home except when on the setting page
@@ -5687,7 +5687,7 @@ p {
 		if ( ! isset( $path ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 			$admin_url = Jetpack::admin_url();
-			$bits      = parse_url( $admin_url );
+			$bits      = wp_parse_url( $admin_url );
 
 			if ( is_array( $bits ) ) {
 				$path   = ( isset( $bits['path'] ) ) ? dirname( $bits['path'] ) : null;
@@ -5821,7 +5821,7 @@ p {
 	public static function staticize_subdomain( $url ) {
 
 		// Extract hostname from URL
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
@@ -5875,7 +5875,7 @@ p {
 			return $url;
 		}
 
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 		$url = strtok( $url, '?' );
 		$url = "$url?{$_SERVER['QUERY_STRING']}";
 		if ( ! empty( $parsed_url['query'] ) )
@@ -6212,9 +6212,9 @@ p {
 	 * @return WP_Error|string
 	 */
 	public static function normalize_url_protocol_agnostic( $url ) {
-		$parsed_url = wp_parse_url( trailingslashit( esc_url_raw( $url ) ) );
+		$parsed_url = wp_wp_parse_url( trailingslashit( esc_url_raw( $url ) ) );
 		if ( ! $parsed_url || empty( $parsed_url['host'] ) || empty( $parsed_url['path'] ) ) {
-			return new WP_Error( 'cannot_parse_url', sprintf( esc_html__( 'Cannot parse URL %s', 'jetpack' ), $url ) );
+			return new WP_Error( 'cannot_wp_parse_url', sprintf( esc_html__( 'Cannot parse URL %s', 'jetpack' ), $url ) );
 		}
 
 		// Strip www and protocols
@@ -6524,7 +6524,7 @@ p {
 	public static function absolutize_css_urls( $css, $css_file_url ) {
 		$pattern = '#url\((?P<path>[^)]*)\)#i';
 		$css_dir = dirname( $css_file_url );
-		$p       = parse_url( $css_dir );
+		$p       = wp_parse_url( $css_dir );
 		$domain  = sprintf(
 					'%1$s//%2$s%3$s%4$s',
 					isset( $p['scheme'] )           ? "{$p['scheme']}:" : '',

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1842,7 +1842,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return false;
 
 		// if we didn't get a URL, let's bail
-		$parsed = @parse_url( $url );
+		$parsed = @wp_parse_url( $url );
 		if ( empty( $parsed ) )
 			return false;
 
@@ -1860,7 +1860,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		// emulate a $_FILES entry
 		$file_array = array(
-			'name' => basename( parse_url( $url, PHP_URL_PATH ) ),
+			'name' => basename( wp_parse_url( $url, PHP_URL_PATH ) ),
 			'tmp_name' => $tmp,
 		);
 

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -94,7 +94,7 @@ class WPCOM_JSON_API {
 			$this->url = $url;
 		}
 
-		$parsed     = parse_url( $this->url );
+		$parsed     = wp_parse_url( $this->url );
 		$this->path = $parsed['path'];
 
 		if ( !empty( $parsed['query'] ) ) {

--- a/class.photon.php
+++ b/class.photon.php
@@ -840,12 +840,12 @@ class Jetpack_Photon {
 	 * @return bool
 	 */
 	protected static function validate_image_url( $url ) {
-		$parsed_url = @parse_url( $url );
+		$parsed_url = @wp_parse_url( $url );
 
 		if ( ! $parsed_url )
 			return false;
 
-		// Parse URL and ensure needed keys exist, since the array returned by `parse_url` only includes the URL components it finds.
+		// Parse URL and ensure needed keys exist, since the array returned by `wp_parse_url` only includes the URL components it finds.
 		$url_info = wp_parse_args( $parsed_url, array(
 			'scheme' => null,
 			'host'   => null,

--- a/functions.compat.php
+++ b/functions.compat.php
@@ -22,7 +22,7 @@ function jetpack_get_youtube_id( $url ) {
 	}
 
 	$url = youtube_sanitize_url( $url );
-	$url = parse_url( $url );
+	$url = wp_parse_url( $url );
 	$id  = false;
 
 	if ( ! isset( $url['query'] ) )

--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -90,7 +90,7 @@ class Jetpack_Gallery_Settings {
 				<span><?php _e( 'Type', 'jetpack' ); ?></span>
 				<select class="type" name="type" data-setting="type">
 					<?php foreach ( $this->gallery_types as $value => $caption ) : ?>
-						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></option>
+						<input type="radio" value="<?php echo esc_attr( $value ); ?>" <?php checked( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></input>
 					<?php endforeach; ?>
 				</select>
 			</label>

--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -89,7 +89,7 @@ class Jetpack_Gallery_Settings {
 			<label class="setting">
 				<span><?php _e( 'Type', 'jetpack' ); ?></span>
 				<select class="type" name="type" data-setting="type">
-					<?php foreach ( $this->gallery_types as $value => $caption ) : ?>
+						<?php foreach ( $this->gallery_types as $value => $caption ) : ?>
 						<input type="radio" value="<?php echo esc_attr( $value ); ?>" <?php checked( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></input>
 					<?php endforeach; ?>
 				</select>

--- a/functions.global.php
+++ b/functions.global.php
@@ -121,7 +121,7 @@ function jetpack_theme_update( $preempt, $r, $url ) {
 		if ( ! $file ) {
 			return new WP_Error( 'problem_creating_theme_file', esc_html__( 'Problem creating file for theme download', 'jetpack' ) );
 		}
-		$theme = pathinfo( parse_url( $url, PHP_URL_PATH ), PATHINFO_FILENAME );
+		$theme = pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_FILENAME );
 
 		// Remove filter to avoid endless loop since wpcom_json_api_request_as_blog uses this too.
 		remove_filter( 'pre_http_request', 'jetpack_theme_update' );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -71,7 +71,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if ( empty( $image_url ) )
 		return $image_url;
 
-	$image_url_parts = @jetpack_photon_parse_url( $image_url );
+	$image_url_parts = @jetpack_photon_wp_parse_url( $image_url );
 
 	// Unable to parse
 	if ( ! is_array( $image_url_parts ) || empty( $image_url_parts['host'] ) || empty( $image_url_parts['path'] ) )
@@ -118,7 +118,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	// Alternately, if it's a *.files.wordpress.com url, and the arguments are supported, keep the domain.
 	if (
 		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
-		|| $image_url_parts['host'] === jetpack_photon_parse_url( $custom_photon_url, PHP_URL_HOST )
+		|| $image_url_parts['host'] === jetpack_photon_wp_parse_url( $custom_photon_url, PHP_URL_HOST )
 		|| $is_wpcom_image_with_safe_args
 	) {
 		$photon_url = add_query_arg( $args, $image_url );
@@ -208,7 +208,7 @@ add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
 add_filter( 'jetpack_photon_pre_args', 'jetpack_photon_parse_wpcom_query_args', 10, 2 );
 
 function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
-	$parsed_url = @parse_url( $image_url );
+	$parsed_url = @wp_parse_url( $image_url );
 
 	if ( ! $parsed_url )
 		return $args;
@@ -266,21 +266,21 @@ function jetpack_photon_url_scheme( $url, $scheme ) {
 }
 
 /**
- * A wrapper for PHP's parse_url, prepending assumed scheme for network path
+ * A wrapper for PHP's wp_parse_url, prepending assumed scheme for network path
  * URLs. PHP versions 5.4.6 and earlier do not correctly parse without scheme.
  *
  * @see http://php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-changelog
  *
  * @param string $url The URL to parse
  * @param integer $component Retrieve specific URL component
- * @return mixed Result of parse_url
+ * @return mixed Result of wp_parse_url
  */
-function jetpack_photon_parse_url( $url, $component = -1 ) {
+function jetpack_photon_wp_parse_url( $url, $component = -1 ) {
 	if ( 0 === strpos( $url, '//' ) ) {
 		$url = ( is_ssl() ? 'https:' : 'http:' ) . $url;
 	}
 
-	return parse_url( $url, $component );
+	return wp_parse_url( $url, $component );
 }
 
 add_filter( 'jetpack_photon_skip_for_url', 'jetpack_photon_banned_domains', 9, 2 );
@@ -292,7 +292,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/\.fbcdn\.net$/'
 	);
 
-	$host = jetpack_photon_parse_url( $image_url, PHP_URL_HOST );
+	$host = jetpack_photon_wp_parse_url( $image_url, PHP_URL_HOST );
 
 	foreach ( $banned_host_patterns as $banned_host_pattern ) {
 		if ( 1 === preg_match( $banned_host_pattern, $host ) ) {

--- a/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -146,7 +146,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 		}
 
 		// if we didn't get a URL, let's bail
-		$parsed = @parse_url( $url );
+		$parsed = @wp_parse_url( $url );
 		if ( empty( $parsed ) ) {
 			return new WP_Error( 'invalid_url', 'No media provided in url.' );
 		}

--- a/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
@@ -49,7 +49,7 @@ class WPCOM_JSON_API_Render_Embed_Endpoint extends WPCOM_JSON_API_Render_Endpoin
 		}
 
 		$embed_url = array_shift( $matches[1] );
-		$parts = parse_url( $embed_url );
+		$parts = wp_parse_url( $embed_url );
 		if ( ! $parts ) {
 			return new WP_Error( 'invalid_embed_url', 'The embed_url parameter must be a valid URL.', 400 );
 		}

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -285,7 +285,7 @@ class Jetpack_Carousel {
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
 			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! Jetpack::is_development_mode() ) {
-				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
+				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.
 				if ( is_user_logged_in() && function_exists( 'stats_get_options' ) ) {

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -39,7 +39,7 @@ class Jetpack_Comment_Likes {
 		$this->settings  = new Jetpack_Likes_Settings();
 		$this->blog_id   = Jetpack_Options::get_option( 'id' );
 		$this->url       = home_url();
-		$this->url_parts = parse_url( $this->url );
+		$this->url_parts = wp_parse_url( $this->url );
 		$this->domain    = $this->url_parts['host'];
 
 		add_action( 'init', array( $this, 'frontend_init' ) );

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -155,7 +155,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		// Detect whether it's a Facebook or Twitter avatar
 		$foreign_avatar          = get_comment_meta( $comment->comment_ID, 'hc_avatar', true );
-		$foreign_avatar_hostname = parse_url( $foreign_avatar, PHP_URL_HOST );
+		$foreign_avatar_hostname = wp_parse_url( $foreign_avatar, PHP_URL_HOST );
 		if ( ! $foreign_avatar_hostname ||
 			! preg_match( '/\.?(graph\.facebook\.com|twimg\.com)$/', $foreign_avatar_hostname ) ) {
 			return $avatar;

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -657,7 +657,7 @@ function grunion_ajax_spam() {
 		do_action( 'contact_form_akismet', 'ham', $akismet_values );
 
 		$comment_author_email = $reply_to_addr = $message = $to = $headers = false;
-		$blog_url = parse_url( site_url() );
+		$blog_url = wp_parse_url( site_url() );
 
 		// resend the original email
 		$email = get_post_meta( $post_id, '_feedback_email', TRUE );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2026,7 +2026,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$to[ $to_key ] = self::add_name_to_address( $to_value );
 		}
 
-		$blog_url = parse_url( site_url() );
+		$blog_url = wp_parse_url( site_url() );
 		$from_email_addr = 'wordpress@' . $blog_url['host'];
 
 		if ( ! empty( $comment_author_email ) ) {

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -161,7 +161,7 @@ class Jetpack_Infinite_Scroll_Extras {
 			}
 
 			// We made it this far, so gather the data needed to track IS views
-			$settings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
+			$settings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 			// Pagetype parameter
 			$settings['stats'] .= '&x_pagetype=infinite';

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -435,7 +435,7 @@ class Jetpack_Likes {
 		} else {
 			$blog_id = Jetpack_Options::get_option( 'id' );
 			$url = home_url();
-			$url_parts = parse_url( $url );
+			$url_parts = wp_parse_url( $url );
 			$domain = $url_parts['host'];
 		}
 		// make sure to include the scripts before the iframe otherwise weird things happen
@@ -520,7 +520,7 @@ class Jetpack_Likes {
 		} else {
 			$blog_id = Jetpack_Options::get_option( 'id' );
 			$url = home_url();
-			$url_parts = parse_url( $url );
+			$url_parts = wp_parse_url( $url );
 			$domain = $url_parts['host'];
 		}
 		// make sure to include the scripts before the iframe otherwise weird things happen

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -123,7 +123,7 @@ function jetpack_mobile_available() {
 function jetpack_mobile_request_handler() {
 	global $wpdb;
 	if (isset($_GET['ak_action'])) {
-		$url = parse_url( get_bloginfo( 'url' ) );
+		$url = wp_parse_url( get_bloginfo( 'url' ) );
 		$domain = $url['host'];
 		if (!empty($url['path'])) {
 			$path = $url['path'];

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -887,14 +887,14 @@ class Jetpack_Protect_Module {
 			$uri = network_home_url();
 		}
 
-		$uridata = parse_url( $uri );
+		$uridata = wp_parse_url( $uri );
 
 		$domain = $uridata['host'];
 
 		// If we still don't have the site_url, get it
 		if ( ! $domain ) {
 			$uri     = get_site_url( 1 );
-			$uridata = parse_url( $uri );
+			$uridata = wp_parse_url( $uri );
 			$domain  = $uridata['host'];
 		}
 

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -211,8 +211,8 @@ function jetpack_clean_ip( $ip ) {
 		$ip = $matches[1];
 	}
 
-	if ( function_exists( 'parse_url' ) ) {
-		$parsed_url = parse_url( $ip );
+	if ( function_exists( 'wp_parse_url' ) ) {
+		$parsed_url = wp_parse_url( $ip );
 
 		if ( isset( $parsed_url['host'] ) ) {
 			$ip = $parsed_url['host'];

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -734,7 +734,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_basehostname( $url ) {
-		return parse_url( $url, PHP_URL_HOST );
+		return wp_parse_url( $url, PHP_URL_HOST );
 	}
 
 	function options_save_tumblr() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -137,7 +137,7 @@ abstract class Publicize_Base {
 		$cmeta = $this->get_connection_meta( $c );
 
 		if ( isset( $cmeta['connection_data']['meta']['link'] ) ) {
-			if ( 'facebook' == $service_name && 0 === strpos( parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
+			if ( 'facebook' == $service_name && 0 === strpos( wp_parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
 				// App-scoped Facebook user IDs are not usable profile links
 				return false;
 			}
@@ -158,7 +158,7 @@ abstract class Publicize_Base {
 				return false;
 			}
 
-			$profile_url_query = parse_url( $cmeta['connection_data']['meta']['profile_url'], PHP_URL_QUERY );
+			$profile_url_query = wp_parse_url( $cmeta['connection_data']['meta']['profile_url'], PHP_URL_QUERY );
 			wp_parse_str( $profile_url_query, $profile_url_query_args );
 			if ( isset( $profile_url_query_args['key'] ) ) {
 				$id = $profile_url_query_args['key'];

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -605,7 +605,7 @@ class Jetpack_Search_Helpers {
 					continue;
 				}
 
-				$parsed = wp_parse_url( $bucket['remove_url'] );
+				$parsed = wp_wp_parse_url( $bucket['remove_url'] );
 				if ( ! $parsed ) {
 					continue;
 				}

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -260,7 +260,7 @@ function dailymotion_channel_reversal( $content ) {
 		}
 
 		foreach ( $matches as $match ) {
-			$url_pieces = parse_url( $match[1] );
+			$url_pieces = wp_parse_url( $match[1] );
 
 			if ( 'type=carousel' === $url_pieces['query'] ) {
 				$type = 'carousel';

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -58,7 +58,7 @@ function getty_add_oembed_endpoint_caller( $provider ) {
 
 		// Only include caller for non-private sites
 		if ( ! function_exists( 'is_private_blog' ) || ! is_private_blog() ) {
-			$host = parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
+			$host = wp_parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
 		}
 
 		// Fall back to WordPress.com
@@ -66,7 +66,7 @@ function getty_add_oembed_endpoint_caller( $provider ) {
 			$host = 'wordpress.com';
 		}
 	} else {
-		$host = parse_url( get_home_url(), PHP_URL_HOST );
+		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
 	}
 
 	return add_query_arg( 'caller', $host, $provider );

--- a/modules/shortcodes/hulu.php
+++ b/modules/shortcodes/hulu.php
@@ -108,7 +108,7 @@ function jetpack_hulu_shortcode( $atts ) {
 
 				// Pull out id from embed url (from oembed API)
 				$embed_url_params = array();
-				parse_str( parse_url( $json->embed_url, PHP_URL_QUERY ), $embed_url_params );
+				parse_str( wp_parse_url( $json->embed_url, PHP_URL_QUERY ), $embed_url_params );
 
 				if ( isset( $embed_url_params['eid'] ) ) {
 					$id = $embed_url_params['eid'];
@@ -208,7 +208,7 @@ function wpcom_shortcodereverse_huluhelper( $attrs ) {
 	$attrs = wpcom_shortcodereverse_parseattr( $attrs );
 
 	$src_attributes = array();
-	parse_str( parse_url( $attrs['src'], PHP_URL_QUERY ), $src_attributes );
+	parse_str( wp_parse_url( $attrs['src'], PHP_URL_QUERY ), $src_attributes );
 
 	$attrs = array_merge( $attrs, $src_attributes );
 

--- a/modules/shortcodes/kickstarter.php
+++ b/modules/shortcodes/kickstarter.php
@@ -24,7 +24,7 @@ function jetpack_kickstarter_shortcode( $atts ) {
 	}
 
 	$url = esc_url_raw( $atts['url'] );
-	if ( ! preg_match( '#^(www\.)?kickstarter\.com$#i', parse_url( $url, PHP_URL_HOST ) ) ) {
+	if ( ! preg_match( '#^(www\.)?kickstarter\.com$#i', wp_parse_url( $url, PHP_URL_HOST ) ) ) {
 		return '<!-- Invalid Kickstarter URL -->';
 	}
 

--- a/modules/shortcodes/lytro.php
+++ b/modules/shortcodes/lytro.php
@@ -202,7 +202,7 @@ function jetpack_lytro_shortcode_url_to_atts( $url ) {
 		$atts['photo']    = $matches[3];
 	}
 
-	$url = parse_url( $url );
+	$url = wp_parse_url( $url );
 	if ( isset( $url['query'] ) ) {
 		parse_str( $url['query'], $qargs );
 

--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -47,7 +47,7 @@ function jetpack_embed_medium_shortcode( $atts ) {
 }
 
 function jetpack_embed_medium_get_embed_type( $url ) {
-	$url_path = parse_url( $url, PHP_URL_PATH );
+	$url_path = wp_parse_url( $url, PHP_URL_PATH );
 	if ( preg_match( '/^\/@[\.\w]+$/', $url_path ) ) {
 		return 'profile';
 	} else if ( preg_match( '/^\/[\da-zA-Z-]+$/', $url_path ) ) {

--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -14,7 +14,7 @@ function pinterest_embed_handler( $matches, $attr, $url ) {
     $script_src = '//assets.pinterest.com/js/pinit.js';
 	wp_enqueue_script( 'pinterest-embed', $script_src, array(), false, true );
 
-	$path = parse_url( $url, PHP_URL_PATH );
+	$path = wp_parse_url( $url, PHP_URL_PATH );
 	if ( 0 === strpos( $path, '/pin/' ) ) {
 		$embed_type = 'embedPin';
 	} elseif ( preg_match( '#^/([^/]+)/?$#', $path ) ) {

--- a/modules/shortcodes/polldaddy.php
+++ b/modules/shortcodes/polldaddy.php
@@ -396,7 +396,7 @@ CONTAINER;
 						$id = preg_replace( '/[\/\?&\{\}]/', '', $id );
 
 						$auto_src = esc_url( "http://{$domain}.polldaddy.com/s/{$id}" );
-						$auto_src = parse_url( $auto_src );
+						$auto_src = wp_parse_url( $auto_src );
 
 						if ( ! is_array( $auto_src ) || count( $auto_src ) == 0 ) {
 							return '<!-- no polldaddy output -->';

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -186,7 +186,7 @@ function soundcloud_oembed_params_callback( $match ) {
 	global $soundcloud_oembed_params;
 
 	// Convert URL to array
-	$url = parse_url( urldecode( $match[1] ) );
+	$url = wp_parse_url( urldecode( $match[1] ) );
 	// Convert URL query to array
 	parse_str( $url['query'], $query_array );
 	// Build new query string
@@ -277,7 +277,7 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 			// if pasted from the visual editor - prevent double encoding
 			$match[1] = str_replace( '&amp;amp;', '&amp;', $match[1] );
 
-			$args = parse_url( html_entity_decode( $match[1] ), PHP_URL_QUERY );
+			$args = wp_parse_url( html_entity_decode( $match[1] ), PHP_URL_QUERY );
 			$args = wp_parse_args( $args );
 
 			if ( ! preg_match( '#^(?:https?:)?//api\.soundcloud\.com/.+$#i', $args['url'], $url_matches ) ) {

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -158,7 +158,7 @@ function youtube_id( $url ) {
 		return '<!--YouTube Error: bad URL entered-->';
 
 	$url = youtube_sanitize_url( $url );
-	$url = parse_url( $url );
+	$url = wp_parse_url( $url );
 
 	if ( ! isset( $url['query'] ) )
 		return false;

--- a/modules/sitemaps/sitemap-finder.php
+++ b/modules/sitemaps/sitemap-finder.php
@@ -45,7 +45,7 @@ class Jetpack_Sitemap_Finder {
 		global $wp_rewrite;
 
 		// Get path fragment from home_url().
-		$home = wp_parse_url( home_url() );
+		$home = wp_wp_parse_url( home_url() );
 		if ( isset( $home['path'] ) ) {
 			$home_path = $home['path'];
 		} else {

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -192,7 +192,7 @@ class Jetpack_SSO_Helpers {
 		$hosts[] = 'public-api.wordpress.com';
 
 		if ( false === strpos( $api_base, 'jetpack.wordpress.com/jetpack' ) ) {
-			$base_url_parts = parse_url( esc_url_raw( $api_base ) );
+			$base_url_parts = wp_parse_url( esc_url_raw( $api_base ) );
 			if ( $base_url_parts && ! empty( $base_url_parts[ 'host' ] ) ) {
 				$hosts[] = $base_url_parts[ 'host' ];
 			}
@@ -298,7 +298,7 @@ class Jetpack_SSO_Helpers {
 
 		$original_request = esc_url_raw( $_COOKIE['jetpack_sso_original_request'] );
 
-		$parsed_url = wp_parse_url( $original_request );
+		$parsed_url = wp_wp_parse_url( $original_request );
 		if ( empty( $parsed_url ) || empty( $parsed_url['query'] ) ) {
 			return false;
 		}

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -187,7 +187,7 @@ function stats_build_view_data() {
 	$blog = Jetpack_Options::get_option( 'id' );
 	$tz = get_option( 'gmt_offset' );
 	$v = 'ext';
-	$blog_url = parse_url( site_url() );
+	$blog_url = wp_parse_url( site_url() );
 	$srv = $blog_url['host'];
 	$j = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
 	if ( $wp_the_query->is_single || $wp_the_query->is_page || $wp_the_query->is_posts_page ) {
@@ -413,7 +413,7 @@ function stats_reports_load() {
 	add_action( 'admin_print_styles', 'stats_reports_css' );
 
 	if ( isset( $_GET['nojs'] ) && $_GET['nojs'] ) {
-		$parsed = parse_url( admin_url() );
+		$parsed = wp_parse_url( admin_url() );
 		// Remember user doesn't want JS.
 		setcookie( 'stnojs', '1', time() + 172800, $parsed['path'] ); // 2 days.
 	}
@@ -455,7 +455,7 @@ function stats_reports_css() {
  * @return void
  */
 function stats_js_remove_stnojs_cookie() {
-	$parsed = parse_url( admin_url() );
+	$parsed = wp_parse_url( admin_url() );
 ?>
 <script type="text/javascript">
 /* <![CDATA[ */
@@ -932,7 +932,7 @@ function stats_update_blog() {
  * @return string
  */
 function stats_get_blog() {
-	$home = parse_url( trailingslashit( get_option( 'home' ) ) );
+	$home = wp_parse_url( trailingslashit( get_option( 'home' ) ) );
 	$blog = array(
 		'host'                => $home['host'],
 		'path'                => $home['path'],

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -288,7 +288,7 @@ class VideoPress_Video {
 	 * @return bool|string host component of the URL, or false if none found
 	 */
 	public static function hostname( $url ) {
-		return parse_url( esc_url_raw( $url ), PHP_URL_HOST );
+		return wp_parse_url( esc_url_raw( $url ), PHP_URL_HOST );
 	}
 
 

--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -24,7 +24,7 @@ function videopress_handle_editor_view_js() {
 		true
 	);
 	wp_localize_script( 'videopress-editor-view', 'vpEditorView', array(
-		'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),
+		'home_url_host'     => wp_parse_url( home_url(), PHP_URL_HOST ),
 		'min_content_width' => VIDEOPRESS_MIN_WIDTH,
 		'content_width'     => $content_width,
 		'modal_labels'      => array(

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -223,7 +223,7 @@ class VideoPress_Shortcode {
 		if ( false === stripos( $oembed_provider, 'videopress.com' ) ) {
 			return $oembed_provider;
 		}
-		return add_query_arg( 'for', parse_url( home_url(), PHP_URL_HOST ), $oembed_provider );
+		return add_query_arg( 'for', wp_parse_url( home_url(), PHP_URL_HOST ), $oembed_provider );
 	}
 
 	/**

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 				 * Parse the URL, and rebuild a URL that's sure to display images.
 				 * Some Flickr Feeds do not display images by default.
 				 */
-				$flickr_parameters = parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'] ) );
+				$flickr_parameters = wp_parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'] ) );
 
 				// Is it a Flickr Feed.
 				if (

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -142,7 +142,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			/** Check if full URL entered in configuration, use it instead of tinkering **/
 			if (
 				in_array(
-					parse_url( $username, PHP_URL_SCHEME ),
+					wp_parse_url( $username, PHP_URL_SCHEME ),
 					array( 'http', 'https' )
 				)
 			) {

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -49,7 +49,7 @@ class WordAds_Params {
 		$this->targeting_tags = array(
 			'WordAds'   => 1,
 			'BlogId'    => Jetpack::is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
-			'Domain'    => esc_js( parse_url( home_url(), PHP_URL_HOST ) ),
+			'Domain'    => esc_js( wp_parse_url( home_url(), PHP_URL_HOST ) ),
 			'PageURL'   => esc_js( $this->url ),
 			'LangId'    => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?
 			'AdSafe'    => 1, // TODO

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -334,7 +334,7 @@ abstract class SAL_Site {
 	}
 
 	function get_xmlrpc_url() {
-		$xmlrpc_scheme = apply_filters( 'wpcom_json_api_xmlrpc_scheme', parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
+		$xmlrpc_scheme = apply_filters( 'wpcom_json_api_xmlrpc_scheme', wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
 		return site_url( 'xmlrpc.php', $xmlrpc_scheme );
 	}
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -232,7 +232,7 @@ class Jetpack_Sync_Functions {
 	public static function get_protocol_normalized_url( $callable, $new_value ) {
 		$option_key = self::HTTPS_CHECK_OPTION_PREFIX . $callable;
 
-		$parsed_url = wp_parse_url( $new_value );
+		$parsed_url = wp_wp_parse_url( $new_value );
 		if ( ! $parsed_url ) {
 			return $new_value;
 		}
@@ -274,8 +274,8 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function normalize_www_in_url( $option, $url_function ) {
-		$url        = wp_parse_url( call_user_func( $url_function ) );
-		$option_url = wp_parse_url( get_option( $option ) );
+		$url        = wp_wp_parse_url( call_user_func( $url_function ) );
+		$option_url = wp_wp_parse_url( get_option( $option ) );
 
 		if ( ! $option_url || ! $url ) {
 			return $url;

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -174,7 +174,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 						$link_url = trim( $link_element->getAttribute( 'href' ) );
 
 						// Add the full admin path to the url if the plugin did not provide it
-						$link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
+						$link_url_scheme = wp_wp_parse_url( $link_url, PHP_URL_SCHEME );
 						if ( empty( $link_url_scheme ) ) {
 							$link_url = admin_url( $link_url );
 						}

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -107,8 +107,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function detect_theme_edit( $redirect_url ) {
-		$url = wp_parse_url( admin_url( $redirect_url ) );
-		$theme_editor_url = wp_parse_url( admin_url( 'theme-editor.php' ) );
+		$url = wp_wp_parse_url( admin_url( $redirect_url ) );
+		$theme_editor_url = wp_wp_parse_url( admin_url( 'theme-editor.php' ) );
 
 		if ( $theme_editor_url['path'] !== $url['path'] ) {
 			return $redirect_url;

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -581,7 +581,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		wp_set_current_user( $user->ID );
 
 		// Build URL to compare scheme and host with the one in response
-		$admin_url = parse_url( admin_url() );
+		$admin_url = wp_parse_url( admin_url() );
 
 		// Create REST request in JSON format and dispatch
 		$response = $this->create_and_get_request( 'connection/url' );
@@ -590,7 +590,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 
 		// Format data to test it
-		$response->data = parse_url( $response->data );
+		$response->data = wp_parse_url( $response->data );
 		parse_str( $response->data['query'], $response->data['query'] );
 
 		// It has a nonce
@@ -648,7 +648,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Success, URL was built
 		$this->assertResponseStatus( 200, $response );
 
-		$response->data = parse_url( $response->data );
+		$response->data = wp_parse_url( $response->data );
 		parse_str( $response->data['query'], $response->data['query'] );
 
 		// Because dotcom will not respond to a fake token, the method

--- a/tests/php/modules/sitemaps/test_class.sitemap-finder.php
+++ b/tests/php/modules/sitemaps/test_class.sitemap-finder.php
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Sitemap_Finder extends WP_UnitTestCase {
 	public function test_sitemap_finder_recognize_default_master_sitemap() {
 		$finder = new Jetpack_Sitemap_Finder();
 
-		$array = parse_url( $finder->construct_sitemap_url( 'sitemap.xml' ) );
+		$array = wp_parse_url( $finder->construct_sitemap_url( 'sitemap.xml' ) );
 
 		$result = $finder->recognize_sitemap_uri(
 			// Get just the path+query part of the URL.

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -779,7 +779,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function add_www_subdomain_to_siteurl( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		return "{$parsed_url['scheme']}://www.{$parsed_url['host']}";
 	}

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -27,7 +27,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photonizing_https_image_adds_ssl_query_arg() {
 		$url = jetpack_photon_url( 'https://example.com/images/photon.jpg' );
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertEquals( '1', $args['ssl'], 'HTTPS image sources should have a ?ssl=1 query string.' );
 	}
 
@@ -38,7 +38,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photonizing_http_image_no_ssl_query_arg() {
 		$url = jetpack_photon_url( 'http://example.com/images/photon.jpg' );
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertArrayNotHasKey( 'ssl', $args, 'HTTP image source should not have an ssl query string.' );
 	}
 
@@ -50,7 +50,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photon_url_no_filter_http() {
 		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		$this->assertEquals( 'https', $parsed_url['scheme'] );
 		$this->assertMatchesPhotonHost( $parsed_url['host'] );
@@ -65,7 +65,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photon_url_no_filter_http_to_http() {
 		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		$this->assertEquals( 'http', $parsed_url['scheme'] );
 		$this->assertMatchesPhotonHost( $parsed_url['host'] );
@@ -343,12 +343,12 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_parse_url
+	 * @covers jetpack_photon_wp_parse_url
 	 * @since  4.5.0
-	 * @group  jetpack_photon_parse_url
+	 * @group  jetpack_photon_wp_parse_url
 	 */
-	public function test_jetpack_photon_parse_url_with_scheme() {
-		$parsed = jetpack_photon_parse_url( 'https://i0.wp.com/example.com/img.jpg' );
+	public function test_jetpack_photon_wp_parse_url_with_scheme() {
+		$parsed = jetpack_photon_wp_parse_url( 'https://i0.wp.com/example.com/img.jpg' );
 
 		$this->assertEquals( array(
 			'scheme' => 'https',
@@ -359,12 +359,12 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_parse_url
+	 * @covers jetpack_photon_wp_parse_url
 	 * @since  4.5.0
-	 * @group  jetpack_photon_parse_url
+	 * @group  jetpack_photon_wp_parse_url
 	 */
-	public function test_jetpack_photon_parse_url_without_scheme() {
-		$parsed = jetpack_photon_parse_url( '//i0.wp.com/example.com/img.jpg' );
+	public function test_jetpack_photon_wp_parse_url_without_scheme() {
+		$parsed = jetpack_photon_wp_parse_url( '//i0.wp.com/example.com/img.jpg' );
 
 		$this->assertArrayHasKey( 'scheme', $parsed );
 		$this->assertEquals( 'i0.wp.com', $parsed['host'] );
@@ -373,24 +373,24 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_parse_url
+	 * @covers jetpack_photon_wp_parse_url
 	 * @since  4.5.0
-	 * @group  jetpack_photon_parse_url
+	 * @group  jetpack_photon_wp_parse_url
 	 */
-	public function test_jetpack_photon_parse_url_with_scheme_specifying_component() {
-		$host = jetpack_photon_parse_url( 'https://i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
+	public function test_jetpack_photon_wp_parse_url_with_scheme_specifying_component() {
+		$host = jetpack_photon_wp_parse_url( 'https://i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
 
 		$this->assertEquals( 'i0.wp.com', $host );
 	}
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_parse_url
+	 * @covers jetpack_photon_wp_parse_url
 	 * @since  4.5.0
-	 * @group  jetpack_photon_parse_url
+	 * @group  jetpack_photon_wp_parse_url
 	 */
-	public function test_jetpack_photon_parse_url_without_scheme_specifying_component() {
-		$host = jetpack_photon_parse_url( '//i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
+	public function test_jetpack_photon_wp_parse_url_without_scheme_specifying_component() {
+		$host = jetpack_photon_wp_parse_url( '//i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
 
 		$this->assertEquals( 'i0.wp.com', $host );
 	}

--- a/tools/export-translations.php
+++ b/tools/export-translations.php
@@ -32,7 +32,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }

--- a/tools/import-translations.php
+++ b/tools/import-translations.php
@@ -30,7 +30,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }


### PR DESCRIPTION
Fixes #6801

#### Changes proposed in this Pull Request:

* Replace all occurrences of `parse_url` to `wp_parse_url`