### PR TITLE
Admin Page Fix popover positioning

### DIFF
--- a/_inc/client/components/popover/index.jsx
+++ b/_inc/client/components/popover/index.jsx
@@ -118,8 +118,9 @@ class Popover extends Component {
 			return null;
 		}
 
-		this.debug( 'Update position after inject DOM' );
-		this.setPosition();
+		this.debug( 'Update position after render completes' );
+
+		setTimeout( () => this.setPosition(), 0 );
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
Fixes positioning of popovers when the window is resized

Mirrors https://github.com/Automattic/wp-calypso/pull/19992

Props to @AnnaMag and @eliorivero 

#### Changes proposed in this Pull Request:

* Defers setting the new position on the popover until next tick.

#### Testing instructions:

* On a connected Jetpack site, Checkout this branch
* Build the admin page
* Get the Jetpack Settings.
* Click the InfoPopover links and expect to see the popover properly positioned.
* Narrow the window , close and reopen the Popovers and expect them to be well positioned.

#### Proposed changelog entry for your changes:

* Fixed the positioning of popovers in Jetpack Settings page.