### PR TITLE
Update notice styles to match Calypso

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -12,7 +12,7 @@ class AdminNotices extends React.Component {
 		if ( $vpDeactivationNotice.length > 0 ) {
 			$vpDeactivationNotice.each( function() {
 				const $notice = jQuery( this ).addClass( 'dops-notice is-success is-dismissable' ).removeClass( 'wrap vp-notice notice notice-success' );
-				const icon = '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>';
+				const icon = '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>';
 				$notice.wrapInner( '<span class="dops-notice__content">' );
 				$notice.find( '.dops-notice__content' ).before( icon ).css( 'display', 'block' );
 				$notice.find( '.dops-notice__content' ).after( dismiss );
@@ -33,8 +33,8 @@ class AdminNotices extends React.Component {
 				const $warningOrSuccess = $success ? 'is-success' : 'is-warning';
 				const $notice = jQuery( this ).addClass( 'dops-notice vp-notice-jp ' + $warningOrSuccess ).removeClass( 'wrap vp-notice' );
 				const icon = $success
-					? '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>'
-					: '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg>';
+					? '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>'
+					: '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg></span>';
 				$notice.wrapInner( '<span class="dops-notice__content">' );
 				$notice.find( '.dops-notice__content' ).before( icon );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );

--- a/_inc/client/components/global-notices/style.scss
+++ b/_inc/client/components/global-notices/style.scss
@@ -3,9 +3,8 @@
 @import '../../scss/z-index';
 
 .global-notices {
-	overflow: hidden;
 	text-align: right;
-	//pointer-events: none;
+	pointer-events: none;
 
 	z-index: z-index( 'root', '.global-notices' );
 	position: fixed;
@@ -39,28 +38,23 @@
 	margin-bottom: 0;
 	text-align: left;
 	pointer-events: auto;
+	border-radius: 0;
+	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
+	0 0 56px rgba( 0, 0, 0, 0.15 );
+
+	.dops-notice__icon-wrapper {
+		border-radius: 0;
+	}
 
 	@include breakpoint( ">660px" ) {
 		display: flex;
-		border-radius: 20px;
 		overflow: hidden;
 		margin-bottom: 24px;
-	}
-}
+		border-radius: 3px;
 
-.global-notices .dops-notice__icon {
-
-	@include breakpoint( ">660px" ) {
-		padding: 8px 0 8px 16px;
-	}
-}
-
-.global-notices .dops-notice__content {
-	flex-basis: auto;
-	flex-grow: 1;
-
-	@include breakpoint( ">660px" ) {
-		padding: 9px 13px;
+		.dops-notice__icon-wrapper {
+			border-radius: 3px 0 0 3px;
+		}
 	}
 }
 
@@ -68,7 +62,7 @@
 
 	@include breakpoint( ">660px" ) {
 		font-size: 14px;
-		padding: 9px 16px;
+		padding: 13px 16px;
 	}
 }
 
@@ -76,6 +70,6 @@
 	flex-shrink: 0;
 
 	@include breakpoint( ">660px" ) {
-		padding: 8px 16px;
+		padding: 13px 16px 0;
 	}
 }

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -78,32 +78,37 @@ export default class SimpleNotice extends React.Component {
 	};
 
 	render() {
-		const { status, className, isCompact, showDismiss } = this.props;
+		const {
+			children,
+			className,
+			icon,
+			isCompact,
+			onDismissClick,
+			showDismiss = ! isCompact, // by default, show on normal notices, don't show on compact ones
+			status,
+			text,
+			dismissText
+		} = this.props;
 		const classes = classnames( 'dops-notice', status, className, {
 			'is-compact': isCompact,
-			'is-dismissable': showDismiss
+			'is-dismissable': showDismiss,
 		} );
-
-		const { icon, text, children, onDismissClick, dismissText } = this.props;
 
 		return (
 			<div className={ classes }>
-				<Gridicon className="dops-notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
+				<span className="dops-notice__icon-wrapper">
+					<Gridicon className="dops-notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
+				</span>
 				<span className="dops-notice__content">
-					<span className="dops-notice__text">
-						{ text ? text : children }
-					</span>
+					<span className="dops-notice__text">{ text ? text : children }</span>
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (
-					<span
-						role="button"
-						tabIndex="0"
-						onClick={ onDismissClick }
-						onKeyDown={ onKeyDownCallback( onDismissClick ) }
-						className="dops-notice__dismiss">
+					<span role="button" onKeyDown={ onKeyDownCallback( onDismissClick ) } tabIndex="0" className="dops-notice__dismiss" onClick={ onDismissClick }>
 						<Gridicon icon="cross" size={ 24 } />
-						<span className="screen-reader-text">{ dismissText }</span>
+						<span className="dops-notice__screen-reader-text screen-reader-text">
+							{ dismissText }
+						</span>
 					</span>
 				) }
 			</div>

--- a/_inc/client/components/notice/style.scss
+++ b/_inc/client/components/notice/style.scss
@@ -88,6 +88,10 @@
 }
 
 .dops-notice__text {
+	a.dops-notice__text-no-underline {
+		text-decoration: none;
+	}
+
 	a,
 	a:visited {
 		text-decoration: underline;

--- a/_inc/client/components/notice/style.scss
+++ b/_inc/client/components/notice/style.scss
@@ -5,120 +5,107 @@
 
 .dops-notice {
 	display: flex;
-	flex-direction: column;
 	position: relative;
 	width: 100%;
 	margin-bottom: 24px;
-	background: lighten( $gray, 30 );
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
-
-	@include breakpoint( ">480px" ) {
-		flex-direction: row;
-	}
+	background: $gray-dark;
+	color: $white;
+	border-radius: 3px;
+	line-height: 1.5;
 
 	// Success!
 	&.is-success {
-		background: $alert-green;
+		.dops-notice__icon-wrapper {
+			background: $alert-green;
+		}
 	}
 
 	// Warning
 	&.is-warning {
-		background: $alert-yellow;
+		.dops-notice__icon-wrapper {
+			background: $alert-yellow;
+		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
-		background: $alert-red;
+		.dops-notice__icon-wrapper {
+			background: $alert-red;
+		}
 	}
 
 	// General notice
 	&.is-info {
-		background: $blue-wordpress;
+		.dops-notice__icon-wrapper {
+			background: $blue-medium;
+		}
+	}
+
+	.dops-notice__dismiss {
+		overflow: hidden;
 	}
 
 	&.is-success,
 	&.is-error,
 	&.is-warning,
 	&.is-info {
-		color: $white;
-
-		.dops-notice__text a {
-			color: $white;
-		}
-
 		.dops-notice__dismiss {
-			color: $white;
+			overflow: hidden;
 		}
-	}
-
-	// Basic - Unobtrusive, no icon
-	&.is-basic {
-		background: $white;
-		color: $gray;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
-
-		.dops-notice__dismiss:focus {
-			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-			0 1px 2px lighten( $gray, 30% );
-		}
-
-		@include breakpoint( ">660px" ) {
-			&:before {
-				display: none;
-			}
-		}
-
-
 	}
 }
 
-.dops-notice__icon {
-	position: absolute;
-	top: 0;
-	left: 0;
+.dops-notice__icon-wrapper {
+	background: $gray-text-min;
+	color: $white;
 	display: flex;
+	align-items: baseline;
+	width: 47px;
+	justify-content: center;
+	border-radius: 3px 0 0 3px;
 	flex-shrink: 0;
-	width: 18px;
-	height: 18px;
-	padding: 14px 16px;
+	align-self: stretch;
 
-	@include breakpoint( ">480px" ) {
-		position: relative;
-		padding: 13px 0 13px 16px;
-		width: 24px;
-		height: 24px;
+	.gridicon {
+		margin-top: 10px;
+
+		@include breakpoint( ">480px" ) {
+			margin-top: 12px;
+		}
 	}
 }
 
 .dops-notice__content {
-	display: flex;
-	flex-grow: 1;
-	padding: 14px 48px;
+	padding: 13px;
 	font-size: 12px;
+	flex-grow: 1;
 
 	@include breakpoint( ">480px" ) {
 		font-size: 14px;
-		padding: 13px;
 	}
 }
 
 .dops-notice__text {
-	max-width: 680px;
-
-	a {
+	a,
+	a:visited {
 		text-decoration: underline;
+		color: $white;
+
+		&:hover {
+			color: $white;
+			text-decoration: none;
+		}
 	}
 
 	ul {
 		margin-bottom: 0;
 		margin-left: 0;
-		list-style: disc;
 	}
 
 	li {
-		margin-left: 1.2em;
+		margin-left: 2em;
 		margin-top: 0.5em;
 	}
 
@@ -139,14 +126,10 @@
 
 // "X" for dismissing a notice
 .dops-notice__dismiss {
-	position: absolute;
-	top: 0;
-	right: 0;
-	display: flex;
 	flex-shrink: 0;
-	padding: 14px 16px;
+	padding: 12px;
 	cursor: pointer;
-	color: $gray;
+	padding-bottom: 0;
 
 	.gridicon {
 		width: 18px;
@@ -154,8 +137,8 @@
 	}
 
 	@include breakpoint( ">480px" ) {
-		position: relative;
-		padding: 13px 16px;
+		padding: 11px;
+		padding-bottom: 0;
 
 		.gridicon {
 			width: 24px;
@@ -163,38 +146,27 @@
 		}
 	}
 
-	&:hover,
-	&:focus {
-		color: $gray-dark;
-	}
-
 	.dops-notice & {
-		color: $gray;
-		opacity: 0.85;
+		color: $gray-lighten-10;
 
 		&:hover,
 		&:focus {
-			opacity: 1;
+			color: $white;
 		}
 	}
 }
 
 // specificity for general `a` elements within notice is too great
 a.dops-notice__action {
-	display: flex;
-	justify-content: center;
-	flex-shrink: 0;
-	flex-grow: 1;
-	box-sizing: border-box;
-	margin: 0 8px 8px 8px;
-	padding: 8px;
-	border-radius: 3px;
 	cursor: pointer;
 	font-size: 12px;
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
-	background: lighten( $gray, 28 );
+	color: $gray-lighten-10;
+	padding: 13px;
+	display: flex;
+	align-items: center;
 
 	@include breakpoint( ">480px" ) {
 		flex-shrink: 1;
@@ -211,28 +183,19 @@ a.dops-notice__action {
 		}
 	}
 
-	.is-success &,
-	.is-error &,
-	.is-warning &,
-	.is-info & {
-		color: $white;
+	&:visited {
+		color: $gray-lighten-10;
 	}
 
-	.is-success & { background: darken( $alert-green, 15 ); }
-	.is-error & { background: darken( $alert-red, 15 ); }
-	.is-warning & { background: darken( $alert-yellow, 15 ); }
-	.is-info & { background: darken( $blue-wordpress, 15 ); }
+	&:hover {
+		color: $white;
+	}
 
 	.gridicon {
 		margin-left: 8px;
 		opacity: 0.7;
 		width: 18px;
 		height: 18px;
-	}
-
-	&:hover,
-	&:focus {
-		background: rgba( 255, 255, 255, 0.2 );
 	}
 }
 
@@ -242,43 +205,45 @@ a.dops-notice__action {
 	flex-wrap: nowrap;
 	flex-direction: row;
 	width: auto;
-	border-radius: 2px;
+	border-radius: 3px;
 	min-height: 20px;
 	margin: 0;
 	padding: 0;
 	text-decoration: none;
 	text-transform: none;
 	vertical-align: middle;
-
-	&.is-success,
-	&.is-error,
-	&.is-warning,
-	&.is-info {
-		color: $white;
-	}
+	line-height: 1.5;
 
 	.dops-notice__content {
 		font-size: 12px;
-		padding: 6px 8px;
+		padding: 6px 10px;
 	}
 
-	.dops-notice__text {
-		line-height: 1;
-	}
+	.dops-notice__icon-wrapper {
+		width: 28px;
 
-	.dops-notice__icon {
-		position: relative;
-		align-self: center;
-		flex-shrink: 0;
-		margin: 0 0 0 8px;
-		padding: 0;
-		width: 18px;
-		height: 18px;
-		vertical-align: middle;
+		.dops-notice__icon {
+			width: 18px;
+			height: 18px;
+			margin: 0;
+		}
+
+		.gridicon {
+			margin-top: 6px;
+		}
 	}
 
 	.dops-notice__dismiss {
-		display: none;
+		position: relative;
+		align-self: center;
+		flex: none;
+		margin: 0 8px 0 0;
+		padding: 0;
+
+		.gridicon {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	a.dops-notice__action {
@@ -286,18 +251,14 @@ a.dops-notice__action {
 		display: inline-block;
 		margin: 0;
 		font-size: 12px;
-		font-weight: 600;
 		align-self: center;
 		margin-left: 16px;
-		padding: 0 8px;
-		text-decoration: underline;
-		text-transform: uppercase;
+		padding: 0 10px;
 
 		&:hover,
 		&:active,
 		&:focus {
 			background: transparent;
-			text-decoration: none;
 		}
 
 		.gridicon {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import analytics from 'lib/analytics';
 import get from 'lodash/get';
 
@@ -116,7 +115,7 @@ class ProStatus extends React.Component {
 					message
 				}
 				{
-					action && <NoticeAction onClick={ this.handleClickForTracking( type, feature ) } href={ actionUrl }>{ action }</NoticeAction>
+					action && <a className="dops-notice__text-no-underline" onClick={ this.handleClickForTracking( type, feature ) } href={ actionUrl }>{ action }</a>
 				}
 			</SimpleNotice>
 		);

--- a/_inc/client/scss/calypso-colors.scss
+++ b/_inc/client/scss/calypso-colors.scss
@@ -21,6 +21,19 @@ $gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text:              $gray-dark;
+$gray-text-min:          darken( $gray, 18% ); //#537994
+
+// Shades of gray
+$gray-lighten-10: lighten( $gray, 10% ); // #a8bece
+$gray-lighten-20: lighten( $gray, 20% ); // #c8d7e1
+$gray-lighten-30: lighten( $gray, 30% ); // #e9eff3
+$gray-darken-10:  darken( $gray, 10% );  // #668eaa
+$gray-darken-20:  darken( $gray, 20% );  // #4f748e
+$gray-darken-30:  darken( $gray, 30% );  // #3d596d
+
 // Oranges
 $orange-jazzy:           #f0821e;
 $orange-fire:            #d54e21;


### PR DESCRIPTION
Fixes #8920 

**To test:** 
Notices should look like this now: 

- Regular notices
![screen shot 2018-03-19 at 2 18 19 pm](https://user-images.githubusercontent.com/7129409/37614766-f6d4afac-2b81-11e8-8bf7-f3d7892244f6.png)

- Global notices: 
![screen shot 2018-03-19 at 2 25 04 pm](https://user-images.githubusercontent.com/7129409/37614799-094aedcc-2b82-11e8-96a2-6a3d53411dd6.png)

- Compact
![screen shot 2018-03-19 at 2 28 35 pm](https://user-images.githubusercontent.com/7129409/37614816-13bde11a-2b82-11e8-8237-103a752ea959.png)

