### PR TITLE
Build: exclude more folders

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function( grunt ) {
 				options: {
 					domainPath: '/languages',
 					exclude: [
+						'docker',
 						'node_modules',
 						'tests',
 						'tools',
@@ -27,6 +28,7 @@ module.exports = function( grunt ) {
 					src: [
 						'*.php',
 						'**/*.php',
+						'!docker/**',
 						'!node_modules/**',
 						'!tests/**',
 						'!tools/**',

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -42,6 +42,9 @@ const meta = require( './package.json' );
 import {} from './tools/builder/frontend-css';
 import {} from './tools/builder/admin-css';
 
+// These paths should alawys be ignored when watching files
+const alwaysIgnoredPaths = [ '!node_modules', '!node_modules/**', '!vendor', '!vendor/**', '!docker/**' ];
+
 function onBuild( done ) {
 	return function( err, stats ) {
 		// Webpack doesn't populate err in case the build fails
@@ -191,7 +194,7 @@ gulp.task( 'sass:build', [ 'react:build' ], doSass );
 
 gulp.task( 'sass:watch', function() {
 	doSass();
-	gulp.watch( [ './**/*.scss' ], doSass );
+	gulp.watch( [ './**/*.scss', ...alwaysIgnoredPaths ], doSass );
 } );
 
 gulp.task( 'react:build', function( done ) {
@@ -333,7 +336,7 @@ gulp.task( 'old-sass:rtl', function() {
  */
 gulp.task( 'check:DIR', function() {
 	// __DIR__ is not available in PHP 5.2...
-	return gulp.src( [ '!vendor', '!vendor/**', '!docker/**', '*.php', '**/*.php' ] )
+	return gulp.src( [ '*.php', '**/*.php', ...alwaysIgnoredPaths ] )
 		.pipe( check( '__DIR__' ) )
 		.on( 'error', function( err ) {
 			log( colors.red( err ) );
@@ -344,7 +347,7 @@ gulp.task( 'check:DIR', function() {
 	PHP Lint
  */
 gulp.task( 'php:lint', function() {
-	return gulp.src( [ '!node_modules', '!node_modules/**', '!vendor', '!vendor/**', '!docker/**', '*.php', '**/*.php' ] )
+	return gulp.src( [ '*.php', '**/*.php', ...alwaysIgnoredPaths ] )
 		.pipe( phplint( '', { skipPassedFiles: true } ) );
 } );
 
@@ -560,7 +563,7 @@ gulp.task( 'languages:extract', function( done ) {
  * Gutenpack!
  */
 gulp.task( 'gutenpack', function() {
-	return gulp.src( '**/*/*block.jsx' )
+	return gulp.src( [ '**/*/*block.jsx', ...alwaysIgnoredPaths ] )
 		.pipe( babel( {
 			plugins: [
 				[
@@ -577,7 +580,7 @@ gulp.task( 'gutenpack', function() {
 } );
 
 gulp.task( 'gutenpack:watch', function() {
-	return gulp.watch( [ '**/*/*block.jsx' ], [ 'gutenpack' ] );
+	return gulp.watch( [ '**/*/*block.jsx', ...alwaysIgnoredPaths ], [ 'gutenpack' ] );
 } );
 
 // Default task

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -43,7 +43,7 @@ import {} from './tools/builder/frontend-css';
 import {} from './tools/builder/admin-css';
 
 // These paths should alawys be ignored when watching files
-const alwaysIgnoredPaths = [ '!node_modules', '!node_modules/**', '!vendor', '!vendor/**', '!docker/**' ];
+const alwaysIgnoredPaths = [ '!node_modules/**', '!vendor/**', '!docker/**' ];
 
 function onBuild( done ) {
 	return function( err, stats ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,7 @@
 
 	<arg name="colors"/>
 
+	<exclude-pattern>/docker/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>


### PR DESCRIPTION
Follow up for https://github.com/Automattic/jetpack/pull/9087

- Use the same list of paths to exclude in different tasks
- Add Docker folder to excluded list in Gruntfile.js
- Move ignored paths to the end from the beginning of glob array in Gulp. Having ignored paths at the end of the glob array reads better to me because I see relevant files first. It should not have any impact on the current setup because:
    > A glob that begins with `!` excludes matching files from the glob results **up to that point**.
    ([via](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/API.md#globs))

### Test

- Add `__DIR__` to some php-file in `./docker` directory and observe `node_modules/.bin/gulp check:DIR` not fail.
- Add `*-block.jsx` file file under in `./docker` directory and observe it not get cloned to `.js` file.  Run e.g. `echo "{ true; }" >> docker/test-block.jsx` — before this PR you'd end up with `docker/test-block.js` after running `yarn build` or `yarn watch`

- Test `yarn build`, `yarn watch`, `yarn add-textdomain` and `yarn build-pot` still work as expected. Last two are grunt -tasks and I'm not exactly sure what to expect from them but they certainly shouldn't see docker-directory.