### PR TITLE
XML RPC request should get hard blocker quicker

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -550,7 +550,7 @@ class Jetpack_Protect_Module {
 		 * @param bool true Should we fallback to the Math questions when an IP is blocked. Default to true.
 		 */
 		$allow_math_fallback_on_fail = apply_filters( 'jpp_use_captcha_when_blocked', true );
-		if ( ! $allow_math_fallback_on_fail ) {
+		if ( ! $allow_math_fallback_on_fail || Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			$this->kill_login();
 		}
 		include_once dirname( __FILE__ ) . '/protect/math-fallback.php';


### PR DESCRIPTION
Currently math fallback doesn't do anything for xml rpc requests. Lets hard block xmlprc requests when they get marked as blocked. This would help prevent more of the requests coming though. 

This PR blocks xmlrpc requests for would regularly show the math test just gets bypassed and allows more valid xml rpc requests though.

#### Testing instructions:
use the following code. composer.json 
```
{
    "name": "xmlrpc-tester",
    "type": "test",
    "require": {
        "hieu-le/wordpress-xmlrpc-client": "~2.0"
    },
    "license": "GPL2",
    "authors": [
        {
            "name": "Enej",
            "email": ""
        }
    ]
}
```
index.php 
```
require __DIR__ . '/vendor/autoload.php';
# Your Wordpress website is at: http://wp-website.com
$endpoint = "https://enej.wpsandbox.me/aaa/xmlrpc.php";

# Create client instance
$wpClient = new \HieuLe\WordpressXmlrpcClient\WordpressClient();
# Log error
$wpClient->onError(function($error, $event) {
	print_r( $error );
});

# Set the credentials for the next requests
$do = $wpClient->setCredentials( $endpoint, 'enejtest999', 'nopassword' );

print_r( $wpClient->getPost( 11395 ) );
```

run `composer install` to install the dependencies
run `php index.php`

You should get blocked pretty after a few attempts. 
with an error. 


<img width="1054" alt="screen_shot_2018-02-15_at_1_08_02_pm" src="https://user-images.githubusercontent.com/115071/36316859-4d964d14-12f0-11e8-930a-1bce836e393b.png">