### PR TITLE
Search: add alt attribute to stats pixel.

### DIFF
--- a/_inc/lib/class.jetpack-search-performance-logger.php
+++ b/_inc/lib/class.jetpack-search-performance-logger.php
@@ -77,7 +77,7 @@ class Jetpack_Search_Performance_Logger {
 			$encoded_json = '{%22beacons%22:[' . implode(',', $beacons ) . ']}';
 			$encoded_site_url = urlencode( site_url() );
 			$url = "https://pixel.wp.com/boom.gif?v=0.9&u={$encoded_site_url}&json={$encoded_json}";
-			echo '<img src="' . $url . '" width="1" height="1" style="display:none;" />';
+			echo '<img src="' . $url . '" width="1" height="1" style="display:none;" alt=":)"/>';
 		}
 	}
 }


### PR DESCRIPTION
The alt value is now set to a smiley, just like the main stats pixel (see r134484-wpcom).

This solves any HTML Validation errors reported on search pages.

Reported here:
https://wordpress.org/support/topic/html-validation-error-11/
