### PR TITLE
Widen the connection banner content

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -237,7 +237,7 @@
 }
 
 .jp-wpcom-connect__content-container {
-	max-width: 800px;
+	width: 1250px;
 	position: relative;
 	padding: rem( 32px );
 	z-index: 0;


### PR DESCRIPTION
Fixes #8677

- Disconnect Jetpack
- View on a wider screen

Set to width 1250px as suggested by @joanrho 

Looks like this now

![banner-better-heights](https://user-images.githubusercontent.com/7129409/37657131-81c3e4c2-2c20-11e8-8c59-e650161beb82.gif)
