### PR TITLE
Fix/5151 add in progress notice

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -107,7 +107,7 @@ abstract class Publicize_Base {
 		// then check meta and publicize based on that. stage 3 implemented on wpcom
 		add_action( 'transition_post_status', array( $this, 'flag_post_for_publicize' ), 10, 3 );
 		add_action( 'save_post', array( &$this, 'save_meta' ), 20, 2 );
-		add_filter( 'post_updated_messages', array( &$this, 'update_published_message' ), 20, 1 );
+		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 20, 1 );
 
 		// Connection test callback
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
@@ -427,7 +427,7 @@ abstract class Publicize_Base {
 		$view_post_link_html = '';
 		$viewable = is_post_type_viewable( $post_type_object );
 		if ( $viewable ) {
-			$view_text = __( 'View post' ); // intentinally omitted domain
+			$view_text = __( 'View post' ); // intentionally omitted domain
 
 			if ( 'jetpack-portfolio' == $post_type ) {
 				$view_text = esc_html__( 'View project', 'jetpack' );
@@ -449,13 +449,13 @@ abstract class Publicize_Base {
 			$labels[] = sprintf(
 				_x( '%1$s: %2$s', 'Service name is %1$s, and account name is %2$s.', 'jetpack' ),
 				esc_html( $service['service_name'] ),
-				esc_html(  $service['display_name'] )
+				esc_html( $service['display_name'] ),
 			);
 		}
 
 		$messages['post'][6] = sprintf(
 			_x( 'Post published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
-			implode(', ', $labels ),
+			implode( ', ', $labels ),
 			$view_post_link_html );
 
 		if ( $post_type == 'post' && class_exists('Jetpack_Subscriptions' ) ) {
@@ -463,14 +463,14 @@ abstract class Publicize_Base {
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
 					_x( 'Post published, sending emails to subscribers and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
-					implode(', ', $labels ),
+					implode( ', ', $labels ),
 					$view_post_link_html );
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
 			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
-			implode(', ', $labels ),
+			implode( ', ', $labels ),
 			$view_post_link_html );
 
 		return $messages;

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -427,7 +427,7 @@ abstract class Publicize_Base {
 		$view_post_link_html = '';
 		$viewable = is_post_type_viewable( $post_type_object );
 		if ( $viewable ) {
-			$view_text = __( 'View post' ); // intentionally omitted domain
+			$view_text = esc_html__( 'View post' ); // intentionally omitted domain
 
 			if ( 'jetpack-portfolio' == $post_type ) {
 				$view_text = esc_html__( 'View project', 'jetpack' );
@@ -448,14 +448,14 @@ abstract class Publicize_Base {
 		foreach ( $services as $service => $display_names ) {
 			$labels[] = sprintf(
 				/* translators: Service name is %1$s, and account name is %2$s. */
-				__( '%1$s (%2$s)', 'jetpack' ),
+				esc_html__( '%1$s (%2$s)', 'jetpack' ),
 				esc_html( $service ),
 				esc_html( implode( ', ', $display_names ) )
 			);
 		}
 
 		$messages['post'][6] = sprintf(
-			/* translators: Services and account string is %1$s */
+			/* translators: %1$s is a comma-separated list of services and accounts. Ex. Facebook (@jetpack), Twitter (@jetpack) */
 			esc_html__( 'Post published and sharing on %1$s.', 'jetpack' ),
 			implode( ', ', $labels )
 		) . $view_post_link_html;
@@ -464,15 +464,15 @@ abstract class Publicize_Base {
 			$subscription = Jetpack_Subscriptions::init();
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
-					/* translators: Services and account string is %1$s */
-               		esc_html__( 'Post published, sending emails to subscribers and sharing post on %1$s.', 'jetpack' ),
-                	implode( ', ', $labels )
-				). $view_post_link_html;
+					/* translators: %1$s is a comma-separated list of services and accounts. Ex. Facebook (@jetpack), Twitter (@jetpack) */
+					esc_html__( 'Post published, sending emails to subscribers and sharing post on %1$s.', 'jetpack' ),
+					implode( ', ', $labels )
+				) . $view_post_link_html;
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
-			/* translators: Published Message: services and account string is %1$s */
+			/* translators: %1$s is a comma-separated list of services and accounts. Ex. Facebook (@jetpack), Twitter (@jetpack) */
 			esc_html__( 'Project published and sharing project on %1$s.', 'jetpack' ),
 			implode( ', ', $labels )
 		) . $view_post_link_html;
@@ -510,7 +510,7 @@ abstract class Publicize_Base {
 	* the publicize_post_types array filter.
 	*
 	* @param string $post_type The post type to check.
-	* $return bool True if the post type can be Publicized.
+	* @return bool True if the post type can be Publicized.
 	*/
 	function post_type_is_publicizeable( $post_type ) {
 		if ( 'post' == $post_type )

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -448,37 +448,34 @@ abstract class Publicize_Base {
 		foreach ( $services as $service => $display_names ) {
 			$labels[] = sprintf(
 				/* translators: Service name is %1$s, and account name is %2$s. */
-				_x( '%1$s (%2$s)', 'Service and account string', 'jetpack' ),
+				__( '%1$s (%2$s)', 'jetpack' ),
 				esc_html( $service ),
 				esc_html( implode( ', ', $display_names ) )
 			);
 		}
 
 		$messages['post'][6] = sprintf(
-			/* translators: Services and account string is %1$s, link to view published post is %2$s */
-			_x( 'Post published and sharing on %1$s. %2$s', 'Post published notice', 'jetpack' ),
-			implode( ', ', $labels ),
-			$view_post_link_html
-		);
+			/* translators: Services and account string is %1$s */
+			esc_html__( 'Post published and sharing on %1$s.', 'jetpack' ),
+			implode( ', ', $labels )
+		) . $view_post_link_html;
 
 		if ( $post_type == 'post' && class_exists('Jetpack_Subscriptions' ) ) {
 			$subscription = Jetpack_Subscriptions::init();
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
-					/* translators: Services and account string is %1$s, link to view published post is %2$s */
-               		_x( 'Post published, sending emails to subscribers and sharing post on %1$s. %2$s', 'Post published notice', 'jetpack' ),
-                	implode( ', ', $labels ),
-                	$view_post_link_html
-				);
+					/* translators: Services and account string is %1$s */
+               		esc_html__( 'Post published, sending emails to subscribers and sharing post on %1$s.', 'jetpack' ),
+                	implode( ', ', $labels )
+				). $view_post_link_html;
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
-			/* translators: Published Message: services and account string is %1$s, link to view published post is %2$s */
-			_x( 'Project published and sharing project on %1$s. %2$s', 'Post published notice', 'jetpack' ),
-			implode( ', ', $labels ),
-			$view_post_link_html
-		);
+			/* translators: Published Message: services and account string is %1$s */
+			esc_html__( 'Project published and sharing project on %1$s.', 'jetpack' ),
+			implode( ', ', $labels )
+		) . $view_post_link_html;
 
 		return $messages;
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -445,16 +445,16 @@ abstract class Publicize_Base {
 		}
 
 		$labels = array();
-		foreach ( $services as $service ) {
+		foreach ( $services as $service => $dispay_names ) {
 			$labels[] = sprintf(
-				_x( '%1$s: %2$s', 'Service name is %1$s, and account name is %2$s.', 'jetpack' ),
-				esc_html( $service['service_name'] ),
-				esc_html( $service['display_name'] ),
+				_x( '%1$s (%2$s)', 'Service name is %1$s, and account name is %2$s.', 'jetpack' ),
+				esc_html( $service ),
+				esc_html( implode( ', ', $dispay_names ) )
 			);
 		}
 
 		$messages['post'][6] = sprintf(
-			_x( 'Post published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			_x( 'Post published and sharing on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
 			implode( ', ', $labels ),
 			$view_post_link_html );
 
@@ -462,14 +462,14 @@ abstract class Publicize_Base {
 			$subscription = Jetpack_Subscriptions::init();
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
-					_x( 'Post published, sending emails to subscribers and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+					_x( 'Post published, sending emails to subscribers and sharing post on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
 					implode( ', ', $labels ),
 					$view_post_link_html );
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
-			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			_x( 'Project published and sharing project on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
 			implode( ', ', $labels ),
 			$view_post_link_html );
 
@@ -492,11 +492,7 @@ abstract class Publicize_Base {
 				if ( get_post_meta( $post_id, $this->POST_SKIP . $unique_id,  true ) ) {
 					continue;
 				}
-
-				$services[] = array(
-					'service_name' => $this->get_service_label( $service_name ),
-					'display_name' => $this->get_display_name( $service_name, $connection ),
-				);
+				$services[ $this->get_service_label( $service_name ) ][] = $this->get_display_name( $service_name, $connection );
 			}
 		}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -427,10 +427,10 @@ abstract class Publicize_Base {
 		$view_post_link_html = '';
 		$viewable = is_post_type_viewable( $post_type_object );
 		if ( $viewable ) {
-			$view_text = __( 'View post' );
+			$view_text = __( 'View post' ); // intentinally omitted domain
 
 			if ( $post_type == 'jetpack-portfolio' ) {
-				$view_text = esc_html__( 'View Project', 'jetpack' );
+				$view_text = esc_html__( 'View project', 'jetpack' );
 			}
 
 			$view_post_link_html = sprintf( ' <a href="%1$s">%2$s</a>',

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -445,33 +445,40 @@ abstract class Publicize_Base {
 		}
 
 		$labels = array();
-		foreach ( $services as $service => $dispay_names ) {
+		foreach ( $services as $service => $display_names ) {
 			$labels[] = sprintf(
-				_x( '%1$s (%2$s)', 'Service name is %1$s, and account name is %2$s.', 'jetpack' ),
+				/* translators: Service name is %1$s, and account name is %2$s. */
+				_x( '%1$s (%2$s)', 'Service and account string', 'jetpack' ),
 				esc_html( $service ),
-				esc_html( implode( ', ', $dispay_names ) )
+				esc_html( implode( ', ', $display_names ) )
 			);
 		}
 
 		$messages['post'][6] = sprintf(
-			_x( 'Post published and sharing on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			/* translators: Services and account string is %1$s, link to view published post is %2$s */
+			_x( 'Post published and sharing on %1$s. %2$s', 'Post published notice', 'jetpack' ),
 			implode( ', ', $labels ),
-			$view_post_link_html );
+			$view_post_link_html
+		);
 
 		if ( $post_type == 'post' && class_exists('Jetpack_Subscriptions' ) ) {
 			$subscription = Jetpack_Subscriptions::init();
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
-					_x( 'Post published, sending emails to subscribers and sharing post on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
-					implode( ', ', $labels ),
-					$view_post_link_html );
+					/* translators: Services and account string is %1$s, link to view published post is %2$s */
+               		_x( 'Post published, sending emails to subscribers and sharing post on %1$s. %2$s', 'Post published notice', 'jetpack' ),
+                	implode( ', ', $labels ),
+                	$view_post_link_html
+				);
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
-			_x( 'Project published and sharing project on %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			/* translators: Published Message: services and account string is %1$s, link to view published post is %2$s */
+			_x( 'Project published and sharing project on %1$s. %2$s', 'Post published notice', 'jetpack' ),
 			implode( ', ', $labels ),
-			$view_post_link_html );
+			$view_post_link_html
+		);
 
 		return $messages;
 	}
@@ -496,19 +503,18 @@ abstract class Publicize_Base {
 			}
 		}
 
-
 		return $services;
 	}
 
 	/**
-	 * Is a given post type Publicize-able?
-	 *
-	 * Not every CPT lends itself to Publicize-ation.  Allow CPTs to register by adding their CPT via
-	 * the publicize_post_types array filter.
-	 *
-	 * @param string $post_type The post type to check.
-	 * $return bool True if the post type can be Publicized.
-	 */
+	* Is a given post type Publicize-able?
+	*
+	* Not every CPT lends itself to Publicize-ation.  Allow CPTs to register by adding their CPT via
+	* the publicize_post_types array filter.
+	*
+	* @param string $post_type The post type to check.
+	* $return bool True if the post type can be Publicized.
+	*/
 	function post_type_is_publicizeable( $post_type ) {
 		if ( 'post' == $post_type )
 			return true;

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -458,6 +458,16 @@ abstract class Publicize_Base {
 			implode(',', $labels ),
 			$view_post_link_html );
 
+		if ( $post_type == 'post' && class_exists('Jetpack_Subscriptions' ) ) {
+			$subscription = Jetpack_Subscriptions::init();
+			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
+				$messages['post'][6] = sprintf(
+					_x( 'Post published, sending emails to subscribers and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
+					implode(',', $labels ),
+					$view_post_link_html );
+			}
+		}
+
 		$messages['jetpack-portfolio'][6] = sprintf(
 			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
 			implode(',', $labels ),

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -426,10 +426,16 @@ abstract class Publicize_Base {
 		}
 		$view_post_link_html = '';
 		$viewable = is_post_type_viewable( $post_type_object );
-		if( $viewable ) {
+		if ( $viewable ) {
+			$view_text = __( 'View post' );
+
+			if ( $post_type == 'jetpack-portfolio' ) {
+				$view_text = esc_html__( 'View Project', 'jetpack' );
+			}
+
 			$view_post_link_html = sprintf( ' <a href="%1$s">%2$s</a>',
 				esc_url( get_permalink( $post ) ),
-				__( 'View post' )
+				$view_text
 			);
 		}
 
@@ -447,10 +453,16 @@ abstract class Publicize_Base {
 			);
 		}
 
-		$messages[6] = sprintf(
+		$messages['post'][6] = sprintf(
 			_x( 'Post published and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
 			implode(',', $labels ),
 			$view_post_link_html );
+
+		$messages['jetpack-portfolio'][6] = sprintf(
+			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
+			implode(',', $labels ),
+			$view_post_link_html );
+
 		return $messages;
 	}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -134,8 +134,8 @@ abstract class Publicize_Base {
 	/**
 	* Returns an external URL to the connection's profile
 	*/
-	function get_profile_link( $service_name, $c ) {
-		$cmeta = $this->get_connection_meta( $c );
+	function get_profile_link( $service_name, $connection ) {
+		$cmeta = $this->get_connection_meta( $connection );
 
 		if ( isset( $cmeta['connection_data']['meta']['link'] ) ) {
 			if ( 'facebook' == $service_name && 0 === strpos( parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
@@ -178,8 +178,8 @@ abstract class Publicize_Base {
 	/**
 	* Returns a display name for the connection
 	*/
-	function get_display_name( $service_name, $connecton ) {
-		$cmeta = $this->get_connection_meta( $connecton );
+	function get_display_name( $service_name, $connection ) {
+		$cmeta = $this->get_connection_meta( $connection );
 
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
 			return $cmeta['connection_data']['meta']['display_name'];
@@ -212,8 +212,8 @@ abstract class Publicize_Base {
 		}
 	}
 
-	function show_options_popup( $service_name, $c ) {
-		$cmeta = $this->get_connection_meta( $c );
+	function show_options_popup( $service_name, $connection ) {
+		$cmeta = $this->get_connection_meta( $connection );
 
 		// always show if no selection has been made for facebook
 		if ( 'facebook' == $service_name && empty( $cmeta['connection_data']['meta']['facebook_profile'] ) && empty( $cmeta['connection_data']['meta']['facebook_page'] ) )
@@ -429,7 +429,7 @@ abstract class Publicize_Base {
 		if ( $viewable ) {
 			$view_text = __( 'View post' ); // intentinally omitted domain
 
-			if ( $post_type == 'jetpack-portfolio' ) {
+			if ( 'jetpack-portfolio' == $post_type ) {
 				$view_text = esc_html__( 'View project', 'jetpack' );
 			}
 
@@ -440,37 +440,37 @@ abstract class Publicize_Base {
 		}
 
 		$services = $this->get_publicizing_services( $post->ID );
-		if( empty( $services ) ) {
+		if ( empty( $services ) ) {
 			return $messages;
 		}
 
 		$labels = array();
-		foreach( $services as $service ) {
+		foreach ( $services as $service ) {
 			$labels[] = sprintf(
-				_x( '%1$s: %2$s', 'Service: Account publicizing to', 'jetpack' ),
+				_x( '%1$s: %2$s', 'Service name is %1$s, and account name is %2$s.', 'jetpack' ),
 				esc_html( $service['service_name'] ),
 				esc_html(  $service['display_name'] )
 			);
 		}
 
 		$messages['post'][6] = sprintf(
-			_x( 'Post published and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
-			implode(',', $labels ),
+			_x( 'Post published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			implode(', ', $labels ),
 			$view_post_link_html );
 
 		if ( $post_type == 'post' && class_exists('Jetpack_Subscriptions' ) ) {
 			$subscription = Jetpack_Subscriptions::init();
 			if ( $subscription->should_email_post_to_subscribers( $post ) ) {
 				$messages['post'][6] = sprintf(
-					_x( 'Post published, sending emails to subscribers and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
-					implode(',', $labels ),
+					_x( 'Post published, sending emails to subscribers and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+					implode(', ', $labels ),
 					$view_post_link_html );
 			}
 		}
 
 		$messages['jetpack-portfolio'][6] = sprintf(
-			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: Accounts to publish to, link to view published post', 'jetpack' ),
-			implode(',', $labels ),
+			_x( 'Project published and publicizing to %1$s. %2$s', 'Published Message: services and account string is %1$s, link to view published post is %2$s', 'jetpack' ),
+			implode(', ', $labels ),
 			$view_post_link_html );
 
 		return $messages;
@@ -483,9 +483,9 @@ abstract class Publicize_Base {
 			// services have multiple connections.
 			foreach ( $connections as $connection ) {
 				$unique_id = '';
-				if ( !empty( $connection->unique_id ) )
+				if ( ! empty( $connection->unique_id ) )
 					$unique_id = $connection->unique_id;
-				else if ( !empty( $connection['connection_data']['token_id'] ) )
+				else if ( ! empty( $connection['connection_data']['token_id'] ) )
 					$unique_id = $connection['connection_data']['token_id'];
 
 				// Did we skip this connection?
@@ -495,7 +495,7 @@ abstract class Publicize_Base {
 
 				$services[] = array(
 					'service_name' => $this->get_service_label( $service_name ),
-					'display_name' => $this->get_display_name( $service_name, $connection )
+					'display_name' => $this->get_display_name( $service_name, $connection ),
 				);
 			}
 		}

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -77,6 +77,8 @@ class Jetpack_Subscriptions {
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
 
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
+
+		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 18, 1 );
 	}
 
 	/**
@@ -158,6 +160,20 @@ class Jetpack_Subscriptions {
 			$set_checkbox = isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ? 1 : 0;
 			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $set_checkbox );
 		}
+	}
+
+	function update_published_message( $messages ) {
+		global $post;
+		if ( ! $this->should_email_post_to_subscribers( $post ) ) {
+			return $messages;
+		}
+
+		$messages['post'][6] = sprintf(
+				__( 'Post published and sending emails to subscribers. <a href="%1$s">%2$s</a>', 'jetpack' ),
+				esc_url( get_permalink( $post ) ),
+				__( 'View Post' )
+			);
+		return $messages;
 	}
 
 	public function should_email_post_to_subscribers( $post ) {
@@ -297,7 +313,6 @@ class Jetpack_Subscriptions {
 	 */
 	function subscriptions_settings_section() {
 	?>
-
 		<p id="jetpack-subscriptions-settings"><?php _e( 'Change whether your visitors can subscribe to your posts or comments or both.', 'jetpack' ); ?></p>
 
 	<?php

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -171,7 +171,7 @@ class Jetpack_Subscriptions {
 		$messages['post'][6] = sprintf(
 				__( 'Post published and sending emails to subscribers. <a href="%1$s">%2$s</a>', 'jetpack' ),
 				esc_url( get_permalink( $post ) ),
-				__( 'View Post' )
+				__( 'View post' ) // intentinally omitted domain
 			);
 		return $messages;
 	}

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -174,10 +174,10 @@ class Jetpack_Subscriptions {
 		);
 
 		$messages['post'][6] = sprintf(
-				/* translators: Link to view published post is %1$s */
-				esc_html__( 'Post published and sending emails to subscribers. %1$s', 'jetpack' ),
-				$view_post_link_html
-			);
+				/* translators: Message shown after a post is published */
+				esc_html__( 'Post published and sending emails to subscribers.', 'jetpack' )
+
+			) . $view_post_link_html;
 		return $messages;
 	}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -174,9 +174,8 @@ class Jetpack_Subscriptions {
 		);
 
 		$messages['post'][6] = sprintf(
-				/* translators: Message shown after a post is published */
-				esc_html__( 'Post published and sending emails to subscribers.', 'jetpack' )
-
+			/* translators: Message shown after a post is published */
+			esc_html__( 'Post published and sending emails to subscribers.', 'jetpack' )
 			) . $view_post_link_html;
 		return $messages;
 	}

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -168,10 +168,15 @@ class Jetpack_Subscriptions {
 			return $messages;
 		}
 
+		$view_post_link_html = sprintf( ' <a href="%1$s">%2$s</a>',
+			esc_url( get_permalink( $post ) ),
+			__( 'View post' ) // intentinally omitted domain
+		);
+
 		$messages['post'][6] = sprintf(
-				__( 'Post published and sending emails to subscribers. <a href="%1$s">%2$s</a>', 'jetpack' ),
-				esc_url( get_permalink( $post ) ),
-				__( 'View post' ) // intentinally omitted domain
+				/* translators: Link to view published post is %1$s */
+				esc_html__( 'Post published and sending emails to subscribers. %1$s', 'jetpack' ),
+				$view_post_link_html
 			);
 		return $messages;
 	}


### PR DESCRIPTION
Fixes #5151 

#### Changes proposed in this Pull Request:

* Add wording to publicize and subscription that tells the user that we are going to send emails to subscribers and publicize to the different accounts.

#### Testing instructions:
Set up publicize and subscriptions. 
You should now see the new notice in the wp-admin when you are publish a post.
![screen shot 2018-03-21 at 4 41 32 pm](https://user-images.githubusercontent.com/115071/37743368-0a8fbd24-2d27-11e8-9383-b60694f152d8.png)

When you have publicize disabled. 
![screen shot 2018-03-21 at 4 42 39 pm](https://user-images.githubusercontent.com/115071/37743369-0aacd8e6-2d27-11e8-8b8d-468d96bf575f.png)

When you have subscriptions disabled. (Note the grouping of the twitter account)
![screen shot 2018-03-21 at 4 38 52 pm](https://user-images.githubusercontent.com/115071/37743367-0a5583a2-2d27-11e8-8cb8-3acdc36acb62.png)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
