### PR TITLE
Dashboard: update scan widget language and visuals

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -95,7 +95,7 @@ class DashScan extends Component {
 						content: [
 							<h2 className="jp-dash-item__count is-warning">{ numberFormat( threats ) }</h2>,
 							<p className="jp-dash-item__description">
-								{__( 'Threat found.', 'Threats found.', {
+								{__( 'Threat found. See below for options.', 'Threats found. See below for options.', {
 									count: threats,
 									args: { number: numberFormat( threats ) }
 								} )}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -20,6 +20,7 @@ import {
 import { isDevMode } from 'state/connection';
 import { isFetchingSiteData } from 'state/site';
 import DashItem from 'components/dash-item';
+import ExternalLink from 'components/external-link';
 import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 
@@ -92,16 +93,21 @@ class DashScan extends Component {
 				if ( threats !== 0 ) {
 					return renderCard( {
 						content: [
-							<h3>{
-								__( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
+							<h2 className="jp-dash-item__count is-warning">{ numberFormat( threats ) }</h2>,
+							<p className="jp-dash-item__description">
+								{__( 'Threat found.', 'Threats found.', {
 									count: threats,
 									args: { number: numberFormat( threats ) }
-								} )
-							}</h3>,
+								} )}
+							</p>,
 							<p className="jp-dash-item__description">
-								{__( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } )}
-								<br />
-								{__( '{{a}}Contact Support{{/a}}', { components: { a: <a href="https://jetpack.com/support" /> } } )}
+								{__( '{{ExternalLink}}Contact support for help with this{{/ExternalLink}}', { components: {
+									ExternalLink: <ExternalLink
+										className="dops-button is-primary"
+										href="https://jetpack.com/support"
+										target="_blank" />
+								} } )}
+								{__( '{{a}}Address issues now{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } )}
 							</p>
 						]
 					} );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -102,7 +102,7 @@ class DashScan extends Component {
 							<p className="jp-dash-item__description">
 								{__( '{{ExternalLink}}Contact support for help with this{{/ExternalLink}}', { components: {
 									ExternalLink: <ExternalLink
-										className="dops-button is-primary"
+										className="dops-button is-primary is-compact"
 										href="https://jetpack.com/support"
 										target="_blank" />
 								} } )}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -95,9 +95,9 @@ class DashScan extends Component {
 						content: [
 							<h2 className="jp-dash-item__count is-warning">{ numberFormat( threats ) }</h2>,
 							<p className="jp-dash-item__description">
-								{__( 'Threat found. See below for options.', 'Threats found. See below for options.', {
-									count: threats }
-								} )}
+								{ __( 'Threat found. See below for options.', 'Threats found. See below for options.', {
+									count: threats
+								} ) }
 							</p>,
 							<p className="jp-dash-item__description">
 								{__( '{{ExternalLink}}Contact support for help with this{{/ExternalLink}}', { components: {

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -96,8 +96,7 @@ class DashScan extends Component {
 							<h2 className="jp-dash-item__count is-warning">{ numberFormat( threats ) }</h2>,
 							<p className="jp-dash-item__description">
 								{__( 'Threat found. See below for options.', 'Threats found. See below for options.', {
-									count: threats,
-									args: { number: numberFormat( threats ) }
+									count: threats }
 								} )}
 							</p>,
 							<p className="jp-dash-item__description">

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -1,6 +1,11 @@
 .jp-dash-item {
 	.jp-dash-item__content a {
 		font-style: italic;
+
+		&.dops-button {
+			margin: 16px 0 8px;
+			font-style: normal;
+		}
 	}
 	.dops-section-header__card-badge .dops-button {
 		background: none;
@@ -36,6 +41,10 @@
 
 	@include breakpoint( "<660px" ) {
 		font-size: rem( 23px );
+	}
+
+	&.is-warning {
+		color: $alert-red;
 	}
 }
 

--- a/_inc/client/components/notice/style.scss
+++ b/_inc/client/components/notice/style.scss
@@ -258,6 +258,7 @@ a.dops-notice__action {
 		align-self: center;
 		margin-left: 16px;
 		padding: 0 10px;
+		text-decoration: none;
 
 		&:hover,
 		&:active,


### PR DESCRIPTION
This code improves the scan widget in the JP Dashboard:

- Removes the “Uh oh” language.
- Uses standard widget visual pattern.
- Turns contact support link into a button
- Reorder button and link.
- Fix underline link on top.

Fixes #8652 

### Before

![image](https://user-images.githubusercontent.com/390760/37163726-64a6c032-22f0-11e8-9fdc-405a7ba94917.png)

### After

![image](https://user-images.githubusercontent.com/390760/37163736-6e00bd18-22f0-11e8-8782-6702a6b2af1c.png)
