### PR TITLE
Dashboard: fix undefined prop type

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -23,7 +23,10 @@ class DashAkismet extends Component {
 		siteAdminUrl: PropTypes.string.isRequired,
 
 		// Connected props
-		akismetData: PropTypes.string.isRequired,
+		akismetData: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.object
+		] ).isRequired,
 		isDevMode: PropTypes.bool.isRequired,
 	};
 


### PR DESCRIPTION
Fixes a bug introduced in #9078 where we were passing an object instead of a string.  Turns out we need to expect either of them, since the state sets a string by default :(
