### PR TITLE
Admin Page: Stats - Fix default value for week and month stats query

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -199,7 +199,8 @@ function JetpackRestApiClient( root, nonce ) {
 
 		fetchStatsData: ( range ) => getRequest( statsDataUrl( range ), getParams )
 			.then( checkStatus )
-			.then( parseJsonResponse ),
+			.then( parseJsonResponse )
+			.then( handleStatsResponseError ),
 
 		getPluginUpdates: () => getRequest( `${ apiRoot }jetpack/v4/updates/plugins`, getParams )
 			.then( checkStatus )
@@ -279,6 +280,16 @@ function JetpackRestApiClient( root, nonce ) {
 			url = url + `?range=${ encodeURIComponent( range ) }`;
 		}
 		return url;
+	}
+
+	function handleStatsResponseError( statsData ) {
+		// If we get a .response property, it means that .com's response is errory.
+		// Probably because the site does not have stats yet.
+		const responseOk =
+			( statsData.general && statsData.general.response === undefined ) ||
+			( statsData.week && statsData.week.response === undefined ) ||
+			( statsData.month && statsData.month.response === undefined );
+		return responseOk ? statsData : {};
 	}
 
 	assign( this, methods );

--- a/_inc/client/state/at-a-glance/actions.js
+++ b/_inc/client/state/at-a-glance/actions.js
@@ -41,7 +41,10 @@ export const fetchStatsData = ( range ) => {
 		return restApi.fetchStatsData( range ).then( statsData => {
 			// If we get a .response property, it means that .com's response is errory.
 			// Probably because the site does not have stats yet.
-			const responseOk = statsData.general.response === undefined;
+			const responseOk =
+				( statsData.general && statsData.general.response === undefined ) ||
+				( statsData.week && statsData.week.response === undefined ) ||
+				( statsData.month && statsData.month.response === undefined );
 			dispatch( {
 				type: STATS_DATA_FETCH_SUCCESS,
 				statsData: responseOk ? statsData : {},

--- a/_inc/client/state/at-a-glance/actions.js
+++ b/_inc/client/state/at-a-glance/actions.js
@@ -39,15 +39,9 @@ export const fetchStatsData = ( range ) => {
 			type: STATS_DATA_FETCH
 		} );
 		return restApi.fetchStatsData( range ).then( statsData => {
-			// If we get a .response property, it means that .com's response is errory.
-			// Probably because the site does not have stats yet.
-			const responseOk =
-				( statsData.general && statsData.general.response === undefined ) ||
-				( statsData.week && statsData.week.response === undefined ) ||
-				( statsData.month && statsData.month.response === undefined );
 			dispatch( {
 				type: STATS_DATA_FETCH_SUCCESS,
-				statsData: responseOk ? statsData : {},
+				statsData: statsData,
 			} );
 		} ).catch( error => {
 			dispatch( {


### PR DESCRIPTION
#9165  only handled error-y API responses from a request for `general`  data. This PR handles error reponses for `month` and `week` data. 

#### Changes proposed in this Pull Request:

* Updates the `getStats` redux action to not handle errors when requesting stats data.
* Moves error handling behaviour to the rest-api client.

#### Testing instructions:

* On a connected site with stats.
* Check this branch
* Visit the dashboard
* Expect to see the general stats
* Switch to month and week view
* Expect to see the stats for the period

