### PR TITLE
E2E tests: Get rid of old, invalid cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ jobs:
                   cd wp-e2e-tests
                   git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
-          key: dependency-cache-{{ checksum "wp-e2e-tests/package.json" }}
+          key: dependency-cache-v1-{{ checksum "wp-e2e-tests/package.json" }}
       - run: cd wp-e2e-tests && npm install
       - save_cache:
           paths:
             - ./wp-e2e-tests/node_modules
-          key: dependency-cache-{{ checksum "wp-e2e-tests/package.json" }}
+          key: dependency-cache-v1-{{ checksum "wp-e2e-tests/package.json" }}
       - run:
           name: Run Jetpack JN activation spec
           command: |


### PR DESCRIPTION
Some of the node dependencies are missing in an old cache. This PR switching to a new cache file.


#### Testing instructions:

See CircleCI build is able to run tests. `env: ./node_modules/.bin/magellan: Permission denied` Error is not present in `test` job.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

fix broken E2E tests CI cache
