### PR TITLE
Add utility for WPCOM API requests as user

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -268,20 +268,20 @@ class Jetpack_Client {
 	}
 
 	/**
-	 * Queries the WordPress.com REST API v2 with a user token.
+	 * Queries the WordPress.com REST API with a user token.
 	 *
-	 * @param  string $path    REST API path.
-	 * @param  array  $args    Arguments to {@see WP_Http}. Default is `array()`.
-	 * @param  string $body    Body passed to {@see WP_Http}. Default is `null`.
-	 * @param  string $root    REST API root. Default is `wpcom`.
-	 * @param  string $version REST API version. Default is `2`.
+	 * @param  string $path             REST API path.
+	 * @param  string $version          REST API version. Default is `2`.
+	 * @param  array  $args             Arguments to {@see WP_Http}. Default is `array()`.
+	 * @param  string $body             Body passed to {@see WP_Http}. Default is `null`.
+	 * @param  string $base_api_path    REST API root. Default is `wpcom`.
 	 *
 	 * @return array|WP_Error $response Response data, else {@see WP_Error} on failure.
 	 */
-	public static function wpcom_json_api_request_as_user( $path, $args = array(), $body = null, $root = 'wpcom', $version = '2' ) {
-		$root    = trim( $root, '/' );
-		$version = ltrim( $version, 'v' );
-		$path    = ltrim( $path, '/' );
+	public static function wpcom_json_api_request_as_user( $path, $version = '2', $args = array(), $body = null, $base_api_path = 'wpcom' ) {
+		$base_api_path = trim( $base_api_path, '/' );
+		$version       = ltrim( $version, 'v' );
+		$path          = ltrim( $path, '/' );
 
 		$args = array_intersect_key( $args, array(
 			'headers'     => 'array',
@@ -295,7 +295,7 @@ class Jetpack_Client {
 
 		$args['user_id'] = get_current_user_id();
 		$args['method']  = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
-		$args['url']     = sprintf( '%s://%s/%s/v%s/%s', self::protocol(), JETPACK__WPCOM_JSON_API_HOST, $root, $version, $path );
+		$args['url']     = sprintf( '%s://%s/%s/v%s/%s', self::protocol(), JETPACK__WPCOM_JSON_API_HOST, $base_api_path, $version, $path );
 
 		if ( isset( $body ) && ! isset( $args['headers'] ) && in_array( $args['method'], array( 'POST', 'PUT', 'PATCH' ), true ) ) {
 			$args['headers'] = array( 'Content-Type' => 'application/json' );

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -268,6 +268,47 @@ class Jetpack_Client {
 	}
 
 	/**
+	 * Queries the WordPress.com REST API v2 with a user token.
+	 *
+	 * @param  string $path    REST API path.
+	 * @param  array  $args    Arguments to {@see WP_Http}. Default is `array()`.
+	 * @param  string $body    Body passed to {@see WP_Http}. Default is `null`.
+	 * @param  string $root    REST API root. Default is `wpcom`.
+	 * @param  string $version REST API version. Default is `2`.
+	 *
+	 * @return array|WP_Error $response Response data, else {@see WP_Error} on failure.
+	 */
+	public static function wpcom_json_api_request_as_user( $path, $args = array(), $body = null, $root = 'wpcom', $version = '2' ) {
+		$root    = trim( $root, '/' );
+		$version = ltrim( $version, 'v' );
+		$path    = ltrim( $path, '/' );
+
+		$args = array_intersect_key( $args, array(
+			'headers'     => 'array',
+			'method'      => 'string',
+			'timeout'     => 'int',
+			'redirection' => 'int',
+			'stream'      => 'boolean',
+			'filename'    => 'string',
+			'sslverify'   => 'boolean',
+		) );
+
+		$args['user_id'] = get_current_user_id();
+		$args['method']  = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
+		$args['url']     = sprintf( '%s://%s/%s/v%s/%s', self::protocol(), JETPACK__WPCOM_JSON_API_HOST, $root, $version, $path );
+
+		if ( isset( $body ) && ! isset( $args['headers'] ) && in_array( $args['method'], array( 'POST', 'PUT', 'PATCH' ), true ) ) {
+			$args['headers'] = array( 'Content-Type' => 'application/json' );
+		}
+
+		if ( isset( $body ) && ! is_string( $body ) ) {
+			$body = wp_json_encode( $body );
+		}
+
+		return self::remote_request( $args, $body );
+	}
+
+	/**
 	 * Query the WordPress.com REST API using the blog token
 	 *
 	 * @param string  $path
@@ -288,22 +329,13 @@ class Jetpack_Client {
 			'sslverify'   => 'boolean',
 		) );
 
-		/**
-		 * Determines whether Jetpack can send outbound https requests to the WPCOM api.
-		 *
-		 * @since 3.6.0
-		 *
-		 * @param bool $proto Defaults to true.
-		 */
-		$proto = apply_filters( 'jetpack_can_make_outbound_https', true ) ? 'https' : 'http';
-
 		// unprecedingslashit
 		$_path = preg_replace( '/^\//', '', $path );
 
 		// Use GET by default whereas `remote_request` uses POST
 		$request_method = ( isset( $filtered_args['method'] ) ) ? $filtered_args['method'] : 'GET';
 
-		$url = sprintf( '%s://%s/%s/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $base_api_path, $version, $_path );
+		$url = sprintf( '%s://%s/%s/v%s/%s', self::protocol(), JETPACK__WPCOM_JSON_API_HOST, $base_api_path, $version, $_path );
 
 		$validated_args = array_merge( $filtered_args, array(
 			'url'     => $url,
@@ -345,5 +377,23 @@ class Jetpack_Client {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Gets protocol string.
+	 *
+	 * @return string `https` (if possible), else `http`.
+	 */
+	public static function protocol() {
+		/**
+		 * Determines whether Jetpack can send outbound https requests to the WPCOM api.
+		 *
+		 * @since 3.6.0
+		 *
+		 * @param bool $proto Defaults to true.
+		 */
+		$https = apply_filters( 'jetpack_can_make_outbound_https', true );
+
+		return $https ? 'https' : 'http';
 	}
 }


### PR DESCRIPTION
This adds a new utility method: `Jetpack_Client::wpcom_json_api_request_as_user()`

- Depends on D11180-code, which has already been merged (now live).

### Getting/Setting GDPR Settings via Jetpack

#### Get current settings:

```php
$response = Jetpack_Client::wpcom_json_api_request_as_user( '/jetpack-user-tracking' );

if ( ! is_wp_error( $response ) ) {
    $settings = json_decode( wp_remote_retrieve_body( $response ) );
}

// var_dump( $settings->tracks_opt_out ); // (bool)
```

#### Update settings:

```php
$response = Jetpack_Client::wpcom_json_api_request_as_user(
    '/jetpack-user-tracking',
    'v2',
    array( 'method' => 'PUT' ),
    array( 'tracks_opt_out' => true )
);

if ( ! is_wp_error( $response ) ) {
    $settings = json_decode( wp_remote_retrieve_body( $response ) );
}

// var_dump( $settings->tracks_opt_out ); // (bool)
```