### PR TITLE
Fix display of site URL on disconnect

### DIFF
--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -149,7 +149,7 @@ export class JetpackDisconnectDialog extends React.Component {
 						{
 							__( 'By disconnecting %(siteName)s from WordPress.com you will no longer have access to the following:', {
 								args: {
-									siteName: this.props.siteRawUrl.replace( '::', '/' )
+									siteName: this.props.siteRawUrl.replace( /::/g, '/' )
 								}
 							} )
 						}


### PR DESCRIPTION
Fixes #8912

#### Changes proposed:

In the Jetpack Disconnect Dialog:
* Use `/::/g` to replace all occurrences with `/`

#### Testing instructions:

* Clear your browser cache.
* Checkout this branch and run `npm run build`.
* Connect a site that's at least two subdirectories deep; e.g., `example.com/wp/personal`
* Then, from the Jetpack Dashboard, click 'Manage site connection' to disconnect it.
* Observe; instead of `::` you should see the correct `/` separators in the URL.

#### WIth the fix in this PR, all instances of `::` are replaced with `/`

![after](https://user-images.githubusercontent.com/1563559/36986916-8af1af50-2047-11e8-9791-c153fc4d3b21.png)

#### Before it was only replacing the first occurence of `::`

![before](https://user-images.githubusercontent.com/1563559/36987093-019dac62-2048-11e8-913a-f2f811f85a68.png)

#### Proposed changelog entry:

* Dashboard: Fix `::` separators (should be `/`) when disconnecting a site in a subdirectory.