### PR TITLE
Docs: Partners: Add documentation for provisioning plan directly

### DIFF
--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -85,7 +85,73 @@ request( options, function ( error, response, body ) {
 
 ### Provisioning a plan
 
-TBD.
+Plans can be provisioned by making a request using your partner token from the step above along with local_username, siteurl, and plan parameters.
+
+#### Endpoint information
+
+- __Method__: POST
+- __URL__:    https://public-api.wordpress.com/rest/v1.3/jpphp/provision
+
+#### Request Parameters
+
+- __local_username__: The username on the local website (not the WordPress.com username) that should own the plan.
+- __siteurl__:        The URL where the WordPress core files reside.
+- __plan__:           A slug representing which plan to provision. One of `personal`, `premium`, or `professional`.
+
+#### Endpoint Errors
+
+The following is non-exhaustive list of errors that could be returned.
+
+| HTTP Code | Error Identifier          | Error Message                                                             |
+| --------- | ------------------------- | ------------------------------------------------------------------------- |
+| 400       | invalid_siteurl           | The required "siteurl" argument is missing.                               |
+| 400       | invalid_local_username    | The required "local_username" argument is missing.                        |
+| 400       | plan_downgrade_disallowed | Can not automatically downgrade plans. Contact support.                   |
+| 400       | invalid_plan              | %s is not a valid plan                                                    |
+| 403       | invalid_scope             | This token is not authorized to provision partner sites                   |
+
+### Examples
+
+Here's an example using cURL in shell.
+
+```shell
+curl --request POST \
+  --url https://public-api.wordpress.com/rest/v1.3/jpphp/provision \
+  --header 'authorization: Bearer access_token_here' \
+  --header 'cache-control: no-cache' \
+  --header 'local_username: local_username_here' \
+  --header 'plan: plan_here' \
+  --header 'siteurl: siteurl_here'
+```
+Here's an example using the request module in NodeJS.
+
+```js
+var request = require( 'request' );
+var accessToken = 'access_token_here';
+var plan = 'plan_here';
+var siteurl = 'http://example.com';
+var local_username = 'username_here';
+
+var options = {
+    method: 'POST',
+    url: 'https://public-api.wordpress.com/rest/v1.3/jpphp/provision',
+    headers: {
+        'cache-control': 'no-cache',
+        authorization: 'Bearer ' + accessToken,
+        plan: plan,
+        siteurl: siteurl,
+        local_username: local_username
+    }
+};
+
+request( options, function ( error, response, body ) {
+    if ( error ) {
+        throw new Error( error );
+    }
+
+    console.log( body );
+} );
+```
 
 ### Cancelling a plan
 


### PR DESCRIPTION
Previously, it was not practical for a partner to provision a plan by calling directly to the WordPress.com API. The issue was that the site needed to have registered with WordPress.com first.

As of #9178, there is a new endpoint that allows hosts to call directly to the WordPress.com API to provision a plan. This PR documents that endpoint.

