### PR TITLE
Fix where if a user isn't logged into wpcom, go to blank screen

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -192,7 +192,7 @@ class PlanGrid extends React.Component {
 			const isActivePlan = this.isCurrentPlanType( planType );
 			const url = isActivePlan
 				? `https://wordpress.com/plans/my-plan/${ this.props.siteRawUrl }`
-				: `https://wordpress.com/checkout/${ this.props.siteRawUrl }/${ planType === 'personal' ? 'jetpack-personal' : planType }`;
+				: `https://jetpack.com/redirect/?source=plans-${ planType }&site=${ this.props.siteRawUrl }&u=${ this.props.userId }`;
 			const isPrimary = this.isPrimary( planType, plan );
 			const className = classNames(
 				'plan-features__table-item',
@@ -253,7 +253,7 @@ class PlanGrid extends React.Component {
 	 */
 	renderBottomButtons() {
 		return map( this.getPlans(), ( plan, planType ) => {
-			const url = `https://jetpack.com/features/comparison/?site=${ this.props.siteRawUrl }`;
+			const url = `https://jetpack.com/redirect/?source=plans-learn-more&site=${ this.props.siteRawUrl }&u=${ this.props.userId }`;
 			return (
 				<td key={ 'bottom-' + planType } className="plan-features__table-item is-bottom-buttons has-border-bottom">
 					<Button href={ url }>{ plan.strings.see_all }</Button>
@@ -331,7 +331,7 @@ class PlanGrid extends React.Component {
 			} );
 		};
 		return (
-			<a onClick={ clickHandler } href={ 'https://jetpack.com/features/' + feature.info }>{ feature.name }</a>
+			<a onClick={ clickHandler } href={ `https://jetpack.com/features/${ feature.info }?site=${ this.props.siteRawUrl }&u=${ this.props.userId }` }>{ feature.name }</a>
 		);
 	}
 

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -12,7 +12,7 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { getSiteRawUrl } from 'state/initial-state';
+import { getSiteRawUrl, getUserId } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
 import analytics from 'lib/analytics';
 import { getPlanClass } from 'lib/plans/constants';
@@ -341,6 +341,7 @@ export default connect( ( state ) => {
 	return {
 		plans: getAvailablePlans( state ),
 		siteRawUrl: getSiteRawUrl( state ),
-		sitePlan: getSitePlan( state )
+		sitePlan: getSitePlan( state ),
+		userId: getUserId( state ),
 	};
 }, null, )( PlanGrid );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -134,6 +134,15 @@ export function getUsername( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'username' ] );
 }
 
+/**
+ * Gets the current wp-admin user id
+ * @param {Object} state Global state tree
+ * @returns {int} The user id in wp-admin
+ */
+export function getUserId( state ) {
+    return get( state.jetpack.initialState.userData.currentUser, 'id' );
+}
+
 export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
 }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -140,7 +140,7 @@ export function getUsername( state ) {
  * @returns {int} The user id in wp-admin
  */
 export function getUserId( state ) {
-    return get( state.jetpack.initialState.userData.currentUser, 'id' );
+	return get( state.jetpack.initialState.userData.currentUser, 'id' );
 }
 
 export function userCanViewStats( state ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -393,6 +393,7 @@ function jetpack_current_user_data() {
 		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),
 		'isMaster'    => $is_master_user,
 		'username'    => $current_user->user_login,
+		'id'          => $current_user->ID,
 		'wpcomUser'   => $dotcom_data,
 		'gravatar'    => get_avatar( $current_user->ID, 40, 'mm', '', array( 'force_display' => true ) ),
 		'permissions' => array(


### PR DESCRIPTION
When viewing the plans page, it is possible to be logged out of wpcom, this makes sure they go to the right flow depending on whether they're logged in or not by using the jetpack redirector.

Due to https://github.com/Automattic/wp-calypso/issues/22857, we need to control the final destination of these links without requiring a jetpack release.

#### Changes proposed in this Pull Request:

* Adds the wp-admin user id to the redux state tree
* Adds a reducer to retrieve the wp-admin user id
* Sends the wp-admin user id to the destination (so tracks aliasing works correctly)
* Links go to the jetpack redirector where it makes sense so they go to the right place

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* View plans page with a free plan
* Open links in new tab to various plans while logged into wpcom, see items auto-added to cart
* Open links in new incognito window to various plans, enter connection flow (plans flow is broken https://github.com/Automattic/wp-calypso/issues/22857)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
