### PR TITLE
Tools: Add Gutenberg, WP Rollback and WP Downgrade checkboxes to Live Branches Script

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.2
+// @version      1.3
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -26,7 +26,10 @@
 			'<ul>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>' +
+			'<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" class="task-list-item-checkbox">Launch with Gutenberg installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>' +
+			'<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>' +
+			'<li class="task-list-item enabled"><input type="checkbox" name="wp-downgrade" class="task-list-item-checkbox">Launch with WP Downgrade installed</li>' +
 			'</ul>' +
 			'</div>';
 		const branchIsForkedText =


### PR DESCRIPTION
* The WP Rollback plugin allows one to test any old version of Jetpack (Any plugin actually).
* The WP Downgrade plugin allows on to test any old version of WordPress.

In combination they're super useful for double-checking user reports about something happening on old versions, and also for quickly confirming regressions and figuring out at which version the regressions was introduced.

#### Changes proposed in this Pull Request:

* Adds the ability to launch a Live Branch site with the Gutenberg, WP Rollback and WP Downgrade plugins


#### Testing instructions:

* Click https://github.com/Automattic/jetpack/raw/add/some-features-to-tampermonkey-script/tools/jetpack-live-branches/jetpack-live-branches.user.js to get the new script version installed. 
* Visit a PR on this repo
* Expect to see three new checkboxes for Gutenberg, WP Downgrade and WP Rollback

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/38562541-7c90a84a-3ce3-11e8-95f0-49e65b8d68b0.png)
