### PR TITLE
Remove outliers for mysql and ES query times

### DIFF
--- a/_inc/lib/class.jetpack-search-performance-logger.php
+++ b/_inc/lib/class.jetpack-search-performance-logger.php
@@ -36,7 +36,9 @@ class Jetpack_Search_Performance_Logger {
 	public function log_mysql_query( $found_posts, $query ) {
 		if ( $this->current_query === $query ) {
 			$duration = microtime( true ) - $this->query_started;
-			$this->record_query_time( $duration, false );
+			if ( $duration < 60 ) { // eliminate outliers, likely tracking errors
+				$this->record_query_time( $duration, false );
+			}
 			$this->reset_query_state();
 		}
 
@@ -45,7 +47,9 @@ class Jetpack_Search_Performance_Logger {
 
 	public function log_jetpack_search_query() {
 		$duration = microtime( true ) - $this->query_started;
-		$this->record_query_time( $duration, true );
+		if ( $duration < 60 ) { // eliminate outliers, likely tracking errors
+			$this->record_query_time( $duration, true );
+		}
 		$this->reset_query_state();
 	}
 


### PR DESCRIPTION
Fixes #8926

#### Changes proposed in this Pull Request:

* Only log mysql and ES query times that are less than 60 seconds. There are some outliers that mess up our stats.

#### Testing instructions:

* Open the browser's debugger tools
* Disable Search
* Run search queries, ?s=foo
* Check that your network requests include a request like `https://pixel.wp.com/boom.gif?(stuff)jetpack.search.mysql(stuff)`
* Do the same with Search enabled, and check that it logs with `jetpack.search.es` instead of `jetpack.search.mysql`

If you want to see if logging happens over the query limit, you might need to throttle your connection to public-api.wordpress.com and your local MySQL server. Instructions on how to do so are system-specific, so up to the tester.