### PR TITLE
GA: This feature is also available for Premium plans

### DIFF
--- a/modules/google-analytics.php
+++ b/modules/google-analytics.php
@@ -9,7 +9,7 @@
  * Auto Activate: No
  * Feature: Engagement
  * Additional Search Queries: webmaster, google, analytics, console
- * Plans: business
+ * Plans: business, premium
  */
 
 include dirname( __FILE__ ) . "/google-analytics/wp-google-analytics.php";


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/23936

#### Changes proposed in this Pull Request:

* Allow Premium customers to activate Google Analytics

#### Testing instructions:

* Add Premium to a test site
* Try to activate GA
* Apply patch.
* Try again.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Resolve conflict preventing Google Analytics from activating for Premium subscribers.