### PR TITLE
Fixed Pinterest embeds for URLs other than .com.

### DIFF
--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -7,7 +7,18 @@
 
 // Example URL: http://pinterest.com/pinterest/pin-pets/
 // Second Example URL: https://uk.pinterest.com/annsawesomepins/travel/
-wp_embed_register_handler( 'pinterest', '#https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.com/([^/]+)(/[^/]+)?#', 'pinterest_embed_handler' );
+wp_embed_register_handler(
+	'pinterest',
+	'#'
+	. 'https?://'
+	. '(?:www\.)?'
+	. '(?:[a-z]{2}\.)?'
+	. 'pinterest\.[a-z.]+/'
+	. '([^/]+)'
+	. '(/[^/]+)?'
+	. '#',
+	'pinterest_embed_handler'
+);
 
 function pinterest_embed_handler( $matches, $attr, $url ) {
 	// Pinterest's JS handles making the embed


### PR DESCRIPTION
Fixes #7968.

For URLs other than pinterest.com that are embedded, the embed doesn't pick them up. This change modifies the regular expression to include any domain that has pinterest. followed with TLDs. This allows for false positives for garbage links and sites not affiliated with pinterest ( like http://pinterest.example.com/something )  to also work with this embed, but it shouldn't be a problem.

#### Changes proposed in this Pull Request:
* Updated the Pinterest embed regular expression.

#### Testing instructions:
* Try to embed an URL from pinterest.co.uk like https://www.pinterest.co.uk/stayandroam/blue-and-white/
* See that it doesn't work
* Use this PR
* See that the embed does work and doesn't break existing .com embeds.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed embeds from Pinterest when using .co.uk, .pt or other TLDs.