### PR TITLE
Admin Page: Replace p for div in jumpstart component

### DIFF
--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -60,7 +60,7 @@ class JumpStart extends React.Component {
 					{ this.activateButton() }
 				</p>
 
-				<p>
+				<div>
 					<h2 className="jp-jumpstart__feature-heading">
 						{ __( "Jetpack's recommended features include:" ) }
 					</h2>
@@ -74,7 +74,7 @@ class JumpStart extends React.Component {
 					<p className="jp-jumpstart__note">
 						{ __( 'Features can be activated or deactivated at any time.' ) }
 					</p>
-				</p>
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes warning reading `Warning: validateDOMNesting(...): <h2> cannot appear as a descendant of <p>. See JumpStart > p > ... > h2` due to an `h2` element being child of `p`.

#### Changes proposed in this Pull Request:

* Updates a `<p>` tag for `<div>` so it's valid markup

#### Testing instructions:

* On a fresh site, unconnected.
* Connect Jetpack
* When you're shown to the Jumpstart dialog, open the javascript console. Don't close the Jumpstart dialog.
* Check the preserve log setting. 
* Clear the log.
* Refresh the page.
* Confirm that you don't see any message reading `Warning: validateDOMNesting(...): <h2> cannot appear as a descendant of <p>. See JumpStart > p > ... > h2.`