### PR TITLE
Update/centralize user privacy + cookie (PR combo)

### DIFF
--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -132,6 +132,11 @@ const analytics = {
 				path: urlPath
 			} );
 		},
+
+		setOptOut: function( isOptingOut ) {
+			debug( 'Pushing setOptOut: %o', isOptingOut );
+			window._tkq.push( [ 'setOptOut', isOptingOut ] );
+		},
 	},
 
 	// Google Analytics usage and event stat tracking

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -143,6 +143,7 @@ export default connect(
 	dispatch => {
 		return {
 			setTracking: ( newValue ) => {
+				analytics.tracks.setOptOut( newValue ); // Sets opt-out cookie.
 				dispatch( updateTrackingSettings( { tracks_opt_out: newValue } ) );
 			},
 			fetchTracking: () => dispatch( fetchTrackingSettings() )

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -55,12 +55,12 @@ class Privacy extends React.Component {
 	};
 
 	togglePrivacy = () => {
-		const current = this.props.tracking.tracks_opt_out;
-		this.props.setTracking( ! current );
+		const current = this.props.trackingSettings.tracks_opt_out;
+		this.props.setTrackingSettings( ! current );
 	}
 
 	componentWillMount() {
-		this.props.fetchTracking();
+		this.props.fetchTrackingSettings();
 	}
 
 	render() {
@@ -107,8 +107,8 @@ class Privacy extends React.Component {
 						<p>
 							<CompactFormToggle
 								compact
-								checked={ ! this.props.tracking.tracks_opt_out }
-								disabled={ this.props.isFetching || this.props.isUpdating() }
+								checked={ ! this.props.trackingSettings.tracks_opt_out }
+								disabled={ this.props.isFetchingTrackingSettings || this.props.isUpdatingTrackingSettings }
 								onChange={ this.togglePrivacy }
 								id="privacy-settings">
 								{ __( 'Send information to help us improve our products.' ) }
@@ -137,17 +137,17 @@ class Privacy extends React.Component {
 export default connect(
 	state => ( {
 		settings: getSettings( state ),
-		tracking: getTrackingSettings( state ),
-		isUpdating: isUpdatingTrackingSettings( state ),
-		isFetching: isFetchingTrackingSettingsList( state )
+		trackingSettings: getTrackingSettings( state ),
+		isUpdatingTrackingSettings: isUpdatingTrackingSettings( state ),
+		isFetchingTrackingSettings: isFetchingTrackingSettingsList( state )
 	} ),
 	dispatch => {
 		return {
-			setTracking: ( newValue ) => {
+			setTrackingSettings: ( newValue ) => {
 				analytics.tracks.setOptOut( newValue ); // Sets opt-out cookie.
 				dispatch( updateTrackingSettings( { tracks_opt_out: newValue } ) );
 			},
-			fetchTracking: () => dispatch( fetchTrackingSettings() )
+			fetchTrackingSettings: () => dispatch( fetchTrackingSettings() )
 		};
 	}
 )( moduleSettingsForm( Privacy ) );

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -54,6 +54,11 @@ class Privacy extends React.Component {
 		active: false,
 	};
 
+	togglePrivacy = () => {
+		const current = this.props.tracking.tracks_opt_out;
+		this.props.setTracking( ! current );
+	}
+
 	componentWillMount() {
 		this.props.fetchTracking();
 	}
@@ -63,10 +68,6 @@ class Privacy extends React.Component {
 			searchTerm,
 			active,
 		} = this.props;
-		const isActive = ! this.props.tracking.tracks_opt_out;
-		const doToggle = () => {
-			this.props.setTracking( isActive );
-		};
 
 		if ( ! searchTerm && ! active ) {
 			return null;
@@ -106,9 +107,9 @@ class Privacy extends React.Component {
 						<p>
 							<CompactFormToggle
 								compact
-								checked={ isActive }
-								disabled={ this.props.isFetching }
-								onChange={ doToggle }
+								checked={ ! this.props.tracking.tracks_opt_out }
+								disabled={ this.props.isFetching || this.props.isUpdating() }
+								onChange={ this.togglePrivacy }
 								id="privacy-settings">
 								{ __( 'Send information to help us improve our products.' ) }
 							</CompactFormToggle>

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -53,7 +53,7 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	static function record_event( $event ) {
-		if ( ! Jetpack::jetpack_tos_agreed() ) {
+		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
 		}
 		


### PR DESCRIPTION
Depends on https://github.com/Automattic/jetpack/pull/9142 and https://github.com/Automattic/jetpack/pull/9154 

---

This PR is a fork of (and alternative to) https://github.com/Automattic/jetpack/pull/9155 (props @mattwiebe) that brings it together with the work I did previously in https://github.com/Automattic/jetpack/pull/9085 to implement `window._tkq.push( [ 'setOptOut', true|false ] )` 

### This PR adds the following to https://github.com/Automattic/jetpack/pull/9155

- Implement the `setOptOut` command; i.e., whenever the new privacy option is changed, this PR will set or unset the opt-out cookie using `window._tkq.push( [ 'setOptOut', true|false ] )`

- Make `Jetpack_Tracks_Client` in PHP aware of the `setOptOut` cookie too. If the opt-out cookie exists, do not record server-side events either.

### How to test:
- First merge https://github.com/Automattic/jetpack/pull/9142 and https://github.com/Automattic/jetpack/pull/9154
- In a browser console, run: `localStorage.setItem( 'debug', 'dops:analytics' );`
- Open the new Privacy setting described and implemented by #8993 and enhanced by this PR.
- Toggle the privacy option on/off and observe browser console.
- Expect to see `Pushing setOptOut: true|false`.

---

### Some Tests Failing at Travis

It's to be expected at this time, because this depends on https://github.com/Automattic/jetpack/pull/9142 and https://github.com/Automattic/jetpack/pull/9154 
