### PR TITLE
comments: Avoid accessing the superglobals directly

### DIFF
--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -17,7 +17,7 @@ class Highlander_Comments_Base {
 	protected function setup_globals() {}
 
 	/**
-	 * Setup actions for methods in this class
+	 * Setup actions for methods in this class	
 	 * @since JetpackComments (1.4)
 	 */
 	protected function setup_actions() {
@@ -208,7 +208,8 @@ class Highlander_Comments_Base {
 		}
 
 		// Bail if user is not logged in or not a post request
-		if ( 'POST' != strtoupper( $_SERVER['REQUEST_METHOD'] ) || !is_user_logged_in() ) {
+		$request_method = filter_input( INPUT_SERVER, 'REQUEST_METHOD' );
+		if ( 'POST' != strtoupper( $request_method ) || !is_user_logged_in() ) {
 			return $comment_data;
 		}
 

--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -46,20 +46,22 @@ class Highlander_Comments_Base {
 	 * @return false|string false if it's not a Highlander POST request.  The matching credentials slug if it is.
 	 */
 	function is_highlander_comment_post() {
-		if ( empty( $_POST['hc_post_as'] ) ) {
+		$hc_post_as = filter_input( INPUT_POST, 'hc_post_as' );
+
+		if ( empty( $hc_post_as ) ) {
 			return false;
 		}
 
 		if ( func_num_args() ) {
 			foreach ( func_get_args() as $id_source ) {
-				if ( $id_source === $_POST['hc_post_as'] ) {
+				if ( $id_source === $hc_post_as ) {
 					return $id_source;
 				}
 			}
 			return false;
 		}
 
-		return is_string( $_POST['hc_post_as'] ) && in_array( $_POST['hc_post_as'], $this->id_sources ) ? $_POST['hc_post_as'] : false;
+		return is_string( $hc_post_as ) && in_array( $hc_post_as, $this->id_sources ) ? $hc_post_as : false;
 	}
 
 	/**
@@ -227,19 +229,22 @@ class Highlander_Comments_Base {
 		}
 
 		if ( get_option( 'require_name_email' ) ) {
-			if ( 6 > strlen( $_POST['email'] ) || empty( $_POST['author'] ) ) {
+			$email = filter_input( INPUT_POST, 'email', FILTER_VALIDATE_EMAIL );
+			$author = filter_input( INPUT_POST, 'author' );
+			if ( 6 > strlen( $$email ) || empty( $author ) ) {
 				wp_die( __( 'Error: please fill the required fields (name, email).', 'jetpack' ) );
-			} elseif ( ! is_email( $_POST['email'] ) ) {
+			} elseif ( ! is_email( $$email ) ) {
 				wp_die( __( 'Error: please enter a valid email address.', 'jetpack' ) );
 			}
 		}
 
 		$author_change = false;
 		foreach ( array( 'comment_author' => 'author', 'comment_author_email' => 'email', 'comment_author_url' => 'url' ) as $comment_field => $post_field ) {
-			if ( $comment_data[$comment_field] != $_POST[$post_field] && 'url' != $post_field ) {
+			$super_post_field = filter_input( INPUT_POST, $post_field );
+			if ( $comment_data[$comment_field] != $super_post_field && 'url' != $post_field ) {
 				$author_change = true;
 			}
-			$comment_data[$comment_field] = $_POST[$post_field];
+			$comment_data[$comment_field] = $super_post_field;
 		}
 
 		// Mark as guest comment if name or email were changed

--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -159,16 +159,20 @@ class Highlander_Comments_Base {
 		$comment_author_email = '';
 		$comment_author_url   = '';
 
-		if ( isset( $_COOKIE['comment_author_' . COOKIEHASH] ) ) {
-			$comment_author = $_COOKIE['comment_author_' . COOKIEHASH];
+		$cookie_comment_author		 = filter_input( INPUT_COOKIE, 'comment_author' . COOKIEHASH );
+		$cookie_comment_author_email = filter_input( INPUT_COOKIE, 'comment_author_email' . COOKIEHASH );
+		$cookie_comment_author_url	 = filter_input( INPUT_COOKIE, 'comment_author_url' . COOKIEHASH );
+
+		if ( isset( $cookie_comment_author ) ) {
+			$comment_author = $cookie_comment_author;
 		}
 
-		if ( isset( $_COOKIE['comment_author_email_' . COOKIEHASH] ) ) {
-			$comment_author_email = $_COOKIE['comment_author_email_' . COOKIEHASH];
+		if ( isset( $cookie_comment_author_email ) ) {
+			$comment_author_email = $cookie_comment_author_email;
 		}
 
-		if ( isset( $_COOKIE['comment_author_url_' . COOKIEHASH] ) ) {
-			$comment_author_url = $_COOKIE['comment_author_url_' . COOKIEHASH];
+		if ( isset( $cookie_comment_author_email ) ) {
+			$comment_author_url = $cookie_comment_author_url;
 		}
 
 		if ( is_user_logged_in() ) {
@@ -184,7 +188,7 @@ class Highlander_Comments_Base {
 	 * Overrides WordPress' core comment_registration option to treat these commenters as "registered" (verified) users.
 	 *
 	 * @since JetpackComments (1.4)
-	 * @return If no
+	 * @return If no$_COOKIE
 	 */
 	function allow_logged_out_user_to_comment_as_external() {
 		if ( !$this->is_highlander_comment_post( 'facebook', 'twitter', 'googleplus' ) ) {

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -279,8 +279,10 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		$params['sig']    = $signature;
 		$url_origin       = set_url_scheme( 'http://jetpack.wordpress.com' );
+		$http_host        = filter_input( INPUT_SERVER, 'HTTP_HOST' );
+		$request_uri      = filter_input( INPUT_SERVER, 'REQUEST_URI' );
 		$url              = "{$url_origin}/jetpack-comment/?" . http_build_query( $params );
-		$url              = "{$url}#parent=" . urlencode( set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );
+		$url              = "{$url}#parent=" . urlencode( set_url_scheme( 'http://' . $http_host . $request_uri ) );
 		$this->signed_url = $url;
 		$height           = $params['comment_registration'] || is_user_logged_in() ? '315' : '430'; // Iframe can be shorter if we're not allowing guest commenting
 		$transparent      = ( $params['color_scheme'] == 'transparent' ) ? 'true' : 'false';

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -287,8 +287,10 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		$height           = $params['comment_registration'] || is_user_logged_in() ? '315' : '430'; // Iframe can be shorter if we're not allowing guest commenting
 		$transparent      = ( $params['color_scheme'] == 'transparent' ) ? 'true' : 'false';
 
-		if ( isset( $_GET['replytocom'] ) ) {
-			$url .= '&replytocom=' . (int) $_GET['replytocom'];
+		$reply_to_com = filter_input( INPUT_GET, 'replytocom', FILTER_VALIDATE_INT );
+		
+		if ( isset( $get_reply_to_com ) ) {
+			$url .= '&replytocom=' . $reply_to_com;
 		}
 
 		/**
@@ -493,30 +495,34 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function add_comment_meta( $comment_id ) {
 		$comment_meta = array();
 
+		$hc_avatar		 = filter_input( INPUT_POST, 'hc_avatar' );
+		$hc_userid		 = filter_input( INPUT_POST, 'hc_userid' );
+		$hc_wpcom_id_sig = filter_input( INPUT_POST, 'hc_wpcom_id_sig' );
+
 		switch ( $this->is_highlander_comment_post() ) {
 			case 'facebook' :
 				$comment_meta['hc_post_as']         = 'facebook';
-				$comment_meta['hc_avatar']          = stripslashes( $_POST['hc_avatar'] );
-				$comment_meta['hc_foreign_user_id'] = stripslashes( $_POST['hc_userid'] );
+				$comment_meta['hc_avatar']          = stripslashes( $hc_avatar );
+				$comment_meta['hc_foreign_user_id'] = stripslashes( $hc_userid );
 				break;
 
 			case 'twitter' :
 				$comment_meta['hc_post_as']         = 'twitter';
-				$comment_meta['hc_avatar']          = stripslashes( $_POST['hc_avatar'] );
-				$comment_meta['hc_foreign_user_id'] = stripslashes( $_POST['hc_userid'] );
+				$comment_meta['hc_avatar']          = stripslashes( $hc_avatar );
+				$comment_meta['hc_foreign_user_id'] = stripslashes( $hc_userid );
 				break;
 
 			case 'wordpress' :
 				$comment_meta['hc_post_as']         = 'wordpress';
-				$comment_meta['hc_avatar']          = stripslashes( $_POST['hc_avatar'] );
-				$comment_meta['hc_foreign_user_id'] = stripslashes( $_POST['hc_userid'] );
-				$comment_meta['hc_wpcom_id_sig']    = stripslashes( $_POST['hc_wpcom_id_sig'] ); //since 1.9
+				$comment_meta['hc_avatar']          = stripslashes( $hc_avatar );
+				$comment_meta['hc_foreign_user_id'] = stripslashes( $hc_userid );
+				$comment_meta['hc_wpcom_id_sig']    = stripslashes( $hc_wpcom_id_sig ); //since 1.9
 				break;
 
 			case 'jetpack' :
 				$comment_meta['hc_post_as']         = 'jetpack';
-				$comment_meta['hc_avatar']          = stripslashes( $_POST['hc_avatar'] );
-				$comment_meta['hc_foreign_user_id'] = stripslashes( $_POST['hc_userid'] );
+				$comment_meta['hc_avatar']          = stripslashes( $hc_avatar );
+				$comment_meta['hc_foreign_user_id'] = stripslashes( $hc_userid );
 				break;
 
 		}
@@ -533,7 +539,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	function capture_comment_post_redirect_to_reload_parent_frame( $url ) {
-		if ( ! isset( $_GET['for'] ) || 'jetpack' != $_GET['for'] ) {
+		$for = filter_input(INPUT_GET, 'for' );
+		if ( ! isset( $for ) || 'jetpack' != $for ) {
 			return $url;
 		}
 		?>

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -145,7 +145,8 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 
 		remove_filter( 'jetpack_lazy_images_new_attributes', array( $this, '__set_height_attribute' ) );
 
-		$expected_html = '<img src="placeholder.jpg" data-lazy-src="image.jpg" style="height: 100px;"><noscript><img src="image.jpg" sizes="(min-width: 36em) 33.3vw, 100vw" /></noscript>';
+		$expected_html = '<img src="placeholder.jpg" data-lazy-src="image.jpg" style="height: 100px;"><noscript><img src="image.jpg" height="100px" /></noscript>';
+		$this->assertSame( $expected_html, $html );
 	}
 
 	function test_wp_get_attachment_image_gets_lazy_treatment() {
@@ -220,7 +221,8 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 
 	public function __set_height_attribute( $attributes ) {
 		if ( ! empty( $attributes['height'] ) ) {
-			$attributes['style'] = sprintf( 'height: %d;', $attributes['height'] );
+			$attributes['style'] = sprintf( 'height: %dpx;', $attributes['height'] );
+			unset( $attributes['height'] );
 		}
 		return $attributes;
 	}


### PR DESCRIPTION
See #4308

This is the third pull request in a series of pull requests to fix this issue.

Changes proposed in this Pull Request:
All occurrences of `$_SERVER`, `$_GET`, `$_POST` and `$_COOKIE `have been replaced with `filter_input` in the **comments** module.