### PR TITLE
Settings: Remove Markdown Settings

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -121,7 +121,6 @@ export const NavigationSettings = createReactClass( {
 					{
 						this.hasAnyOfThese( [
 							'masterbar',
-							'markdown',
 							'after-the-deadline',
 							'custom-content-types',
 							'photon',
@@ -156,7 +155,6 @@ export const NavigationSettings = createReactClass( {
 						this.hasAnyOfThese( [
 							'comments',
 							'gravatar-hovercards',
-							'markdown',
 							'subscriptions'
 						] ) && (
 							<NavItem

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -19,27 +19,12 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 class CommentsComponent extends React.Component {
-	/**
-	 * If markdown module is inactive and this is toggling markdown for comments on, activate module.
-	 * If markdown for posts is off and this is toggling markdown for comments off, deactivate module.
-	 *
-	 * @param {string} module	the module slug.
-	 * @returns {*}             the updated value
-	 */
-	updateFormStateByMarkdown = module => {
-		if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_posts_with_markdown', module ) ) {
-			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_comments_with_markdown' );
-		}
-		return this.props.updateFormStateModuleOption( module, 'wpcom_publish_comments_with_markdown', true );
-	};
-
 	render() {
 		const foundComments = this.props.isModuleFound( 'comments' ),
 			foundGravatar = this.props.isModuleFound( 'gravatar-hovercards' ),
-			foundMarkdown = this.props.isModuleFound( 'markdown' ),
 			foundCommentLikes = this.props.isModuleFound( 'comment-likes' );
 
-		if ( ! foundComments && ! foundGravatar && ! foundMarkdown && ! foundCommentLikes ) {
+		if ( ! foundComments && ! foundGravatar && ! foundCommentLikes ) {
 			return null;
 		}
 
@@ -49,7 +34,6 @@ class CommentsComponent extends React.Component {
 			isCommentsActive = this.props.getOptionValue( 'comments' ),
 			commentsUnavailableInDevMode = this.props.isUnavailableInDevMode( 'comments' ),
 			gravatar = this.props.getModule( 'gravatar-hovercards' ),
-			markdown = this.props.getModule( 'markdown' ),
 			commentLikesUnavailable = isUnavailableInDevMode( 'comment-likes' ),
 			commentLikesActive = getOptionValue( 'comment-likes' );
 
@@ -111,7 +95,7 @@ class CommentsComponent extends React.Component {
 					)
 				}
 				{
-					( foundGravatar || foundMarkdown || foundCommentLikes ) && (
+					( foundGravatar || foundCommentLikes ) && (
 						<SettingsGroup>
 							{
 								foundGravatar && (
@@ -128,28 +112,6 @@ class CommentsComponent extends React.Component {
 													gravatar.description + ' '
 												}
 												<a href={ gravatar.learn_more_button } target="_blank" rel="noopener noreferrer">
-													{ __( 'Learn more' ) }
-												</a>
-											</span>
-										</ModuleToggle>
-									</FormFieldset>
-								)
-							}
-							{
-								foundMarkdown && (
-									<FormFieldset>
-										<ModuleToggle
-											slug="markdown"
-											compact
-											activated={ !! this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
-											toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
-											toggleModule={ this.updateFormStateByMarkdown }
-										>
-											<span className="jp-form-toggle-explanation">
-												{
-													__( 'Enable Markdown use for comments.' ) + ' '
-												}
-												<a href={ markdown.learn_more_button } target="_blank" rel="noopener noreferrer">
 													{ __( 'Learn more' ) }
 												</a>
 											</span>

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -28,7 +28,6 @@ export class Discussion extends React.Component {
 		};
 
 		const foundComments = this.props.isModuleFound( 'comments' ),
-			foundMarkdown = this.props.isModuleFound( 'markdown' ),
 			foundGravatar = this.props.isModuleFound( 'gravatar-hovercards' ),
 			foundSubscriptions = this.props.isModuleFound( 'subscriptions' ),
 			foundCommentLikes = this.props.isModuleFound( 'comment-likes' );
@@ -37,7 +36,7 @@ export class Discussion extends React.Component {
 			return null;
 		}
 
-		if ( ! foundComments && ! foundSubscriptions && ! foundMarkdown && ! foundGravatar && ! foundCommentLikes ) {
+		if ( ! foundComments && ! foundSubscriptions && ! foundGravatar && ! foundCommentLikes ) {
 			return null;
 		}
 

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -170,20 +170,6 @@ export class Composing extends React.Component {
 		);
 	};
 
-	/**
-	 * If markdown module is inactive and this is toggling markdown for posts on, activate module.
-	 * If markdown for comments is off and this is toggling markdown for posts off, deactivate module.
-	 *
-	 * @param {string} module the slug of the module to update
-	 * @returns {*}           the updated value
-	 */
-	updateFormStateByMarkdown = module => {
-		if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_comments_with_markdown', module ) ) {
-			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown' );
-		}
-		return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown', true );
-	};
-
 	trackOpenCard = () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'foldable-settings-open',
@@ -192,38 +178,14 @@ export class Composing extends React.Component {
 	};
 
 	render() {
-		const foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
-			foundMarkdown = this.props.isModuleFound( 'markdown' );
+		const foundAtD = this.props.isModuleFound( 'after-the-deadline' );
 
-		if ( ! foundMarkdown && ! foundAtD ) {
+		if ( ! foundAtD ) {
 			return null;
 		}
 
-		const markdown = this.props.module( 'markdown' ),
-			atd = this.props.module( 'after-the-deadline' ),
+		const atd = this.props.module( 'after-the-deadline' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
-			markdownSettings = (
-				<SettingsGroup
-					module={ markdown }
-					support={ {
-						text: __( 'Allows you to compose content with links, lists, and other styles using the Markdown syntax.' ),
-						link: 'https://jetpack.com/support/markdown/',
-					} }
-					>
-					<FormFieldset>
-						<ModuleToggle
-							slug="markdown"
-							activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
-							disabled={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
-							toggleModule={ this.updateFormStateByMarkdown }>
-							<span className="jp-form-toggle-explanation">
-								{ markdown.description }
-							</span>
-						</ModuleToggle>
-					</FormFieldset>
-				</SettingsGroup>
-			),
 			atdSettings = (
 				<FoldableCard
 					onOpen={ this.trackOpenCard }
@@ -262,7 +224,6 @@ export class Composing extends React.Component {
 				module="composing"
 				saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 			>
-				{ foundMarkdown && markdownSettings }
 				{ foundAtD && atdSettings }
 			</SettingsCard>
 		);

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -41,7 +41,6 @@ export class Writing extends React.Component {
 
 		const found = [
 			'masterbar',
-			'markdown',
 			'after-the-deadline',
 			'custom-content-types',
 			'photon',


### PR DESCRIPTION
Fixes #6669. For rationale, see discussion there.

### Testing instructions:

On the Settings page:
* In the 'Writing' tab, verify that the 'Write posts or pages in plain-text Markdown syntax' option is gone.
* In the 'Discussion' tab, verify that the 'Enable Markdown use for comments' toggle is gone.
* Verify that modifying and saving other settings still works.

### Screenshots:

#### Before:

![image](https://user-images.githubusercontent.com/96308/37165975-c9c6d4ca-22f5-11e8-8404-ca3fba99a068.png)

![image](https://user-images.githubusercontent.com/96308/37165995-d450d620-22f5-11e8-87f1-2bd180293a59.png)

#### After:

![image](https://user-images.githubusercontent.com/96308/37166637-7adeb9c0-22f7-11e8-943a-e408aef5d596.png)

![image](https://user-images.githubusercontent.com/96308/37166664-8982f360-22f7-11e8-82d5-0b34a3c415d8.png)

#### Proposed changelog entry for your changes:

* Removed Markdown Settings