### PR TITLE
Code sync: bring divergent SAL files in sync

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -319,7 +319,7 @@ abstract class SAL_Site {
 			'name' => $name,
 			'numberposts' => 1,
 			'post_type' => $this->get_whitelisted_post_types(),
-		    'suppress_filters' => false,
+			'suppress_filters' => false,
 		) );
 
 		if ( ! $posts || ! isset( $posts[0]->ID ) || ! $posts[0]->ID ) {

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -1,5 +1,4 @@
 <?php
-
 require_once dirname( __FILE__ ) . '/class.json-api-site-base.php';
 
 abstract class Abstract_Jetpack_Site extends SAL_Site {


### PR DESCRIPTION
Brings these two files in sync with wpcom.  

Is a blocker for #9177 to merge

Pretty much just adds new methods, but a sanity check is appreciated. 

The wpcom-side changes have been merged in 
r172582-wpcom
r172580-wpcom #