### PR TITLE
Connection: Update connection banner text to clarify ToS acceptance on click

### DIFF
--- a/functions.global.php
+++ b/functions.global.php
@@ -98,7 +98,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the Set up Jetpack button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -98,7 +98,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the Set up Jetpack button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);


### PR DESCRIPTION
Follow-up to #9053.

Since some tracking begins upon any attempted connection, we need to clarify the statement provided alongside our connection (“Set up Jetpack”) button so that it is apparent to folks connecting to
WordPress.com. 

As mentioned by  @eliorivero in https://github.com/Automattic/jetpack/pull/9053#issuecomment-374216586 this banner may need an update too

#### Changes proposed in this Pull Request:


* Updates text from `By connecting your site you agree to our fascinating `, to `By clicking the Set up Button, you agree to our fascinating...`.

#### Testing instructions:
1. On a disconnected site, visit the plugins page (for example) and confirm the text before the button reads `By clicking the Set up Jetpack button, you agree to our fascinating...`.

##### Screenshot

**Before**

![image](https://user-images.githubusercontent.com/746152/37970318-8d38ba74-31a9-11e8-84ee-bd9ca02c8994.png)


**After**

![image](https://user-images.githubusercontent.com/746152/37970846-e1650890-31aa-11e8-9a36-aac588218f25.png)


#### Proposed changelog entry for your changes:

Updated connection banner to clarify when tracking of events begins.