### PR TITLE
Settings: update searchable modules to accept the new object format

### DIFF
--- a/_inc/client/components/settings-group/README.md
+++ b/_inc/client/components/settings-group/README.md
@@ -11,7 +11,13 @@ var SettingsGroup = require( 'components/settings-group' );
 
 render: function() {
 	return (
-		<SettingsGroup hasChild support={ this.props.getModule( 'related-posts' ).learn_more_button }>
+		<SettingsGroup
+			hasChild
+			support={
+				text: 'A short explanation about the feature.',
+				link: 'https://jetpack.com/support/feature-doc',
+			}
+			>
 			<FormFieldset>
 				// form elements
 			</FormFieldset>

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -30,9 +30,7 @@ export const SettingsGroup = props => {
 	}
 
 	const disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module );
-	const support = props.support.text && props.support.link
-			? props.support
-			: false;
+	const support = props.support.link ? props.support : false;
 	let displayFadeBlock = disableInDevMode;
 
 	if ( ( 'post-by-email' === module.module && ! props.isLinked ) ||
@@ -71,7 +69,7 @@ export const SettingsGroup = props => {
 								onClick={ trackInfoClick }
 								screenReaderText={ __( 'Learn more' ) }
 								>
-								{ props.support.text + ' ' }
+								{ props.support.text && ( props.support.text + ' ' ) }
 								<ExternalLink
 									onClick={ trackLearnMoreClick }
 									icon={ false }

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -112,7 +112,7 @@ class ActiveCard extends Component {
 				<SettingsGroup
 					disableInDevMode={ devMode }
 					module={ { module: m.module } }
-					support={ m.learn_more_button }
+					support={ { link: m.learn_more_button } }
 				>
 					{ m.description }
 				</SettingsGroup>


### PR DESCRIPTION
This PR:
- fixes issue with search where modules didn't display the help popover with the support link.
- fixes a warning in JS console since these searchable modules were passing a string instead of an object.
- updates the readme file for `SettingsGroup`

<img width="743" alt="captura de pantalla 2018-03-30 a la s 12 25 14" src="https://user-images.githubusercontent.com/1041600/38143194-c953703a-3415-11e8-93eb-f730d2007af2.png">