### PR TITLE
WP Dashboard: fix site stats column spacing

### DIFF
--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -112,6 +112,10 @@
 			text-align: left;
 		}
 
+		.protect {
+			padding-right: 3%;
+		}
+
 		h3 {
 			font-size: 1.5em;
 			font-weight: normal;

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1250,6 +1250,9 @@ jQuery( function($) {
 	float: left;
 	width: 50%;
 }
+#stats-info #top-posts {
+	padding-right: 3%;
+}
 #top-posts .stats-section-inner p {
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
This PR addresses column spacing styling issues in WP Dashboard > JP Site Stats.

It adds a slight `padding-right` to the first column of each block.

### Before

### After

Addresses issue in #8678 