### PR TITLE
Position Jumpstart dialog close button same as upgrade dialog close button

### DIFF
--- a/_inc/client/components/jetpack-dialogue/index.jsx
+++ b/_inc/client/components/jetpack-dialogue/index.jsx
@@ -44,8 +44,8 @@ class JetpackDialogue extends Component {
 		);
 		return (
 			<div className="jp-dialogue-full__container" role="dialog" onClick={ this.maybeDismiss } onKeyDown={ onKeyDownCallback( this.maybeDismiss ) }>
-				<img src={ imagePath + 'stars-full.svg' } width="60" height="60" alt={ __( 'Stars' ) } className="jp-jumpstart-full__svg-stars" />
-				<img src={ imagePath + 'jupiter.svg' } width="50" height="100" alt={ __( 'Jupiter' ) } className="jp-jumpstart-full__svg-jupiter" />
+				<img src={ imagePath + 'stars-full.svg' } width="60" height="60" alt={ __( 'Stars' ) } className="jp-dialogue-full__svg-stars" />
+				<img src={ imagePath + 'jupiter.svg' } width="50" height="100" alt={ __( 'Jupiter' ) } className="jp-dialogue-full__svg-jupiter" />
 
 				<div className={ classes } role="dialog" onClick={ this.clickForeground } onKeyDown={ onKeyDownCallback( this.clickForeground ) }>
 					{ this.props.svg }

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -4,10 +4,8 @@
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Card from 'components/card';
 import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -18,8 +16,8 @@ import {
 	isJumpstarting as _isJumpstarting
 } from 'state/jumpstart';
 import { getModulesByFeature as _getModulesByFeature } from 'state/modules';
-import onKeyDownCallback from 'utils/onkeydown-callback';
 import { imagePath } from 'constants/urls';
+import JetpackDialogue from 'components/jetpack-dialogue';
 
 class JumpStart extends React.Component {
 	static displayName = 'JumpStart';
@@ -34,7 +32,7 @@ class JumpStart extends React.Component {
 		</Button>;
 	};
 
-	render() {
+	renderInnerContent() {
 		/* eslint-disable react/no-danger */
 		const jumpstartModules = this.props.jumpstartFeatures.map( ( module ) => (
 			<div
@@ -51,52 +49,44 @@ class JumpStart extends React.Component {
 			</div>
 		) );
 		/* eslint-enable react/no-danger */
+
 		return (
-			<div className="jp-jumpstart-full__container">
-				<img src={ imagePath + 'stars-full.svg' } width="60" height="60" alt={ __( 'Stars' ) } className="jp-jumpstart-full__svg-stars" />
-				<img src={ imagePath + 'jupiter.svg' } width="50" height="100" alt={ __( 'Jupiter' ) } className="jp-jumpstart-full__svg-jupiter" />
-				<Gridicon
-					icon="cross-small"
-					className="jp-jumpstart-full__dismiss"
-					tabIndex="0"
-					onKeyDown={ onKeyDownCallback( this.props.jumpStartSkip ) }
-					onClick={ this.props.jumpStartSkip }
-				/>
+			<div className="jp-jumpstart">
+				<p>
+					{ __( "We're now collecting stats, securing your site, and speeding up your images. Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard." ) }
+				</p>
 
-				<div className="jp-jumpstart">
-					<img src={ imagePath + 'man-and-laptop.svg' } width="199" height="153" alt={ __( 'Person with laptop' ) } />
+				<p>
+					{ this.activateButton() }
+				</p>
 
-					<h1 className="jp-jumpstart__title">
-						{ __( 'Your Jetpack site is ready to go!' ) }
-					</h1>
+				<p>
+					<h2 className="jp-jumpstart__feature-heading">
+						{ __( "Jetpack's recommended features include:" ) }
+					</h2>
 
-					<Card className="jp-jumpstart__description">
-						<p>
-							{ __( "We're now collecting stats, securing your site, and speeding up your images. Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard." ) }
-						</p>
-					</Card>
+					<div className="jp-jumpstart__feature-list">
+						{ jumpstartModules }
+					</div>
 
-					<Card>
-						{ this.activateButton() }
-					</Card>
+					{ this.activateButton() }
 
-					<Card>
-						<h2 className="jp-jumpstart__feature-heading">
-							{ __( "Jetpack's recommended features include:" ) }
-						</h2>
-
-						<div className="jp-jumpstart__feature-list">
-							{ jumpstartModules }
-						</div>
-
-						{ this.activateButton() }
-
-						<p className="jp-jumpstart__note">
-							{ __( 'Features can be activated or deactivated at any time.' ) }
-						</p>
-					</Card>
-				</div>
+					<p className="jp-jumpstart__note">
+						{ __( 'Features can be activated or deactivated at any time.' ) }
+					</p>
+				</p>
 			</div>
+		);
+	}
+
+	render() {
+		return (
+			<JetpackDialogue
+				svg={ <img src={ imagePath + 'man-and-laptop.svg' } width="199" height="153" alt={ __( 'Person with laptop' ) } /> }
+				title={ __( 'Your Jetpack site is ready to go!' ) }
+				content={ this.renderInnerContent() }
+				dismiss={ this.props.jumpStartSkip }
+			/>
 		);
 	}
 }

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -1,15 +1,4 @@
-.jp-jumpstart-full__container {
-	box-sizing: border-box;
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	z-index: 100; // to sit over other elements
-	background: rgba($gray-light, .95);
-	text-align: center;
-	padding: rem( 32px );
-}
+
 
 .jp-jumpstart {
 	text-align: center;
@@ -19,17 +8,6 @@
 	@include breakpoint( "<660px" ) {
 		text-align: left;
 	}
-}
-
-.jp-jumpstart-full__dismiss {
-	cursor: pointer;
-	position: absolute;
-	right: 0;
-	top: 0;
-	fill: $gray;
-	padding: rem( 16px );
-	height: rem( 24px );
-	width: rem( 24px );
 }
 
 .jp-jumpstart__cta-container {
@@ -160,19 +138,4 @@
 	font-size: rem( 14px );
 	clear: both;
 	font-style: italic;
-}
-
-// Planet + star svgs for decoration only
-.jp-jumpstart-full__svg-jupiter {
-	position: absolute;
-	right: 0;
-	top: rem( 80px );
-	opacity: .90;
-}
-
-.jp-jumpstart-full__svg-stars {
-	position: absolute;
-	left: rem( 100px );
-	top: rem( 100px );
-	opacity: .90;
 }

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -163,7 +163,6 @@ function jetpack_get_module_i18n( $key ) {
 			'seo-tools' => array(
 				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'sharedaddy' => array(


### PR DESCRIPTION
Fixes #7666 and #8744

#### Changes proposed in this Pull Request:

* Move close button into Jumpstart dialog, as per #8697, by reusing the same Jetpack Dialogue component
* Fix some existing bugs with missing CSS on dialogue background.

#### Important design note

Because this page now reuses the Jetpack Dialogue component that powers other modals, it doesn't have the gap between the top two cards. 

This could be implemented by making the Dialogue component transparent, and requiring wrapped components to implement cards where they want translucency. I didn't do this because I wasn't sure if anyone cared either way. Let me know if you need this refinement.

#### Testing instructions:

* On a Jetpack site that is already connected
* Open `wp shell` and run `Jetpack_Options::update_option( 'jumpstart', 'new_connection' )`
* Open `/wp-admin/admin.php?page=jetpack#/jumpstart`
* Dialog should have close button inside dialog frame; hitting `esc`, clicking background, or clicking close button should all close the dialog.
* Dialog should also work properly with assistive devices/programs like screen readers.

#### Screenshot

Before:

![jumpstart-before](https://user-images.githubusercontent.com/51896/36869609-3dca8c90-1d51-11e8-9eb0-ff93629ea773.jpg)

After:

<img width="1679" alt="jumpstart-after" src="https://user-images.githubusercontent.com/51896/36869618-43bf20e8-1d51-11e8-87ef-c10734036bc4.png">

After, mobile (Pixel XL):

![screenshot_20180301-160433](https://user-images.githubusercontent.com/51896/36876618-b5791a54-1d6a-11e8-8856-980088d52028.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
