### PR TITLE
API: Jetpack: API: Updates /sites/%s/jetpack/modules endpoints respon…

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -686,7 +686,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 				'introduced'  => '(string)   The Jetpack version when the module was introduced.',
 				'changed'     => '(string)   The Jetpack version when the module was changed.',
 				'free'        => '(boolean)  The module\'s Free or Paid status.',
-				'module_tags' => '(array)    The module\'s tags.'
+				'module_tags' => '(array)    The module\'s tags.',
+				'override'    => '(string)   The module\'s override. Empty if no override, otherwise \'active\' or \'inactive\'',
 			);
 			$return[$key] = (object) $this->cast_and_filter(
 				$value,


### PR DESCRIPTION
…se format to add override

Currently, it is possible to override the active modules in Jetpack and force some to be active or inactive. The issue with this is that our UI does not respond to that. So, while a module may be forced on, a user is shown UI that allows them to attempt to disable the module, except, when the page is refreshed, the module is still enabled.

See: https://github.com/Automattic/jetpack/pull/8836
See: https://github.com/Automattic/jetpack/issues/8800

Differential Revision: D10224-code

This commit syncs r170223-wpcom.

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
