### PR TITLE
REST API: Core Update, fix fatal on PHP 7.1

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
@@ -18,7 +18,7 @@ class Jetpack_JSON_API_Core_Modify_Endpoint extends Jetpack_JSON_API_Core_Endpoi
 		return true;
 	}
 
-	protected function update( $version, $locale ) {
+	protected function update() {
 		$args = $this->input();
 		$version    = isset( $args['version'] ) ? $args['version'] : false;
 		$locale     = isset( $args['locale'] ) ? $args['locale'] : get_locale();


### PR DESCRIPTION
The `update` method is called without parameters within the endpoint, causing fatals on newer PHP versions.

cc @kraftbj

@dereksmart can we merge this into 6.0?