### PR TITLE
Add menu_items to option whitelist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -69,6 +69,7 @@ class Jetpack_Sync_Defaults {
 		'comment_whitelist',
 		'comment_max_links',
 		'moderation_keys',
+		'menu_items',
 		'jetpack_wga',
 		'disabled_likes',
 		'disabled_reblogs',


### PR DESCRIPTION
Part of fix for https://github.com/Automattic/wp-calypso/issues/11759