### PR TITLE
Build: Take in account _x and _n in languages:build gulp task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -447,7 +447,10 @@ gulp.task( 'languages:build', [ 'languages:get' ], function( done ) {
 	} );
 
 	rl.on( 'line', function( line ) {
-		const brace_index = line.indexOf( '__(' );
+		// Here we take in account all possible function used for localization (__(), _x(), _n())
+		let brace_index = line.indexOf( '__(' );
+		brace_index = brace_index === -1 ? line.indexOf( '_x(' ) : brace_index;
+		brace_index = brace_index === -1 ? line.indexOf( '_n(' ) : brace_index;
 
 		// Skipping lines that do not call translation functions
 		if ( -1 === brace_index ) {


### PR DESCRIPTION
Fixes missing translated strings from being present in the final `json` files used for the admin page.

#### Changes proposed in this Pull Request:

* Checks for `_n()` and `_x()` usage too in `language:build` gulp task

#### Testing instructions:

* Check this branch
* Run `yarn build-languages`
* Open a file like `languages/json/jetpack-es_ES.json` and confirm the `At a Glance` string is there with its matching translation.

#### Proposed changelog entry for your changes:

Fixed the tool we use for generating translated string for the Admin Page