### PR TITLE
Activity log: add user-login to failed login attempts

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -277,12 +277,13 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
+		 * @param string IP
 		 * @param array Information about failed login attempt
 		 *   [
 		 *     'user_login' => (string) Username or email used in failed login attempt
 		 *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', array( 'login_user' => $login_user ) );
+		do_action( 'jpp_log_failed_attempt', jetpack_protect_get_ip(), array( 'login_user' => $login_user ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -277,13 +277,12 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param string jetpack_protect_get_ip IP stored by Protect
 		 * @param array Information about failed login attempt
 		 *   [
 		 *     'user_login' => (string) Username or email used in failed login attempt
 		 *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', jetpack_protect_get_ip(), array( 'login_user' => $login_user ) );
+		do_action( 'jpp_log_failed_attempt', array( 'login_user' => $login_user ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -268,7 +268,13 @@ class Jetpack_Protect_Module {
 	 *
 	 * @return void
 	 */
-	function log_failed_attempt() {
+	function log_failed_attempt( $login_user = null ) {
+
+		$failed_attept = array(
+			'ip' => jetpack_protect_get_ip(),
+			'login_user' => $login_user,
+		);
+
 		/**
 		 * Fires before every failed login attempt.
 		 *
@@ -276,9 +282,13 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param string jetpack_protect_get_ip IP stored by Protect.
+		 * @param array $failed_attept Array containing information about failed login attempt
+		 *   $failed_attept = [
+		 *     'ip' => (string) jetpack_protect_get_ip IP stored by Protect
+		 *     'user_login' => (string) User login stored by Protect
+	   *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', jetpack_protect_get_ip() );
+		do_action( 'jpp_log_failed_attempt', $failed_attept );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -279,10 +279,10 @@ class Jetpack_Protect_Module {
 		 *
 		 * @param array Information about failed login attempt
 		 *   [
-		 *     'user_login' => (string) Username or email used in failed login attempt
+		 *     'login' => (string) Username or email used in failed login attempt
 		 *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', array( 'login_user' => $login_user ) );
+		do_action( 'jpp_log_failed_attempt', array( 'login' => $login_user ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -277,7 +277,7 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param string IP
+		 * @param string jetpack_protect_get_ip IP stored by Protect
 		 * @param array Information about failed login attempt
 		 *   [
 		 *     'user_login' => (string) Username or email used in failed login attempt

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -271,7 +271,6 @@ class Jetpack_Protect_Module {
 	function log_failed_attempt( $login_user = null ) {
 
 		$failed_attept = array(
-			'ip' => jetpack_protect_get_ip(),
 			'login_user' => $login_user,
 		);
 
@@ -284,9 +283,8 @@ class Jetpack_Protect_Module {
 		 *
 		 * @param array $failed_attept Array containing information about failed login attempt
 		 *   $failed_attept = [
-		 *     'ip' => (string) jetpack_protect_get_ip IP stored by Protect
-		 *     'user_login' => (string) User login stored by Protect
-	   *   ]
+		 *     'user_login' => (string) Username or email used in failed login attempt
+		 *   ]
 		 */
 		do_action( 'jpp_log_failed_attempt', $failed_attept );
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -277,8 +277,8 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param array $failed_attept Array containing information about failed login attempt
-		 *   $failed_attept = [
+		 * @param array Information about failed login attempt
+		 *   [
 		 *     'user_login' => (string) Username or email used in failed login attempt
 		 *   ]
 		 */

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -270,10 +270,6 @@ class Jetpack_Protect_Module {
 	 */
 	function log_failed_attempt( $login_user = null ) {
 
-		$failed_attept = array(
-			'login_user' => $login_user,
-		);
-
 		/**
 		 * Fires before every failed login attempt.
 		 *
@@ -286,7 +282,7 @@ class Jetpack_Protect_Module {
 		 *     'user_login' => (string) Username or email used in failed login attempt
 		 *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', $failed_attept );
+		do_action( 'jpp_log_failed_attempt', array( 'login_user' => $login_user ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 

--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -14,10 +14,10 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 		add_action( 'jetpack_valid_failed_login_attempt', $callback );
 	}
 
-	function maybe_log_failed_login_attempt( $ip ) {
+	function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = Jetpack_Protect_Module::instance();
 		if ( $protect->has_login_ability() ) {
-			do_action( 'jetpack_valid_failed_login_attempt', $ip );
+			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}
 }

--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -10,11 +10,11 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 	}
 
 	function init_listeners( $callback ) {
-		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ), 10, 2 );
+		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ) );
 		add_action( 'jetpack_valid_failed_login_attempt', $callback );
 	}
 
-	function maybe_log_failed_login_attempt( $ip, $failed_attempt ) {
+	function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = Jetpack_Protect_Module::instance();
 		if ( $protect->has_login_ability() ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );

--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -10,11 +10,11 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 	}
 
 	function init_listeners( $callback ) {
-		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ) );
+		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ), 10, 2 );
 		add_action( 'jetpack_valid_failed_login_attempt', $callback );
 	}
 
-	function maybe_log_failed_login_attempt( $failed_attempt ) {
+	function maybe_log_failed_login_attempt( $ip, $failed_attempt ) {
 		$protect = Jetpack_Protect_Module::instance();
 		if ( $protect->has_login_ability() ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -9,13 +9,26 @@ require_once dirname( __FILE__ ) . '/../../../modules/protect.php';
 class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_failed_login_message() {
+		$user_id = $this->factory->user->create();
 
-			Jetpack_Protect_Module::instance()->log_failed_attempt();
+		$user = get_userdata( $user_id );
 
-			$this->sender->do_sync();
+		Jetpack_Protect_Module::instance()->log_failed_attempt( $user->user_email );
 
-			$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+		$this->sender->do_sync();
 
-			$this->assertEquals( '127.0.0.1', $action->args[0] );
-		}
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+
+		$this->assertEquals( $user->user_email, $action->args[0]['login_user'] );
+	}
+
+	function test_sends_failed_login_empty_message() {
+		Jetpack_Protect_Module::instance()->log_failed_attempt();
+
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+
+		$this->assertEquals( '', $action->args[0]['login_user'] );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -19,7 +19,7 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
 
-		$this->assertEquals( $user->user_email, $action->args[0]['login_user'] );
+		$this->assertEquals( $user->user_email, $action->args[0]['login'] );
 	}
 
 	function test_sends_failed_login_empty_message() {
@@ -29,6 +29,6 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
 
-		$this->assertEquals( '', $action->args[0]['login_user'] );
+		$this->assertEquals( '', $action->args[0]['login'] );
 	}
 }


### PR DESCRIPTION
An activity for failed login attempt should look like:
>[user_login] had a failed login attempt from IP Address: 123.123.123.123
![image](https://user-images.githubusercontent.com/87168/36149999-ae5f32fa-10ca-11e8-8d1a-af4a0fa3d031.png)


But it currently looks like :
![image](https://user-images.githubusercontent.com/87168/36149471-7da45840-10c8-11e8-9985-b4b96d893260.png)

This adds user login we can then show in Calypso.

- Send `user_login` (_username_ or _email_) used in a failed login attempt.
- Removes IP from `args` since it's [already being sent](https://github.com/Automattic/jetpack/blob/dd45834afcac620eb9048960b2676499f1a00602/sync/class.jetpack-sync-listener.php#L264-L268) in `author` object.

### Backwards compatibility?
Should I be worrying about backwards compatibility for `jpp_log_failed_attempt `action?

In the new version, it'll send an array containing `login_user` instead of a string containing IP.

Before:
https://github.com/Automattic/jetpack/blob/1db8bc30853208b57c988d726f45fd4f2cb926c2/modules/protect.php#L272-L281

After:
https://github.com/Automattic/jetpack/blob/ee0f162869e546d8411525dd984fbf01904bcea9/modules/protect.php#L273-L285
