### PR TITLE
Add markdown support for bbpress CPTs

### DIFF
--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -15,6 +15,18 @@ function jetpack_bbpress_compat() {
 	}
 
 	/**
+	 * Enable Markdown support for bbpress post types.
+	 *
+	 * @author Brandon Kraft
+	 * @since 6.0.0
+	 */
+	 if ( function_exists( 'bbp_get_topic_post_type' ) ) {
+		 add_post_type_support( bbp_get_topic_post_type(), 'wpcom-markdown' );
+		 add_post_type_support( bbp_get_reply_post_type(), 'wpcom-markdown' );
+		 add_post_type_support( bbp_get_forum_post_type(), 'wpcom-markdown' );
+	 }
+
+	/**
 	 * Use Photon for all images in Topics and replies.
 	 *
 	 * @since 4.9.0


### PR DESCRIPTION
Fixes #8952 . Docblock for 6.0 since we're past 5.9 code freeze.

#### Changes proposed in this Pull Request:

* Add markdown support for bbPress CPTs

#### Testing instructions:

* Enable bbPress, Jetpack, Jetpack's Markdown feature
* While editing a topic/forum/reply, use Markdown (e.g. underscores wrapping a word).

Expected: Content is transformed (e.g. the text becomes italics).

#### Proposed changelog entry for your changes:
Enhancement: Markdown support added for bbPress CPTs.