### PR TITLE
Settings: update learn more info

### DIFF
--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -11,6 +11,7 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import includes from 'lodash/includes';
 import noop from 'lodash/noop';
+import isString from 'lodash/isString';
 import analytics from 'lib/analytics';
 
 /**
@@ -70,13 +71,28 @@ export const SettingsGroup = props => {
 								onClick={ trackInfoClick }
 								screenReaderText={ __( 'Learn more' ) }
 							>
-								<ExternalLink
-									onClick={ trackLearnMoreClick }
-									icon={ false }
-									href={ support }
-									target="_blank" rel="noopener noreferrer">
-									{ __( 'Learn more' ) }
-								</ExternalLink>
+								{
+									isString( props.support )
+										? (
+											<ExternalLink
+												onClick={ trackLearnMoreClick }
+												icon={ false }
+												href={ support }
+												target="_blank" rel="noopener noreferrer">
+												{ __( 'Learn more' ) }
+											</ExternalLink>
+										)
+										: [
+											props.support.text + ' ',
+											<ExternalLink
+												onClick={ trackLearnMoreClick }
+												icon={ false }
+												href={ props.support.link }
+												target="_blank" rel="noopener noreferrer">
+												{ __( 'Learn more' ) }
+											</ExternalLink>
+										]
+								}
 							</InfoPopover>
 						</div>
 					)
@@ -90,7 +106,7 @@ export const SettingsGroup = props => {
 };
 
 SettingsGroup.propTypes = {
-	support: PropTypes.string,
+	// support: PropTypes.string,
 	module: PropTypes.object,
 	disableInDevMode: PropTypes.bool.isRequired,
 	isDevMode: PropTypes.bool.isRequired,

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -11,7 +11,6 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import includes from 'lodash/includes';
 import noop from 'lodash/noop';
-import isString from 'lodash/isString';
 import analytics from 'lib/analytics';
 
 /**
@@ -62,7 +61,7 @@ export const SettingsGroup = props => {
 				'jp-form-settings-disable': disableInDevMode
 			} ) }>
 				{
-					displayFadeBlock && <div className="jp-form-block-fade"></div>
+					displayFadeBlock && <div className="jp-form-block-fade" />
 				}
 				{
 					support && (
@@ -70,29 +69,16 @@ export const SettingsGroup = props => {
 							<InfoPopover
 								onClick={ trackInfoClick }
 								screenReaderText={ __( 'Learn more' ) }
-							>
-								{
-									isString( props.support )
-										? (
-											<ExternalLink
-												onClick={ trackLearnMoreClick }
-												icon={ false }
-												href={ support }
-												target="_blank" rel="noopener noreferrer">
-												{ __( 'Learn more' ) }
-											</ExternalLink>
-										)
-										: [
-											props.support.text + ' ',
-											<ExternalLink
-												onClick={ trackLearnMoreClick }
-												icon={ false }
-												href={ props.support.link }
-												target="_blank" rel="noopener noreferrer">
-												{ __( 'Learn more' ) }
-											</ExternalLink>
-										]
-								}
+								>
+								{ props.support.text + ' ' }
+								<ExternalLink
+									onClick={ trackLearnMoreClick }
+									icon={ false }
+									href={ props.support.link }
+									target="_blank" rel="noopener noreferrer"
+									>
+									{ __( 'Learn more' ) }
+								</ExternalLink>
 							</InfoPopover>
 						</div>
 					)
@@ -106,7 +92,7 @@ export const SettingsGroup = props => {
 };
 
 SettingsGroup.propTypes = {
-	// support: PropTypes.string,
+	support: PropTypes.object,
 	module: PropTypes.object,
 	disableInDevMode: PropTypes.bool.isRequired,
 	isDevMode: PropTypes.bool.isRequired,
@@ -117,7 +103,7 @@ SettingsGroup.propTypes = {
 };
 
 SettingsGroup.defaultProps = {
-	support: '',
+	support: { text: '', link: '' },
 	module: {},
 	disableInDevMode: false,
 	isDevMode: false,

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -29,10 +29,10 @@ export const SettingsGroup = props => {
 		return <span />;
 	}
 
-	const disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module ),
-		support = ! props.support && module && '' !== module.learn_more_button
-			? module.learn_more_button
-			: props.support;
+	const disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module );
+	const support = props.support.text && props.support.link
+			? props.support
+			: false;
 	let displayFadeBlock = disableInDevMode;
 
 	if ( ( 'post-by-email' === module.module && ! props.isLinked ) ||

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -67,6 +67,7 @@ export const SettingsGroup = props => {
 					support && (
 						<div className="jp-module-settings__learn-more">
 							<InfoPopover
+								position="left"
 								onClick={ trackInfoClick }
 								screenReaderText={ __( 'Learn more' ) }
 								>

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -56,7 +56,10 @@ describe( 'SettingsGroup', () => {
 		];
 
 	let testProps = {
-		learn_more_button: 'https://jetpack.com/support/protect',
+		info: {
+			text: 'Help text about Protect',
+			link: 'https://jetpack.com/support/protect',
+		},
 		isDevMode: false,
 		isSitePublic: true,
 		userCanManageModules: true,
@@ -64,7 +67,7 @@ describe( 'SettingsGroup', () => {
 		isUnavailableInDevMode: () => false
 	};
 
-	const settingsGroup = shallow( <SettingsGroup support={ testProps.learn_more_button } hasChild /> );
+	const settingsGroup = shallow( <SettingsGroup support={ testProps.info } hasChild /> );
 
 	it( 'outputs a special CSS class when it has the hasChild property', () => {
 		expect( settingsGroup.find( 'Card' ).props().className ).to.contain( 'jp-form-has-child' );
@@ -75,11 +78,7 @@ describe( 'SettingsGroup', () => {
 		expect( settingsGroup.find( 'ExternalLink' ).get( 0 ).props.href ).to.be.equal( 'https://jetpack.com/support/protect' );
 	} );
 
-	it( 'if no support link is passed directly, looks for one in the module', () => {
-		expect( shallow( <SettingsGroup module={ testProps } /> ).find( 'InfoPopover' ) ).to.have.length( 1 );
-	} );
-
-	it( 'does not have a learn more icon if there is no link or module are passed', () => {
+	it( 'does not have a learn more icon if no link or module was passed', () => {
 		expect( shallow( <SettingsGroup /> ).find( 'InfoPopover' ) ).to.have.length( 0 );
 	} );
 

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -62,7 +62,16 @@ class CommentsComponent extends React.Component {
 			>
 				{
 					foundComments && (
-						<SettingsGroup hasChild disableInDevMode module={ comments }>
+						<SettingsGroup
+							hasChild
+							disableInDevMode
+							module={ comments }
+							support={ {
+								text: __( 'Replaces the standard WordPress comment form with a new comment system ' +
+									'that includes social media login options.' ),
+								link: 'https://jetpack.com/support/comments',
+							} }
+							>
 							<ModuleToggle
 								slug="comments"
 								compact

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -73,7 +73,16 @@ class SubscriptionsComponent extends React.Component {
 				{ ...this.props }
 				hideButton
 				module="subscriptions">
-				<SettingsGroup hasChild disableInDevMode module={ subscriptions }>
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ subscriptions }
+					support={ {
+						text: __( 'Allows readers to subscribe to your posts or comments, ' +
+							'and receive notifications of new content by email.' ),
+						link: 'https://jetpack.com/support/subscriptions/',
+					} }
+					>
 					<ModuleToggle
 						slug="subscriptions"
 						disabled={ unavailableInDevMode }

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -137,7 +137,12 @@ export const Antispam = moduleSettingsForm(
 					feature={ FEATURE_SPAM_AKISMET_PLUS }
 				>
 					<FoldableCard onOpen={ this.trackOpenCard } header={ foldableHeader }>
-						<SettingsGroup support="https://akismet.com/jetpack/">
+						<SettingsGroup
+							support={ {
+								text: __( 'Removes spam from comments and contact forms.' ),
+								link: 'https://akismet.com/jetpack/',
+							} }
+							>
 							<FormFieldset>
 								<FormLabel>
 									<span className="jp-form-label-wide">{ __( 'Your API key' ) }</span>

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -38,7 +38,11 @@ class LoadingCard extends Component {
 				<SettingsGroup
 					disableInDevMode
 					module={ { module: 'backups' } }
-					support="https://help.vaultpress.com/get-to-know/">
+					support={ {
+						text: __( 'Backs up your site to the global WordPress.com servers, ' +
+							'allowing you to restore your content in the event of an emergency or error.' ),
+						link: 'https://help.vaultpress.com/get-to-know/',
+					} }>
 					{
 						__( 'Checking site status…' )
 					}
@@ -169,7 +173,11 @@ export const BackupsScan = moduleSettingsForm(
 					<SettingsGroup
 						disableInDevMode
 						module={ { module: 'backups' } }
-						support="https://help.vaultpress.com/get-to-know/">
+						support={ {
+							text: __( 'Backs up your site to the global WordPress.com servers, ' +
+								'allowing you to restore your content in the event of an emergency or error.' ),
+							link: 'https://help.vaultpress.com/get-to-know/',
+						} }>
 						{
 							this.getCardText()
 						}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -103,7 +103,15 @@ export const Protect = moduleSettingsForm(
 						header={ toggle }
 						className={ classNames( { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
 					>
-						<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'protect' ) }>
+						<SettingsGroup
+							hasChild
+							disableInDevMode
+							module={ this.props.getModule( 'protect' ) }
+							support={ {
+								text: __( 'Protects your site from traditional and distributed brute force login attacks.' ),
+								link: 'https://jetpack.com/support/protect/',
+							} }
+							>
 							<FormFieldset>
 								{ this.props.currentIp &&
 									<div>

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -63,7 +63,15 @@ export const SSO = moduleSettingsForm(
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }
 				>
-					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'sso' ) }>
+					<SettingsGroup
+						hasChild
+						disableInDevMode
+						module={ this.props.getModule( 'sso' ) }
+						support={ {
+							text: __( 'Allows registered users to log in to your site with their WordPress.com accounts.' ),
+							link: 'https://jetpack.com/support/sso/',
+						} }
+						>
 						<ModuleToggle
 							slug="sso"
 							disabled={ unavailableInDevMode }

--- a/_inc/client/sharing/likes.jsx
+++ b/_inc/client/sharing/likes.jsx
@@ -15,8 +15,8 @@ import { ModuleToggle } from 'components/module-toggle';
 export const Likes = moduleSettingsForm(
 	class extends Component {
 		render() {
-			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'likes' ),
-				isActive = this.props.getOptionValue( 'likes' );
+			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'likes' );
+			const isActive = this.props.getOptionValue( 'likes' );
 
 			return (
 				<SettingsCard
@@ -24,7 +24,14 @@ export const Likes = moduleSettingsForm(
 					header={ __( 'Like buttons', { context: 'Settings header' } ) }
 					module="likes"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'likes' } } support="https://jetpack.com/support/likes/">
+					<SettingsGroup
+						disableInDevMode
+						module={ { module: 'likes' } }
+						support={ {
+							text: __( 'Adds like buttons to your content so that visitors can show their appreciation or enjoyment.' ),
+							link: 'https://jetpack.com/support/likes/',
+						} }
+						>
 						<ModuleToggle
 							slug="likes"
 							disabled={ unavailableInDevMode }

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -68,18 +68,22 @@ export const Publicize = moduleSettingsForm(
 					hideButton>
 					{
 						userCanManageModules && (
-							<SettingsGroup disableInDevMode module={ { module: 'publicize' } }
-								support="https://jetpack.com/support/publicize/"
-							>
+							<SettingsGroup
+								disableInDevMode
+								module={ { module: 'publicize' } }
+								support={ {
+									text: __( 'Allows you to automatically share your newest content on social media sites, ' +
+										'including Facebook and Twitter.' ),
+									link: 'https://jetpack.com/support/publicize/',
+								} }
+								>
 								<ModuleToggle
 									slug="publicize"
 									disabled={ unavailableInDevMode }
 									activated={ isActive }
 									toggling={ this.props.isSavingAnyOption( 'publicize' ) }
 									toggleModule={ this.props.toggleModuleNow }>
-									{
-										__( 'Automatically share your posts to social networks' )
-									}
+									{ __( 'Automatically share your posts to social networks' ) }
 								</ModuleToggle>
 							</SettingsGroup>
 						)

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -49,15 +49,20 @@ export const ShareButtons = moduleSettingsForm(
 					header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
 					module="sharing"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'sharing' } } support="https://jetpack.com/support/sharing/">
+					<SettingsGroup
+						disableInDevMode
+						module={ { module: 'sharing' } }
+						support={ {
+							text: __( 'Adds sharing buttons to your content so that visitors can share it on social media sites.' ),
+							link: 'https://jetpack.com/support/sharing/',
+						} }
+						>
 						<ModuleToggle
 							slug="sharedaddy"
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 							toggleModule={ this.props.toggleModuleNow }>
-							{
-								__( 'Add sharing buttons to your posts' )
-							}
+								{ __( 'Add sharing buttons to your posts' ) }
 							</ModuleToggle>
 					</SettingsGroup>
 					{

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -67,7 +67,10 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 					disableInDevMode
 					hasChild
 					module={ { module: 'wordads' } }
-					support="https://jetpack.com/support/ads/">
+					support={ {
+						text: __( 'Displays high-quality ads on your site that allow you to earn income.' ),
+						link: 'https://jetpack.com/support/ads/',
+					} }>
 					<p>
 						{ __( 'Show ads on the first article on your home page or at the end of every page and post. Place additional ads at the top of your site and to any widget area to increase your earnings.' ) }
 						<br />

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -27,7 +27,15 @@ export const GoogleAnalytics = moduleSettingsForm(
 					header={ __( 'Google Analytics', { context: 'Settings header' } ) }
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
+					<SettingsGroup
+						disableInDevMode
+						module={ { module: 'google-analytics' } }
+						support={ {
+							text: __( 'Integrates your WordPress site with Google Analytics, ' +
+								'a platform that offers insights into your traffic, visitors, and conversions.' ),
+							link: 'https://jetpack.com/support/google-analytics/',
+						} }
+						>
 						<p>
 							{ __(
 								'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -60,7 +60,15 @@ class RelatedPostsComponent extends React.Component {
 				{ ...this.props }
 				hideButton
 				module="related-posts">
-				<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'related-posts' ) }>
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ this.props.getModule( 'related-posts' ) }
+					support={ {
+						text: __( 'Automatically displays similar content at the end of each post.' ),
+						link: 'https://jetpack.com/support/related-posts/',
+					} }
+					>
 					<ModuleToggle
 						slug="related-posts"
 						disabled={ unavailableInDevMode }

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -28,7 +28,13 @@ class Search extends React.Component {
 				feature={ FEATURE_SEARCH_JETPACK }
 				hideButton
 			>
-				<SettingsGroup module={ { module: 'search' } } hasChild support="https://jetpack.com/support/search">
+				<SettingsGroup
+					hasChild
+					module={ { module: 'search' } }
+					support={ {
+						text: __( 'Replaces the default WordPress search with a faster, filterable search experience.' ),
+						link: 'https://jetpack.com/support/search',
+					} }>
 					<ModuleToggle
 						slug="search"
 						compact

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -26,7 +26,13 @@ class SeoComponent extends React.Component {
 				header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
 				feature={ FEATURE_SEO_TOOLS_JETPACK }
 				hideButton>
-				<SettingsGroup disableInDevMode module={ { module: 'seo-tools' } } support="https://jetpack.com/support/seo-tools/">
+				<SettingsGroup
+					disableInDevMode
+					module={ { module: 'seo-tools' } }
+					support={ {
+						text: __( 'Allows you to optimize your site and its content for better results in search engines.' ),
+						link: 'https://jetpack.com/support/seo-tools/',
+					} }>
 					<span>
 						{
 							__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -169,7 +169,14 @@ class SiteStatsComponent extends React.Component {
 					clickableHeader={ true }
 					className={ classNames( 'jp-foldable-settings-standalone', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
 				>
-					<SettingsGroup disableInDevMode module={ stats }>
+					<SettingsGroup
+						disableInDevMode
+						module={ stats }
+						support={ {
+							text: __( 'Displays information on your site activity, including visitors and popular posts or pages.' ),
+							link: 'https://jetpack.com/support/wordpress-com-stats/',
+						} }
+						>
 						<FormFieldset>
 							<ModuleToggle
 								slug="stats"

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -40,7 +40,14 @@ export class Sitemaps extends React.Component {
 				module="sitemaps"
 				hideButton
 			>
-				<SettingsGroup module={ { module: 'sitemaps' } } hasChild support={ sitemaps.learn_more_button }>
+				<SettingsGroup
+					hasChild
+					module={ { module: 'sitemaps' } }
+					support={ {
+						text: __( 'Automatically generates the files required for search engines to index your site.' ),
+						link: 'https://jetpack.com/support/sitemaps/',
+					} }
+					>
 					<ModuleToggle
 						slug="sitemaps"
 						compact

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -45,7 +45,13 @@ class VerificationServicesComponent extends React.Component {
 				module="verification-tools"
 				saveDisabled={ this.props.isSavingAnyOption( [ 'google', 'bing', 'pinterest', 'yandex' ] ) }
 			>
-				<SettingsGroup module={ verification } support={ verification.learn_more_button }>
+				<SettingsGroup
+					module={ verification }
+					support={ {
+						text: __( 'Provides the necessary hidden tags needed to verify your WordPress site with various services.' ),
+						link: 'https://jetpack.com/support/site-verification-tools',
+					} }
+					>
 					<p>
 						{ __(
 							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -101,7 +101,16 @@ export class Composing extends React.Component {
 	getAtdSettings = () => {
 		const ignoredPhrases = this.props.getOptionValue( 'ignored_phrases' );
 		return (
-			<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'after-the-deadline' ) }>
+			<SettingsGroup
+				hasChild
+				disableInDevMode
+				module={ this.props.getModule( 'after-the-deadline' ) }
+				support={ {
+					text: __( 'Checks your content for correct grammar and spelling, ' +
+						'misused words, and style while you write.' ),
+					link: 'https://jetpack.com/support/spelling-and-grammar/',
+				} }
+				>
 				<FormFieldset>
 					<FormLegend> { __( 'Proofreading' ) } </FormLegend>
 					<span className="jp-form-setting-explanation">
@@ -194,7 +203,13 @@ export class Composing extends React.Component {
 			atd = this.props.module( 'after-the-deadline' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
 			markdownSettings = (
-				<SettingsGroup module={ markdown }>
+				<SettingsGroup
+					module={ markdown }
+					support={ {
+						text: __( 'Allows you to compose content with links, lists, and other styles using the Markdown syntax.' ),
+						link: 'https://jetpack.com/support/markdown/',
+					} }
+					>
 					<FormFieldset>
 						<ModuleToggle
 							slug="markdown"

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -59,7 +59,15 @@ export class CustomContentTypes extends React.Component {
 				{ ...this.props }
 				module="custom-content-types"
 				hideButton>
-				<SettingsGroup hasChild module={ module } support={ module.learn_more_button }>
+				<SettingsGroup
+					hasChild
+					module={ module }
+					support={ {
+						text: __( 'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+							'and display testimonials on your site.' ),
+						link: 'https://jetpack.com/support/custom-content-types/',
+					} }
+					>
 					<CompactFormToggle
 								checked={ this.state.testimonial }
 								disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) }
@@ -83,6 +91,15 @@ export class CustomContentTypes extends React.Component {
 							}
 						</p>
 					</FormFieldset>
+				</SettingsGroup>
+				<SettingsGroup
+					hasChild
+					module={ module }
+					support={ {
+						text: __( 'Adds the Portfolio custom post type, allowing you to manage and showcase projects on your site.' ),
+						link: 'https://jetpack.com/support/custom-content-types/',
+					} }
+					>
 					<CompactFormToggle
 								checked={ this.state.portfolio }
 								disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) }

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -26,7 +26,15 @@ export const Masterbar = moduleSettingsForm(
 					header={ __( 'WordPress.com toolbar', { context: 'Settings header' } ) }
 					module="masterbar"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
+					<SettingsGroup
+						disableInDevMode
+						module={ { module: 'masterbar' } }
+						support={ {
+							text: __( 'Adds a toolbar with links to all your sites, notifications, ' +
+								'your WordPress.com profile, and the Reader.' ),
+							link: 'https://jetpack.com/support/masterbar/',
+						} }
+						>
 						<ModuleToggle
 							slug="masterbar"
 							disabled={ unavailableInDevMode || ! isLinked }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -70,7 +70,15 @@ class Media extends React.Component {
 			planClass = getPlanClass( this.props.sitePlan.product_slug );
 
 		const carouselSettings = (
-			<SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
+			<SettingsGroup
+				hasChild
+				module={ { module: 'carousel' } }
+				support={ {
+					text: __( 'Replaces the standard WordPress galleries with a ' +
+						'full-screen photo browsing experience, including comments and EXIF metadata.' ),
+					link: 'https://jetpack.com/support/carousel',
+				} }
+				>
 				<ModuleToggle
 					slug="carousel"
 					activated={ isCarouselActive }
@@ -111,22 +119,27 @@ class Media extends React.Component {
 
 		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
 			<SettingsGroup
-					hasChild
-					disableInDevMode
-					module={ videoPress }>
-					<ModuleToggle
-						slug="videopress"
-						disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
-						activated={ this.props.getOptionValue( 'videopress' ) }
-						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-						toggleModule={ this.props.toggleModuleNow }
-						>
-						<span className="jp-form-toggle-explanation">
-							{
-								videoPress.description
-							}
-						</span>
-					</ModuleToggle>
+				hasChild
+				disableInDevMode
+				module={ videoPress }
+				support={ {
+					text: __( 'Hosts your video files on the global WordPress.com servers.' ),
+					link: 'https://jetpack.com/support/videopress/',
+				} }
+				>
+				<ModuleToggle
+					slug="videopress"
+					disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+					activated={ this.props.getOptionValue( 'videopress' ) }
+					toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+					toggleModule={ this.props.toggleModuleNow }
+					>
+					<span className="jp-form-toggle-explanation">
+						{
+							videoPress.description
+						}
+					</span>
+				</ModuleToggle>
 			</SettingsGroup>
 		);
 

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -57,7 +57,15 @@ class PostByEmail extends React.Component {
 				{ ...this.props }
 				module="post-by-email"
 				hideButton>
-				<SettingsGroup hasChild disableInDevMode module={ postByEmail }>
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ postByEmail }
+					support={ {
+						text: __( 'Allows you to publish new posts by sending an email to a special address.' ),
+						link: 'https://jetpack.com/support/post-by-email/',
+					} }
+					>
 					{
 						this.props.userCanManageModules
 							? (

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -53,7 +53,12 @@ const SpeedUpSite = moduleSettingsForm(
 						<SettingsGroup
 							hasChild
 							disableInDevMode
-							module={ photon }>
+							module={ photon }
+							support={ {
+								text: __( 'Hosts your image files on the global WordPress.com servers.' ),
+								link: 'https://jetpack.com/support/photon/',
+							} }
+							>
 							<ModuleToggle
 								slug="photon"
 								disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
@@ -76,7 +81,12 @@ const SpeedUpSite = moduleSettingsForm(
 					{ foundLazyImages &&
 						<SettingsGroup
 							hasChild
-							module={ lazyImages }>
+							module={ lazyImages }
+							support={ {
+								text: __( "Delays the loading of images until they are visible in the visitor's browser." ),
+								link: 'https://jetpack.com/support/lazy-images/',
+							} }
+							>
 							<ModuleToggle
 								slug="lazy-images"
 								disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -105,11 +105,11 @@ class ThemeEnhancements extends React.Component {
 
 	handleInfiniteScrollModeChange = ( key ) => {
 		return () => this.updateInfiniteMode( key );
-	}
+	};
 
 	handleMinilevenOptionChange = ( optionName, module ) => {
 		return () => this.updateOptions( optionName, module );
-	}
+	};
 
 	render() {
 		const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
@@ -119,6 +119,10 @@ class ThemeEnhancements extends React.Component {
 			return null;
 		}
 
+		const infScr = this.props.getModule( 'infinite-scroll' );
+		const minileven = this.props.getModule( 'minileven' );
+		const isMinilevenActive = this.props.getOptionValue( minileven.module );
+
 		return (
 			<SettingsCard
 				{ ...this.props }
@@ -127,136 +131,108 @@ class ThemeEnhancements extends React.Component {
 				>
 				{
 					foundInfiniteScroll && (
-						[ {
-							...this.props.getModule( 'infinite-scroll' ),
-							radios: [
-								{
-									key: 'infinite_default',
-									label: __( 'Load more posts using the default theme behavior' )
-								},
-								{
-									key: 'infinite_button',
-									label: __( 'Load more posts in page with a button' )
-								},
-								{
-									key: 'infinite_scroll',
-									label: __( 'Load more posts as the reader scrolls down' )
-								}
-							]
-						} ].map( item => {
-							if ( ! this.props.isModuleFound( item.module ) ) {
-								return null;
-							}
-
-							return (
-								<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
-									<FormLegend className="jp-form-label-wide">
+						<SettingsGroup
+							hasChild
+							module={ { module: infScr.module } }
+							key={ `theme_enhancement_${ infScr.module }` }
+							support={ {
+								text: __( 'Loads the next posts automatically when the reader approaches the bottom of the page.' ),
+								link: 'https://jetpack.com/support/infinite-scroll',
+							} }
+						>
+							<FormLegend className="jp-form-label-wide">{ infScr.name }</FormLegend>
+							{
+								this.props.isInfiniteScrollSupported
+									? [
 										{
-											item.name
+											key: 'infinite_default',
+											label: __( 'Load more posts using the default theme behavior' )
+										},
+										{
+											key: 'infinite_button',
+											label: __( 'Load more posts in page with a button' )
+										},
+										{
+											key: 'infinite_scroll',
+											label: __( 'Load more posts as the reader scrolls down' )
 										}
-									</FormLegend>
-									{
-										this.props.isInfiniteScrollSupported
-										? item.radios.map( radio => {
-											return (
-												<FormLabel key={ `${ item.module }_${ radio.key }` }>
-													<input
-														type="radio"
-														name="infinite_mode"
-														value={ radio.key }
-														checked={ radio.key === this.state.infinite_mode }
-														disabled={ this.props.isSavingAnyOption( [ item.module, radio.key ] ) }
-														onChange={ this.handleInfiniteScrollModeChange( radio.key ) }
-													/>
-													<span className="jp-form-toggle-explanation">
-														{
-															radio.label
-														}
-													</span>
-												</FormLabel>
-											);
-										} )
-										: (
-											<span>
-												{
-													__( 'Theme support required.' ) + ' '
-												}
-												<a onClick={ this.trackLearnMoreIS } href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
-													{
-														__( 'Learn more' )
-													}
-												</a>
-											</span>
-										)
-									}
-								</SettingsGroup>
-							);
-						} )
+									].map( radio => (
+										<FormLabel key={ `${ infScr.module }_${ radio.key }` }>
+											<input
+												type="radio"
+												name="infinite_mode"
+												value={ radio.key }
+												checked={ radio.key === this.state.infinite_mode }
+												disabled={ this.props.isSavingAnyOption( [ infScr.module, radio.key ] ) }
+												onChange={ this.handleInfiniteScrollModeChange( radio.key ) }
+												/>
+											<span className="jp-form-toggle-explanation">{ radio.label }</span>
+										</FormLabel>
+									) )
+									: (
+										<span>
+											{ __( 'Theme support required.' ) + ' ' }
+											<a
+												onClick={ this.trackLearnMoreIS }
+												href={ infScr.learn_more_button + '#theme' }
+												title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }
+												>
+													{ __( 'Learn more' ) }
+											</a>
+										</span>
+									)
+							}
+						</SettingsGroup>
 					)
 				}
 				{
 					foundMinileven && (
-						[ {
-							...this.props.getModule( 'minileven' ),
-							checkboxes: [
+						<SettingsGroup
+							hasChild
+							module={ { module: minileven.module } }
+							key={ `theme_enhancement_${ minileven.module }` }
+							support={ {
+								text: __( 'Enables a lightweight, mobile-friendly theme ' +
+									'that will be displayed to visitors on mobile devices.' ),
+								link: 'https://jetpack.com/support/mobile-theme',
+							} }
+							>
+							<ModuleToggle
+								slug={ minileven.module }
+								activated={ isMinilevenActive }
+								toggling={ this.props.isSavingAnyOption( minileven.module ) }
+								toggleModule={ this.props.toggleModuleNow }
+								>
+								<span className="jp-form-toggle-explanation">{ minileven.description }</span>
+							</ModuleToggle>
+							<FormFieldset>
 								{
-									key: 'wp_mobile_excerpt',
-									label: __( 'Use excerpts instead of full posts on front page and archive pages' )
-								},
-								{
-									key: 'wp_mobile_featured_images',
-									label: __( 'Show featured images' )
-								},
-								{
-									key: 'wp_mobile_app_promos',
-									label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
-								}
-							]
-						} ].map( item => {
-							const isItemActive = this.props.getOptionValue( item.module );
-
-							if ( ! this.props.isModuleFound( item.module ) ) {
-								return null;
-							}
-
-							return (
-								<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
-									{
-										<ModuleToggle
-											slug={ item.module }
-											activated={ isItemActive }
-											toggling={ this.props.isSavingAnyOption( item.module ) }
-											toggleModule={ this.props.toggleModuleNow }
-										>
-										<span className="jp-form-toggle-explanation">
-											{
-												item.description
-											}
-										</span>
-										</ModuleToggle>
-									}
-									<FormFieldset>
+									[
 										{
-											item.checkboxes.map( chkbx => {
-												return (
-													<CompactFormToggle
-														checked={ this.state[ chkbx.key ] }
-														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
-														onChange={ this.handleMinilevenOptionChange( chkbx.key, item.module ) }
-														key={ `${ item.module }_${ chkbx.key }` }>
-													<span className="jp-form-toggle-explanation">
-														{
-															chkbx.label
-														}
-													</span>
-													</CompactFormToggle>
-												);
-											} )
+											key: 'wp_mobile_excerpt',
+											label: __( 'Use excerpts instead of full posts on front page and archive pages' )
+										},
+										{
+											key: 'wp_mobile_featured_images',
+											label: __( 'Show featured images' )
+										},
+										{
+											key: 'wp_mobile_app_promos',
+											label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
 										}
-									</FormFieldset>
-								</SettingsGroup>
-							);
-						} )
+									].map( chkbx => (
+										<CompactFormToggle
+											checked={ this.state[ chkbx.key ] }
+											disabled={ ! isMinilevenActive || this.props.isSavingAnyOption( [ minileven.module, chkbx.key ] ) }
+											onChange={ this.handleMinilevenOptionChange( chkbx.key, minileven.module ) }
+											key={ `${ minileven.module }_${ chkbx.key }` }
+											>
+											<span className="jp-form-toggle-explanation">{ chkbx.label }</span>
+										</CompactFormToggle>
+									) )
+								}
+							</FormFieldset>
+						</SettingsGroup>
 					)
 				}
 			</SettingsCard>


### PR DESCRIPTION
Fixes #8922

#### Changes proposed in this Pull Request:

* allow to display a short text and a link in the info popover. The `support` property of `SettingsGroup` component is no longer a string and no longer receives a URL. It receives and object with `text` and `link` properties, that are the text blurb and the link to the support doc respectively.
* add support text & link to all settings group in Writing tab. Introduce new settings group for portfolios in custom content types. Refactor theme enhancements to remove unnecessary code
* add support text & link to all settings group in the Sharing, Discussion, Traffic, and Security tabs.
* align popover towards left to follow Calypso's style

Popovers now look like this with the text and link

<img width="750" alt="captura de pantalla 2018-03-26 a la s 14 02 25" src="https://user-images.githubusercontent.com/1041600/37920839-58e58c12-30fe-11e8-8fb6-c3d8a4d50cf5.png">

#### Testing instructions:

* verify that on each settings card the text corresponds to [the one provided here](https://github.com/Automattic/jetpack/issues/8922#issuecomment-371324110)
* ensure that the support link is correct

#### Proposed changelog entry for your changes:

* Settings in Jetpack dashboard now feature contextual help and a link to learn more about it.