### PR TITLE
Sync: Add Jetpack debug option

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -53,6 +53,7 @@ class Jetpack_Options {
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
+				'api_base_domain'			   // (string)
 			);
 
 		case 'private' :
@@ -89,6 +90,7 @@ class Jetpack_Options {
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
 			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget
+			'debug',
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4862,10 +4862,11 @@ p {
 	 * @return boolean
 	 */
 	public static function permit_ssl( $force_recheck = false ) {
+		$api_base = Jetpack::get_api_base_domain(); //
 		// Do some fancy tests to see if ssl is being supported
 		if ( $force_recheck || false === ( $ssl = get_transient( 'jetpack_https_test' ) ) ) {
 			$message = '';
-			if ( 'https' !== substr( JETPACK__API_BASE, 0, 5 ) ) {
+			if ( 'https' !== substr( $api_base, 0, 5 ) ) {
 				$ssl = 0;
 			} else {
 				switch ( JETPACK_CLIENT__HTTPS ) {
@@ -4886,7 +4887,7 @@ p {
 						$ssl = 0;
 						$message = __( 'WordPress reports no SSL support', 'jetpack' );
 					} else {
-						$response = wp_remote_get( JETPACK__API_BASE . 'test/1/' );
+						$response = wp_remote_get( $api_base . 'test/1/' );
 						if ( is_wp_error( $response ) ) {
 							$ssl = 0;
 							$message = __( 'WordPress reports no SSL support', 'jetpack' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4957,13 +4957,24 @@ p {
 		<?php
 	}
 
+	public static function get_api_base_domain(){
+		if ( Jetpack_Options::get_option('debug' ) ) {
+			if ( $domain = Jetpack_Options::get_option( 'jetpack_api_base_domain', JETPACK__API_BASE ) ) {
+				return $domain;
+			}
+		}
+		return JETPACK__API_BASE;
+	}
+
+
 	/**
 	 * Returns the Jetpack XML-RPC API
 	 *
 	 * @return string
 	 */
 	public static function xmlrpc_api_url() {
-		$base = preg_replace( '#(https?://[^?/]+)(/?.*)?$#', '\\1', JETPACK__API_BASE );
+		$jetpack_api_base = Jetpack::get_api_base_domain();
+		$base = preg_replace( '#(https?://[^?/]+)(/?.*)?$#', '\\1', $jetpack_api_base );
 		return untrailingslashit( $base ) . '/xmlrpc.php';
 	}
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -111,6 +111,7 @@ class Jetpack_Sync_Defaults {
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 		'jetpack_api_cache_enabled',
+		'jetpack_api_base_domain', // usally not set to anything // unless Jetpack_Options::get_option( 'debug' ) is set to true.
 	);
 
 	public static function get_options_whitelist() {


### PR DESCRIPTION
This will enable us to set the jetpack_api_base_domain to something else remotely.
So that we send sync actions to developer sandboxes and make debuging sync easier. 

