### PR TITLE
Not showing connection view if the user cannot connect.

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -14,7 +14,11 @@ import NoticesList from 'components/global-notices';
  */
 import JetpackStateNotices from './state-notices';
 import { getSiteConnectionStatus, getSiteDevMode, isStaging, isInIdentityCrisis, isCurrentUserLinked } from 'state/connection';
-import { isDevVersion, userCanManageModules, userIsSubscriber } from 'state/initial-state';
+import {
+	isDevVersion,
+	userCanConnectSite,
+	userIsSubscriber
+} from 'state/initial-state';
 import DismissableNotices from './dismissable';
 import { getConnectUrl as _getConnectUrl } from 'state/connection';
 import JetpackBanner from 'components/jetpack-banner';
@@ -203,7 +207,10 @@ class JetpackNotices extends React.Component {
 					siteConnected={ true === this.props.siteConnectionStatus }
 					isLinked={ this.props.isLinked } />
 				{
-					( ! this.props.siteConnectionStatus && ! this.props.userCanManageModules ) && (
+					(
+						! this.props.siteConnectionStatus &&
+						! this.props.userCanConnectSite
+					) && (
 						<SimpleNotice
 							showDismiss={ false }
 							status="is-warning"
@@ -221,7 +228,7 @@ export default connect(
 		return {
 			connectUrl: _getConnectUrl( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
-			userCanManageModules: userCanManageModules( state ),
+			userCanConnectSite: userCanConnectSite( state ),
 			userIsSubscriber: userIsSubscriber( state ),
 			isLinked: isCurrentUserLinked( state ),
 			isDevVersion: isDevVersion( state ),

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -25,7 +25,8 @@ import {
 	getSiteAdminUrl,
 	getApiNonce,
 	getApiRootUrl,
-	userCanManageModules
+	userCanManageModules,
+	userCanConnectSite
 } from 'state/initial-state';
 import { areThereUnsavedSettings, clearUnsavedSettingsFlag, showWelcomeForNewPlan } from 'state/settings';
 import { getSearchTerm } from 'state/search';
@@ -156,7 +157,7 @@ class Main extends React.Component {
 		// Track page views
 		this.props.isSiteConnected && analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
-		if ( ! this.props.userCanManageModules ) {
+		if ( ! this.props.userCanManageModules || ! this.props.userCanConnectSite ) {
 			if ( ! this.props.siteConnectionStatus ) {
 				return false;
 			}
@@ -282,6 +283,7 @@ export default connect(
 			tracksUserData: getTracksUserData( state ),
 			areThereUnsavedSettings: areThereUnsavedSettings( state ),
 			userCanManageModules: userCanManageModules( state ),
+			userCanConnectSite: userCanConnectSite( state ),
 			isSiteConnected: isSiteConnected( state ),
 			newPlanActivated: showWelcomeForNewPlan( state ),
 			rewindStatus: getRewindStatus( state ),

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -114,6 +114,10 @@ export function userCanDisconnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
 }
 
+export function userCanConnectSite( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'connect', false );
+}
+
 export function userIsMaster( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, 'isMaster', false );
 }


### PR DESCRIPTION
Fixes #8066.

This PR adds a check to the connection view condition. Before we would not show anything to the user if they could not manage modules. Now we add the connect privilege check here as well, so the same thing happens if a user does not have the 'jetpack_connect' cap.

#### Changes proposed in this Pull Request:
* Adds the connect capability to initial state reducer.
* Adds a check for this capability when determining whether to show the connection view or not.

#### Testing instructions:
* Disconnect Jetpack.
* Remove connect capability for every user in the client by adding something like `false &&` here: https://github.com/Automattic/jetpack/blob/master/_inc/lib/admin-pages/class.jetpack-react-page.php#L397
* View the dashboard, check that no connection prompts appear.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed the dashboard view for non-admin users on disconnected sites.