### PR TITLE
Dashboard: fixes connection settings overflow text

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -323,6 +323,7 @@
 .jp-connection-settings__text {
 	width: 70%;
 	margin-left: rem( 16px );
+	word-break: break-word;
 }
 .jp-connection-settings__info {
 	.gridicon {


### PR DESCRIPTION
This PR forces words to break on long usernames and email addresses in the account connection settings in the dashboard.

### Before

### After

Fixes #8779 