### PR TITLE
Infinite Scroll: Prevent first page duplication, and fix main query detection

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -131,7 +131,7 @@ Scroller.prototype.render = function( response ) {
  */
 Scroller.prototype.query = function() {
 	return {
-		page           : this.page,
+		page           : this.page + this.offset, // Load the next page.
 		currentday     : this.currentday,
 		order          : this.order,
 		scripts        : window.infiniteScroll.settings.scripts,
@@ -318,7 +318,7 @@ Scroller.prototype.refresh = function() {
 				}
 
 				// stash the response in the page cache
-				self.pageCache[self.page] = response;
+				self.pageCache[self.page+self.offset] = response;
 
 				// Increment the page number
 				self.page++;
@@ -601,9 +601,6 @@ Scroller.prototype.determineURL = function () {
 	// If a page number could be determined, update the URL
 	// -1 indicates that the original requested URL should be used.
 	if ( 'number' == typeof pageNum ) {
-		if ( pageNum != -1 )
-			pageNum++;
-
 		self.updateURL( pageNum );
 	}
 }
@@ -618,8 +615,7 @@ Scroller.prototype.updateURL = function( page ) {
 		return;
 	}
 	var self = this,
-		offset = self.offset > 0 ? self.offset - 1 : 0,
-		pageSlug = -1 == page ? self.origURL : window.location.protocol + '//' + self.history.host + self.history.path.replace( /%d/, page + offset ) + self.history.parameters;
+		pageSlug = -1 == page ? self.origURL : window.location.protocol + '//' + self.history.host + self.history.path.replace( /%d/, page ) + self.history.parameters;
 
 	if ( window.location.href != pageSlug ) {
 		history.pushState( null, null, pageSlug );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -825,7 +825,7 @@ class The_Neverending_Home_Page {
 			'scripts'          => array(),
 			'styles'           => array(),
 			'google_analytics' => false,
-			'offset'           => self::wp_query()->get( 'paged' ),
+			'offset'           => max( 1, self::wp_query()->get( 'paged' ) ), // Pass through the current page so we can use that to offset the first load.
 			'history'          => array(
 				'host'                 => preg_replace( '#^http(s)?://#i', '', untrailingslashit( esc_url( get_home_url() ) ) ),
 				'path'                 => self::get_request_path(),

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1243,7 +1243,9 @@ class The_Neverending_Home_Page {
 		// Add query filter that checks for posts below the date
 		add_filter( 'posts_where', array( $this, 'query_time_filter' ), 10, 2 );
 
-		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'] = new WP_Query( $query_args );
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'] = $infinite_scroll_query = new WP_Query();
+
+		$infinite_scroll_query->query( $query_args );
 
 		remove_filter( 'posts_where', array( $this, 'query_time_filter' ), 10, 2 );
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -323,7 +323,7 @@ class The_Neverending_Home_Page {
 		if ( 0 == $entries ) {
 			return (bool) ( count( self::wp_query()->posts ) < $posts_per_page );
 		}
-		$paged = self::wp_query()->get( 'paged' );
+		$paged = max( 1, self::wp_query()->get( 'paged' ) );
 
 		// Are there enough posts for more than the first page?
 		if ( $entries <= $posts_per_page ) {


### PR DESCRIPTION
I believe this fixes #1135 but we have slightly different reproduction steps in that we're simply running this on a custom post type archive. I found issues in the way pagination works which I'll do my best to explain below.

There are 2 main issues this PR aims to resolve;

1. Page "1" being loaded when you're already viewing page 1.
2. Queries from other plugins failing because the Infinite scroll query is not the "main query".

#### Changes proposed in this Pull Request:

**Globals**

This PR adjusts the order in which the globals `wp_the_query` and `wp_query`  are set so that `is_main_query` is accurate when ran on the `pre_get_posts` hook.

Looking at the code where it set `wp_the_query` and `wp_query` it looks like the intention here was to be the 'main query' but because the query is RAN before these globals are set, any functions hooking into `pre_get_posts` will not see correct results.

Before:

- Query is ran in the constructor of `WP_Query`
- `pre_get_posts` fires during the query. 
- At this point `wp_the_query` and `wp_query` have the original values. This means `is_main_query` will return false.

After:

- New `WP_Query` is constructed.
- `wp_the_query` and `wp_query` are set to this new `WP_Query` object.
- query is ran.
- `pre_get_posts` fires during the query. 
- At this point `wp_the_query` and `wp_query` contain the current query object, so `is_main_query` will return true.

This fixes a conflict with WooCommerce which only adjusts the main query.

**Pagination JavaScript**

When viewing the first page and scrolling, IS loads page 1 again. The adjustment in the script I made makes it load page 1 plus the current page (offset).

So example, WooCommerce shop page at `local.wordpress.test/shop/` is showing page 1 already. When you scroll it loads page 1 + offset 1 = page 2.

If you start at `local.wordpress.test/shop/page/2` it loads page 1 + offset 2 + page 3.

Both the results are correct, and the address bar is updated accordingly.

I'm not sure how or if it actually worked before :)

#### Testing instructions:

So these are the testing instructions for our WooCommerce use case. @tiagonoronha May comment for general blog testing instructions but basically.

- Checkout this branch
- Checkout this branch of WooCommerce https://github.com/woocommerce/woocommerce/pull/19477
- In customizer > woocommerce > product catalog, set orderby to title, and show 3 products per row and 1 row per page.
- View the shop page. 
- Scroll/load more, and you'll see another row of products added until complete.

Before the patch you'd see random number of products, in random order, with missing items in the grid. Page 1 would also be duplicated.

#### Proposed changelog entry for your changes:

* Fixes `is_main_query` detection within infinite scroll's WP_Query object.
* Fixes first page pagination to prevent duplicate pages being returned.
