### PR TITLE
Dashboard Stats: render spinner/empty stats card correctly

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -187,7 +187,7 @@ export class DashStats extends Component {
 			const statsChart = this.statsChart( this.props.activeTab ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
-				showEmptyStats = chartData.length > 0 && totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
+				showEmptyStats = chartData.length && totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
 
 			return (
 				<div className="jp-at-a-glance__stats-container">

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -187,7 +187,7 @@ export class DashStats extends Component {
 			const statsChart = this.statsChart( this.props.activeTab ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
-				showEmptyStats = totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
+				showEmptyStats = chartData.length > 0 && totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
 
 			return (
 				<div className="jp-at-a-glance__stats-container">

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -79,7 +79,7 @@ describe( 'Dashboard Stats', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 0 );
 		} );
 
-		describe( 'when stats are still loading', function() {
+		describe( 'when stats are present, but empty', function() {
 			before( function() {
 				testProps.statsData.day = {
 					unit: 'day',

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -70,7 +70,6 @@ describe( 'Dashboard Stats', () => {
 			wrapper = shallow( <DashStats { ...testProps } /> );
 		} );
 
-		/*
 		it( 'renders header and card', () => {
 			expect( wrapper.find( 'DashSectionHeader' ) ).to.have.length( 1 );
 			expect( wrapper.find( '.jp-at-a-glance__stats-card' ) ).to.have.length( 1 );
@@ -78,7 +77,7 @@ describe( 'Dashboard Stats', () => {
 
 		it( 'does not render date range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 0 );
-		} ); */
+		} );
 
 		describe( 'when stats are still loading', function() {
 			before( function() {
@@ -96,7 +95,7 @@ describe( 'Dashboard Stats', () => {
 			} );
 		} );
 	} );
-/*
+
 	describe( 'When empty stats card was dismissed', () => {
 		before( function() {
 			wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
@@ -125,5 +124,5 @@ describe( 'Dashboard Stats', () => {
 		it( 'and range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
 		} );
-	} );*/
+	} );
 } );

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -11,58 +11,66 @@ import { shallow } from 'enzyme';
 import { DashStats } from '../index';
 
 describe( 'Dashboard Stats', () => {
-	const testProps = {
-		siteRawUrl: 'example.org',
-		siteAdminUrl: 'example.org/wp-admin',
-		statsData: {
-			general: {
-				date: '2018-03-21',
-				stats: {
-					visitors_today: 0,
-					visitors_yesterday: 0,
-					visitors: 24,
-					views_today: 0,
-					views_yesterday: 0,
-					views_best_day: '2017-05-18',
-					views_best_day_total: 11,
-					views: 59,
-					comments: 6,
-					posts: 11,
-					followers_blog: 0,
-					followers_comments: 0,
-					comments_per_month: 0,
-					comments_most_active_recent_day: '2016-03-08 20:37:56',
-					comments_most_active_time: '17:00',
-					comments_spam: 0,
-					categories: 3,
-					tags: 0,
-					shares: 0,
-					shares_twitter: 0,
-					'shares_google-plus-1': 0,
-					'shares_custom-1513105119': 0,
-					shares_facebook: 0
+	let wrapper,
+		testProps;
+
+	before( function() {
+		testProps = {
+			siteRawUrl: 'example.org',
+			siteAdminUrl: 'example.org/wp-admin',
+			statsData: {
+				general: {
+					date: '2018-03-21',
+					stats: {
+						visitors_today: 0,
+						visitors_yesterday: 0,
+						visitors: 24,
+						views_today: 0,
+						views_yesterday: 0,
+						views_best_day: '2017-05-18',
+						views_best_day_total: 11,
+						views: 59,
+						comments: 6,
+						posts: 11,
+						followers_blog: 0,
+						followers_comments: 0,
+						comments_per_month: 0,
+						comments_most_active_recent_day: '2016-03-08 20:37:56',
+						comments_most_active_time: '17:00',
+						comments_spam: 0,
+						categories: 3,
+						tags: 0,
+						shares: 0,
+						shares_twitter: 0,
+						'shares_google-plus-1': 0,
+						'shares_custom-1513105119': 0,
+						shares_facebook: 0
+					},
+					visits: {
+						unit: 'day',
+						fields: [ 'period', 'views', 'visitors' ],
+						data: [ [ '2018-02-20', 0, 0 ] ]
+					}
 				},
-				visits: {
-					unit: 'day',
-					fields: [ 'period', 'views', 'visitors' ],
-					data: [ [ '2018-02-20', 0, 0 ] ]
-				}
+				day: undefined,
 			},
-			day: undefined,
-		},
-		isModuleAvailable: true,
-		isDevMode: false,
-		moduleList: { stats: {} },
-		activeTab: 'day',
-		isLinked: true,
-		connectUrl: 'https://wordpress.com/jetpack/connect/',
-		isEmptyStatsCardDismissed: false,
-		getOptionValue: module => 'stats' === module,
-	};
+			isModuleAvailable: true,
+			isDevMode: false,
+			moduleList: { stats: {} },
+			activeTab: 'day',
+			isLinked: true,
+			connectUrl: 'https://wordpress.com/jetpack/connect/',
+			isEmptyStatsCardDismissed: false,
+			getOptionValue: module => 'stats' === module,
+		};
+	} );
 
 	describe( 'Initially', () => {
-		const wrapper = shallow( <DashStats { ...testProps } /> );
+		before( function() {
+			wrapper = shallow( <DashStats { ...testProps } /> );
+		} );
 
+		/*
 		it( 'renders header and card', () => {
 			expect( wrapper.find( 'DashSectionHeader' ) ).to.have.length( 1 );
 			expect( wrapper.find( '.jp-at-a-glance__stats-card' ) ).to.have.length( 1 );
@@ -70,15 +78,29 @@ describe( 'Dashboard Stats', () => {
 
 		it( 'does not render date range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 0 );
-		} );
+		} ); */
 
-		it( 'renders the empty stats container', () => {
-			expect( wrapper.find( '.jp-at-a-glance__stats-empty' ) ).to.have.length( 1 );
+		describe( 'when stats are still loading', function() {
+			before( function() {
+				testProps.statsData.day = {
+					unit: 'day',
+					fields: [ 'period', 'views', 'visitors' ],
+					// Mock no views for this date
+					data: [ [ '2018-02-20', 0, 0 ] ]
+				};
+				wrapper = shallow( <DashStats { ...testProps } /> );
+			} );
+
+			it( 'renders the empty stats container', () => {
+				expect( wrapper.find( '.jp-at-a-glance__stats-empty' ) ).to.have.length( 1 );
+			} );
 		} );
 	} );
-
+/*
 	describe( 'When empty stats card was dismissed', () => {
-		const wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
+		before( function() {
+			wrapper = shallow( <DashStats { ...testProps } isEmptyStatsCardDismissed={ true } /> );
+		} );
 
 		it( 'renders date range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
@@ -86,20 +108,22 @@ describe( 'Dashboard Stats', () => {
 	} );
 
 	describe( 'When there is stats data', () => {
-		testProps.statsData.day = {
-			unit: 'day',
-			fields: [ 'period', 'views', 'visitors' ],
-			// Mock 32 views for this date
-			data: [ [ '2018-02-20', 32, 0 ] ]
-		};
-		const wrapper = shallow(
-			<DashStats { ...testProps } />
-		);
+		before( function() {
+			testProps.statsData.day = {
+				unit: 'day',
+				fields: [ 'period', 'views', 'visitors' ],
+				// Mock 32 views for this date
+				data: [ [ '2018-02-20', 32, 0 ] ]
+			};
+			wrapper = shallow(
+				<DashStats { ...testProps } />
+			);
+		} );
 		it( 'renders some stats', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-chart' ) ).to.have.length( 1 );
 		} );
 		it( 'and range tabs', () => {
 			expect( wrapper.find( '.jp-at-a-glance__stats-views' ) ).to.have.length( 1 );
 		} );
-	} );
+	} );*/
 } );


### PR DESCRIPTION
Alternate to #9190

This will show a spinner as we're retrieving data, rather than the "empty stats card", which is meant to be shown for empty stats, and for it to be dismissible. 

You should see this when the page is loading regardless if it has views or not: 
![screen shot 2018-04-02 at 5 36 32 pm](https://user-images.githubusercontent.com/7129409/38217450-6d8976ee-369c-11e8-9566-c02f73b7ac9a.png)

For a site with no views recorded, you should see the "empty stats card" as expected. 