### PR TITLE
Sync AMP permalink URL

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -314,6 +314,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$post->permalink = get_permalink( $post->ID );
 		$post->shortlink = wp_get_shortlink( $post->ID );
 
+		if ( function_exists( 'amp_get_permalink' ) ) {
+			$post->amp_permalink = amp_get_permalink( $post->ID );
+		}
+
 		return $post;
 	}
 


### PR DESCRIPTION
When syncing content to WordPress.com for display or syndication, it is helpful to know if a post has an AMP URL. This PR detects the `amp_get_permalink()` function and uses it to sync the AMP URL alongside the permalink and shortlink.

#### Changes proposed in this Pull Request:

* Detect and sync AMP permalink for a post object.

#### Testing instructions:

* Install this Jetpack branch on a site which is set up to sync via a WPCOM sandbox, and which has the [AMP plugin](https://github.com/Automattic/amp-wp) installed, and Jetpack connected.
* Subscribe to posts from the site in your reader
* Create a new post
* Confirm that the post has an "amphtml" meta in the page `<head>` section
* Run this Calypso PR: https://github.com/Automattic/wp-calypso/pull/23603
* Reload the Reader until the new post appears
* The post should be displayed as AMP content, rather than the native Reader view

The server side of this has already been deployed, so posts synced with this new value will have `_jetpack_amp_permalink` meta set against them, and this adds an `amp` link to the `meta->links` section of the API output for posts and reader feed items.

The Calypso branch is an experiment in one way we could surface AMP content, but I think this branch should be merged even if we don't intend to merge the Calypso PR, as it is useful to know which sites are serving AMP content.

#### Changelog entry

Sync: Make sure we sync back the fact that a post was created with AMP capabilities.