### PR TITLE
Upgraded i18n-calypso to 1.9.1 to fix the Beta Builder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^2.1.2",
     "history": "3",
-    "i18n-calypso": "github:automattic/i18n-calypso",
+    "i18n-calypso": "^1.9.1",
     "jsdom": "^9.2.1",
     "jsdom-global": "^2.1.0",
     "jshint": "2.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4558,9 +4558,9 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-"i18n-calypso@github:automattic/i18n-calypso":
-  version "1.9.0"
-  resolved "https://codeload.github.com/automattic/i18n-calypso/tar.gz/a6e9fce235b4759eda4cc48dc0d2acdd7dba1545"
+i18n-calypso@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/i18n-calypso/-/i18n-calypso-1.9.1.tgz#56eee2a6f4f6b1f6dae421a939c68df400a2234f"
   dependencies:
     async "^1.5.2"
     commander "^2.9.0"


### PR DESCRIPTION
An error in the dependency was breaking static files generation on the latest step of the build, leading to the 'static.html file missing' error. You should be able to use this branch in the Beta plugin.

Fixes #9020 
