### PR TITLE
Unit tests: Remove PHP 5.2 from travis allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,6 @@ matrix:
   - php: "7.1"
   - php: "7.2"
 
-  allow_failures:
-#  - php: "7.0"
-#    env: "SWITCH_TO_PHP=5.2"
-#  - php: "nightly"
-
 # whitelist branches for the "push" build check.
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ matrix:
   - php: "7.2"
 
   allow_failures:
-  - php: "7.0"
-    env: "SWITCH_TO_PHP=5.2"
+#  - php: "7.0"
+#    env: "SWITCH_TO_PHP=5.2"
 #  - php: "nightly"
 
 # whitelist branches for the "push" build check.


### PR DESCRIPTION
Depends on #8790.

#### Changes proposed in this Pull Request:

* Removes PHP 5.2 runner from Travis allowed failures in `.travis.yml`.

#### Testing instructions:

* Either set up a php 5.2 installation, have wordpress source code at hand, configure the testing db, install phpunit and run all the test confirming that they pass or...
* ...check if Travis says this PR is good to go as it runs the PHP 5.2 job blocking this PR from getting merged if tests don't pass.