### PR TITLE
Google Analytics: fix PHP notice on search reported by some users.

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -77,7 +77,10 @@ class Jetpack_Google_Analytics_Legacy {
 		if ( is_404() ) {
 			// This is a 404 and we are supposed to track them.
 			$custom_vars[] = "_gaq.push(['_trackEvent', '404', document.location.href, document.referrer]);";
-		} elseif ( is_search() ) {
+		} elseif (
+			is_search()
+			&& isset( $_REQUEST['s'] )
+		) {
 			// Set track for searches, if it's a search, and we are supposed to.
 			$track['data'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ); // Input var okay.
 			$track['code'] = 'search';


### PR DESCRIPTION
```
PHP Notice: Undefined index: s in /wp-content/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php on line 82
```
Reported in 1034382-zen

I could not reproduce the error on my end, unfortunately.

#### Proposed changelog entry for your changes:
* Google Analytics: fix PHP notice on search