### PR TITLE
Remove likes from jumpstart

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -2,13 +2,12 @@
 /**
  * Module Name: Likes
  * Module Description: Give visitors an easy way to show they appreciate your content.
- * Jumpstart Description: Give visitors an easy way to show they appreciate your content.
  * First Introduced: 2.2
  * Sort Order: 23
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
- * Feature: Engagement, Jumpstart
+ * Feature: Engagement
  * Additional Search Queries: like, likes, wordpress.com
  */
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -88,7 +88,6 @@ function jetpack_get_module_i18n( $key ) {
 			'likes' => array(
 				'name' => _x( 'Likes', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Give visitors an easy way to show they appreciate your content.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Give visitors an easy way to show they appreciate your content.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'manage' => array(


### PR DESCRIPTION
Remove Likes from Jump start - usage patterns suggest it's better as an opt-in.