### PR TITLE
Remove/account creation links

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -69,6 +69,7 @@ export class ConnectButton extends React.Component {
 					<a
 						role="button"
 						tabIndex="0"
+						className="jp-jetpack-unlink__button"
 						onKeyDown={ onKeyDownCallback( this.props.unlinkUser ) }
 						onClick={ this.props.unlinkUser }
 						disabled={ this.props.isUnlinking } >

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -137,7 +137,7 @@ export class ConnectButton extends React.Component {
 				{ ! this.props.isSiteConnected &&
 					<p className="jp-banner__tos-blurb">
 					{ __(
-						'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
+						'By connecting your site you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
 						{
 							components: {
 								tosLink: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank" />,

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -134,8 +134,6 @@ export class ConnectButton extends React.Component {
 	render() {
 		return (
 			<div>
-				{ this.renderContent() }
-				{ this.props.children }
 				{ ! this.props.isSiteConnected &&
 					<p className="jp-banner__tos-blurb">
 					{ __(
@@ -149,6 +147,8 @@ export class ConnectButton extends React.Component {
 					) }
 					</p>
 				}
+				{ this.renderContent() }
+				{ this.props.children }
 				<JetpackDisconnectDialog
 					show={ this.state.showModal }
 					toggleModal={ this.toggleVisibility }

--- a/_inc/client/components/connect-button/style.scss
+++ b/_inc/client/components/connect-button/style.scss
@@ -9,10 +9,6 @@
 	border-color: $green-secondary;
 	color: $white;
 
-	&.dops-button {
-		margin-top: 20px;
-	}
-	
 	&:hover, &:focus {
 		background: $green-secondary;
 		border-color: $green-dark;

--- a/_inc/client/components/connect-button/style.scss
+++ b/_inc/client/components/connect-button/style.scss
@@ -9,6 +9,10 @@
 	border-color: $green-secondary;
 	color: $white;
 
+	&.dops-button {
+		margin-top: 20px;
+	}
+	
 	&:hover, &:focus {
 		background: $green-secondary;
 		border-color: $green-dark;

--- a/_inc/client/components/connect-button/test/component.js
+++ b/_inc/client/components/connect-button/test/component.js
@@ -64,15 +64,15 @@ describe( 'ConnectButton', () => {
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
 		it( 'does not link to a URL', () => {
-			expect( wrapper.find( 'a' ).first().props().href ).to.not.exist;
+			expect( wrapper.find( 'a.jp-jetpack-unlink__button' ).first().props().href ).to.not.exist;
 		} );
 
 		it( 'has an onClick method', () => {
-			expect( wrapper.find( 'a' ).first().props().onClick ).to.exist;
+			expect( wrapper.find( 'a.jp-jetpack-unlink__button' ).first().props().onClick ).to.exist;
 		} );
 
 		it( 'when clicked, unlinkUser() is called once', () => {
-			wrapper.find( 'a' ).first().simulate( 'click' );
+			wrapper.find( 'a.jp-jetpack-unlink__button' ).first().simulate( 'click' );
 			expect( unlinkUser.calledOnce ).to.be.true;
 		} );
 

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -17,8 +17,6 @@ class JetpackConnect extends React.Component {
 	static displayName = 'JetpackConnect';
 
 	render() {
-		const newAccountUrl = this.props.connectUrl + '&from=new-account-button';
-
 		return (
 			<div className="jp-jetpack-connect__container">
 				<h1 className="jp-jetpack-connect__container-title" title="Welcome to Jetpack">

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -29,13 +29,7 @@ class JetpackConnect extends React.Component {
 					<p className="jp-jetpack-connect__description">
 						{ __( 'Hassle-free design, marketing, and security for your WordPress site. Connect Jetpack to a WordPress.com account to start building your own success story.' ) }
 					</p>
-					<ConnectButton from="landing-page-top">
-						<p>
-							<a href={ newAccountUrl } className="jp-jetpack-connect__link">
-								{ __( 'No account? Create one for free.' ) }
-							</a>
-						</p>
-					</ConnectButton>
+					<ConnectButton from="landing-page-top"></ConnectButton>
 				</Card>
 
 				<Card className="jp-jetpack-connect__feature jp-jetpack-connect__design">
@@ -217,13 +211,7 @@ class JetpackConnect extends React.Component {
 							'We\'re passionate about WordPress and here to make your life easier.'
 						) }
 					</p>
-					<ConnectButton from="landing-page-bottom">
-						<p>
-							<a href={ newAccountUrl } className="jp-jetpack-connect__link">
-								{ __( 'No account? Create one for free.' ) }
-							</a>
-						</p>
-					</ConnectButton>
+					<ConnectButton from="landing-page-bottom"></ConnectButton>
 				</Card>
 			</div>
 		);

--- a/_inc/client/components/jetpack-connect/style.scss
+++ b/_inc/client/components/jetpack-connect/style.scss
@@ -13,8 +13,8 @@
 	.jp-banner__tos-blurb {
 		font-size: rem( 11px );
 		color: $gray-dark;
-		margin-bottom: 0;
 		padding-top: 5px;
+		margin-bottom: 30px;
 	}
 }
 
@@ -24,6 +24,8 @@
 	}
 	.jp-jetpack-connect__description {
 		padding: 0 0 rem( 16px );
+		margin-top: 20px;
+		margin-bottom: 10px;
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/Automattic/jetpack/issues/8943

This PR removes the wpcom account creation link from below the connection buttons:

![image](https://user-images.githubusercontent.com/1554855/36973662-2166b0d0-2074-11e8-8862-f7f1a28fbfed.png)


How to test it
==========
1. Go to your jetpack menu in an unconnected site: You should see the top & bottom connect buttons, but the old "no account?" link shouldn't be after them anymore