### PR TITLE
Modules: Confirm array is present

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1515,6 +1515,9 @@ class Jetpack {
 		// get available features
 		foreach ( self::get_available_modules() as $module_slug ) {
 			$module = self::get_module( $module_slug );
+			if ( ! isset( $module ) || ! is_array( $module ) {
+				continue;
+			}
 			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
 				$supports[] = $module_slug;
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1515,7 +1515,7 @@ class Jetpack {
 		// get available features
 		foreach ( self::get_available_modules() as $module_slug ) {
 			$module = self::get_module( $module_slug );
-			if ( ! isset( $module ) || ! is_array( $module ) {
+			if ( ! isset( $module ) || ! is_array( $module ) ) {
 				continue;
 			}
 			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {


### PR DESCRIPTION
After https://github.com/Automattic/jetpack/commit/d2fc8b97de7c082e6c512455b6a0412b37dfa25c , some sites were seeing warnings:

```
Warning: in_array() expects parameter 2 to be array, null given in 
/home/public_html/wp-content/plugins/jetpack/class.jetpack.php on 
line 1518
``` 

It appears we should be setting a default `array('free')` if there are no headers present, so I am not sure _where_ this failure is coming from. This would prevent the warning.

cc: @gravityrail 