### PR TITLE
Lazy Images: Initialize lazy images on wp hook

### DIFF
--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -24,4 +24,16 @@
  */
 
 require_once( JETPACK__PLUGIN_DIR . 'modules/lazy-images/lazy-images.php' );
-Jetpack_Lazy_Images::instance();
+
+/*
+ * Initialize lazy images on the wp action so that conditional
+ * tags are safe to use.
+ *
+ * As an example, this is important if a theme wants to disable lazy images except
+ * on single posts, pages, or attachments by short-circuiting lazy images when
+ * is_singular() returns false.
+ *
+ * See: https://github.com/Automattic/jetpack/issues/8888
+ */
+
+add_action( 'wp', array( 'Jetpack_Lazy_Images', 'instance' ) );


### PR DESCRIPTION
Fixes #8888 

In #8888 an a11n reported that the `lazyload_is_enabled` filter wasn't working as expecting. He expected it to work like this:

```php
/**
 * Disable Lazy Loading on non-singular views
 *
 * @filter lazyload_is_enabled
 * @return bool
 */
add_filter( 'lazyload_is_enabled', 'turn_off_lazyload_on_hfeed' );
function turn_off_lazyload_on_hfeed( $enabled ) {
    if ( ! is_singular() ) {
        $enabled = false;
    }
    return $enabled;
}
```

The root issue here is that we run that filter as the plugin is loaded which is way before conditional tags are available. My first thought was to load lazy images on `init`, but that wouldn't work either since conditional tags aren't available until the `wp` action. See the docs on conditional tags here:

https://codex.wordpress.org/Conditional_Tags

To test:

- Add snippet above to an integration plugin
- Add a few posts with multiple images
- Ensure that images load lazily on the blog page and on single posts
    - You can verify that by checking if an image has the `jetpack-lazy-image--handled` class or by looking in the network tab and seeing if the initiator to download an image was `lazy-image...` and not `(index)`.
- Checkout this branch
- Ensure that images load lazily on single posts but not on the blog page

