### PR TITLE
Add/sync callable timezone

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -193,6 +193,7 @@ class Jetpack_Sync_Defaults {
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
 		'roles'                            =>  array( 'Jetpack_Sync_Functions', 'roles' ),
+		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
 	);
 
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -187,12 +187,12 @@ class Jetpack_Sync_Defaults {
 		'sso_bypass_default_login_form'    => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 		'wp_version'                       => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
-		'get_plugins_action_links'		   => array( 'Jetpack_Sync_functions', 'get_plugins_action_links' ),
+		'get_plugins_action_links'         => array( 'Jetpack_Sync_functions', 'get_plugins_action_links' ),
 		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
 		'hosting_provider'                 => array( 'Jetpack_Sync_Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
-		'roles'                            =>  array( 'Jetpack_Sync_Functions', 'roles' ),
+		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
 	);
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -354,4 +354,37 @@ class Jetpack_Sync_Functions {
 		return $wp_roles->roles;
 	}
 
+	/**
+	* Determine time zone from WordPress' options "timezone_string"
+	* and "gmt_offset".
+	*
+	* 1. Check if `timezone_string` is set and return it.
+	* 2. Check if `gmt_offset` is set, formats UTC-offset from it and return it.
+	* 3. Default to "UTC+0" if nothing is set.
+	*
+	* @return string
+	*/
+	public static function get_timezone() {
+		$timezone_string = get_option( 'timezone_string' );
+
+		if ( ! empty( $timezone_string ) ) {
+			return str_replace( '_', ' ', $timezone_string );
+		}
+
+		$gmt_offset = intval( get_option( 'gmt_offset', 0 ) );
+
+		if ( 0 <= $gmt_offset ) {
+			$formatted_gmt_offset = '+' . (string) $gmt_offset;
+		} else {
+			$formatted_gmt_offset = (string) $gmt_offset;
+		}
+
+		$formatted_gmt_offset = str_replace(
+			array( '.25', '.5', '.75' ),
+			array( ':15', ':30', ':45' ),
+			$formatted_gmt_offset
+		);
+
+		return sprintf( 'UTC%s', $formatted_gmt_offset );
+	}
 }

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -371,7 +371,7 @@ class Jetpack_Sync_Functions {
 			return str_replace( '_', ' ', $timezone_string );
 		}
 
-		$gmt_offset = intval( get_option( 'gmt_offset', 0 ) );
+		$gmt_offset = floatval( get_option( 'gmt_offset', 0 ) );
 
 		if ( 0 <= $gmt_offset ) {
 			$formatted_gmt_offset = '+' . (string) $gmt_offset;

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -371,18 +371,14 @@ class Jetpack_Sync_Functions {
 			return str_replace( '_', ' ', $timezone_string );
 		}
 
-		$gmt_offset = floatval( get_option( 'gmt_offset', 0 ) );
+		$gmt_offset = get_option( 'gmt_offset', 0 );
 
-		if ( 0 <= $gmt_offset ) {
-			$formatted_gmt_offset = '+' . (string) $gmt_offset;
-		} else {
-			$formatted_gmt_offset = (string) $gmt_offset;
-		}
+		$formatted_gmt_offset = sprintf( '%+g', floatval( $gmt_offset ) );
 
 		$formatted_gmt_offset = str_replace(
 			array( '.25', '.5', '.75' ),
 			array( ':15', ':30', ':45' ),
-			$formatted_gmt_offset
+			(string) $formatted_gmt_offset
 		);
 
 		/* translators: %s is UTC offset, e.g. "+1" */

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -385,6 +385,7 @@ class Jetpack_Sync_Functions {
 			$formatted_gmt_offset
 		);
 
-		return sprintf( 'UTC%s', $formatted_gmt_offset );
+		/* translators: %s is UTC offset, e.g. "+1" */
+		return sprintf( __( 'UTC%s' ), $formatted_gmt_offset );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -935,9 +935,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_get_timezone_from_timezone_string() {
-		update_option( 'timezone_string', 'San_Marino/Berlin' );
+		update_option( 'timezone_string', 'America/Rankin_Inlet' );
 		update_option( 'gmt_offset', '' );
-		$this->assertEquals( 'San Marino/Berlin', Jetpack_Sync_Functions::get_timezone() );
+		$this->assertEquals( 'America/Rankin Inlet', Jetpack_Sync_Functions::get_timezone() );
 	}
 
 	function test_get_timezone_from_gmt_offset_zero() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -937,7 +937,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	function test_get_timezone_from_timezone_string() {
 		update_option( 'timezone_string', 'San_Marino/Berlin' );
 		update_option( 'gmt_offset', '' );
-		$this->assertEquals( 'San Marino/Berlin', Jetpack_Sync_Functions::get_timezone_() );
+		$this->assertEquals( 'San Marino/Berlin', Jetpack_Sync_Functions::get_timezone() );
 	}
 
 	function test_get_timezone_from_gmt_offset_zero() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -83,6 +83,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'site_icon_url'                    => Jetpack_Sync_Functions::site_icon_url(),
 			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
 			'roles'                            => Jetpack_Sync_Functions::roles(),
+			'timezone'                         => Jetpack_Sync_Functions::get_timezone(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {
@@ -933,6 +934,35 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		);
 	}
 
+	function test_get_timezone_from_timezone_string() {
+		update_option( 'timezone_string', 'San_Marino/Berlin' );
+		update_option( 'gmt_offset', '' );
+		$this->assertEquals( 'San Marino/Berlin', Jetpack_Sync_Functions::get_timezone_() );
+	}
+
+	function test_get_timezone_from_gmt_offset_zero() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', '0' );
+		$this->assertEquals( 'UTC+0', Jetpack_Sync_Functions::get_timezone() );
+	}
+
+	function test_get_timezone_from_gmt_offset_plus() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', '1' );
+		$this->assertEquals( 'UTC+1', Jetpack_Sync_Functions::get_timezone() );
+	}
+
+	function test_get_timezone_from_gmt_offset_fractions() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', '5.5' );
+		$this->assertEquals( 'UTC+5:30', Jetpack_Sync_Functions::get_timezone() );
+	}
+
+	function test_get_timezone_from_gmt_offset_minus() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', '-1' );
+		$this->assertEquals( 'UTC-1', Jetpack_Sync_Functions::get_timezone() );
+	}
 }
 
 function jetpack_foo_is_callable_random() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds sync callable for `timezone`, so that we can show timezone setting changes in the Activity Log.

Normal `option_updated` events for the timezone syncs two separate events: `timezone_string` and `gmt_offset`. That's because in the wp-admin and Calypso they're presented like this:

![image](https://user-images.githubusercontent.com/87168/38885217-e71bf11e-427a-11e8-9f9d-df51e0a73466.png)

This callable syncs only the current timezone, so we won't get previous timezone setting in the activity log. We'll be able to show only "Time zone set to X" where X is either "Europe/Berlin" or "UTC+2".

`get_timezone()` —
1. Checks if `timezone_string` is set and returns it.
2. Checks if `gmt_offset` is set, formats UTC-offset from it and returns it.
3. Defaults to "UTC+0" if nothing is set.

### Testing

1. Change timezone from **Settings** → **General** in `/wp-admin/options-general.php`
2. Observe sync callable get called
3. Tests should pass: `phpunit --filter=WP_Test_Jetpack_Sync_Options`