### PR TITLE
Likes: Make posts with manually enabled likes still be likeable if Likes are enabled for all posts

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -56,8 +56,9 @@ class Jetpack_Likes_Settings {
 		$disabled        = ! $this->is_enabled_sitewide();
 		$switched_status = get_post_meta( $post_id, 'switch_like_status', true );
 
-		if ( $disabled && empty( $switched_status ) )
+		if ( $disabled && empty( $switched_status ) || ! $disabled && $switched_status === '0' ) {
 			$checked = false;
+		}
 
 		/**
 		 * Fires before the Likes meta box content in the post editor.
@@ -135,10 +136,20 @@ class Jetpack_Likes_Settings {
 		}
 
 		// Record a change in like status for this post - only if it contradicts the
-		// site like setting.
-		if ( ( $this->is_enabled_sitewide() && empty( $_POST['wpl_enable_post_likes'] ) ) || ( ! $this->is_enabled_sitewide() && ! empty( $_POST['wpl_enable_post_likes'] ) ) ) {
+		// site like setting. If it doesn't contradict, then we delete the new individual status.
+		if ( ! $this->is_enabled_sitewide() && ! empty( $_POST['wpl_enable_post_likes'] ) ) {
+			// Likes turned on for individual posts. User wants to add the button to a single post
 			update_post_meta( $post_id, 'switch_like_status', 1 );
-		} else {
+		} else if ( $this->is_enabled_sitewide() && empty( $_POST['wpl_enable_post_likes'] ) ) {
+			// Likes turned on for all posts. User wants to remove the button from a single post
+			update_post_meta( $post_id, 'switch_like_status', 0 );
+		} else if (
+			( ! $this->is_enabled_sitewide() && empty( $_POST['wpl_enable_post_likes'] ) ) ||
+			( $this->is_enabled_sitewide() && ! empty( $_POST['wpl_enable_post_likes'] ) )
+		) {
+			// User wants to update the likes button status for an individual post, but the new status
+			// is the same as if they're asking for the default behaviour according to the current Likes setting.
+			// So we delete the meta.
 			delete_post_meta( $post_id, 'switch_like_status' );
 		}
 
@@ -216,9 +227,9 @@ class Jetpack_Likes_Settings {
 		}
 
 		$sitewide_likes_enabled = (bool) $this->is_enabled_sitewide();
-		$post_likes_switched    = (bool) get_post_meta( $post->ID, 'switch_like_status', true );
+		$post_likes_switched    = get_post_meta( $post->ID, 'switch_like_status', true );
 
-		return $post_likes_switched || $sitewide_likes_enabled;
+		return $post_likes_switched || ( $sitewide_likes_enabled && $post_likes_switched !== '0' );
 	}
 
 	/**

--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -56,7 +56,7 @@ class Jetpack_Likes_Settings {
 		$disabled        = ! $this->is_enabled_sitewide();
 		$switched_status = get_post_meta( $post_id, 'switch_like_status', true );
 
-		if ( $disabled && empty( $switched_status ) || false == $disabled && !empty( $switched_status ) )
+		if ( $disabled && empty( $switched_status ) )
 			$checked = false;
 
 		/**

--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -218,7 +218,7 @@ class Jetpack_Likes_Settings {
 		$sitewide_likes_enabled = (bool) $this->is_enabled_sitewide();
 		$post_likes_switched    = (bool) get_post_meta( $post->ID, 'switch_like_status', true );
 
-		return $post_likes_switched xor $sitewide_likes_enabled;
+		return $post_likes_switched || $sitewide_likes_enabled;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2044

#### Changes proposed in this Pull Request:

* Makes the single post edit metabox not have likes forcedly unchecked when Likes are enabled for all posts.
* Replace a `xor` comparsion for a regular `or` when deciding whether to show the Likes button or not based on the metadata of the post and the global setting for Likes

#### Testing instructions:

1. Likes module enabled, Settings->Sharing set to likes on a per post basis
2. On a post, check the box to enable likes for that post, save.
3. Confirm likes are visible.
4. Change the setting on Settings->Sharing to enable likes for all posts.
5. View the previously likeable post.
6. Confirm you see the Likes button.
7. Edit the post and see the checkbox remains checked.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Made manually enabled likes to still be likeable if Likes are enabled for all posts