### PR TITLE
Infinite Scroll: Improved rendering callbacks w/ WooCommerce support

### DIFF
--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -19,7 +19,6 @@ function jetpack_woocommerce_integration() {
 	 */
 	if ( function_exists( 'wc_get_default_products_per_row' ) ) {
 		add_filter( 'infinite_scroll_render_callbacks', 'jetpack_woocommerce_infinite_scroll_render_callback', 10 );
-		add_filter( 'infinite_scroll_settings', 'jetpack_woocommerce_infinite_scroll_settings', 10 );
 		add_action( 'wp_enqueue_scripts', 'jetpack_woocommerce_infinite_scroll_style', 10 );
 	}
 }
@@ -62,20 +61,6 @@ function jetpack_woocommerce_infinite_scroll_render() {
 	}
 
 	woocommerce_product_loop_end();
-}
-
-/**
- * Adjust settings
- *
- * @param [type] $settings
- * @return void
- */
-function jetpack_woocommerce_infinite_scroll_settings( $settings ) {
-	if ( ! is_shop() && ! is_product_taxonomy() && ! is_product_category() && ! is_product_tag() ) {
-		return $settings;
-	}
-
-	return $settings;
 }
 
 /**

--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -20,6 +20,7 @@ function jetpack_woocommerce_integration() {
 	if ( function_exists( 'wc_get_default_products_per_row' ) ) {
 		add_filter( 'infinite_scroll_render_callbacks', 'jetpack_woocommerce_infinite_scroll_render_callback', 10 );
 		add_filter( 'infinite_scroll_settings', 'jetpack_woocommerce_infinite_scroll_settings', 10 );
+		add_action( 'wp_enqueue_scripts', 'jetpack_woocommerce_infinite_scroll_style', 10 );
 	}
 }
 
@@ -75,4 +76,15 @@ function jetpack_woocommerce_infinite_scroll_settings( $settings ) {
 	}
 	$settings['posts_per_page'] = absint( apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
 	return $settings;
+}
+
+/**
+ * Basic styling when infinite scroll is active only.
+ */
+function jetpack_woocommerce_infinite_scroll_style() {
+	$custom_css = "
+	.infinite-scroll .woocommerce-pagination {
+		display: none;
+	}";
+	wp_add_inline_style( 'woocommerce-layout', $custom_css );
 }

--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -74,7 +74,7 @@ function jetpack_woocommerce_infinite_scroll_settings( $settings ) {
 	if ( ! is_shop() && ! is_product_taxonomy() && ! is_product_category() && ! is_product_tag() ) {
 		return $settings;
 	}
-	$settings['posts_per_page'] = absint( apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
+
 	return $settings;
 }
 

--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -1,6 +1,27 @@
 <?php
+/**
+ * This file contains compatibility functions for WooCommerce to improve Jetpack feature support.
+ */
+add_action( 'woocommerce_init', 'jetpack_woocommerce_integration' );
 
-add_action( 'woocommerce_share', 'jetpack_woocommerce_social_share_icons', 10 );
+function jetpack_woocommerce_integration() {
+	/**
+	 * Double check WooCommerce exists - unlikely to fail due to the hook being used but better safe than sorry.
+	 */
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		return;
+	}
+
+	add_action( 'woocommerce_share', 'jetpack_woocommerce_social_share_icons', 10 );
+
+	/**
+	 * Wrap in function exists check since this requires WooCommerce 3.3+.
+	 */
+	if ( function_exists( 'wc_get_default_products_per_row' ) ) {
+		add_filter( 'infinite_scroll_render_callbacks', 'jetpack_woocommerce_infinite_scroll_render_callback', 10 );
+		add_filter( 'infinite_scroll_settings', 'jetpack_woocommerce_infinite_scroll_settings', 10 );
+	}
+}
 
 /*
  * Make sure the social sharing icons show up under the product's short description
@@ -11,4 +32,47 @@ function jetpack_woocommerce_social_share_icons() {
 		remove_filter( 'the_excerpt', 'sharing_display', 19 );
 		echo sharing_display();
 	}
+}
+
+/**
+ * Add a callback for WooCommerce product rendering in infinite scroll.
+ *
+ * @param array $callbacks
+ * @return array
+ */
+function jetpack_woocommerce_infinite_scroll_render_callback( $callbacks ) {
+	$callbacks[] = 'jetpack_woocommerce_infinite_scroll_render';
+	return $callbacks;
+}
+
+/**
+ * Add a default renderer for WooCommerce products within infinite scroll.
+ */
+function jetpack_woocommerce_infinite_scroll_render() {
+	if ( ! is_shop() && ! is_product_taxonomy() && ! is_product_category() && ! is_product_tag() ) {
+		return;
+	}
+
+	woocommerce_product_loop_start();
+
+	while ( have_posts() ) {
+		the_post();
+		wc_get_template_part( 'content', 'product' );
+	}
+
+	woocommerce_product_loop_end();
+}
+
+/**
+ * Adjust settings
+ *
+ * @param [type] $settings
+ * @return void
+ */
+function jetpack_woocommerce_infinite_scroll_settings( $settings ) {
+	if ( ! is_shop() && ! is_product_taxonomy() && ! is_product_category() && ! is_product_tag() ) {
+		return $settings;
+	}
+	$settings['posts_per_page'] = absint( apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
+	return $settings;
 }

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -131,7 +131,7 @@ Scroller.prototype.render = function( response ) {
  */
 Scroller.prototype.query = function() {
 	return {
-		page           : this.page,
+		page           : this.page + this.offset, // Load the next page.
 		currentday     : this.currentday,
 		order          : this.order,
 		scripts        : window.infiniteScroll.settings.scripts,
@@ -318,7 +318,7 @@ Scroller.prototype.refresh = function() {
 				}
 
 				// stash the response in the page cache
-				self.pageCache[self.page] = response;
+				self.pageCache[self.page+self.offset] = response;
 
 				// Increment the page number
 				self.page++;
@@ -601,9 +601,6 @@ Scroller.prototype.determineURL = function () {
 	// If a page number could be determined, update the URL
 	// -1 indicates that the original requested URL should be used.
 	if ( 'number' == typeof pageNum ) {
-		if ( pageNum != -1 )
-			pageNum++;
-
 		self.updateURL( pageNum );
 	}
 }
@@ -618,8 +615,7 @@ Scroller.prototype.updateURL = function( page ) {
 		return;
 	}
 	var self = this,
-		offset = self.offset > 0 ? self.offset - 1 : 0,
-		pageSlug = -1 == page ? self.origURL : window.location.protocol + '//' + self.history.host + self.history.path.replace( /%d/, page + offset ) + self.history.parameters;
+		pageSlug = -1 == page ? self.origURL : window.location.protocol + '//' + self.history.host + self.history.path.replace( /%d/, page ) + self.history.parameters;
 
 	if ( window.location.href != pageSlug ) {
 		history.pushState( null, null, pageSlug );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -825,7 +825,7 @@ class The_Neverending_Home_Page {
 			'scripts'          => array(),
 			'styles'           => array(),
 			'google_analytics' => false,
-			'offset'           => self::wp_query()->get( 'paged' ),
+			'offset'           => max( 1, self::wp_query()->get( 'paged' ) ), // Pass through the current page so we can use that to offset the first load.
 			'history'          => array(
 				'host'                 => preg_replace( '#^http(s)?://#i', '', untrailingslashit( esc_url( get_home_url() ) ) ),
 				'path'                 => self::get_request_path(),

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1274,10 +1274,9 @@ class The_Neverending_Home_Page {
 			 *
 			 * @since 6.0.0
 			 */
-			$callbacks = apply_filters( 'infinite_scroll_render_callbacks', array() );
-
-			// Append the setting callback e.g. from add theme support.
-			$callbacks[] = self::get_settings()->render;
+			$callbacks = apply_filters( 'infinite_scroll_render_callbacks', array(
+				self::get_settings()->render, // This is the setting callback e.g. from add theme support.
+			) );
 
 			// Append fallback callback. That rhymes.
 			$callbacks[] = array( $this, 'render' );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1243,7 +1243,9 @@ class The_Neverending_Home_Page {
 		// Add query filter that checks for posts below the date
 		add_filter( 'posts_where', array( $this, 'query_time_filter' ), 10, 2 );
 
-		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'] = new WP_Query( $query_args );
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'] = $infinite_scroll_query = new WP_Query();
+
+		$infinite_scroll_query->query( $query_args );
 
 		remove_filter( 'posts_where', array( $this, 'query_time_filter' ), 10, 2 );
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -799,7 +799,7 @@ class The_Neverending_Home_Page {
 
 				if ( isset( $cpt_text ) ) {
 					/* translators: %s is the name of a custom post type */
-					$click_handle_text = sprintf( __( 'Older %s', 'jetpack' ), $cpt_text );
+					$click_handle_text = sprintf( __( 'More %s', 'jetpack' ), $cpt_text );
 					unset( $cpt_text );
 				}
 			}

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -323,7 +323,7 @@ class The_Neverending_Home_Page {
 		if ( 0 == $entries ) {
 			return (bool) ( count( self::wp_query()->posts ) < $posts_per_page );
 		}
-		$paged = self::wp_query()->get( 'paged' );
+		$paged = max( 1, self::wp_query()->get( 'paged' ) );
 
 		// Are there enough posts for more than the first page?
 		if ( $entries <= $posts_per_page ) {


### PR DESCRIPTION
Adds basic WooCommerce support in the 3rd party scripts directory for WooCommerce.

This branch was branched from https://github.com/Automattic/jetpack/pull/9112 which will need reviewing and merging first.

The following changes are all related to WooCommerce and other plugin compatibility and are hence grouped into this single PR.

---

**Posts per page changes**

The current system is quite odd; it uses a fixed number of 7 or the 'posts per page' setting in WP Admin. This isn't suitable for custom post types where they have their own posts_per_page setting or preference. WC is a perfect example whereby posts_per_page is set to match our products grid.

To make this more robust we pass through the posts per page setting from the original query and use this instead.

If the theme defines a different `posts_per_page` value, we can default to that.

---

**Render callbacks**

The previous system relied on a setting, and a fallback, for the render callback. One could also use `infinite_scroll_render` action. 

There are a few problems with this:

- When the render setting is loaded, the action is immediately hooked in
- Multiple 'things' can attach to `infinite_scroll_render` action, and the only way to prevent other callbacks outputting things is to `remove_action`
- Sites can have multiple types of content e.g. posts and products, so a single callback is unlikely to be able to cover all use cases unless it's specifically handled by the theme.

Our solution is to have a filter of registered callbacks which get ran in sequence. If a callback returns nothing (perhaps wrong post type is being shown?), it continues to the next until content is returned. Callbacks registered through theme support are still called, and the final fallback is the default `render` method in infinite scroll class.

The filter is `infinite_scroll_render_callbacks`. So example use:

```
add_filter( 'infinite_scroll_render_callbacks', 'register_some_custom_render_callbacks' );

function register_some_custom_render_callbacks( $callbacks ) {
$callbacks[] = 'my_post_render_callback';
$callbacks[] = 'my_product_render_callback';
return $callbacks;
}
```

With this example it would call the following functions/methods in this order until content is returned:

1. `my_post_render_callback()`
2. `my_product_render_callback()`
3. Whatever was added via `add_theme_support`
4. `The_Neverending_Home_Page::render()`

---

**WooCommerce compatibility**

All we need to do on this side is use the correct template for the content and render our wrappers. This should be fairly standard to any theme. 

`jetpack_woocommerce_infinite_scroll_render` does the rendering of this loop, and `jetpack_woocommerce_infinite_scroll_render_callback ` registers this renderer using the system outlined above.

`jetpack_woocommerce_infinite_scroll_style` simply hides the default numbered pagination WooCommerce outputs with CSS.