### PR TITLE
Ads: Adding site id to head meta

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -180,9 +180,10 @@ class WordAds {
 		$themename = esc_js( get_stylesheet() );
 		$pagetype = intval( $this->params->get_page_type_ipw() );
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
+		$site_id = $this->params->blog_id;
 		echo <<<HTML
 		<script$data_tags type="text/javascript">
-			var __ATA_PP = { pt: $pagetype, ht: 2, tn: '$themename', amp: false };
+			var __ATA_PP = { pt: $pagetype, ht: 2, tn: '$themename', amp: false, siteid: $site_id };
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};


### PR DESCRIPTION
Adding blog/site id to IPW metadata in head.

**To Test**
1. Enable Jetpack Ads module
1. Go to any page with ads, view source, and check that `siteid` with site's blog_id is added in `__ATA_PP` object.

e.g.
<img width="653" alt="screen shot 2018-02-27 at 4 28 19 pm" src="https://user-images.githubusercontent.com/273708/36763076-4947f3a4-1bdb-11e8-8e47-32e2a14d247c.png">
