### PR TITLE
Widgets - EU Cookie Law: fix issue with custom URL choice and selective refresh

### DIFF
--- a/modules/widgets/customizer-utils.js
+++ b/modules/widgets/customizer-utils.js
@@ -1,4 +1,4 @@
-/* global gapi, FB, twttr */
+/* global wp, gapi, FB, twttr */
 
 /**
  * Utilities to work with widgets in Customizer.
@@ -56,6 +56,9 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 					// Refresh Twitter
 					else if ( wp.isJetpackWidgetPlaced( placement, 'twitter_timeline' ) && 'object' === typeof twttr && 'object' === typeof twttr.widgets && 'function' === typeof twttr.widgets.load ) {
 						twttr.widgets.load( placement.container[0] );
+					} else if ( wp.isJetpackWidgetPlaced( placement, 'eu_cookie_law_widget' ) ) {
+						// Refresh EU Cookie Law
+						placement.container.fadeIn();
 					}
 				}
 			} );

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -181,15 +181,24 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 				$instance['text'] = $this->text_options[0];
 			}
 
-			if ( isset( $new_instance['custom-policy-url'] ) ) {
+			if ( isset( $new_instance['policy-url'] ) ) {
+				$instance['policy-url'] = 'custom' === $new_instance['policy-url']
+					? 'custom'
+					: 'default';
+			} else {
+				$instance['policy-url'] = $this->policy_url_options[0];
+			}
+
+			if ( 'custom' === $instance['policy-url'] && isset( $new_instance['custom-policy-url'] ) ) {
 				$instance['custom-policy-url'] = esc_url( $new_instance['custom-policy-url'], array( 'http', 'https' ) );
 
 				if ( strlen( $instance['custom-policy-url'] ) < 10 ) {
 					unset( $instance['custom-policy-url'] );
-					$instance['policy-url'] = $this->policy_url_options[0];
+					global $wp_customize;
+					if ( ! isset( $wp_customize ) ) {
+						$instance['policy-url'] = $this->policy_url_options[0];
+					}
 				}
-			} else {
-				$instance['policy-url'] = $this->policy_url_options[0];
 			}
 
 			if ( isset( $new_instance['policy-link-text'] ) ) {

--- a/modules/widgets/eu-cookie-law/form.php
+++ b/modules/widgets/eu-cookie-law/form.php
@@ -148,10 +148,10 @@
 			<input
 				class="widefat"
 				name="<?php echo esc_attr( $this->get_field_name( 'custom-policy-url' ) ); ?>"
-				placeholder="<?php echo esc_attr( $instance['default-policy-url'] ); ?>"
+				placeholder="<?php echo esc_url( $instance['default-policy-url'] ); ?>"
 				style="margin-top: .5em;"
 				type="text"
-				value="<?php echo esc_attr( $instance['custom-policy-url'] ); ?>"
+				value="<?php echo esc_url( $instance['custom-policy-url'] ); ?>"
 			/>
 		</li>
 	</ul>


### PR DESCRIPTION
Fixes #8998

#### Changes proposed in this Pull Request:

* fix issue where custom URL choice wasn't preserved in Customizer
* fix issue where widget didn't selectively refresh in Customizer. While the widget declared support, it didn't reinitialized itself after it was selectively refreshed.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* add a EU Cookie Law Banner widget and make sure you can choose a Custom URL for the policy
* make sure selective refresh works fine

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
