### PR TITLE
WooCommerce Services JITM: use redirect parameter.

### DIFF
--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -60,7 +60,7 @@ class WC_Services_Installer {
 				break;
 		}
 
-		$redirect = wp_get_referer();
+		$redirect = isset( $_GET['redirect'] ) ? admin_url( $_GET['redirect'] ) : wp_get_referer();
 
 		if ( $result ) {
 			$this->jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* In WooCommerce Services JITM: Use the `redirect` JITM parameter, only using HTTP referer as a fallback.

_Relying on referer alone fails in browsers that strip those headers for DNT purposes._

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* In a browser that doesn't send HTTP referer (like Firefox), verify that the CTA in the Install/Activate WCS JITM does not properly redirect
  * JITM is shown to administrators on the WooCommerce > Orders page if WooCommerce is active and WooCommerce Services is either uninstalled, or inactive
* Check out this branch
* Verify that the CTA redirects back to the originating page

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
