### PR TITLE
Lazy Images: Use W3C IntersectionObserver polyfill

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -121,36 +121,736 @@ var jetpackLazyImagesModule = function( $ ) {
 };
 
 /**
- * The following is an Intersection observer polyfill which is licensed under MIT
- * and can be found at https://github.com/que-etc/intersection-observer-polyfill
- */
-
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016 Denis Rul
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * The following is an Intersection observer polyfill which is licensed under
+ * the W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE and can be found at:
+ * https://github.com/w3c/IntersectionObserver/tree/master/polyfill
  */
 
 /* jshint ignore:start */
-!function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.IntersectionObserver=e():t.IntersectionObserver=e()}(this,function(){return function(t){function e(n){if(r[n])return r[n].exports;var o=r[n]={exports:{},id:n,loaded:!1};return t[n].call(o.exports,o,o.exports,e),o.loaded=!0,o.exports}var r={};return e.m=t,e.c=r,e.p="",e(0)}([function(t,e,r){"use strict";function n(t){return t&&t.__esModule?t:{"default":t}}Object.defineProperty(e,"__esModule",{value:!0});var o=r(1),i=n(o),s=void 0;s="function"==typeof window.IntersectionObserver?window.IntersectionObserver:i["default"],e["default"]=s,t.exports=e["default"]},function(t,e,r){"use strict";function n(t){return t&&t.__esModule?t:{"default":t}}function o(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(e,"__esModule",{value:!0});var i="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol?"symbol":typeof t},s=function(){function t(t,e){for(var r=0;r<e.length;r++){var n=e[r];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(t,n.key,n)}}return function(e,r,n){return r&&t(e.prototype,r),n&&t(e,n),e}}(),a=r(2),u=r(3),c=n(u),l=r(5),h=n(l),f=new c["default"],p=new a.WeakMap,d=function(){function t(e,r){if(o(this,t),!arguments.length)throw new TypeError("1 argument required, but only 0 present.");var n=new h["default"](e,r,f,this);Object.defineProperties(this,{root:{value:n.root},thresholds:{value:n.thresholds},rootMargin:{value:n.rootMargin}}),p.set(this,n)}return s(t,null,[{key:"idleTimeout",get:function(){return f.idleTimeout},set:function(t){if("number"!=typeof t)throw new TypeError('type of "idleTimeout" value must be a number.');if(("undefined"==typeof t?"undefined":i(t))<0)throw new TypeError('"idleTimeout" value must be greater than 0.');f.idleTimeout=t}},{key:"trackHovers",get:function(){return f.isHoverEnabled()},set:function(t){if("boolean"!=typeof t)throw new TypeError('type of "trackHovers" value must be a boolean.');t?f.enableHover():f.disableHover()}}]),t}();["observe","unobserve","disconnect","takeRecords"].forEach(function(t){d.prototype[t]=function(){var e;return(e=p.get(this))[t].apply(e,arguments)}}),e["default"]=d,t.exports=e["default"]},function(t,e){"use strict";function r(t,e){if(!t)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e}function n(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)}function o(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(e,"__esModule",{value:!0});var i=function(){function t(t,e){for(var r=0;r<e.length;r++){var n=e[r];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(t,n.key,n)}}return function(e,r,n){return r&&t(e.prototype,r),n&&t(e,n),e}}(),s="function"==typeof window.WeakMap&&"function"==typeof window.Map,a=function(){function t(t,e){var r=-1;return t.some(function(t,n){var o=t[0]===e;return o&&(r=n),o}),r}return s?window.WeakMap:function(){function e(){o(this,e),this.__entries__=[]}return e.prototype.get=function(e){var r=t(this.__entries__,e);return this.__entries__[r][1]},e.prototype.set=function(e,r){var n=t(this.__entries__,e);~n?this.__entries__[n][1]=r:this.__entries__.push([e,r])},e.prototype["delete"]=function(e){var r=this.__entries__,n=t(r,e);~n&&r.splice(n,1)},e.prototype.has=function(e){return!!~t(this.__entries__,e)},e}()}(),u=function(){return s?window.Map:function(t){function e(){return o(this,e),r(this,t.apply(this,arguments))}return n(e,t),e.prototype.clear=function(){this.__entries__.splice(0,this.__entries__.length)},e.prototype.entries=function(){return this.__entries__.slice()},e.prototype.keys=function(){return this.__entries__.map(function(t){return t[0]})},e.prototype.values=function(){return this.__entries__.map(function(t){return t[1]})},e.prototype.forEach=function(t){for(var e=arguments.length<=1||void 0===arguments[1]?null:arguments[1],r=this.__entries__,n=Array.isArray(r),o=0,r=n?r:r[Symbol.iterator]();;){var i;if(n){if(o>=r.length)break;i=r[o++]}else{if(o=r.next(),o.done)break;i=o.value}var s=i;t.call(e,s[1],s[0])}},i(e,[{key:"size",get:function(){return this.__entries__.length}}]),e}(a)}();e.Map=u,e.WeakMap=a},function(t,e,r){"use strict";function n(t){return t&&t.__esModule?t:{"default":t}}function o(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function i(t){var e=arguments.length<=1||void 0===arguments[1]?0:arguments[1],r=!1;return function(){for(var n=this,o=arguments.length,i=Array(o),s=0;s<o;s++)i[s]=arguments[s];r!==!1&&clearTimeout(r),r=setTimeout(function(){r=!1,t.apply(n,i)},e)}}Object.defineProperty(e,"__esModule",{value:!0});var s=function(){function t(t,e){for(var r=0;r<e.length;r++){var n=e[r];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(t,n.key,n)}}return function(e,r,n){return r&&t(e.prototype,r),n&&t(e,n),e}}(),a=r(4),u=n(a),c="function"==typeof window.MutationObserver,l=function(){return window.requestAnimationFrame?window.requestAnimationFrame:function(t){return setTimeout(function(){return t((0,u["default"])())},1e3/60)}}(),h=function(){function t(){var e=arguments.length<=0||void 0===arguments[0]?50:arguments[0],r=!(arguments.length<=1||void 0===arguments[1])&&arguments[1];o(this,t),this._idleTimeout=e,this._trackHovers=r,this._cycleStartTime=-1,this._isUpdateScheduled=!1,this._repeatCycle=!1,this._hoverInitiated=!1,this._mutationsObserver=null,this._isListening=!1,this._observers=[],this.startUpdateCycle=this.startUpdateCycle.bind(this),this.scheduleUpdate=this.scheduleUpdate.bind(this),this._onMutation=this._onMutation.bind(this),this._repeatHandler=i(this.scheduleUpdate,200),this._onMouseOver=i(this.startUpdateCycle,200)}return t.prototype.connect=function(t){this.isConnected(t)||this._observers.push(t),this._isListening||this._initListeners()},t.prototype.disconnect=function(t){var e=this._observers,r=e.indexOf(t);~r&&e.splice(r,1),!e.length&&this._isListening&&this._removeListeners()},t.prototype.isConnected=function(t){return!!~this._observers.indexOf(t)},t.prototype._updateObservers=function(){for(var t=!1,e=this._observers,r=Array.isArray(e),n=0,e=r?e:e[Symbol.iterator]();;){var o;if(r){if(n>=e.length)break;o=e[n++]}else{if(n=e.next(),n.done)break;o=n.value}var i=o;i.updateObservations()&&(t=!0),i.hasEntries()&&i.notifySubscriber()}return t},t.prototype.startUpdateCycle=function(){this._cycleStartTime=(0,u["default"])(),this.scheduleUpdate()},t.prototype.scheduleUpdate=function(t){var e="number"==typeof t;if(e){var r=this._updateObservers();if(this._isUpdateScheduled=!1,!this._wasCycleStarted())return;r?this.startUpdateCycle():this._hasIdleTimeEnded()?this._onCycleEnded():this.scheduleUpdate()}else this._isUpdateScheduled||(l(this.scheduleUpdate),this._isUpdateScheduled=!0)},t.prototype._hasIdleTimeEnded=function(){return(0,u["default"])()-this._cycleStartTime>this._idleTimeout},t.prototype._wasCycleStarted=function(){return this._cycleStartTime!==-1},t.prototype._onCycleEnded=function(){this._cycleStartTime=-1,this._repeatCycle&&(this._cycleStartTime=0,this._repeatHandler())},t.prototype._initListeners=function(){this._isListening||(this._isListening=!0,window.addEventListener("resize",this.startUpdateCycle,!0),window.addEventListener("scroll",this.scheduleUpdate,!0),this._trackHovers&&this._addHoverListener(),c?(this._mutationsObserver=new MutationObserver(this._onMutation),this._mutationsObserver.observe(document,{attributes:!0,childList:!0,characterData:!0,subtree:!0})):(this._repeatCycle=!0,window.addEventListener("click",this.startUpdateCycle,!0),this.startUpdateCycle()))},t.prototype._removeListeners=function(){this._isListening&&(window.removeEventListener("resize",this.startUpdateCycle,!0),window.removeEventListener("scroll",this.scheduleUpdate,!0),this._removeHoverListener(),c?this._mutationsObserver&&(this._mutationsObserver.disconnect(),this._mutationsObserver=null):(this._repeatCycle=!1,window.removeEventListener("click",this.startUpdateCycle,!0)),this._isListening=!1)},t.prototype.enableHover=function(){this._trackHovers=!0,this._isListening&&this._addHoverListener()},t.prototype.disableHover=function(){this._trackHovers=!1,this._removeHoverListener()},t.prototype.isHoverEnabled=function(){return this._trackHovers},t.prototype._addHoverListener=function(){this._hoverInitiated||(window.addEventListener("mouseover",this._onMouseOver,!0),this._hoverInitiated=!0)},t.prototype._removeHoverListener=function(){this._hoverInitiated&&(window.removeEventListener("mouseover",this._onMouseOver,!0),this._hoverInitiated=!1)},t.prototype._onMutation=function(t){var e=t.every(function(t){return"attributes"!==t.type});e?this.scheduleUpdate():this.startUpdateCycle()},s(t,[{key:"idleTimeout",get:function(){return this._idleTimeout},set:function(t){this._idleTimeout=t}}]),t}();e["default"]=h,t.exports=e["default"]},function(t,e){"use strict";Object.defineProperty(e,"__esModule",{value:!0}),e["default"]=function(){return window.performance&&window.performance.now?function(){return window.performance.now()}:function(){return Date.now()}}(),t.exports=e["default"]},function(t,e,r){"use strict";function n(t){return t&&t.__esModule?t:{"default":t}}function o(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function i(){var t=arguments.length<=0||void 0===arguments[0]?0:arguments[0],e=t;return Array.isArray(t)?t.length||(e=[0]):e=[t],e.map(function(t){if(t=Number(t),!window.isFinite(t))throw new TypeError("The provided double value is non-finite.");if(t<0||t>1)throw new RangeError("Threshold values must be between 0 and 1.");return t}).sort()}function s(){var t=arguments.length<=0||void 0===arguments[0]?"0px":arguments[0];if(t=(t+"").split(/\s+/),t.length>4)throw new Error("Extra text found at the end of rootMargin.");t[0]=t[0]||"0px",t[1]=t[1]||t[0],t[2]=t[2]||t[0],t[3]=t[3]||t[1];var e=t.join(" "),r=t.map(function(t){var e=/^(-?\d*\.?\d+)(px|%)$/.exec(t)||[],r=e[1],n=e[2],o="px"===n;if(r=parseFloat(r),!window.isFinite(r))throw new Error("rootMargin must be specified in pixels or percent.");return o||(r/=100),{value:r,pixels:o}});return{rawData:e,parsedData:r}}function a(t,e){e=e.map(function(e,r){var n=e.value;return e.pixels||(n*=r%2?t.width:t.height),n});var r={top:t.top-e[0],right:t.right+e[1],bottom:t.bottom+e[2],left:t.left-e[3]};return r.width=r.right-r.left,r.height=r.bottom-r.top,r}Object.defineProperty(e,"__esModule",{value:!0});var u="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol?"symbol":typeof t},c=r(2),l=r(6),h=r(7),f=n(h),p=function(){function t(e){var r=arguments.length<=1||void 0===arguments[1]?{}:arguments[1],n=arguments[2],a=arguments[3];if(o(this,t),"function"!=typeof e)throw new TypeError("The callback provided as parameter 1 is not a function.");if("object"!==("undefined"==typeof r?"undefined":u(r)))throw new TypeError("parameter 2 is not an object.");if("root"in r&&!(r.root instanceof Element))throw new TypeError("member root is not of type Element.");var l=i(r.threshold),h=s(r.rootMargin);this.root=r.root||null,this.rootMargin=h.rawData,this.thresholds=Object.freeze(l),this._root=r.root||document.documentElement,this._callback=e,this._rootMargin=h.parsedData,this._targets=new c.Map,this._quedEntries=[],this._publicObserver=a||this,this.controller=n}return t.prototype.observe=function(t){if(!arguments.length)throw new TypeError("1 argument required, but only 0 present.");if(!(t instanceof Element))throw new TypeError('parameter 1 is not of type "Element".');var e=this._targets;e.has(t)||(e.set(t,new f["default"](t,this)),this.controller.isConnected(this)||this.controller.connect(this),this.controller.startUpdateCycle())},t.prototype.unobserve=function(t){if(!arguments.length)throw new TypeError("1 argument required, but only 0 present.");if(!(t instanceof Element))throw new TypeError('parameter 1 is not of type "Element".');var e=this._targets;e.has(t)&&e["delete"](t),e.size||this.disconnect()},t.prototype.disconnect=function(){this._targets.clear(),this.controller.disconnect(this)},t.prototype.takeRecords=function(){return this._quedEntries.splice(0)},t.prototype.notifySubscriber=function(){var t=this.takeRecords(),e=this._publicObserver;t.length&&this._callback.call(e,t,e)},t.prototype.queueEntry=function(t){this._quedEntries.push(t)},t.prototype.hasEntries=function(){return!!this._quedEntries.length},t.prototype.updateObservations=function(){var t=this._root,e=this.getRootRect(),r=!1;return this._targets.forEach(function(n){var o=n.updateIntersection(t,e);(o.ratioChanged||o.targetRectChanged)&&(r=!0)}),r},t.prototype.getThresholdGreaterThan=function(t){for(var e=this.thresholds,r=e.length,n=0;n<r&&e[n]<=t;)++n;return n},t.prototype.getRootRect=function(){var t=(0,l.getRectangle)(this._root);return a(t,this._rootMargin)},t}();e["default"]=p,t.exports=e["default"]},function(t,e){"use strict";function r(t){for(var e={},r=Object.keys(t),n=Array.isArray(r),o=0,r=n?r:r[Symbol.iterator]();;){var i;if(n){if(o>=r.length)break;i=r[o++]}else{if(o=r.next(),o.done)break;i=o.value}var s=i;e[s]={value:t[s]}}return Object.defineProperties({},e)}function n(){var t=arguments.length<=0||void 0===arguments[0]?0:arguments[0],e=arguments.length<=1||void 0===arguments[1]?0:arguments[1],r=arguments.length<=2||void 0===arguments[2]?0:arguments[2],n=arguments.length<=3||void 0===arguments[3]?0:arguments[3];return{left:t,top:e,width:r,height:n,bottom:e+n,right:t+r}}function o(t){return t===document.documentElement?n(0,0,t.clientWidth,t.clientHeight):t.getBoundingClientRect()}function i(t){return t.width*t.height}function s(t){return 0===t.height&&0===t.width}function a(t,e){return t.top===e.top&&t.left===e.left&&t.right===e.right&&t.bottom===e.bottom}Object.defineProperty(e,"__esModule",{value:!0}),e.mapToClientRect=r,e.createRectangle=n,e.getRectangle=o,e.getArea=i,e.isEmpty=s,e.isEqual=a},function(t,e,r){"use strict";function n(t){return t&&t.__esModule?t:{"default":t}}function o(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function i(t,e){var r=document.documentElement;return t!==r&&!r.contains(t)||!t.contains(e)}function s(t,e){var r=Math.max(e.left,t.left),n=Math.min(e.right,t.right),o=Math.max(e.top,t.top),i=Math.min(e.bottom,t.bottom),s=n-r,a=i-o;return(0,l.createRectangle)(r,o,s,a)}function a(t,e,r,n){for(var o=n,i=e.parentNode,a=!1;!a;){var u=null;i===t||1!==i.nodeType?(a=!0,u=r):"visible"!==window.getComputedStyle(i).overflow&&(u=(0,l.getRectangle)(i)),u&&(o=s(o,u)),i=i.parentNode}return o}Object.defineProperty(e,"__esModule",{value:!0});var u=r(4),c=n(u),l=r(6),h=r(8),f=n(h),p=(0,l.createRectangle)(),d=function(){function t(e,r){o(this,t),this.target=e,this.observer=r,this.prevTargetRect=p,this.prevThreshold=0,this.prevRatio=0}return t.prototype.updateIntersection=function(t,e){var r=(0,l.getRectangle)(this.target),n=this.getIntersectionData(t,e,r),o=+n.exists,i=n.ratio!==this.prevRatio,s=!(0,l.isEqual)(r,this.prevTargetRect),a=void 0;if(n.exists&&!(0,l.isEmpty)(r)&&(o=this.observer.getThresholdGreaterThan(n.ratio)),a=o!==this.prevThreshold,this.prevTargetRect=r,this.prevThreshold=o,this.prevRatio=n.ratio,n.exists||(n.ratio=0,n.rect=p),a){var u=new f["default"](this.target,r,n.rect,n.ratio,e,(0,c["default"])());this.observer.queueEntry(u)}return{ratioChanged:i,thresholdChanged:a,targetRectChanged:s}},t.prototype.getIntersectionData=function(t,e,r){var n=this.target;r||(r=(0,l.getRectangle)(this.target)),e||(e=(0,l.getRectangle)(t));var o=i(t,n),s=o?p:a(t,n,e,r),u=!o&&s.width>=0&&s.height>=0,c=(0,l.getArea)(s)/(0,l.getArea)(r)||0;return{rect:s,ratio:c,exists:u}},t}();e["default"]=d,t.exports=e["default"]},function(t,e,r){"use strict";function n(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(e,"__esModule",{value:!0});var o=r(6),i=function s(t,e,r,i,a,u){n(this,s),Object.defineProperties(this,{boundingClientRect:{value:e},intersectionRatio:{value:i},intersectionRect:{value:(0,o.mapToClientRect)(r)},rootBounds:{value:(0,o.mapToClientRect)(a)},target:{value:t},time:{value:u}})};e["default"]=i,t.exports=e["default"]}])});
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE.
+ *
+ *  https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ */
+
+(function(window, document) {
+	'use strict';
+
+
+	// Exits early if all IntersectionObserver and IntersectionObserverEntry
+	// features are natively supported.
+	if ('IntersectionObserver' in window &&
+		'IntersectionObserverEntry' in window &&
+		'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+
+	  // Minimal polyfill for Edge 15's lack of `isIntersecting`
+	  // See: https://github.com/w3c/IntersectionObserver/issues/211
+	  if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
+		Object.defineProperty(window.IntersectionObserverEntry.prototype,
+		  'isIntersecting', {
+		  get: function () {
+			return this.intersectionRatio > 0;
+		  }
+		});
+	  }
+	  return;
+	}
+
+
+	/**
+	 * An IntersectionObserver registry. This registry exists to hold a strong
+	 * reference to IntersectionObserver instances currently observering a target
+	 * element. Without this registry, instances without another reference may be
+	 * garbage collected.
+	 */
+	var registry = [];
+
+
+	/**
+	 * Creates the global IntersectionObserverEntry constructor.
+	 * https://w3c.github.io/IntersectionObserver/#intersection-observer-entry
+	 * @param {Object} entry A dictionary of instance properties.
+	 * @constructor
+	 */
+	function IntersectionObserverEntry(entry) {
+	  this.time = entry.time;
+	  this.target = entry.target;
+	  this.rootBounds = entry.rootBounds;
+	  this.boundingClientRect = entry.boundingClientRect;
+	  this.intersectionRect = entry.intersectionRect || getEmptyRect();
+	  this.isIntersecting = !!entry.intersectionRect;
+
+	  // Calculates the intersection ratio.
+	  var targetRect = this.boundingClientRect;
+	  var targetArea = targetRect.width * targetRect.height;
+	  var intersectionRect = this.intersectionRect;
+	  var intersectionArea = intersectionRect.width * intersectionRect.height;
+
+	  // Sets intersection ratio.
+	  if (targetArea) {
+		this.intersectionRatio = intersectionArea / targetArea;
+	  } else {
+		// If area is zero and is intersecting, sets to 1, otherwise to 0
+		this.intersectionRatio = this.isIntersecting ? 1 : 0;
+	  }
+	}
+
+
+	/**
+	 * Creates the global IntersectionObserver constructor.
+	 * https://w3c.github.io/IntersectionObserver/#intersection-observer-interface
+	 * @param {Function} callback The function to be invoked after intersection
+	 *     changes have queued. The function is not invoked if the queue has
+	 *     been emptied by calling the `takeRecords` method.
+	 * @param {Object=} opt_options Optional configuration options.
+	 * @constructor
+	 */
+	function IntersectionObserver(callback, opt_options) {
+
+	  var options = opt_options || {};
+
+	  if (typeof callback != 'function') {
+		throw new Error('callback must be a function');
+	  }
+
+	  if (options.root && options.root.nodeType != 1) {
+		throw new Error('root must be an Element');
+	  }
+
+	  // Binds and throttles `this._checkForIntersections`.
+	  this._checkForIntersections = throttle(
+		  this._checkForIntersections.bind(this), this.THROTTLE_TIMEOUT);
+
+	  // Private properties.
+	  this._callback = callback;
+	  this._observationTargets = [];
+	  this._queuedEntries = [];
+	  this._rootMarginValues = this._parseRootMargin(options.rootMargin);
+
+	  // Public properties.
+	  this.thresholds = this._initThresholds(options.threshold);
+	  this.root = options.root || null;
+	  this.rootMargin = this._rootMarginValues.map(function(margin) {
+		return margin.value + margin.unit;
+	  }).join(' ');
+	}
+
+
+	/**
+	 * The minimum interval within which the document will be checked for
+	 * intersection changes.
+	 */
+	IntersectionObserver.prototype.THROTTLE_TIMEOUT = 100;
+
+
+	/**
+	 * The frequency in which the polyfill polls for intersection changes.
+	 * this can be updated on a per instance basis and must be set prior to
+	 * calling `observe` on the first target.
+	 */
+	IntersectionObserver.prototype.POLL_INTERVAL = null;
+
+	/**
+	 * Use a mutation observer on the root element
+	 * to detect intersection changes.
+	 */
+	IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
+
+
+	/**
+	 * Starts observing a target element for intersection changes based on
+	 * the thresholds values.
+	 * @param {Element} target The DOM element to observe.
+	 */
+	IntersectionObserver.prototype.observe = function(target) {
+	  var isTargetAlreadyObserved = this._observationTargets.some(function(item) {
+		return item.element == target;
+	  });
+
+	  if (isTargetAlreadyObserved) {
+		return;
+	  }
+
+	  if (!(target && target.nodeType == 1)) {
+		throw new Error('target must be an Element');
+	  }
+
+	  this._registerInstance();
+	  this._observationTargets.push({element: target, entry: null});
+	  this._monitorIntersections();
+	  this._checkForIntersections();
+	};
+
+
+	/**
+	 * Stops observing a target element for intersection changes.
+	 * @param {Element} target The DOM element to observe.
+	 */
+	IntersectionObserver.prototype.unobserve = function(target) {
+	  this._observationTargets =
+		  this._observationTargets.filter(function(item) {
+
+		return item.element != target;
+	  });
+	  if (!this._observationTargets.length) {
+		this._unmonitorIntersections();
+		this._unregisterInstance();
+	  }
+	};
+
+
+	/**
+	 * Stops observing all target elements for intersection changes.
+	 */
+	IntersectionObserver.prototype.disconnect = function() {
+	  this._observationTargets = [];
+	  this._unmonitorIntersections();
+	  this._unregisterInstance();
+	};
+
+
+	/**
+	 * Returns any queue entries that have not yet been reported to the
+	 * callback and clears the queue. This can be used in conjunction with the
+	 * callback to obtain the absolute most up-to-date intersection information.
+	 * @return {Array} The currently queued entries.
+	 */
+	IntersectionObserver.prototype.takeRecords = function() {
+	  var records = this._queuedEntries.slice();
+	  this._queuedEntries = [];
+	  return records;
+	};
+
+
+	/**
+	 * Accepts the threshold value from the user configuration object and
+	 * returns a sorted array of unique threshold values. If a value is not
+	 * between 0 and 1 and error is thrown.
+	 * @private
+	 * @param {Array|number=} opt_threshold An optional threshold value or
+	 *     a list of threshold values, defaulting to [0].
+	 * @return {Array} A sorted list of unique and valid threshold values.
+	 */
+	IntersectionObserver.prototype._initThresholds = function(opt_threshold) {
+	  var threshold = opt_threshold || [0];
+	  if (!Array.isArray(threshold)) threshold = [threshold];
+
+	  return threshold.sort().filter(function(t, i, a) {
+		if (typeof t != 'number' || isNaN(t) || t < 0 || t > 1) {
+		  throw new Error('threshold must be a number between 0 and 1 inclusively');
+		}
+		return t !== a[i - 1];
+	  });
+	};
+
+
+	/**
+	 * Accepts the rootMargin value from the user configuration object
+	 * and returns an array of the four margin values as an object containing
+	 * the value and unit properties. If any of the values are not properly
+	 * formatted or use a unit other than px or %, and error is thrown.
+	 * @private
+	 * @param {string=} opt_rootMargin An optional rootMargin value,
+	 *     defaulting to '0px'.
+	 * @return {Array<Object>} An array of margin objects with the keys
+	 *     value and unit.
+	 */
+	IntersectionObserver.prototype._parseRootMargin = function(opt_rootMargin) {
+	  var marginString = opt_rootMargin || '0px';
+	  var margins = marginString.split(/\s+/).map(function(margin) {
+		var parts = /^(-?\d*\.?\d+)(px|%)$/.exec(margin);
+		if (!parts) {
+		  throw new Error('rootMargin must be specified in pixels or percent');
+		}
+		return {value: parseFloat(parts[1]), unit: parts[2]};
+	  });
+
+	  // Handles shorthand.
+	  margins[1] = margins[1] || margins[0];
+	  margins[2] = margins[2] || margins[0];
+	  margins[3] = margins[3] || margins[1];
+
+	  return margins;
+	};
+
+
+	/**
+	 * Starts polling for intersection changes if the polling is not already
+	 * happening, and if the page's visibilty state is visible.
+	 * @private
+	 */
+	IntersectionObserver.prototype._monitorIntersections = function() {
+	  if (!this._monitoringIntersections) {
+		this._monitoringIntersections = true;
+
+		// If a poll interval is set, use polling instead of listening to
+		// resize and scroll events or DOM mutations.
+		if (this.POLL_INTERVAL) {
+		  this._monitoringInterval = setInterval(
+			  this._checkForIntersections, this.POLL_INTERVAL);
+		}
+		else {
+		  addEvent(window, 'resize', this._checkForIntersections, true);
+		  addEvent(document, 'scroll', this._checkForIntersections, true);
+
+		  if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in window) {
+			this._domObserver = new MutationObserver(this._checkForIntersections);
+			this._domObserver.observe(document, {
+			  attributes: true,
+			  childList: true,
+			  characterData: true,
+			  subtree: true
+			});
+		  }
+		}
+	  }
+	};
+
+
+	/**
+	 * Stops polling for intersection changes.
+	 * @private
+	 */
+	IntersectionObserver.prototype._unmonitorIntersections = function() {
+	  if (this._monitoringIntersections) {
+		this._monitoringIntersections = false;
+
+		clearInterval(this._monitoringInterval);
+		this._monitoringInterval = null;
+
+		removeEvent(window, 'resize', this._checkForIntersections, true);
+		removeEvent(document, 'scroll', this._checkForIntersections, true);
+
+		if (this._domObserver) {
+		  this._domObserver.disconnect();
+		  this._domObserver = null;
+		}
+	  }
+	};
+
+
+	/**
+	 * Scans each observation target for intersection changes and adds them
+	 * to the internal entries queue. If new entries are found, it
+	 * schedules the callback to be invoked.
+	 * @private
+	 */
+	IntersectionObserver.prototype._checkForIntersections = function() {
+	  var rootIsInDom = this._rootIsInDom();
+	  var rootRect = rootIsInDom ? this._getRootRect() : getEmptyRect();
+
+	  this._observationTargets.forEach(function(item) {
+		var target = item.element;
+		var targetRect = getBoundingClientRect(target);
+		var rootContainsTarget = this._rootContainsTarget(target);
+		var oldEntry = item.entry;
+		var intersectionRect = rootIsInDom && rootContainsTarget &&
+			this._computeTargetAndRootIntersection(target, rootRect);
+
+		var newEntry = item.entry = new IntersectionObserverEntry({
+		  time: now(),
+		  target: target,
+		  boundingClientRect: targetRect,
+		  rootBounds: rootRect,
+		  intersectionRect: intersectionRect
+		});
+
+		if (!oldEntry) {
+		  this._queuedEntries.push(newEntry);
+		} else if (rootIsInDom && rootContainsTarget) {
+		  // If the new entry intersection ratio has crossed any of the
+		  // thresholds, add a new entry.
+		  if (this._hasCrossedThreshold(oldEntry, newEntry)) {
+			this._queuedEntries.push(newEntry);
+		  }
+		} else {
+		  // If the root is not in the DOM or target is not contained within
+		  // root but the previous entry for this target had an intersection,
+		  // add a new record indicating removal.
+		  if (oldEntry && oldEntry.isIntersecting) {
+			this._queuedEntries.push(newEntry);
+		  }
+		}
+	  }, this);
+
+	  if (this._queuedEntries.length) {
+		this._callback(this.takeRecords(), this);
+	  }
+	};
+
+
+	/**
+	 * Accepts a target and root rect computes the intersection between then
+	 * following the algorithm in the spec.
+	 * TODO(philipwalton): at this time clip-path is not considered.
+	 * https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo
+	 * @param {Element} target The target DOM element
+	 * @param {Object} rootRect The bounding rect of the root after being
+	 *     expanded by the rootMargin value.
+	 * @return {?Object} The final intersection rect object or undefined if no
+	 *     intersection is found.
+	 * @private
+	 */
+	IntersectionObserver.prototype._computeTargetAndRootIntersection =
+		function(target, rootRect) {
+
+	  // If the element isn't displayed, an intersection can't happen.
+	  if (window.getComputedStyle(target).display == 'none') return;
+
+	  var targetRect = getBoundingClientRect(target);
+	  var intersectionRect = targetRect;
+	  var parent = getParentNode(target);
+	  var atRoot = false;
+
+	  while (!atRoot) {
+		var parentRect = null;
+		var parentComputedStyle = parent.nodeType == 1 ?
+			window.getComputedStyle(parent) : {};
+
+		// If the parent isn't displayed, an intersection can't happen.
+		if (parentComputedStyle.display == 'none') return;
+
+		if (parent == this.root || parent == document) {
+		  atRoot = true;
+		  parentRect = rootRect;
+		} else {
+		  // If the element has a non-visible overflow, and it's not the <body>
+		  // or <html> element, update the intersection rect.
+		  // Note: <body> and <html> cannot be clipped to a rect that's not also
+		  // the document rect, so no need to compute a new intersection.
+		  if (parent != document.body &&
+			  parent != document.documentElement &&
+			  parentComputedStyle.overflow != 'visible') {
+			parentRect = getBoundingClientRect(parent);
+		  }
+		}
+
+		// If either of the above conditionals set a new parentRect,
+		// calculate new intersection data.
+		if (parentRect) {
+		  intersectionRect = computeRectIntersection(parentRect, intersectionRect);
+
+		  if (!intersectionRect) break;
+		}
+		parent = getParentNode(parent);
+	  }
+	  return intersectionRect;
+	};
+
+
+	/**
+	 * Returns the root rect after being expanded by the rootMargin value.
+	 * @return {Object} The expanded root rect.
+	 * @private
+	 */
+	IntersectionObserver.prototype._getRootRect = function() {
+	  var rootRect;
+	  if (this.root) {
+		rootRect = getBoundingClientRect(this.root);
+	  } else {
+		// Use <html>/<body> instead of window since scroll bars affect size.
+		var html = document.documentElement;
+		var body = document.body;
+		rootRect = {
+		  top: 0,
+		  left: 0,
+		  right: html.clientWidth || body.clientWidth,
+		  width: html.clientWidth || body.clientWidth,
+		  bottom: html.clientHeight || body.clientHeight,
+		  height: html.clientHeight || body.clientHeight
+		};
+	  }
+	  return this._expandRectByRootMargin(rootRect);
+	};
+
+
+	/**
+	 * Accepts a rect and expands it by the rootMargin value.
+	 * @param {Object} rect The rect object to expand.
+	 * @return {Object} The expanded rect.
+	 * @private
+	 */
+	IntersectionObserver.prototype._expandRectByRootMargin = function(rect) {
+	  var margins = this._rootMarginValues.map(function(margin, i) {
+		return margin.unit == 'px' ? margin.value :
+			margin.value * (i % 2 ? rect.width : rect.height) / 100;
+	  });
+	  var newRect = {
+		top: rect.top - margins[0],
+		right: rect.right + margins[1],
+		bottom: rect.bottom + margins[2],
+		left: rect.left - margins[3]
+	  };
+	  newRect.width = newRect.right - newRect.left;
+	  newRect.height = newRect.bottom - newRect.top;
+
+	  return newRect;
+	};
+
+
+	/**
+	 * Accepts an old and new entry and returns true if at least one of the
+	 * threshold values has been crossed.
+	 * @param {?IntersectionObserverEntry} oldEntry The previous entry for a
+	 *    particular target element or null if no previous entry exists.
+	 * @param {IntersectionObserverEntry} newEntry The current entry for a
+	 *    particular target element.
+	 * @return {boolean} Returns true if a any threshold has been crossed.
+	 * @private
+	 */
+	IntersectionObserver.prototype._hasCrossedThreshold =
+		function(oldEntry, newEntry) {
+
+	  // To make comparing easier, an entry that has a ratio of 0
+	  // but does not actually intersect is given a value of -1
+	  var oldRatio = oldEntry && oldEntry.isIntersecting ?
+		  oldEntry.intersectionRatio || 0 : -1;
+	  var newRatio = newEntry.isIntersecting ?
+		  newEntry.intersectionRatio || 0 : -1;
+
+	  // Ignore unchanged ratios
+	  if (oldRatio === newRatio) return;
+
+	  for (var i = 0; i < this.thresholds.length; i++) {
+		var threshold = this.thresholds[i];
+
+		// Return true if an entry matches a threshold or if the new ratio
+		// and the old ratio are on the opposite sides of a threshold.
+		if (threshold == oldRatio || threshold == newRatio ||
+			threshold < oldRatio !== threshold < newRatio) {
+		  return true;
+		}
+	  }
+	};
+
+
+	/**
+	 * Returns whether or not the root element is an element and is in the DOM.
+	 * @return {boolean} True if the root element is an element and is in the DOM.
+	 * @private
+	 */
+	IntersectionObserver.prototype._rootIsInDom = function() {
+	  return !this.root || containsDeep(document, this.root);
+	};
+
+
+	/**
+	 * Returns whether or not the target element is a child of root.
+	 * @param {Element} target The target element to check.
+	 * @return {boolean} True if the target element is a child of root.
+	 * @private
+	 */
+	IntersectionObserver.prototype._rootContainsTarget = function(target) {
+	  return containsDeep(this.root || document, target);
+	};
+
+
+	/**
+	 * Adds the instance to the global IntersectionObserver registry if it isn't
+	 * already present.
+	 * @private
+	 */
+	IntersectionObserver.prototype._registerInstance = function() {
+	  if (registry.indexOf(this) < 0) {
+		registry.push(this);
+	  }
+	};
+
+
+	/**
+	 * Removes the instance from the global IntersectionObserver registry.
+	 * @private
+	 */
+	IntersectionObserver.prototype._unregisterInstance = function() {
+	  var index = registry.indexOf(this);
+	  if (index != -1) registry.splice(index, 1);
+	};
+
+
+	/**
+	 * Returns the result of the performance.now() method or null in browsers
+	 * that don't support the API.
+	 * @return {number} The elapsed time since the page was requested.
+	 */
+	function now() {
+	  return window.performance && performance.now && performance.now();
+	}
+
+
+	/**
+	 * Throttles a function and delays its executiong, so it's only called at most
+	 * once within a given time period.
+	 * @param {Function} fn The function to throttle.
+	 * @param {number} timeout The amount of time that must pass before the
+	 *     function can be called again.
+	 * @return {Function} The throttled function.
+	 */
+	function throttle(fn, timeout) {
+	  var timer = null;
+	  return function () {
+		if (!timer) {
+		  timer = setTimeout(function() {
+			fn();
+			timer = null;
+		  }, timeout);
+		}
+	  };
+	}
+
+
+	/**
+	 * Adds an event handler to a DOM node ensuring cross-browser compatibility.
+	 * @param {Node} node The DOM node to add the event handler to.
+	 * @param {string} event The event name.
+	 * @param {Function} fn The event handler to add.
+	 * @param {boolean} opt_useCapture Optionally adds the even to the capture
+	 *     phase. Note: this only works in modern browsers.
+	 */
+	function addEvent(node, event, fn, opt_useCapture) {
+	  if (typeof node.addEventListener == 'function') {
+		node.addEventListener(event, fn, opt_useCapture || false);
+	  }
+	  else if (typeof node.attachEvent == 'function') {
+		node.attachEvent('on' + event, fn);
+	  }
+	}
+
+
+	/**
+	 * Removes a previously added event handler from a DOM node.
+	 * @param {Node} node The DOM node to remove the event handler from.
+	 * @param {string} event The event name.
+	 * @param {Function} fn The event handler to remove.
+	 * @param {boolean} opt_useCapture If the event handler was added with this
+	 *     flag set to true, it should be set to true here in order to remove it.
+	 */
+	function removeEvent(node, event, fn, opt_useCapture) {
+	  if (typeof node.removeEventListener == 'function') {
+		node.removeEventListener(event, fn, opt_useCapture || false);
+	  }
+	  else if (typeof node.detatchEvent == 'function') {
+		node.detatchEvent('on' + event, fn);
+	  }
+	}
+
+
+	/**
+	 * Returns the intersection between two rect objects.
+	 * @param {Object} rect1 The first rect.
+	 * @param {Object} rect2 The second rect.
+	 * @return {?Object} The intersection rect or undefined if no intersection
+	 *     is found.
+	 */
+	function computeRectIntersection(rect1, rect2) {
+	  var top = Math.max(rect1.top, rect2.top);
+	  var bottom = Math.min(rect1.bottom, rect2.bottom);
+	  var left = Math.max(rect1.left, rect2.left);
+	  var right = Math.min(rect1.right, rect2.right);
+	  var width = right - left;
+	  var height = bottom - top;
+
+	  return (width >= 0 && height >= 0) && {
+		top: top,
+		bottom: bottom,
+		left: left,
+		right: right,
+		width: width,
+		height: height
+	  };
+	}
+
+
+	/**
+	 * Shims the native getBoundingClientRect for compatibility with older IE.
+	 * @param {Element} el The element whose bounding rect to get.
+	 * @return {Object} The (possibly shimmed) rect of the element.
+	 */
+	function getBoundingClientRect(el) {
+	  var rect;
+
+	  try {
+		rect = el.getBoundingClientRect();
+	  } catch (err) {
+		// Ignore Windows 7 IE11 "Unspecified error"
+		// https://github.com/w3c/IntersectionObserver/pull/205
+	  }
+
+	  if (!rect) return getEmptyRect();
+
+	  // Older IE
+	  if (!(rect.width && rect.height)) {
+		rect = {
+		  top: rect.top,
+		  right: rect.right,
+		  bottom: rect.bottom,
+		  left: rect.left,
+		  width: rect.right - rect.left,
+		  height: rect.bottom - rect.top
+		};
+	  }
+	  return rect;
+	}
+
+
+	/**
+	 * Returns an empty rect object. An empty rect is returned when an element
+	 * is not in the DOM.
+	 * @return {Object} The empty rect.
+	 */
+	function getEmptyRect() {
+	  return {
+		top: 0,
+		bottom: 0,
+		left: 0,
+		right: 0,
+		width: 0,
+		height: 0
+	  };
+	}
+
+	/**
+	 * Checks to see if a parent element contains a child elemnt (including inside
+	 * shadow DOM).
+	 * @param {Node} parent The parent element.
+	 * @param {Node} child The child element.
+	 * @return {boolean} True if the parent node contains the child node.
+	 */
+	function containsDeep(parent, child) {
+	  var node = child;
+	  while (node) {
+		if (node == parent) return true;
+
+		node = getParentNode(node);
+	  }
+	  return false;
+	}
+
+
+	/**
+	 * Gets the parent node of an element or its host element if the parent node
+	 * is a shadow root.
+	 * @param {Node} node The node whose parent to get.
+	 * @return {Node|null} The parent node or null if no parent exists.
+	 */
+	function getParentNode(node) {
+	  var parent = node.parentNode;
+
+	  if (parent && parent.nodeType == 11 && parent.host) {
+		// If the parent is a shadow root, return the host element.
+		return parent.host;
+	  }
+	  return parent;
+	}
+
+
+	// Exposes the constructors globally.
+	window.IntersectionObserver = IntersectionObserver;
+	window.IntersectionObserverEntry = IntersectionObserverEntry;
+
+	}(window, document));
 /* jshint ignore:end */
 
 // Let's kick things off now


### PR DESCRIPTION
Fixes #8821

When we first worked on Lazy Images, we were using the W3TC IntersectionObserver polyfill, but near the end, we moved to another polyfill because the W3TC version had conflicting licenses. Specifically, in one case they were using an Apache 2.0 license which isn't GPL compatible. You can see more discussion about that in #8093.

As of https://github.com/w3c/IntersectionObserver/commit/4a9a908f88f6d38be068b9dd523f86d281c5398b and https://github.com/w3c/IntersectionObserver/commit/b025731ab0f4bdbd444ad1b0917b8d5991774548, they have updated their licenses to "W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE", which is GPL compatible!

Since this is the one being worked on by W3C, I imagine that it's the most up-to-date and well tested. Using this polyfill fixes the Twitter embed issue reported in #8821.

We should do regression testing in other browsers before shipping.

Note: This is a large PR, but it is essentially copying and pasting a new polyfill in. 😄 

To test:

- Checkout branch
- run `yarn build` to build the minified files
- Ensure that license appears in the minified lazy images JavaScript files
- Create several posts with images
- Turn lazy images on
- Ensure that images load lazily as expected
- Set `define( 'SCRIPT_DEBUG', true );` in `wp-config.php` or an integration plugin, which will use the non-minified scripts
- Ensure that images load lazily as expected