### PR TITLE
WordAds: Avoid usage of create_function

### DIFF
--- a/modules/wordads/php/widgets.php
+++ b/modules/wordads/php/widgets.php
@@ -108,10 +108,9 @@ HTML;
 	}
 }
 
-add_action(
-	'widgets_init',
-	create_function(
-		'',
-		'return register_widget( "WordAds_Sidebar_Widget" );'
-	)
-);
+function jetpack_wordads_widgets_init_callback() {
+	return register_widget( 'WordAds_Sidebar_Widget' );
+}
+
+add_action( 'widgets_init', 'jetpack_wordads_widgets_init_callback' );
+


### PR DESCRIPTION
Part of #8156.

Fixes https://wordpress.org/support/topic/deprecated-function-create_function-2/

#### Changes proposed in this Pull Request:

* Introduces function `jetpack_wordads_widgets_init_callback `.
* Replaces usage of `create_function` for `jetpack_wordads_widgets_init_callback` as `widgets_init` callback.


#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
