### PR TITLE
Add back holiday snow

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -3,6 +3,7 @@ _inc/jquery.spin.js
 _inc/postmessage.js
 _inc/spin.js
 modules/custom-css/custom-css/js/codemirror.min.js
+modules/holiday-snow/snowstorm.js
 modules/shortcodes/js/jmpress.js
 modules/shortcodes/js/jquery.cycle.min.js
 modules/theme-tools/responsive-videos/responsive-videos.min.js

--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -112,6 +112,7 @@ Action types dispatched during the UI lifecycle are listed in `state/action-type
 * **getPluginUpdates( state )**
 * **getProtectCount( state )**
 * **getSearchTerm( state )**
+* **getSettingName( state, name )**
 * **getSettings( state )**
 * **getSiteAdminUrl( state )**
 * **getSiteConnectionStatus( state )**

--- a/_inc/client/components/setting-toggle/README.md
+++ b/_inc/client/components/setting-toggle/README.md
@@ -17,7 +17,7 @@ render() {
 						activated="setting_name"
 						toggleSetting={ toggleSetting }
 						disabled={ isFetchingSettingsList }
-					>The setting description.</SettingToggle>
+					>Show falling snow on my blog until January 4<sup>th</sup>.</SettingToggle>
 		</div>
 	);
 }

--- a/_inc/client/components/settings/README.md
+++ b/_inc/client/components/settings/README.md
@@ -1,7 +1,7 @@
 Settings
 =========
 
-This component is a stateless container that wraps several controls used to set miscellaneous settings that aren't a module option.
+This component is a stateless container that wraps several controls used to set miscellaneous settings that aren't a module option, like Holiday Snow.
 
 #### How to use:
 

--- a/_inc/client/components/settings/index.jsx
+++ b/_inc/client/components/settings/index.jsx
@@ -12,7 +12,8 @@ import {
 	fetchSettings,
 	isSettingActivated,
 	updateSetting,
-	isFetchingSettingsList
+	isFetchingSettingsList,
+	getSettingName
 } from 'state/settings';
 import { SettingToggle } from 'components/setting-toggle';
 
@@ -31,11 +32,13 @@ export class Settings extends React.Component {
 	}
 
 	render() {
+		// The snow setting requires special care since the option name has a WP filter applied.
+		const settingSlug = 'snow' === this.props.slug ? this.props.snowSlug : this.props.slug;
 		return (
 			<div>
 				<SettingToggle
-					slug={ this.props.slug }
-					activated={ this.props.isSettingActivated( this.props.slug ) }
+					slug={ settingSlug }
+					activated={ this.props.isSettingActivated( settingSlug ) }
 					toggleSetting={ this.props.toggleSetting }
 					disabled={ this.props.isFetchingSettingsList }
 				/>
@@ -47,6 +50,7 @@ export class Settings extends React.Component {
 export default connect(
 	( state ) => {
 		return {
+			snowSlug: getSettingName( state, 'jetpack_holiday_snow_enabled' ),
 			isSettingActivated: ( setting_name ) => isSettingActivated( state, setting_name ),
 			isFetchingSettingsList: isFetchingSettingsList( state ),
 			settings: fetchSettings( state )

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -166,6 +166,16 @@ export function toggleSetting( state, name ) {
 }
 
 /**
+ * Returns the slug of a general setting.
+ * @param  {Object}  state Global state tree
+ * @param  {String}  name  A setting's name
+ * @return {String}       The setting name
+ */
+export function getSettingName( state, name ) {
+	return get( state.jetpack.initialState.settingNames, [ name ] );
+}
+
+/**
  * Returns true if there are unsaved settings.
  * @param  {Object}  state Global state tree
  * @return {Boolean}  Whether there are unsaved settings

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -272,6 +272,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'currentVersion' => JETPACK__VERSION,
 			'getModules' => $modules,
 			'showJumpstart' => jetpack_show_jumpstart(),
+			'showHolidaySnow' => function_exists( 'jetpack_show_holiday_snow_option' ) ? jetpack_show_holiday_snow_option() : false,
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),
 			'adminUrl' => esc_url( admin_url() ),
 			'stats' => array(
@@ -285,6 +286,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'roles' => $stats_roles,
 			),
 			'settings' => $this->get_flattened_settings( $modules ),
+			'settingNames' => array(
+				'jetpack_holiday_snow_enabled' => function_exists( 'jetpack_holiday_snow_option_name' ) ? jetpack_holiday_snow_option_name() : false,
+			),
 			'userData' => array(
 //				'othersLinked' => Jetpack::get_other_linked_admins(),
 				'currentUser'  => jetpack_current_user_data(),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -816,6 +816,62 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Returns the proper name for Jetpack Holiday Snow setting.
+	 * When the REST route starts, the holiday-snow.php file where jetpack_holiday_snow_option_name() function is defined is not loaded,
+	 * so where using this to replicate it and have the same functionality.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return string
+	 */
+	public static function holiday_snow_option_name() {
+		/** This filter is documented in modules/holiday-snow.php */
+		return apply_filters( 'jetpack_holiday_snow_option_name', 'jetpack_holiday_snow_enabled' );
+	}
+
+	/**
+	 * Update a single miscellaneous setting for this Jetpack installation, like Holiday Snow.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return object Jetpack miscellaneous settings.
+	 */
+	public static function update_setting( $request ) {
+		// Get parameters to update the module.
+		$param = $request->get_params();
+
+		// Exit if no parameters were passed.
+		if ( ! is_array( $param ) ) {
+			return new WP_Error( 'missing_setting', esc_html__( 'Missing setting.', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		// Get option name and value.
+		$option = key( $param );
+		$value  = current( $param );
+
+		// Log success or not
+		$updated = false;
+
+		switch ( $option ) {
+			case self::holiday_snow_option_name():
+				$updated = update_option( $option, ( true == (bool) $value ) ? 'letitsnow' : '' );
+				break;
+		}
+
+		if ( $updated ) {
+			return rest_ensure_response( array(
+				'code' 	  => 'success',
+				'message' => esc_html__( 'Setting updated.', 'jetpack' ),
+				'value'   => $value,
+			) );
+		}
+
+		return new WP_Error( 'setting_not_updated', esc_html__( 'The setting was not updated.', 'jetpack' ), array( 'status' => 400 ) );
+	}
+
+	/**
 	 * Unlinks current user from the WordPress.com Servers.
 	 *
 	 * @since 4.3.0
@@ -1833,6 +1889,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => 9,
 				'validate_callback' => __CLASS__ . '::validate_posint',
 				'jp_group'          => 'stats',
+			),
+
+			// Settings - Not a module
+			self::holiday_snow_option_name() => array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'settings',
 			),
 
 			// Akismet - Not a module, but a plugin. The options can be passed and handled differently.

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -412,6 +412,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		$settings = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'settings' );
+		$holiday_snow_option_name = Jetpack_Core_Json_Api_Endpoints::holiday_snow_option_name();
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -434,6 +435,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 					$value = get_option( 'WPLANG' );
 					$response[ $setting ] = empty( $value ) ? 'en_US' : $value;
+					break;
+
+				case $holiday_snow_option_name:
+					$response[ $setting ] = get_option( $holiday_snow_option_name ) === 'letitsnow';
 					break;
 
 				case 'wordpress_api_key':
@@ -871,6 +876,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 					// If option value was the same, consider it done.
 					$updated = $grouped_options_current != $grouped_options ? update_option( 'stats_options', $grouped_options ) : true;
+					break;
+
+				case Jetpack_Core_Json_Api_Endpoints::holiday_snow_option_name():
+					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? 'letitsnow' : '' ) : true;
 					break;
 
 				case 'akismet_show_user_comments_approved':

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6529,12 +6529,6 @@ p {
 			'jetpack_is_post_mailable'                               => null,
 			'jetpack_seo_site_host'                                  => null,
 			'jetpack_installed_plugin'                               => 'jetpack_plugin_installed',
-			'jetpack_holiday_snow_option_name'                       => null,
-			'jetpack_holiday_chance_of_snow'                         => null,
-			'jetpack_holiday_snow_js_url'                            => null,
-			'jetpack_is_holiday_snow_season'                         => null,
-			'jetpack_holiday_snow_option_updated'                    => null,
-			'jetpack_holiday_snowing'                                => null,
 		);
 
 		// This is a silly loop depth. Better way?

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -80,6 +80,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'twitter_via'                  => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag' => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'         => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                  => '(bool) Enable snowfall on frontend of site?',
 		'timezone_string'              => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                   => '(int) Site offset from UTC in hours',
 		'date_format'                  => '(string) PHP Date-compatible date format',
@@ -276,6 +277,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					)
 				);
 
+				$holiday_snow = false;
+				if ( function_exists( 'jetpack_holiday_snow_option_name' ) ) {
+					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
+				}
+
 				$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
 				$response[ $key ] = array(
@@ -326,6 +332,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'twitter_via'             => (string) get_option( 'twitter_via' ),
 					'jetpack-twitter-cards-site-tag' => (string) get_option( 'jetpack-twitter-cards-site-tag' ),
 					'eventbrite_api_token'    => $this->get_cast_option_value_or_null( 'eventbrite_api_token', 'intval' ),
+					'holidaysnow'             => $holiday_snow,
 					'gmt_offset'              => get_option( 'gmt_offset' ),
 					'timezone_string'         => get_option( 'timezone_string' ),
 					'date_format'             => get_option( 'date_format' ),
@@ -566,6 +573,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						} else if ( update_option( $key, $value ) ) {
 							$updated[ $key ] = (int) $value;
 						}
+					}
+					break;
+
+				case 'holidaysnow':
+					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
+						if ( function_exists( 'jetpack_holiday_snow_option_name' ) && delete_option( jetpack_holiday_snow_option_name() ) ) {
+							$updated[ $key ] = false;
+						}
+					} else if ( function_exists( 'jetpack_holiday_snow_option_name' ) && update_option( jetpack_holiday_snow_option_name(), 'letitsnow' ) ) {
+						$updated[ $key ] = true;
 					}
 					break;
 

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -79,6 +79,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                          => '(bool) Enable snowfall on front end of site?',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -86,6 +86,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                          => '(bool) Enable snowfall on front end of site?',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -86,6 +86,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                          => '(bool) Enable snowfall on front end of site?',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',

--- a/modules/holiday-snow.php
+++ b/modules/holiday-snow.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Holiday Snow
+ * Adds falling snow to a blog starting December 1 and ending January 3.
+ * Not a module that is activated/deactivated
+ * First Introduced: 2.0.3 ??
+ * Requires Connection: No
+ * Auto Activate: Yes
+ */
+
+class Jetpack_Holiday_Snow_Settings {
+	function __construct() {
+		add_filter( 'admin_init' , array( &$this , 'register_fields' ) );
+	}
+
+	public function register_fields() {
+		register_setting( 'general', jetpack_holiday_snow_option_name(), 'esc_attr' );
+		add_settings_field( jetpack_holiday_snow_option_name(), '<label for="' . esc_attr( jetpack_holiday_snow_option_name() ) . '">' . __( 'Snow' , 'jetpack') . '</label>' , array( &$this, 'blog_field_html' ) , 'general' );
+		add_action( 'update_option_' . jetpack_holiday_snow_option_name(), array( &$this, 'holiday_snow_option_updated' ) );
+	}
+
+	public function blog_field_html() {
+		$id = esc_attr( jetpack_holiday_snow_option_name() );
+		?>
+			<label for="<?php echo $id; ?>">
+				<input type="checkbox" name="<?php echo $id; ?>" id="<?php echo $id; ?>" value="letitsnow"<?php checked( get_option( jetpack_holiday_snow_option_name() ), 'letitsnow' ); ?> />
+				<span><?php _e( 'Show falling snow on my blog until January 4<sup>th</sup>.' , 'jetpack'); ?></span>
+			</label>
+		<?php
+	}
+
+	public function holiday_snow_option_updated() {
+
+		/**
+		 * Fires when the holiday snow option is updated.
+		 *
+		 * @module theme-tools
+		 *
+		 * @since 2.0.3
+		 */
+		do_action( 'jetpack_holiday_snow_option_updated' );
+	}
+}
+
+function jetpack_holiday_snow_script() {
+
+	/**
+	 * Allow holiday snow.
+	 *
+	 * Note: there's no actual randomness involved in whether it snows
+	 * or not, despite the filter mentioning a "chance of snow."
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 2.0.3
+	 *
+	 * @param bool True to allow snow, false to disable it.
+	 */
+	if ( ! apply_filters( 'jetpack_holiday_chance_of_snow', true ) )
+		return;
+
+	/**
+	 * Fires when it's snowing.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 2.0.3
+	 */
+	do_action( 'jetpack_holiday_snowing' );
+
+	/**
+	 * Filter the holiday snow JavaScript URL.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 2.0.3
+	 *
+	 * @param str URL to the holiday snow JavaScript file.
+	 */
+	$snowstorm_url = apply_filters( 'jetpack_holiday_snow_js_url', plugins_url( 'holiday-snow/snowstorm.js', __FILE__ ) );
+	wp_enqueue_script( 'snowstorm', $snowstorm_url, array(), '1.43.20111201', true );
+}
+
+function jetpack_maybe_holiday_snow() {
+	if ( ! jetpack_is_holiday_snow_season() )
+		return;
+
+	if ( is_admin() ) {
+		global $jetpack_holiday_snow;
+		$jetpack_holiday_snow = new Jetpack_Holiday_Snow_Settings();
+	} elseif ( get_option( jetpack_holiday_snow_option_name() ) ) {
+		add_action( 'init', 'jetpack_holiday_snow_script' );
+	}
+}
+
+function jetpack_holiday_snow_option_name() {
+
+	/**
+	 * Filter the holiday snow option name.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 2.0.3
+	 *
+	 * @param str The holiday snow option name.
+	 */
+	return apply_filters( 'jetpack_holiday_snow_option_name', 'jetpack_holiday_snow_enabled' );
+}
+
+function jetpack_show_holiday_snow_option() {
+	// Always show snow option if a custom snow season has been set.
+	if ( has_filter( 'jetpack_is_holiday_snow_season' ) ) {
+		return true;
+	}
+
+	$today            = time();
+	$first_option_day = mktime( 0, 0, 0, 11, 24 ); // Nov 24
+	$last_option_day  = mktime( 0, 0, 0, 1, 4 );   // Jan 4
+
+	return ( $today >= $first_option_day || $today < $last_option_day );
+}
+
+function jetpack_is_holiday_snow_season() {
+	$today          = time();
+	$first_snow_day = mktime( 0, 0, 0, 12, 1 );
+	$last_snow_day  = mktime( 0, 0, 0, 1, 4 );
+
+	$snow = ( $today >= $first_snow_day || $today < $last_snow_day );
+
+	/**
+	 * Filter whether it's winter or not.
+	 *
+	 * You can use this filter if, for example, you live in the
+	 * Southern Hemisphere. In that case, the dates for winter
+	 * above are incorrect for your location.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool $snow True if it's snow season, false if not.
+	 */
+	return apply_filters( 'jetpack_is_holiday_snow_season', $snow );
+}
+
+jetpack_maybe_holiday_snow();

--- a/modules/holiday-snow.php
+++ b/modules/holiday-snow.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer included in Jetpack.
- *
- * @package Jetpack
- */

--- a/modules/holiday-snow/snowstorm.js
+++ b/modules/holiday-snow/snowstorm.js
@@ -1,0 +1,541 @@
+/** @license
+ * DHTML Snowstorm! JavaScript-based Snow for web pages
+ * --------------------------------------------------------
+ * Version 1.43.20111201 (Previous rev: 1.42.20111120)
+ * Copyright (c) 2007, Scott Schiller. All rights reserved.
+ * Code provided under the BSD License:
+ * http://schillmania.com/projects/snowstorm/license.txt
+ */
+
+/*global window, document, navigator, clearInterval, setInterval */
+/*jslint white: false, onevar: true, plusplus: false, undef: true, nomen: true, eqeqeq: true, bitwise: true, regexp: true, newcap: true, immed: true */
+
+var snowStorm = (function(window, document) {
+
+  // --- common properties ---
+
+  this.autoStart = true;          // Whether the snow should start automatically or not.
+  this.flakesMax = 60;           // Limit total amount of snow made (falling + sticking)
+  this.flakesMaxActive = 60;      // Limit amount of snow falling at once (less = lower CPU use)
+  this.animationInterval = 40;    // Theoretical "miliseconds per frame" measurement. 20 = fast + smooth, but high CPU use. 50 = more conservative, but slower
+  this.excludeMobile = true;      // Snow is likely to be bad news for mobile phones' CPUs (and batteries.) By default, be nice.
+  this.flakeBottom = null;        // Integer for Y axis snow limit, 0 or null for "full-screen" snow effect
+  this.followMouse = true;        // Snow movement can respond to the user's mouse
+  this.snowColor = '#fff';        // Don't eat (or use?) yellow snow.
+  this.snowCharacter = '&bull;';  // &bull; = bullet, &middot; is square on some systems etc.
+  this.snowStick = false;          // Whether or not snow should "stick" at the bottom. When off, will never collect.
+  this.targetElement = null;      // element which snow will be appended to (null = document.body) - can be an element ID eg. 'myDiv', or a DOM node reference
+  this.useMeltEffect = true;      // When recycling fallen snow (or rarely, when falling), have it "melt" and fade out if browser supports it
+  this.useTwinkleEffect = false;  // Allow snow to randomly "flicker" in and out of view while falling
+  this.usePositionFixed = false;  // true = snow does not shift vertically when scrolling. May increase CPU load, disabled by default - if enabled, used only where supported
+
+  // --- less-used bits ---
+
+  this.freezeOnBlur = true;       // Only snow when the window is in focus (foreground.) Saves CPU.
+  this.flakeLeftOffset = 0;       // Left margin/gutter space on edge of container (eg. browser window.) Bump up these values if seeing horizontal scrollbars.
+  this.flakeRightOffset = 0;      // Right margin/gutter space on edge of container
+  this.flakeWidth = 5;            // Max pixel width reserved for snow element
+  this.flakeHeight = 5;           // Max pixel height reserved for snow element
+  this.vMaxX = 2.5;                 // Maximum X velocity range for snow
+  this.vMaxY = 2.5;                 // Maximum Y velocity range for snow
+  this.zIndex = 100000;                // CSS stacking order applied to each snowflake
+
+  // --- End of user section ---
+
+  var s = this, storm = this, i,
+  // UA sniffing and backCompat rendering mode checks for fixed position, etc.
+  isIE = navigator.userAgent.match(/msie/i),
+  isIE6 = navigator.userAgent.match(/msie 6/i),
+  isWin98 = navigator.appVersion.match(/windows 98/i),
+  isMobile = navigator.userAgent.match(/mobile|opera m(ob|in)/i),
+  isBackCompatIE = (isIE && document.compatMode === 'BackCompat'),
+  noFixed = (isMobile || isBackCompatIE || isIE6),
+  screenX = null, screenX2 = null, screenY = null, scrollY = null, vRndX = null, vRndY = null,
+  windOffset = 1,
+  windMultiplier = 2,
+  flakeTypes = 6,
+  fixedForEverything = false,
+  opacitySupported = (function(){
+    try {
+      document.createElement('div').style.opacity = '0.5';
+    } catch(e) {
+      return false;
+    }
+    return true;
+  }()),
+  didInit = false,
+  docFrag = document.createDocumentFragment();
+
+  this.timers = [];
+  this.flakes = [];
+  this.disabled = false;
+  this.active = false;
+  this.meltFrameCount = 20;
+  this.meltFrames = [];
+
+  this.events = (function() {
+
+    var old = (!window.addEventListener && window.attachEvent), slice = Array.prototype.slice,
+    evt = {
+      add: (old?'attachEvent':'addEventListener'),
+      remove: (old?'detachEvent':'removeEventListener')
+    };
+
+    function getArgs(oArgs) {
+      var args = slice.call(oArgs), len = args.length;
+      if (old) {
+        args[1] = 'on' + args[1]; // prefix
+        if (len > 3) {
+          args.pop(); // no capture
+        }
+      } else if (len === 3) {
+        args.push(false);
+      }
+      return args;
+    }
+
+    function apply(args, sType) {
+      var element = args.shift(),
+          method = [evt[sType]];
+      if (old) {
+        element[method](args[0], args[1]);
+      } else {
+        element[method].apply(element, args);
+      }
+    }
+
+    function addEvent() {
+      apply(getArgs(arguments), 'add');
+    }
+
+    function removeEvent() {
+      apply(getArgs(arguments), 'remove');
+    }
+
+    return {
+      add: addEvent,
+      remove: removeEvent
+    };
+
+  }());
+
+  function rnd(n,min) {
+    if (isNaN(min)) {
+      min = 0;
+    }
+    return (Math.random()*n)+min;
+  }
+
+  function plusMinus(n) {
+    return (parseInt(rnd(2),10)===1?n*-1:n);
+  }
+
+  this.randomizeWind = function() {
+    var i;
+    vRndX = plusMinus(rnd(s.vMaxX,0.2));
+    vRndY = rnd(s.vMaxY,0.2);
+    if (this.flakes) {
+      for (i=0; i<this.flakes.length; i++) {
+        if (this.flakes[i].active) {
+          this.flakes[i].setVelocities();
+        }
+      }
+    }
+  };
+
+  this.scrollHandler = function() {
+    var i;
+    // "attach" snowflakes to bottom of window if no absolute bottom value was given
+    scrollY = (s.flakeBottom?0:parseInt(window.scrollY||document.documentElement.scrollTop||document.body.scrollTop,10));
+    if (isNaN(scrollY)) {
+      scrollY = 0; // Netscape 6 scroll fix
+    }
+    if (!fixedForEverything && !s.flakeBottom && s.flakes) {
+      for (i=s.flakes.length; i--;) {
+        if (s.flakes[i].active === 0) {
+          s.flakes[i].stick();
+        }
+      }
+    }
+  };
+
+  this.resizeHandler = function() {
+    if (window.innerWidth || window.innerHeight) {
+      screenX = window.innerWidth-16-s.flakeRightOffset;
+      screenY = (s.flakeBottom?s.flakeBottom:window.innerHeight);
+    } else {
+      screenX = (document.documentElement.clientWidth||document.body.clientWidth||document.body.scrollWidth)-(!isIE?8:0)-s.flakeRightOffset;
+      screenY = s.flakeBottom?s.flakeBottom:(document.documentElement.clientHeight||document.body.clientHeight||document.body.scrollHeight);
+    }
+    screenX2 = parseInt(screenX/2,10);
+  };
+
+  this.resizeHandlerAlt = function() {
+    screenX = s.targetElement.offsetLeft+s.targetElement.offsetWidth-s.flakeRightOffset;
+    screenY = s.flakeBottom?s.flakeBottom:s.targetElement.offsetTop+s.targetElement.offsetHeight;
+    screenX2 = parseInt(screenX/2,10);
+  };
+
+  this.freeze = function() {
+    // pause animation
+    var i;
+    if (!s.disabled) {
+      s.disabled = 1;
+    } else {
+      return false;
+    }
+    for (i=s.timers.length; i--;) {
+      clearInterval(s.timers[i]);
+    }
+  };
+
+  this.resume = function() {
+    if (s.disabled) {
+       s.disabled = 0;
+    } else {
+      return false;
+    }
+    s.timerInit();
+  };
+
+  this.toggleSnow = function() {
+    if (!s.flakes.length) {
+      // first run
+      s.start();
+    } else {
+      s.active = !s.active;
+      if (s.active) {
+        s.show();
+        s.resume();
+      } else {
+        s.stop();
+        s.freeze();
+      }
+    }
+  };
+
+  this.stop = function() {
+    var i;
+    this.freeze();
+    for (i=this.flakes.length; i--;) {
+      this.flakes[i].o.style.display = 'none';
+    }
+    s.events.remove(window,'scroll',s.scrollHandler);
+    s.events.remove(window,'resize',s.resizeHandler);
+    if (s.freezeOnBlur) {
+      if (isIE) {
+        s.events.remove(document,'focusout',s.freeze);
+        s.events.remove(document,'focusin',s.resume);
+      } else {
+        s.events.remove(window,'blur',s.freeze);
+        s.events.remove(window,'focus',s.resume);
+      }
+    }
+  };
+
+  this.show = function() {
+    var i;
+    for (i=this.flakes.length; i--;) {
+      this.flakes[i].o.style.display = 'block';
+    }
+  };
+
+  this.SnowFlake = function(parent,type,x,y) {
+    var s = this, storm = parent;
+    this.type = type;
+    this.x = x||parseInt(rnd(screenX-20),10);
+    this.y = (!isNaN(y)?y:-rnd(screenY)-12);
+    this.vX = null;
+    this.vY = null;
+    this.vAmpTypes = [1,1.2,1.4,1.6,1.8]; // "amplification" for vX/vY (based on flake size/type)
+    this.vAmp = this.vAmpTypes[this.type];
+    this.melting = false;
+    this.meltFrameCount = storm.meltFrameCount;
+    this.meltFrames = storm.meltFrames;
+    this.meltFrame = 0;
+    this.twinkleFrame = 0;
+    this.active = 1;
+    this.fontSize = (10+(this.type/5)*10);
+    this.o = document.createElement('div');
+    this.o.setAttribute('aria-hidden', 'true');
+    this.o.setAttribute('role', 'presentation');
+    this.o.innerHTML = storm.snowCharacter;
+    this.o.style.color = storm.snowColor;
+    this.o.style.position = (fixedForEverything?'fixed':'absolute');
+    this.o.style.width = storm.flakeWidth+'px';
+    this.o.style.height = storm.flakeHeight+'px';
+    this.o.style.fontFamily = 'arial,verdana';
+    this.o.style.cursor = 'default';
+    this.o.style.overflow = 'hidden';
+    this.o.style.fontWeight = 'normal';
+    this.o.style.zIndex = storm.zIndex;
+    docFrag.appendChild(this.o);
+
+    this.refresh = function() {
+      if (isNaN(s.x) || isNaN(s.y)) {
+        // safety check
+        return false;
+      }
+      s.o.style.left = s.x+'px';
+      s.o.style.top = s.y+'px';
+    };
+
+    this.stick = function() {
+      if (noFixed || (storm.targetElement !== document.documentElement && storm.targetElement !== document.body)) {
+        s.o.style.top = (screenY+scrollY-storm.flakeHeight)+'px';
+      } else if (storm.flakeBottom) {
+        s.o.style.top = storm.flakeBottom+'px';
+      } else {
+        s.o.style.display = 'none';
+        s.o.style.top = 'auto';
+        s.o.style.bottom = '0px';
+        s.o.style.position = 'fixed';
+        s.o.style.display = 'block';
+      }
+    };
+
+    this.vCheck = function() {
+      if (s.vX>=0 && s.vX<0.2) {
+        s.vX = 0.2;
+      } else if (s.vX<0 && s.vX>-0.2) {
+        s.vX = -0.2;
+      }
+      if (s.vY>=0 && s.vY<0.2) {
+        s.vY = 0.2;
+      }
+    };
+
+    this.move = function() {
+      var vX = s.vX*windOffset, yDiff;
+      s.x += vX;
+      s.y += (s.vY*s.vAmp);
+      if (s.x >= screenX || screenX-s.x < storm.flakeWidth) { // X-axis scroll check
+        s.x = 0;
+      } else if (vX < 0 && s.x-storm.flakeLeftOffset < -storm.flakeWidth) {
+        s.x = screenX-storm.flakeWidth-1; // flakeWidth;
+      }
+      s.refresh();
+      yDiff = screenY+scrollY-s.y;
+      if (yDiff<storm.flakeHeight) {
+        s.active = 0;
+        if (storm.snowStick) {
+          s.stick();
+        } else {
+          s.recycle();
+        }
+      } else {
+        if (storm.useMeltEffect && s.active && s.type < 3 && !s.melting && Math.random()>0.998) {
+          // ~1/1000 chance of melting mid-air, with each frame
+          s.melting = true;
+          s.melt();
+          // only incrementally melt one frame
+          // s.melting = false;
+        }
+        if (storm.useTwinkleEffect) {
+          if (!s.twinkleFrame) {
+            if (Math.random()>0.9) {
+              s.twinkleFrame = parseInt(Math.random()*20,10);
+            }
+          } else {
+            s.twinkleFrame--;
+            s.o.style.visibility = (s.twinkleFrame && s.twinkleFrame%2===0?'hidden':'visible');
+          }
+        }
+      }
+    };
+
+    this.animate = function() {
+      // main animation loop
+      // move, check status, die etc.
+      s.move();
+    };
+
+    this.setVelocities = function() {
+      s.vX = vRndX+rnd(storm.vMaxX*0.12,0.1);
+      s.vY = vRndY+rnd(storm.vMaxY*0.12,0.1);
+    };
+
+    this.setOpacity = function(o,opacity) {
+      if (!opacitySupported) {
+        return false;
+      }
+      o.style.opacity = opacity;
+    };
+
+    this.melt = function() {
+      if (!storm.useMeltEffect || !s.melting) {
+        s.recycle();
+      } else {
+        if (s.meltFrame < s.meltFrameCount) {
+          s.setOpacity(s.o,s.meltFrames[s.meltFrame]);
+          s.o.style.fontSize = s.fontSize-(s.fontSize*(s.meltFrame/s.meltFrameCount))+'px';
+          s.o.style.lineHeight = storm.flakeHeight+2+(storm.flakeHeight*0.75*(s.meltFrame/s.meltFrameCount))+'px';
+          s.meltFrame++;
+        } else {
+          s.recycle();
+        }
+      }
+    };
+
+    this.recycle = function() {
+      s.o.style.display = 'none';
+      s.o.style.position = (fixedForEverything?'fixed':'absolute');
+      s.o.style.bottom = 'auto';
+      s.setVelocities();
+      s.vCheck();
+      s.meltFrame = 0;
+      s.melting = false;
+      s.setOpacity(s.o,1);
+      s.o.style.padding = '0px';
+      s.o.style.margin = '0px';
+      s.o.style.fontSize = s.fontSize+'px';
+      s.o.style.lineHeight = (storm.flakeHeight+2)+'px';
+      s.o.style.textAlign = 'center';
+      s.o.style.verticalAlign = 'baseline';
+      s.x = parseInt(rnd(screenX-storm.flakeWidth-20),10);
+      s.y = parseInt(rnd(screenY)*-1,10)-storm.flakeHeight;
+      s.refresh();
+      s.o.style.display = 'block';
+      s.active = 1;
+    };
+
+    this.recycle(); // set up x/y coords etc.
+    this.refresh();
+
+  };
+
+  this.snow = function() {
+    var active = 0, used = 0, waiting = 0, flake = null, i;
+    for (i=s.flakes.length; i--;) {
+      if (s.flakes[i].active === 1) {
+        s.flakes[i].move();
+        active++;
+      } else if (s.flakes[i].active === 0) {
+        used++;
+      } else {
+        waiting++;
+      }
+      if (s.flakes[i].melting) {
+        s.flakes[i].melt();
+      }
+    }
+    if (active<s.flakesMaxActive) {
+      flake = s.flakes[parseInt(rnd(s.flakes.length),10)];
+      if (flake.active === 0) {
+        flake.melting = true;
+      }
+    }
+  };
+
+  this.mouseMove = function(e) {
+    if (!s.followMouse) {
+      return true;
+    }
+    var x = parseInt(e.clientX,10);
+    if (x<screenX2) {
+      windOffset = -windMultiplier+(x/screenX2*windMultiplier);
+    } else {
+      x -= screenX2;
+      windOffset = (x/screenX2)*windMultiplier;
+    }
+  };
+
+  this.createSnow = function(limit,allowInactive) {
+    var i;
+    for (i=0; i<limit; i++) {
+      s.flakes[s.flakes.length] = new s.SnowFlake(s,parseInt(rnd(flakeTypes),10));
+      if (allowInactive || i>s.flakesMaxActive) {
+        s.flakes[s.flakes.length-1].active = -1;
+      }
+    }
+    storm.targetElement.appendChild(docFrag);
+  };
+
+  this.timerInit = function() {
+    s.timers = (!isWin98?[setInterval(s.snow,s.animationInterval)]:[setInterval(s.snow,s.animationInterval*3),setInterval(s.snow,s.animationInterval)]);
+  };
+
+  this.init = function() {
+    var i;
+    for (i=0; i<s.meltFrameCount; i++) {
+      s.meltFrames.push(1-(i/s.meltFrameCount));
+    }
+    s.randomizeWind();
+    s.createSnow(s.flakesMax); // create initial batch
+    s.events.add(window,'resize',s.resizeHandler);
+    s.events.add(window,'scroll',s.scrollHandler);
+    if (s.freezeOnBlur) {
+      if (isIE) {
+        s.events.add(document,'focusout',s.freeze);
+        s.events.add(document,'focusin',s.resume);
+      } else {
+        s.events.add(window,'blur',s.freeze);
+        s.events.add(window,'focus',s.resume);
+      }
+    }
+    s.resizeHandler();
+    s.scrollHandler();
+    if (s.followMouse) {
+      s.events.add(isIE?document:window,'mousemove',s.mouseMove);
+    }
+    s.animationInterval = Math.max(20,s.animationInterval);
+    s.timerInit();
+  };
+
+  this.start = function(bFromOnLoad) {
+    if (!didInit) {
+      didInit = true;
+    } else if (bFromOnLoad) {
+      // already loaded and running
+      return true;
+    }
+    if (typeof s.targetElement === 'string') {
+      var targetID = s.targetElement;
+      s.targetElement = document.getElementById(targetID);
+      if (!s.targetElement) {
+        throw new Error('Snowstorm: Unable to get targetElement "'+targetID+'"');
+      }
+    }
+    if (!s.targetElement) {
+      s.targetElement = (!isIE?(document.documentElement?document.documentElement:document.body):document.body);
+    }
+    if (s.targetElement !== document.documentElement && s.targetElement !== document.body) {
+      s.resizeHandler = s.resizeHandlerAlt; // re-map handler to get element instead of screen dimensions
+    }
+    s.resizeHandler(); // get bounding box elements
+    s.usePositionFixed = (s.usePositionFixed && !noFixed); // whether or not position:fixed is supported
+    fixedForEverything = s.usePositionFixed;
+    if (screenX && screenY && !s.disabled) {
+      s.init();
+      s.active = true;
+    }
+  };
+
+  function doDelayedStart() {
+    window.setTimeout(function() {
+      s.start(true);
+    }, 20);
+    // event cleanup
+    s.events.remove(isIE?document:window,'mousemove',doDelayedStart);
+  }
+
+  function doStart() {
+    if (!s.excludeMobile || !isMobile) {
+      if (s.freezeOnBlur) {
+        s.events.add(isIE?document:window,'mousemove',doDelayedStart);
+      } else {
+        doDelayedStart();
+      }
+    }
+    // event cleanup
+    s.events.remove(window, 'load', doStart);
+  }
+
+  // hooks for starting the snow
+  if (s.autoStart) {
+    s.events.add(window, 'load', doStart, false);
+  }
+
+  return this;
+
+}(window, document));

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -7,6 +7,7 @@
 // Include extra tools that aren't modules, in a filterable way
 $tools = array(
 	'theme-tools/social-links.php',
+	'holiday-snow.php', // Happy Holidays!!!
 	'theme-tools/random-redirect.php',
 	'theme-tools/featured-content.php',
 	'theme-tools/infinite-scroll.php',

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -758,7 +758,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'settings', array( 'show' => array( 'post', 'page' ) ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
-
+		
 		// It should also work correctly with a POST body that is not JSON encoded
 		$response = $this->create_and_get_request( 'settings', array(), 'POST',  array( 'show' => 'post' ) );
 		$this->assertResponseStatus( 400, $response );
@@ -772,6 +772,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * Here we test three types of settings:
 	 * - module settings
 	 * - module activation state
+	 * - misc setting (holiday snow)
 	 *
 	 * @since 4.6.0
 	 */
@@ -784,6 +785,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		Jetpack::update_active_modules( array( 'carousel' ) );
 		update_option( 'carousel_background_color', 'white' );
+		update_option( 'jetpack_holiday_snow_enabled', 'letitsnow' );
 
 		$response = $this->create_and_get_request( 'settings', array(), 'GET' );
 		$response_data = $response->get_data();
@@ -795,6 +797,10 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'carousel', $response_data );
 		$this->assertTrue( $response_data['carousel'] );
+
+		$this->assertArrayHasKey( 'jetpack_holiday_snow_enabled', $response_data );
+		$this->assertTrue( $response_data['jetpack_holiday_snow_enabled'] );
+
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add back Holiday Snow. The primary goal of Jetpack is 1:1 features from WordPress.com, so we either need to add it back to Jetpack, or remove Holiday Snow from WPCOM.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Enable Holiday Snow in the settings
* Set server time to any date between December 1st and January 1st
* Front end of your site should have delightful, whimsical holiday snow

