### PR TITLE
Build: add `private:true` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://jetpack.com",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/jetpack.git"


### PR DESCRIPTION
Adding `private:true` to `package.json` will suppress yarn warnings about invalid license field.

https://docs.npmjs.com/files/package.json#private

It'll also prevent accidental publication using `npm publish`.

#### Testing instructions:

Previously running `yarn` commands would show:

> warning package.json: License should be a valid SPDX license expression

Adding `private:true` to `package.json` will make warnings dissapear.

Noting that we do have a valid SPDX license expression but `GPL-2.0-or-later` is so new format that Yarn v1.3 just didn't recognise it.