### PR TITLE
Admin Page: check if wordads is forced active in admin page so to not show the banner for upgrading the plan

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -29,6 +29,7 @@ import {
 } from 'lib/plans/constants';
 
 import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
+import { isModuleForcedActive } from 'state/modules';
 import {
 	isAkismetKeyValid,
 	isCheckingAkismetKey,
@@ -108,7 +109,8 @@ export const SettingsCard = props => {
 			case FEATURE_WORDADS_JETPACK:
 				if (
 					'is-premium-plan' === planClass ||
-					'is-business-plan' === planClass
+					'is-business-plan' === planClass ||
+					props.isAdsForcedActive
 				) {
 					return '';
 				}
@@ -318,6 +320,7 @@ SettingsCard.defaultProps = {
 export default connect(
 	( state ) => {
 		return {
+			isAdsForcedActive: isModuleForcedActive( state, 'wordads' ),
 			sitePlan: getSitePlan( state ),
 			fetchingSiteData: isFetchingSiteData( state ),
 			siteRawUrl: getSiteRawUrl( state ),
@@ -325,7 +328,7 @@ export default connect(
 			userCanManageModules: userCanManageModules( state ),
 			isAkismetKeyValid: isAkismetKeyValid( state ),
 			isCheckingAkismetKey: isCheckingAkismetKey( state ),
-			vaultPressData: getVaultPressData( state )
+			vaultPressData: getVaultPressData( state ),
 		};
 	}
 )( SettingsCard );


### PR DESCRIPTION
Depends on #9263.

#### Changes proposed in this Pull Request:

* Makes the Upgrade banner for getting the Ads feature not show if the module is force-activated. 


#### Testing instructions:

* Start with a site with Jetpack connected.
* Before checking out to this branch, deactivate the WordAds Module.
* Checkout  this branch.
* Add a code snippet like this to force enable WordAds:
    ```
    add_filter( 'jetpack_active_modules', function( $active ) {
      $active[] = 'wordads';
      return $active;
    }, -10 );
    ```

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:
