### PR TITLE
Masterbar: fixes "origin" undefined error.

### DIFF
--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -137,7 +137,7 @@
 			return;
 		}
 
-		var event = ! e.data && e.originalEvent.data ? e.originalEvent : event;
+		var event = ! e.data && e.originalEvent.data ? e.originalEvent : e;
 		if ( event.origin !== 'https://widgets.wp.com' ) {
 			return;
 		}


### PR DESCRIPTION
Follow up of D10762-code

#### Changes proposed in this Pull Request:

With the Grammarly extension enabled on Chrome macOS, the following error occurs when navigating to a site with the WordPress.com Masterbar module active, logged in as a WordPress.com user:

```
Uncaught TypeError: Cannot read property 'origin' of undefined
    at masterbar-tracks.js?m=1520506909h&ver=20171026:130
    at dispatch (jquery.js?m=1466523978h&ver=1.12.4:3)
    at r.handle (jquery.js?m=1466523978h&ver=1.12.4:3)
```

Also the code is wrong. There's no `event` variable.

#### Testing instructions:

Navigate to a Jetpack site with the Masterbar module active and there should be no regressions, all _Tracks_ events should fire.