### PR TITLE
Focusing strapline on more broadly-applicable keywords and features

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Stable tag: 5.8
 Requires at least: 4.7
 Tested up to: 4.9
 
-The one plugin you need for stats, related posts, search engine optimization, Elasticsearch-powered search, social sharing, protection, backups, speed, and email list management.
+The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.
 
 == Description ==
 


### PR DESCRIPTION
Fixes #8906

#### Changes proposed in this Pull Request:

* Change strapline to focus more on popular features: 

> The ideal plugin for stats, related posts, SEO, social sharing, backups, security, and themes.

Should now look like this on the plugins pages:

<img width="468" alt="wordpress_plugins_ _plugins_extend_and_expand_the_functionality_of_wordpress_" src="https://user-images.githubusercontent.com/2287740/37087813-4ad21024-21f3-11e8-97cc-57881c951786.png">
