### PR TITLE
Sync: Add action hook to enqueue_action

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -176,11 +176,11 @@ class Jetpack_Sync_Listener {
 		/**
 		 * Add an action hook to execute when anything on the whitelist gets sent to the queue to sync.
 		 *
-		 * @since 5.8
+		 * @module sync
 		 *
-		 * @param array The action parameters
+		 * @since 5.9.0
 		 */
-		do_action( "jetpack_action_before_enqueue" );
+		do_action( 'jetpack_sync_action_before_enqueue' );
 
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -174,6 +174,15 @@ class Jetpack_Sync_Listener {
 		}
 
 		/**
+		 * Add an action hook to execute when anything on the whitelist gets sent to the queue to sync.
+		 *
+		 * @since 5.8
+		 *
+		 * @param array The action parameters
+		 */
+		do_action( "jetpack_action_before_enqueue" );
+
+		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *
 		 * @since 4.2.0


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:
* I'd like to add an action hook to `enqueue_action` when anything on the whitelist gets sent to the queue to sync.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Hook onto it via `add_action`.
