### PR TITLE
CLI: Do not allow managing partner plans while in safe mode

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -960,8 +960,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		// functions/callables so that we can test if this site is in IDC.
 		if ( Jetpack::is_active() && ! Jetpack::validate_sync_error_idc_option() ) {
 			WP_CLI::runcommand( 'jetpack sync start --modules=functions --sync_wait_time=0', array(
-				'return'     => false,
-				'exit_error' => true,
+				'return'     => true, // Capture output so that we don't output errors or successes.
+				'exit_error' => false,
 			) );
 		}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -843,6 +843,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( new WP_Error( 'missing_access_token', __( 'Missing or invalid access token', 'jetpack' ) ) );
 		}
 
+		if ( Jetpack::validate_sync_error_idc_option() ) {
+			$this->partner_provision_error( new WP_Error(
+				'site_in_safe_mode',
+				esc_html__( 'Can not cancel a plan while in safe mode. See: https://jetpack.com/support/safe-mode/', 'jetpack' )
+			) );
+		}
+
 		$site_identifier = Jetpack_Options::get_option( 'id' );
 
 		if ( ! $site_identifier ) {
@@ -947,6 +954,22 @@ class Jetpack_CLI extends WP_CLI_Command {
 					define( $constant_name, $named_args[ $url_arg ] );
 				}
 			}
+		}
+
+		// If Jetpack is currently connected, and is not in Safe Mode already, kick off a sync of the current
+		// functions/callables so that we can test if this site is in IDC.
+		if ( Jetpack::is_active() && ! Jetpack::validate_sync_error_idc_option() ) {
+			WP_CLI::runcommand( 'jetpack sync start --modules=functions --sync_wait_time=0', array(
+				'return'     => false,
+				'exit_error' => true,
+			) );
+		}
+
+		if ( Jetpack::validate_sync_error_idc_option() ) {
+			$this->partner_provision_error( new WP_Error(
+				'site_in_safe_mode',
+				esc_html__( 'Can not provision a plan while in safe mode. See: https://jetpack.com/support/safe-mode/', 'jetpack' )
+			) );
 		}
 
 		$blog_id    = Jetpack_Options::get_option( 'id' );


### PR DESCRIPTION
It's currently possible to provision/cancel a plan to a site that is in safe mode. This can cause interesting issues such as a cloned site cancelling the production site's plan.

For more details, see: p7kMJG-4mB-p2

Testing instructions:

- Put site in safe mode
- I tend to do this by ensuring a site is accessible by two domains
    - Connect on the first domain `idc.jetpack.com` for example
    - Update home and siteurl values to other domain. 
        - `wp update option home http://idcclone.jetpack.com`
        - `wp update option siteurl http://idcclone.jetpack.com`
- Login to site at new domain
    - This fires off a sync event that usually will put the site in safe mode
- Ensure safe mode notice shows
- Ensure you have a partner ID and secret
    - Follow instructions here if you don't: PCYsg-emq-p2
- Run JPS scripts
    - `sh jetpack/bin/partner-provision.sh --partner_id=PARTNER_ID_HERE --partner_secret=PARTNER_SECRET_HERE --plan=premium --user=1`
     - `sh jetpack/partner-cancel.sh --partner_id=PARTNER_ID_HERE--partner_secret=PARTNER_SECRET_HERE`