### PR TITLE
Load the Search widget even if Extra Sidebar Widgets is disabled

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -25,7 +25,6 @@ $tools = array(
 	'simple-payments/simple-payments.php',
 	'verification-tools/verification-tools-utils.php',
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
-	'widgets/search.php', // Load even if Extra Sidebar Widgets is disabled
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -25,6 +25,7 @@ $tools = array(
 	'simple-payments/simple-payments.php',
 	'verification-tools/verification-tools-utils.php',
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
+	'widgets/search.php', // Load even if Extra Sidebar Widgets is disabled
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode
@@ -53,3 +54,11 @@ if ( ! empty( $jetpack_tools_to_include ) ) {
 		}
 	}
 }
+
+/**
+ * Add the "(Jetpack)" suffix to the widget names
+ */
+function jetpack_widgets_add_suffix( $widget_name ) {
+	return sprintf( __( '%s (Jetpack)', 'jetpack' ), $widget_name );
+}
+add_filter( 'jetpack_widget_name', 'jetpack_widgets_add_suffix' );

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -160,8 +160,9 @@ class Jetpack_Search {
 			return;
 		}
 
-		require_once( dirname( __FILE__ ) . '/class.jetpack-search-helpers.php' );
-		require_once( dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php' );
+		require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
+		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
+		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
 
 		$this->init_hooks();
 	}

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -29,7 +29,7 @@ function jetpack_load_widgets() {
 	$widgets_include = apply_filters( 'jetpack_widgets_to_include', $widgets_include );
 
 	foreach( $widgets_include as $include ) {
-		include $include;
+		include_once $include;
 	}
 
 	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/image-widget.php';
@@ -47,14 +47,6 @@ function jetpack_widgets_configuration_load() {
 	wp_safe_redirect( admin_url( 'widgets.php' ) );
 	exit;
 }
-
-/**
- * Add the "(Jetpack)" suffix to the widget names
- */
-function jetpack_widgets_add_suffix( $widget_name ) {
-	return sprintf( __( '%s (Jetpack)', 'jetpack' ), $widget_name );
-}
-add_filter( 'jetpack_widget_name', 'jetpack_widgets_add_suffix' );
 
 
 

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -29,7 +29,7 @@ function jetpack_load_widgets() {
 	$widgets_include = apply_filters( 'jetpack_widgets_to_include', $widgets_include );
 
 	foreach( $widgets_include as $include ) {
-		include_once $include;
+		include $include;
 	}
 
 	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/image-widget.php';

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -29,7 +29,7 @@ function jetpack_load_widgets() {
 	$widgets_include = apply_filters( 'jetpack_widgets_to_include', $widgets_include );
 
 	foreach( $widgets_include as $include ) {
-		include $include;
+		include_once $include;
 	}
 
 	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/image-widget.php';

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -7,14 +7,14 @@
  * @since      5.0.0
  */
 
-require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-helpers.php';
-
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 
 function jetpack_search_widget_init() {
 	if ( ! Jetpack::is_active() || ! Jetpack::active_plan_supports( 'search' ) ) {
 		return;
 	}
+
+	require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-helpers.php';
 
 	register_widget( 'Jetpack_Search_Widget' );
 }


### PR DESCRIPTION
Fixes #9041

~~Not 100% sure this is the best way to always load a widget or not. Suggestions welcome for alternate code choices.~~

#### Changes proposed in this Pull Request:

~~Always load the Search widget, even if the Extra Sidebar Widgets module is disabled. It's already loaded even if the Search module isn't loaded.~~

Force the Search widget to be loaded via the Search module so that even if Extra Sidebar Widgets is disabled, the widget is still available for use.

If both the Search module and the Extra Sidebar Widgets module are disabled, then the widget will not be loaded.

#### Testing instructions:

0. Make sure your test site has a Professional plan.
1. Visit `/wp-admin/admin.php?page=jetpack_modules` and disable both the Extra Sidebar Widgets module and Search module.
2. Visit Appearance -> Widgets and make sure that "Search (Jetpack)" is **not** listed.
3. Visit the Customizer and repeat the above confirmation.
4. Enable the Search module. Verify that the Search widget and only the Search widget is available and that it's called "Search (Jetpack)".
5. Disable the Search module.
4. Enable the Extra Sidebar Widgets module. Verify that the Search widget and all of the other Jetpack widgets are available.