### PR TITLE
Build: eslint --fix build files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,44 +1,43 @@
 /* global module, require */
 
-module.exports = function(grunt) {
-    var path = require( 'path' ),
-        cfg = {
-            pkg: grunt.file.readJSON('package.json'),
-            makepot: {
-                jetpack: {
-                    options: {
-                        domainPath: '/languages',
-                        exclude: [
-                            'node_modules',
-                            'tests',
-                            'tools',
-                            'vendor'
-                        ],
-                        mainFile:    'jetpack.php',
-                        potFilename: 'jetpack.pot'
-                    }
-                }
-            },
-            addtextdomain: {
-                jetpack: {
-                    options: {
-                        textdomain: 'jetpack'
-                    },
-                    files: {
-                        src: [
-                            '*.php',
-                            '**/*.php',
-                            '!node_modules/**',
-                            '!tests/**',
-                            '!tools/**',
-                            '!vendor/**'
-                        ]
-                    }
-                }
-            }
-        };
+module.exports = function( grunt ) {
+	const cfg = {
+		pkg: grunt.file.readJSON( 'package.json' ),
+		makepot: {
+			jetpack: {
+				options: {
+					domainPath: '/languages',
+					exclude: [
+						'node_modules',
+						'tests',
+						'tools',
+						'vendor'
+					],
+					mainFile: 'jetpack.php',
+					potFilename: 'jetpack.pot'
+				}
+			}
+		},
+		addtextdomain: {
+			jetpack: {
+				options: {
+					textdomain: 'jetpack'
+				},
+				files: {
+					src: [
+						'*.php',
+						'**/*.php',
+						'!node_modules/**',
+						'!tests/**',
+						'!tools/**',
+						'!vendor/**'
+					]
+				}
+			}
+		}
+	};
 
-    grunt.initConfig( cfg );
+	grunt.initConfig( cfg );
 
-    grunt.loadNpmTasks('grunt-wp-i18n');
+	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 };

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -107,7 +107,7 @@ function onBuild( done ) {
 		// Source any JS for whitelisted modules, which will minimize us shipping much
 		// more JS that we haven't pointed to in PHP yet.
 		// Example output: modules/(shortcodes|widgets)/**/*.js
-		const supportedModulesSource = `modules/@(${supportedModules.join( '|' ) })/**/*.js`;
+		const supportedModulesSource = `modules/@(${ supportedModules.join( '|' ) })/**/*.js`;
 
 		// Uglify other JS from _inc and supported modules
 		const sources = [
@@ -262,7 +262,7 @@ function doStatic( done ) {
 				} );
 		} catch ( error ) {
 			log( colors.yellow(
-				"Warning: gulp was unable to update static HTML files.\n\n" +
+				'Warning: gulp was unable to update static HTML files.\n\n' +
 				'If this is happening during watch, this warning is OK to dismiss: sometimes webpack fires watch handlers when source code is not yet built.'
 			) );
 		}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
     "build-production": "yarn distclean && yarn && gulp languages:extract && yarn build-production-client",
     "build-languages": "gulp languages",
-    "lint": "yarn build && eslint --ext .js --ext .jsx _inc/client -c .eslintrc",
+    "lint": "yarn build && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,25 +1,26 @@
 require( 'es6-promise' ).polyfill();
 
-var path = require( 'path' );
-var webpack = require( 'webpack' );
-var fs = require('fs');
-var NODE_ENV = process.env.NODE_ENV || 'development';
-var ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const NODE_ENV = process.env.NODE_ENV || 'development';
+const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
-var IS_HOT_UPDATE = ( process.env.NODE_ENV !== 'production' );
+// This file is written in ES5 because it is run via Node.js and is not
+// transpiled by babel. We want to support various versions of node,
+// so it is best to not use any ES6 features even if newer versions
+// support ES6 features out of the box.
+const webpackConfig = {
 
-// This file is written in ES5 because it is run via Node.js and is not transpiled by babel. We want to support various versions of node, so it is best to not use any ES6 features even if newer versions support ES6 features out of the box.
-var webpackConfig = {
-
-	// Entry points point to the javascript module that is used to generate the script file.
+	// Entry points point to the javascript module
+	// that is used to generate the script file.
 	// The key is used as the name of the script.
 	entry: {
 		admin: './_inc/client/admin.js',
-		static: './_inc/client/static.jsx'
+		'static': './_inc/client/static.jsx'
 	},
 	output: {
 		path: path.join( __dirname, '_inc/build' ),
-		filename: "[name].js"
+		filename: '[name].js'
 	},
 	module: {
 
@@ -28,30 +29,22 @@ var webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				use: [
-					// {
-					// 	loader: 'eslint-loader',
-					// 	query: {
-					// 		configFile: path.join(__dirname, '.eslintrc'),
-					// 		quiet: true
-					// 	},
-					// },
 					{
 						loader: 'babel-loader',
 						options: {
-							presets: ['es2015', 'stage-1', 'react'],
+							presets: [ 'es2015', 'stage-1', 'react' ],
 							plugins: [
-								"transform-runtime",
-								"add-module-exports",
-								"transform-es3-member-expression-literals",
-								"transform-export-extensions"
+								'transform-runtime',
+								'add-module-exports',
+								'transform-es3-member-expression-literals',
+								'transform-export-extensions'
 							]
 
 						}
 					},
 				],
-
-				// exclude: /node_modules/,
-				// include both typical npm-linked locations and default module locations to handle both cases
+				// include both typical npm-linked locations and default module
+				// locations to handle both cases
 				include: [
 					path.join( __dirname, 'test' ),
 					path.join( __dirname, '_inc/client' ),
@@ -63,10 +56,10 @@ var webpackConfig = {
 			},
 			{
 				test: /\.css$/,
-				use: ExtractTextPlugin.extract({
-					fallback: "style-loader",
-					use: [ "css-loader", "autoprefixer-loader" ]
-				})
+				use: ExtractTextPlugin.extract( {
+					fallback: 'style-loader',
+					use: [ 'css-loader', 'autoprefixer-loader' ]
+				} )
 			},
 			{
 				test: /\.html$/,
@@ -74,10 +67,10 @@ var webpackConfig = {
 			},
 			{
 				test: /\.scss$/,
-				use: ExtractTextPlugin.extract({
-				  fallback: "style-loader",
-				  use: [ "css-loader", "sass-loader" ]
-				})
+				use: ExtractTextPlugin.extract( {
+					fallback: 'style-loader',
+					use: [ 'css-loader', 'sass-loader' ]
+				} )
 			},
 			{
 				test: /\.svg/,
@@ -88,7 +81,7 @@ var webpackConfig = {
 	resolve: {
 		extensions: [ '.js', '.jsx' ],
 		alias: {
-			"react": path.join(__dirname, "/node_modules/react")
+			react: path.join( __dirname, '/node_modules/react' )
 		},
 		modules: [
 			path.resolve( __dirname, 'node_modules' ),
@@ -99,18 +92,16 @@ var webpackConfig = {
 		modules: [ path.join( __dirname, 'node_modules' ) ]
 	},
 	node: {
-		fs: "empty",
+		fs: 'empty',
 		process: true
 	},
 	plugins: [
-		new webpack.DefinePlugin({
-
-			// NODE_ENV is used inside React to enable/disable features that should only
-			// be used in development
+		new webpack.DefinePlugin( {
+			// NODE_ENV is used inside React to enable/disable features that should
+			// only be used in development
 			'process.env.NODE_ENV': JSON.stringify( NODE_ENV )
-		}),
+		} ),
 		new ExtractTextPlugin( '[name].dops-style.css' ),
-		// new webpack.optimize.UglifyJsPlugin(),
 	],
 	externals: {
 		'react/addons': true,
@@ -121,10 +112,11 @@ var webpackConfig = {
 };
 
 if ( NODE_ENV === 'production' ) {
-
+	// eslint-disable-next-line no-new
 	new webpack.DefinePlugin( {
 		// This has effect on the react lib size
-		'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ) // TODO switch depending on actual environment
+		// TODO switch depending on actual environment
+		'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV )
 	} );
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,6 @@ const webpack = require( 'webpack' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
-// This file is written in ES5 because it is run via Node.js and is not
-// transpiled by babel. We want to support various versions of node,
-// so it is best to not use any ES6 features even if newer versions
-// support ES6 features out of the box.
 const webpackConfig = {
 
 	// Entry points point to the javascript module

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,6 +110,7 @@ const webpackConfig = {
 };
 
 if ( NODE_ENV === 'production' ) {
+	// Create global process.env.NODE_ENV constant available at the browser window
 	// eslint-disable-next-line no-new
 	new webpack.DefinePlugin( {
 		// This has effect on the react lib size

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-require( 'es6-promise' ).polyfill();
-
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const NODE_ENV = process.env.NODE_ENV || 'development';


### PR DESCRIPTION
Follow up for #8861 since we now [require](https://github.com/Automattic/jetpack/blob/master/package.json#L150) Node.js 8, this should be safe.

1. Fix with eslint:
  ```
  npx eslint *.js -c .eslintrc --fix
  ```

2. Manually fixing these warnings:
  ```
  Gruntfile.js
    4:6  error    'path' is assigned a value but never used        no-unused-vars
    4:6  warning  'path' is never reassigned. Use 'const' instead  prefer-const
    5:3  warning  'cfg' is never reassigned. Use 'const' instead   prefer-const

  webpack.config.js
      5:7  error  'fs' is assigned a value but never used             no-unused-vars
      9:7  error  'IS_HOT_UPDATE' is assigned a value but never used  no-unused-vars
     78:2  error  Mixed spaces and tabs                               no-mixed-spaces-and-tabs
     79:2  error  Mixed spaces and tabs                               no-mixed-spaces-and-tabs
    124:2  error  Do not use 'new' for side effects                   no-new
  ```

3. Clean out commented out code from `webpack.config.js`

4. Leave one eslint warning ([`no-new`](https://eslint.org/docs/rules/no-new) for `new webpack.DefinePlugin()`) in `webpack.config.js` and just add ignore-rule. Adds a note explaining what this part of config does.

5. Reorganise comments to fit 80 chars line width in `webpack.config.js`

6. Remove `es6-promise` polyfill from `webpack.config.js` (since we're requiring Node.js 8 now)

7. Test `*.js` files in the root folder with `yarn lint`


### Testing

All [scripts](https://github.com/Automattic/jetpack/blob/260ca952a6bc7b66ada04cdce159a9de3662e2fa/package.json#L15-L30) still sail smoothly?

- `yarn lint ` → _Now tests also `./*.js`. React class warnings are going to be addressed in #8714._
- `yarn watch`
- `yarn build`
- `yarn build-production-client`
- `yarn build-client`
- `yarn build-production`
- `yarn build-languages` → _Please someone who knows how to operate this — make sure to test it? Thanks!_
- `yarn add-textdomain`
- `yarn build-pot`
