### PR TITLE
Add icon and font parity with other Publish items

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -554,7 +554,7 @@ jQuery( function($) {
 		?>
 		<div id="publicize" class="misc-pub-section misc-pub-section-last">
 			<span id="publicize-title">
-				<?php esc_html_e( 'Social Sharing:', 'jetpack' ); ?>
+				<?php esc_html_e( 'Publicize:', 'jetpack' ); ?>
 				<?php if ( 0 < count( $services ) ) : ?>
 					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected( $services ); ?>
 					<span id="publicize-defaults">

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -554,11 +554,15 @@ jQuery( function($) {
 		?>
 		<div id="publicize" class="misc-pub-section misc-pub-section-last">
 			<span id="publicize-title">
-				<?php _e( 'Social Sharing:', 'jetpack' ); ?>
+				<?php esc_html_e( 'Social Sharing:', 'jetpack' ); ?>
 				<?php if ( 0 < count( $services ) ) : ?>
 					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected( $services ); ?>
-					<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span><br />
-					<a href="#" id="publicize-form-edit"><?php _e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+					<span id="publicize-defaults">
+						<?php foreach ( $active as $item ) : ?>
+							<strong><?php echo esc_html( $item ); ?></strong>
+						<?php endforeach; ?>
+					</span>
+					<a href="#" id="publicize-form-edit"><?php _e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php else : ?>
 					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
 					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>
@@ -766,7 +770,7 @@ jQuery( function($) {
 			<ul class="not-connected">
 				<?php foreach ( $available_services as $service_name => $service ) : ?>
 				<li>
-					<a class="pub-service" data-service="<?php echo esc_attr( $service_name ); ?>" title="<?php echo esc_attr( sprintf( __( 'Connect and share your posts on %s', 'jetpack' ), $this->publicize->get_service_label( $service_name ) ) ); ?>" target="_blank" href="<?php echo $this->publicize->connect_url( $service_name ); ?>">
+					<a class="pub-service" data-service="<?php echo esc_attr( $service_name ); ?>" title="<?php echo esc_attr( sprintf( __( 'Connect and share your posts on %s', 'jetpack' ), $this->publicize->get_service_label( $service_name ) ) ); ?>" target="_blank" href="<?php echo esc_url( $this->publicize->connect_url( $service_name ) ); ?>">
 						<?php echo esc_html( $this->publicize->get_service_label( $service_name ) ); ?>
 					</a>
 				</li>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -562,11 +562,11 @@ jQuery( function($) {
 							<strong><?php echo esc_html( $item ); ?></strong>
 						<?php endforeach; ?>
 					</span>
-					<a href="#" id="publicize-form-edit"><?php _e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php else : ?>
 					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
 					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>
-					<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Edit', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-disconnected-form-show"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a><br />
 				<?php endif; ?>
 			</span>
 			<?php
@@ -655,8 +655,9 @@ jQuery( function($) {
 
 					// If this one has already been publicized to, don't let it happen again
 					$disabled = '';
-					if ( $done )
+					if ( $done ) {
 						$disabled = ' disabled="disabled"';
+					}
 
 					// If this is a global connection and this user doesn't have enough permissions to modify
 					// those connections, don't let them change it

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -558,11 +558,11 @@ jQuery( function($) {
 				<?php if ( 0 < count( $services ) ) : ?>
 					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected( $services ); ?>
 					<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span><br />
-					<a href="#" id="publicize-form-edit"><?php _e( 'Edit Details', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-form-edit"><?php _e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php else : ?>
 					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
 					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>
-					<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Show', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Edit', 'jetpack' ); ?></a><br />
 				<?php endif; ?>
 			</span>
 			<?php
@@ -743,7 +743,7 @@ jQuery( function($) {
 
 			<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
 
-			<a href="#" class="hide-if-no-js" id="publicize-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
+			<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php _e( 'OK', 'jetpack' ); ?></a>
 			<input type="hidden" name="wpas[0]" value="1" />
 
 		</div>
@@ -761,7 +761,7 @@ jQuery( function($) {
 		?><div id="publicize-form" class="hide-if-js">
 			<div id="add-publicize-check" style="display: none;"></div>
 
-			<strong><?php _e( 'Connect to', 'jetpack' ); ?>:</strong>
+			<?php _e( 'Connect to', 'jetpack' ); ?>:
 
 			<ul class="not-connected">
 				<?php foreach ( $available_services as $service_name => $service ) : ?>
@@ -772,7 +772,7 @@ jQuery( function($) {
 				</li>
 				<?php endforeach; ?>
 			</ul>
-			<a href="#" class="hide-if-no-js" id="publicize-disconnected-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
+			<a href="#" class="hide-if-no-js button" id="publicize-disconnected-form-hide"><?php _e( 'OK', 'jetpack' ); ?></a>
 		</div><?php // #publicize-form
 		return ob_get_clean();
 	}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -748,7 +748,7 @@ jQuery( function($) {
 
 			<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
 
-			<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php _e( 'OK', 'jetpack' ); ?></a>
+			<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
 			<input type="hidden" name="wpas[0]" value="1" />
 
 		</div>
@@ -777,7 +777,7 @@ jQuery( function($) {
 				</li>
 				<?php endforeach; ?>
 			</ul>
-			<a href="#" class="hide-if-no-js button" id="publicize-disconnected-form-hide"><?php _e( 'OK', 'jetpack' ); ?></a>
+			<a href="#" class="hide-if-no-js button" id="publicize-disconnected-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
 		</div><?php // #publicize-form
 		return ob_get_clean();
 	}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -506,6 +506,16 @@ jQuery( function($) {
 	list-style: square;
 	padding-left: 1em;
 }
+#publicize-title:before {
+	content: "\f237";
+	font: normal 20px/1 dashicons;
+	speak: none;
+	margin-left: -1px;
+	padding-right: 3px;
+	vertical-align: top;
+	-webkit-font-smoothing: antialiased;
+	color: #82878c;
+}
 .post-new-php .authorize-link, .post-php .authorize-link {
 	line-height: 1.5em;
 }
@@ -541,225 +551,20 @@ jQuery( function($) {
 
 		if ( ! is_array( $services ) )
 			$services = array();
-
-		$active = array(); ?>
-
+		?>
 		<div id="publicize" class="misc-pub-section misc-pub-section-last">
-			<?php
-			_e( 'Publicize:', 'jetpack' );
-
-			if ( 0 < count( $services ) ) :
-					ob_start();
-				?>
-
-				<div id="publicize-form" class="hide-if-js">
-					<ul>
-
-					<?php
-					// We can set an _all flag to indicate that this post is completely done as
-					// far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
-					// have Publicize disabled.
-					$all_done = get_post_meta( $post->ID, $this->publicize->POST_DONE . 'all', true ) || ( $this->in_jetpack && 'publish' == $post->post_status );
-
-					// We don't allow Publicizing to the same external id twice, to prevent spam
-					$service_id_done = (array) get_post_meta( $post->ID, $this->publicize->POST_SERVICE_DONE, true );
-
-					foreach ( $services as $name => $connections ) {
-						foreach ( $connections as $connection ) {
-							$connection_data = '';
-							if ( method_exists( $connection, 'get_meta' ) )
-								$connection_data = $connection->get_meta( 'connection_data' );
-							elseif ( ! empty( $connection['connection_data'] ) )
-								$connection_data = $connection['connection_data'];
-
-							/**
-							 * Filter whether a post should be publicized to a given service.
-							 *
-							 * @module publicize
-							 *
-							 * @since 2.0.0
-							 *
-							 * @param bool true Should the post be publicized to a given service? Default to true.
-							 * @param int $post->ID Post ID.
-							 * @param string $name Service name.
-							 * @param array $connection_data Array of information about all Publicize details for the site.
-							 */
-							if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
-								continue;
-							}
-
-							if ( ! empty( $connection->unique_id ) ) {
-								$unique_id = $connection->unique_id;
-							} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
-								$unique_id = $connection['connection_data']['token_id'];
-							}
-
-							// Should we be skipping this one?
-							$skip = (
-								(
-									in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
-									&&
-									get_post_meta( $post->ID, $this->publicize->POST_SKIP . $unique_id, true )
-								)
-								||
-								(
-									is_array( $connection )
-									&&
-									(
-										( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] ) )
-										||
-										// Jetpack's connection data looks a little different.
-										( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['external_id'] ] ) )
-									)
-								)
-							);
-
-							// Was this connections (OR, old-format service) already Publicized to?
-							$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags
-
-							// If this one has already been publicized to, don't let it happen again
-							$disabled = '';
-							if ( $done )
-								$disabled = ' disabled="disabled"';
-
-							// If this is a global connection and this user doesn't have enough permissions to modify
-							// those connections, don't let them change it
-							$cmeta = $this->publicize->get_connection_meta( $connection );
-							$hidden_checkbox = false;
-							if ( !$done && ( 0 == $cmeta['connection_data']['user_id'] && !current_user_can( $this->publicize->GLOBAL_CAP ) ) ) {
-								$disabled = ' disabled="disabled"';
-								/**
-								 * Filters the checkboxes for global connections with non-prilvedged users.
-								 *
-								 * @module publicize
-								 *
-								 * @since 3.7.0
-								 *
-								 * @param bool   $checked Indicates if this connection should be enabled. Default true.
-								 * @param int    $post->ID ID of the current post
-								 * @param string $name Name of the connection (Facebook, Twitter, etc)
-								 * @param array  $connection Array of data about the connection.
-								 */
-								$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
-							}
-
-							// Determine the state of the checkbox (on/off) and allow filtering
-							$checked = $skip != 1 || $done;
-							/**
-							 * Filter the checkbox state of each Publicize connection appearing in the post editor.
-							 *
-							 * @module publicize
-							 *
-							 * @since 2.0.1
-							 *
-							 * @param bool $checked Should the Publicize checkbox be enabled for a given service.
-							 * @param int $post->ID Post ID.
-							 * @param string $name Service name.
-							 * @param array $connection Array of connection details.
-							 */
-							$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
-
-							// Force the checkbox to be checked if the post was DONE, regardless of what the filter does
-							if ( $done ) {
-								$checked = true;
-							}
-
-							// This post has been handled, so disable everything
-							if ( $all_done ) {
-								$disabled = ' disabled="disabled"';
-							}
-
-							$label = sprintf(
-								_x( '%1$s: %2$s', 'Service: Account connected as', 'jetpack' ),
-								esc_html( $this->publicize->get_service_label( $name ) ),
-								esc_html( $this->publicize->get_display_name( $name, $connection ) )
-							);
-							if ( !$skip || $done ) {
-								$active[] = $label;
-							}
-							?>
-							<li>
-								<label for="wpas-submit-<?php echo esc_attr( $unique_id ); ?>">
-									<input type="checkbox" name="wpas[submit][<?php echo $unique_id; ?>]" id="wpas-submit-<?php echo $unique_id; ?>" class="wpas-submit-<?php echo $name; ?>" value="1" <?php
-										checked( true, $checked );
-										echo $disabled;
-									?> />
-									<?php
-									if ( $hidden_checkbox ) {
-										// Need to submit a value to force a global connection to post
-										echo '<input type="hidden" name="wpas[submit][' . $unique_id . ']" value="1" />';
-									}
-									echo esc_html( $label );
-									?>
-								</label>
-							</li>
-							<?php
-						}
-					}
-
-					if ( $title = get_post_meta( $post->ID, $this->publicize->POST_MESS, true ) ) {
-						$title = esc_html( $title );
-					} else {
-						$title = '';
-					}
-					?>
-
-					</ul>
-
-					<label for="wpas-title"><?php _e( 'Custom Message:', 'jetpack' ); ?></label>
-					<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
-
-					<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
-
-					<a href="#" class="hide-if-no-js" id="publicize-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
-					<input type="hidden" name="wpas[0]" value="1" />
-
-				</div>
-				<?php if ( ! $all_done ) : ?>
-					<div id="pub-connection-tests"></div>
+			<span id="publicize-title">
+				<?php _e( 'Social Sharing:', 'jetpack' ); ?>
+				<?php if ( 0 < count( $services ) ) : ?>
+					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected( $services ); ?>
+					<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span><br />
+					<a href="#" id="publicize-form-edit"><?php _e( 'Edit Details', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+				<?php else : ?>
+					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
+					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>
+					<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Show', 'jetpack' ); ?></a><br />
 				<?php endif; ?>
-				<?php // #publicize-form
-
-				$publicize_form = ob_get_clean();
-			else :
-				echo "&nbsp;" . __( 'Not Connected', 'jetpack' );
-					ob_start();
-				?>
-
-				<div id="publicize-form" class="hide-if-js">
-					<div id="add-publicize-check" style="display: none;"></div>
-
-					<strong><?php _e( 'Connect to', 'jetpack' ); ?>:</strong>
-
-					<ul class="not-connected">
-						<?php foreach ( $available_services as $service_name => $service ) : ?>
-						<li>
-							<a class="pub-service" data-service="<?php echo esc_attr( $service_name ); ?>" title="<?php echo esc_attr( sprintf( __( 'Connect and share your posts on %s', 'jetpack' ), $this->publicize->get_service_label( $service_name ) ) ); ?>" target="_blank" href="<?php echo $this->publicize->connect_url( $service_name ); ?>">
-								<?php echo esc_html( $this->publicize->get_service_label( $service_name ) ); ?>
-							</a>
-						</li>
-						<?php endforeach; ?>
-					</ul>
-
-					<?php if ( 0 < count( $services ) ) : ?>
-						<a href="#" class="hide-if-no-js" id="publicize-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
-					<?php else : ?>
-						<a href="#" class="hide-if-no-js" id="publicize-disconnected-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
-					<?php endif; ?>
-				</div> <?php // #publicize-form
-
-				$publicize_form = ob_get_clean();
-			endif;
-			?>
-
-			<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span><br />
-
-			<?php if ( 0 < count( $services ) ) : ?>
-				<a href="#" id="publicize-form-edit"><?php _e( 'Edit Details', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
-			<?php else : ?>
-				<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Show', 'jetpack' ); ?></a><br />
-			<?php endif; ?>
-
+			</span>
 			<?php
 			/**
 			 * Filter the Publicize details form.
@@ -772,8 +577,203 @@ jQuery( function($) {
 			 */
 			echo apply_filters( 'publicize_form', $publicize_form );
 			?>
-
 		</div> <?php // #publicize
 	}
 
+	private function get_metabox_form_connected( $services ) {
+		global $post;
+		$active = array();
+		ob_start();
+		?> <div id="publicize-form" class="hide-if-js">
+			<ul>
+
+			<?php
+			// We can set an _all flag to indicate that this post is completely done as
+			// far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
+			// have Publicize disabled.
+			$all_done = get_post_meta( $post->ID, $this->publicize->POST_DONE . 'all', true ) || ( $this->in_jetpack && 'publish' == $post->post_status );
+
+			// We don't allow Publicizing to the same external id twice, to prevent spam
+			$service_id_done = (array) get_post_meta( $post->ID, $this->publicize->POST_SERVICE_DONE, true );
+
+			foreach ( $services as $name => $connections ) {
+				foreach ( $connections as $connection ) {
+					$connection_data = '';
+					if ( method_exists( $connection, 'get_meta' ) )
+						$connection_data = $connection->get_meta( 'connection_data' );
+					elseif ( ! empty( $connection['connection_data'] ) )
+						$connection_data = $connection['connection_data'];
+
+					/**
+					 * Filter whether a post should be publicized to a given service.
+					 *
+					 * @module publicize
+					 *
+					 * @since 2.0.0
+					 *
+					 * @param bool true Should the post be publicized to a given service? Default to true.
+					 * @param int $post->ID Post ID.
+					 * @param string $name Service name.
+					 * @param array $connection_data Array of information about all Publicize details for the site.
+					 */
+					if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
+						continue;
+					}
+
+					if ( ! empty( $connection->unique_id ) ) {
+						$unique_id = $connection->unique_id;
+					} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
+						$unique_id = $connection['connection_data']['token_id'];
+					}
+
+					// Should we be skipping this one?
+					$skip = (
+						(
+							in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
+							&&
+							get_post_meta( $post->ID, $this->publicize->POST_SKIP . $unique_id, true )
+						)
+						||
+						(
+							is_array( $connection )
+							&&
+							(
+								( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] ) )
+								||
+								// Jetpack's connection data looks a little different.
+								( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['external_id'] ] ) )
+							)
+						)
+					);
+
+					// Was this connections (OR, old-format service) already Publicized to?
+					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags
+
+					// If this one has already been publicized to, don't let it happen again
+					$disabled = '';
+					if ( $done )
+						$disabled = ' disabled="disabled"';
+
+					// If this is a global connection and this user doesn't have enough permissions to modify
+					// those connections, don't let them change it
+					$cmeta = $this->publicize->get_connection_meta( $connection );
+					$hidden_checkbox = false;
+					if ( !$done && ( 0 == $cmeta['connection_data']['user_id'] && !current_user_can( $this->publicize->GLOBAL_CAP ) ) ) {
+						$disabled = ' disabled="disabled"';
+						/**
+						 * Filters the checkboxes for global connections with non-prilvedged users.
+						 *
+						 * @module publicize
+						 *
+						 * @since 3.7.0
+						 *
+						 * @param bool   $checked Indicates if this connection should be enabled. Default true.
+						 * @param int    $post->ID ID of the current post
+						 * @param string $name Name of the connection (Facebook, Twitter, etc)
+						 * @param array  $connection Array of data about the connection.
+						 */
+						$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
+					}
+
+					// Determine the state of the checkbox (on/off) and allow filtering
+					$checked = $skip != 1 || $done;
+					/**
+					 * Filter the checkbox state of each Publicize connection appearing in the post editor.
+					 *
+					 * @module publicize
+					 *
+					 * @since 2.0.1
+					 *
+					 * @param bool $checked Should the Publicize checkbox be enabled for a given service.
+					 * @param int $post->ID Post ID.
+					 * @param string $name Service name.
+					 * @param array $connection Array of connection details.
+					 */
+					$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
+
+					// Force the checkbox to be checked if the post was DONE, regardless of what the filter does
+					if ( $done ) {
+						$checked = true;
+					}
+
+					// This post has been handled, so disable everything
+					if ( $all_done ) {
+						$disabled = ' disabled="disabled"';
+					}
+
+					$label = sprintf(
+						_x( '%1$s: %2$s', 'Service: Account connected as', 'jetpack' ),
+						esc_html( $this->publicize->get_service_label( $name ) ),
+						esc_html( $this->publicize->get_display_name( $name, $connection ) )
+					);
+					if ( !$skip || $done ) {
+						$active[] = $label;
+					}
+					?>
+					<li>
+						<label for="wpas-submit-<?php echo esc_attr( $unique_id ); ?>">
+							<input type="checkbox" name="wpas[submit][<?php echo $unique_id; ?>]" id="wpas-submit-<?php echo $unique_id; ?>" class="wpas-submit-<?php echo $name; ?>" value="1" <?php
+								checked( true, $checked );
+								echo $disabled;
+							?> />
+							<?php
+							if ( $hidden_checkbox ) {
+								// Need to submit a value to force a global connection to post
+								echo '<input type="hidden" name="wpas[submit][' . $unique_id . ']" value="1" />';
+							}
+							echo esc_html( $label );
+							?>
+						</label>
+					</li>
+					<?php
+				}
+			}
+
+			if ( $title = get_post_meta( $post->ID, $this->publicize->POST_MESS, true ) ) {
+				$title = esc_html( $title );
+			} else {
+				$title = '';
+			}
+			?>
+
+			</ul>
+
+			<label for="wpas-title"><?php _e( 'Custom Message:', 'jetpack' ); ?></label>
+			<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
+
+			<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
+
+			<a href="#" class="hide-if-no-js" id="publicize-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
+			<input type="hidden" name="wpas[0]" value="1" />
+
+		</div>
+		<?php if ( ! $all_done ) : ?>
+			<div id="pub-connection-tests"></div>
+		<?php endif; ?>
+		<?php // #publicize-form
+
+		return array( ob_get_clean(), $active );
+	}
+
+
+	private function get_metabox_form_disconnected( $available_services ) {
+		ob_start();
+		?><div id="publicize-form" class="hide-if-js">
+			<div id="add-publicize-check" style="display: none;"></div>
+
+			<strong><?php _e( 'Connect to', 'jetpack' ); ?>:</strong>
+
+			<ul class="not-connected">
+				<?php foreach ( $available_services as $service_name => $service ) : ?>
+				<li>
+					<a class="pub-service" data-service="<?php echo esc_attr( $service_name ); ?>" title="<?php echo esc_attr( sprintf( __( 'Connect and share your posts on %s', 'jetpack' ), $this->publicize->get_service_label( $service_name ) ) ); ?>" target="_blank" href="<?php echo $this->publicize->connect_url( $service_name ); ?>">
+						<?php echo esc_html( $this->publicize->get_service_label( $service_name ) ); ?>
+					</a>
+				</li>
+				<?php endforeach; ?>
+			</ul>
+			<a href="#" class="hide-if-no-js" id="publicize-disconnected-form-hide"><?php _e( 'Hide', 'jetpack' ); ?></a>
+		</div><?php // #publicize-form
+		return ob_get_clean();
+	}
 }


### PR DESCRIPTION
Fixes #8919

#### Changes proposed in this Pull Request:

* Add sharing icon in publish metabox
* Refactor form rendering to make code easier to understand
* Change "Show Details" and "Show" links to "Edit"
* Renamed "Publicize" to "Social Sharing" (ooh - controversial!)
* Change 'Hide' links to 'OK' buttons

#### Testing instructions:

* Enable Publicize, ensure no connected accounts
* Start a new post
* Ensure styling looks consistent with other elements of the Publish metabox
* Click "Edit" next to Social Sharing section
* Add one or more accounts
* Start a new post again
* Ensure styling looks consistent with other elements of the Publish metabox

#### Screenshots

Not connected, closed:

<img width="269" alt="not-connected-closed" src="https://user-images.githubusercontent.com/51896/37128641-ed642926-222f-11e8-9cf8-c837f6d91918.png">

Not connected, open:

<img width="264" alt="not-connected-open" src="https://user-images.githubusercontent.com/51896/37128645-f3724ad2-222f-11e8-8cb0-698f04ca3074.png">

Connected, closed:

<img width="262" alt="connected-closed" src="https://user-images.githubusercontent.com/51896/37128647-f765292a-222f-11e8-86e5-60c7dfb33d5c.png">

Connected, open:

<img width="265" alt="connected-open" src="https://user-images.githubusercontent.com/51896/37128654-fba76f66-222f-11e8-9194-7a71f2026c1c.png">

#### Proposed changelog entry for your changes:

Make styling of Publicize more consistent with wp-admin.