### PR TITLE
no-store cache policy for admin pages

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -1,5 +1,10 @@
 <?php
 
+function add_no_store_header( $headers ) {
+	$headers[ 'Cache-Control' ] .= ', no-store';
+	return 	$headers;
+}
+
 // Shared logic between Jetpack admin pages
 abstract class Jetpack_Admin_Page {
 	// Add page specific actions given the page hook
@@ -41,6 +46,10 @@ abstract class Jetpack_Admin_Page {
 		self::$block_page_rendering_for_idc = (
 			Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
 		);
+		if( $_GET[ 'page' ] == 'jetpack' ) {
+			add_filter( 'nocache_headers', 'add_no_store_header' );
+			nocache_headers();
+		}
 	}
 
 	function add_actions() {

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -1,10 +1,5 @@
 <?php
 
-function add_no_store_header( $headers ) {
-	$headers[ 'Cache-Control' ] .= ', no-store';
-	return 	$headers;
-}
-
 // Shared logic between Jetpack admin pages
 abstract class Jetpack_Admin_Page {
 	// Add page specific actions given the page hook
@@ -46,10 +41,6 @@ abstract class Jetpack_Admin_Page {
 		self::$block_page_rendering_for_idc = (
 			Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
 		);
-		if( $_GET[ 'page' ] == 'jetpack' ) {
-			add_filter( 'nocache_headers', 'add_no_store_header' );
-			nocache_headers();
-		}
 	}
 
 	function add_actions() {

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -15,10 +15,19 @@ class Jetpack_Admin {
 	private $jetpack;
 
 	static function init() {
+		if( $_GET['page'] === 'jetpack' ) {
+			add_filter( 'nocache_headers', array( 'Jetpack_Admin', 'add_no_store_header' ), 100 );
+		}
+
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_Admin;
 		}
 		return self::$instance;
+	}
+
+	static function add_no_store_header( $headers ) {
+		$headers['Cache-Control'] .= ', no-store';
+		return $headers;
 	}
 
 	private function __construct() {


### PR DESCRIPTION
fixes https://github.com/Automattic/jetpack/issues/8723

Right now, if you navigate to WordPress.com from the Jetpack dashboard and then come back via back button, you are getting the previous state of the app because of browser's cache. This PR add no-store cache policy to jetpack admin pages so you don't get a cached version of the dashboard when you click 'back' from wpcom

How to test
=========
1. Activate Jetpack (or if it's already active and you don't want to deactivate, run `wp option update show_welcome_for_new_plan true` with wp-cli)
2. You should get the Warm Welcome modal (if you used wp-cli, you may need to navigate to the jetpack dashboard or reload the page)
3. Click on the "view more stats in WordPress.com" button. 
4. Once you get to wp.com, click on the browser's back button
5. You should be taken back to your jetpack dashboard, and the Warm Welcome modal shouldn't show