### PR TITLE
Sync: Bug fix empty the queue if there is nothing to send and only skip

### DIFF
--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -28,6 +28,10 @@ class Jetpack_Sync_Server_Eventstore {
 
 		if ( $action_name ) {
 			$events = array();
+			if ( ! isset( $this->events, $this->events[ $blog_id ] ) ) {
+				return $events;
+			}
+
 			foreach ( $this->events[ $blog_id ] as $event ) {
 				if ( $event->action === $action_name ) {
 					$events[] = $event;


### PR DESCRIPTION
Currently if there is nothing to send and only things to skip we would be clearing the info from sometimes on the successful syncs. but if we were only dealing with skiped items the sync queue would get stuck and would not clear anything.

This PR make sure that we clear skipped items when there is nothing to send. 
And also not try to talk to .com if there  is nothing to send. 

cc: @lezama 