### PR TITLE
Dashboard - Security Scan: if Rewind is available, change VP reference to AL/R

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -82,7 +82,7 @@ class AtAGlance extends Component {
 			<DashScan
 				{ ...settingsProps }
 				siteRawUrl={ this.props.siteRawUrl }
-				isRewindActive={ isRewindActive }
+				rewindStatus={ this.props.rewindStatus }
 			/>,
 			<DashBackups
 				{ ...settingsProps }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -6,6 +6,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
 import { getPlanClass } from 'lib/plans/constants';
+import get from 'lodash/get';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -21,7 +23,6 @@ import { isDevMode } from 'state/connection';
 import { isFetchingSiteData } from 'state/site';
 import DashItem from 'components/dash-item';
 import isArray from 'lodash/isArray';
-import get from 'lodash/get';
 
 /**
  * Displays a card for Security Scan based on the props given.
@@ -48,6 +49,7 @@ const renderCard = ( props ) => (
 class DashScan extends Component {
 	static propTypes = {
 		siteRawUrl: PropTypes.string.isRequired,
+		rewindStatus: PropTypes.object,
 
 		// Connected props
 		vaultPressData: PropTypes.any.isRequired,
@@ -60,6 +62,7 @@ class DashScan extends Component {
 
 	static defaultProps = {
 		siteRawUrl: '',
+		rewindStatus: { state: 'unavailable' },
 		vaultPressData: '',
 		scanThreats: 0,
 		sitePlan: '',
@@ -154,11 +157,16 @@ class DashScan extends Component {
 			} );
 		}
 
+		const isRewindActive = includes(
+			[ 'active', 'provisioning', 'awaiting_credentials' ],
+			get( this.props.rewindStatus, [ 'state' ], '' )
+		);
+
 		return (
 			<div className="jp-dash-item__interior">
 				<QueryVaultPressData />
 				{
-					this.props.isRewindActive
+					isRewindActive
 						? (
 							<div className="jp-dash-item__interior">
 								{

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -165,17 +165,17 @@ export class DashScan extends Component {
 		return (
 			includes( [ 'active', 'provisioning', 'awaiting_credentials' ], rewindStatus )
 				? renderCard( {
+					feature: 'rewind',
+					status: rewindNeedsCredentials ? 'is-awaiting-credentials' : 'is-working',
 					className: rewindNeedsCredentials
 						? 'jp-dash-item__is-awaiting-credentials'
 						: 'jp-dash-item__is-active',
-					status: 'is-working',
 					content: rewindNeedsCredentials
 						? __( 'Security scanning requires access to your site to work properly. ' +
 							'{{a}}Add site credentials{{/a}}.', { components: {
 								a: <a href={ encodeURI( `https://wordpress.com/stats/activity/${ this.props.siteRawUrl }?rewind-redirect=/wp-admin/admin.php?page=jetpack` ) } />
 							} } )
 						: __( 'We are making sure your site stays free of security threats. You will be notified if we find one.' ),
-					feature: 'rewind',
 				} )
 				: <div><QueryVaultPressData />{ this.getVPContent() }</div>
 		);

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -29,7 +29,6 @@ const renderCard = ( props ) => (
 		module="search"
 		className={ props.className }
 		status={ props.status }
-		isModule={ props.pro_inactive }
 		pro={ true }
 	>
 		<p className="jp-dash-item__description">
@@ -59,7 +58,6 @@ class DashSearch extends Component {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
-				pro_inactive: true,
 				content: __( 'Unavailable in Dev Mode' )
 			} );
 		}
@@ -68,7 +66,6 @@ class DashSearch extends Component {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
-				pro_inactive: true,
 				content: __( 'Give your visitors {{a}}a great search experience{{/a}}.', {
 					components: {
 						a: <a
@@ -87,7 +84,7 @@ class DashSearch extends Component {
 					label={ __( 'Search' ) }
 					module="search"
 					className="jp-dash-item__is-active"
-					isModule={ false }
+					isModule={ true }
 					pro={ true }
 				>
 					<p className="jp-dash-item__description">
@@ -100,7 +97,7 @@ class DashSearch extends Component {
 
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
-			pro_inactive: false,
+			status: 'has-pro-can-activate',
 			content: __( '{{a}}Activate{{/a}} to replace the WordPress built-in search with an improved search experience.', {
 				components: {
 					a: <a href="javascript:void(0)" onClick={ activateSearch } />

--- a/_inc/client/at-a-glance/test/component.js
+++ b/_inc/client/at-a-glance/test/component.js
@@ -9,9 +9,11 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { DashConnections } from '../connections';
+import { DashScan } from '../scan';
+import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 
 describe( 'Connections', () => {
-	let testProps = {
+	const testProps = {
 		siteConnectionStatus: true,
 		isDevMode: false,
 		userCanDisconnectSite: true,
@@ -21,11 +23,11 @@ describe( 'Connections', () => {
 		userWpComEmail: 'jetpack',
 		userWpComAvatar: 'https://example.org/avatar.png',
 		username: 'jetpack',
-		siteIcon: 'https://example.org/site-icon.png'
+		siteIcon: 'https://example.org/site-icon.png',
+		rewindStatus: { state: 'active' },
 	};
 
 	describe( 'Initially', () => {
-
 		const wrapper = shallow( <DashConnections { ...testProps } /> );
 
 		it( 'renders correctly', () => {
@@ -35,11 +37,9 @@ describe( 'Connections', () => {
 		it( 'renders cards for site and user connection', () => {
 			expect( wrapper.find( '.jp-connection-settings__info' ) ).to.have.length( 2 );
 		} );
-
 	} );
 
 	describe( 'Site connection', () => {
-
 		const wrapper = shallow( <DashConnections { ...testProps } /> );
 
 		it( 'indicates if user is the connection owner', () => {
@@ -57,21 +57,17 @@ describe( 'Connections', () => {
 		it( 'if there is no site icon a Gridicon is displayed', () => {
 			expect( shallow( <DashConnections { ...testProps } siteIcon="" /> ).find( 'Gridicon' ) ).to.have.length( 1 );
 		} );
-
 	} );
 
 	describe( 'when site is in Dev Mode', () => {
-
 		const wrapper = shallow( <DashConnections { ...testProps } siteConnectionStatus={ false } isDevMode={ true } /> );
 
 		it( 'does not show a disconnection link', () => {
 			expect( wrapper.find( 'Connect(ConnectButton)' ) ).to.have.length( 0 );
 		} );
-
 	} );
 
 	describe( 'User connection', () => {
-
 		const wrapper = shallow( <DashConnections { ...testProps } /> ).find( '.jp-connection-type' ).at( 1 );
 
 		it( 'shows an avatar if user is linked', () => {
@@ -81,22 +77,57 @@ describe( 'Connections', () => {
 		it( 'does not show a disconnection link for master users', () => {
 			expect( wrapper.find( 'Connect(ConnectButton)' ) ).to.have.length( 0 );
 		} );
-
 	} );
 
 	describe( 'when user is not linked', () => {
-
 		const wrapper = shallow( <DashConnections { ...testProps } userIsMaster={ false } isLinked={ false } /> ).find( '.jp-connection-type' ).at( 1 );
 
 		it( 'shows a link to connect the account', () => {
 			expect( wrapper.find( 'Connect(ConnectButton)' ) ).to.have.length( 1 );
-
 		} );
 
 		it( 'does not show an avatar', () => {
 			expect( wrapper.find( 'img' ) ).to.have.length( 0 );
 		} );
+	} );
+} );
 
+describe( 'When security scanning is available', () => {
+	const scanProps = {
+		siteRawUrl: 'jetpack.com',
+		rewindStatus: { state: 'active' },
+		scanThreats: 0,
+		sitePlan: { product_slug: PLAN_JETPACK_BUSINESS },
+		isDevMode: false,
+		fetchingSiteData: false,
+	};
+
+	describe( 'if Rewind requires configuration', () => {
+		const wrapper = shallow( <DashScan { ...scanProps } rewindStatus={ { state: 'awaiting_credentials' } } /> );
+
+		it( 'shows a link to configure credentials', () => {
+			expect( wrapper.find( '.jp-dash-item__is-awaiting-credentials' ).find( 'a' ).props( 'href' ).href ).has.string(
+				'/stats/activity/jetpack.com?rewind-redirect=/wp-admin/admin.php?page=jetpack'
+			);
+		} );
 	} );
 
+	describe( 'if Rewind is ready', () => {
+		const wrapper = shallow( <DashScan { ...scanProps } /> );
+
+		it( 'shows content related to Rewind', () => {
+			expect( wrapper.find( '.jp-dash-item__is-active' ) ).to.have.length( 1 );
+		} );
+	} );
+
+	describe( 'if Rewind is not available', () => {
+		const isVaultPressActive = () => true;
+		const wrapper = shallow( <DashScan
+			{ ...scanProps }
+			rewindStatus={ { state: 'unavailable' } }
+			getOptionValue={ isVaultPressActive } /> );
+		it( 'queries VaultPress data', () => {
+			expect( wrapper.find( 'Connect(QueryVaultPressData)' ) ).to.have.length( 1 );
+		} );
+	} );
 } );

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -124,15 +124,17 @@ export class DashItem extends Component {
 					: this.getModuleToggle();
 
 			case 'monitor':
-				return this.props.getOptionValue( this.props.module ) && (
-					<Button
-						compact
-						onClick={ trackMonitorSettingsClick }
-						href={ `https://wordpress.com/settings/security/${ this.props.siteRawUrl }` }
-						>
-						{ __( 'Settings' ) }
-					</Button>
-				);
+				return this.props.getOptionValue( this.props.module )
+					? (
+						<Button
+							compact
+							onClick={ trackMonitorSettingsClick }
+							href={ `https://wordpress.com/settings/security/${ this.props.siteRawUrl }` }
+							>
+							{ __( 'Settings' ) }
+						</Button>
+					)
+					: this.getModuleToggle();
 
 			case 'rewind':
 				if ( 'is-awaiting-credentials' === this.props.status ) {

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -74,6 +74,16 @@ export class DashItem extends Component {
 
 	toggleModule = () => this.props.updateOptions( { [ this.props.module ]: ! this.props.getOptionValue( this.props.module ) } );
 
+	getModuleToggle = () => (
+		<ModuleToggle
+			slug={ this.props.module }
+			activated={ this.props.getOptionValue( this.props.module ) }
+			toggling={ this.props.isUpdating( this.props.module ) }
+			toggleModule={ this.toggleModule }
+			compact={ true }
+		/>
+	);
+
 	getToggle = () => {
 		if ( 'manage' === this.props.module ) {
 			switch ( this.props.status ) {
@@ -106,16 +116,12 @@ export class DashItem extends Component {
 		switch ( this.props.module ) {
 			case 'protect':
 			case 'photon':
+				return this.getModuleToggle();
+
 			case 'search':
-				return (
-					<ModuleToggle
-						slug={ this.props.module }
-						activated={ this.props.getOptionValue( this.props.module ) }
-						toggling={ this.props.isUpdating( this.props.module ) }
-						toggleModule={ this.toggleModule }
-						compact={ true }
-					/>
-				);
+				return 'no-pro-uninstalled-or-inactive' === this.props.status
+					? <ProStatus proFeature={ this.props.module } siteAdminUrl={ this.props.siteAdminUrl } />
+					: this.getModuleToggle();
 
 			case 'monitor':
 				return this.props.getOptionValue( this.props.module ) && (

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -203,7 +203,7 @@ describe( 'DashItem', () => {
 			userCanToggle: true,
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			siteRawUrl: 'example.org',
-			getOptionValue: () => true,
+			getOptionValue: () => false,
 			isUpdating: () => false
 		};
 
@@ -215,6 +215,11 @@ describe( 'DashItem', () => {
 
 		it( 'the toggle references the module this card belongs to', () => {
 			expect( wrapper.find( 'ModuleToggle' ).props().slug ).to.be.equal( 'monitor' );
+		} );
+
+		it( "displays a button when it's active", () => {
+			const monitorActive = shallow( <DashItem { ...monitorProps } getOptionValue={ () => true } /> );
+			expect( monitorActive.find( 'Button' ).children().text() ).to.be.equal( 'Settings' );
 		} );
 
 	} );

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -13,8 +13,8 @@ import { DashItem } from '../index';
 describe( 'DashItem', () => {
 
 	let testProps = {
-		label: 'Protect',
-		module: 'protect',
+		label: 'Backups',
+		module: 'backups',
 		status: '',
 		statusText: '',
 		disabled: true,
@@ -32,7 +32,7 @@ describe( 'DashItem', () => {
 
 	it( 'has the right label for header', () => {
 		expect( wrapper.find( 'SectionHeader' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'Protect' );
+		expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'Backups' );
 	} );
 
 	it( 'the card body is built and has its href property correctly set', () => {
@@ -69,7 +69,7 @@ describe( 'DashItem', () => {
 		} );
 
 		it( 'the badge references the module', () => {
-			expect( proStatus.props().proFeature ).to.be.equal( 'protect' );
+			expect( proStatus.props().proFeature ).to.be.equal( 'backups' );
 		} );
 
 		it( 'the admin URL is correct', () => {
@@ -95,6 +95,8 @@ describe( 'DashItem', () => {
 	describe( 'when site is connected, not a PRO module, user can toggle', () => {
 
 		testProps = Object.assign( testProps, {
+			label: 'Protect',
+			module: 'protect',
 			pro: false,
 			userCanToggle: true
 		} );
@@ -114,6 +116,8 @@ describe( 'DashItem', () => {
 	describe( 'when site is connected, not a PRO module, user can not toggle', () => {
 
 		testProps = Object.assign( testProps, {
+			label: 'Protect',
+			module: 'protect',
 			userCanToggle: false
 		} );
 
@@ -213,6 +217,28 @@ describe( 'DashItem', () => {
 			expect( wrapper.find( 'ModuleToggle' ).props().slug ).to.be.equal( 'monitor' );
 		} );
 
+	} );
+
+	describe( 'When this is in the Security scanning', () => {
+		const scanProps = {
+			module: 'scan',
+			label: 'Security Scanning',
+			status: 'is-warning',
+			feature: 'rewind',
+			pro: true,
+			isDevMode: false,
+			userCanToggle: true,
+			siteAdminUrl: 'https://example.org/wp-admin/',
+			siteRawUrl: 'example.org',
+			getOptionValue: () => true,
+			isUpdating: () => false
+		};
+
+		const scanDash = shallow( <DashItem { ...scanProps } /> );
+
+		it( 'show ', () => {
+			expect( scanDash ).to.have.length( 1 );
+		} );
 	} );
 
 } );


### PR DESCRIPTION
This PR fixes a reference to VaultPress when threats were found in the Security Scan dashboard item.
The issue could be seen for example when a site acquired a plan including Rewind, and went back to dashboard: site now has Rewind, but Rewind is not yet `active` because it's `awaiting_credentials`. After credentials have been entered, Rewind is briefly in the `provisioning` state for that site. In all these cases, we should not display any VP reference.
Right now this PR won't display different messages for the three different states. That's work that will be done later when the JP dashboard is revisited for better integration with AL/R.

#### Before

<img width="377" alt="captura de pantalla 2018-03-19 a la s 16 29 19" src="https://user-images.githubusercontent.com/1041600/37617728-c21cfd26-2b92-11e8-9e3e-8471dd6f6088.png">

#### After, when Rewind is active

<img width="371" alt="captura de pantalla 2018-03-20 a la s 00 42 06" src="https://user-images.githubusercontent.com/1041600/37634950-8dac83c8-2bd7-11e8-8536-7f96e8a86051.png">

#### After, when Rewind awaits credentials

<img width="364" alt="captura de pantalla 2018-03-29 a la s 00 09 55" src="https://user-images.githubusercontent.com/1041600/38068086-928f99f6-32e5-11e8-9f9c-d5d310e34921.png">

The last sentence is linked to the flow to enter site credentials for Rewind in Calypso.

#### Testing instructions:

In a site that has Rewind in `awaiting_credentials` or `provisioning` states, and has a threat, make sure you see a reference and link to Activity Log instead of VaultPress. The Rewind state for the site can be achieved by removing credentials, which will put the Rewind for that site in the `awaiting_credentials` state. Threats can be mocked up with the Dev Tools link found at the JP dashboard footer.
Sites with VaultPress alone should still show the previous reference and link.

**Since this PR refactors `DashItem`, make sure all dashboardcards are working like before**.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Sites with Rewind where threats are found are now directed to Activity Log to instantly fix the threat.