### PR TITLE
VaultPress: remove WP core notice that says that the plugin was activated

### DIFF
--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -9,6 +9,11 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 	// The deactivation is performed here because there may be pages that admin_init runs on,
 	// such as admin_ajax, that could deactivate the plugin without showing this notification.
 	deactivate_plugins( 'vaultpress/vaultpress.php' );
+
+	// Remove WP core notice that says that the plugin was activated.
+	if ( isset( $_GET['activate'] ) ) {
+		unset( $_GET['activate'] );
+	}
 	?>
 	<div class="notice notice-success vp-deactivated">
 		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>


### PR DESCRIPTION
Follow up #9056

#### Changes proposed in this Pull Request:

* Remove WP core notice that says that the plugin was activated

#### Before

<img width="966" alt="captura de pantalla 2018-03-19 a la s 13 42 03" src="https://user-images.githubusercontent.com/1041600/37609235-5c65952c-2b7b-11e8-9958-497e0a566b1d.png">

#### After

<img width="972" alt="captura de pantalla 2018-03-19 a la s 13 41 09" src="https://user-images.githubusercontent.com/1041600/37609242-62ab665a-2b7b-11e8-915e-65757a885a96.png">

#### Testing instructions:

1. test with a site with Rewind active
2. activate the VaultPress plugin. It will be automatically deactivated and a notice will show.
3. make sure there's not a `Plugin activated.` notice