### PR TITLE
JPO: Delete onboarding token after connecting the site

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -130,6 +130,9 @@ class Jetpack_Client_Server {
 			return 'linked';
 		}
 
+		// If this site has been through the Jetpack Onboarding flow, delete the onboarding token
+		Jetpack::invalidate_onboarding_token();
+
 		// If redirect_uri is SSO, ensure SSO module is enabled
 		parse_str( parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
 


### PR DESCRIPTION
This PR suggests that we delete the JPO token after a successful connection.

Part of the solution for https://github.com/Automattic/wp-calypso/issues/21680. You can use in conjunction with https://github.com/Automattic/wp-calypso/pull/22763 if you want

To test:
* Start a fresh JN site with this branch on it (you can do that by loading https://jurassic.ninja/create?jetpack-beta&branch=update/delete-jpo-token-after-connecting)
* Make sure you are logged into WP.com and the Jetpack site.
* Start the onboarding flow by going to `/wp-admin/admin.php?page=jetpack&action=onboard` and get redirected to the site title step in Calypso
* Open a ssh session for the Jetpack site and verify a `wp option get jetpack_onboarding` returns the token.
* Go to https://wordpress.com/jetpack/connect/ and connect the site.
* Verify a `wp option get jetpack_onboarding` no longer returns the token.
* Start another fresh JN site with this branch on it.
* Without going to the JPO flow, connect the site.
* Verify there are no errors in the connection process and the site connects successfully.