### PR TITLE
Added a loading container when stats are being loaded.

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -29,7 +29,8 @@ import {
 	getStatsData,
 	statsSwitchTab,
 	fetchStatsData,
-	getActiveStatsTab
+	getActiveStatsTab,
+	isFetchingStatsData,
 } from 'state/at-a-glance';
 import { isModuleAvailable } from 'state/modules';
 import { emptyStatsCardDismissed } from 'state/settings';
@@ -41,6 +42,7 @@ export class DashStats extends Component {
 		siteAdminUrl: PropTypes.string.isRequired,
 		statsData: PropTypes.any.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
+		fetchingStatsData: PropTypes.bool.isRequired,
 	};
 
 	constructor( props ) {
@@ -184,6 +186,12 @@ export class DashStats extends Component {
 				);
 			}
 
+			if ( this.props.fetchingStatsData ) {
+				return (
+					<div className="jp-at-a-glance__stats-container-loading" />
+				);
+			}
+
 			const statsChart = this.statsChart( this.props.activeTab ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
@@ -304,6 +312,7 @@ export default connect(
 		connectUrl: getConnectUrl( state ),
 		statsData: isEmpty( getStatsData( state ) ) ? getInitialStateStatsData( state ) : getStatsData( state ),
 		isEmptyStatsCardDismissed: emptyStatsCardDismissed( state ),
+		fetchingStatsData: isFetchingStatsData( state ),
 	} ),
 	dispatch => ( {
 		switchView: tab => dispatch( statsSwitchTab( tab ) ),

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -188,7 +188,11 @@ export class DashStats extends Component {
 
 			if ( this.props.fetchingStatsData ) {
 				return (
-					<div className="jp-at-a-glance__stats-container-loading" />
+					<div className="jp-at-a-glance__stats-container-loading">
+						<div className="jp-at-a-glance__stats-chart">
+							<Spinner />
+						</div>
+					</div>
 				);
 			}
 

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -127,7 +127,7 @@ export class DashStats extends Component {
 				<div className="jp-at-a-glance__stats-chart">
 					<Chart data={ chartData } barClick={ this.barClick } />
 					{
-						0 === chartData.length && <Spinner />
+						( 0 === chartData.length || this.props.fetchingStatsData ) && <Spinner />
 					}
 				</div>
 				<div id="stats-bottom" className="jp-at-a-glance__stats-bottom">
@@ -186,20 +186,10 @@ export class DashStats extends Component {
 				);
 			}
 
-			if ( this.props.fetchingStatsData ) {
-				return (
-					<div className="jp-at-a-glance__stats-container-loading">
-						<div className="jp-at-a-glance__stats-chart">
-							<Spinner />
-						</div>
-					</div>
-				);
-			}
-
 			const statsChart = this.statsChart( this.props.activeTab ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
-				showEmptyStats = totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
+				showEmptyStats = totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed && ! this.props.fetchingStatsData;
 
 			return (
 				<div className="jp-at-a-glance__stats-container">

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -11,57 +11,65 @@ import { shallow } from 'enzyme';
 import { DashStats } from '../index';
 
 describe( 'Dashboard Stats', () => {
-	const testProps = {
-		siteRawUrl: 'example.org',
-		siteAdminUrl: 'example.org/wp-admin',
-		statsData: {
-			general: {
-				date: '2018-03-21',
-				stats: {
-					visitors_today: 0,
-					visitors_yesterday: 0,
-					visitors: 24,
-					views_today: 0,
-					views_yesterday: 0,
-					views_best_day: '2017-05-18',
-					views_best_day_total: 11,
-					views: 59,
-					comments: 6,
-					posts: 11,
-					followers_blog: 0,
-					followers_comments: 0,
-					comments_per_month: 0,
-					comments_most_active_recent_day: '2016-03-08 20:37:56',
-					comments_most_active_time: '17:00',
-					comments_spam: 0,
-					categories: 3,
-					tags: 0,
-					shares: 0,
-					shares_twitter: 0,
-					'shares_google-plus-1': 0,
-					'shares_custom-1513105119': 0,
-					shares_facebook: 0
+	let wrapper,
+		testProps = {};
+
+	before( function() {
+		testProps = {
+			siteRawUrl: 'example.org',
+			siteAdminUrl: 'example.org/wp-admin',
+			statsData: {
+				general: {
+					date: '2018-03-21',
+					stats: {
+						visitors_today: 0,
+						visitors_yesterday: 0,
+						visitors: 24,
+						views_today: 0,
+						views_yesterday: 0,
+						views_best_day: '2017-05-18',
+						views_best_day_total: 11,
+						views: 59,
+						comments: 6,
+						posts: 11,
+						followers_blog: 0,
+						followers_comments: 0,
+						comments_per_month: 0,
+						comments_most_active_recent_day: '2016-03-08 20:37:56',
+						comments_most_active_time: '17:00',
+						comments_spam: 0,
+						categories: 3,
+						tags: 0,
+						shares: 0,
+						shares_twitter: 0,
+						'shares_google-plus-1': 0,
+						'shares_custom-1513105119': 0,
+						shares_facebook: 0
+					},
+					visits: {
+						unit: 'day',
+						fields: [ 'period', 'views', 'visitors' ],
+						data: [ [ '2018-02-20', 0, 0 ] ]
+					}
 				},
-				visits: {
-					unit: 'day',
-					fields: [ 'period', 'views', 'visitors' ],
-					data: [ [ '2018-02-20', 0, 0 ] ]
-				}
+				day: undefined,
 			},
-			day: undefined,
-		},
-		isModuleAvailable: true,
-		isDevMode: false,
-		moduleList: { stats: {} },
-		activeTab: 'day',
-		isLinked: true,
-		connectUrl: 'https://wordpress.com/jetpack/connect/',
-		isEmptyStatsCardDismissed: false,
-		getOptionValue: module => 'stats' === module,
-	};
+			isModuleAvailable: true,
+			isDevMode: false,
+			moduleList: { stats: {} },
+			activeTab: 'day',
+			isLinked: true,
+			connectUrl: 'https://wordpress.com/jetpack/connect/',
+			isEmptyStatsCardDismissed: false,
+			fetchingStatsData: false,
+			getOptionValue: module => 'stats' === module,
+		};
+	} );
 
 	describe( 'Initially', () => {
-		const wrapper = shallow( <DashStats { ...testProps } /> );
+		before( function() {
+			wrapper = shallow( <DashStats { ...testProps } /> );
+		} );
 
 		it( 'renders header and card', () => {
 			expect( wrapper.find( 'DashSectionHeader' ) ).to.have.length( 1 );
@@ -78,23 +86,43 @@ describe( 'Dashboard Stats', () => {
 	} );
 
 	describe( 'When empty stats card was dismissed', () => {
-		const wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
+		before( function() {
+			wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
+		} );
 
 		it( 'renders date range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
 		} );
 	} );
 
+	describe( 'When stats are still loading', () => {
+		before( function() {
+			testProps.fetchingStatsData = true;
+
+			wrapper = shallow(
+				<DashStats { ...testProps } />
+			);
+		} );
+
+		it( 'renders a loading stats container', () => {
+			expect( wrapper.find( '.jp-at-a-glance__stats-container-loading' ) ).to.have.length( 1 );
+		} );
+	} );
+
 	describe( 'When there is stats data', () => {
-		testProps.statsData.day = {
-			unit: 'day',
-			fields: [ 'period', 'views', 'visitors' ],
-			// Mock 32 views for this date
-			data: [ [ '2018-02-20', 32, 0 ] ]
-		};
-		const wrapper = shallow(
-			<DashStats { ...testProps } />
-		);
+		before( function() {
+			testProps.fetchingStatsData = false;
+			testProps.statsData.day = {
+				unit: 'day',
+				fields: [ 'period', 'views', 'visitors' ],
+				// Mock 32 views for this date
+				data: [ [ '2018-02-20', 32, 0 ] ]
+			};
+			wrapper = shallow(
+				<DashStats { ...testProps } />
+			);
+		} );
+
 		it( 'renders some stats', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-chart' ) ).to.have.length( 1 );
 		} );

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -68,6 +68,11 @@
 	position: relative;
 }
 
+.jp-at-a-glance__stats-container-loading {
+	height: 4em;
+}
+
+.jp-at-a-glance__stats-container-loading .dops-spinner,
 .jp-at-a-glance__stats-chart .dops-spinner {
 	position: absolute;
 	top: 50%;


### PR DESCRIPTION
Fixes #9141 

#### Changes proposed in this Pull Request:
* Adds a loading container instead of the stats block when stats are still being fetched.

#### Testing instructions:
* Refresh the Dashboard with stats visible.
* See that the empty stats block shows up until stats are loaded.
* Check this PR out.
* See that the stats block disappears when stats are loading.

This is still in progress, we need to display a spinner of some sort there.

![screenshot from 2018-03-30 15-00-04](https://user-images.githubusercontent.com/374293/38137065-2412ac10-342b-11e8-86a6-ff0582a70792.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed the flashing missing stats notice on load.