### PR TITLE
Network Settings: secure footer links

### DIFF
--- a/views/admin/network-admin-footer.php
+++ b/views/admin/network-admin-footer.php
@@ -6,7 +6,11 @@
 						<?php _e( 'Answer a short survey to let us know how we&#8217;re doing and what to add in the future.', 'jetpack' ); ?>
 					</div>
 					<div class="jp-survey-button-container">
-						<p class="submit"><?php printf( '<a id="jp-survey-button" class="button-primary" target="_blank" href="%1$s">%2$s</a>', 'http://jetpack.com/survey/?rel=' . JETPACK__VERSION, __( 'Take Survey', 'jetpack' ) ); ?></p>
+						<p class="submit">
+							<a id="jp-survey-button" class="button-primary" target="_blank" rel="noopener noreferrer" href="https://jetpack.com/survey/?rel=<?php echo esc_html( JETPACK__VERSION ); ?>">
+								<?php _e( 'Take Survey', 'jetpack' ); ?>
+							</a>
+						</p>
 					</div>
 				</div>
 			</div>
@@ -14,13 +18,13 @@
 			<div id="jp-footer">
 				<p class="automattic"><?php _e( 'An <span>Automattic</span> Airline', 'jetpack' ) ?></p>
 				<p class="small">
-					<a href="http://jetpack.com/" target="_blank">Jetpack <?php echo esc_html( JETPACK__VERSION ); ?></a> |
-					<a href="http://automattic.com/privacy/" target="_blank"><?php _e( 'Privacy Policy', 'jetpack' ); ?></a> |
-					<a href="https://wordpress.com/tos/" target="_blank"><?php _e( 'Terms of Service', 'jetpack' ); ?></a> |
+					<a href="https://jetpack.com/" target="_blank" rel="noopener noreferrer">Jetpack <?php echo esc_html( JETPACK__VERSION ); ?></a> |
+					<a href="https://automattic.com/privacy/" target="_blank" rel="noopener noreferrer"><?php _e( 'Privacy Policy', 'jetpack' ); ?></a> |
+					<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer"><?php _e( 'Terms of Service', 'jetpack' ); ?></a> |
 <?php if ( current_user_can( 'manage_options' ) ) : ?>
 					<a href="<?php echo Jetpack::admin_url( array(	'page' => 'jetpack-debugger' ) ); ?>"><?php _e( 'Debug', 'jetpack' ); ?></a> |
 <?php endif; ?>
-					<a href="http://jetpack.com/support/" target="_blank"><?php _e( 'Support', 'jetpack' ); ?></a>
+					<a href="https://jetpack.com/support/" target="_blank" rel="noopener noreferrer"><?php _e( 'Support', 'jetpack' ); ?></a>
 				</p>
 			</div>
 		</div>

--- a/views/admin/network-admin-footer.php
+++ b/views/admin/network-admin-footer.php
@@ -7,7 +7,7 @@
 					</div>
 					<div class="jp-survey-button-container">
 						<p class="submit">
-							<a id="jp-survey-button" class="button-primary" target="_blank" rel="noopener noreferrer" href="https://jetpack.com/survey/?rel=<?php echo esc_html( JETPACK__VERSION ); ?>">
+							<a id="jp-survey-button" class="button-primary" target="_blank" rel="noopener noreferrer" href="https://jetpack.com/survey/?rel=<?php echo esc_attr( JETPACK__VERSION ); ?>">
 								<?php _e( 'Take Survey', 'jetpack' ); ?>
 							</a>
 						</p>


### PR DESCRIPTION
Just some small cleanup.

#### Changes proposed in this Pull Request:
In Jetpack settings page for WP network:
- http → https links in the footer
- Add `rel="noopener noreferrer"` to links with `target="_blank"` as a security measure
- Move HTML code out from survey button translation string

#### Testing instructions:

1. create WP network site
2. Go to `/wp-admin/network/admin.php?page=jetpack-settings` 
3. Check footer links and survey button

![image](https://user-images.githubusercontent.com/87168/37879982-003a957c-308a-11e8-9766-ada23f23d824.png)
