### PR TITLE
Move like/share metaboxes to right side

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -43,7 +43,7 @@ class Jetpack_Likes_Settings {
 		 */
 		$title = apply_filters( 'likes_meta_box_title', __( 'Likes', 'jetpack' ) );
 		foreach( $post_types as $post_type ) {
-			add_meta_box( 'likes_meta', $title, array( $this, 'meta_box_content' ), $post_type, 'advanced', 'high' );
+			add_meta_box( 'likes_meta', $title, array( $this, 'meta_box_content' ), $post_type, 'side', 'default' );
 		}
 	}
 

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -143,7 +143,7 @@ function sharing_add_meta_box() {
 	$title = apply_filters( 'sharing_meta_box_title', __( 'Sharing', 'jetpack' ) );
 	if ( $post->ID !== get_option( 'page_for_posts' ) ) {
 		foreach( $post_types as $post_type ) {
-			add_meta_box( 'sharing_meta', $title, 'sharing_meta_box_content', $post_type, 'advanced', 'high' );
+			add_meta_box( 'sharing_meta', $title, 'sharing_meta_box_content', $post_type, 'side', 'default' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8924

#### Changes proposed:

Update Like & Sharing metaboxes:
* Use `side` context.
* Use `default` priority.

#### Testing instructions:

* Enable **Sharing → Sharing Buttons**
  * Confirm metabox shows on right side when adding a new Post.
* Enable **Sharing → Like Buttons**
  * Confirm metabox shows on right side when adding a new Post.
* Also test when one or the other is disabled.

#### Proposed changelog entry:

* Likes/Sharing: Move metabox in post editor to the right side for a better fit.