### PR TITLE
WooCommerce Analytics: fix PHP warning.

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -5,7 +5,7 @@
 * https://developers.google.com/analytics/devguides/collection/analyticsjs/
 * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce
 *
-* @author allendav 
+* @author allendav
 */
 
 /**
@@ -263,7 +263,7 @@ class Jetpack_Google_Analytics_Universal {
 			esc_attr( $product->get_id() ),
 			esc_attr( $product->get_sku() )
 			);
-		$url = str_replace( 'href=', $new_attributes );
+		$url = str_replace( 'href=', $new_attributes, $url );
 		return $url;
 	}
 

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -179,7 +179,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			esc_attr( $product->get_id() ),
 			esc_attr( $product->get_sku() )
 		);
-		$url = str_replace( 'href=', $new_attributes );
+		$url = str_replace( 'href=', $new_attributes, $url );
 		return $url;
 	}
 


### PR DESCRIPTION
"PHP Warning: str_replace() expects at least 3 parameters, 2 given"

Adding the last parameter should help.

Reported here:
https://wordpress.org/support/topic/php-warning-156/

#### Proposed changelog entry for your changes:
* WooCommerce Analytics: fix PHP warning.