### PR TITLE
Gravatar: always use HTTPS to query images

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -185,7 +185,7 @@ function grofiles_attach_cards() {
 		return;
 	}
 
-	wp_enqueue_script( 'grofiles-cards', ( is_ssl() ? 'https://secure' : 'http://s' ) . '.gravatar.com/js/gprofiles.js', array( 'jquery' ), GROFILES__CACHE_BUSTER, true );
+	wp_enqueue_script( 'grofiles-cards', 'https://secure.gravatar.com/js/gprofiles.js', array( 'jquery' ), GROFILES__CACHE_BUSTER, true );
 	wp_enqueue_script( 'wpgroho', plugins_url( 'wpgroho.js', __FILE__ ), array( 'grofiles-cards' ), false, true );
 	if ( is_user_logged_in() ) {
 		$cu = wp_get_current_user();
@@ -246,7 +246,7 @@ function grofiles_hovercards_data_html( $author ) {
 	} elseif ( is_a( $author, 'WP_User' ) ) {
 		$hash = md5( $author->user_email );
 	}
-	
+
 	if ( ! $hash ) {
 		return;
 	}

--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -344,10 +344,16 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 		$cache_key = 'grofile-' . $hashed_email;
 
 		if( ! $profile = get_transient( $cache_key ) ) {
-			$profile_url = esc_url_raw( sprintf( '%s.gravatar.com/%s.json', ( is_ssl() ? 'https://secure' : 'http://www' ), $hashed_email ), array( 'http', 'https' ) );
+			$profile_url = sprintf(
+				'https://secure.gravatar.com/%s.json',
+				$hashed_email
+			);
 
 			$expire = 300;
-			$response = wp_remote_get( $profile_url, array( 'User-Agent' => 'WordPress.com Gravatar Profile Widget' ) );
+			$response = wp_remote_get(
+				esc_url_raw( $profile_url ),
+				array( 'User-Agent' => 'WordPress.com Gravatar Profile Widget' ),
+			);
 			$response_code = wp_remote_retrieve_response_code( $response );
 			if ( 200 == $response_code ) {
 				$profile = wp_remote_retrieve_body( $response );


### PR DESCRIPTION
Fixes 1820-gh-jpop-issues

It's not useful to conditionally load those over HTTP anymore. It only creates issues from time to time, for sites with a redirection from HTTP to HTTPS but not actually using HTTPS in the site settings.

#### Testing instructions:

* Add a Gravatar Profile widget to your site's sidebar.
* Make sure it works.
* Check comments on a page where that widget is not there.
* Make sure Gravatar Hovercards are triggered and work.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Gravatar Hovercards: always load script via HTTPS.