### PR TITLE
Settings: Auto-focus the widgets panel in the Customizer for Search module

### DIFF
--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -47,7 +47,7 @@ class Search extends React.Component {
 				</SettingsGroup>
 				{
 					this.props.getOptionValue( 'search' ) && (
-						<Card compact className="jp-settings-card__configure-link" href="customize.php">{ __( 'Add Jetpack Search Widget' ) }</Card>
+						<Card compact className="jp-settings-card__configure-link" href="customize.php?autofocus[panel]=widgets">{ __( 'Add Jetpack Search Widget' ) }</Card>
 					)
 				}
 			</SettingsCard>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Make the "Add Jetpack Search Widget" link in the Search module settings card open the widgets section of the customizer.

#### Testing instructions:

Go to Jetpack → Settings → Traffic and enable the Search module. Click on "Add Jetpack Search Widget" and verify that the widgets section of the Customizer opens once it fully loads (it'll take a moment).