### PR TITLE
Shortcodes: Sync Mixcloud with WP.com

### DIFF
--- a/modules/shortcodes/mixcloud.php
+++ b/modules/shortcodes/mixcloud.php
@@ -9,44 +9,66 @@
  * [mixcloud http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ width=640 height=480 /]
  * [mixcloud]http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]
  * [mixcloud]MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]
+ * [mixcloud http://www.mixcloud.com/mat/playlists/classics/ width=660 height=208 hide_cover=1 hide_tracklist=1]
 */
 
 // Register oEmbed provider
 // Example URL: http://www.mixcloud.com/oembed/?url=http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/
-wp_oembed_add_provider('#https?://(?:www\.)?mixcloud\.com/\S*#i', 'http://www.mixcloud.com/oembed', true);
+wp_oembed_add_provider( '#https?://(?:www\.)?mixcloud\.com/\S*#i', 'https://www.mixcloud.com/oembed', true );
 
 // Register mixcloud shortcode
 add_shortcode( 'mixcloud', 'mixcloud_shortcode' );
 function mixcloud_shortcode( $atts, $content = null ) {
 
-	if ( empty( $atts[0] ) && empty( $content ) )
-		return "<!-- mixcloud error: invalid mixcloud resource -->";
+	if ( empty( $atts[0] ) && empty( $content ) ) {
+		return '<!-- mixcloud error: invalid mixcloud resource -->';
+	}
 
-	$regular_expression = '#((?<=mixcloud.com/)([A-Za-z0-9%-]+/[A-Za-z0-9%-]+))|^([A-Za-z0-9%-]+/[A-Za-z0-9%-]+)#i';
+	$regular_expression = '/((?<=mixcloud\\.com\\/)[\\w-\\/]+$)|(^[\\w-\\/]+$)/i';
 	preg_match( $regular_expression, $content, $match );
 	if ( ! empty( $match ) ) {
 		$resource_id = trim( $match[0] );
 	} else {
 		preg_match( $regular_expression, $atts[0], $match );
-		if ( ! empty( $match ) )
+		if ( ! empty( $match ) ) {
 			$resource_id = trim( $match[0] );
+		}
 	}
 
-	if ( empty( $resource_id ) )
-		return "<!-- mixcloud error: invalid mixcloud resource -->";
+	if ( empty( $resource_id ) ) {
+		return '<!-- mixcloud error: invalid mixcloud resource -->';
+	}
 
-	$atts = shortcode_atts( array(
-		'width'    => 300,
-		'height'   => 300,
-	), $atts, 'mixcloud' );
+	$mixcloud_url = 'https://mixcloud.com/' . $resource_id;
 
+	$atts = shortcode_atts(
+		array(
+			'width'          => false,
+			'height'         => false,
+			'color'          => false,
+			'light'          => false,
+			'dark'           => false,
+			'hide_tracklist' => false,
+			'hide_cover'     => false,
+			'mini'           => false,
+			'hide_followers' => false,
+			'hide_artwork'   => false,
+		), $atts
+	);
 
-	// Build URL
-	$url = add_query_arg( $atts, "http://api.mixcloud.com/$resource_id/embed-html/" );
-	$head = wp_remote_head( $url );
-	if ( is_wp_error( $head ) || 200 != $head['response']['code'] )
-		return "<!-- mixcloud error: invalid mixcloud resource -->";
+	// remove falsey values
+	$atts = array_filter( $atts );
 
-	return sprintf( '<iframe width="%d" height="%d" scrolling="no" frameborder="no" src="%s"></iframe>', $atts['width'], $atts['height'], esc_url( $url ) );
+	$query_args = array( 'url' => $mixcloud_url );
+	$query_args = array_merge( $query_args, $atts );
 
+	$url               = add_query_arg( urlencode_deep( $query_args ), 'https://www.mixcloud.com/oembed/' );
+	$mixcloud_response = wp_remote_get( $url, array( 'redirection' => 0 ) );
+	if ( is_wp_error( $mixcloud_response ) || 200 !== $mixcloud_response['response']['code'] || empty( $mixcloud_response['body'] ) ) {
+		return '<!-- mixcloud error: invalid mixcloud resource -->';
+	}
+
+	$response_body = json_decode( $mixcloud_response['body'] );
+
+	return $response_body->html;
 }


### PR DESCRIPTION
WP.com previously switched from iframe embed to oEmbed, which also switches over to https support.

Fixes #9006 

#### Proposed changelog entry for your changes:
Update: Mixcloud shortcode now uses oEmbed.