### PR TITLE
Masterbar: Always sign out from WordPress.com

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -45,8 +45,6 @@ class A8C_WPCOM_Masterbar {
 			// override user setting that hides masterbar from site's front.
 			// https://github.com/Automattic/jetpack/issues/7667
 			add_filter( 'show_admin_bar', '__return_true' );
-			// Always sign out from .com from the masterbar
-			add_filter( 'jetpack_masterbar_should_logout_from_wpcom', '__return_true' );
 		}
 
 		$this->user_data = Jetpack::get_connected_user_data( $this->user_id );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -92,9 +92,9 @@ class A8C_WPCOM_Masterbar {
 		 *
 		 * @since 5.9.0
 		 *
-		 * @param bool $masterbar_should_logout_from_wpcom False by default.
+		 * @param bool $masterbar_should_logout_from_wpcom True by default.
 		 */
-		$masterbar_should_logout_from_wpcom = apply_filters( 'jetpack_masterbar_should_logout_from_wpcom', false );
+		$masterbar_should_logout_from_wpcom = apply_filters( 'jetpack_masterbar_should_logout_from_wpcom', true );
 		if (
 			isset( $_GET['context'] ) &&
 			'masterbar' === $_GET['context'] &&


### PR DESCRIPTION
Fixes p1HpG7-4X1-p2
Fixes #9044.

#### Changes proposed in this Pull Request:

* Sets the `jetpack_masterbar_should_logout_from_wpcom` to be `true` by default.

#### Testing instructions:

* Activate masterbar
* Sign out from the site
* Expect to be signed out from WordPress.com too.

#### Proposed changelog entry for your changes:

* Made the Sign Out link in the Master always log you out from WordPress.com