### PR TITLE
Update SEO/analytics links to avoid redirects

### DIFF
--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -100,7 +100,7 @@ export class Traffic extends React.Component {
 					foundSeo && (
 						<SEO
 							{ ...commonProps }
-							configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
+							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
 						/>
 					)
 				}
@@ -108,7 +108,7 @@ export class Traffic extends React.Component {
 					foundAnalytics && (
 						<GoogleAnalytics
 							{ ...commonProps }
-							configureUrl={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl }
+							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
 						/>
 					)
 				}

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -100,7 +100,7 @@ export class Traffic extends React.Component {
 					foundSeo && (
 						<SEO
 							{ ...commonProps }
-							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
+							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl + '#seo' }
 						/>
 					)
 				}
@@ -108,7 +108,7 @@ export class Traffic extends React.Component {
 					foundAnalytics && (
 						<GoogleAnalytics
 							{ ...commonProps }
-							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
+							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl + '#analytics' }
 						/>
 					)
 				}


### PR DESCRIPTION
Fixes #8704

#### Changes proposed:

Update links to avoid unnecessary redirects. The following links redirect to these locations anyway, so this PR is simply linking directly to the ultimate destination.

* https://wordpress.com/settings/seo/yoursite → https://wordpress.com/settings/traffic/yoursite
* https://wordpress.com/settings/analytics/yoursite → https://wordpress.com/settings/traffic/yoursite

#### Testing instructions:

* Checkout this branch and run `npm run build`
* Visit **Jetpack → Settings → Traffic → Search engine optimization**
  * Confirm "Configure your SEO settings" points to: https://wordpress.com/settings/traffic/yoursite
* Visit **Jetpack → Settings → Traffic → Search engine optimization**
  * Confirm "Configure your Google Analytics settings" points to: https://wordpress.com/settings/traffic/yoursite

#### Proposed changelog entry:

* Settings: Update SEO/analytics links to avoid unnecessary redirects.