### PR TITLE
Scripts: remove `yarn build` command from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
     "build-production": "yarn distclean && yarn && gulp languages:extract && yarn build-production-client",
     "build-languages": "gulp languages",
-    "lint": "yarn build && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
+    "lint": "eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",


### PR DESCRIPTION
Doesn't look like we need to build the client before linting and this renders the `yarn lint` command useless if wanting to use it locally for fast linting.

#### Changes proposed in this Pull Request:

* Removes the command `yarn build` from the npm script `yarn lint`

#### Testing instructions:

* Checkout this branch
* run `yarn lint` and check that you get `eslint` run.
* If an error happens, you may have to run `yarn` before to install dependencies
