### PR TITLE
REST API: Add support for stats module in JPO endpoints

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -459,6 +459,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						'addContactForm' => intval( get_option( 'jpo_contact_page' ) ),
 						'businessAddress' => $business_address,
 						'installWooCommerce' => is_plugin_active( 'woocommerce/woocommerce.php' ),
+						'stats' => Jetpack::is_active() && Jetpack::is_module_active( 'stats' ),
 					);
 					break;
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1158,6 +1158,21 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
+		if ( ! empty( $data['stats'] ) ) {
+			if ( Jetpack::is_active() ) {
+				$stats_module_active = Jetpack::is_module_active( 'stats' );
+				if ( ! $stats_module_active ) {
+					$stats_module_active = Jetpack::activate_module( 'stats', false, false );
+				}
+
+				if ( ! $stats_module_active ) {
+					$error[] = 'stats activate';
+				}
+			} else {
+				$error[] = 'stats not connected';
+			}
+		}
+
 		return empty( $error )
 			? ''
 			: join( ', ', $error );


### PR DESCRIPTION
This PR adds support for enabling stats through JPO - preparatory work for https://github.com/Automattic/wp-calypso/issues/22532. 

The PR introduces:
* A new boolean `stats` parameter for JPO saving POST endpoint - when enabled, will try to enable the stats module. Requires connection.
* A new boolean `stats` field to return in the GET endpoint, which will return `true` if the stats module is enabled and the site is connected; false in all other cases.

To test: 
* Load local Calypso.
* Checkout this branch on a fresh Jetpack site.
* Start the onboarding flow (`/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`)
* In your console, enter `dispatch( { type: 'JETPACK_ONBOARDING_SETTINGS_REQUEST', siteId: 12345678 } )`, where `12345678` is the ID of your site.
* Verify the response contains a `stats` field in the `onboarding` option and it's disabled.
* In your console, enter `dispatch( { type: 'JETPACK_ONBOARDING_SETTINGS_SAVE', siteId: 12345678, settings: { stats: true } } )` , where `12345678` is the ID of your site.
* Verify you get a `stats not connected` error.
* Connect the site.
* In your console, enter `dispatch( { type: 'JETPACK_ONBOARDING_SETTINGS_SAVE', siteId: 12345678, settings: { stats: true } } )` , where `12345678` is the ID of your site.
* Verify you receive a successful response, and the stats module gets enabled.