### PR TITLE
change from daily cache busting to weekly - inline with e.js

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -68,7 +68,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * Place script to call s.js, Store Analytics
 	 */
 	public function wp_head_bottom() {
-		$filename = 's-' . gmdate( 'YWd' ) . '.js';
+		$filename = 's-' . gmdate( 'YW' ) . '.js';
 		$async_code = "<script async src='https://stats.wp.com/" . $filename . "'></script>";
 		echo "$async_code\r\n";
 	}


### PR DESCRIPTION
Fixes #8898 

#### Changes proposed in this Pull Request:

* Brings the `s.js` cache busting inline with `e.js` to reduce http requests for the analytics library

#### Testing instructions:

![screen shot 2018-02-22 at 15 44 42](https://user-images.githubusercontent.com/1160732/36541685-5bb14290-17e7-11e8-8bcb-04f7be7aac12.png)


* Open Network, reload a product page and you should see a `s.js` file with a YW format like `s-201808.js`

