### PR TITLE
Security: add Monitor toggles to Jetpack and unify copy

### DIFF
--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -21,7 +21,7 @@ class DashMonitor extends Component {
 	};
 
 	getContent() {
-		const labelName = __( 'Downtime Monitoring' );
+		const labelName = __( 'Downtime monitoring' );
 		const activateAndTrack = () => {
 			analytics.tracks.recordEvent(
 				'jetpack_wpa_module_toggle',

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -55,7 +55,7 @@ class DashMonitor extends Component {
 				<p className="jp-dash-item__description">
 					{
 						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' )
-							: __( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.', {
+							: __( '{{a}}Activate Monitor{{/a}} to receive email notifications if your site goes down.', {
 								components: {
 									a: <a href="javascript:void(0)" onClick={ activateAndTrack } />
 								}

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -27,16 +27,6 @@ import {
 	userCanManageModules
 } from 'state/initial-state';
 
-/**
- * Track clicks on monitor settings
- *
- * @returns {undefined}
- */
-const trackMonitorSettingsClick = () => analytics.tracks.recordJetpackClick( {
-	target: 'monitor-settings',
-	page: 'aag'
-} );
-
 export class DashItem extends Component {
 	static propTypes = {
 		label: PropTypes.string,
@@ -74,7 +64,7 @@ export class DashItem extends Component {
 			};
 
 		if ( '' !== this.props.module ) {
-			toggle = ( includes( [ 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ], this.props.module ) && this.props.isDevMode ) ? '' : (
+			toggle = ( includes( [ 'monitor', 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ], this.props.module ) && this.props.isDevMode ) ? '' : (
 				<ModuleToggle
 					slug={ this.props.module }
 					activated={ this.props.getOptionValue( this.props.module ) }
@@ -104,19 +94,6 @@ export class DashItem extends Component {
 				if ( 'is-working' === this.props.status ) {
 					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>;
 				}
-			}
-
-			if ( 'monitor' === this.props.module ) {
-				toggle = ! this.props.isDevMode && this.props.getOptionValue( this.props.module ) && (
-					<Button
-						onClick={ trackMonitorSettingsClick }
-						href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
-						compact>
-						{
-							__( 'Settings' )
-						}
-					</Button>
-				);
 			}
 
 			if ( 'rewind' === this.props.module ) {

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -205,13 +205,12 @@ describe( 'DashItem', () => {
 
 		const wrapper = shallow( <DashItem { ...monitorProps } /> );
 
-		it( 'shows a button to configure settings in wpcom', () => {
-			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+		it( 'displays a toggle for users that can toggle', () => {
+			expect( wrapper.find( 'ModuleToggle' ) ).to.have.length( 1 );
 		} );
 
-		it( 'has a link to Calypso settings', () => {
-			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'Button' ).props().href ).to.contain( 'https://wordpress.com/settings/security/' + monitorProps.siteRawUrl );
+		it( 'the toggle references the module this card belongs to', () => {
+			expect( wrapper.find( 'ModuleToggle' ).props().slug ).to.be.equal( 'monitor' );
 		} );
 
 	} );

--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -104,7 +104,7 @@ export class JetpackDisconnectDialog extends React.Component {
 						icon: 'stats-alt'
 					},
 					{
-						text: __( 'Brute force attack protection and uptime monitoring' ),
+						text: __( 'Brute force attack protection and downtime monitoring' ),
 						icon: 'lock'
 					},
 					{

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -46,7 +46,6 @@ export const SearchableModules = moduleSettingsForm(
 				'enhanced-distribution',
 				'json-api',
 				'latex',
-				'monitor',
 				'notes',
 				'shortcodes',
 				'shortlinks',

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -17,6 +17,7 @@ import QuerySite from 'components/data/query-site';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
 import BackupsScan from './backups-scan';
 import Antispam from './antispam';
+import { Monitor } from './monitor';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
@@ -67,13 +68,14 @@ export class Security extends Component {
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
-			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive;
+			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
+			foundMonitor = this.props.isModuleFound( 'monitor' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups ) {
+		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor ) {
 			return null;
 		}
 
@@ -81,6 +83,7 @@ export class Security extends Component {
 			<div>
 				<QuerySite />
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
+				{ foundMonitor && <Monitor { ...commonProps } /> }
 				{ foundAkismet &&
 					<div>
 						<Antispam { ...commonProps } />

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { translate as __ } from 'i18n-calypso';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldset } from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import {
+	ModuleSettingsForm as moduleSettingsForm,
+} from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+
+export const Monitor = moduleSettingsForm(
+	class extends Component {
+		/**
+		 * Get options for initial state.
+		 */
+		state = {
+			monitor_receive_notifications: this.props.getOptionValue( 'monitor_receive_notifications', 'monitor' ),
+			monitor_receive_wp_notifications: this.props.getOptionValue( 'monitor_receive_wp_notifications', 'monitor' ),
+		};
+
+		handleWPNotificationsToggleChange = () => {
+			this.updateOptions( 'monitor_receive_wp_notifications' );
+		}
+
+		handleEmailNotificationsToggleChange = () => {
+			this.updateOptions( 'monitor_receive_notifications' );
+		}
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName The slug of the option to update
+		 */
+		updateOptions = optionName => {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ],
+				},
+				this.props.updateFormStateModuleOption( 'monitor', optionName )
+			);
+		};
+
+		render() {
+			const isMonitorActive = this.props.getOptionValue( 'monitor' ),
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'monitor' );
+			return (
+				<SettingsCard
+					{ ...this.props }
+					hideButton
+					module="monitor"
+					header={ __( 'Monitor', { context: 'Settings header' } ) }
+				>
+					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'monitor' ) }>
+						<ModuleToggle
+							slug="monitor"
+							disabled={ unavailableInDevMode }
+							activated={ isMonitorActive }
+							toggling={ this.props.isSavingAnyOption( 'monitor' ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( "Monitor your site's uptime" ) }
+							</span>
+						</ModuleToggle>
+						<FormFieldset>
+							<CompactFormToggle
+								checked={ this.state.monitor_receive_notifications }
+								disabled={
+									! isMonitorActive ||
+										unavailableInDevMode ||
+										this.props.isSavingAnyOption( [ 'monitor', 'monitor_receive_notifications' ] )
+								}
+								onChange={ this.handleEmailNotificationsToggleChange }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Send notifications to your {{a}}WordPress.com email address{{/a}}', {
+										components: {
+											a: (
+												<a
+													href="https://wordpress.com/me/account"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									} ) }
+								</span>
+							</CompactFormToggle>
+							<CompactFormToggle
+								checked={ this.state.monitor_receive_wp_notifications }
+								disabled={
+									! isMonitorActive ||
+										unavailableInDevMode ||
+										this.props.isSavingAnyOption( [ 'monitor', 'monitor_receive_wp_notifications' ] )
+								}
+								onChange={ this.handleWPNotificationsToggleChange }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Send notifications via WordPress.com notification' ) }
+								</span>
+							</CompactFormToggle>
+						</FormFieldset>
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	}
+);

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -23,12 +23,7 @@ export const Monitor = moduleSettingsForm(
 		 */
 		state = {
 			monitor_receive_notifications: this.props.getOptionValue( 'monitor_receive_notifications', 'monitor' ),
-			monitor_receive_wp_notifications: this.props.getOptionValue( 'monitor_receive_wp_notifications', 'monitor' ),
 		};
-
-		handleWPNotificationsToggleChange = () => {
-			this.updateOptions( 'monitor_receive_wp_notifications' );
-		}
 
 		handleEmailNotificationsToggleChange = () => {
 			this.updateOptions( 'monitor_receive_notifications' );
@@ -91,19 +86,6 @@ export const Monitor = moduleSettingsForm(
 											),
 										},
 									} ) }
-								</span>
-							</CompactFormToggle>
-							<CompactFormToggle
-								checked={ this.state.monitor_receive_wp_notifications }
-								disabled={
-									! isMonitorActive ||
-										unavailableInDevMode ||
-										this.props.isSavingAnyOption( [ 'monitor', 'monitor_receive_wp_notifications' ] )
-								}
-								onChange={ this.handleWPNotificationsToggleChange }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Send notifications via WordPress.com notification' ) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -30,7 +30,7 @@ export const Monitor = moduleSettingsForm(
 					{ ...this.props }
 					hideButton
 					module="monitor"
-					header={ __( 'Downtime Monitoring', { context: 'Settings header' } ) }
+					header={ __( 'Downtime monitoring', { context: 'Settings header' } ) }
 				>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'monitor' ) }>
 						<ModuleToggle

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -3,12 +3,12 @@
  */
 import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
 
 /**
  * Internal dependencies
  */
-import { FormFieldset } from 'components/forms';
+import analytics from 'lib/analytics';
+import Card from 'components/card';
 import { ModuleToggle } from 'components/module-toggle';
 import {
 	ModuleSettingsForm as moduleSettingsForm,
@@ -18,29 +18,8 @@ import SettingsGroup from 'components/settings-group';
 
 export const Monitor = moduleSettingsForm(
 	class extends Component {
-		/**
-		 * Get options for initial state.
-		 */
-		state = {
-			monitor_receive_notifications: this.props.getOptionValue( 'monitor_receive_notifications', 'monitor' ),
-		};
-
-		handleEmailNotificationsToggleChange = () => {
-			this.updateOptions( 'monitor_receive_notifications' );
-		}
-
-		/**
-		 * Update state so toggles are updated.
-		 *
-		 * @param {string} optionName The slug of the option to update
-		 */
-		updateOptions = optionName => {
-			this.setState(
-				{
-					[ optionName ]: ! this.state[ optionName ],
-				},
-				this.props.updateFormStateModuleOption( 'monitor', optionName )
-			);
+		trackConfigureClick = () => {
+			analytics.tracks.recordJetpackClick( 'configure-monitor' );
 		};
 
 		render() {
@@ -51,7 +30,7 @@ export const Monitor = moduleSettingsForm(
 					{ ...this.props }
 					hideButton
 					module="monitor"
-					header={ __( 'Monitor', { context: 'Settings header' } ) }
+					header={ __( 'Downtime Monitoring', { context: 'Settings header' } ) }
 				>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'monitor' ) }>
 						<ModuleToggle
@@ -62,34 +41,20 @@ export const Monitor = moduleSettingsForm(
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( "Monitor your site's uptime" ) }
+								{ __( "Monitor your site's downtime" ) }
 							</span>
 						</ModuleToggle>
-						<FormFieldset>
-							<CompactFormToggle
-								checked={ this.state.monitor_receive_notifications }
-								disabled={
-									! isMonitorActive ||
-										unavailableInDevMode ||
-										this.props.isSavingAnyOption( [ 'monitor', 'monitor_receive_notifications' ] )
-								}
-								onChange={ this.handleEmailNotificationsToggleChange }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Send notifications to your {{a}}WordPress.com email address{{/a}}', {
-										components: {
-											a: (
-												<a
-													href="https://wordpress.com/me/account"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									} ) }
-								</span>
-							</CompactFormToggle>
-						</FormFieldset>
 					</SettingsGroup>
+					{
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackConfigureClick }
+							href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
+						>
+							{ __( 'Configure your notification settings' ) }
+						</Card>
+					}
 				</SettingsCard>
 			);
 		}

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -52,7 +52,7 @@ class Jetpack_Monitor {
 
 	public function jetpack_configuration_screen() {
 		?>
-		<p><?php esc_html_e( 'Nobody likes downtime, and that\'s why Jetpack Monitor is on the job, keeping tabs on your site by checking it every five minutes. As soon as any downtime is detected, you will receive an email notification alerting you to the issue. That way you can act quickly, to get your site back online again!', 'jetpack' ); ?>
+		<p><?php esc_html_e( 'Nobody likes downtime, and that\'s why Downtime Monitor is on the job, keeping tabs on your site by checking it every five minutes. As soon as any downtime is detected, you will receive an email notification alerting you to the issue. That way you can act quickly, to get your site back online again!', 'jetpack' ); ?>
 		<p><?php esc_html_e( 'We’ll also let you know as soon as your site is up and running, so you can keep an eye on total downtime.', 'jetpack'); ?></p>
 		<div class="narrow">
 		<?php if ( Jetpack::is_user_connected() && current_user_can( 'manage_options' ) ) : ?>


### PR DESCRIPTION
Closes #7484
Resolves partly https://github.com/Automattic/jetpack/issues/9086

## Changes
- **Settings** → **Security**: add **Monitor** module toggle
- **Dashboard**: change button to a toggle
- Unify language used about the module:
  - We've been using terms "Jetpack Monitor", "Uptime Monitor", "Downtime Monitor".  This unifies everything to be "Downtime Monitor". 

    "Downtime Monitor" term is already used all over [Jetpack plans page](https://jetpack.com/pricing/) and [feature intro page](https://jetpack.com/features/security/downtime-monitoring/).

    "Read more" link brings users to [Monitor's support page](https://jetpack.com/support/monitor/) which still needs updating. 

    Similar change in Calypso: https://github.com/Automattic/wp-calypso/pull/23729
  - Adds word "email" to where we speak about notifications, not to confuse people with other types of notifications.
- Does _not_ add that 2nd email toggle from Calypso to Jetpack:

    ![image](https://user-images.githubusercontent.com/87168/38034590-4871c2e8-32ab-11e8-83c9-a947736416b6.png)

    API for that is kinda incomplete and might need a rewrite.

### New Jetpack Dashboard + Settings
`/wp-admin/admin.php?page=jetpack#/security`

![image](https://user-images.githubusercontent.com/87168/38031527-02f0d81e-32a4-11e8-94ad-4374b1393e90.png)

`/wp-admin/admin.php?page=jetpack#/dashboard`

![image](https://user-images.githubusercontent.com/87168/38031532-0b5eecb6-32a4-11e8-94f9-a99b269336da.png)

![image](https://user-images.githubusercontent.com/87168/38031536-0f09f0ae-32a4-11e8-99b8-e299a5c19ad0.png)

### Old Jetpack dashboard
`/wp-admin/admin.php?page=jetpack#/dashboard`

![image](https://user-images.githubusercontent.com/87168/38031579-35c001f2-32a4-11e8-9a86-0b12090576cd.png)

### Currently in Calypso
https://wordpress.com/settings/security

![image](https://user-images.githubusercontent.com/87168/38034960-fd976a38-32ab-11e8-8c42-e837713f6148.png)


## Testing
1. Connect Jetpack site to Calypso
1. Open in different tabs:
    - `/wp-admin/admin.php?page=jetpack#/security`
    - `https://wordpress.com/settings/security/YOURSITE`
1. Toggle module on/off and observe it gets updated both ways (Calypso→Jetpack & Jetpack→Calypso)
1. Change setting at Jetpack settings and dashboard and observe change get reflected in both:
    - `/wp-admin/admin.php?page=jetpack#/dashboard`
    - `/wp-admin/admin.php?page=jetpack#/security`
1. Change the setting at Jetpack on/off and take your site down. Observe if you receive email notifications or not within ~15mins.
1. Try searching "monitor" at Jetpack admin and observe monitor settings show up