### PR TITLE
Widgets: Social Icons - Load admin form supporting javascript without scoping it to the customizer or the widgets page

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -42,13 +42,9 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	/**
 	 * Script & styles for admin widget form.
 	 */
-	public function enqueue_admin_scripts( $hook ) {
-		global $wp_customize;
-
-		if ( isset( $wp_customize ) || 'widgets.php' === $hook ) {
-			wp_enqueue_script( 'jetpack-widget-social-icons-script', plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20170506' );
-			wp_enqueue_style( 'jetpack-widget-social-icons-admin', plugins_url( 'social-icons/social-icons-admin.css', __FILE__ ), array(), '20170506' );
-		}
+	public function enqueue_admin_scripts() {
+		wp_enqueue_script( 'jetpack-widget-social-icons-script', plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20170506' );
+		wp_enqueue_style( 'jetpack-widget-social-icons-admin', plugins_url( 'social-icons/social-icons-admin.css', __FILE__ ), array(), '20170506' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes: #9234

It seems that we're not scoping js in this way on other widgets.


#### Changes proposed in this Pull Request:

* Removes the check to see if we're on the customizer or the widgets page before enqueuing the admin form for the Social Icons Widget

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Starting with a connected Jetpack site
* With a plugin like [Page Builder](https://wordpress.org/plugins/siteorigin-panels/) that allows to add widgets from a page different than the customizer or the widgets one.
* Attempt to add the Social Icons widget on a page.
* Confirm that you can add and remove icons (JS-powered behaviour).

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
