### PR TITLE
Admin Page: Add isModuleForcedInactive and isModuleForcedActive convenience selectors

### DIFF
--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -264,3 +264,23 @@ export function isModuleAvailable( state, moduleSlug ) {
 export function getModuleOverride( state, name ) {
 	return get( state.jetpack.modules.items, [ name, 'override' ], false );
 }
+
+/**
+ * Returns true if the module is forced to be active.
+ * @param {Object}   state Global state tree
+ * @param {String}   name  A module's name
+ * @return {Boolean}       Whether the module is forced to be active.
+ */
+export function isModuleForcedActive( state, name ) {
+	return getModuleOverride( state, name ) === 'active';
+}
+
+/**
+* Returns true if the module is forced to be inactive.
+* @param {Object}   state Global state tree
+* @param {String}   name  A module's name
+* @return {Boolean}       Whether the module is forced to be inactive.
+*/
+export function isModuleForcedInactive( state, name ) {
+	return getModuleOverride( state, name ) === 'inactive';
+}

--- a/_inc/client/state/modules/test/selectors.js
+++ b/_inc/client/state/modules/test/selectors.js
@@ -8,7 +8,9 @@ import {
 	getModules,
 	getModule,
 	isModuleActivated,
-	getModuleOverride
+	getModuleOverride,
+	isModuleForcedActive,
+	isModuleForcedInactive,
 } from '../reducer';
 
 let state = {
@@ -124,6 +126,26 @@ describe( 'items selectors', () => {
 
 		it( 'should return false when module not overriden', () => {
 			expect( getModuleOverride( state, 'module-c' ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#isModuleForcedActive',  () => {
+		it( 'should return true when module forced on', () => {
+			expect( isModuleForcedActive( state, 'module-a' ) ).to.be.true;
+		} );
+
+		it( 'should return false when module not overriden', () => {
+			expect( getModuleOverride( state, 'module-c' ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#isModuleForcedInactive',  () => {
+		it( 'should return true when module forced off', () => {
+			expect( isModuleForcedInactive( state, 'module-b' ) ).to.be.true;
+		} );
+
+		it( 'should return false when module not overriden', () => {
+			expect( isModuleForcedInactive( state, 'module-c' ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
Builds on the work introduced with #9168.

#### Changes proposed in this Pull Request:

* Adds the selector `isModuleForcedInactive` which returns `true` if the module is forced to be active by a filter ad `false` otherwise.
* Adds the selector `isModuleForcedActive` which returns `true` if the module is forced to be inactive by a filter and `false` otherwise.

#### Testing instructions:

* Checkout to  this branch.
* Run `yarn test-client`.
* Expect the tests to pass.