### PR TITLE
Admin Page: Add module override selectors

### DIFF
--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -249,3 +249,17 @@ export function isModuleActivated( state, name ) {
 export function isModuleAvailable( state, moduleSlug ) {
 	return includes( Object.keys( state.jetpack.modules.items ), moduleSlug );
 }
+
+/**
+ * Returns the module override for a given module slug.
+ *
+ * Expected values are false if no override, active if module forced on,
+ * or inactive if module forced off.
+ * @param {Object} state Global state tree
+ * @param {String} name  A module's name
+ *
+ * @return {Boolean|String} Whether the override, and if so, how.
+ */
+export function getModuleOverride( state, name ) {
+	return get( state.jetpack.modules.items, [ name, 'override' ], false );
+}

--- a/_inc/client/state/modules/test/selectors.js
+++ b/_inc/client/state/modules/test/selectors.js
@@ -7,7 +7,8 @@ import {
 	isUpdatingModuleOption,
 	getModules,
 	getModule,
-	isModuleActivated
+	isModuleActivated,
+	getModuleOverride
 } from '../reducer';
 
 let state = {
@@ -16,7 +17,8 @@ let state = {
 			items: {
 				'module-a': {
 					module: 'module-a',
-					activated: false
+					activated: false,
+					override: 'active',
 				},
 				'module-b': {
 					module: 'module-b',
@@ -25,8 +27,14 @@ let state = {
 						c: {
 							currentValue: 2
 						}
-					}
-				}
+					},
+					override: 'inactive',
+				},
+				'module-c': {
+					module: 'module-c',
+					activated: false,
+					override: false,
+				},
 			},
 			requests: {
 				fetchingModulesList: true,
@@ -102,6 +110,20 @@ describe( 'items selectors', () => {
 			const stateIn = state;
 			const output = isModuleActivated( stateIn, 'module-a' );
 			expect( output ).to.eql( stateIn.jetpack.modules.items[ 'module-a' ].activated );
+		} );
+	} );
+
+	describe( '#getModuleOverride',  () => {
+		it( 'should return active when module forced on', () => {
+			expect( getModuleOverride( state, 'module-a' ) ).to.eql( 'active' );
+		} );
+
+		it( 'should return inactive when module forced off', () => {
+			expect( getModuleOverride( state, 'module-b' ) ).to.eql( 'inactive' );
+		} );
+
+		it( 'should return false when module not overriden', () => {
+			expect( getModuleOverride( state, 'module-c' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -73,6 +73,7 @@ class Jetpack_Admin {
 		$active_modules    = Jetpack::get_active_modules();
 		$modules           = array();
 		$jetpack_active = Jetpack::is_active() || Jetpack::is_development_mode();
+		$overrides = Jetpack_Modules_Overrides::instance();
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = Jetpack::get_module( $module ) ) {
 				/**
@@ -100,6 +101,7 @@ class Jetpack_Admin {
 				$module_array['available']         = self::is_module_available( $module_array );
 				$module_array['short_description'] = $short_desc_trunc;
 				$module_array['configure_url']     = Jetpack::module_configuration_url( $module );
+				$module_array['override']          = $overrides->get_module_override( $module );
 
 				ob_start();
 				/**


### PR DESCRIPTION
Factors out selectors from #8934.

In order to get some forward progress, let's go ahead and ship the data part of #8934 so that we can use #8934 to work exclusively on UI. This has the benefit of minimize our surface area and how many merge conflicts we'll have in the near future.

To test:

- 