### PR TITLE
Stats: don't display the date range tabs when the initial dialog is shown

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -29,12 +29,12 @@ import {
 	getStatsData,
 	statsSwitchTab,
 	fetchStatsData,
-	getActiveStatsTab as _getActiveStatsTab
+	getActiveStatsTab
 } from 'state/at-a-glance';
 import { getModules } from 'state/modules';
 import { emptyStatsCardDismissed } from 'state/settings';
 
-class DashStats extends Component {
+export class DashStats extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -176,10 +176,10 @@ class DashStats extends Component {
 				);
 			}
 
-			const statsChart = this.statsChart( this.props.activeTab() ),
+			const statsChart = this.statsChart( this.props.activeTab ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
-				showEmptyStats = chartData.length > 0 && totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
+				showEmptyStats = totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
 
 			return (
 				<div className="jp-at-a-glance__stats-container">
@@ -221,7 +221,9 @@ class DashStats extends Component {
 	}
 
 	maybeShowStatsTabs() {
-		if ( ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed ) {
+		const statsChart = this.statsChart( this.props.activeTab );
+
+		if ( false === statsChart.totalViews && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed ) {
 			return false;
 		}
 
@@ -265,7 +267,7 @@ class DashStats extends Component {
 	}
 
 	getClass( view ) {
-		return this.props.activeTab() === view
+		return this.props.activeTab === view
 			? 'jp-at-a-glance__stats-view-link is-current'
 			: 'jp-at-a-glance__stats-view-link';
 	}
@@ -276,7 +278,7 @@ class DashStats extends Component {
 			return null;
 		}
 
-		const range = this.props.activeTab();
+		const range = this.props.activeTab;
 		return (
 			<div>
 				<QueryStatsData range={ range } />
@@ -302,7 +304,7 @@ export default connect(
 	( state ) => {
 		return {
 			moduleList: getModules( state ),
-			activeTab: () => _getActiveStatsTab( state ),
+			activeTab: getActiveStatsTab( state ),
 			isDevMode: isDevMode( state ),
 			isLinked: isCurrentUserLinked( state ),
 			connectUrl: getConnectUrl( state ),

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -117,7 +117,7 @@ class DashStats extends Component {
 				<div className="jp-at-a-glance__stats-chart">
 					<Chart data={ chartData } barClick={ this.barClick } />
 					{
-						0 < chartData.length ? '' : <Spinner />
+						chartData.length <= 0 && <Spinner />
 					}
 				</div>
 				<div id="stats-bottom" className="jp-at-a-glance__stats-bottom">
@@ -148,7 +148,7 @@ class DashStats extends Component {
 				</p>
 				<Button
 					onClick={ dismissCard }
-					primary={ true }
+					primary
 				>
 					{ __( 'Okay, got it!' ) }
 				</Button>
@@ -160,8 +160,7 @@ class DashStats extends Component {
 		const activateStats = () => this.props.updateOptions( { stats: true } );
 
 		if ( this.props.getOptionValue( 'stats' ) ) {
-			const statsErrors = this.statsErrors();
-			if ( statsErrors ) {
+			if ( this.statsErrors() ) {
 				return (
 					<div className="jp-at-a-glance__stats-inactive">
 						<span>
@@ -184,7 +183,7 @@ class DashStats extends Component {
 
 			return (
 				<div className="jp-at-a-glance__stats-container">
-					{ ! showEmptyStats ? this.renderStatsChart( chartData ) : this.renderEmptyStatsCard() }
+					{ showEmptyStats ? this.renderEmptyStatsCard() : this.renderStatsChart( chartData ) }
 				</div>
 			);
 		}
@@ -206,11 +205,11 @@ class DashStats extends Component {
 					}
 				</div>
 				{
-					this.props.isDevMode ? '' : (
+					! this.props.isDevMode && (
 						<div className="jp-at-a-glance__stats-inactive-button">
 							<Button
 								onClick={ activateStats }
-								primary={ true }
+								primary
 							>
 								{ __( 'Activate Site Stats' ) }
 							</Button>
@@ -222,6 +221,10 @@ class DashStats extends Component {
 	}
 
 	maybeShowStatsTabs() {
+		if ( ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed ) {
+			return false;
+		}
+
 		const switchToDay = () => {
 				analytics.tracks.recordJetpackClick( { target: 'stats_switch_view', view: 'day' } );
 				this.props.switchView( 'day' );

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -117,7 +117,7 @@ export class DashStats extends Component {
 				<div className="jp-at-a-glance__stats-chart">
 					<Chart data={ chartData } barClick={ this.barClick } />
 					{
-						chartData.length <= 0 && <Spinner />
+						0 === chartData.length && <Spinner />
 					}
 				</div>
 				<div id="stats-bottom" className="jp-at-a-glance__stats-bottom">

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { DashStats } from '../index';
+
+describe( 'Dashboard Stats', () => {
+	const testProps = {
+		siteRawUrl: 'example.org',
+		siteAdminUrl: 'example.org/wp-admin',
+		statsData: {
+			general: {
+				date: '2018-03-21',
+				stats: {
+					visitors_today: 0,
+					visitors_yesterday: 0,
+					visitors: 24,
+					views_today: 0,
+					views_yesterday: 0,
+					views_best_day: '2017-05-18',
+					views_best_day_total: 11,
+					views: 59,
+					comments: 6,
+					posts: 11,
+					followers_blog: 0,
+					followers_comments: 0,
+					comments_per_month: 0,
+					comments_most_active_recent_day: '2016-03-08 20:37:56',
+					comments_most_active_time: '17:00',
+					comments_spam: 0,
+					categories: 3,
+					tags: 0,
+					shares: 0,
+					shares_twitter: 0,
+					'shares_google-plus-1': 0,
+					'shares_custom-1513105119': 0,
+					shares_facebook: 0
+				},
+				visits: {
+					unit: 'day',
+					fields: [ 'period', 'views', 'visitors' ],
+					data: [ [ '2018-02-20', 0, 0 ] ]
+				}
+			},
+			day: undefined,
+		},
+		isDevMode: false,
+		moduleList: { stats: {} },
+		activeTab: 'day',
+		isLinked: true,
+		connectUrl: 'https://wordpress.com/jetpack/connect/',
+		isEmptyStatsCardDismissed: false,
+		getOptionValue: module => 'stats' === module,
+	};
+
+	describe( 'Initially', () => {
+		const wrapper = shallow( <DashStats { ...testProps } /> );
+
+		it( 'renders header and card', () => {
+			expect( wrapper.find( 'DashSectionHeader' ) ).to.have.length( 1 );
+			expect( wrapper.find( '.jp-at-a-glance__stats-card' ) ).to.have.length( 1 );
+		} );
+
+		it( 'does not render date range tabs', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 0 );
+		} );
+
+		it( 'renders the empty stats container', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-empty' ) ).to.have.length( 1 );
+		} );
+	} );
+
+	describe( 'When empty stats card was dismissed', () => {
+		const wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
+
+		it( 'renders date range tabs', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
+		} );
+	} );
+
+	describe( 'When there is stats data', () => {
+		testProps.statsData.day = {
+			unit: 'day',
+			fields: [ 'period', 'views', 'visitors' ],
+			// Mock 32 views for this date
+			data: [ [ '2018-02-20', 32, 0 ] ]
+		};
+		const wrapper = shallow(
+			<DashStats { ...testProps } />
+		);
+		it( 'renders some stats', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-chart' ) ).to.have.length( 1 );
+		} );
+		it( 'and range tabs', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR hides the date range tabs shown in the Stats in the dasboard when the dialog explaining about the time needed to collect data is shown and it hasn't been yet dismissed.

Fixes #7899

#### Changes proposed in this Pull Request:

* when empty Stats dialog hasn't been dismissed, hide the date range tabs

#### Testing instructions:

* use a new site and connect
* verify that you see the dialog "Hello there! Your stats have been activated." and that the date range tabs aren't shown

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Hide the date range tabs when the initial dialog is shown