### PR TITLE
Jetpack Connect URL: use correct URL to auto-approve

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -84,7 +84,7 @@ class Jetpack_Connection_Banner {
 			false,
 			sprintf( 'banner-%s-slide-%s-%s', $jp_version_banner_added, $slide_num, $current_screen->base )
 		);
-		return add_query_arg( 'already_authorized', 'true', $url );
+		return add_query_arg( 'auth_approved', 'true', $url );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4009,6 +4009,10 @@ p {
 					$url = add_query_arg( 'onboarding', $_GET['onboarding'], $url );
 				}
 
+				if ( ! empty( $_GET['auth_approved'] ) && 'true' === $_GET['auth_approved'] ) {
+					$url = add_query_arg( 'auth_approved', 'true', $url );
+				}
+
 				wp_redirect( $url );
 				exit;
 			case 'activate' :


### PR DESCRIPTION
`already_authorized` is a connection URL param that lets a connecting customer know they've already connected the site.

`auth_approved` is a connection URL param that let's a connecting customer skip
the screen that shows the terms-of-service-acceptance button.

In #8544 we meant to use `auth_approved`

Fixes #8783 

To reproduce:

On an unconnected jetpack site, try connecting from the banner on the plugins page. Not that you get an odd "Already connected..." error when you land on wordpress.com

Then apply this patch to your jetpack site, and try again from the banner on the plugins page. You will not see the error, and you should skip the terms-of-service-acceptence and be auto authorized.