### PR TITLE
Plans: don't hide on small screens

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -41,6 +41,11 @@ class PlanGrid extends React.Component {
 
 		return (
 			<div className="plan-features">
+				<div className="plans-mobile-notice dops-card">
+					<h2>Your plan</h2>
+					<p>You're currently on the Jetpack [plan name].</p>
+					<a href="https://wordpress.com/plans" className="dops-button">Manage your plan</a> <a href="https://wordpress.com/plans" className="dops-button is-primary">View all Jetpack plans</a>
+				</div>
 				<div className="plan-features__content">
 					<table className={ tableClasses }>
 						<tbody>

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -16,6 +16,7 @@ import { getSiteRawUrl } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
 import analytics from 'lib/analytics';
 import { getPlanClass } from 'lib/plans/constants';
+import { translate as __ } from 'i18n-calypso';
 
 class PlanGrid extends React.Component {
 
@@ -41,11 +42,7 @@ class PlanGrid extends React.Component {
 
 		return (
 			<div className="plan-features">
-				<div className="plans-mobile-notice dops-card">
-					<h2>Your plan</h2>
-					<p>You're currently on the Jetpack [plan name].</p>
-					<a href="https://wordpress.com/plans" className="dops-button">Manage your plan</a> <a href="https://wordpress.com/plans" className="dops-button is-primary">View all Jetpack plans</a>
-				</div>
+				{ this.renderMobileCard() }
 				<div className="plan-features__content">
 					<table className={ tableClasses }>
 						<tbody>
@@ -57,6 +54,27 @@ class PlanGrid extends React.Component {
 						</tbody>
 					</table>
 				</div>
+			</div>
+		);
+	}
+
+	renderMobileCard() {
+		const currently = __( 'You’re currently on Jetpack %(plan)s.', {
+			args: { plan: this.props.sitePlan.product_name_short }
+		} );
+		const myPlanUrl = `https://wordpress.com/plans/my-plan/${ this.props.siteRawUrl }`;
+		const plansUrl = `https://wordpress.com/plans/${ this.props.siteRawUrl }`;
+
+		return (
+			<div className="plans-mobile-notice dops-card">
+				<h2>{ __( 'Your Plan' ) }</h2>
+				<p>{ currently }</p>
+				<Button href={ myPlanUrl }>
+					{ __( 'Manage your plan' ) }
+				</Button>
+				<Button href={ plansUrl } primary>
+					{ __( 'View all Jetpack plans' ) }
+				</Button>
 			</div>
 		);
 	}

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -9,6 +9,16 @@
 	}
 }
 
+.plans-mobile-notice {
+	@include breakpoint( ">660px" ) {
+		display: none;
+	}
+}
+
+.plans-mobile-notice.dops-card h2 {
+	margin-top: 0;
+}
+
 .jp-landing-plans__header {
 	background: $gray-dark;
 
@@ -303,6 +313,10 @@ $plan-features-sidebar-width: 272px;
 
 	@include breakpoint( ">660px" ) {
 		display: table;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: none;
 	}
 
 	@include breakpoint( "<1040px" ) {

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -13,6 +13,10 @@
 	@include breakpoint( ">660px" ) {
 		display: none;
 	}
+	.dops-button:first-of-type {
+		margin-right: 6px;
+		margin-bottom: 6px;
+	}
 }
 
 .plans-mobile-notice.dops-card h2 {

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -287,61 +287,8 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__mobile {
-	color: $gray-text-min;
-	margin: 0 16px;
-	display: block;
-
-	@include breakpoint( ">660px" ) {
-		display: none;
-	}
-
-	.foldable-card {
-		box-shadow: none;
-	}
-
-	.foldable-card.card.is-expanded { //original rule has this specificity
-		margin: 0;
-	}
-
-	.foldable-card.is-expanded .foldable-card__content { //original rule has this specificity
-		padding: 0;
-	}
-
-	.plan-features__header-banner {
-		display: none;
-	}
-
-	.plan-features__item {
-		border-bottom: solid 1px lighten( $gray, 27% );
-		font-size: 14px;
-	}
-
-	.plan-features__item:last-child {
-		border-bottom: none;
-	}
-}
-
-.plan-features__mobile .plan-features__header .plan-features__header-figure,
-.plan-features__table.has-1-cols .plan-features__header-figure,
-.plan-features__table.has-2-cols .plan-features__header-figure {
-	display: block;
-	width: 50px;
-	height: 50px;
-}
-
-.plan-features__mobile-plan {
-	font-size: 14px;
-	border: solid 1px lighten( $gray, 27% );
-	background-color: $white;
-	margin-bottom: 24px;
-}
-
 .is-section-plans .plan-features__table {
-	display: none;
-	@media ( min-width: $plan-features-sidebar-width + 480px ) {
-		display: table;
-	}
+	display: table;
 }
 
 .plan-features__table {
@@ -349,7 +296,7 @@ $plan-features-sidebar-width: 272px;
 	color: $gray-text-min;
 	border-spacing: 16px 0;
 	margin-top: -16px;
-	display: none;
+	display: table;
 	table-layout: fixed;
 	width: 100%;
 	text-align: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* don't hide the plans table on small screens

#### Testing instructions:

View the Plans tab on a screen smaller than 600px wide. Before this PR, the table will be hidden. After, it shows.

It does look bad on very small screens, and we should plan to bring over the plans cards view from Calypso in the next release.