### PR TITLE
Social Icons: bundle screen reader text CSS class.

### DIFF
--- a/modules/widgets/social-icons/social-icons.css
+++ b/modules/widgets/social-icons/social-icons.css
@@ -55,3 +55,21 @@
 	height: 48px;
 	width: 48px;
 }
+
+/*
+Text meant only for screen readers.
+Provides support for themes that do not bundle this CSS yet.
+@see https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/
+***********************************/
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute ! important;
+	width: 1px;
+	word-wrap: normal ! important;
+}


### PR DESCRIPTION
Modern themes must include this snippet nowadays:
https://make.wordpress.org/themes/2015/01/26/supporting-screen-reader-text/
Jetpack must remain compatible with non-modern themes, so let's include the snippet
with the Social Icons widget, since it relies on this CSS class.

Reported here:
https://twitter.com/RebaBaskett/status/981211671111913472
https://twitter.com/davezatz/status/981310446522249216

#### Proposed changelog entry for your changes:
* Social Icons Widget: bundle support for screen reader text for themes that do not provide support out of the box.