### PR TITLE
Backups: Update "install and activate" link

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -97,7 +97,7 @@ class DashBackups extends Component {
 					status: isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled',
 					content: __( 'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.', {
 						components: {
-							a: <a href="https://wordpress.com/plugins/vaultpress" target="_blank" rel="noopener noreferrer" />
+							a: <a href={ `https://wordpress.com/plugins/setup/${ siteRawUrl }?only=backups` } target="_blank" rel="noopener noreferrer" />
 						}
 					} )
 				} );


### PR DESCRIPTION
Fixes #8487 

#### Changes proposed in this Pull Request:

* Update the "install and activate" link in the _Backups_ card to be a functional link matching the "Set up" button.

![backups](https://user-images.githubusercontent.com/841763/37019792-eee9923e-2119-11e8-9cb6-8536be6c24db.png)


#### Testing instructions:

* Get a new Jetpack site with this branch (JN with `?shortlived&jetpack-beta&branch=fix/8487-backup-install-link`)
* Set up the site with a paid plan
* After checkout but before allowing set up to run, return to the site dashboard.
* You will see the link on "install and activate" now points to the same URL as the "Set up" button.
* Click the link and verify that the _Backups_ set up is performed correctly.