### PR TITLE
Add border and new layout to dashboard numbers

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -74,7 +74,7 @@ class DashPluginUpdates extends Component {
 					{
 						updatesAvailable
 							? [
-								__( 'plugin needs updating.', 'plugins need updating.', { count: pluginUpdates.count } ) + ' ',
+								__( 'Plugin needs updating.', 'Plugins need updating.', { count: pluginUpdates.count } ) + ' ',
 								! this.props.isDevMode && __( '{{a}}Turn on plugin autoupdates{{/a}}', {
 									components: { a: <a href={ managePluginsUrl } /> }
 								} )

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -62,7 +62,7 @@ class DashPluginUpdates extends Component {
 					updatesAvailable && (
 						<h2 className="jp-dash-item__count">
 							{
-								__( '%(number)s plugin', '%(number)s plugins', {
+								__( '%(number)s', '%(number)s', {
 									count: pluginUpdates.count,
 									args: { number: pluginUpdates.count }
 								} )
@@ -74,7 +74,7 @@ class DashPluginUpdates extends Component {
 					{
 						updatesAvailable
 							? [
-								__( 'Needs updating.', 'Need updating.', { count: pluginUpdates.count } ) + ' ',
+								__( 'plugin needs updating.', 'plugins need updating.', { count: pluginUpdates.count } ) + ' ',
 								! this.props.isDevMode && __( '{{a}}Turn on plugin autoupdates{{/a}}', {
 									components: { a: <a href={ managePluginsUrl } /> }
 								} )

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -29,10 +29,17 @@
 .jp-dash-item__count {
 	margin-top: 0;
 	margin-bottom: 0;
-	width: 100%;
+	margin-right: 8px;
 	color: $blue-medium;
 	font-weight: 500;
 	font-size: rem( 32px );
+	display: inline;
+    border: 1px solid $dashboard-number-border;
+    border-radius: 4px;
+    padding: 0px 4px;
+    float: left;
+    min-width: 36px;
+	text-align: center;
 
 	@include breakpoint( "<660px" ) {
 		font-size: rem( 23px );

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -34,11 +34,11 @@
 	font-weight: 500;
 	font-size: rem( 32px );
 	display: inline;
-    border: 1px solid $dashboard-number-border;
-    border-radius: 4px;
-    padding: 0px 4px;
-    float: left;
-    min-width: 36px;
+	border: 1px solid $dashboard-number-border;
+	border-radius: 4px;
+	padding: 0px 4px;
+	float: left;
+	min-width: 36px;
 	text-align: center;
 
 	@include breakpoint( "<660px" ) {

--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -61,6 +61,8 @@ $sidebar-bg-color:         lighten( $gray, 30% );
 $sidebar-text-color:       $gray-dark;
 $sidebar-selected-color:   $gray;
 
+// Dashboard
+$dashboard-number-border: #CBD7E1;
 
 //Social media colors
 $color-facebook: #39579a;


### PR DESCRIPTION
Fixes #9196

Screenshot:

<img width="679" alt="dashboard-number-border" src="https://user-images.githubusercontent.com/51896/38152764-1063b57c-341e-11e8-8226-67f48fea5ffb.png">

#### Changes proposed in this Pull Request:

* Add more consistent layout and neat border to dash numbers

#### Testing instructions:

* Build Jetpack
* Go to dashboard
* Should look like screenshots in #9196

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
