### PR TITLE
Exploration: Check e2e tests after JN started supporting SSL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
                   cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
                   cd /wp-e2e-tests
-                  git checkout origin/${E2E_BRANCH-master}
+                  git checkout add/jn-to-https-hosts
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Rogue change
 Another rogue change
+Third rogue change.
 == Changelog ==
 
 = 5.7.1 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Rogue change
+Another rogue change
 == Changelog ==
 
 = 5.7.1 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+Rogue change
 == Changelog ==
 
 = 5.7.1 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Rogue change
 Another rogue change
 Third rogue change.
+Fourth rogue change.
 == Changelog ==
 
 = 5.7.1 =


### PR DESCRIPTION
Fixes nothing. Probably breaks: something.

Just enabled site launching with SSL and used a branch with name include `e2e` to see if e2e jobs run ok.
