### PR TITLE
Widgets: WordPress Posts - Add rel=noopener attribute to links in WordPress posts widget if set to open in new window

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -795,7 +795,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 			$target = '';
 			if ( isset( $instance['open_in_new_window'] ) && $instance['open_in_new_window'] == true ) {
-				$target = ' target="_blank"';
+				$target = ' target="_blank" rel="noopener"';
 			}
 			$content .= '<h4><a href="' . esc_url( $single_post['url'] ) . '"' . $target . '>' . esc_html( $post_title ) . '</a></h4>' . "\n";
 			if ( ( $instance['featured_image'] == true ) && ( ! empty ( $single_post['featured_image'] ) ) ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Adds `rel="noopener"` to post links shown by the WordPress Posts widget if the `Open links in new window/tab:` setting is active.

#### Testing instructions:

* Check this branch.
* Add a  **Display WordPress Posts** widgets to the sidebar (listed as `DisplayWordPress Posts (Jetpack)`).
* Add a WordPress site as **Blog URL**.
* Check the box **Open links in new window/tab** and save the widget.
* Visit a page on your site that will show the widget.
* Inspect the links and confirm that the links to the other site posts include the attribute `rel="noopener"`.

Tested in MacOs with:

* Firefox
* Opera
* Safari
* Chrome 

#### Proposed Changelog Entry

* Adds rel=noopener attribute to links in the Display WordPress Posts widget if set to open in a new window.