### PR TITLE
VaultPress: if Rewind is enabled, remove its entry in sidebar and hide its notice

### DIFF
--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -1,26 +1,36 @@
 <?php
 
+/**
+ * Notify user that VaultPress has been disabled. Hide VaultPress notice that requested attention.
+ *
+ * @since 5.8
+ */
 function jetpack_vaultpress_rewind_enabled_notice() {
-	$plugin_file = 'vaultpress/vaultpress.php';
-
-	deactivate_plugins( $plugin_file );
 	?>
 	<div class="notice notice-success vp-deactivated">
 		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>
 		<p><?php _e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
 	</div>
+	<style>#vp-notice{display:none;}</style>
 	<?php
 }
 
-// If Rewind is enabled, then show a notification to disable VaultPress.
+/**
+ * If Rewind is enabled, remove its entry in sidebar, deactivate VaultPress, and show a notification.
+ *
+ * @since 5.8
+ */
 function jetpack_vaultpress_rewind_check() {
 	if ( Jetpack::is_active() &&
 		 Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) &&
 		 Jetpack::is_rewind_enabled()
 		) {
+		remove_submenu_page( 'jetpack', 'vaultpress' );
+
+		deactivate_plugins( 'vaultpress/vaultpress.php' );
+
 		add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );
 	}
 }
-
 
 add_action( 'admin_init', 'jetpack_vaultpress_rewind_check', 11 );

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -6,6 +6,9 @@
  * @since 5.8
  */
 function jetpack_vaultpress_rewind_enabled_notice() {
+	// The deactivation is performed here because there may be pages that admin_init runs on,
+	// such as admin_ajax, that could deactivate the plugin without showing this notification.
+	deactivate_plugins( 'vaultpress/vaultpress.php' );
 	?>
 	<div class="notice notice-success vp-deactivated">
 		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>
@@ -26,8 +29,6 @@ function jetpack_vaultpress_rewind_check() {
 		 Jetpack::is_rewind_enabled()
 		) {
 		remove_submenu_page( 'jetpack', 'vaultpress' );
-
-		deactivate_plugins( 'vaultpress/vaultpress.php' );
 
 		add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );
 	}


### PR DESCRIPTION
Fixes #8691

This PR fixes issues with VaultPress deactivation driven by Jetpack when Rewind is active:

#### Proposed changes

The Jetpack menu was previously still showing the VaultPress submenu and clicking it lead to a blank page. This is now fixed here.

The notice saying "VaultPress needs your attention!" was still shown before, but it's now hidden. It was complex to remove it since it wasn't possible to remove the actions hooked to `user_admin_notices` and `admin_notices`. To overcome this, a `<style>` tag was added with a rule to hide the notice.

Updated PHPDocs.

#### Testing instructions:

1. test with a site with Rewind active
2. activate the VaultPress plugin. It will be automatically deactivated and a notice will show.
3. ensure that:
    - there's not a **VaultPress** submenu entry under the **Jetpack** menu
    - the notice **VaultPress needs your attention!** is not visible

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
VaultPress: menu item going nowhere is now suppressed.
