### PR TITLE
Use JS sourcemaps during development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,8 @@ const webpackConfig = {
 		'react/lib/ExecutionEnvironment': true,
 		'react/lib/ReactContext': true,
 		jsdom: 'window'
-	}
+	},
+	devtool: NODE_ENV === 'development' ? 'source-map' : false,
 };
 
 if ( NODE_ENV === 'production' ) {


### PR DESCRIPTION
It looks like maybe this used to work, but it sure makes debugging easier during development.