### PR TITLE
Publicize: remove cursor css property from publicize disconnect button

### DIFF
--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -109,7 +109,6 @@ div.publicize-service-right li {
 	border-top-style: none;
 	border-top-width: 0px;
 	color: #CCC;
-	cursor: auto;
 	display: inline;
 	font-size: 20px;
 	font-style: normal;

--- a/modules/publicize/assets/rtl/publicize-rtl.css
+++ b/modules/publicize/assets/rtl/publicize-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Jan 15 2014 20:27:52 */
+/* This file was automatically generated on Mar 01 2018 13:02:41 */
 
 div#publicize-services-block {
 	display: block;
@@ -111,7 +111,6 @@ div.publicize-service-right li {
 	border-top-style: none;
 	border-top-width: 0px;
 	color: #CCC;
-	cursor: auto;
 	display: inline;
 	font-family: sans-serif;
 	font-size: 20px;

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -86,9 +86,9 @@ class Publicize_UI {
 			'20121019'
 		);
 		if( is_rtl() ) {
-			wp_enqueue_style( 'publicize', plugins_url( 'assets/rtl/publicize-rtl.css', __FILE__ ), array(), '20120925' );
+			wp_enqueue_style( 'publicize', plugins_url( 'assets/rtl/publicize-rtl.css', __FILE__ ), array(), '20180301' );
 		} else {
-			wp_enqueue_style( 'publicize', plugins_url( 'assets/publicize.css', __FILE__ ), array(), '20120925' );
+			wp_enqueue_style( 'publicize', plugins_url( 'assets/publicize.css', __FILE__ ), array(), '20180301' );
 		}
 
 


### PR DESCRIPTION
The publicize disconnect buttons on the Sharing page currently have a cursor css property with a value auto applied, which probably wasn't intended. When properly implemented by the browser vendor (like in a release version of Firefox or Chrome 63+), cursor: auto on a text link must display the so called text selection cursor according to the CSS specification.

Additional reading (incl. comments by some browser vendors): https://github.com/w3c/csswg-drafts/issues/1598
Official CSS test: https://test.csswg.org/harness/test/css-ui-3_dev/single/cursor-auto-002/format/html5/

#### Changes proposed in this Pull Request:

* Remove the cursor css property for the publicize disconnect buttons in the publicize.css and publicize-rtl.css files.

#### Testing instructions:

* Compare the cursor when hovering a publicize disconnect button in Firefox or Chrome 63+ and any other browser (or older version of Chrome) - with and without this patch. Don't forget to bump the version number of the css files.

* Screenshot of the current state:
![sharing-close-button-firefox](https://user-images.githubusercontent.com/19647328/36844854-9fae5eca-1d54-11e8-9d6d-b5c032e2174a.png)

