### PR TITLE
Search: When clicking a filter link, toggle the checkbox too.

### DIFF
--- a/modules/search/js/search-widget.js
+++ b/modules/search/js/search-widget.js
@@ -1,14 +1,17 @@
 jQuery( document ).ready( function() {
-	var checkboxes = jQuery( '.jetpack-search-filters-widget__filter-list input[type="checkbox"]' );
+	var filter_list = jQuery( '.jetpack-search-filters-widget__filter-list' );
 
-	checkboxes.prop( 'disabled', false ).css( 'cursor', 'inherit' );
-	checkboxes.on( 'click change', function( e ) {
-		var anchor;
-		e.preventDefault();
+	filter_list.on( 'click', 'a', function() {
+		var checkbox = jQuery( this ).children( 'input[type="checkbox"]' );
 
-		anchor = jQuery( this ).closest( 'a' );
-		if ( anchor.length ) {
-			window.location.href = anchor.prop( 'href' );
-		}
+		toggle_checkbox( checkbox );
 	} );
+
+	filter_list.find( 'input[type="checkbox"]' ).prop( 'disabled', false ).css( 'cursor', 'inherit' ).on( 'click', function() {
+		toggle_checkbox( jQuery( this ) );
+	} );
+
+	function toggle_checkbox( checkbox ) {
+		checkbox.prop( 'checked', ! checkbox.prop( 'checked' ) );
+	}
 } );


### PR DESCRIPTION
Fixes #8761

#### Changes proposed in this Pull Request:

In the search filters widget, clicking the checkbox should check it before the page reloads and clicking the link should check the checkbox as well.

#### Testing instructions:

0. Hard refresh your test site in order to clear the browser cache.
1. Add the search widget.
2. Search for something in order to get filters (facets) to show up.
3. Check a checkbox. Verify that it checks before the page reloads.
4. Uncheck a checkbox. Verify that it unchecks before the page reloads.
5. Click a filter label (link). Verify that the checkbox to the left of it gets checked before the page reloads.
6. Click an active filter label. Verify that the checkbox to the left of it gets unchecked before the page reloads.