### PR TITLE
Update e2e CircleCI config to use generic container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 defaults: &defaults
-    working_directory: /wp-e2e-tests
+    working_directory: ~
     docker:
-      - image: automattic/wp-e2e-tests:0.0.7
+      - image: circleci/node:8.9.4-browsers
         environment:
                 JETPACKHOST: JN
                 NODE_ENV: test
                 TARGET: JETPACK
+                E2E_BRANCH: try/generic-circleci-container
 version: 2
 jobs:
   build:
@@ -14,25 +15,24 @@ jobs:
       - run:
           name: Clone wp-e2e-tests repo
           command: |
-                  cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
-                  cd /wp-e2e-tests
+                  cd wp-e2e-tests
                   git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
-          key: << checksum "package.json" >>
-      - run: source $HOME/.nvm/nvm.sh && npm install
+          key: dependency-cache-{{ checksum "wp-e2e-tests/package.json" }}
+      - run: cd wp-e2e-tests && npm install
       - save_cache:
           paths:
-            - /wp-e2e-tests/node_modules
-          key: << checksum "package.json" >>
+            - ./wp-e2e-tests/node_modules
+          key: dependency-cache-{{ checksum "wp-e2e-tests/package.json" }}
       - run:
           name: Run Jetpack JN activation spec
           command: |
-                  source $HOME/.nvm/nvm.sh
+                  cd wp-e2e-tests
                   npm run decryptconfig
-                  xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
+                  HEADLESS=1 ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-jn-activate.js
       - persist_to_workspace:
-          root: /wp-e2e-tests
+          root: wp-e2e-tests
           paths:
             - .
       - store_test_results:
@@ -46,13 +46,13 @@ jobs:
     parallelism: 2
     steps:
       - attach_workspace:
-          at: /wp-e2e-tests
+          at: ~/wp-e2e-tests
       - run:
           name: Randomize spec execution order
           command: ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: xvfb-run ./run.sh -R -j -p
+          command: ./run.sh -R -j -p -x
       - store_test_results:
           path: reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs:
           paths:
             - .
       - store_test_results:
-          path: reports/
+          path: wp-e2e-tests/reports/
       - store_artifacts:
-          path: reports/
+          path: wp-e2e-tests/reports/
       - store_artifacts:
-          path: screenshots/
+          path: wp-e2e-tests/screenshots/
   test:
     <<: *defaults
     parallelism: 2
@@ -49,16 +49,16 @@ jobs:
           at: ~/wp-e2e-tests
       - run:
           name: Randomize spec execution order
-          command: ./scripts/randomize.sh specs
+          command: ./wp-e2e-tests/scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: ./run.sh -R -j -p -x
+          command: ./wp-e2e-tests/run.sh -R -j -p -x
       - store_test_results:
-          path: reports/
+          path: wp-e2e-tests/reports/
       - store_artifacts:
-          path: screenshots/
+          path: wp-e2e-tests/screenshots/
       - store_artifacts:
-          path: reports/
+          path: wp-e2e-tests/reports/
 workflows:
   version: 2
   build_test_destroy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ defaults: &defaults
                 JETPACKHOST: JN
                 NODE_ENV: test
                 TARGET: JETPACK
-                E2E_BRANCH: try/generic-circleci-container
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs:
           paths:
             - .
       - store_test_results:
-          path: wp-e2e-tests/reports/
+          path: ~/wp-e2e-tests/reports/
       - store_artifacts:
-          path: wp-e2e-tests/reports/
+          path: ~/wp-e2e-tests/reports/
       - store_artifacts:
-          path: wp-e2e-tests/screenshots/
+          path: ~/wp-e2e-tests/screenshots/
   test:
     <<: *defaults
     parallelism: 2
@@ -49,16 +49,16 @@ jobs:
           at: ~/wp-e2e-tests
       - run:
           name: Randomize spec execution order
-          command: cd wp-e2e-tests && ./scripts/randomize.sh specs
+          command: cd ~/wp-e2e-tests && ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: cd wp-e2e-tests && ./run.sh -R -j -p -x
+          command: cd ~/wp-e2e-tests && ./run.sh -R -j -p -x
       - store_test_results:
-          path: wp-e2e-tests/reports/
+          path: ~/wp-e2e-tests/reports/
       - store_artifacts:
-          path: wp-e2e-tests/screenshots/
+          path: ~/wp-e2e-tests/screenshots/
       - store_artifacts:
-          path: wp-e2e-tests/reports/
+          path: ~/wp-e2e-tests/reports/
 workflows:
   version: 2
   build_test_destroy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,10 @@ jobs:
           at: ~/wp-e2e-tests
       - run:
           name: Randomize spec execution order
-          command: ./wp-e2e-tests/scripts/randomize.sh specs
+          command: cd wp-e2e-tests && ./scripts/randomize.sh specs
       - run:
           name: Run e2e tests
-          command: ./wp-e2e-tests/run.sh -R -j -p -x
+          command: cd wp-e2e-tests && ./run.sh -R -j -p -x
       - store_test_results:
           path: wp-e2e-tests/reports/
       - store_artifacts:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This depends on https://github.com/Automattic/wp-e2e-tests/pull/982
* That PR moves the e2e tests from a custom Docker container to use one provided by CircleCI instead.  Details can be found on that PR. 

#### Testing instructions:

* It's unfortunately not possible to trigger a CircleCI Workflow build via API, so the only way to test this ahead of time is to set the `E2E_BRANCH` envvar to `try/generic-circleci-container` (the branch from the wp-e2e-tests PR above) in the CircleCI UI and trigger a rebuild of the last workflow.

Note that this PR runs Chrome Headless rather than using xvfb as we were previously.  The last time we turned that feature on there were a lot of unexplained timeout failures, but as best I can tell at the moment that's no longer an issue.  But it's something to watch out for when this is merged just in case.

cc: @Automattic/flowpatrol 