### PR TITLE
Search: Strip slashes from search terms

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -30,7 +30,7 @@ class Jetpack_Search_Helpers {
 	 * @return string The search URL.
 	 */
 	static function get_search_url() {
-		$query_args = $_GET;
+		$query_args = stripslashes_deep( $_GET );
 
 		// Handle the case where a permastruct is being used, such as /search/{$query}
 		if ( ! isset( $query_args['s'] ) ) {


### PR DESCRIPTION
Fixes #9101.

#### Changes proposed in this Pull Request:

Strip slashes from `$_GET` when constructing the search URL.

#### Testing instructions:

1. Search for "_something_" with `something` being a term that'll result in search results.
2. Click on one of the filters.
3. Make sure the search term doesn't change, namely not to having the quotes escaped.

#### Proposed changelog entry for your changes:

Fixes for searching for terms containing quotes.