### PR TITLE
Plans In Plugin: Add plans endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -358,7 +358,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	public static function get_plans( $request ) {
 		$data      = get_transient( 'jetpack_plans' );
-		$use_cache = apply_filters( 'cache_jetpack_plans', '__return_true', 1 );
+
+		/**
+		 * Filter to turn off caching of Jetpack plans
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param bool true Whether to cache Jetpack plans locally
+		 */
+		$use_cache = apply_filters( 'cache_jetpack_plans', true );
 
 		if ( $data === false ) {
 			$path = '/plans';

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -357,7 +357,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	public static function get_plans( $request ) {
-		$data      = get_transient( 'jetpack_plans' );
+		$data = get_transient( 'jetpack_plans' );
 
 		/**
 		 * Filter to turn off caching of Jetpack plans
@@ -366,9 +366,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		 *
 		 * @param bool true Whether to cache Jetpack plans locally
 		 */
-		$use_cache = apply_filters( 'cache_jetpack_plans', true );
+		$use_cache = apply_filters( 'jetpack_cache_plans', true );
 
-		if ( $data === false ) {
+		if ( false === $data ) {
 			$path = '/plans';
 			$ip   = $_SERVER['HTTP_X_FORWARDED_FOR']; // used to calculate which currency to show
 			if ( empty( $ip ) ) {
@@ -377,7 +377,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			}
 			$data = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );
 
-			if ( $use_cache ) {
+			if ( true === $use_cache ) {
 				set_transient( 'jetpack_plans', $data, DAY_IN_SECONDS );
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This adds a local endpoint to get the current plans available. Works with D10122-code

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Apply D10122-code
* Apply this PR
* hit `/jetpack/v4/plans` from the api explorer while logged in (using the plugin found at https://wordpress.org/plugins/rest-api-console/)

You will get back an api response that contains a localized list of plans in the correct currency for your location.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
