### PR TITLE
SSO: Fix typo in auth cookie expiration filter

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6563,6 +6563,7 @@ p {
 			'jetpack_is_holiday_snow_season'                         => null,
 			'jetpack_holiday_snow_option_updated'                    => null,
 			'jetpack_holiday_snowing'                                => null,
+			'jetpack_sso_auth_cookie_expirtation'                    => 'jetpack_sso_auth_cookie_expiration',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -253,7 +253,7 @@ class Jetpack_SSO_Helpers {
 		 *
 		 * @param int YEAR_IN_SECONDS
 		 */
-		return intval( apply_filters( 'jetpack_sso_auth_cookie_expirtation', YEAR_IN_SECONDS ) );
+		return intval( apply_filters( 'jetpack_sso_auth_cookie_expiration', YEAR_IN_SECONDS ) );
 	}
 
 	/**

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -114,17 +114,17 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() );
 		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
 	}
-	
+
 	function test_sso_helpers_require_two_step_disabled() {
 		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
 		$this->assertTrue( Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled() );
 		remove_filter( 'jetpack_sso_require_two_step', '__return_true' );
 	}
-	
+
 	function test_sso_helpers_require_two_step_enabled() {
 		$this->assertFalse( Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled() );
 	}
-	
+
 	function test_sso_helpers_match_by_email_disabled() {
 		add_filter( 'jetpack_sso_match_by_email', '__return_true' );
 		$this->assertTrue( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() );
@@ -134,7 +134,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	function test_sso_helpers_match_by_email_enabled() {
 		$this->assertFalse( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() );
 	}
-	
+
 	function test_allow_redirect_hosts_adds_default_hosts() {
 		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts( array( 'test.com' ) );
 		$this->assertInternalType( 'array', $hosts );
@@ -187,7 +187,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 
 		wp_delete_user( $user->ID );
 	}
-	
+
 	function test_generate_user_returns_false_when_no_more_tries_and_username_exists() {
 		add_filter( 'jetpack_sso_allowed_username_generate_retries', '__return_zero' );
 		$this->factory->user->create( array( 'user_login' => $this->user_data->login ) );
@@ -201,9 +201,9 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	}
 
 	function test_extend_auth_cookie_casts_to_int() {
-		add_filter( 'jetpack_sso_auth_cookie_expirtation', array( $this, '__return_string_value' ) );
+		add_filter( 'jetpack_sso_auth_cookie_expiration', array( $this, '__return_string_value' ) );
 		$this->assertSame( intval( $this->__return_string_value() ), Jetpack_SSO_Helpers::extend_auth_cookie_expiration_for_sso() );
-		remove_filter( 'jetpack_sso_auth_cookie_expirtation', array( $this, '__return_string_value' ) );
+		remove_filter( 'jetpack_sso_auth_cookie_expiration', array( $this, '__return_string_value' ) );
 	}
 
 	function test_extend_auth_cookie_default_value_greater_than_default() {


### PR DESCRIPTION
While walking through a big of SSO code today, @oskosk pointed out a typo in `Jetpack_SSO_Helpers. Specifically, the string we were using for a filter was `jetpack_sso_auth_cookie_expirtation`. Note the last word there. It should be `expiration`. :facepalm:

This PR fixes that issue as well as deprecate the incorrectly spelled filter.

To test:

- `phpunit --testsuite=sso`