### PR TITLE
Admin Page: Remove unnecessary wrapping with connect from Banner component

### DIFF
--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import size from 'lodash/size';
@@ -165,8 +164,5 @@ class Banner extends Component {
 
 }
 
-const mapStateToProps = () => ( {} );
+export default Banner;
 
-export default connect(
-	mapStateToProps
-)( Banner );


### PR DESCRIPTION
Removes unnecessary statements that wrapped the default export with a call to `connect()`.


#### Changes proposed in this Pull Request:

* exports the component without using the `connect()` HoC.

#### Testing instructions:

* Check this branch.
* Confirm the admin  page builds `yarn build`. 
