### PR TITLE
Fix contact form styling for `input[type="url"]`

### DIFF
--- a/modules/contact-form/css/editor-inline-editing-style.css
+++ b/modules/contact-form/css/editor-inline-editing-style.css
@@ -117,7 +117,8 @@ label:first-of-type {
 
 input[type="text"],
 input[type="tel"],
-input[type="email"] {
+input[type="email"],
+input[type="url"] {
 	border-radius: 0;
 	appearance: none;
 	box-sizing: border-box;
@@ -135,19 +136,22 @@ input[type="email"] {
 
 input[type="text"]::placeholder,
 input[type="tel"]::placeholder,
-input[type="email"]::placeholder {
+input[type="email"]::placeholder,
+input[type="url"]::placeholder {
 	color: #87a6bc;
 }
 
 input[type="text"]:hover,
 input[type="tel"]:hover,
-input[type="email"]:hover {
+input[type="email"]:hover,
+input[type="url"]:hover {
 	border-color: #a8bece;
 }
 
 input[type="text"]:focus,
 input[type="tel"]:focus,
-input[type="email"]:focus {
+input[type="email"]:focus,
+input[type="url"]:focus {
 	border-color: #0087be;
 	outline: none;
 	box-shadow: 0 0 0 2px #78dcfa;
@@ -155,13 +159,15 @@ input[type="email"]:focus {
 
 input[type="text"]:focus::-ms-clear,
 input[type="tel"]:focus::-ms-clear,
-input[type="email"]:focus::-ms-clear {
+input[type="email"]:focus::-ms-clear,
+input[type="url"]:focus::-ms-clear {
 	display: none;
 }
 
 input[type="text"]:disabled,
 input[type="tel"]:disabled,
-input[type="email"]:disabled {
+input[type="email"]:disabled,
+input[type="url"]:disabled {
 	background: #f3f6f8;
 	border-color: #e9eff3;
 	color: #a8bece;
@@ -170,13 +176,15 @@ input[type="email"]:disabled {
 
 input[type="text"]:disabled:hover,
 input[type="tel"]:disabled:hover,
-input[type="email"]:disabled:hover {
+input[type="email"]:disabled:hover,
+input[type="url"]:disabled:hover {
 	cursor: default;
 }
 
 input[type="text"]:disabled::placeholder,
 input[type="tel"]:disabled::placeholder,
-input[type="email"]:disabled::placeholder {
+input[type="email"]:disabled::placeholder,
+input[type="url"]:disabled::placeholder {
 	color: #a8bece;
 }
 

--- a/modules/contact-form/css/editor-style.css
+++ b/modules/contact-form/css/editor-style.css
@@ -64,7 +64,8 @@ label {
 
 input[type="text"],
 input[type="tel"],
-input[type="email"] {
+input[type="email"],
+input[type="url"] {
 	border-radius: 0;
 	appearance: none;
 	box-sizing: border-box;
@@ -82,19 +83,22 @@ input[type="email"] {
 
 input[type="text"]::placeholder,
 input[type="tel"]::placeholder,
-input[type="email"]::placeholder {
+input[type="email"]::placeholder,
+input[type="url"]::placeholder {
 	color: #87a6bc;
 }
 
 input[type="text"]:hover,
 input[type="tel"]:hover,
-input[type="email"]:hover {
+input[type="email"]:hover,
+input[type="url"]:hover {
 	border-color: #a8bece;
 }
 
 input[type="text"]:focus,
 input[type="tel"]:focus,
-input[type="email"]:focus {
+input[type="email"]:focus,
+input[type="url"]:focus {
 	border-color: #0087be;
 	outline: none;
 	box-shadow: 0 0 0 2px #78dcfa;
@@ -102,13 +106,15 @@ input[type="email"]:focus {
 
 input[type="text"]:focus::-ms-clear,
 input[type="tel"]:focus::-ms-clear,
-input[type="email"]:focus::-ms-clear {
+input[type="email"]:focus::-ms-clear,
+input[type="url"]:focus::-ms-clear {
 	display: none;
 }
 
 input[type="text"]:disabled,
 input[type="tel"]:disabled,
-input[type="email"]:disabled {
+input[type="email"]:disabled,
+input[type="url"]:disabled {
 	background: #f3f6f8;
 	border-color: #e9eff3;
 	color: #a8bece;
@@ -117,13 +123,15 @@ input[type="email"]:disabled {
 
 input[type="text"]:disabled:hover,
 input[type="tel"]:disabled:hover,
-input[type="email"]:disabled:hover {
+input[type="email"]:disabled:hover,
+input[type="url"]:disabled:hover {
 	cursor: default;
 }
 
 input[type="text"]:disabled::placeholder,
 input[type="tel"]:disabled::placeholder,
-input[type="email"]:disabled::placeholder {
+input[type="email"]:disabled::placeholder,
+input[type="url"]:disabled::placeholder {
 	color: #a8bece;
 }
 


### PR DESCRIPTION
Fixes #8923

#### Changes proposed:

In Contact Form module:
* Add styles for `input[type="url"]`

#### Testing instructions:

* Create a new Post.
* Click 'Add Contact Form'
* Confirm 'Website' field is styled like other text fields.
* Preview the new post, confirm 'Website' field is styled like other text fields.

![after](https://user-images.githubusercontent.com/1563559/36992174-98c8a91c-2056-11e8-9879-1e9ef2078db4.png)

![after2](https://user-images.githubusercontent.com/1563559/36992178-9be9dec2-2056-11e8-8641-0280101036e3.png)

#### Proposed changelog entry:

* Contact Form: Fix style/width of `input[type="url"]` for Website address.