### PR TITLE
Add new settings route and page for Privacy settings

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -82,6 +82,7 @@ function render() {
 					<Route path="/sharing" name={ i18n.translate( 'Sharing', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/wpbody-content" component={ Main } />
 					<Route path="/wp-toolbar" component={ Main } />
+					<Route path="/privacy" component={ Main } />
 					<Route path="*" component={ Main } />
 				</Router>
 			</Provider>

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -145,8 +145,7 @@ export class Footer extends React.Component {
 							onClick={ this.trackVersionClick }
 							href="https://jetpack.com"
 							target="_blank"
-							rel="noopener noreferrer"
-							className="jp-footer__link"
+							rel="noopener noreferrer" className="jp-footer__link"
 							title={ __( 'Jetpack version' ) }
 						>
 							{
@@ -170,8 +169,7 @@ export class Footer extends React.Component {
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.trackPrivacyClick }
-							href="https://automattic.com/privacy/"
-							target="_blank"
+							href="#/privacy"
 							rel="noopener noreferrer"
 							title={ __( "Automattic's Privacy Policy" ) }
 							className="jp-footer__link">

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -25,6 +25,14 @@ import {
 import DevCard from 'components/dev-card';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 
+const smoothScroll = () => {
+	const jpContentY = document.getElementById( 'jp-navigation' ).offsetTop;
+	window.scrollTo( 0, window.scrollY - jpContentY / 1.5 );
+	if ( window.scrollY > jpContentY ) {
+		window.requestAnimationFrame( smoothScroll );
+	}
+};
+
 export class Footer extends React.Component {
 	static displayName = 'Footer';
 
@@ -49,6 +57,7 @@ export class Footer extends React.Component {
 	};
 
 	trackPrivacyClick = () => {
+		window.requestAnimationFrame( smoothScroll );
 		analytics.tracks.recordJetpackClick( {
 			target: 'footer_link',
 			link: 'privacy'

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -242,7 +242,7 @@ export const NavigationSettings = createReactClass( {
 		}
 
 		return (
-			<div className="dops-navigation">
+			<div id="jp-navigation" className="dops-navigation">
 				<QuerySitePlugins />
 				<SectionNav selectedText={ this.props.route.name }>
 					{ navItems }

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -64,7 +64,7 @@ export class Navigation extends React.Component {
 			);
 		}
 		return (
-			<div className="dops-navigation">
+			<div id="jp-navigation" className="dops-navigation">
 				<SectionNav selectedText={ this.props.route.name }>
 					{ navTabs }
 				</SectionNav>

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -214,6 +214,7 @@ class Main extends React.Component {
 			case '/discussion':
 			case '/writing':
 			case '/sharing':
+			case '/privacy':
 				navComponent = settingsNav;
 				pageComponent = <SearchableSettings
 					route={ this.props.route }
@@ -309,7 +310,8 @@ window.wpNavMenuClassChange = function() {
 			'#/security',
 			'#/traffic',
 			'#/writing',
-			'#/sharing'
+			'#/sharing',
+			'#/privacy',
 		],
 		dashboardRoutes = [
 			'#/',

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -47,7 +47,7 @@ class Privacy extends React.Component {
 		active: false,
 	};
 
-	togglePrivacy = () => this.props.toggleTracking( this.props.getOptionValue( 'disable_tracking' ) );
+	togglePrivacy = () => this.props.toggleTracking( this.props.getOptionValue( 'jetpack_event_tracking' ) );
 
 	render() {
 		const {
@@ -85,8 +85,8 @@ class Privacy extends React.Component {
 						<p>
 							<ModuleToggle
 								compact
-								activated={ getOptionValue( 'disable_tracking' ) }
-								toggling={ isSavingAnyOption( 'disable_tracking' ) }
+								activated={ getOptionValue( 'jetpack_event_tracking' ) }
+								toggling={ isSavingAnyOption( 'jetpack_event_tracking' ) }
 								toggleModule={ this.togglePrivacy }>
 								{ __( 'Send usage statistics to help us improve our products.' ) }
 							</ModuleToggle>
@@ -116,6 +116,6 @@ export default connect(
 		settings: getSettings( state ),
 	} ),
 	{
-		toggleTracking: isEnabled => updateSettings( { disable_tracking: ! isEnabled } ),
+		toggleTracking: isEnabled => updateSettings( { jetpack_event_tracking: ! isEnabled } ),
 	}
 )( moduleSettingsForm( Privacy ) );

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -22,6 +22,11 @@ const trackPrivacyPolicyView = () => analytics.tracks.recordJetpackClick( {
 	feature: 'privacy'
 } );
 
+const trackWhatJetpackSyncView = () => analytics.tracks.recordJetpackClick( {
+	target: 'what-data-jetpack-sync',
+	feature: 'privacy'
+} );
+
 const trackPrivacyBlogView = () => analytics.tracks.recordJetpackClick( {
 	target: 'privacy-blog',
 	feature: 'privacy'
@@ -70,14 +75,24 @@ class Privacy extends React.Component {
 				>
 					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
 						<p>
+							{
+								__( 'We are committed to your privacy and security. ' )
+							}
+							<br />
 							{ __(
-								'We are committed to keep your privacy. See our {{a}}privacy policy{{/a}}.', {
+								'Read about how Jetpack uses your data in {{pp}}Automattic Privacy Policy{{/pp}} ' +
+								'and {{js}}What Data Does Jetpack Sync{{/js}}?', {
 									components: {
-										a: <ExternalLink
-											href="https://automattic.com/privacy/"
-											onClick={ trackPrivacyPolicyView }
-											target="_blank" rel="noopener noreferrer"
-											/>
+										pp: <ExternalLink
+												href="https://automattic.com/privacy/"
+												onClick={ trackPrivacyPolicyView }
+												target="_blank" rel="noopener noreferrer"
+												/>,
+										js: <ExternalLink
+												href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+												onClick={ trackWhatJetpackSyncView }
+												target="_blank" rel="noopener noreferrer"
+												/>
 									}
 								} )
 							}
@@ -88,12 +103,12 @@ class Privacy extends React.Component {
 								activated={ getOptionValue( 'jetpack_event_tracking' ) }
 								toggling={ isSavingAnyOption( 'jetpack_event_tracking' ) }
 								toggleModule={ this.togglePrivacy }>
-								{ __( 'Send usage statistics to help us improve our products.' ) }
+								{ __( 'Send information to help us improve our products.' ) }
 							</ModuleToggle>
 						</p>
 						<p>
 							{ __(
-								'Visit the {{a}}Privacy blog{{/a}} to learn more about it in Automattic and WordPress.', {
+								'See more WordPress privacy information and resources on {{a}}privacy.blog{{/a}}.', {
 									components: {
 										a: <ExternalLink
 											href="https://privacy.blog/"

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -22,6 +22,11 @@ const trackPrivacyPolicyView = () => analytics.tracks.recordJetpackClick( {
 	feature: 'privacy'
 } );
 
+const trackPrivacyBlogView = () => analytics.tracks.recordJetpackClick( {
+	target: 'privacy-blog',
+	feature: 'privacy'
+} );
+
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
 
@@ -77,13 +82,28 @@ class Privacy extends React.Component {
 								} )
 							}
 						</p>
-						<ModuleToggle
-							compact
-							activated={ getOptionValue( 'disable_tracking' ) }
-							toggling={ isSavingAnyOption( 'disable_tracking' ) }
-							toggleModule={ this.togglePrivacy }>
-							{ __( 'Send usage statistics to help us improve our products.' ) }
-						</ModuleToggle>
+						<p>
+							<ModuleToggle
+								compact
+								activated={ getOptionValue( 'disable_tracking' ) }
+								toggling={ isSavingAnyOption( 'disable_tracking' ) }
+								toggleModule={ this.togglePrivacy }>
+								{ __( 'Send usage statistics to help us improve our products.' ) }
+							</ModuleToggle>
+						</p>
+						<p>
+							{ __(
+								'Visit the {{a}}Privacy blog{{/a}} to learn more about it in Automattic and WordPress.', {
+									components: {
+										a: <ExternalLink
+											href="https://privacy.blog/"
+											onClick={ trackPrivacyBlogView }
+											target="_blank" rel="noopener noreferrer"
+										/>
+									}
+								} )
+							}
+						</p>
 					</SettingsGroup>
 				</SettingsCard>
 			</div>

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -13,7 +13,14 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
+import ExternalLink from 'components/external-link';
 import { updateSettings, getSettings } from 'state/settings';
+import analytics from 'lib/analytics';
+
+const trackPrivacyPolicyView = () => analytics.tracks.recordJetpackClick( {
+	target: 'privacy-policy',
+	feature: 'privacy'
+} );
 
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
@@ -48,6 +55,7 @@ class Privacy extends React.Component {
 		if ( ! searchTerm && ! active ) {
 			return null;
 		}
+
 		return (
 			<div>
 				<SettingsCard
@@ -56,6 +64,19 @@ class Privacy extends React.Component {
 					hideButton
 				>
 					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
+						<p>
+							{ __(
+								'We are committed to keep your privacy. See our {{a}}privacy policy{{/a}}.', {
+									components: {
+										a: <ExternalLink
+											href="https://automattic.com/privacy/"
+											onClick={ trackPrivacyPolicyView }
+											target="_blank" rel="noopener noreferrer"
+											/>
+									}
+								} )
+							}
+						</p>
 						<ModuleToggle
 							compact
 							activated={ getOptionValue( 'disable_tracking' ) }

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+
+class Privacy extends React.Component {
+	static displayName = 'PrivacySettings';
+
+	togglePrivacy = () => {
+		return true;
+	};
+
+	render() {
+		if ( ! this.props.searchTerm && ! this.props.active ) {
+			return null;
+		}
+		return (
+			<div>
+				<SettingsCard
+					{ ...this.props }
+					hideButton
+				>
+					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
+						<ModuleToggle
+							compact
+							activated={ false }
+							toggling={ false }
+							toggleModule={ this.togglePrivacy }>
+							{ __( 'Disable Tracking' ) }
+						</ModuleToggle>
+					</SettingsGroup>
+				</SettingsCard>
+			</div>
+		);
+	}
+}
+
+export default Privacy;

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -2,31 +2,50 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
-import { updateSettings } from 'state/settings';
-import { getSettings } from 'state/settings';
+import { updateSettings, getSettings } from 'state/settings';
 
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
 
-	togglePrivacy = () => {
-		const isTracksEnabled = this.props.getOptionValue( 'disable_tracking' );
-		this.props.toggleTracking( isTracksEnabled );
+	static propTypes = {
+		searchTerm: PropTypes.string,
+		active: PropTypes.bool,
+
+		// Connected
+		toggleTracking: PropTypes.func,
+
+		// Provided by moduleSettingsForm
+		getOptionValue: PropTypes.func,
+		isSavingAnyOption: PropTypes.func,
 	};
 
-	render() {
-		// eslint-disable-next-line
-		console.log( this.props );
+	static defaultProps = {
+		searchTerm: '',
+		active: false,
+	};
 
-		if ( ! this.props.searchTerm && ! this.props.active ) {
+	togglePrivacy = () => this.props.toggleTracking( this.props.getOptionValue( 'disable_tracking' ) );
+
+	render() {
+		const {
+			searchTerm,
+			active,
+			getOptionValue,
+			isSavingAnyOption,
+		} = this.props;
+
+		if ( ! searchTerm && ! active ) {
 			return null;
 		}
 		return (
@@ -39,8 +58,8 @@ class Privacy extends React.Component {
 					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
 						<ModuleToggle
 							compact
-							activated={ false }
-							toggling={ false }
+							activated={ getOptionValue( 'disable_tracking' ) }
+							toggling={ isSavingAnyOption( 'disable_tracking' ) }
 							toggleModule={ this.togglePrivacy }>
 							{ __( 'Send usage statistics to help us improve our products.' ) }
 						</ModuleToggle>
@@ -52,14 +71,10 @@ class Privacy extends React.Component {
 }
 
 export default connect(
-	( state ) => {
-		return {
-			settings: getSettings( state ),
-		};
-	},
-	( dispatch ) => ( {
-		toggleTracking: ( isEnabled ) => {
-			return dispatch( updateSettings( { disable_tracking: isEnabled ? false : true } ) );
-		}
-	} )
-)( Privacy );
+	state => ( {
+		settings: getSettings( state ),
+	} ),
+	{
+		toggleTracking: isEnabled => updateSettings( { disable_tracking: ! isEnabled } ),
+	}
+)( moduleSettingsForm( Privacy ) );

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,15 +11,21 @@ import { translate as __ } from 'i18n-calypso';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
+import { updateSettings } from 'state/settings';
+import { getSettings } from 'state/settings';
 
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
 
 	togglePrivacy = () => {
-		return true;
+		const isTracksEnabled = this.props.getOptionValue( 'disable_tracking' );
+		this.props.toggleTracking( isTracksEnabled );
 	};
 
 	render() {
+		// eslint-disable-next-line
+		console.log( this.props );
+
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
@@ -26,6 +33,7 @@ class Privacy extends React.Component {
 			<div>
 				<SettingsCard
 					{ ...this.props }
+					header={ __( 'Privacy Settings', { context: 'Settings header' } ) }
 					hideButton
 				>
 					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
@@ -34,7 +42,7 @@ class Privacy extends React.Component {
 							activated={ false }
 							toggling={ false }
 							toggleModule={ this.togglePrivacy }>
-							{ __( 'Disable Tracking' ) }
+							{ __( 'Send usage statistics to help us improve our products.' ) }
 						</ModuleToggle>
 					</SettingsGroup>
 				</SettingsCard>
@@ -43,4 +51,15 @@ class Privacy extends React.Component {
 	}
 }
 
-export default Privacy;
+export default connect(
+	( state ) => {
+		return {
+			settings: getSettings( state ),
+		};
+	},
+	( dispatch ) => ( {
+		toggleTracking: ( isEnabled ) => {
+			return dispatch( updateSettings( { disable_tracking: isEnabled ? false : true } ) );
+		}
+	} )
+)( Privacy );

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -13,6 +13,7 @@ import Traffic from 'traffic';
 import Writing from 'writing/index.jsx';
 import Sharing from 'sharing/index.jsx';
 import SearchableModules from 'searchable-modules/index.jsx';
+import Privacy from 'privacy/index.jsx';
 
 export default class extends React.Component {
 	static displayName = 'SearchableSettings';
@@ -67,6 +68,10 @@ export default class extends React.Component {
 				<Sharing
 					siteAdminUrl={ this.props.siteAdminUrl }
 					active={ ( '/sharing' === this.props.route.path ) }
+					{ ...commonProps }
+				/>
+				<Privacy
+					active={ ( '/privacy' === this.props.route.path ) }
 					{ ...commonProps }
 				/>
 				<SearchableModules searchTerm={ this.props.searchTerm } />

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1908,8 +1908,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
-			// Show welcome for newly purchased plan
-			'disable_tracking' => array(
+			// Whether user allows usage statistics.
+			'jetpack_event_tracking' => array(
 				'description'       => 'Disables event tracking.',
 				'type'              => 'boolean',
 				'default'           => 0,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1908,6 +1908,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			// Show welcome for newly purchased plan
+			'disable_tracking' => array(
+				'description'       => 'Disables event tracking.',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'settings',
+			),
+
 		);
 
 		// Add modules to list so they can be toggled

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -466,6 +466,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					);
 					break;
 
+				case 'jetpack_event_tracking':
+					jetpack_require_lib( 'class.jetpack-user-event-tracking' );
+					$response[ $setting ] = Jetpack_User_Event_Tracking::is_enabled( get_current_user_id() );
+					break;
+
 				default:
 					$response[ $setting ] = Jetpack_Core_Json_Api_Endpoints::cast_value( get_option( $setting ), $settings[ $setting ] );
 					break;
@@ -950,8 +955,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					}
 					break;
 
+				case 'jetpack_event_tracking':
+					jetpack_require_lib( 'class.jetpack-user-event-tracking' );
+					$updated = $value
+						? Jetpack_User_Event_Tracking::enable( get_current_user_id() )
+						: Jetpack_User_Event_Tracking::disable( get_current_user_id() );
+					break;
+
 				case 'show_welcome_for_new_plan':
-				case 'disable_tracking':
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;
 					break;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -951,10 +951,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'show_welcome_for_new_plan':
-					// If option value was the same, consider it done.
-					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;
-					break;
-
 				case 'disable_tracking':
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -955,6 +955,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;
 					break;
 
+				case 'disable_tracking':
+					// If option value was the same, consider it done.
+					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;
+					break;
+
 				default:
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;


### PR DESCRIPTION
~~Must be merged after #9003 is merged.~~ It's merged

This PR introduces a new page accessible through the Privacy link at the bottom of the Jetpack dashboard.

<img width="701" alt="captura de pantalla 2018-03-21 a la s 23 46 58" src="https://user-images.githubusercontent.com/1041600/37748321-2beca46a-2d62-11e8-87e1-c09d565488b7.png">

The page features links to the Automattic privacy policy and to the upcoming privacy.blog. The support link goes through what data does Jetpack sync.
The page also introduces a toggle so users can opt-out of information tracking that Automattic collects for its own purpose.

<img width="737" alt="captura de pantalla 2018-03-09 a la s 20 01 36" src="https://user-images.githubusercontent.com/1041600/37234107-b51ee884-23d4-11e8-9911-d51c023dadf5.png">
