### PR TITLE
Admin Page: Show app dismissal button only for admin users in Dashboard

### DIFF
--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -15,7 +15,7 @@ import analytics from 'lib/analytics';
  */
 import { imagePath } from 'constants/urls';
 import { updateSettings, appsCardDismissed } from 'state/settings';
-import { arePromotionsActive } from 'state/initial-state';
+import { arePromotionsActive, userCanManageOptions } from 'state/initial-state';
 
 class AppsCard extends React.Component {
 	static displayName = 'AppsCard';
@@ -74,10 +74,14 @@ class AppsCard extends React.Component {
 							{ __( 'Download the free apps' ) }
 						</Button>
 						<br />
-						<a
-							href="javascript:void(0)"
-							onClick={ this.dismissCard }
-						>{ __( 'I already use this app.' ) }</a>
+						{
+							this.props.userCanManageOptions && (
+								<a
+									href="javascript:void(0)"
+									onClick={ this.dismissCard }
+									>{ __( 'I already use this app.' ) }</a>
+							)
+						}
 					</div>
 				</Card>
 			</div>
@@ -93,7 +97,8 @@ export default connect(
 	state => {
 		return {
 			isAppsCardDismissed: appsCardDismissed( state ),
-			arePromotionsActive: arePromotionsActive( state )
+			arePromotionsActive: arePromotionsActive( state ),
+			userCanManageOptions: userCanManageOptions( state ),
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
Fixes #7299 in a way.

#### Changes proposed in this Pull Request:

* Makes the dismissal link only be shown for users that can manage options.
Another option would be replacing  `update_option` for something per user.

#### Testing instructions:

1. Checkout this branch
2. Build the admin page
3. Connect Jetpack if it's not. Create an editor user if there's not one on the site.
4. Login in incognito with that editor
4. Visit the Jetpack Dashboard, scroll to the bottom until you see the Apps card.
5. Confirm that you don't see the dismissal link

**Before**

![image](https://user-images.githubusercontent.com/746152/36225246-cd054ab2-11a8-11e8-8111-68e7e02266bc.png)

**After**

![image](https://user-images.githubusercontent.com/746152/36225400-508d1cfc-11a9-11e8-8bf6-bfcacb84492d.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
