### PR TITLE
Sharing: remove LinkedIn sharing counts.

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -19,12 +19,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				}
 
 				requests = {
-					// LinkedIn actually gets the share count for both the http and https version automatically -- so we don't need to do extra magic
-					linkedin: [
-							'https://www.linkedin.com/countserv/count/share?format=jsonp&callback=updateLinkedInCount&url=' +
-							encodeURIComponent( url )
-					],
-					// Pinterest, like LinkedIn, handles share counts for both http and https
+					// Pinterest handles share counts for both http and https
 					pinterest: [
 						window.location.protocol +
 							'//api.pinterest.com/v1/urls/count.json?callback=WPCOMSharing.update_pinterest_count&url=' +
@@ -85,11 +80,6 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ permalink ], data[ url ].share.share_count );
 			}
 		},
-		update_linkedin_count : function( data ) {
-			if ( 'undefined' !== typeof data.count && ( data.count * 1 ) > 0 ) {
-				WPCOMSharing.inject_share_count( 'sharing-linkedin-' + WPCOM_sharing_counts[ data.url ], data.count );
-			}
-		},
 		update_pinterest_count : function( data ) {
 			if ( 'undefined' !== typeof data.count && ( data.count * 1 ) > 0 ) {
 				WPCOMSharing.inject_share_count( 'sharing-pinterest-' + WPCOM_sharing_counts[ data.url ], data.count );
@@ -114,10 +104,6 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		}
 	};
 }
-
-var updateLinkedInCount = function( data ) {
-	WPCOMSharing.update_linkedin_count( data );
-};
 
 (function($){
 	var $body, $sharing_email;


### PR DESCRIPTION
LinkedIn has deprecated sharing counts in their share plugin:
https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter

@see 1564-gh-jpop-issues

#### Testing instructions:

1. After setting up this branch, enable the sharing feature on your site.
2. Go to Settings > Sharing and enable the LinkedIn button as well as the Pinterest and Facebook.
3. Pick a non-official sharing style.
4. Save your changes.
5. Make sure the 3 sharing buttons work, and that sharing counts can still appear for Facebook and Pinterest.

#### Proposed changelog entry for your changes:
* Sharing: remove LinkedIn sharing count functions as [LinkedIn has deprecated sharing counts](https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter).