### PR TITLE
Translate Widget: default to responsive vertical layout.

### DIFF
--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -88,14 +88,14 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 			 *
 			 * @param string $layout layout of the Google Translate Widget.
 			 */
-			$button_layout = apply_filters( 'jetpack_google_translate_widget_layout', 2 );
+			$button_layout = apply_filters( 'jetpack_google_translate_widget_layout', 0 );
 
 			if (
 				! is_int( $button_layout )
 				|| 0 > $button_layout
 				|| 2 < $button_layout
 			) {
-				$button_layout = 2;
+				$button_layout = 0;
 			}
 
 			wp_localize_script(


### PR DESCRIPTION
Fixes #5962 again.

When I worked on #7296 to first fix this issue, I wanted to change from the old unresponsive dropdown only layout (`2`)
to the new vertical layout that would be responsive (`0`).
But while addressing other feedback on the PR I reverted that change, ant the old layout remained the default.

This fixes that. The default is 0 (vertical layout) now.

Related WordPress.com diff: D10767-code

#### Testing instructions:

1. On a site using the Google Translate Widget, apply the patch.
2. The widget should go from

<img width="324" alt="screen shot 2018-03-09 at 12 53 17" src="https://user-images.githubusercontent.com/426388/37206468-04aab478-2399-11e8-84e6-2684efe24b0e.png">

To 

<img width="322" alt="screen shot 2018-03-09 at 12 43 28" src="https://user-images.githubusercontent.com/426388/37206476-09e19844-2399-11e8-80c2-7b3a8c6fabc4.png">


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Google Translate Widget: make sure the widget is responsive by default.