### PR TITLE
Ignore yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log
 tests/php/files/jetpack-150x150.jpg
 *.unison.tmp
 .eslintcache
+yarn-error.log
 
 ## Things we will need in release branches
 /_inc/build


### PR DESCRIPTION
Newer versions of Yarn product yarn-error.log. We don't want anyone to accidentally commit this. This change ignores it using .gitignore.
