### PR TITLE
Build: Ignore docker directory in gulp tasks that glob with **/*.php

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -333,7 +333,7 @@ gulp.task( 'old-sass:rtl', function() {
  */
 gulp.task( 'check:DIR', function() {
 	// __DIR__ is not available in PHP 5.2...
-	return gulp.src( [ '!vendor', '!vendor/**', '*.php', '**/*.php' ] )
+	return gulp.src( [ '!vendor', '!vendor/**', '!docker/**', '*.php', '**/*.php' ] )
 		.pipe( check( '__DIR__' ) )
 		.on( 'error', function( err ) {
 			log( colors.red( err ) );

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -344,7 +344,7 @@ gulp.task( 'check:DIR', function() {
 	PHP Lint
  */
 gulp.task( 'php:lint', function() {
-	return gulp.src( [ '!node_modules', '!node_modules/**', '!vendor', '!vendor/**', '*.php', '**/*.php' ] )
+	return gulp.src( [ '!node_modules', '!node_modules/**', '!vendor', '!vendor/**', '!docker/**', '*.php', '**/*.php' ] )
 		.pipe( phplint( '', { skipPassedFiles: true } ) );
 } );
 


### PR DESCRIPTION
Fixes `yarn build` and `gulp php:unit` when having Rewind temporary files .

#### Changes proposed in this Pull Request:

* Ignores `docker/**` in check:DIR gulp task.
* Ignores `docker/**` in php:lint gulp task.

#### Testing instructions:


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Start with a dir structure that has wordpress and temporary rewind files on it `jetpack-temp`.
* Run `yarn build` and expect nothing to fail.
* Run `node_modules/.bin/gulp php:lint` and expect nothing to fail.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
