### PR TITLE
Prevent module activation when plan doesn't support them

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -211,15 +211,15 @@ abstract class Jetpack_Admin_Page {
 				$active = Jetpack::get_active_modules();
 				switch ( $current->plan->product_slug ) {
 					case 'jetpack_free':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
+						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
 						break;
 					case 'jetpack_personal':
 					case 'jetpack_personal_monthly':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
+						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
 						break;
 					case 'jetpack_premium':
 					case 'jetpack_premium_monthly':
-						$to_deactivate = array( 'seo-tools', 'google-analytics' );
+						$to_deactivate = array( 'seo-tools', 'google-analytics', 'search' );
 						break;
 				}
 				$to_deactivate = array_intersect( $active, $to_deactivate );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -67,6 +67,14 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
+		if ( ! Jetpack::active_plan_supports( $module_slug ) ) {
+			return new WP_Error(
+				'not_supported',
+				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),
+				array( 'status' => 424 )
+			);
+		}
+
 		if ( Jetpack::activate_module( $module_slug, false, false ) ) {
 			return rest_ensure_response( array(
 				'code' 	  => 'success',

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -184,7 +184,12 @@ class Jetpack_Admin {
 		if ( Jetpack::is_development_mode() ) {
 			return ! ( $module['requires_connection'] );
 		} else {
-			return Jetpack::is_active();
+			if ( ! Jetpack::is_active() ) {
+				return false;
+			}
+
+			$plan = Jetpack::get_active_plan();
+			return in_array( $module['module'], $plan['supports'] );
 		}
 	}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -362,8 +362,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 			case 'activate':
 				$module = Jetpack::get_module( $module_slug );
 				Jetpack::log( 'activate', $module_slug );
-				Jetpack::activate_module( $module_slug, false, false );
-				WP_CLI::success( sprintf( __( '%s has been activated.', 'jetpack' ), $module['name'] ) );
+				if ( Jetpack::activate_module( $module_slug, false, false ) ) {
+					WP_CLI::success( sprintf( __( '%s has been activated.', 'jetpack' ), $module['name'] ) );
+				} else {
+					WP_CLI::error( sprintf( __( '%s could not be activated.', 'jetpack' ), $module['name'] ) );
+				}
 				break;
 			case 'activate_all':
 				$modules = Jetpack::get_available_modules();

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -221,7 +221,6 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			$row_class .= ' active';
 
 		if ( ! Jetpack_Admin::is_module_available( $item ) ) {
-			error_log($item['module']." is NOT available");
 			$row_class .= ' unavailable';
 		}
 

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -174,17 +174,6 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		return array_filter( $modules, array( $this, 'is_module_displayed' ) );
 	}
 
-	static function is_module_available( $module ) {
-		if ( ! is_array( $module ) || empty( $module ) )
-			return false;
-
-		if ( Jetpack::is_development_mode() ) {
-			return ! ( $module['requires_connection'] );
-		} else {
-			return Jetpack::is_active();
-		}
-	}
-
 	static function is_module_displayed( $module ) {
 		// Handle module tag based filtering.
 		if ( ! empty( $_REQUEST['module_tag'] ) ) {
@@ -231,8 +220,10 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		if ( ! empty( $item['activated'] )  )
 			$row_class .= ' active';
 
-		if ( ! $this->is_module_available( $item ) )
+		if ( ! Jetpack_Admin::is_module_available( $item ) ) {
+			error_log($item['module']." is NOT available");
 			$row_class .= ' unavailable';
+		}
 
 		echo '<tr class="jetpack-module' . esc_attr( $row_class ) . '" id="' . esc_attr( $item['module'] ) . '">';
 		$this->single_row_columns( $item );
@@ -244,7 +235,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	function column_cb( $item ) {
-		if ( ! $this->is_module_available( $item ) )
+		if ( ! Jetpack_Admin::is_module_available( $item ) )
 			return '';
 
 		return sprintf( '<input type="checkbox" name="modules[]" value="%s" />', $item['module'] );
@@ -273,7 +264,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			$actions['configure'] = $item['configurable'];
 		}
 
-		if ( empty( $item['activated'] ) && $this->is_module_available( $item ) ) {
+		if ( empty( $item['activated'] ) && Jetpack_Admin::is_module_available( $item ) ) {
 			$url = wp_nonce_url(
 				Jetpack::admin_url( array(
 					'page'   => 'jetpack',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2448,6 +2448,7 @@ class Jetpack {
 		if ( $mod['plan_classes'] ) {
 			$mod['plan_classes'] = explode( ',', $mod['plan_classes'] );
 			$mod['plan_classes'] = array_map( 'strtolower', array_map( 'trim', $mod['plan_classes'] ) );
+			$mod['plan_classes'][] = 'free';
 		} else {
 			$mod['plan_classes'] = array( 'free' );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4052,7 +4052,7 @@ p {
 				check_admin_referer( "jetpack_activate-$module" );
 				Jetpack::log( 'activate', $module );
 				if ( ! Jetpack::activate_module( $module ) ) {
-					Jetpack::state( 'error', sprintf( __( 'Could not activated %s', 'jetpack' ), $module ) );
+					Jetpack::state( 'error', sprintf( __( 'Could not activate %s', 'jetpack' ), $module ) );
 				}
 				// The following two lines will rarely happen, as Jetpack::activate_module normally exits at the end.
 				wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1515,7 +1515,7 @@ class Jetpack {
 		// get available features
 		foreach( self::get_available_modules() as $module_slug ) {
 			$module = self::get_module( $module_slug );
-			if ( in_array( $plan['class'], $module['plan_classes'] ) ) {
+			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
 				$supports[] = $module_slug;
 			}
 		}
@@ -2448,7 +2448,6 @@ class Jetpack {
 		if ( $mod['plan_classes'] ) {
 			$mod['plan_classes'] = explode( ',', $mod['plan_classes'] );
 			$mod['plan_classes'] = array_map( 'strtolower', array_map( 'trim', $mod['plan_classes'] ) );
-			$mod['plan_classes'][] = 'free';
 		} else {
 			$mod['plan_classes'] = array( 'free' );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1513,7 +1513,7 @@ class Jetpack {
 		}
 
 		// get available features
-		foreach( self::get_available_modules() as $module_slug ) {
+		foreach ( self::get_available_modules() as $module_slug ) {
 			$module = self::get_module( $module_slug );
 			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
 				$supports[] = $module_slug;

--- a/modules/google-analytics.php
+++ b/modules/google-analytics.php
@@ -9,6 +9,7 @@
  * Auto Activate: No
  * Feature: Engagement
  * Additional Search Queries: webmaster, google, analytics, console
+ * Plans: business
  */
 
 include dirname( __FILE__ ) . "/google-analytics/wp-google-analytics.php";

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -163,7 +163,6 @@ function jetpack_get_module_i18n( $key ) {
 			'seo-tools' => array(
 				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'sharedaddy' => array(

--- a/modules/search.php
+++ b/modules/search.php
@@ -10,6 +10,7 @@
  * Auto Activate: No
  * Feature: Search
  * Additional Search Queries: search
+ * Plans: business
  */
 
 require_once( dirname( __FILE__ ) . '/search/class.jetpack-search.php' );

--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -10,6 +10,7 @@
  * Module Tags: Social, Appearance
  * Feature: Traffic
  * Additional Search Queries: search engine optimization, social preview, meta description, custom title format
+ * Plans: business
  */
 
 include dirname( __FILE__ ) . '/seo-tools/jetpack-seo.php';

--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -9,6 +9,7 @@
  * Module Tags: Photos and Videos
  * Feature: Writing
  * Additional Search Queries: video, videos, videopress
+ * Plans: business, premium
  */
 
 include_once dirname( __FILE__ ) . '/videopress/utility-functions.php';

--- a/modules/wordads.php
+++ b/modules/wordads.php
@@ -8,6 +8,7 @@
  * Auto Activate: No
  * Module Tags: Traffic, Appearance
  * Additional Search Queries: advertising, ad codes, ads
+ * Plans: premium, business
  */
 
 function jetpack_load_wordads() {


### PR DESCRIPTION
Fixes #7867

Some plans support different modules. This change declares plan support in the module header, and checks for that support when rendering the "active plan" information.

This allows us to easily render inactive rows in the `jetpack_modules` page and elsewhere, so that users know which modules are truly available.

This change also adds some basic checking in WP-cli and elsewhere for whether plan activation was successful.

#### Changes proposed in this Pull Request:

* Declare modules with a `Plan: business, premium, personal` (default is `free`) attribute
* Render full list of supported modules and plugins (in the case of vaultpress/akismet) in the `Jetpack::get_active_plan()` response
* Render rows as inactive in the `jetpack_modules` list if they are not supported by the current plan

The goal is NOT to prevent users from being able to hack the code to enable modules they shouldn't (since that is impossible anyway) but to help users understand what features their plan supports, and prevent them from accidentally enabling features that it doesn't.

#### Further work:

* Allow users to click to upgrade to a supporting plan from within the `jetpack_modules` page.

#### Testing instructions:

* On a site with a free plan:
  * Go to `/wp-admin/admin.php?page=jetpack_modules`
  * Ads, Data Backups, Google Analytics, SEO Tools, Search and VideoPress should be greyed out. Only Data Backups should be clickable, with a `Configure` link.
  * Go to `/settings/traffic/{site_domain}` in Calypso
    * Attempt to enable SEO tools using the `Enable` link next to `SEO Tools module is disabled in Jetpack.`
    * You should see a message `There was a problem saving your changes. Please try again.` (TODO: a better error message - in the network response you will see the actual error is `{error: "not_supported", message: "The requested Jetpack module is not supported by your plan."}`)
* On a site with a Premium plan
  * VideoPress should become available
* On a site with a Professional plan
  * SEO Tools, Google Analytics and Search should become available

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

* Show correct `available` status in Jetpack modules list
* Return error in wp-cli if activating a module that is unsupported by your plan

