### PR TITLE
Sync: Remove Woo _stock* meta from whitelist

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -206,8 +206,8 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_tax_status',
 		'_tax_class',
 		'_manage_stock',
-		'_stock',
-		'_stock_status',
+//		'_stock', // Skip
+//		'_stock_status', // Skip
 		'_backorders',
 		'_sold_individually',
 		'_weight',

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -206,8 +206,6 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_tax_status',
 		'_tax_class',
 		'_manage_stock',
-//		'_stock', // Skip
-//		'_stock_status', // Skip
 		'_backorders',
 		'_sold_individually',
 		'_weight',
@@ -234,8 +232,6 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_product_image_gallery',
 		'_product_version',
 		'_wp_old_slug',
-//		'_edit_last', // Skip
-//		'_edit_lock', // Skip
 
 		//woocommerce orders
 		// https://github.com/woocommerce/woocommerce/blob/8ed6e7436ff87c2153ed30edd83c1ab8abbdd3e9/includes/data-stores/class-wc-order-data-store-cpt.php#L27
@@ -264,8 +260,6 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_shipping_country',
 		'_completed_date',
 		'_paid_date',
-		'_edit_lock',
-		'_edit_last',
 		'_cart_discount',
 		'_cart_discount_tax',
 		'_order_shipping',
@@ -295,11 +289,9 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		//woocommerce order refunds
 		// https://github.com/woocommerce/woocommerce/blob/b8a2815ae546c836467008739e7ff5150cb08e93/includes/data-stores/class-wc-order-refund-data-store-cpt.php#L20
 		'_order_currency',
-		'_cart_discount',
 		'_refund_amount',
 		'_refunded_by',
 		'_refund_reason',
-		'_cart_discount_tax',
 		'_order_shipping',
 		'_order_shipping_tax',
 		'_order_tax',


### PR DESCRIPTION
Background: p7rcWF-IV-p2

Currently there seem to be some 3rd party Woo integrations of the drop-ship variety that perform massive product/inventory updates on JP-connected sites, which result in thousands of objects being synced.

I have searched both the wpcom and calypso codebases and currently it doesn't look like we are using the `_stock` and `_stock_status` meta on the shadow site at all, so this PR removes both items from the `$wc_post_meta_whitelist`.

I opted to comment out with "skip" akin to other values in this file to show that we acknowledge the meta exists, but are purposely choosing to not have it trigger a sync.

/cc @nabsul just to verify that you aren't using these values in any of your queries