### PR TITLE
Admin Page Fix all eslint warnings about the react/jsx-no-bind rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,7 @@
 		"quote-props": [ 2, "as-needed", { "keywords": true } ],
 		"quotes": [ 2, "single", "avoid-escape" ],
 		"react/jsx-curly-spacing": [ 2, "always" ],
-		"react/jsx-no-bind": 0,
+		"react/jsx-no-bind": 2,
 		"react/jsx-space-before-closing": 2,
 		"react/no-danger": 2,
 		"react/no-did-mount-set-state": 2,

--- a/_inc/client/components/form/input-checkbox-multiple.jsx
+++ b/_inc/client/components/form/input-checkbox-multiple.jsx
@@ -77,12 +77,11 @@ module.exports = createReactClass( {
 		}
 	},
 
-	render: function() {
+	mapChoices() {
 		const uniqueId = this.state.uniqueId;
 		const currentSelected = this.getValue();
-		let errorMessage, selectAll;
 
-		const checkboxes = this.props.choices.map( function( choice, i ) {
+		return this.props.choices.map( ( choice, i ) => {
 			const checked = ( -1 !== currentSelected.indexOf( choice.value ) );
 			return (
 				<div className="dops-form-checkbox" key={ i }>
@@ -91,7 +90,14 @@ module.exports = createReactClass( {
 					</Label>
 				</div>
 			);
-		}.bind( this ) );
+		} );
+	},
+
+	render: function() {
+		const uniqueId = this.state.uniqueId;
+		let errorMessage, selectAll;
+
+		const checkboxes = this.mapChoices();
 
 		if ( ! this.isPristine() ) {
 			errorMessage = this.showError() ? this.getErrorMessage() : null;

--- a/_inc/client/components/form/input-radio.jsx
+++ b/_inc/client/components/form/input-radio.jsx
@@ -29,18 +29,22 @@ class Radios extends React.Component {
 		this.props.changeValue( event );
 	};
 
+	mapChoices() {
+		const uniqueId = this.props.uniqueId;
+		return this.props.choices.map( ( choice, i ) => {
+			const checked = this.props.selected === choice.value;
+			return (
+				<div className="dops-form-checkbox" key={ i }>
+					<Label inline label={ choice.label } htmlFor={ uniqueId + i }>
+						<input type="radio" id={ uniqueId + i } value={ choice.value } name={ this.props.name } checked={ checked } onChange={ this.onChange } />
+					</Label>
+				</div>
+			);
+		} );
+	}
+
 	render() {
-		const uniqueId = this.props.uniqueId,
-			choices = this.props.choices.map( function( choice, i ) {
-				const checked = this.props.selected === choice.value;
-				return (
-					<div className="dops-form-checkbox" key={ i }>
-						<Label inline label={ choice.label } htmlFor={ uniqueId + i }>
-							<input type="radio" id={ uniqueId + i } value={ choice.value } name={ this.props.name } checked={ checked } onChange={ this.onChange } />
-						</Label>
-					</div>
-				);
-			}.bind( this ) );
+		const choices = this.mapChoices();
 
 		return (
 			<fieldset>

--- a/_inc/client/components/global-notices/index.jsx
+++ b/_inc/client/components/global-notices/index.jsx
@@ -45,6 +45,14 @@ class NoticesList extends React.Component {
 		}
 	};
 
+	handleLocalNoticeDismissClick = ( notice ) => {
+		return () => this.removeNotice( notice );
+	};
+
+	handleReduxNoticeDismissClick = ( noticeId ) => {
+		return () => this.props.removeNotice( noticeId );
+	};
+
 	render() {
 		const noticesRaw = this.props.notices[ this.props.id ] || [];
 		let noticesList = noticesRaw.map( function( notice, index ) {
@@ -55,7 +63,7 @@ class NoticesList extends React.Component {
 					duration={ notice.duration || null }
 					text={ notice.text }
 					isCompact={ notice.isCompact }
-					onDismissClick={ this.removeNotice.bind( this, notice ) }
+					onDismissClick={ this.handleLocalNoticeDismissClick( notice ) }
 					showDismiss={ notice.showDismiss }
 				>
 					{ notice.button &&
@@ -79,7 +87,7 @@ class NoticesList extends React.Component {
 					status={ notice.status }
 					duration = { notice.duration || null }
 					showDismiss={ notice.showDismiss }
-					onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
+					onDismissClick={ this.handleReduxNoticeDismissClick( notice.noticeId ) }
 					text={ notice.text }>
 				</SimpleNotice>
 			);

--- a/_inc/client/components/jetpack-notices/dismissable.jsx
+++ b/_inc/client/components/jetpack-notices/dismissable.jsx
@@ -21,6 +21,10 @@ import {
 class DismissableNotices extends React.Component {
 	static displayName = 'DismissableNotices';
 
+	dismissJetpackActionNotice = () => {
+		this.props.dismissJetpackActionNotice( this.props.jetpackNotices );
+	};
+
 	renderNotices = () => {
 		const notices = this.props.jetpackNotices;
 
@@ -32,7 +36,7 @@ class DismissableNotices extends React.Component {
 				return (
 					<div>
 						<SimpleNotice
-							onDismissClick={ this.props.dismissJetpackActionNotice.bind( null, notices ) }
+							onDismissClick={ this.dismissJetpackActionNotice }
 						>
 							{ __( 'You have successfully disconnected Jetpack' ) }
 							<br />

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -62,7 +62,7 @@ export const NavigationSettings = createReactClass( {
 		if ( this.props.userCanManageModules ) {
 			return (
 				<Search
-					onClick={ () => this.trackNavClick( 'search' ) }
+					onClick={ this.handleClickForTracking( 'search' ) }
 					pinned={ true }
 					fitsContainer={ true }
 					placeholder={ __( 'Search for a Jetpack feature.' ) }
@@ -109,6 +109,10 @@ export const NavigationSettings = createReactClass( {
 		return 0 < intersection( this.moduleList, modules ).length;
 	},
 
+	handleClickForTracking( target ) {
+		return () => this.trackNavClick( target );
+	},
+
 	render: function() {
 		let navItems, sharingTab;
 		if ( this.props.userCanManageModules ) {
@@ -128,7 +132,7 @@ export const NavigationSettings = createReactClass( {
 						] ) && (
 							<NavItem
 								path="#writing"
-								onClick={ () => this.trackNavClick( 'writing' ) }
+								onClick={ this.handleClickForTracking( 'writing' ) }
 								selected={ this.props.route.path === '/writing' || this.props.route.path === '/settings' }>
 								{ __( 'Writing', { context: 'Navigation item.' } ) }
 							</NavItem>
@@ -142,7 +146,7 @@ export const NavigationSettings = createReactClass( {
 						] ) && (
 							<NavItem
 								path="#sharing"
-								onClick={ () => this.trackNavClick( 'sharing' ) }
+								onClick={ this.handleClickForTracking( 'sharing' ) }
 								selected={ this.props.route.path === '/sharing' }>
 								{ __( 'Sharing', { context: 'Navigation item.' } ) }
 							</NavItem>
@@ -157,7 +161,7 @@ export const NavigationSettings = createReactClass( {
 						] ) && (
 							<NavItem
 								path="#discussion"
-								onClick={ () => this.trackNavClick( 'discussion' ) }
+								onClick={ this.handleClickForTracking( 'discussion' ) }
 								selected={ this.props.route.path === '/discussion' }>
 								{ __( 'Discussion', { context: 'Navigation item.' } ) }
 							</NavItem>
@@ -175,7 +179,7 @@ export const NavigationSettings = createReactClass( {
 						] ) && (
 							<NavItem
 								path="#traffic"
-								onClick={ () => this.trackNavClick( 'traffic' ) }
+								onClick={ this.handleClickForTracking( 'traffic' ) }
 								selected={ this.props.route.path === '/traffic' }>
 								{ __( 'Traffic', { context: 'Navigation item.' } ) }
 							</NavItem>
@@ -189,7 +193,7 @@ export const NavigationSettings = createReactClass( {
 						] ) || this.props.isPluginActive( 'akismet/akismet.php' ) ) && (
 							<NavItem
 								path="#security"
-								onClick={ () => this.trackNavClick( 'security' ) }
+								onClick={ this.handleClickForTracking( 'security' ) }
 								selected={ this.props.route.path === '/security' }>
 								{ __( 'Security', { context: 'Navigation item.' } ) }
 							</NavItem>
@@ -208,7 +212,7 @@ export const NavigationSettings = createReactClass( {
 				] ) && (
 					<NavItem
 						path="#sharing"
-						onClick={ () => this.trackNavClick( 'sharing' ) }
+						onClick={ this.handleClickForTracking( 'sharing' ) }
 						selected={ this.props.route.path === '/sharing' }>
 						{ __( 'Sharing', { context: 'Navigation item.' } ) }
 					</NavItem>
@@ -223,7 +227,7 @@ export const NavigationSettings = createReactClass( {
 						] ) && (
 							<NavItem
 								path="#writing"
-								onClick={ () => this.trackNavClick( 'writing' ) }
+								onClick={ this.handleClickForTracking( 'writing' ) }
 								selected={ this.props.route.path === '/writing' || this.props.route.path === '/settings' }>
 								{ __( 'Writing', { context: 'Navigation item.' } ) }
 							</NavItem>

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -25,6 +25,14 @@ export class Navigation extends React.Component {
 		} );
 	};
 
+	trackDashboardClick = () => {
+		this.trackNavClick( 'dashboard' );
+	};
+
+	trackPlansClick = () => {
+		this.trackNavClick( 'dashboard' );
+	};
+
 	render() {
 		let navTabs;
 		if ( this.props.userCanManageModules ) {
@@ -32,13 +40,13 @@ export class Navigation extends React.Component {
 				<NavTabs selectedText={ this.props.route.name }>
 					<NavItem
 						path="#/dashboard"
-						onClick={ () => this.trackNavClick( 'dashboard' ) }
+						onClick={ this.trackDashboardClick }
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
 						path="#/plans"
-						onClick={ () => this.trackNavClick( 'plans' ) }
+						onClick={ this.trackPlansClick }
 						selected={ this.props.route.path === '/plans' }>
 						{ __( 'Plans', { context: 'Navigation item.' } ) }
 					</NavItem>

--- a/_inc/client/components/popover/docs/example.jsx
+++ b/_inc/client/components/popover/docs/example.jsx
@@ -143,6 +143,24 @@ const Popovers = createReactClass( {
 		);
 	},
 
+	handleClick( i, positions ) {
+		return event => {
+			const index = parseInt( event.currentTarget.innerText );
+			if ( i === 4 ) {
+				return null;
+			}
+
+			this.setState( {
+				showRubicPopover: ! this.state.showRubicPopover,
+				rubicPosition: positions[ index ]
+			} );
+		};
+	},
+
+	handleClose() {
+		this.setState( { showRubicPopover: false } );
+	},
+
 	renderPopoverRubic() {
 		const squares = [];
 		const width = 150;
@@ -176,17 +194,7 @@ const Popovers = createReactClass( {
 						boxSixing: 'border-box'
 					} }
 					key={ `rubic-${ i }` }
-					onClick={ event => {
-						const index = parseInt( event.currentTarget.innerText );
-						if ( i === 4 ) {
-							return null;
-						}
-
-						this.setState( {
-							showRubicPopover: ! this.state.showRubicPopover,
-							rubicPosition: positions[ index ]
-						} );
-					} }
+					onClick={ this.handleClick( i, positions ) }
 				>
 					{ i === 4 ? null : i }
 				</div>
@@ -208,9 +216,7 @@ const Popovers = createReactClass( {
 
 				<Popover
 					id="popover__rubic"
-					onClose={ () => {
-						this.setState( { showRubicPopover: false } );
-					} }
+					onClose={ this.handleClose }
 					isVisible={ this.state.showRubicPopover }
 					position={ this.state.rubicPosition }
 					context={ this.refs && this.refs[ 'popover-rubic-reference' ] }

--- a/_inc/client/components/section-nav/docs/example.jsx
+++ b/_inc/client/components/section-nav/docs/example.jsx
@@ -85,7 +85,7 @@ const SectionNavigation = createReactClass( {
 	render: function() {
 		const demoSections = {};
 
-		forEach( this.props, function( prop, key ) {
+		forEach( this.props, ( prop, key ) => {
 			demoSections[ key ] = [];
 
 			prop.forEach( function( item, index ) {
@@ -100,7 +100,7 @@ const SectionNavigation = createReactClass( {
 					</NavItem>
 				) );
 			}, this );
-		}.bind( this ) );
+		} );
 
 		return (
 			<div className="design-assets__group">

--- a/_inc/client/components/select-dropdown/docs/example.jsx
+++ b/_inc/client/components/select-dropdown/docs/example.jsx
@@ -42,6 +42,13 @@ const SelectDropdownDemo = createReactClass( {
 		};
 	},
 
+	handleSelectItem: function( childSelected, count ) {
+		return event => {
+			event.preventDefault();
+			this.selectItem( childSelected, count );
+		};
+	},
+
 	toggleButtons: function() {
 		this.setState( { compactButtons: ! this.state.compactButtons } );
 	},
@@ -75,7 +82,7 @@ const SelectDropdownDemo = createReactClass( {
 					<DropdownItem
 						count={ 10 }
 						selected={ this.state.childSelected === 'Published' }
-						onClick={ this.selectItem.bind( this, 'Published', 10 ) }
+						onClick={ this.handleSelectItem( 'Published', 10 ) }
 					>
 						Published
 					</DropdownItem>
@@ -83,14 +90,14 @@ const SelectDropdownDemo = createReactClass( {
 					<DropdownItem
 						count={ 4 }
 						selected={ this.state.childSelected === 'Scheduled' }
-						onClick={ this.selectItem.bind( this, 'Scheduled', 4 ) }
+						onClick={ this.handleSelectItem( 'Scheduled', 4 ) }
 					>
 						Scheduled
 					</DropdownItem>
 
 					<DropdownItem
 						selected={ this.state.childSelected === 'Drafts' }
-						onClick={ this.selectItem.bind( this, 'Drafts', null ) }
+						onClick={ this.handleSelectItem( 'Drafts', null ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -100,7 +107,7 @@ const SelectDropdownDemo = createReactClass( {
 					<DropdownItem
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
-						onClick={ this.selectItem.bind( this, 'Trashed', 3 ) }
+						onClick={ this.handleSelectItem( 'Trashed', 3 ) }
 					>
 						Trashed
 					</DropdownItem>
@@ -109,9 +116,7 @@ const SelectDropdownDemo = createReactClass( {
 		);
 	},
 
-	selectItem: function( childSelected, count, event ) {
-		event.preventDefault();
-
+	selectItem: function( childSelected, count ) {
 		this.setState( {
 			childSelected: childSelected,
 			selectedCount: count

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -51,6 +51,10 @@ export const SettingsCard = props => {
 		} );
 	};
 
+	const handleClickForTracking = feature => {
+		return () => trackBannerClick( feature );
+	};
+
 	const module = props.module
 			? props.getModule( props.module )
 			: false,
@@ -96,7 +100,7 @@ export const SettingsCard = props => {
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-video-premium&site=' + siteRawUrl }
 					/>
 				);
@@ -115,7 +119,7 @@ export const SettingsCard = props => {
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-ads&site=' + siteRawUrl }
 					/>
 				);
@@ -132,7 +136,7 @@ export const SettingsCard = props => {
 							plan={ PLAN_JETPACK_BUSINESS }
 							callToAction={ upgradeLabel }
 							feature={ feature }
-							onClick={ () => trackBannerClick( feature ) }
+							onClick={ handleClickForTracking( feature ) }
 							href={ 'https://jetpack.com/redirect/?source=settings-security-pro&site=' + siteRawUrl }
 						/>
 					);
@@ -144,7 +148,7 @@ export const SettingsCard = props => {
 						title={ __( 'Protect against data loss, malware, and malicious attacks.' ) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-security-premium&site=' + siteRawUrl }
 					/>
 				);
@@ -159,7 +163,7 @@ export const SettingsCard = props => {
 						title={ __( 'Integrate easily with Google Analytics.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-ga&site=' + siteRawUrl }
 					/>
 				);
@@ -174,7 +178,7 @@ export const SettingsCard = props => {
 						title={ __( 'Help your content get found and shared with SEO tools.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-seo&site=' + siteRawUrl }
 					/>
 				);
@@ -190,7 +194,7 @@ export const SettingsCard = props => {
 						title={ __( 'Faster, more relevant and more powerful sitewide search.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
-						onClick={ () => trackBannerClick( feature ) }
+						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-search&site=' + siteRawUrl }
 					/>
 				);

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -45,6 +45,14 @@ class SubscriptionsComponent extends React.Component {
 		analytics.tracks.recordJetpackClick( 'view-followers' );
 	};
 
+	handleSubscribeToBlogToggleChange = () => {
+		this.updateOptions( 'stb_enabled' );
+	};
+
+	handleSubscribeToCommentToggleChange = () => {
+		this.updateOptions( 'stc_enabled' );
+	};
+
 	render() {
 		const subscriptions = this.props.getModule( 'subscriptions' ),
 			isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' ),
@@ -83,7 +91,7 @@ class SubscriptionsComponent extends React.Component {
 							<CompactFormToggle
 								checked={ this.state.stb_enabled }
 								disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'subscriptions', 'stb_enabled' ] ) }
-								onChange={ () => this.updateOptions( 'stb_enabled' ) }>
+								onChange={ this.handleSubscribeToBlogToggleChange }>
 								<span className="jp-form-toggle-explanation">
 									{
 										__( 'Show a "follow blog" option in the comment form' )
@@ -93,7 +101,7 @@ class SubscriptionsComponent extends React.Component {
 							<CompactFormToggle
 								checked={ this.state.stc_enabled }
 								disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'subscriptions', 'stc_enabled' ] ) }
-								onChange={ () => this.updateOptions( 'stc_enabled' ) }>
+								onChange={ this.handleSubscribeToCommentToggleChange }>
 								<span className="jp-form-toggle-explanation">
 									{
 										__( 'Show a "follow comments" option in the comment form' )

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -47,6 +47,10 @@ class PlanBody extends React.Component {
 		} );
 	};
 
+	handleButtonClickForTracking = target => {
+		return () => this.trackPlansClick( target );
+	}
+
 	activateAds = () => {
 		this.props.activateModule( 'wordads' );
 		this.trackPlansClick( 'activate_wordads' );
@@ -112,7 +116,7 @@ class PlanBody extends React.Component {
 					<div className="jp-landing__plan-features-card">
 						<h3 className="jp-landing__plan-features-title">{ __( 'Backups' ) }</h3>
 						<p>{ __( 'Real-time backup of all your site data with unlimited space, one-click restores, and automated security scanning.' ) }</p>
-						<Button onClick={ () => this.trackPlansClick( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl } className="is-primary">
+						<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl } className="is-primary">
 							{ __( 'View your security activity' ) }
 						</Button>
 					</div>
@@ -125,12 +129,12 @@ class PlanBody extends React.Component {
 					<p>{ description + __( ' (powered by VaultPress).' ) }</p>
 					{
 						this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) && this.props.isPluginActive( 'vaultpress/vaultpress.php' ) ? (
-							<Button onClick={ () => this.trackPlansClick( 'view_security_dash' ) } href="https://dashboard.vaultpress.com/" className="is-primary">
+							<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash' ) } href="https://dashboard.vaultpress.com/" className="is-primary">
 								{ __( 'View your security dashboard' ) }
 							</Button>
 						)
 							: (
-							<Button onClick={ () => this.trackPlansClick( 'configure_vault' ) } href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=vaultpress' } className="is-primary">
+							<Button onClick={ this.handleButtonClickForTracking( 'configure_vault' ) } href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=vaultpress' } className="is-primary">
 								{ __( 'Configure VaultPress' ) }
 							</Button>
 						)
@@ -151,7 +155,7 @@ class PlanBody extends React.Component {
 									<h3 className="jp-landing__plan-features-title">{ __( 'Unlimited Premium Themes' ) }</h3>
 									<p>{ __( 'Exclusive hand-crafted designs you will love with dedicated support directly from the theme authors.' ) }</p>
 									<Button
-										onClick={ () => this.trackPlansClick( 'premium_themes' ) }
+										onClick={ this.handleButtonClickForTracking( 'premium_themes' ) }
 										href={ 'https://wordpress.com/themes/premium/' + this.props.siteRawUrl }
 										className="is-primary">
 										{ __( 'Browse Themes' ) }
@@ -164,12 +168,12 @@ class PlanBody extends React.Component {
 							<p>{ __( 'State-of-the-art spam defense powered by Akismet.' ) }</p>
 							{
 							this.props.isPluginInstalled( 'akismet/akismet.php' ) && this.props.isPluginActive( 'akismet/akismet.php' ) ? (
-							<Button onClick={ () => this.trackPlansClick( 'view_spam_stats' ) } href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
+							<Button onClick={ this.handleButtonClickForTracking( 'view_spam_stats' ) } href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
 								{ __( 'View your spam stats' ) }
 							</Button>
 							)
 								: (
-									<Button onClick={ () => this.trackPlansClick( 'configure_akismet' ) } href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=akismet' } className="is-primary">
+									<Button onClick={ this.handleButtonClickForTracking( 'configure_akismet' ) } href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=akismet' } className="is-primary">
 										{ __( 'Configure Akismet' ) }
 									</Button>
 								)
@@ -195,7 +199,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Earn income by allowing Jetpack to display high quality ads (powered by WordAds).' ) }</p>
 								{
 									this.props.isModuleActivated( 'wordads' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'view_earnings' ) } href={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl } className="is-primary">
+										<Button onClick={ this.handleButtonClickForTracking( 'view_earnings' ) } href={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl } className="is-primary">
 											{ __( 'View your earnings' ) }
 										</Button>
 									)
@@ -220,7 +224,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Replace the default WordPress search with better results that will help your users find what they are looking for.' ) }</p>
 								{
 									this.props.isModuleActivated( 'search' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'search_customize' ) } href={ this.props.siteAdminUrl + 'widgets.php' } className="is-primary">
+										<Button onClick={ this.handleButtonClickForTracking( 'search_customize' ) } href={ this.props.siteAdminUrl + 'widgets.php' } className="is-primary">
 											{ __( 'Customize Search Widget' ) }
 										</Button>
 									)
@@ -246,7 +250,7 @@ class PlanBody extends React.Component {
 								{
 									this.props.isModuleActivated( 'publicize' )
 										? (
-											<Button onClick={ () => this.trackPlansClick( 'schedule_posts' ) } href={ 'https://wordpress.com/posts/' + this.props.siteRawUrl } className="is-primary">
+											<Button onClick={ this.handleButtonClickForTracking( 'schedule_posts' ) } href={ 'https://wordpress.com/posts/' + this.props.siteRawUrl } className="is-primary">
 												{ __( 'Schedule Posts' ) }
 											</Button>
 										)
@@ -271,7 +275,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Fast, optimized, ad-free, and unlimited video hosting for your site.' ) }</p>
 								{
 									this.props.isModuleActivated( 'videopress' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'upload_videos' ) } href={ this.props.siteAdminUrl + 'upload.php?mode=grid' } className="is-primary">
+										<Button onClick={ this.handleButtonClickForTracking( 'upload_videos' ) } href={ this.props.siteAdminUrl + 'upload.php?mode=grid' } className="is-primary">
 											{ __( 'Upload Videos Now' ) }
 										</Button>
 									)
@@ -296,7 +300,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Advanced SEO tools to help your site get found when people search for relevant content.' ) }</p>
 								{
 									this.props.isModuleActivated( 'seo-tools' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'configure_seo' ) } href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
+										<Button onClick={ this.handleButtonClickForTracking( 'configure_seo' ) } href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
 											{ __( 'Configure Site SEO' ) }
 										</Button>
 									)
@@ -321,7 +325,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Track website statistics with Google Analytics for a deeper understanding of your website visitors and customers.' ) }</p>
 								{
 									this.props.isModuleActivated( 'google-analytics' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'configure_ga' ) } href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
+										<Button onClick={ this.handleButtonClickForTracking( 'configure_ga' ) } href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
 											{ __( 'Configure Google Analytics' ) }
 										</Button>
 									)
@@ -347,7 +351,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Always-on security including real-time backups, malware scanning, and automatic threat resolution.' ) }</p>
 								<p>{ __( 'Grow your traffic and revenue with social media scheduling, enhanced site search, SEO tools, PayPal payments, and an ad program.' ) }</p>
 								<p>
-									<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + this.props.siteRawUrl } className="is-primary">
+									<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + this.props.siteRawUrl } className="is-primary">
 										{ __( 'Compare Plans' ) }
 									</Button>
 								</p>
@@ -362,7 +366,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Unlimited access to hundreds of premium WordPress themes with dedicated support directly from the theme authors.' ) }</p>
 								<p>{ __( 'A superior search experience powered by Elasticsearch providing your users with faster and more relevant search results. Previously only available to WordPress.com VIP customers and trusted by industry-leading brands.' ) }</p>
 								<p>
-									<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-premium&site=' + this.props.siteRawUrl } className="is-primary">
+									<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-premium&site=' + this.props.siteRawUrl } className="is-primary">
 										{ __( 'Explore Jetpack Professional' ) }
 									</Button>
 								</p>
@@ -398,7 +402,7 @@ class PlanBody extends React.Component {
 						</div>
 
 						<p>
-							<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'is-free-plan' === planClass
+							<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'is-free-plan' === planClass
 								? 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl
 								: 'https://jetpack.com/redirect/?source=plans-main-bottom-dev-mode' } className="is-primary">
 								{ __( 'Compare Plans' ) }

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -58,6 +58,10 @@ class ProStatus extends React.Component {
 		} );
 	};
 
+	handleClickForTracking = ( type, feature ) => {
+		return () => this.trackProStatusClick( type, feature );
+	};
+
 	getProActions = ( type, feature ) => {
 		let status = '',
 			message = false,
@@ -112,7 +116,7 @@ class ProStatus extends React.Component {
 					message
 				}
 				{
-					action && <NoticeAction onClick={ () => this.trackProStatusClick( type, feature ) } href={ actionUrl }>{ action }</NoticeAction>
+					action && <NoticeAction onClick={ this.handleClickForTracking( type, feature ) } href={ actionUrl }>{ action }</NoticeAction>
 				}
 			</SimpleNotice>
 		);
@@ -128,7 +132,7 @@ class ProStatus extends React.Component {
 	getSetUpButton = feature => {
 		return (
 			<Button
-				onClick={ () => this.trackProStatusClick( 'set_up', feature ) }
+				onClick={ this.handleClickForTracking( 'set_up', feature ) }
 				compact={ true }
 				primary={ true }
 				href={ `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }` }

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -23,6 +23,10 @@ import { isDevMode, isUnavailableInDevMode } from 'state/connection';
 
 export const SearchableModules = moduleSettingsForm(
 	class extends Component {
+		handleBannerClick = module => {
+			return () => this.props.updateOptions( { [ module ]: true } );
+		}
+
 		render() {
 			// Only admins plz
 			if ( ! this.props.canManageModules ) {
@@ -73,7 +77,7 @@ export const SearchableModules = moduleSettingsForm(
 								description={ moduleData.description }
 								href="javascript:void( 0 )"
 								icon="cog"
-								onClick={ this.props.updateOptions.bind( null, { [ moduleData.module ]: true } ) }
+								onClick={ this.handleBannerClick( moduleData.module ) }
 								title={ moduleData.name }
 							/>
 						);

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -31,6 +31,14 @@ export const SSO = moduleSettingsForm(
 			),
 		};
 
+		handleTwoStepToggleChange = () => {
+			this.updateOptions( 'jetpack_sso_require_two_step' );
+		}
+
+		handleMatchByEmailToggleChange = () => {
+			this.updateOptions( 'jetpack_sso_match_by_email' );
+		}
+
 		/**
 		 * Update state so toggles are updated.
 		 *
@@ -75,7 +83,7 @@ export const SSO = moduleSettingsForm(
 										unavailableInDevMode ||
 										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] )
 								}
-								onChange={ () => this.updateOptions( 'jetpack_sso_match_by_email' ) }
+								onChange={ this.handleMatchByEmailToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Match accounts using email addresses' ) }
@@ -88,7 +96,7 @@ export const SSO = moduleSettingsForm(
 										unavailableInDevMode ||
 										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] )
 								}
-								onChange={ () => this.updateOptions( 'jetpack_sso_require_two_step' ) }
+								onChange={ this.handleTwoStepToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Require accounts to use WordPress.com Two-Step Authentication' ) }

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -50,6 +50,10 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 		analytics.tracks.recordJetpackClick( 'view-earnings' );
 	};
 
+	handleChange = setting => {
+		return () => this.updateOptions( setting );
+	};
+
 	render() {
 		const isAdsActive = this.props.getOptionValue( 'wordads' );
 		const unavailableInDevMode = this.props.isUnavailableInDevMode( 'wordads' );
@@ -91,7 +95,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.wordads_display_front_page }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_front_page' ] ) }
-							onChange={ () => this.updateOptions( 'wordads_display_front_page' ) }>
+							onChange={ this.handleChange( 'wordads_display_front_page' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Front page' ) }
 							</span>
@@ -99,7 +103,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.wordads_display_post }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_post' ] ) }
-							onChange={ () => this.updateOptions( 'wordads_display_post' ) }>
+							onChange={ this.handleChange( 'wordads_display_post' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Posts' ) }
 							</span>
@@ -107,7 +111,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.wordads_display_page }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_page' ] ) }
-							onChange={ () => this.updateOptions( 'wordads_display_page' ) }>
+							onChange={ this.handleChange( 'wordads_display_page' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Pages' ) }
 							</span>
@@ -115,7 +119,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.wordads_display_archive }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_archive' ] ) }
-							onChange={ () => this.updateOptions( 'wordads_display_archive' ) }>
+							onChange={ this.handleChange( 'wordads_display_archive' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Archives' ) }
 							</span>
@@ -126,7 +130,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.enable_header_ad }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'enable_header_ad' ] ) }
-							onChange={ () => this.updateOptions( 'enable_header_ad' ) }>
+							onChange={ this.handleChange( 'enable_header_ad' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Top of each page' ) }
 							</span>
@@ -134,7 +138,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<CompactFormToggle
 							checked={ this.state.wordads_second_belowpost }
 							disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_second_belowpost' ] ) }
-							onChange={ () => this.updateOptions( 'wordads_second_belowpost' ) }>
+							onChange={ this.handleChange( 'wordads_second_belowpost' ) }>
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Second ad below post' ) }
 							</span>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -44,6 +44,14 @@ class RelatedPostsComponent extends React.Component {
 		);
 	};
 
+	handleShowHeadlineToggleChange = () => {
+		this.updateOptions( 'show_headline' );
+	};
+
+	handleShowThumbnailsToggleChange = () => {
+		this.updateOptions( 'show_thumbnails' );
+	};
+
 	render() {
 		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'related-posts' );
@@ -70,7 +78,7 @@ class RelatedPostsComponent extends React.Component {
 						<CompactFormToggle
 									checked={ this.state.show_headline }
 									disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'related-posts', 'show_headline' ] ) }
-									onChange={ () => this.updateOptions( 'show_headline' ) }>
+									onChange={ this.handleShowHeadlineToggleChange }>
 									<span className="jp-form-toggle-explanation">
 										{
 											__( 'Show a "Related" header to more clearly separate the related section from posts' )
@@ -80,7 +88,7 @@ class RelatedPostsComponent extends React.Component {
 						<CompactFormToggle
 									checked={ this.state.show_thumbnails }
 									disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'related-posts', 'show_thumbnails' ] ) }
-									onChange={ () => this.updateOptions( 'show_thumbnails' ) }>
+									onChange={ this.handleShowThumbnailsToggleChange }>
 									<span className="jp-form-toggle-explanation">
 										{
 											__( 'Use a large and visually striking layout' )

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -107,6 +107,14 @@ class SiteStatsComponent extends React.Component {
 		} );
 	};
 
+	handleRoleToggleChange = ( role, setting ) => {
+		return () => this.updateOptions( role, setting );
+	}
+
+	handleModuleToggle = ( option_slug ) => {
+		return module_slug => this.props.updateFormStateModuleOption( module_slug, option_slug );
+	}
+
 	render() {
 		const stats = this.props.getModule( 'stats' ),
 			isStatsActive = this.props.getOptionValue( 'stats' ),
@@ -169,7 +177,7 @@ class SiteStatsComponent extends React.Component {
 								disabled={ ! isStatsActive || unavailableInDevMode }
 								activated={ !! this.props.getOptionValue( 'admin_bar' ) }
 								toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
-								toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }
+								toggleModule={ this.handleModuleToggle( 'admin_bar' ) }
 							>
 								<span className="jp-form-toggle-explanation">
 									{
@@ -182,7 +190,7 @@ class SiteStatsComponent extends React.Component {
 								disabled={ ! isStatsActive || unavailableInDevMode }
 								activated={ !! this.props.getOptionValue( 'hide_smile' ) }
 								toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
-								toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }
+								toggleModule={ this.handleModuleToggle( 'hide_smile' ) }
 							>
 								<span className="jp-form-toggle-explanation">
 									{
@@ -203,7 +211,7 @@ class SiteStatsComponent extends React.Component {
 									<CompactFormToggle
 										checked={ this.state[ `count_roles_${ key }` ] }
 										disabled={ ! isStatsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] ) }
-										onChange={ () => this.updateOptions( key, 'count_roles' ) }
+										onChange={ this.handleRoleToggleChange( key, 'count_roles' ) }
 										key={ `count_roles-${ key }` }>
 											<span className="jp-form-toggle-explanation">
 												{ siteRoles[ key ].name }
@@ -227,7 +235,7 @@ class SiteStatsComponent extends React.Component {
 										<CompactFormToggle
 											checked={ this.state[ `roles_${ key }` ] }
 											disabled={ ! isStatsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'roles' ] ) }
-											onChange={ () => this.updateOptions( key, 'roles' ) }
+											onChange={ this.handleRoleToggleChange( key, 'roles' ) }
 											key={ `roles-${ key }` }>
 												<span className="jp-form-toggle-explanation">
 													{ siteRoles[ key ].name }

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -74,6 +74,10 @@ export class Composing extends React.Component {
 		);
 	};
 
+	handleToggleChange = setting => {
+		return () => this.updateOptions( setting );
+	};
+
 	/**
 	 * Render a toggle for a single option.
 	 *
@@ -86,7 +90,7 @@ export class Composing extends React.Component {
 			<CompactFormToggle
 				checked={ this.state[ setting ] }
 				disabled={ ! this.props.getOptionValue( 'after-the-deadline' ) || this.props.isUnavailableInDevMode( 'after-the-deadline' ) || this.props.isSavingAnyOption( [ 'after-the-deadline', setting ] ) }
-				onChange={ () => this.updateOptions( setting ) }>
+				onChange={ this.handleToggleChange( setting ) }>
 				<span className="jp-form-toggle-explanation">
 					{ label }
 				</span>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -40,6 +40,14 @@ export class CustomContentTypes extends React.Component {
 			: <span />;
 	};
 
+	handleTestimonialToggleChange = () => {
+		this.updateCPTs( 'testimonial' );
+	}
+
+	handlePortfolioToggleChange = () => {
+		this.updateCPTs( 'portfolio' );
+	}
+
 	render() {
 		if ( ! this.props.isModuleFound( 'custom-content-types' ) ) {
 			return null;
@@ -55,7 +63,7 @@ export class CustomContentTypes extends React.Component {
 					<CompactFormToggle
 								checked={ this.state.testimonial }
 								disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) }
-								onChange={ () => this.updateCPTs( 'testimonial' ) }>
+								onChange={ this.handleTestimonialToggleChange }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Testimonials' )
@@ -78,7 +86,7 @@ export class CustomContentTypes extends React.Component {
 					<CompactFormToggle
 								checked={ this.state.portfolio }
 								disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) }
-								onChange={ () => this.updateCPTs( 'portfolio' ) }>
+								onChange={ this.handlePortfolioToggleChange }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Portfolios' )

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -52,6 +52,10 @@ class Media extends React.Component {
 		);
 	};
 
+	handleCarouselDisplayExifChange = () => {
+		this.updateOptions( 'carousel_display_exif' );
+	};
+
 	render() {
 		const foundCarousel = this.props.isModuleFound( 'carousel' ),
 			foundVideoPress = this.props.isModuleFound( 'videopress' );
@@ -83,7 +87,7 @@ class Media extends React.Component {
 					<CompactFormToggle
 						checked={ this.state.carousel_display_exif }
 						disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
-						onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
+						onChange={ this.handleCarouselDisplayExifChange }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Show photo metadata (Exif) in carousel, when available' )
@@ -107,22 +111,22 @@ class Media extends React.Component {
 
 		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
 			<SettingsGroup
-				hasChild
-				disableInDevMode
-				module={ videoPress }>
-				<ModuleToggle
-					slug="videopress"
-					disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
-					activated={ this.props.getOptionValue( 'videopress' ) }
-					toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-					toggleModule={ this.props.toggleModuleNow }
-					>
-					<span className="jp-form-toggle-explanation">
-						{
-							videoPress.description
-						}
-					</span>
-				</ModuleToggle>
+					hasChild
+					disableInDevMode
+					module={ videoPress }>
+					<ModuleToggle
+						slug="videopress"
+						disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+						activated={ this.props.getOptionValue( 'videopress' ) }
+						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+						toggleModule={ this.props.toggleModuleNow }
+						>
+						<span className="jp-form-toggle-explanation">
+							{
+								videoPress.description
+							}
+						</span>
+					</ModuleToggle>
 			</SettingsGroup>
 		);
 

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -103,6 +103,14 @@ class ThemeEnhancements extends React.Component {
 		wp_mobile_app_promos: this.props.getOptionValue( 'wp_mobile_app_promos', 'minileven' )
 	};
 
+	handleInfiniteScrollModeChange = ( key ) => {
+		return () => this.updateInfiniteMode( key );
+	}
+
+	handleMinilevenOptionChange = ( optionName, module ) => {
+		return () => this.updateOptions( optionName, module );
+	}
+
 	render() {
 		const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
 			foundMinileven = this.props.isModuleFound( 'minileven' );
@@ -158,7 +166,7 @@ class ThemeEnhancements extends React.Component {
 														value={ radio.key }
 														checked={ radio.key === this.state.infinite_mode }
 														disabled={ this.props.isSavingAnyOption( [ item.module, radio.key ] ) }
-														onChange={ () => this.updateInfiniteMode( radio.key ) }
+														onChange={ this.handleInfiniteScrollModeChange( radio.key ) }
 													/>
 													<span className="jp-form-toggle-explanation">
 														{
@@ -234,7 +242,7 @@ class ThemeEnhancements extends React.Component {
 													<CompactFormToggle
 														checked={ this.state[ chkbx.key ] }
 														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
-														onChange={ () => this.updateOptions( chkbx.key, item.module ) }
+														onChange={ this.handleMinilevenOptionChange( chkbx.key, item.module ) }
 														key={ `${ item.module }_${ chkbx.key }` }>
 													<span className="jp-form-toggle-explanation">
 														{


### PR DESCRIPTION
Fixes all eslint warnings about the react/jsx-no-bind rule.

#### Changes proposed in this Pull Request:

* Upgrades the `react/jsx-no-bind rule` to an error.
* Refactors several components to drop `.bind()` and `onEvent={ () => {} }` patterns among jsx code.

#### Testing instructions:

* Run `npm run lint` and expect to see no linting warnings.
* Build the admin page and confirm it does it properly (`yarn build`).

