### PR TITLE
Admin Page Update default state value for stats reducer

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import forEach from 'lodash/forEach';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import Card from 'components/card';
 import Chart from 'components/chart';
 import { connect } from 'react-redux';
@@ -301,7 +302,7 @@ export default connect(
 		isDevMode: isDevMode( state ),
 		isLinked: isCurrentUserLinked( state ),
 		connectUrl: getConnectUrl( state ),
-		statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state ),
+		statsData: isEmpty( getStatsData( state ) ) ? getInitialStateStatsData( state ) : getStatsData( state ),
 		isEmptyStatsCardDismissed: emptyStatsCardDismissed( state ),
 	} ),
 	dispatch => ( {

--- a/_inc/client/state/at-a-glance/actions.js
+++ b/_inc/client/state/at-a-glance/actions.js
@@ -39,9 +39,12 @@ export const fetchStatsData = ( range ) => {
 			type: STATS_DATA_FETCH
 		} );
 		return restApi.fetchStatsData( range ).then( statsData => {
+			// If we get a .response property, it means that .com's response is errory.
+			// Probably because the site does not have stats yet.
+			const responseOk = statsData.general.response === undefined;
 			dispatch( {
 				type: STATS_DATA_FETCH_SUCCESS,
-				statsData: statsData
+				statsData: responseOk ? statsData : {},
 			} );
 		} ).catch( error => {
 			dispatch( {

--- a/_inc/client/state/at-a-glance/reducer.js
+++ b/_inc/client/state/at-a-glance/reducer.js
@@ -79,7 +79,7 @@ const activeStatsTab = ( state = 'day', action ) => {
 	}
 };
 
-const statsData = ( state = 'N/A', action ) => {
+const statsData = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case STATS_DATA_FETCH_SUCCESS:
 			return assign( {}, state, action.statsData );


### PR DESCRIPTION
Fixes wrong handling of a first request for a site that has no stats collected yet.

With current default, the state is left in this form:

![image](https://user-images.githubusercontent.com/746152/37977232-bc44e152-31b9-11e8-9269-9afd9771e695.png)

#### Changes proposed in this Pull Request:

* Updates the default state for the stats reducer from `'N/A'`. to `{}`. (from string N/A to empty object).

#### Testing instructions:

1. Launch a new site
2. Connect Jetpack.
3. Quickly when you're dropped into Jetpack's Dashboard, attempt to Jumpstart.
4. Expect to see no errors.




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
