### PR TITLE
Remove Jumpstart reference from SEO Tools

### DIFF
--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -2,14 +2,13 @@
 /**
  * Module Name: SEO Tools
  * Module Description: Better results on search engines and social media.
- * Jumpstart Description: Better results on search engines and social media.
  * Sort Order: 35
  * Recommendation Order: 15
  * First Introduced: 4.4
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social, Appearance
- * Feature: Traffic, Jumpstart
+ * Feature: Traffic
  * Additional Search Queries: search engine optimization, social preview, meta description, custom title format
  */
 


### PR DESCRIPTION
Fixes #8693

#### Changes proposed in this Pull Request:

* Don't recommend SEO tools in Jumpstart screen
* Don't activate SEO tools by default

#### Testing instructions:

* On any connected Jetpack site
* Run `wp jetpack reset` (warning, this discards all your settings)
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Observe Jumpstart screen should not include SEO tools
* Click to activate Jumpstart
* Observe that SEO tools should not be enabled

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Remove SEO Tools from Jumpstart