### PR TITLE
Sync: Include file.php before calling request_filesystem_credentials

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -165,6 +165,11 @@ class Jetpack_Sync_Functions {
 		}
 
 		ob_start();
+
+		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
+
 		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
 		ob_end_clean();
 		if ( $filesystem_credentials_are_stored ) {


### PR DESCRIPTION
Fixes a fatal error:

```
Uncaught Error: Call to undefined function request_filesystem_credentials() in wp-admin/includes/class-wp-upgrader-skin.php:97`
```

#### Changes proposed in this Pull Request:

* Includes `wp-admin/includes/file.php` if `request_filesystem_credentials` is not defined.

#### Testing instructions:

* On a connected Jetpack site.
* Make sure `WP_DEBUG_LOG` is enabled or that you're able to see the log.
* Install a plugin like `WP Crontrol`, get to Tools->Cron Events an click "Run" for the Hook named `wp_version_check`. 
* Check the log and confirm you don't see the Fatal Error logged

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Sync: Fixed a fatal error coming from hooking into the `wp_version_check` cron task.
