### PR TITLE
Docker: set ServerName directive for Apache

### DIFF
--- a/docker/config/apache_default
+++ b/docker/config/apache_default
@@ -1,3 +1,5 @@
+ServerName localhost
+
 <VirtualHost *:80>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
@@ -6,15 +8,15 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
-	#ServerName www.example.com
+	ServerName localhost
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/html
 
-    <Directory /var/www/html>
-        AllowOverride All
-        Require all granted
-    </Directory>
+		<Directory /var/www/html>
+				AllowOverride All
+				Require all granted
+		</Directory>
 
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
 	# error, crit, alert, emerg.
@@ -22,8 +24,8 @@
 	# modules, e.g.
 	#LogLevel info ssl:warn
 
-    # ErrorLog /var/log/apache-errors.log
-    # CustomLog /var/log/apache-access.log combined
+		# ErrorLog /var/log/apache-errors.log
+		# CustomLog /var/log/apache-access.log combined
 
 	# For most configuration files from conf-available/, which are
 	# enabled or disabled at a global level, it is possible to
@@ -33,7 +35,5 @@
 	#Include conf-available/serve-cgi-bin.conf
 
 </VirtualHost>
-
-
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,5 +81,3 @@ services:
       WORDPRESS_DB_HOST: db:3306
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
-    extra_hosts:
-       - "localhost:172.22.0.4"


### PR DESCRIPTION
Fixes error during Apache startup:

> Could not reliably determine the server's fully qualified domain name, using 172.22.0.5. Set the 'ServerName' directive globally to suppress this message

### Test

- Rebuild: `yarn docker:build`
- Up: `yarn docker:up`
- No error during installation and test accessing via localhost and proxied URL