### PR TITLE
API: SAL: Remove skyword-tracking shortcode when querying for post via SAL

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -112,6 +112,10 @@ abstract class SAL_Site {
 	}
 
 	public function get_post_by_id( $post_id, $context ) {
+		// Remove the skyword tracking shortcode for posts returned via the API.
+		remove_shortcode( 'skyword-tracking' );
+		add_shortcode( 'skyword-tracking', '__return_empty_string' );
+
 		$post = get_post( $post_id, OBJECT, $context );
 
 		if ( ! $post ) {


### PR DESCRIPTION
This will remove the skyword-tracking shortcode, which is used on our main WordPress.com blog and Jetpack.com from posts that are returned via the API. Before this patch, the shortcode was being output unrendered. Even rendered, it would be a script tag which I'm not sure makes sense in content returned via the API.

This commit syncs r172151-wpcom.