### PR TITLE
Shortcode: Specifically check for DOMDocument

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -242,7 +242,7 @@ class Filter_Embedded_HTML_Objects {
 	}
 
 	static function get_attrs( $html ) {
-		if ( ! ( function_exists( 'libxml_use_internal_errors' ) && function_exists( 'simplexml_load_string' ) ) ) {
+		if ( ! ( class_exists( 'DOMDocument' ) && function_exists( 'libxml_use_internal_errors' ) && function_exists( 'simplexml_load_string' ) ) ) {
 			trigger_error( __( "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension." ) );
 			return array();
 		}


### PR DESCRIPTION
A little bit more defensive coding to avoid a hard fatal when the class is not present. Seen in support ticket 1037952-zen .

Not a blocker for 6.0 release.