### PR TITLE
Search: Keep the posts in the order that ES returns them to us in.

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -474,19 +474,12 @@ class Jetpack_Search {
 		// Query all posts now
 		$args = array(
 			'post__in'            => $post_ids,
+			'orderby'             => 'post__in',
 			'perm'                => 'readable',
 			'post_type'           => 'any',
 			'ignore_sticky_posts' => true,
 			'suppress_filters'    => true,
 		);
-
-		if ( isset( $query->query_vars['order'] ) ) {
-			$args['order'] = $query->query_vars['order'];
-		}
-
-		if ( isset( $query->query_vars['orderby'] ) ) {
-			$args['orderby'] = $query->query_vars['orderby'];
-		}
 
 		$posts_query = new WP_Query( $args );
 


### PR DESCRIPTION
I have no idea how we missed this but we were having WordPress re-sort the search results instead of relying on Elasticsearch's ordering.

This means that we were getting the most relevant search results per page (as intended) but the individual posts weren't sorted by relevance too. 🤦‍♂️ 

#### Testing instructions:

1. Install the plugin [Query Monitor](https://wordpress.org/plugins/query-monitor/) or Debug Bar.
2. Search for something.
3. Verify that the posts displayed are in the same order as they appear in the ES response (you can find that in the debug panel in your admin bar). To easily find the IDs of the displayed posts, I tend to use the edit post links (the ID is in there).
4. You can also look at the query section and make sure `ORDER BY FIELD` is in the query.