### PR TITLE
Default to grid view when uploading videos

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -271,7 +271,7 @@ class PlanBody extends React.Component {
 								<p>{ __( 'Fast, optimized, ad-free, and unlimited video hosting for your site.' ) }</p>
 								{
 									this.props.isModuleActivated( 'videopress' ) ? (
-										<Button onClick={ () => this.trackPlansClick( 'upload_videos' ) } href={ this.props.siteAdminUrl + 'upload.php' } className="is-primary">
+										<Button onClick={ () => this.trackPlansClick( 'upload_videos' ) } href={ this.props.siteAdminUrl + 'upload.php?mode=grid' } className="is-primary">
 											{ __( 'Upload Videos Now' ) }
 										</Button>
 									)

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -163,7 +163,6 @@ function jetpack_get_module_i18n( $key ) {
 			'seo-tools' => array(
 				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'sharedaddy' => array(

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -163,6 +163,7 @@ function jetpack_get_module_i18n( $key ) {
 			'seo-tools' => array(
 				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'sharedaddy' => array(


### PR DESCRIPTION
Fixes #6111

#### Changes proposed in this Pull Request:

* Default to grid view when linking to upload videos

#### Testing instructions:

* Activate Pro plan
* Activate VaultPress
* Go to plans description page from dashboard
* Click "Upload Videos" link
* Link should be `/wp-admin/upload.php?mode=grid`, and displayed in grid mode