### PR TITLE
Add Gutenberg Publicize Support

### DIFF
--- a/modules/publicize/assets/async-publicize.js
+++ b/modules/publicize/assets/async-publicize.js
@@ -1,0 +1,41 @@
+/**
+ * Scripts for asynchronous Publicize.
+ *
+ * Scripts ot support asynchronous Publicize features:
+ * Allows for publishing a post, and then later (optionally)
+ * sharing it with Publicize
+ *
+ * @file   Scripts for asynchronous Publicize.
+ * @author ChrisShultz.
+ * @since  5.9.1
+ */
+
+jQuery( function( $ ) {
+
+	/**
+	 * Publishes post without publicizing it.
+	 *
+	 * Calls publicize/posts/<post_id>/publish-wo-publicize to
+	 * publish the provided post id without triggering Publicize
+	 * to share the post. Post can later be publicized directly.
+	 *
+	 * @since      5.9.1
+	 *
+	 * @fires   ajaxSend
+	 *
+	 * @param {int}   post_id           Post id of post being published
+	 *
+	 * @return None
+	 */
+	publicizeGutenbergPublish = function( post_id ) {
+		$.ajax({
+			type: 'POST',
+			url: async_publicize_setup.base_url + '/wp-json/publicize/posts/'+ post_id.toString() + '/publish-wo-publicize',
+			dataType: 'json',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', async_publicize_setup.api_nonce );
+			}
+		});
+	}
+
+} );

--- a/modules/publicize/assets/async-publicize.js
+++ b/modules/publicize/assets/async-publicize.js
@@ -13,24 +13,26 @@
 jQuery( function( $ ) {
 
 	/**
-	 * Publishes post without publicizing it.
+	 * Flags a soon-to-be-published post for no automatic publicizing.
 	 *
-	 * Calls publicize/posts/<post_id>/publish-wo-publicize to
-	 * publish the provided post id without triggering Publicize
-	 * to share the post. Post can later be publicized directly.
+	 * Calls publicize/posts/<post_id>/flag-no-publicize to
+	 * flag a post to NOT be automatically shared via Publicize.
+	 * This is used to decouple publishing and publicizing of a post.
+	 * This should only be called immediately before publishing because
+	 * the flag expires after a timeout.
 	 *
 	 * @since      5.9.1
 	 *
 	 * @fires   ajaxSend
 	 *
-	 * @param {int}   post_id           Post id of post being published
+	 * @param {int}   post_id           Post id of post being flagged
 	 *
 	 * @return None
 	 */
-	publicizeGutenbergPublish = function( post_id ) {
+	flagPostNoPublicize = function( post_id ) {
 		$.ajax({
 			type: 'POST',
-			url: async_publicize_setup.base_url + '/wp-json/publicize/posts/'+ post_id.toString() + '/publish-wo-publicize',
+			url: async_publicize_setup.base_url + '/wp-json/publicize/posts/'+ post_id.toString() + '/flag-no-publicize',
 			dataType: 'json',
 			beforeSend: function ( xhr ) {
 				xhr.setRequestHeader( 'X-WP-Nonce', async_publicize_setup.api_nonce );

--- a/modules/publicize/assets/async-publicize.js
+++ b/modules/publicize/assets/async-publicize.js
@@ -40,4 +40,40 @@ jQuery( function( $ ) {
 		});
 	}
 
+	/**
+	 * Shares a post to connected social with Publicize
+	 *
+	 * Calls publicize/posts/<post_id>/publicize to directly
+	 * publicize a post. This allows a post that was not previously
+	 * shared with Publicize to be shared at a later time, which
+	 * enables the following series of events in Gutenberg:
+	 * 1. <User pushes 'Publish">
+	 *    1.1. Call to flagPostNoPublicize( <post-id> ) so post will
+	 *    not be automatically publicized.
+	 *    1.2. <Gutenberg publishes to its normal endpoint>
+	 * 2. <User pushes 'Share'>
+	 *    2.1. Call to postPublishPublicizePost( <post-id> )
+	 *         shares post.
+	 *
+	 * @since      5.9.1
+	 *
+	 * @fires   ajaxSend
+	 *
+	 * @param {int}   post_id           Post id of post being flagged
+	 *
+	 * @return None
+	 */
+	postPublishPublicizePost = function ( post_id, message ) {
+		$.ajax( {
+			type: 'POST',
+			url: async_publicize_setup.base_url + '/wp-json/publicize/posts/' + post_id.toString() + '/publicize',
+			headers: {
+				message: message,
+			},
+			dataType: 'json',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', async_publicize_setup.api_nonce );
+			}
+		} );
+	}
 } );

--- a/modules/publicize/class-async-publicize.php
+++ b/modules/publicize/class-async-publicize.php
@@ -200,8 +200,8 @@ class Async_Publicize {
 	 *
 	 * @since 5.9.1
 	 *
-	 * @param int $post_id ID number of post being published
-	 * @param array $flags {@see class.jetpack-sync-module-posts.php/send_published()}
+	 * @param int   $post_id ID number of post being published.
+	 * @param array $flags {@see class.jetpack-sync-module-posts.php/send_published()}.
 	 */
 	public function post_publish_cleanup( $post_id, $flags ) {
 		// Clean post meta since it's purpose has been served.

--- a/modules/publicize/class-async-publicize.php
+++ b/modules/publicize/class-async-publicize.php
@@ -36,7 +36,7 @@ class Async_Publicize {
 	 * @since 5.9.1
 	 * @var string $PUBLICIZE_BLOCK_META_KEY
 	 */
-	const PUBLICIZE_BLOCK_META_KEY = '_NO_PUBLICIZE';
+	const PUBLICIZE_BLOCK_META_KEY = '_no_publicize';
 
 	/**
 	 * Time out in seconds before PUBLICIZE_BLOCK_META_KEY meta key expires.

--- a/modules/publicize/class-async-publicize.php
+++ b/modules/publicize/class-async-publicize.php
@@ -36,7 +36,7 @@ class Async_Publicize {
 	 * @since 5.9.1
 	 * @var string $PUBLICIZE_BLOCK_META_KEY
 	 */
-	const PUBLICIZE_BLOCK_META_KEY = '_NO_PUBCLICIZE';
+	const PUBLICIZE_BLOCK_META_KEY = '_NO_PUBLICIZE';
 
 	/**
 	 * Cosntructor for Async_Publicize

--- a/modules/publicize/class-async-publicize.php
+++ b/modules/publicize/class-async-publicize.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Provides REST endpoints to accommodate asynchronous Publicize use
+ *
+ * Provides REST endpoints to publish a post without publicizing and to publicize
+ * an already published post. Publicize was originally written to publicize
+ * a post right as it's being published. This class extends the standard
+ * Publicize behavior to accommodate user interface designs
+ * that separate publish and publicize actions (i.e. in Gutenberg).
+ *
+ * @package Jetpack
+ * @subpackage Publicize
+ * @since 5.9.1
+ */
+
+/**
+ * Class to set up asynchronous (publish and later publicize) support.
+ *
+ * This class sets up REST endpoints for publishing posts and then
+ * later sharing them with Publicize.
+ *
+ * @since 5.9.1
+ */
+class Async_Publicize {
+	/**
+	 * Instance of publicize class, used to access helper methods.
+	 *
+	 * @since 5.9.1
+	 * @var  Publicize $publicize
+	 */
+	protected $publicize;
+
+	/**
+	 * Meta key name to mark publishing posts that should not be publicized.
+	 *
+	 * @since 5.9.1
+	 * @var string $PUBLICIZE_BLOCK_META_KEY
+	 */
+	const PUBLICIZE_BLOCK_META_KEY = '_NO_PUBCLICIZE';
+
+	/**
+	 * Cosntructor for Async_Publicize
+	 *
+	 * Set up hooks to extend legacy Publicize behavior.
+	 *
+	 * @since 5.9.1
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'publicize/', '/posts/(?P<post_id>\d+)/publish-wo-publicize', array(
+				'methods'  => 'POST',
+				'callback' => array( $this, 'publish_wo_publicize' ),
+				'post_id'  => array(
+					'validate_post_id' => function( $param, $request, $key ) {
+						return is_int( $param );
+					},
+				),
+				'permission_callback' => function () {
+					return current_user_can( 'publish_posts' );
+				},
+			) );
+		} );
+
+		// This filter is documented in publicize-jetpack.php.
+		add_filter( 'publicize_should_publicize_published_post', array( $this, 'can_publicize' ), 1, 2 );
+
+		// Do post edit page specific setup.
+		add_action( 'admin_enqueue_scripts', array( $this, 'post_page_enqueue' ) );
+	}
+
+	/**
+	 * Enqueue scripts when they are needed for the edit page
+	 *
+	 * Enqueues necessary scripts for edit page.
+	 * is open.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param string $hook_suffix File name of current page.
+	 */
+	public function post_page_enqueue( $hook_suffix ) {
+		if ( ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) ) {
+			wp_enqueue_script( 'async_publicize_js', plugins_url( 'assets/async-publicize.js', __FILE__ ), array( 'jquery' ) );
+			wp_localize_script( 'async_publicize_js', 'async_publicize_setup',
+				array(
+					'api_nonce' => wp_create_nonce( 'wp_rest' ),
+					'base_url'  => site_url(),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Filter function to block publicize on 'async' published post.
+	 *
+	 * Used as a 'publicize_should_publicize_published_post' filter callback to
+	 * block publicize on posts that have been marked with the
+	 * self::PUBLICIZE_BLOCK_META_KEY meta key, which is set
+	 * for posts that have been published via {@see 'publish_wo_publicize()'}.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @see publish_wo_publicize()
+	 *
+	 * @param boolean $should_publicize True of post should be publicized.
+	 * @param  WP_Post $post Post instance in question.
+	 * @return boolean True if post should be published, false otherwise.
+	 */
+	public function can_publicize( $should_publicize, $post ) {
+
+		// Catch posts that are being published with asynchronous publicization and don't publicize them.
+		if ( metadata_exists( 'post', $post->ID, self::PUBLICIZE_BLOCK_META_KEY ) ) {
+			// Clean post meta since it's purpose has been served.
+			delete_post_meta( $post->ID, self::PUBLICIZE_BLOCK_META_KEY );
+
+			// Don't publicize.
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	/**
+	 * REST api callback for publishing a post without publicizing it.
+	 *
+	 * Function exposed as endpoint 'publicize/posts/<post_id>/publish-wo-publicize'.
+	 * Marks a post (using post meta key) so that it is NOT later publicized, and
+	 * then directly publishes the post. This should be called if the caller
+	 * wants to publish a post but not publicize it, so publicize can be later
+	 * completed if desired.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @see __construct()
+	 *
+	 * @param WP_REST_Request $request Request instance from REST call.
+	 * @return string|null Result body to return to REST caller
+	 */
+	public function publish_wo_publicize( $request ) {
+		$post_id = $request['post_id'];
+
+		if ( ! current_user_can( 'publish_post', $post_id ) ) {
+			return 'Current user cannot publish this post';
+		}
+
+		// If post does not exist.
+		if ( get_post_status( $post_id ) === false ) {
+			return 'Post ID does not exist';
+
+		}
+		if ( get_post_status( $post_id ) === 'publish' ) {
+			return 'Post already published.';
+		}
+
+		/*
+		 * Mark post for NO publicizing upon publish
+		 *
+		 * Gutenberg user interface publishes a post without
+		 * publicizing it. The user can later (optionally) choose to publicize
+		 * the post after it has already been published.
+		 * To keep backwards compatibility, this post meta key
+		 * is introduced so that Publicize knows the post is
+		 * coming from Gutenberg and can ignore the post.
+		 * Meta key checked when 'publicize_should_publicize_published_post'
+		 * filter is triggered {@see can_publicize()}
+		 */
+		update_post_meta( $post_id, self::PUBLICIZE_BLOCK_META_KEY, true );
+
+		wp_publish_post( $post_id );
+		return null;
+
+	}
+
+
+
+}

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -39,6 +39,10 @@ class Publicize extends Publicize_Base {
 		add_filter( 'jetpack_sharing_twitter_via', array( $this, 'get_publicized_twitter_account' ), 10, 2 );
 
 		include_once( JETPACK__PLUGIN_DIR . 'modules/publicize/enhanced-open-graph.php' );
+
+		include_once( JETPACK__PLUGIN_DIR . 'modules/publicize/class-async-publicize.php' );
+		// Extend publicize with support for asynchronous use (publish, and then later publicize)
+		$async_publicizer = new Async_Publicize();
 	}
 
 	function force_user_connection() {

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -41,8 +41,9 @@ class Publicize extends Publicize_Base {
 		include_once( JETPACK__PLUGIN_DIR . 'modules/publicize/enhanced-open-graph.php' );
 
 		include_once( JETPACK__PLUGIN_DIR . 'modules/publicize/class-async-publicize.php' );
-		// Extend publicize with support for asynchronous use (publish, and then later publicize)
-		$async_publicizer = new Async_Publicize();
+
+		// Extend publicize with support for asynchronous use (publish, and then later publicize).
+		$async_publicizer = new Async_Publicize( $this );
 	}
 
 	function force_user_connection() {


### PR DESCRIPTION
**WIP**

Fixes #9039 
Fixes WordPress/gutenberg#3264

## Changes proposed in this Pull Request:
#### Summary
Publicize is currently missing from Gutenberg editor; posts are automatically shared by Publicize without allowing for any any user notification or interaction.

This PR is adding Publicize support in Gutenberg based on @MichaelArestad's [post-publish flow design concept](https://automattic.invisionapp.com/share/2EGBADFXKAD#/screens/284765844_Start). This design separates the publish and Publicize actions, so a post is first published, then the user can interact with Publicize before choosing the share the post (or not share the post).

#### List of changes
- Extends Publicize backend to allow for Gutenberg integration while preserving backwards compatibility with classic editor and API publishing.

   - Adds `publicize/posts/<post_id>/flag-no-publicize` REST endpoint: to be called _immediately_ before Gutenberg publish so that post is not automatically shared after publish

  - Adds `publicize/posts/<post_id>/publicize` REST endpoint: to be called when user is ready to share post.

- Frontend Gutenberg integration (**in progress**)
   - JavaScript functions that call the two above endpoints, respectively : `flagPostNoPublicize( post_id )` and `postPublishPublicizePost( post_id )`. These will surely evolve as the front end is developed, but they are useful for testing so far.
   - Extends Gutenberg UI to utilize the above work: **TODO**

## Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

JavaScript functions `flagPostNoPublicize( post_id )` and `postPublishPublicizePost( post_id )` can be called from browser console on Gutenberg post edit page to test endpoint behavior.

As development progresses, unit tests will be added, and the extended Gutenberg UI will be available to test functionality.


