### PR TITLE
CLI: Partner: Updates partner provisioning to allow REST API

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -140,7 +140,7 @@ class Jetpack_Provision {
 			return $verify_response;
 		}
 
-		$request_body = $this->register_and_build_request_body();
+		$request_body = self::register_and_build_request_body( $named_args );
 		if ( is_wp_error( $request_body ) ) {
 			return $request_body;
 		}
@@ -155,6 +155,7 @@ class Jetpack_Provision {
 			'body'    => json_encode( $request_body )
 		);
 
+		$blog_id = Jetpack_Options::get_option( 'id' );
 		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%d/partner-provision', self::get_api_host(), $blog_id );
 		if ( ! empty( $named_args['partner_tracking_id'] ) ) {
 			$url = esc_url_raw( add_query_arg( 'partner_tracking_id', $named_args['partner_tracking_id'], $url ) );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -127,10 +127,6 @@ class Jetpack_XMLRPC_Server {
 	}
 
 	function remote_provision( $request ) {
-		if ( ! isset( $request['access_token'] ) ) {
-			return $this->error( new Jetpack_Error( 'access_token_missing', sprintf( 'The required "%s" parameter is missing.', 'access_token' ), 400 ), 'jpc_remote_provision_fail' );
-		}
-
 		if ( ! isset( $request['local_username'] ) ) {
 			return $this->error( new Jetpack_Error( 'local_username_missing', sprintf( 'The required "%s" parameter is missing.', 'local_username' ), 400 ), 'jpc_remote_provision_fail' );
 		}
@@ -152,22 +148,17 @@ class Jetpack_XMLRPC_Server {
 
 		wp_set_current_user( $user->ID );
 
-		// filter allowed parameters
-		$allowed_provision_args = array( 'access_token', 'wpcom_user_id', 'wpcom_user_email', 'local_username', 'plan', 'force_register', 'force_connect', 'onboarding', 'partner_tracking_id' );
+		// Filter allowed parameters.
+		$allowed_provision_args = array( 'wpcom_user_id', 'wpcom_user_email', 'local_username', 'plan', 'force_register', 'force_connect', 'onboarding', 'partner_tracking_id' );
 		$args = array_intersect_key(
 			$request,
 			array_flip( $allowed_provision_args )
 		);
 
-		$result = Jetpack_Provision::partner_provision( $access_token, $args );
+		$result = Jetpack_Provision::register_and_build_request_body( $args );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->error( $result, 'jpc_remote_provision_fail' );
-		}
-
-		// this is to prevent us from returning the access_token secret via a potentially unsecured channel.
-		if ( isset( $result->access_token ) && ! empty( $result->access_token ) ) {
-			unset( $result->access_token );
 		}
 
 		return $result;

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -220,10 +220,6 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( $result, 'jpc_remote_provision_fail' );
 		}
 
-		if ( ! empty( $result['secret'] ) ) {
-			unset( $result['secret'] );
-		}
-
 		$result['client_id'] = Jetpack_Options::get_option( 'id' );
 
 		return $result;

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -127,11 +127,33 @@ class Jetpack_XMLRPC_Server {
 	}
 
 	function remote_provision( $request ) {
-		if ( ! isset( $request['local_username'] ) ) {
-			return $this->error( new Jetpack_Error( 'local_username_missing', sprintf( 'The required "%s" parameter is missing.', 'local_username' ), 400 ), 'jpc_remote_provision_fail' );
+		if ( ! isset( $request['nonce'] ) ) {
+			return $this->error(
+				new Jetpack_Error(
+					'nonce_missing',
+					esc_html__( 'The required "nonce" parameter is missing.', 'jetpack' ),
+					400
+				),
+				'jpc_remote_provision_fail'
+			);
 		}
 
-		$access_token = $request['access_token'];
+		$nonce = $request['nonce'];
+		unset( $request['nonce'] );
+
+		// TODO: validate nonce here
+
+		if ( ! isset( $request['local_username'] ) ) {
+			return $this->error(
+				new Jetpack_Error(
+					'local_username_missing',
+					'The required "local_username" parameter is missing.',
+					400
+				),
+				'jpc_remote_provision_fail'
+			);
+		}
+
 		$local_username = $request['local_username'];
 
 		$user = get_user_by( 'login', $local_username );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -127,11 +127,22 @@ class Jetpack_XMLRPC_Server {
 	}
 
 	function remote_provision( $request ) {
-		if ( ! isset( $request['nonce'] ) ) {
+		if ( empty( $request['nonce'] ) ) {
 			return $this->error(
 				new Jetpack_Error(
 					'nonce_missing',
 					esc_html__( 'The required "nonce" parameter is missing.', 'jetpack' ),
+					400
+				),
+				'jpc_remote_provision_fail'
+			);
+		}
+
+		if ( empty( $request['local_username'] ) ) {
+			return $this->error(
+				new Jetpack_Error(
+					'local_username_missing',
+					esc_html__( 'The required "local_username" parameter is missing.', 'jetpack' ),
 					400
 				),
 				'jpc_remote_provision_fail'

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -126,7 +126,15 @@ class Jetpack_XMLRPC_Server {
 		return $response;
 	}
 
-	function remote_provision( $request ) {
+	/**
+	 * This XML-RPC method is called from the /jpphp/provision endpoint on WPCOM in order to
+	 * register this site so that a plan can be provisioned.
+	 *
+	 * @param array $request An array containing at minimum a nonce key and a local_username key.
+	 *
+	 * @return WP_Error|array
+	 */
+	public function remote_provision( $request ) {
 		if ( empty( $request['nonce'] ) ) {
 			return $this->error(
 				new Jetpack_Error(
@@ -152,7 +160,7 @@ class Jetpack_XMLRPC_Server {
 		$nonce = sanitize_text_field( $request['nonce'] );
 		unset( $request['nonce'] );
 
-		$api_url = Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'partner_provision_nonce_check' ) );
+		$api_url  = Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'partner_provision_nonce_check' ) );
 		$response = Jetpack_Client::_wp_remote_request(
 			esc_url_raw( add_query_arg( 'nonce', $nonce, $api_url ) ),
 			array( 'method' => 'GET' ),
@@ -190,7 +198,17 @@ class Jetpack_XMLRPC_Server {
 		wp_set_current_user( $user->ID );
 
 		// Filter allowed parameters.
-		$allowed_provision_args = array( 'wpcom_user_id', 'wpcom_user_email', 'local_username', 'plan', 'force_register', 'force_connect', 'onboarding', 'partner_tracking_id' );
+		$allowed_provision_args = array(
+			'wpcom_user_id',
+			'wpcom_user_email',
+			'local_username',
+			'plan',
+			'force_register',
+			'force_connect',
+			'onboarding',
+			'partner_tracking_id',
+		);
+
 		$args = array_intersect_key(
 			$request,
 			array_flip( $allowed_provision_args )

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -138,12 +138,13 @@ class Jetpack_XMLRPC_Server {
 			);
 		}
 
-		$nonce = sanitize_key( $request['nonce'] );
+		$nonce = sanitize_text_field( $request['nonce'] );
 		unset( $request['nonce'] );
 
+		$api_url = Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'partner_provision_nonce_check' ) );
 		$response = Jetpack_Client::_wp_remote_request(
-			Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'partner_provision_nonce_check' ) ),
-			array( 'nonce' => $nonce ),
+			esc_url_raw( add_query_arg( 'nonce', $nonce, $api_url ) ),
+			array( 'method' => 'GET' ),
 			true
 		);
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -202,6 +202,12 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( $result, 'jpc_remote_provision_fail' );
 		}
 
+		if ( ! empty( $result['secret'] ) ) {
+			unset( $result['secret'] );
+		}
+
+		$result['client_id'] = Jetpack_Options::get_option( 'id' );
+
 		return $result;
 	}
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -138,16 +138,23 @@ class Jetpack_XMLRPC_Server {
 			);
 		}
 
-		$nonce = $request['nonce'];
+		$nonce = sanitize_key( $request['nonce'] );
 		unset( $request['nonce'] );
 
-		// TODO: validate nonce here
+		$response = Jetpack_Client::_wp_remote_request(
+			Jetpack::fix_url_for_bad_hosts( Jetpack::api_url( 'partner_provision_nonce_check' ) ),
+			array( 'nonce' => $nonce ),
+			true
+		);
 
-		if ( ! isset( $request['local_username'] ) ) {
+		if (
+			200 !== wp_remote_retrieve_response_code( $response ) ||
+			'OK' !== trim( wp_remote_retrieve_body( $response ) )
+		) {
 			return $this->error(
 				new Jetpack_Error(
-					'local_username_missing',
-					'The required "local_username" parameter is missing.',
+					'invalid_nonce',
+					esc_html__( 'There was an issue validating this request.', 'jetpack' ),
 					400
 				),
 				'jpc_remote_provision_fail'

--- a/tests/php/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/test_class.jetpack-xmlrpc-server.php
@@ -6,7 +6,7 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 	function test_xmlrpc_features_available() {
 		$server = new Jetpack_XMLRPC_Server();
 		$response = $server->features_available();
-		
+
 		// trivial assertion
 		$this->assertTrue( in_array( 'publicize', $response ) );
 	}
@@ -30,7 +30,7 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		$codec = Jetpack_Sync_Sender::get_instance()->get_codec();
 		$decoded_object = $codec->decode( $response );
 
-		$this->assertFalse( $decoded_object );	
+		$this->assertFalse( $decoded_object );
 	}
 
 	function test_xmlrpc_get_sync_object_for_user() {
@@ -47,4 +47,3 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, $decoded_object->ID );
 	}
 }
-	


### PR DESCRIPTION
Previously, partners had to provision plans via CLI commands. The documentation for that can be found here:

https://github.com/Automattic/jetpack/blob/master/docs/partners/plan-provisioning.md

This works fine, but can be a bit awkward for some hosts to implement. This PR refactors so that hosts will be able to call to the WordPress.com API in order to provision a plan. Things get a bit interesting since the there is a bit of back-and-forth between the Jetpack site and WordPress.com, but we do that so that we don't require sending bearer tokens to and from the Jetpack site.

The testing instructions are "fun" and can be found on D11321, which this PR relies on. So please see that patch for the instructions.

At this point, I believe this PR is in a pretty good place. I'd like to follow-up with much more complete unit testing as well as a security audit. But, I'd prefer to do that in follow-up PRs. For example, we could more completely test the `remote_provision` method in `Jetpack_XMLRPC_Server` if `Jetpack_Provision` was a singleton instance so that we could mock its methods.

To test:

- The testing instructions are "fun" and can be found on D11321, which this PR relies on. So please see that patch for the instructions.
- Test the provisioning script in `bin/partner_provision.sh` by doing the following:
    - Checkout branch
    - Ensure you have a partner ID and secret by following instructions at PCYsg-5vj-p2
    - Run `sh jetpack/bin/partner-provision.sh --partner_id="$partner_id" --partner_secret="$secret" --plan=premium --user="$user_identifier"`
    - Ensure that you get a response that includes `next_url`
    - Enter `next_url` into your browser and finish the connection process