### PR TITLE
Fix ignored phrase overflow/overlap

### DIFF
--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -1,6 +1,6 @@
 .react-tagsinput {
 	border: 1px solid #e9eff3;
-	padding: rem( 5px );
+	padding: rem( 2.5px );
 }
 
 .react-tagsinput--focused {
@@ -14,8 +14,8 @@
 	color: #fff;
 	display: inline-block;
 	font-size: 13px;
-	padding: rem( 5px );
-	margin-right: rem( 5px );
+	padding: rem( 2px ) rem( 6px ) rem( 3px ) rem( 8px );
+	margin: rem( 2.5px );
 	transition: background-color .2s ease-out;
 
 	&:hover {

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -47,3 +47,7 @@ input[type=text].react-tagsinput-input {
 	border: none;
 	box-shadow: none;
 }
+
+input[type=text].react-tagsinput-input::-ms-clear {
+	display: none;
+}

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -1,7 +1,6 @@
 .react-tagsinput {
 	border: 1px solid #e9eff3;
 	padding: rem( 5px );
-	height: rem( 30px );
 }
 
 .react-tagsinput--focused {


### PR DESCRIPTION
Fixes #8702

#### Changes proposed:

* Remove `height:` property in CSS giving the container an ability to resize based on the number of ignored phrases it contains.

#### Testing instructions:

* Checkout this branch and `npm run build`.
* Open Jetpack **Settings → Writing → Composing → Check your spelling, style, and grammar**.
* Fill in lots of ignored phrases. Enough to consume three or more lines.
* Observe; the bordered container grows with the number of ignored phrases.

![2018-03-05_12-46-14](https://user-images.githubusercontent.com/1563559/37001511-3a31e66c-2073-11e8-94a1-b93ba48adacb.png)

Before, this was overflowing/overlapping:

<img width="388" alt="screen-shot-2018-01-31-at-12-38-27-pm" src="https://user-images.githubusercontent.com/426388/35673077-b67eab8e-0740-11e8-88b8-2216623339fa.png">

#### Proposed changelog entry:

* Settings: Fix overflow/overlap when there are many ignored phrases in spelling options.
