### PR TITLE
Remove Manage from the legacy settings page if active

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -91,7 +91,8 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			<# var i = 0;
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
-				if ( item === undefined ) return; #>
+				if ( item === undefined ) return;
+				if ( 'manage' == item.module && item.activated ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
 						<# if ( 'videopress' !== item.module ) { #>


### PR DESCRIPTION
We intended to hide this from the legacy settings page, but it has not been working.  

To Test: 
- Make sure you do not see Manage in the module list at `/wp-admin/admin.php?page=jetpack_modules`
- Deactivate manage with CLI.  You should see it in the list again.  