### PR TITLE
Docs: Add README.md for docs/partners directory

### DIFF
--- a/docs/partners/README.md
+++ b/docs/partners/README.md
@@ -1,0 +1,9 @@
+# Welcome to the Jetpack Hosting Partners Program!
+
+To make documentation easier for our partners to view, and to ensure our partners are always viewing the most up-to-date documentation, we've decided to source-control the documentation in the Jetpack directory itself.
+
+In this directory, you'll find information such as how to provision Jetpack plans as well as customizing Jetpack.
+
+### Want to become a Jetpack Hosting Partner?
+
+If you're not already a Jetpack Hosting Partner and you'd like some more information, head on over to [https://jetpack.com/for/hosts/](https://jetpack.com/for/hosts/) to get started!

--- a/docs/partners/README.md
+++ b/docs/partners/README.md
@@ -2,7 +2,9 @@
 
 To make documentation easier for our partners to view, and to ensure our partners are always viewing the most up-to-date documentation, we've decided to source-control the documentation in the Jetpack directory itself.
 
-In this directory, you'll find information such as how to provision Jetpack plans as well as customizing Jetpack.
+In this directory, you'll find information such as how to provision and cancel Jetpack plans as well as how to customize Jetpack.
+
+If you have any technical questions or concerns, don’t hesitate to get in touch with either Dan Walmsley (@gravityrail) at dan.walmsley@automattic.com or Eric Binnion (@ebinnion) at eric.binnion@automattic.com.
 
 ### Want to become a Jetpack Hosting Partner?
 

--- a/docs/partners/managing-modules.md
+++ b/docs/partners/managing-modules.md
@@ -2,6 +2,8 @@
 
 Occasionally, hosts have asked how they could customize Jetpack's modules. The documentation below will provide use cases and instructions on how to manage modules.
 
+If you have any questions or issues, our contact information can be found on the [README.md document](README.md).
+
 ### How to get a list of modules
 
 Before we can disable or force a module on or off, we need to know the slug of the module we want to modify. To get the slugs, we have a couple of options:modules

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -2,6 +2,8 @@
 
 In [another document](plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
 
+If you have any questions or issues, our contact information can be found on the [README.md document](README.md).
+
 ### Getting a Jetpack Partner access token
 
 When you become a Jetpack partner, we will provide you with your partner ID and a secret key. Typically you just pass these values directly in to the `bin/partner-provision.sh` and `bin/partner_cancel.sh` scripts. But, when calling the WordPress.com API directly, you'll first need to get an access token with for your partner ID with a scope of `jetpack-partner`.

--- a/docs/partners/plan-provisioning.md
+++ b/docs/partners/plan-provisioning.md
@@ -1,8 +1,6 @@
 # Provisioning and Cancelling Jetpack Plans
 
-Hello, and welcome to the Jetpack Partners program. We’re glad to have you!
-
-In this document, we’ll briefly go over the technical concerns of the Jetpack Partnership. If you have any questions or issues, our contact information can be found at the bottom of this document.
+In this document, we’ll briefly go over how to provision and cancel Jetpack plans via the shell scripts that ship with Jetpack. If you have any questions or issues, our contact information can be found on the [README.md document](README.md).
 
 ## What is Jetpack Start?
 
@@ -104,7 +102,3 @@ After running the script above, PARTNER_KEY_INFO should contain a value like thi
 ```
 
 The client_id and client_secret values are the ones you should or your customers should use to license Jetpack plans with the partner-provision.sh script.
-
-Having trouble?
-
-If you have any technical questions, or concerns don’t hesitate to get in touch with either Dan Walmsley (@gravityrail) at dan.walmsley@automattic.com or Eric Binnion (@ebinnion) at eric.binnion@automattic.com.


### PR DESCRIPTION
In #8801 and #8804 I'm proposing that we add partner documentation directly to the Jetpack repo. With our documentation going public, it seems like a waster opportunity if we don't try to reach out to interested hosts.

Creating this `README.md` file means that any time someone is browsing the Jetpack repo and they visit the `/docs/partners` directory, that they will see this file below the list of of other partner documentation.

As I added the READM.me file, it seemed like that was the best place to add mine and Dan's contact information. So, I put it there and referenced the README.md in other files.