### PR TITLE
Add search to the Professional plan warm welcome

### DIFF
--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -21,6 +21,7 @@ class WelcomeProfessional extends Component {
 		// Preparing event handlers once to avoid calling bind on every render
 		this.clickCtaDismissThemes = this.clickCtaDismiss.bind( this, 'themes' );
 		this.clickCtaDismissAds = this.clickCtaDismiss.bind( this, 'ads' );
+		this.clickCtaDismissSearch = this.clickCtaDismiss.bind( this, 'search' );
 		this.clickCtaDismissSeo = this.clickCtaDismiss.bind( this, 'seo' );
 	}
 
@@ -44,7 +45,7 @@ class WelcomeProfessional extends Component {
 			<div>
 				<p>
 					{ __( 'Thanks for choosing Jetpack Professional. Jetpack is now backing up your content in real-time,' +
-						' scanning for security threats, and granting access to premium themes.'
+						' indexing your content for search, scanning for security threats, and granting access to premium themes.'
 					) }
 				</p>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
@@ -53,6 +54,9 @@ class WelcomeProfessional extends Component {
 						' WordPress themes, including more than 200 premium themes. Customize your content with a variety of ' +
 						'widgets, or add unlimited videos to your posts and pages -- displayed free of ads or watermarks.'
 					) }
+				</p>
+				<p>
+					{ __( "Give your visitor's a great search experience by letting them filter and sort fast, relevant search results." ) }
 				</p>
 				<img src={ imagePath + 'wordads.svg' } className="jp-welcome__svg" alt={ __( 'Sharing' ) } />
 				<p>
@@ -93,6 +97,14 @@ class WelcomeProfessional extends Component {
 					onClick={ this.clickCtaDismissAds }
 				>
 					{ __( 'Monetize your site with ads' ) }
+				</Card>
+				<Card
+					href={ 'customize.php?autofocus[panel]=widgets' }
+					compact
+					className="jp-dialogue-card__below"
+					onClick={ this.clickCtaDismissSearch }
+				>
+					{ __( 'Add the Search (Jetpack) widget to your sidebar' ) }
 				</Card>
 				<Card
 					href={ '#/traffic' }


### PR DESCRIPTION
Fixes #8694.

#### Changes proposed in this Pull Request:

https://github.com/Automattic/jetpack/issues/8694#issuecomment-368961905

![2018-02-27_19-27-52](https://user-images.githubusercontent.com/406254/36768504-6f08ad04-1bf4-11e8-9693-d273e9b23281.png)

#### Testing instructions:

1. Comment out this `return` to get the dialog to show up: https://github.com/Automattic/jetpack/blob/master/_inc/client/components/welcome-new-plan/index.jsx#L50
2. Run `yarn build` to build a fresh set of the JavaScript app.
3. Visit the Jetpack dashboard in `wp-admin` on a site that has the Professional plan. Check out the updated dialog box.
4. Verify that the new link at the bottom takes you to the Customizer's widget section.
5. Verify that the Tracks event triggers when you click on that new link.