### PR TITLE
Privacy Settings: Fix PropTypes error

### DIFF
--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -73,7 +73,7 @@ class Privacy extends React.Component {
 					header={ __( 'Privacy Settings', { context: 'Settings header' } ) }
 					hideButton
 				>
-					<SettingsGroup hasChild support="https://jetpack.com/support/privacy">
+					<SettingsGroup hasChild>
 						<p>
 							{
 								__( 'We are committed to your privacy and security. ' )


### PR DESCRIPTION
`SettingsGroup` expects an object with `text` and `link` properties, but a string is being passed. We don't need this since the card already has the pertinent information. Bug introduced in #8993


#### Testing instructions:

Load `master` before this and click the Privacy link in the Footer. See this error in your console:

```
Failed prop type: Invalid prop `support` of type `string` supplied to `SettingsGroup`, expected `object`
```

After this, the error is gone because the prop is no longer being passed.