### PR TITLE
Search: When disabling the search module, move any active search widgets to the inactive list.

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -186,6 +186,8 @@ class Jetpack_Search {
 		} else {
 			add_action( 'update_option', array( $this, 'track_widget_updates' ), 10, 3 );
 		}
+
+		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
 	}
 
 	/**
@@ -1747,5 +1749,47 @@ class Jetpack_Search {
 			sprintf( 'jetpack_search_widget_%s', $event['action'] ),
 			$event['widget']
 		);
+	}
+
+	/**
+	 * Moves any active search widgets to the inactive category.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $module Unused. The Jetpack module being disabled.
+	 */
+	public function move_search_widgets_to_inactive( $module ) {
+		if ( ! is_active_widget( false, false, Jetpack_Search_Helpers::FILTER_WIDGET_BASE, true ) ) {
+			return;
+		}
+
+		$sidebars_widgets = wp_get_sidebars_widgets();
+
+		if ( ! is_array( $sidebars_widgets ) ) {
+			return;
+		}
+
+		$changed = false;
+
+		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
+			if ( 'wp_inactive_widgets' === $sidebar || 'orphaned_widgets' === substr( $sidebar, 0, 16 ) ) {
+				continue;
+			}
+
+			if ( is_array( $widgets ) ) {
+				foreach ( $widgets as $key => $widget ) {
+					if ( _get_widget_id_base( $widget ) == Jetpack_Search_Helpers::FILTER_WIDGET_BASE ) {
+						$changed = true;
+
+						array_unshift( $sidebars_widgets['wp_inactive_widgets'], $widget );
+						unset( $sidebars_widgets[ $sidebar ][ $key ] );
+					}
+				}
+			}
+		}
+
+		if ( $changed ) {
+			wp_set_sidebars_widgets( $sidebars_widgets );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #8929

#### Changes proposed in this Pull Request:

Due to #8822, having the search widget active will enable the search module. This makes it impossible to disable the module while the widget is in use.

This change moves any active search widgets to the inactive list if you disable the search module.

#### Testing instructions:

1. Add the Jetpack Search widget to your sidebar. Ideally give it a custom title so you can more easily track it.
2. Disable the search module.
3. Refresh the page and verify that the search module is still disabled.
4. Visit the widgets configuration page and make sure that the widget you added in step one is now listed at the top of the inactive widgets list.