### PR TITLE
Add SEO tools to the premium plan in module meta

### DIFF
--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -10,7 +10,7 @@
  * Module Tags: Social, Appearance
  * Feature: Traffic
  * Additional Search Queries: search engine optimization, social preview, meta description, custom title format
- * Plans: business
+ * Plans: business, premium
  */
 
 include dirname( __FILE__ ) . '/seo-tools/jetpack-seo.php';


### PR DESCRIPTION
Fixes #9033

#### Changes proposed in this Pull Request:

* Ensure that `Jetpack::active_plan_supports( 'seo-tools' )` returns `true` for people with the Premium plan.

#### Testing instructions:

* Upgrade to Jetpack Premium
* Activate SEO tools via Calypso or WP Admin
* SEO tools should be activated without error
