### PR TITLE
lacking valid underscores from mixcloud url

### DIFF
--- a/modules/shortcodes/mixcloud.php
+++ b/modules/shortcodes/mixcloud.php
@@ -22,7 +22,7 @@ function mixcloud_shortcode( $atts, $content = null ) {
 	if ( empty( $atts[0] ) && empty( $content ) )
 		return "<!-- mixcloud error: invalid mixcloud resource -->";
 
-	$regular_expression = '#((?<=mixcloud.com/)([A-Za-z0-9%-]+/[A-Za-z0-9%-]+))|^([A-Za-z0-9%-]+/[A-Za-z0-9%-]+)#i';
+	$regular_expression = '#((?<=mixcloud.com/)([A-Za-z0-9%-_]+/[A-Za-z0-9%-_]+))|^([A-Za-z0-9%-_]+/[A-Za-z0-9%-_]+)#i';
 	preg_match( $regular_expression, $content, $match );
 	if ( ! empty( $match ) ) {
 		$resource_id = trim( $match[0] );

--- a/modules/shortcodes/mixcloud.php
+++ b/modules/shortcodes/mixcloud.php
@@ -22,7 +22,7 @@ function mixcloud_shortcode( $atts, $content = null ) {
 	if ( empty( $atts[0] ) && empty( $content ) )
 		return "<!-- mixcloud error: invalid mixcloud resource -->";
 
-	$regular_expression = '#((?<=mixcloud.com/)([A-Za-z0-9%-_]+/[A-Za-z0-9%-_]+))|^([A-Za-z0-9%-_]+/[A-Za-z0-9%-_]+)#i';
+	$regular_expression = '#((?<=mixcloud.com/)([A-Za-z0-9%_-]+/[A-Za-z0-9%_-]+))|^([A-Za-z0-9%_-]+/[A-Za-z0-9%_-]+)#i';
 	preg_match( $regular_expression, $content, $match );
 	if ( ! empty( $match ) ) {
 		$resource_id = trim( $match[0] );


### PR DESCRIPTION
example https://www.mixcloud.com/radiofm/balaz-a-hubinak_fm-27102017/

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
