### PR TITLE
Fix where jitms may return an empty response where it shouldn't

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -343,7 +343,8 @@ class Jetpack_JITM {
 
 			// no point in showing an empty message
 			if ( empty( $envelope->content->message ) ) {
-				return array();
+				unset( $envelopes[ $idx ] );
+				continue;
 			}
 
 			switch ( $envelope->content->icon ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This fixes an issue where if one of the jitms in the response is a woo jitm from a hook, it would return a completely empty response instead of any other matching jitms. @Davidlenehan discovered today while building a new jitm.

Please cherry pick into release.