### PR TITLE
Add custom search terms for the Privacy card

### DIFF
--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -54,10 +54,30 @@ class Privacy extends React.Component {
 		active: false,
 	};
 
+	isPrivacyFound = () => {
+		if ( this.props.searchTerm ) {
+			return (
+				[
+					__( 'privacy' ),
+					__( 'tracks' ),
+					__( 'data' ),
+					__( 'gdpr' ),
+					__( 'tos' ),
+					__( 'terms of service' ),
+				]
+					.join( ' ' )
+					.toLowerCase()
+					.indexOf( this.props.searchTerm.toLowerCase() ) > -1
+			);
+		}
+
+		return true;
+	};
+
 	togglePrivacy = () => {
 		const current = this.props.trackingSettings.tracks_opt_out;
 		this.props.setTrackingSettings( ! current );
-	}
+	};
 
 	componentWillMount() {
 		this.props.fetchTrackingSettings();
@@ -73,7 +93,7 @@ class Privacy extends React.Component {
 			return null;
 		}
 
-		return (
+		return this.isPrivacyFound() && (
 			<div>
 				<SettingsCard
 					{ ...this.props }

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -58,12 +58,12 @@ class Privacy extends React.Component {
 		if ( this.props.searchTerm ) {
 			return (
 				[
-					__( 'privacy' ),
-					__( 'tracks' ),
-					__( 'data' ),
-					__( 'gdpr' ),
-					__( 'tos' ),
-					__( 'terms of service' ),
+					__( 'privacy', { context: 'Search term.' } ),
+					__( 'tracks', { context: 'Search term.' } ),
+					__( 'data', { context: 'Search term.' } ),
+					__( 'gdpr', { context: 'Search term.' } ),
+					__( 'tos', { context: 'Search term.' } ),
+					__( 'terms of service', { context: 'Search term.' } ),
 				]
 					.join( ' ' )
 					.toLowerCase()

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -25,7 +25,7 @@ export const SearchableModules = moduleSettingsForm(
 	class extends Component {
 		handleBannerClick = module => {
 			return () => this.props.updateOptions( { [ module ]: true } );
-		};
+		}
 
 		render() {
 			// Only admins plz

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -25,7 +25,7 @@ export const SearchableModules = moduleSettingsForm(
 	class extends Component {
 		handleBannerClick = module => {
 			return () => this.props.updateOptions( { [ module ]: true } );
-		}
+		};
 
 		render() {
 			// Only admins plz


### PR DESCRIPTION
Fixes a current issue where the new Privacy card surfaces on all search results, even if none are found.  

This adds a hard-coded list of search terms that will surface the card. Any ideas for more? 

To Test: 
- Make sure this card only surfaces when searching for the terms listed in the changeset. 