### PR TITLE
Fixes context usage in i18n in client side code.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -432,7 +432,7 @@ gulp.task( 'languages:get', function( callback ) {
 	} );
 } );
 
-gulp.task( 'languages:build', function() {
+gulp.task( 'languages:build', [ 'languages:get' ], function() {
 	const terms = [];
 
 	// Defining global that will be used from jetpack-strings.js

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,7 @@ import check from 'gulp-check';
 import cleanCSS from 'gulp-clean-css';
 import colors from 'ansi-colors';
 import del from 'del';
+import deleteLines from 'gulp-delete-lines';
 import fs from 'fs';
 import gulp from 'gulp';
 import eslint from 'gulp-eslint';
@@ -20,12 +21,10 @@ import PluginError from 'plugin-error';
 import po2json from 'gulp-po2json';
 import qunit from 'gulp-qunit';
 import rename from 'gulp-rename';
-import readline from 'readline';
 import request from 'request';
 import rtlcss from 'gulp-rtlcss';
 import sass from 'gulp-sass';
 import { spawn } from 'child_process';
-import Stream from 'stream';
 import sourcemaps from 'gulp-sourcemaps';
 import tap from 'gulp-tap';
 import uglify from 'gulp-uglify';
@@ -433,59 +432,53 @@ gulp.task( 'languages:get', function( callback ) {
 	} );
 } );
 
-gulp.task( 'languages:build', [ 'languages:get' ], function( done ) {
-	let terms = [];
-	const instream = fs.createReadStream( './_inc/jetpack-strings.php' );
-	const outstream = new Stream;
-	outstream.readable = true;
-	outstream.writable = true;
+gulp.task( 'languages:build', function() {
+	const terms = [];
 
-	const rl = readline.createInterface( {
-		input: instream,
-		output: outstream,
-		terminal: false
-	} );
+	// Defining global that will be used from jetpack-strings.js
+	global.$jetpack_strings = [];
+	global.array = function() {};
 
-	rl.on( 'line', function( line ) {
-		const brace_index = line.indexOf( '__(' );
+	// Plural gettext call doesn't make a difference for Jed, the singular value is still used as the key.
+	global.__ = global._n = function( term ) {
+		terms[ term ] = '';
+	};
 
-		// Skipping lines that do not call translation functions
-		if ( -1 === brace_index ) {
-			return;
-		}
+	// Context prefixes the term and is separated with a unicode character U+0004
+	global._x = function( term, context ) {
+		terms[ context + '\u0004' + term ] = '';
+	};
 
-		line = line
-			.slice( brace_index + 3, line.lastIndexOf( ')' ) )
-			.replace( /[\b\f\n\r\t]/g, ' ' );
+	return gulp.src( [ '_inc/jetpack-strings.php' ] )
+		.pipe( deleteLines( {
+			filters: [ /<\?php/ ]
+		} ) )
+		.pipe( rename( 'jetpack-strings.js' ) )
+		.pipe( gulp.dest( '_inc' ) )
+		.on( 'end', function() {
+			// Requiring the file that will call __, _x and _n
+			require( './_inc/jetpack-strings.js' );
 
-		// Making the line look like a JSON array to parse it as such later
-		line = [ '[', line.trim(), ']' ].join( '' );
+			return gulp.src( [ 'languages/*.po' ] )
+				.pipe( po2json() )
+				.pipe( json_transform( function( data ) {
+					const filtered = {
+						'': data[ '' ]
+					};
 
-		terms.push( line );
-	} ).on( 'close', function() {
-		// Extracting only the first argument to the translation function
-		terms = JSON.parse( '[' + terms.join( ',' ) + ']' ).map( function( term ) {
-			return term[ 0 ];
-		} );
+					Object.keys( data ).forEach( function( term ) {
+						if ( terms.hasOwnProperty( term ) ) {
+							filtered[ term ] = data[ term ];
+						}
+					} );
 
-		gulp.src( [ 'languages/*.po' ] )
-			.pipe( po2json() )
-			.pipe( json_transform( function( data ) {
-				const filtered = {
-					'': data[ '' ]
-				};
-
-				Object.keys( data ).forEach( function( term ) {
-					if ( -1 !== terms.indexOf( term ) ) {
-						filtered[ term ] = data[ term ];
-					}
+					return filtered;
+				} ) )
+				.pipe( gulp.dest( 'languages/json/' ) )
+				.on( 'end', function() {
+					fs.unlinkSync( './_inc/jetpack-strings.js' );
 				} );
-
-				return filtered;
-			} ) )
-			.pipe( gulp.dest( 'languages/json/' ) )
-			.on( 'end', done );
-	} );
+		} );
 } );
 
 gulp.task( 'php:module-headings', function( callback ) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -432,7 +432,7 @@ gulp.task( 'languages:get', function( callback ) {
 	} );
 } );
 
-gulp.task( 'languages:build', [ 'languages:get' ], function() {
+gulp.task( 'languages:build', [ 'languages:get' ], function( done ) {
 	const terms = [];
 
 	// Defining global that will be used from jetpack-strings.js
@@ -449,7 +449,7 @@ gulp.task( 'languages:build', [ 'languages:get' ], function() {
 		terms[ context + '\u0004' + term ] = '';
 	};
 
-	return gulp.src( [ '_inc/jetpack-strings.php' ] )
+	gulp.src( [ '_inc/jetpack-strings.php' ] )
 		.pipe( deleteLines( {
 			filters: [ /<\?php/ ]
 		} ) )
@@ -477,6 +477,7 @@ gulp.task( 'languages:build', [ 'languages:get' ], function() {
 				.pipe( gulp.dest( 'languages/json/' ) )
 				.on( 'end', function() {
 					fs.unlinkSync( './_inc/jetpack-strings.js' );
+					done();
 				} );
 		} );
 } );

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "glob": "^7.1.1",
     "grunt": "^0.4.2",
     "grunt-wp-i18n": "~0.4.6",
+    "gulp-delete-lines": "^0.0.7",
     "husky": "^0.14.3",
     "mocha": "^2.4.5",
     "mockery": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,6 +3949,13 @@ gulp-debug@2.1.2:
     through2 "^2.0.0"
     tildify "^1.1.2"
 
+gulp-delete-lines@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/gulp-delete-lines/-/gulp-delete-lines-0.0.7.tgz#512143429ce7ae7f2e0a8a309f7a0f61ea069555"
+  dependencies:
+    event-stream "~3.1.0"
+    gulp-util ">=2.2.0"
+
 gulp-download-stream@0.0.13:
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/gulp-download-stream/-/gulp-download-stream-0.0.13.tgz#5b84f1c688951a4d95f66a5a4d24d9b5cf52440e"
@@ -4188,7 +4195,7 @@ gulp-uglify@^2.1.2:
     uglify-save-license "^0.4.1"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@*, gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.2, gulp-util@^3.0.6, gulp-util@^3.0.7, gulp-util@^3.0.8, gulp-util@~3.0.0, gulp-util@~3.0.7:
+gulp-util@*, gulp-util@>=2.2.0, gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.2, gulp-util@^3.0.6, gulp-util@^3.0.7, gulp-util@^3.0.8, gulp-util@~3.0.0, gulp-util@~3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:


### PR DESCRIPTION
Previously we were ignoring gettext calls with context and calls with plural strings. This has caused many strings to not be available. This change overhauls the way we export strings from po files into JSON for client side usage and fixes the problem.

Huge kudos for @johnHackworth and @oskosk for bringing this to my attention!

#### Changes proposed in this Pull Request:
* Instead of parsing jetpack-strings, modify it slightly and require it as JS, capturing gettext method calls.

#### Testing instructions:
* Run `yarn build-languages`.
* Use Jetpack settings with any language that we have close to 100% translations, you should see no untranslated strings where strings have been added some time ago, like in navigation, module descriptions and miscellaneous texts.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed translation handling to fully use community provided strings in the Settings area.