### PR TITLE
Add flag/option for whether TOS has been agreed upon

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -53,7 +53,7 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	static function record_event( $event ) {
-		if ( ! Jetpack::is_active() ) {
+		if ( ! Jetpack::jetpack_tos_agreed() ) {
 			return false;
 		}
 		

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -53,6 +53,7 @@ class Jetpack_Options {
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
+				'tos_agreed',                   // (bool)   Whether or not the TOS for connection has been agreed upon.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -53,7 +53,7 @@ class Jetpack_Options {
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
-				'tos_agreed',                   // (bool)   Whether or not the TOS for connection has been agreed upon.
+				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 			);
 
 		case 'private' :

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -9,7 +9,7 @@ class JetpackTracking {
 	static $product_name = 'jetpack';
 
 	static function track_jetpack_usage() {
-		if ( ! Jetpack::is_active() ) {
+		if ( ! Jetpack::jetpack_tos_agreed() ) {
 			return;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3208,6 +3208,9 @@ p {
 	 * Attempts Jetpack registration.  If it fail, a state flag is set: @see ::admin_page_load()
 	 */
 	public static function try_registration() {
+		// The user has agreed to the TOS at some point by now.
+		Jetpack_Options::update_option( 'tos_agreed', true );
+
 		// Let's get some testing in beta versions and such.
 		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
 			// Before attempting to connect, let's make sure that the domains are viable.
@@ -7053,5 +7056,13 @@ p {
 			set_transient( 'jetpack_rewind_enabled', $rewind_enabled, 10 * MINUTE_IN_SECONDS );
 		}
 		return $rewind_enabled;
+	}
+
+	/**
+	 * Checks whether or not TOS has been agreed upon.
+	 * Will return true if a user has clicked to register, or is already connected.
+	 */
+	public static function jetpack_tos_agreed() {
+		return Jetpack_Options::get_option( 'tos_agreed' ) || Jetpack::is_active();
 	}
 }


### PR DESCRIPTION
This adds a Jetpack option `tos_agreed` as well as a method `Jetpack::jetpack_tos_agreed` for checking whether or not the TOS has been agreed upon.  

#8685 introduced a regression, blocking some of the Tracks events sending during the connection flow, since the tokens were not yet created, `is_active()` was not a suitable check for blocking the events from sending. 

To Test: 
- Start with a fresh site 
- Either add some error logging in `Jetpack_Tracks_Client::record_event()`, or look at the live tracks feed in mc for your username.
- Click on any of the connection buttons.  The option should have been set.  You can check with `Jetpack_Options::get_option( 'tos_agreed' );`
- You're looking for the events `jetpack_jpc_register_begin`, `jetpack_jpc_register_success` events specifically.  
- Make sure that previously connected sites are still sending tracks events. 
- Delete the plugin. The option should have been cleared along with the other Jetpack options.  