### PR TITLE
Make sure that $output is an array before treating it as an array

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -9,6 +9,10 @@ class WPCOM_JSON_API_List_Comments_Walker extends Walker {
 	);
 
 	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
+		if ( ! is_array( $output ) ) {
+			$output = array();
+		}
+
 		$output[] = $object->comment_ID;
 	}
 


### PR DESCRIPTION
Trying to treat a string like an array results in a fatal error in PHP 7.2

Fixes #

#### Changes proposed in this Pull Request:

* Fix a fatal error under PHP 7.2

#### Testing instructions:

* Calling sites/X/posts/Y/replies triggers a fatal error condition under PHP 7.2.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Make sure that $output is an array before treating it as an array.  Trying to treat a string like an array results in a fatal error in PHP 7.2.