### PR TITLE
Markdown: Avoid usage of create_function

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -63,6 +63,19 @@ function Markdown($text) {
 	return $parser->transform($text);
 }
 
+/**
+ * Returns the length of $text loosely counting the number of UTF-8 characters with regular expression.
+ * Used by the Markdown_Parser class when mb_strlen is not available.
+ *
+ * @since 5.9
+ *
+ * @return string Length of the multibyte string
+ *
+ */
+function jetpack_utf8_strlen( $text ) {
+	return preg_match_all( '/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/', $test, $m );
+}
+
 #
 # Markdown Parser Class
 #
@@ -1518,14 +1531,14 @@ class Markdown_Parser {
 	function _initDetab() {
 	#
 	# Check for the availability of the function in the `utf8_strlen` property
-	# (initially `mb_strlen`). If the function is not available, create a
-	# function that will loosely count the number of UTF-8 characters with a
+	# (initially `mb_strlen`). If the function is not available, use jetpack_utf8_strlen 
+	# that will loosely count the number of UTF-8 characters with a
 	# regular expression.
 	#
-		if (function_exists($this->utf8_strlen)) return;
-		$this->utf8_strlen = create_function('$text', 'return preg_match_all(
-			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/",
-			$text, $m);');
+		if ( function_exists( $this->utf8_strlen ) )  {
+			return;
+		}
+		$this->utf8_strlen = 'jetpack_utf8_strlen';
 	}
 
 

--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -73,7 +73,7 @@ function Markdown($text) {
  *
  */
 function jetpack_utf8_strlen( $text ) {
-	return preg_match_all( '/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/', $test, $m );
+	return preg_match_all( "/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", $text, $m );
 }
 
 #


### PR DESCRIPTION
Part of #8156.
Alternative to #8869.

Fixes https://wordpress.org/support/topic/deprecated-function-create_function-2/


#### Changes proposed in this Pull Request:

* Introduces function `jetpack_utf8_strlen`.
* Replaces usage of `create_function` for `jetpack_utf8_strlen` in `markdown/extra.php`.

~**Note:** `mb_strlen` has been available since PHP 4. Should we drop this conditional usage instead ? This alternative is implemented in #8869.~ Apparently there's still a chance that a php installation lacks the `mbstring` extension.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
