### PR TITLE
Admin Page: Hide pro set up button for searchable modules

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -214,15 +214,13 @@ class ProStatus extends React.Component {
 					return this.getProActions( 'invalid_key', 'anti-spam' );
 				}
 			}
-
-			if ( sitePlan.product_slug && pluginSlug ) {
-				if ( ! hasFree ) {
-					if ( active && installed ) {
-						return this.getProActions( 'active' );
-					}
-
-					return this.getSetUpButton( feature );
+			// Show set up or active status only for paid features that depend on a plugin, and only under a pid plan
+			if ( sitePlan.product_slug && pluginSlug && ! hasFree ) {
+				if ( active && installed ) {
+					return this.getProActions( 'active' );
 				}
+
+				return this.getSetUpButton( feature );
 			}
 
 			return '';

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -143,10 +143,14 @@ class ProStatus extends React.Component {
 
 	render() {
 		const sitePlan = this.props.sitePlan(),
-			vpData = this.props.getVaultPressData(),
-			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature
-				? 'vaultpress/vaultpress.php'
-				: 'akismet/akismet.php';
+			vpData = this.props.getVaultPressData();
+		let pluginSlug = '';
+		if ( 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature ) {
+			pluginSlug = 'vaultpress/vaultpress.php';
+		}
+		if ( 'akismet' === this.props.proFeature ) {
+			pluginSlug = 'akismet/akismet.php';
+		}
 
 		const hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
 			hasFree = /jetpack_free*/.test( sitePlan.product_slug ),
@@ -211,7 +215,7 @@ class ProStatus extends React.Component {
 				}
 			}
 
-			if ( sitePlan.product_slug ) {
+			if ( sitePlan.product_slug && pluginSlug ) {
 				if ( ! hasFree ) {
 					if ( active && installed ) {
 						return this.getProActions( 'active' );

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -27,16 +27,14 @@ import {
 	getVaultPressScanThreatCount,
 	getVaultPressData,
 	isFetchingVaultPressData,
-	getAkismetData
+	getAkismetData,
+	isAkismetKeyValid,
+	isFetchingAkismetData
 } from 'state/at-a-glance';
 import {
 	getSitePlan,
 	isFetchingSiteData
 } from 'state/site';
-import {
-	isAkismetKeyValid,
-	isFetchingAkismetData
-} from 'state/at-a-glance';
 
 /**
  * Track click on Pro status badge.
@@ -215,7 +213,7 @@ class ProStatus extends React.Component {
 					break;
 			}
 
-			// Show set up or active status only for paid features that depend on a plugin, and only under a pid plan
+			// Show set up or active status only for paid features that depend on a plugin, and only under a paid plan
 			if ( sitePlan.product_slug && pluginSlug && ! hasFree ) {
 				return active && installed
 					? this.getProActions( 'active' )


### PR DESCRIPTION
Fixes #8525 
Fixes #9113

#### Changes proposed in this Pull Request:

* Makes the Set Up show only for paid features related to plugins.

#### Testing instructions:

* Go to wp-admin > Jetpack > Settings,
*  Search for the "Widget Visibility" . Expect to see no setup button.


**Searchable module active Before**

When Akismet is active: 
![image](https://user-images.githubusercontent.com/746152/37674333-640b31a2-2c51-11e8-833a-6b67095da5e6.png)

When Akismet is deactivated:

![image](https://user-images.githubusercontent.com/746152/37676950-32cce1f6-2c58-11e8-8239-34759ee367dc.png)


Note that the ACTIVE label is intended for paid features depending on plugin configuration

**Searchable module active After**

![image](https://user-images.githubusercontent.com/746152/37674828-7b68d7cc-2c52-11e8-9e97-d350ad727de5.png)
