### PR TITLE
Settings: introduce new selector to check module availability

### DIFF
--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -5,17 +5,21 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
-import { getModules } from 'state/modules';
+import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 import DashItem from 'components/dash-item';
 
 class DashMonitor extends Component {
+	static propTypes = {
+		isDevMode: PropTypes.bool.isRequired,
+		isModuleAvailable: PropTypes.bool.isRequired,
+	};
+
 	getContent() {
 		const labelName = __( 'Downtime Monitoring' );
 		const activateAndTrack = () => {
@@ -64,28 +68,13 @@ class DashMonitor extends Component {
 	}
 
 	render() {
-		const moduleList = Object.keys( this.props.moduleList );
-		if ( ! includes( moduleList, 'monitor' ) ) {
-			return null;
-		}
-
-		return (
-			<div>
-				{ this.getContent() }
-			</div>
-		);
+		return this.props.isModuleAvailable && this.getContent();
 	}
 }
 
-DashMonitor.propTypes = {
-	isDevMode: PropTypes.bool.isRequired
-};
-
 export default connect(
-	( state ) => {
-		return {
-			isDevMode: isDevMode( state ),
-			moduleList: getModules( state )
-		};
-	}
+	state => ( {
+		isDevMode: isDevMode( state ),
+		isModuleAvailable: isModuleAvailable( state, 'monitor' ),
+	} )
 )( DashMonitor );

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -6,15 +6,19 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
-import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
-import { getModules } from 'state/modules';
+import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
 class DashPhoton extends Component {
+	static propTypes = {
+		isDevMode: PropTypes.bool.isRequired,
+		isModuleAvailable: PropTypes.bool.isRequired,
+	};
+
 	getContent() {
 		const labelName = __( 'Image Performance' ),
 			activatePhoton = () => this.props.updateOptions( { photon: true } );
@@ -51,28 +55,13 @@ class DashPhoton extends Component {
 	}
 
 	render() {
-		const moduleList = Object.keys( this.props.moduleList );
-		if ( ! includes( moduleList, 'photon' ) ) {
-			return null;
-		}
-
-		return (
-			<div className="jp-dash-item__interior">
-				{ this.getContent() }
-			</div>
-		);
+		return this.props.isModuleAvailable && this.getContent();
 	}
 }
 
-DashPhoton.propTypes = {
-	isDevMode: PropTypes.bool.isRequired
-};
-
 export default connect(
-	( state ) => {
-		return {
-			isDevMode: isDevMode( state ),
-			moduleList: getModules( state )
-		};
-	}
+	state => ( {
+		isDevMode: isDevMode( state ),
+		isModuleAvailable: isModuleAvailable( state, 'photon' ),
+	} )
 )( DashPhoton );

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -14,17 +13,23 @@ import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import QueryPluginUpdates from 'components/data/query-plugin-updates';
 import { getPluginUpdates } from 'state/at-a-glance';
-import { getModules } from 'state/modules';
+import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
 class DashPluginUpdates extends Component {
-
 	static propTypes = {
 		isDevMode: PropTypes.bool.isRequired,
 		siteRawUrl: PropTypes.string.isRequired,
 		siteAdminUrl: PropTypes.string.isRequired,
-		pluginUpdates: PropTypes.any.isRequired
+		pluginUpdates: PropTypes.any.isRequired,
+		isModuleAvailable: PropTypes.bool.isRequired,
 	};
+
+	activateAndRedirect( e ) {
+		e.preventDefault();
+		this.props.activateManage()
+			.then( window.location = 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl );
+	}
 
 	getContent() {
 		const labelName = __( 'Plugin Updates' );
@@ -92,12 +97,7 @@ class DashPluginUpdates extends Component {
 	}
 
 	render() {
-		const moduleList = Object.keys( this.props.moduleList );
-		if ( ! includes( moduleList, 'manage' ) ) {
-			return null;
-		}
-
-		return (
+		return this.props.isModuleAvailable && (
 			<div>
 				<QueryPluginUpdates />
 				{ this.getContent() }
@@ -110,6 +110,6 @@ export default connect(
 	state => ( {
 		pluginUpdates: getPluginUpdates( state ),
 		isDevMode: isDevMode( state ),
-		moduleList: getModules( state )
+		isModuleAvailable: isModuleAvailable( state, 'manage' ),
 	} )
 )( DashPluginUpdates );

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -6,17 +6,22 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { numberFormat, translate as __ } from 'i18n-calypso';
-import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
 import QueryProtectCount from 'components/data/query-dash-protect';
-import { getModules } from 'state/modules';
+import { isModuleAvailable } from 'state/modules';
 import { getProtectCount } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
 
 class DashProtect extends Component {
+	static propTypes = {
+		isDevMode: PropTypes.bool.isRequired,
+		protectCount: PropTypes.any.isRequired,
+		isModuleAvailable: PropTypes.bool.isRequired,
+	};
+
 	getContent() {
 		const activateProtect = () => this.props.updateOptions( { protect: true } );
 
@@ -70,12 +75,7 @@ class DashProtect extends Component {
 	}
 
 	render() {
-		const moduleList = Object.keys( this.props.moduleList );
-		if ( ! includes( moduleList, 'protect' ) ) {
-			return null;
-		}
-
-		return (
+		return this.props.isModuleAvailable && (
 			<div className="jp-dash-item__interior">
 				<QueryProtectCount />
 				{ this.getContent() }
@@ -84,17 +84,10 @@ class DashProtect extends Component {
 	}
 }
 
-DashProtect.propTypes = {
-	isDevMode: PropTypes.bool.isRequired,
-	protectCount: PropTypes.any.isRequired
-};
-
 export default connect(
-	( state ) => {
-		return {
-			protectCount: getProtectCount( state ),
-			isDevMode: isDevMode( state ),
-			moduleList: getModules( state )
-		};
-	}
+	state => ( {
+		protectCount: getProtectCount( state ),
+		isDevMode: isDevMode( state ),
+		isModuleAvailable: isModuleAvailable( state, 'protect' ),
+	} )
 )( DashProtect );

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -50,6 +50,7 @@ describe( 'Dashboard Stats', () => {
 			},
 			day: undefined,
 		},
+		isModuleAvailable: true,
 		isDevMode: false,
 		moduleList: { stats: {} },
 		activeTab: 'day',

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -4,6 +4,7 @@
 import { combineReducers } from 'redux';
 import get from 'lodash/get';
 import assign from 'lodash/assign';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -237,4 +238,14 @@ export function getModulesThatRequireConnection( state ) {
  */
 export function isModuleActivated( state, name ) {
 	return get( state.jetpack.modules.items, [ name, 'activated' ], false ) ? true : false;
+}
+
+/**
+ * Returns true if the module is available.
+ * @param  {Object}  state      Global state tree.
+ * @param  {String}  moduleSlug The slug of a module.
+ * @return {Boolean}            Whether a module is available to be displayed in the dashboard.
+ */
+export function isModuleAvailable( state, moduleSlug ) {
+	return includes( Object.keys( state.jetpack.modules.items ), moduleSlug );
 }


### PR DESCRIPTION
This PR introduces a new selector `isModuleAvailable( state, 'module-slug' )` to consolidate in a single place a bunch of duplicated code scattered around components used in At a Glance.

Fixes #9111 

#### Changes proposed in this Pull Request:

* introduce `isModuleAvailable( state, 'module-slug' )`
* remove duplicated code
* remove unused class `.jp-dash-item__interior`. It's added in components but doesn't have any rule applied to it. Furthermore, it wasn't in Monitor card for example.

#### Testing instructions:

* test that everything is working like before
