### PR TITLE
after-the-deadline: Avoid accessing the superglobals directly

### DIFF
--- a/modules/after-the-deadline/config-options.php
+++ b/modules/after-the-deadline/config-options.php
@@ -117,8 +117,10 @@ function AtD_get_options( $user_id, $name ) {
  */
 function AtD_update_options( $user_id, $name ) {
 	/* We should probably run $_POST[name] through an esc_*() function... */
-	if ( isset( $_POST[$name] ) && is_array( $_POST[$name] ) ) {
-		$copy = array_map( 'strip_tags', array_keys( $_POST[$name] ) );
+	$post_name = filter_input(INPUT_POST, $name, FILTER_DEFAULT , FILTER_REQUIRE_ARRAY);
+	
+	if ( isset( $post_name ) && is_array( $post_name ) ) {
+		$copy = array_map( 'strip_tags', array_keys( $post_name ) );
 		AtD_update_setting( $user_id, AtD_sanitize( $name ), implode( ',', $copy )  );
 	} else {
 		AtD_update_setting( $user_id, AtD_sanitize( $name ), '');

--- a/modules/after-the-deadline/config-unignore.php
+++ b/modules/after-the-deadline/config-unignore.php
@@ -15,7 +15,7 @@ function AtD_ignore_call() {
 	check_admin_referer( 'atd_ignore' );
 
 	$ignores = explode( ',', AtD_get_setting( $user->ID, 'AtD_ignored_phrases') );
-	array_push( $ignores, $_GET['phrase'] );
+	array_push( $ignores, filter_input( INPUT_GET, 'phrase' ) );
 
 	$ignores = array_filter( array_map( 'strip_tags', $ignores ) );
 

--- a/modules/after-the-deadline/config-unignore.php
+++ b/modules/after-the-deadline/config-unignore.php
@@ -33,8 +33,10 @@ function AtD_process_unignore_update() {
 
 	if ( ! AtD_is_allowed() )
 		return;
-
-	if ( ! isset( $_POST['AtD_ignored_phrases'] ) )
+	
+	$atd_ignored_phrases = filter_input( INPUT_POST, 'AtD_ignored_phrases' );
+	
+	if ( ! isset( $atd_ignored_phrases ) )
 		return;
 
         $user = wp_get_current_user();
@@ -42,7 +44,7 @@ function AtD_process_unignore_update() {
         if ( ! $user || $user->ID == 0 )
                 return;
 
-	$ignores = array_filter( array_map( 'strip_tags', explode( ',', $_POST['AtD_ignored_phrases'] ) ) );
+	$ignores = array_filter( array_map( 'strip_tags', explode( ',', $atd_ignored_phrases ) ) );
         AtD_update_setting( $user->ID, 'AtD_ignored_phrases', join( ',', $ignores ) );
 }
 

--- a/modules/after-the-deadline/proxy.php
+++ b/modules/after-the-deadline/proxy.php
@@ -65,7 +65,7 @@ function AtD_http_post( $request, $host, $path, $port = 80 ) {
  *  This function is called as an action handler to admin-ajax.php
  */
 function AtD_redirect_call() {
-	if ( $_SERVER['REQUEST_METHOD'] === 'POST' )
+	if ( filter_input( INPUT_SERVER, 'REQUEST_METHOD' ) === 'POST' )
 		$postText = trim(  file_get_contents( 'php://input' )  );
 
 	check_admin_referer( 'proxy_atd' );

--- a/modules/after-the-deadline/proxy.php
+++ b/modules/after-the-deadline/proxy.php
@@ -70,7 +70,7 @@ function AtD_redirect_call() {
 
 	check_admin_referer( 'proxy_atd' );
 
-	$url = $_GET['url'];
+	$url = filter_input( INPUT_GET, 'url', FILTER_VALIDATE_URL );
 	/**
 	 * Change the AtD service domain.
 	 *


### PR DESCRIPTION
See #4308

This is the first pull request in a series of pull requests to fix this issue.
Since there would be too many changes to review in one PR, I'm sending in one PR per module of Jetpack

Changes proposed in this Pull Request:
All occurrences of $_SERVER, $_GET and $_POST have been replaced with filter_input (or filter_has_var wherever necessary) in the afrer-the-deadline module.

PRs for other modules to follow.