### PR TITLE
Fix php warning when adding new header

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -15,7 +15,7 @@ class Jetpack_Admin {
 	private $jetpack;
 
 	static function init() {
-		if( $_GET['page'] === 'jetpack' ) {
+		if( isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] ) {
 			add_filter( 'nocache_headers', array( 'Jetpack_Admin', 'add_no_store_header' ), 100 );
 		}
 


### PR DESCRIPTION
fixes https://github.com/Automattic/jetpack/issues/9069

A notice was being thrown because of the lack of existence check for 'page' in the conditional that checks if we should add the no store cache header. 

How to test
====
1. Activate the debug mode in your site
2. Load any page in your wp-admin. You shouldn't see any warning (or at least, not any originated in jetpack)
