### PR TITLE
Plans in Plugin: correctly forward the client IP for currency localization

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -357,8 +357,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	public static function get_plans( $request ) {
-		$data = get_transient( 'jetpack_plans' );
-
 		/**
 		 * Filter to turn off caching of Jetpack plans
 		 *
@@ -368,13 +366,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 		 */
 		$use_cache = apply_filters( 'jetpack_cache_plans', true );
 
+		$data = $use_cache ? get_transient( 'jetpack_plans' ) : false;
+
 		if ( false === $data ) {
 			$path = '/plans';
-			$ip   = $_SERVER['HTTP_X_FORWARDED_FOR']; // used to calculate which currency to show
-			if ( empty( $ip ) ) {
-				// no ip list to forward, so create one:
-				$ip = $_SERVER['HTTP_CLIENT_IP'];
-			}
+			// passing along from client to help geolocate currency
+			$ip   = $_SERVER['REMOTE_ADDR'];
 			$data = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );
 
 			if ( true === $use_cache ) {
@@ -703,7 +700,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		$body = wp_remote_retrieve_body( $response );
-		
+
 		return json_decode( $body );
 	}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -371,7 +371,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( false === $data ) {
 			$path = '/plans';
 			// passing along from client to help geolocate currency
-			$ip   = $_SERVER['REMOTE_ADDR'];
+			$ip = $_SERVER['HTTP_X_FORWARDED_FOR']; // if we already have an list of forwarded ips, then just use that
+			if ( empty( $ip ) ) {
+				$ip = $_SERVER['HTTP_CLIENT_IP']; // another popular one for proxy servers
+			}
+			if ( empty( $ip ) ) {
+				$ip = $_SERVER['REMOTE_ADDR']; // if we don't have an ip by now, take the closest node's ip (likely directly connected client)
+			}
 			$data = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );
 
 			if ( true === $use_cache ) {


### PR DESCRIPTION
Follows on from #8834 

#### Changes proposed in this Pull Request:

* use the correct `$_SERVER` var from the client so that the wpcom plans endpoint can guess the client's locale and localize the currencty
* correctly bypass caching when the `jetpack_cache_plans` filter returns false