### PR TITLE
Sync: Do bulk delete of post meta on daily akismet cleanup

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -59,9 +59,30 @@ class Grunion_Contact_Form_Plugin {
 			return;
 		}
 
+		/**
+		 * Fires right before deleting the _feedback_akismet_values post meta on $feedback_ids
+		 *
+		 * @module contact-form
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param array $feedback_ids list of feedback post ID
+		 */
+		do_action( 'jetpack_daily_akismet_meta_cleanup_before', $feedback_ids );
 		foreach ( $feedback_ids as $feedback_id ) {
 			delete_post_meta( $feedback_id, '_feedback_akismet_values' );
 		}
+
+		/**
+		 * Fires right after deleting the _feedback_akismet_values post meta on $feedback_ids
+		 *
+		 * @module contact-form
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param array $feedback_ids list of feedback post ID
+		 */
+		do_action( 'jetpack_daily_akismet_meta_cleanup_after', $feedback_ids );
 	}
 
 	/**

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -64,7 +64,7 @@ class Grunion_Contact_Form_Plugin {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 5.9.0
+		 * @since 6.0.0
 		 *
 		 * @param array $feedback_ids list of feedback post ID
 		 */
@@ -78,7 +78,7 @@ class Grunion_Contact_Form_Plugin {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 5.9.0
+		 * @since 6.0.0
 		 *
 		 * @param array $feedback_ids list of feedback post ID
 		 */

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -64,7 +64,7 @@ class Grunion_Contact_Form_Plugin {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @param array $feedback_ids list of feedback post ID
 		 */
@@ -78,7 +78,7 @@ class Grunion_Contact_Form_Plugin {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @param array $feedback_ids list of feedback post ID
 		 */

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -47,6 +47,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$this->init_listeners_for_meta_type( 'post', $callable );
 		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
 
+		add_action( 'jetpack_daily_akismet_meta_cleanup_before', array( $this, 'daily_akismet_meta_cleanup_before' ) );
+		add_action( 'jetpack_daily_akismet_meta_cleanup_after', array( $this, 'daily_akismet_meta_cleanup_after' ) );
+		add_action( 'jetpack_batch_delete_post_meta', $callable, 10, 2 );
+
 		add_action( 'export_wp', $callable );
 		add_action( 'jetpack_sync_import_end', $callable, 10, 2 );
 
@@ -74,6 +78,25 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
 		$this->import_end = true;
+	}
+
+	public function daily_akismet_meta_cleanup_before( $feedback_ids ) {
+		remove_action( 'deleted_post_meta', $this->action_handler );
+		/**
+		 * Used for syncing deletion of batch post meta
+		 *
+		 * @since 5.9.0
+		 *
+		 * @module sync
+		 *
+		 * $param array $feedback_ids feedback post IDs
+		 * $param string $meta_key to be deleted
+		 */
+		do_action( 'jetpack_batch_delete_post_meta', $feedback_ids, '_feedback_akismet_values');
+	}
+
+	public function daily_akismet_meta_cleanup_after( $feedback_ids ) {
+		add_action( 'deleted_post_meta', $this->action_handler );
 	}
 
 	public function sync_import_end() {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -85,7 +85,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		/**
 		 * Used for syncing deletion of batch post meta
 		 *
-		 * @since 5.9.0
+		 * @since 6.0.0
 		 *
 		 * @module sync
 		 *

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -49,7 +49,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		add_action( 'jetpack_daily_akismet_meta_cleanup_before', array( $this, 'daily_akismet_meta_cleanup_before' ) );
 		add_action( 'jetpack_daily_akismet_meta_cleanup_after', array( $this, 'daily_akismet_meta_cleanup_after' ) );
-		add_action( 'jetpack_batch_delete_post_meta', $callable, 10, 2 );
+		add_action( 'jetpack_post_meta_batch_delete', $callable, 10, 2 );
 
 		add_action( 'export_wp', $callable );
 		add_action( 'jetpack_sync_import_end', $callable, 10, 2 );
@@ -92,7 +92,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 * $param array $feedback_ids feedback post IDs
 		 * $param string $meta_key to be deleted
 		 */
-		do_action( 'jetpack_batch_delete_post_meta', $feedback_ids, '_feedback_akismet_values');
+		do_action( 'jetpack_post_meta_batch_delete', $feedback_ids, '_feedback_akismet_values');
 	}
 
 	public function daily_akismet_meta_cleanup_after( $feedback_ids ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -85,7 +85,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		/**
 		 * Used for syncing deletion of batch post meta
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @module sync
 		 *

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -379,11 +379,28 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		}
 
 		foreach ( $meta_ids as $meta_id ) {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM $table WHERE meta_id = %d", $meta_id ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $table WHERE meta_id = %d ", $meta_id ) );
 		}
 
 		// if we don't have an object ID what do we do - invalidate ALL meta?
 		if ( $object_id ) {
+			wp_cache_delete( $object_id, $type . '_meta' );
+		}
+	}
+
+	// todo: test this out to make sure it works as expected.
+	public function delete_batch_metadata( $type, $object_ids, $meta_key ) {
+		global $wpdb;
+
+		$table = _get_meta_table( $type );
+		if ( ! $table ) {
+			return false;
+		}
+		$column = sanitize_key($type . '_id' );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $table WHERE $column IN (%s) && meta_key = %s", implode( ',', $object_ids ),  $meta_key ) );
+
+		// if we don't have an object ID what do we do - invalidate ALL meta?
+		foreach ( $object_ids as $object_id ) {
 			wp_cache_delete( $object_id, $type . '_meta' );
 		}
 	}
@@ -595,7 +612,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	public function delete_user_locale( $user_id ) {
 		$this->invalid_call();
 	}
-	
+
 	public function get_user_locale( $user_id ) {
 		return jetpack_get_user_locale( $user_id );
 	}
@@ -636,7 +653,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				$where_sql    = Jetpack_Sync_Settings::get_whitelisted_post_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
-				
+
 				if ( empty( $columns ) ) {
 					$columns  = Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
 				}

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -379,7 +379,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		}
 
 		foreach ( $meta_ids as $meta_id ) {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM $table WHERE meta_id = %d ", $meta_id ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $table WHERE meta_id = %d", $meta_id ) );
 		}
 
 		// if we don't have an object ID what do we do - invalidate ALL meta?

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -74,6 +74,8 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_metadata( $type, $object_id, $meta_ids );
 
+	public function delete_batch_metadata( $type, $object_ids, $meta_key );
+
 	// constants
 	public function get_constant( $constant );
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -102,7 +102,11 @@ class Jetpack_Sync_Server_Replicator {
 				$type = $matches[1];
 				$this->store->delete_metadata( $type, $object_id, $meta_ids );
 				break;
-
+			case 'jetpack_batch_delete_post_meta':
+				list( $object_ids, $meta_key ) = $args;
+				$type = 'post';
+				$this->store->delete_batch_metadata( $type, $object_ids, $meta_key );
+				break;
 			// constants
 			case 'jetpack_sync_constant':
 				list( $name, $value ) = $args;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -102,7 +102,7 @@ class Jetpack_Sync_Server_Replicator {
 				$type = $matches[1];
 				$this->store->delete_metadata( $type, $object_id, $meta_ids );
 				break;
-			case 'jetpack_batch_delete_post_meta':
+			case 'jetpack_post_meta_batch_delete':
 				list( $object_ids, $meta_key ) = $args;
 				$type = 'post';
 				$this->store->delete_batch_metadata( $type, $object_ids, $meta_key );

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -313,6 +313,24 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		}
 	}
 
+	public function delete_batch_metadata( $type, $object_ids, $meta_key ) {
+		$meta_ids = array();
+		foreach ( $this->meta[ get_current_blog_id() ][ $type ] as $meta_id => $meta_data ) {
+			if (
+				$meta_data->meta_key === $meta_key &&
+				in_array( $meta_data->object_id, $object_ids )
+			) {
+			$meta_ids[] = $meta_id;
+			}
+		}
+
+		foreach ( $meta_ids as $meta_id ) {
+			unset( $this->meta[ get_current_blog_id() ][ $type ][ $meta_id ] );
+		}
+	}
+
+
+
 	// constants
 	public function get_constant( $constant ) {
 		if ( ! isset( $this->constants[ get_current_blog_id() ][ $constant ] ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -101,9 +101,9 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
 
 		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( '_private_meta' ) ) );
-		
+
 		add_post_meta( $this->post_id, '_private_meta', 'boo' );
-		
+
 		$this->sender->do_sync();
 
 		$this->assertEquals( 'boo', $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
@@ -111,7 +111,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_comment_meta_whitelist_cab_be_appened_in_settings() {
 		$comment_ids = $this->factory->comment->create_post_comments( $this->post_id );
-		
+
 		add_comment_meta( $comment_ids[0], '_private_meta', 'foo' );
 		$this->sender->do_sync();
 
@@ -185,6 +185,30 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->assertOptionIsSynced( '_wpas_skip_1234', '1', 'post', $this->post_id );
+	}
+
+	public function test_sync_daily_akismet_meta_cleanup() {
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+		$post_id = wp_insert_post( array( 'post_type' => 'feedback', 'post_title' => 'fun' ) );
+		// This event can trigger a deletion of many _feedbacakismet_values terms.
+		add_post_meta( $post_id, '_feedback_akismet_values', '1' );
+
+		$grunion = Grunion_Contact_Form_Plugin::init();
+		$grunion->daily_akismet_meta_cleanup();
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_batch_delete_post_meta' );
+
+		$this->assertEquals( array( $post_id ), $event->args[0] );
+		$this->assertEquals( '_feedback_akismet_values', $event->args[1] );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' );
+
+		$this->assertFalse( $event );
+		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $post_id, '_feedback_akismet_values', true );
+		$this->assertEquals( get_post_meta( $post_id, '_feedback_akismet_values', true ), $meta_key_value );
 	}
 
 	function assertOptionIsSynced( $meta_key, $value, $type, $object_id ) {

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -199,7 +199,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_batch_delete_post_meta' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_post_meta_batch_delete' );
 
 		$this->assertEquals( array( $post_id ), $event->args[0] );
 		$this->assertEquals( '_feedback_akismet_values', $event->args[1] );


### PR DESCRIPTION
Performance optimization: Instead of sending 100s of delete post meta events we send only 1. That tells us to bulk delete the post_meta for the array of post_id supplied. 

#### Changes proposed in this Pull Request:
* Stop sending individual post meta events. 
* send 1 bulk post meta event.

#### Testing instructions:
- Do the tests pass?
- Trigger a daily cron event via a cron plugin. 
- Do you see any errors? 
- The .com side still needs to be implemented for this. 



