### PR TITLE
JITM: Do not use all caps for button text

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -77,9 +77,8 @@
 	&.is-compact {
 		padding: rem( 7px );
 		color: darken( $gray, 10% );
-		font-size: rem( 11px );
+		font-size: rem( 12px );
 		line-height: 1;
-		text-transform: uppercase;
 
 		&:disabled {
 			color: lighten( $gray, 30% );


### PR DESCRIPTION
Based on @kellychoffman's suggestion, this removes the all caps from the button text.

Before:

<img width="1105" alt="jitm-banner-button-before" src="https://user-images.githubusercontent.com/11487924/37679063-3ed524ba-2c56-11e8-9057-0d2e0958d0c0.png">

After:

<img width="1102" alt="jitm-banner-button-after" src="https://user-images.githubusercontent.com/11487924/37691299-2810fc6e-2c87-11e8-900f-0017d4b9e21e.png">

cc @jeffgolenski as the original designer for a 👍 