### PR TITLE
Content Options: Add a check for WooCommerce Shop page in order to exclude it from the is_archive check

### DIFF
--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -14,6 +14,7 @@ function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $
 	if (
 		( true === $opts['archive']
 			&& ( is_home() || is_archive() || is_search() )
+			&& ! jetpack_is_shop_page()
 			&& ! $opts['archive-option']
 			&& ( isset( $meta_key )
 			&& '_thumbnail_id' === $meta_key )
@@ -56,4 +57,23 @@ add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail'
  */
 function jetpack_is_product() {
 	return ( function_exists( 'is_product' ) ) ? is_product() : false;
+}
+
+/**
+ * Check if we are on a WooCommerce Shop in order to exclude it from the is_archive check.
+ */
+function jetpack_is_shop_page() {
+	global $wp_query;
+
+	$front_page_id        = get_option( 'page_on_front' );
+	$current_page_id      = $wp_query->get( 'page_id' );
+	$is_static_front_page = 'page' === get_option( 'show_on_front' );
+
+	if ( $is_static_front_page && $front_page_id === $current_page_id  ) {
+		$is_shop_page = ( $current_page_id === wc_get_page_id( 'shop' ) ) ? true : false;
+	} else {
+		$is_shop_page = is_shop();
+	}
+
+	return $is_shop_page;
 }

--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -60,9 +60,14 @@ function jetpack_is_product() {
 }
 
 /**
- * Check if we are on a WooCommerce Shop in order to exclude it from the is_archive check.
+ * Check if we are in a WooCommerce Shop in order to exclude it from the is_archive check.
  */
 function jetpack_is_shop_page() {
+	// Check if WooCommerce is active first.
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		return false;
+	}
+
 	global $wp_query;
 
 	$front_page_id        = get_option( 'page_on_front' );


### PR DESCRIPTION
Fixes #8835.

#### Changes proposed in this Pull Request:

* Added a function that checks if WooCommerce Shop page is being displayed. It's a copy of a function we include in our WooCommerce compatible themes.

### Testing:
1. Activate a theme that supports Content Options, for example Lodestar or Shoreditch.
2. Activate WooCommerce and add a few products.
3. Go to Customizer > Content Options and make sure "Display on blog and archives" under Featured Images is checked.
4. Visit Shop page - the product images should be visible. Visit blog page - the featured images should be visible.
5. Go to Customizer > Content Options and uncheck "Display on blog and archives" under Featured.
6. Visit Shop page - the product images should be visible. Visit blog page - the featured images should not be visible.
7. Deactivate WooCommerce and check if Content Options are working as expected, and there aren't any errors or warnings.