### PR TITLE
Use encrypted config for E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ defaults: &defaults
         environment:
                 JETPACKHOST: JN
                 NODE_ENV: test
+                TARGET: JETPACK
 version: 2
 jobs:
   build:
@@ -19,14 +20,14 @@ jobs:
                   git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           key: << checksum "package.json" >>
-      - run: source $HOME/.nvm/nvm.sh && npm install
+      - run: source $HOME/.nvm/nvm.sh && npm install && npm run decryptconfig
       - save_cache:
           paths:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run:
           name: Run Jetpack JN activation spec
-          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
+          command: source $HOME/.nvm/nvm.sh && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - persist_to_workspace:
           root: /wp-e2e-tests
           paths:
@@ -48,7 +49,7 @@ jobs:
           command: ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: xvfb-run ./run.sh -R -j -H JN -p
+          command: NODE_CONFIG={} xvfb-run ./run.sh -R -j -H JN -p
       - store_test_results:
           path: reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ jobs:
           key: << checksum "package.json" >>
       - run:
           name: Run Jetpack JN activation spec
-          command: source $HOME/.nvm/nvm.sh && npm run decryptconfig && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
-      - run:
-          name: TEST check if config in place
-          command: ls -la ./config
+          command: |
+                  source $HOME/.nvm/nvm.sh
+                  npm run decryptconfig
+                  xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - persist_to_workspace:
           root: /wp-e2e-tests
           paths:
@@ -48,14 +48,11 @@ jobs:
       - attach_workspace:
           at: /wp-e2e-tests
       - run:
-          name: TEST check if config in place
-          command: ls -la ./config
-      - run:
           name: Randomize spec execution order
           command: ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: NODE_CONFIG={} xvfb-run ./run.sh -R -j -H JN -p
+          command: xvfb-run ./run.sh -R -j -p
       - store_test_results:
           path: reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
       - run:
           name: Run Jetpack JN activation spec
           command: source $HOME/.nvm/nvm.sh && npm run decryptconfig && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
+      - run:
+          name: TEST: check if config in place
+          command: ls -la ./config
       - persist_to_workspace:
           root: /wp-e2e-tests
           paths:
@@ -44,6 +47,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /wp-e2e-tests
+      - run:
+          name: TEST: check if config in place
+          command: ls -la ./config
       - run:
           name: Randomize spec execution order
           command: ./scripts/randomize.sh specs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: Run Jetpack JN activation spec
           command: source $HOME/.nvm/nvm.sh && npm run decryptconfig && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - run:
-          name: TEST: check if config in place
+          name: TEST check if config in place
           command: ls -la ./config
       - persist_to_workspace:
           root: /wp-e2e-tests
@@ -48,7 +48,7 @@ jobs:
       - attach_workspace:
           at: /wp-e2e-tests
       - run:
-          name: TEST: check if config in place
+          name: TEST check if config in place
           command: ls -la ./config
       - run:
           name: Randomize spec execution order

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,14 @@ jobs:
                   git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           key: << checksum "package.json" >>
-      - run: source $HOME/.nvm/nvm.sh && npm install && npm run decryptconfig
+      - run: source $HOME/.nvm/nvm.sh && npm install
       - save_cache:
           paths:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run:
           name: Run Jetpack JN activation spec
-          command: source $HOME/.nvm/nvm.sh && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
+          command: source $HOME/.nvm/nvm.sh && npm run decryptconfig && NODE_CONFIG={} xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - persist_to_workspace:
           root: /wp-e2e-tests
           paths:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Using encrypted config file instead of bare NODE_CONFIG env variable for E2E tests

#### Testing instructions:

Make sure that CircleCI build is passing:
https://circleci.com/gh/Automattic/jetpack/tree/try%2Fuse-e2e-encrypted-config
