### PR TITLE
Add user tracking endpoint proxy for `tracks_opt_out`

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -911,10 +911,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 				array(
 					'method'  => 'PUT',
 					'headers' => array(
+						'Content-Type'    => 'application/json',
 						'X-Forwarded-For' => Jetpack::current_user_ip( true ),
 					),
 				),
-				$request->get_params()
+				wp_json_encode( $request->get_params() )
 			);
 			if ( ! is_wp_error( $response ) ) {
 				$response = json_decode( wp_remote_retrieve_body( $response ), true );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -876,6 +876,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		} else {
 			$response = Jetpack_Client::wpcom_json_api_request_as_user(
 				'/jetpack-user-tracking',
+				'v2',
 				array(
 					'method'  => 'GET',
 					'headers' => array(
@@ -908,6 +909,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		} else {
 			$response = Jetpack_Client::wpcom_json_api_request_as_user(
 				'/jetpack-user-tracking',
+				'v2',
 				array(
 					'method'  => 'PUT',
 					'headers' => array(

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -123,7 +123,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Current user: get or set tracking settings.
-		register_rest_route( 'jetpack/v4', '/tracking-settings', array(
+		register_rest_route( 'jetpack/v4', '/tracking/settings', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => __CLASS__ . '::get_user_tracking_settings',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -122,6 +122,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::get_user_connection_data_permission_callback',
 		) );
 
+		// Current user: get or set tracking settings.
+		register_rest_route( 'jetpack/v4', '/tracking-settings', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_user_tracking_settings',
+				'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::update_user_tracking_settings',
+				'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
+				'args'                => array(
+					'tracks_opt_out' => array( 'type' => 'boolean' ),
+				),
+			),
+		) );
+
 		// Disconnect site from WordPress.com servers
 		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::EDITABLE,
@@ -840,6 +857,71 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return new WP_Error( 'unlink_user_failed', esc_html__( 'Was not able to unlink the user.  Please try again.', 'jetpack' ), array( 'status' => 400 ) );
+	}
+
+	/**
+	 * Gets current user's tracking settings.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param  WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return WP_REST_Response|WP_Error Response, else error.
+	 */
+	public static function get_user_tracking_settings( $request ) {
+		if ( ! Jetpack::is_user_connected() ) {
+			$response = array(
+				'tracks_opt_out' => true, // Default to opt-out if not connected to wp.com.
+			);
+		} else {
+			$response = Jetpack_Client::wpcom_json_api_request_as_user(
+				'/jetpack-user-tracking',
+				array(
+					'method'  => 'GET',
+					'headers' => array(
+						'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+					),
+				)
+			);
+			if ( ! is_wp_error( $response ) ) {
+				$response = json_decode( wp_remote_retrieve_body( $response ), true );
+			}
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Updates current user's tracking settings.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param  WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return WP_REST_Response|WP_Error Response, else error.
+	 */
+	public static function update_user_tracking_settings( $request ) {
+		if ( ! Jetpack::is_user_connected() ) {
+			$response = array(
+				'tracks_opt_out' => true, // Default to opt-out if not connected to wp.com.
+			);
+		} else {
+			$response = Jetpack_Client::wpcom_json_api_request_as_user(
+				'/jetpack-user-tracking',
+				array(
+					'method'  => 'PUT',
+					'headers' => array(
+						'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+					),
+				),
+				$request->get_params()
+			);
+			if ( ! is_wp_error( $response ) ) {
+				$response = json_decode( wp_remote_retrieve_body( $response ), true );
+			}
+		}
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1727,6 +1727,34 @@ class Jetpack {
 	}
 
 	/**
+	 * Gets current user IP address.
+	 *
+	 * @param  bool $check_all_headers Check all headers? Default is `false`.
+	 *
+	 * @return string                  Current user IP address.
+	 */
+	public static function current_user_ip( $check_all_headers = false ) {
+		if ( $check_all_headers ) {
+			foreach ( array(
+				'HTTP_CF_CONNECTING_IP',
+				'HTTP_CLIENT_IP',
+				'HTTP_X_FORWARDED_FOR',
+				'HTTP_X_FORWARDED',
+				'HTTP_X_CLUSTER_CLIENT_IP',
+				'HTTP_FORWARDED_FOR',
+				'HTTP_FORWARDED',
+				'HTTP_VIA',
+			) as $key ) {
+				if ( ! empty( $_SERVER[ $key ] ) ) {
+					return $_SERVER[ $key ];
+				}
+			}
+		}
+
+		return ! empty( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+	}
+
+	/**
 	 * Add any extra oEmbed providers that we know about and use on wpcom for feature parity.
 	 */
 	function extra_oembed_providers() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a  new endpoint proxy for D11180-code (to get/set `tracks_opt_out`). Note that D11180-code has been merged already and is now live.
* Uses a new utility added by this PR: `Jetpack::current_user_ip()`

#### Testing instructions:

* Merge https://github.com/Automattic/jetpack/pull/9122  first.
* Merge this branch.
* Install [REST API Console](https://wordpress.org/plugins/rest-api-console/) plugin.
* From the console, test `/jetpack/v4/tracking-settings` (GET & POST methods).
* Confirm `tracks_opt_out` changes when POSTing an update.
