### PR TITLE
Dashboard: add link to manage plugins and moderate comments in Calypso

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -4,22 +4,39 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import DashItem from 'components/dash-item';
 import { numberFormat, translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
+import DashItem from 'components/dash-item';
 import QueryAkismetData from 'components/data/query-akismet-data';
 import { getAkismetData } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
+import { isDevMode } from 'state/connection';
 
 class DashAkismet extends Component {
+
+	static propTypes = {
+		siteRawUrl: PropTypes.string.isRequired,
+		siteAdminUrl: PropTypes.string.isRequired,
+
+		// Connected props
+		akismetData: PropTypes.string.isRequired,
+		isDevMode: PropTypes.bool.isRequired,
+	};
+
+	static defaultProps = {
+		siteRawUrl: '',
+		siteAdminUrl: '',
+		akismetData: 'N/A',
+		isDevMode: '',
+	};
+
 	getContent() {
-		const akismetData = this.props.akismetData,
-			akismetSettingsUrl = this.props.siteAdminUrl + 'admin.php?page=akismet-key-config',
-			labelName = __( 'Spam Protection' ),
-			hasSitePlan = false !== this.props.sitePlan;
+		const akismetData = this.props.akismetData;
+		const labelName = __( 'Spam Protection' );
 
 		if ( akismetData === 'N/A' ) {
 			return (
@@ -34,6 +51,8 @@ class DashAkismet extends Component {
 				</DashItem>
 			);
 		}
+
+		const hasSitePlan = false !== this.props.sitePlan;
 
 		if ( akismetData === 'not_installed' ) {
 			return (
@@ -93,7 +112,7 @@ class DashAkismet extends Component {
 						{
 							__( 'Whoops! Your Akismet key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.', {
 								components: {
-									akismetSettings: <a href={ akismetSettingsUrl } />
+									akismetSettings: <a href={ `${ this.props.siteAdminUrl }admin.php?page=akismet-key-config` } />
 								}
 							} )
 						}
@@ -102,8 +121,9 @@ class DashAkismet extends Component {
 			);
 		}
 
-		return (
+		return [
 			<DashItem
+				key="comment-moderation"
 				label={ labelName }
 				module="akismet"
 				status="is-working"
@@ -117,8 +137,18 @@ class DashAkismet extends Component {
 						} )
 					}
 				</p>
-			</DashItem>
-		);
+			</DashItem>,
+			! this.props.isDevMode && (
+				<Card
+					key="moderate-comments"
+					className="jp-dash-item__manage-in-wpcom"
+					compact
+					href={ `https://wordpress.com/comments/all/${ this.props.siteRawUrl }` }
+				>
+					{ __( 'Moderate comments' ) }
+				</Card>
+			)
+		];
 	}
 
 	render() {
@@ -131,16 +161,10 @@ class DashAkismet extends Component {
 	}
 }
 
-DashAkismet.propTypes = {
-	siteRawUrl: PropTypes.string.isRequired,
-	siteAdminUrl: PropTypes.string.isRequired
-};
-
 export default connect(
-	( state ) => {
-		return {
-			akismetData: getAkismetData( state ),
-			sitePlan: getSitePlan( state )
-		};
-	}
+	state => ( {
+		akismetData: getAkismetData( state ),
+		sitePlan: getSitePlan( state ),
+		isDevMode: isDevMode( state ),
+	} )
 )( DashAkismet );

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -78,14 +78,16 @@ class DashPluginUpdates extends Component {
 					}
 				</p>
 			</DashItem>,
-			<Card
-				key="manage-plugins"
-				className="jp-dash-item__manage-plugins"
-				compact
-				href={ managePluginsUrl }
-			>
-				{ __( 'Manage your plugins' ) }
-			</Card>
+			! this.props.isDevMode && (
+				<Card
+					key="manage-plugins"
+					className="jp-dash-item__manage-plugins"
+					compact
+					href={ managePluginsUrl }
+				>
+					{ __( 'Manage your plugins' ) }
+				</Card>
+			)
 		];
 	}
 

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -69,7 +69,7 @@ class DashPluginUpdates extends Component {
 						{
 							this.props.isDevMode
 								? ''
-								: __( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
+								: __( '{{a}}Turn on plugin autoupdates{{/a}}', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
 						}
 					</p>
 				</DashItem>

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -81,7 +81,7 @@ class DashPluginUpdates extends Component {
 			! this.props.isDevMode && (
 				<Card
 					key="manage-plugins"
-					className="jp-dash-item__manage-plugins"
+					className="jp-dash-item__manage-in-wpcom"
 					compact
 					href={ managePluginsUrl }
 				>

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -85,6 +85,10 @@ class DashPluginUpdates extends Component {
 					{
 						__( 'All plugins are up-to-date. Awesome work!' )
 					}
+					{ ' ' }
+					{
+						! this.props.isDevMode && __( '{{a}}Manage your plugins{{/a}}.', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
+					}
 				</p>
 			</DashItem>
 		);

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -40,6 +40,10 @@ class DashPluginUpdates extends Component {
 			);
 		}
 
+		const linkToManagePlugins = {
+			components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> }
+		};
+
 		if ( 'updates-available' === pluginUpdates.code ) {
 			return (
 				<DashItem
@@ -67,9 +71,7 @@ class DashPluginUpdates extends Component {
 							} )
 						}
 						{
-							this.props.isDevMode
-								? ''
-								: __( '{{a}}Turn on plugin autoupdates{{/a}}', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
+							! this.props.isDevMode && __( '{{a}}Turn on plugin autoupdates{{/a}}', linkToManagePlugins )
 						}
 					</p>
 				</DashItem>
@@ -87,7 +89,7 @@ class DashPluginUpdates extends Component {
 					}
 					{ ' ' }
 					{
-						! this.props.isDevMode && __( '{{a}}Manage your plugins{{/a}}.', { components: { a: <a href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl } /> } } )
+						! this.props.isDevMode && __( '{{a}}Manage your plugins{{/a}}.', linkToManagePlugins )
 					}
 				</p>
 			</DashItem>

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -420,3 +420,8 @@
 	color: $blue-wordpress;
 	text-decoration: underline;
 }
+
+.jp-dash-item__manage-plugins {
+	margin-top: 1px;
+	width: 100%;
+}

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -421,7 +421,7 @@
 	text-decoration: underline;
 }
 
-.jp-dash-item__manage-plugins {
+.jp-dash-item__manage-in-wpcom {
 	margin-top: 1px;
 	width: 100%;
 }


### PR DESCRIPTION
Fixes #4549

#### Changes proposed in this Pull Request:

Adds a clickable card so users can go and manage plugins in Calypso when plugin autoupdates are enabled. This card will be persistent and always displayed.

#### Before

<img width="373" alt="captura de pantalla 2018-03-19 a la s 15 33 48" src="https://user-images.githubusercontent.com/1041600/37615023-0b9b0db0-2b8b-11e8-89a4-6157610f4849.png">

#### After

<img width="370" alt="captura de pantalla 2018-03-21 a la s 20 49 04" src="https://user-images.githubusercontent.com/1041600/37743548-5b3029ea-2d49-11e8-97f4-6633910d6b8c.png">

And this is how it looks when autoupdates aren't turned on:

<img width="364" alt="captura de pantalla 2018-03-21 a la s 20 47 06" src="https://user-images.githubusercontent.com/1041600/37743605-a6bb0f88-2d49-11e8-9501-3378a70bb432.png">

The clickable card is not shown in Dev Mode

<img width="364" alt="captura de pantalla 2018-03-22 a la s 14 38 26" src="https://user-images.githubusercontent.com/1041600/37787894-d57ed544-2dde-11e8-9f75-03252129c876.png">

#### Spam Protection 

This card also got a clickable card to go to comment moderation at 
https://wordpress.com/comments/all/SITESLUG

#### Before

<img width="366" alt="captura de pantalla 2018-03-22 a la s 15 13 20" src="https://user-images.githubusercontent.com/1041600/37789894-d59af27e-2de3-11e8-9f2c-0def5da0e334.png">

#### After

<img width="365" alt="captura de pantalla 2018-03-22 a la s 15 13 11" src="https://user-images.githubusercontent.com/1041600/37789892-d5634edc-2de3-11e8-84cb-9d67abd74240.png">

As with plugins card, the clickable card is not shown in dev mode.

#### Testing instructions:

* turn on auto-updates
* make sure the link is there

#### Proposed changelog entry for your changes:

Dashboard - Plugins: new link allows to go to WordPress.com to manage plugins even when auto-updates are enabled.
