### PR TITLE
Docs: Partner: First pass at documenting endpoints

### DIFF
--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -67,7 +67,7 @@ var options = {
         client_id: clientId,
         client_secret: clientSecret,
         grant_type: 'client_credentials',
-         scope: 'jetpack-partner'
+        scope: 'jetpack-partner'
     }
 };
 
@@ -87,7 +87,7 @@ TBD.
 
 ### Cancelling a plan
 
-Cancelling a Jetpack for a given Jetpack site, as long as the partner making the cancellation request is also the partner that provisioned that plan, is fairly straightforward. To move forward, you'll need your partner secret as well as the URL of the site that you'd like to cancel the plan for.
+Plans can be cancelled by making a request using your partner token from the step above and the URL of the site being cancelled.
 
 #### Endpoint Information
 
@@ -96,10 +96,11 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 
 `$site` is the site's domain and path where `/` in the path is replaced with `::`. For example:
 
-| Site URL            | $site Identifier    |
-| ------------------- | ------------------- |
-| `example.com`       | `example.com`       |
-| `example.com/test1` | `example.com::test` |
+| Site URL              | $site Identifier        |
+| --------------------- | -------------------     |
+| `example.com`         | `example.com`           |
+| `example.com/demo`    | `example.com::demo`     |
+| `example.com/demo/wp` | `example.com::demo::wp` |
 
 #### Query Parameters
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -10,9 +10,8 @@ To do that, you'll make a `POST` request to the `https://public-api.wordpress.co
 
 #### Endpoint Information
 
-__Method__: POST
-
-__URL__:    https://public-api.wordpress.com/oauth2/token
+- __Method__: POST
+- __URL__:    https://public-api.wordpress.com/oauth2/token
 
 #### Request Parameters
 
@@ -23,11 +22,11 @@ __URL__:    https://public-api.wordpress.com/oauth2/token
 
 #### Response Parameters
 
-__access_token__: (string) This is the access token we'll need for the API calls below.
-__token_type__:   (string) This should be `bearer`.
-__blog_id__:      (int) This should be `0`.
-__blog_url__:     (int) This should be `0`.
-__scope__:        (string) This should be `jetpack-partner`.
+- __access_token__: (string) This is the access token we'll need for the API calls below.
+- __token_type__:   (string) This should be `bearer`.
+- __blog_id__:      (int) This should be `0`.
+- __blog_url__:     (int) This should be `0`.
+- __scope__:        (string) This should be `jetpack-partner`.
 
 Note: You only need to create the `access_token` once.
 
@@ -86,9 +85,8 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 
 #### Endpoint Information
 
-__Method__: POST
-
-__URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/{$site}/partner-cancel
+- __Method__: POST
+- __URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/{$site}/partner-cancel
 
 `$site` is the site's domain and path where `/` in the path is replaced with `::`. For example:
 
@@ -99,15 +97,14 @@ __URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/{$site}/partner-can
 
 #### Query Parameters
 
-__http_envelope__: Default to `false`. Sending `true` will force the HTTP status code to always be `200`. The JSON response is wrapped in an envelope containing the "real" HTTP status code and headers.
-
-__pretty__:        Defaults to `false`. Setting to `true` will output pretty JSON.
+- __http_envelope__: Default to `false`. Sending `true` will force the HTTP status code to always be `200`. The JSON response is wrapped in an envelope containing the "real" HTTP status code and headers.
+- __pretty__:        Defaults to `false`. Setting to `true` will output pretty JSON.
 
 #### Response Parameters
 
-__success__:       (bool) Was the operation successful?.
-__error_code__:    (string) Error code, if any'.
-__error_message__: (string) Error message, if any'.
+- __success__:       (bool) Was the operation successful?.
+- __error_code__:    (string) Error code, if any'.
+- __error_message__: (string) Error message, if any'.
 
 #### Endpoint errors
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -8,6 +8,8 @@ When you become a Jetpack partner, we will provide you with your partner ID and 
 
 To do that, you'll make a `POST` request to the `https://public-api.wordpress.com/oauth2/token` endpoint passing with the request parameters mentioned below.
 
+For more detailed information about oAuth on WordPress.com, visit the [documentation on oAuth2 authentication](https://developer.wordpress.com/docs/oauth2/).
+
 #### Endpoint Information
 
 - __Method__: POST

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -2,6 +2,85 @@
 
 In [another document](plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
 
+### Getting a Jetpack Partner access token
+
+When you become a Jetpack partner, we will provide you with your partner ID and a secret key. Typically you just pass these values directly in to the `bin/partner-provision.sh` and `bin/partner_cancel.sh` scripts. But, when calling the WordPress.com API directly, you'll first need to get an access token with for your partner ID with a scope of `jetpack-partner`.
+
+
+To do that, you'll make a `POST` request to the `https://public-api.wordpress.com/oauth2/token` endpoint passing with the request parameters mentioned below.
+
+- `grant_type`:    Value should be `client_credentials`
+- `scope`:         Value should be `jetpack-partner`
+- `client_id`:     The partner ID that we provide you
+- `client_secret`: The partner secret that we provide you
+
+#### Endpoint Information
+
+__Method__: POST
+
+__URL__:    https://public-api.wordpress.com/oauth2/token
+
+#### Request Parameters
+
+- __grant_type__:    Value should be `client_credentials`
+- __scope__:         Value should be `jetpack-partner`
+- __client_id__:     The partner ID that we provide you
+- __client_secret__: The partner secret that we provide you
+
+#### Response Parameters
+
+__access_token__: (string) This is the access token we'll need for the API calls below.
+__token_type__:   (string) This should be `bearer`.
+__blog_id__:      (int) This should be `0`.
+__blog_url__:     (int) This should be `0`.
+__scope__:        (string) This should be `jetpack-partner`.
+
+Note: You only need to create the `access_token` once.
+
+#### Examples
+
+Here is an example using cURL in shell.
+
+```shell
+curl --request POST \
+    --url https://public-api.wordpress.com/oauth2/token \
+    --header 'cache-control: no-cache' \
+    --header 'content-type: multipart/form-data;' \
+    --form client_id={PARTNER_ID} \
+    --form client_secret={PARTNER_SECRET} \
+    --form grant_type=client_credentials \
+    --form scope=jetpack-partner
+```
+
+Here's an example using the request module in Node JS.
+
+```javascript
+var request = require("request");
+
+var options = { method: 'POST',
+    url: 'https://public-api.wordpress.com/oauth2/token',
+    headers: {
+        'cache-control': 'no-cache',
+        'content-type': 'multipart/form-data;'
+    },
+    formData: {
+        client_id: {PARTNER_ID},
+        client_secret: {PARTNER_SECRET},
+        grant_type: 'client_credentials',
+         scope: 'jetpack-partner'
+    }
+};
+
+request( options, function ( error, response, body ) {
+    if ( error ) {
+        throw new Error(error);
+    }
+
+    console.log( body );
+} );
+
+```
+
 ### Provisioning a plan
 
 TBD.

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -1,0 +1,46 @@
+# Provisioning and Cancelling Jetpack Plans – Querying the API Directly
+
+In [another document](../plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
+
+### Provisioning a plan
+
+TBD.
+
+### Cancelling a plan
+
+Cancelling a Jetpack for a given Jetpack site, as long as the partner making the cancellation request is also the partner that provisioned that plan, is fairly straightforward. To move forward, you'll need your partner secret as well as the URL of the site that you'd like to cancel the plan for.
+
+#### Endpoint Information
+
+__Method__: Get
+
+__URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/{$site}/partner-cancel
+
+`$site` is the site's domain and path where `/` in the path is replaced with `::`. For example:
+
+| Site URL            | $site Identifier    |
+| ------------------- | ------------------- |
+| `example.com1`      | `example.com`       |
+| `example.com/test1` | `example.com::test` |
+
+#### Query Parameters
+
+__http_envelope__: Default to `false`. Sending `true` will force the HTTP status code to always be `200`. The JSON response is wrapped in an envelope containing the "real" HTTP status code and headers.
+
+__pretty__:        Defaults to `false`. Setting to `true` will output pretty JSON.
+
+#### Response Parameters
+
+__success__:       (bool) Was the operation successful?.
+__error_code__:    (string) Error code, if any'.
+__error_message__: (string) Error message, if any'.
+
+#### Endpoint errors
+
+| HTTP Code | Error Identifier      | Error Message                                                             |
+| --------- | --------------------- | ------------------------------------------------------------------------- |
+| 400       | invalid_input         | Unable to delete subscription                                             |
+| 400       | not_jps_plan          | The plan for this site was not provisioned by Jetpack Start               |
+| 403       | invalid_scope         | This token is not authorized to provision partner sites                   |
+| 403       | invalid_blog          | The blog ID %s is invalid                                                 |
+| 403       | incorrect_partner_key | Subscriptions can only be cancelled by the oAuth client that created them |

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -103,8 +103,8 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 #### Response Parameters
 
 - __success__:       (bool) Was the operation successful?.
-- __error_code__:    (string) Error code, if any'.
-- __error_message__: (string) Error message, if any'.
+- __error_code__:    (string) Error code, if any.
+- __error_message__: (string) Error message, if any.
 
 #### Endpoint errors
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -1,6 +1,6 @@
 # Provisioning and Cancelling Jetpack Plans – Querying the API Directly
 
-In [another document](../plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
+In [another document](plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
 
 ### Provisioning a plan
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -6,13 +6,7 @@ In [another document](plan-provisioning.md), we discussed how to provision and c
 
 When you become a Jetpack partner, we will provide you with your partner ID and a secret key. Typically you just pass these values directly in to the `bin/partner-provision.sh` and `bin/partner_cancel.sh` scripts. But, when calling the WordPress.com API directly, you'll first need to get an access token with for your partner ID with a scope of `jetpack-partner`.
 
-
 To do that, you'll make a `POST` request to the `https://public-api.wordpress.com/oauth2/token` endpoint passing with the request parameters mentioned below.
-
-- `grant_type`:    Value should be `client_credentials`
-- `scope`:         Value should be `jetpack-partner`
-- `client_id`:     The partner ID that we provide you
-- `client_secret`: The partner secret that we provide you
 
 #### Endpoint Information
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -92,7 +92,7 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 
 | Site URL            | $site Identifier    |
 | ------------------- | ------------------- |
-| `example.com1`      | `example.com`       |
+| `example.com`       | `example.com`       |
 | `example.com/test1` | `example.com::test` |
 
 #### Query Parameters

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -12,7 +12,7 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 
 #### Endpoint Information
 
-__Method__: Get
+__Method__: POST
 
 __URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/{$site}/partner-cancel
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -123,3 +123,37 @@ __error_message__: (string) Error message, if any'.
 | 403       | invalid_scope         | This token is not authorized to provision partner sites                   |
 | 403       | invalid_blog          | The blog ID %s is invalid                                                 |
 | 403       | incorrect_partner_key | Subscriptions can only be cancelled by the oAuth client that created them |
+
+### Examples
+
+Here's an example using cURL in shell.
+
+```shell
+curl --request POST \
+    --url https://public-api.wordpress.com/rest/v1.3/jpphp/{SITE_DOMAIN}/partner-cancel \
+    --header 'authorization: Bearer {ACCESS_TOKEN}' \
+    --header 'cache-control: no-cache' \
+```
+
+Here's an example using the request module in Node JS.
+
+```javascript
+var request = require( 'request ');
+
+var options = {
+    method: 'POST',
+    url: 'https://public-api.wordpress.com/rest/v1.3/jpphp/{SITE_DOMAIN}/partner-cancel',
+    headers: {
+        'cache-control': 'no-cache',
+        authorization: 'Bearer {ACCESS_TOKEN}'
+    }
+};
+
+request( options, function ( error, response, body ) {
+    if ( error ) {
+        throw new Error( error );
+    }
+
+    console.log( body );
+} );
+```

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -37,12 +37,14 @@ Note: You only need to create the `access_token` once.
 Here is an example using cURL in shell.
 
 ```shell
+PARTNER_ID="your_partner_id_here"
+PARTNER_SECRET="your_partner_secret_here"
 curl --request POST \
     --url https://public-api.wordpress.com/oauth2/token \
     --header 'cache-control: no-cache' \
     --header 'content-type: multipart/form-data;' \
-    --form client_id={PARTNER_ID} \
-    --form client_secret={PARTNER_SECRET} \
+    --form client_id="$PARTNER_ID" \
+    --form client_secret="$PARTNER_SECRET" \
     --form grant_type=client_credentials \
     --form scope=jetpack-partner
 ```
@@ -51,6 +53,8 @@ Here's an example using the request module in Node JS.
 
 ```javascript
 var request = require( 'request' );
+var clientId = 'your_partner_id_here';
+var clientSecret = 'your_partner_secret_here';
 
 var options = {
     method: 'POST',
@@ -60,8 +64,8 @@ var options = {
         'content-type': 'multipart/form-data;'
     },
     formData: {
-        client_id: {PARTNER_ID},
-        client_secret: {PARTNER_SECRET},
+        client_id: clientId,
+        client_secret: clientSecret,
         grant_type: 'client_credentials',
          scope: 'jetpack-partner'
     }
@@ -123,9 +127,11 @@ Cancelling a Jetpack for a given Jetpack site, as long as the partner making the
 Here's an example using cURL in shell.
 
 ```shell
+ACCESS_TOKEN="access_token_here"
+SITE_DOMAIN="example.com"
 curl --request POST \
-    --url https://public-api.wordpress.com/rest/v1.3/jpphp/{SITE_DOMAIN}/partner-cancel \
-    --header 'authorization: Bearer {ACCESS_TOKEN}' \
+    --url https://public-api.wordpress.com/rest/v1.3/jpphp/"$SITE_DOMAIN"/partner-cancel \
+    --header "authorization: Bearer $ACCESS_TOKEN" \
     --header 'cache-control: no-cache' \
 ```
 
@@ -133,13 +139,15 @@ Here's an example using the request module in Node JS.
 
 ```javascript
 var request = require( 'request ');
+var accessToken = 'access_token_here';
+var siteDomain = 'example.com';
 
 var options = {
     method: 'POST',
-    url: 'https://public-api.wordpress.com/rest/v1.3/jpphp/{SITE_DOMAIN}/partner-cancel',
+    url: 'https://public-api.wordpress.com/rest/v1.3/jpphp/' + siteDomain + '/partner-cancel',
     headers: {
         'cache-control': 'no-cache',
-        authorization: 'Bearer {ACCESS_TOKEN}'
+        authorization: 'Bearer ' + accessToken
     }
 };
 

--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -55,9 +55,10 @@ curl --request POST \
 Here's an example using the request module in Node JS.
 
 ```javascript
-var request = require("request");
+var request = require( 'request' );
 
-var options = { method: 'POST',
+var options = {
+    method: 'POST',
     url: 'https://public-api.wordpress.com/oauth2/token',
     headers: {
         'cache-control': 'no-cache',
@@ -73,7 +74,7 @@ var options = { method: 'POST',
 
 request( options, function ( error, response, body ) {
     if ( error ) {
-        throw new Error(error);
+        throw new Error( error );
     }
 
     console.log( body );


### PR DESCRIPTION
JPS v1 required hosting partners perform a lot of integration work setting up oAuth and then integrating in our APIs. We tried to simplify this as much as possible in JPS v2 by shipping two shell scripts that handle provisioning and cancellation of plans.

But, there are cases where a host may actually want to call the API instead of running a CLI command. For example, what if the site is already gone by the time the CLI command can be run?

It's currently pretty straightforward to cancel a plan by making calls directly to the API. A hosting partner simply needs to get an access token then call the cancellation endpoint, passing the domain and access token. That process is what is documented in this PR.

Provisioning a plan via calls directly to the API is much less straightforward. Currently, we require details such as the blog ID to be passed with the plan provisioning call, things that are better handled via the CLI.

For now, provisioning a plan is marked as TBD while we consider how to approach that.

To test:

- Create a partner and key by following instructions here in PCYsg-emq-p2
- Provision a plan manually via Jetpack Start and shell on WPCOM
- Run through commands in this documentation to cancel the plan via the API