### PR TITLE
Settings: don't show a Set Up button for non pro features in search

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -10,6 +10,7 @@ import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import analytics from 'lib/analytics';
 import get from 'lodash/get';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -212,12 +213,12 @@ class ProStatus extends React.Component {
 				}
 			}
 
-			if ( sitePlan.product_slug ) {
-				if ( ! hasFree ) {
-					if ( active && installed ) {
-						return this.getProActions( 'active' );
-					}
+			if ( sitePlan.product_slug && ! hasFree ) {
+				if ( active && installed ) {
+					return this.getProActions( 'active' );
+				}
 
+				if ( includes( [ 'akismet', 'backups', 'rewind', 'scan' ], feature ) ) {
 					return this.getSetUpButton( feature );
 				}
 			}


### PR DESCRIPTION
Fixes #8525

#### Changes proposed in this Pull Request:

* Ensures that if the only features tested where a Set Up button might be displayed, are the PRO features: akismet, backups, rewind, scan.

#### Before

<img width="737" alt="captura de pantalla 2018-03-20 a la s 12 29 16" src="https://user-images.githubusercontent.com/1041600/37664602-66e5815a-2c3a-11e8-94cb-0b718bdcea83.png">

#### After

<img width="738" alt="captura de pantalla 2018-03-20 a la s 12 29 44" src="https://user-images.githubusercontent.com/1041600/37664608-6bd231cc-2c3a-11e8-80dc-c530a3a86ea3.png">

#### Testing instructions:

* see #8525 and test in VIP site
