### PR TITLE
3rd Party: Add override support for jetpack_active_modules filter

### DIFF
--- a/3rd-party/class.jetpack-modules-overrides.php
+++ b/3rd-party/class.jetpack-modules-overrides.php
@@ -32,7 +32,7 @@ class Jetpack_Modules_Overrides {
 	 * @return bool Whether there is a filter on the jetpack_active_modules option.
 	 */
 	public function do_overrides_exist() {
-		return (bool) has_filter( 'option_jetpack_active_modules' );
+		return (bool) ( has_filter( 'option_jetpack_active_modules' ) || has_filter( 'jetpack_active_modules' ) );
 	}
 
 	/**
@@ -79,6 +79,9 @@ class Jetpack_Modules_Overrides {
 		/** This filter is documented in wp-includes/option.php */
 		$filtered = apply_filters( 'option_jetpack_active_modules', array() );
 
+		/** This filter is documented in class.jetpack.php */
+		$filtered = apply_filters( 'jetpack_active_modules', $filtered );
+
 		$forced_on = array_diff( $filtered, array() );
 
 		/**
@@ -87,6 +90,9 @@ class Jetpack_Modules_Overrides {
 
 		/** This filter is documented in wp-includes/option.php */
 		$filtered = apply_filters( 'option_jetpack_active_modules', $available_modules );
+
+		/** This filter is documented in class.jetpack.php */
+		$filtered = apply_filters( 'jetpack_active_modules', $filtered );
 
 		$forced_off = array_diff( $available_modules, $filtered );
 

--- a/tests/php/3rd-party/test_class.jetpack-modules-overrides.php
+++ b/tests/php/3rd-party/test_class.jetpack-modules-overrides.php
@@ -11,28 +11,35 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 
 	public function tearDown() {
 		remove_all_filters( 'option_jetpack_active_modules' );
+		remove_all_filters( 'jetpack_active_modules' );
 		$this->instance->clear_cache();
 	}
 
-	public function test_do_overrides_exist() {
+	/**
+	 * @dataProvider get_supported_filters
+	 */
+	public function test_do_overrides_exist( $filter_name ) {
 		$this->assertFalse( $this->instance->do_overrides_exist() );
 
-		add_filter( 'option_jetpack_active_modules', '__return_true' );
+		add_filter( $filter_name, '__return_true' );
 		$this->assertTrue( $this->instance->do_overrides_exist() );
-		remove_filter( 'option_jetpack_active_modules', '__return_true' );
+		remove_filter( $filter_name, '__return_true' );
 	}
 
-	public function test_get_overrides() {
+	/**
+	 * @dataProvider get_supported_filters
+	 */
+	public function test_get_overrides( $filter_name ) {
 		$this->assertEmpty( $this->instance->get_overrides() );
 
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_active_modules' ) );
+		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
 		$expected = array(
 			'photon' => 'active',
 			'lazy-images' => 'active',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides( false ) );
 
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_inactive_module' ) );
+		add_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 		$expected = array(
 			'photon' => 'active',
 			'lazy-images' => 'active',
@@ -40,40 +47,46 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides( false ) );
 
-		remove_filter( 'option_jetpack_active_modules', array( $this, 'force_active_modules' ) );
+		remove_filter( $filter_name, array( $this, 'force_active_modules' ) );
 
 		$expected = array(
 			'sitemaps' => 'inactive',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides( false ) );
 
-		remove_filter( 'option_jetpack_active_modules', array( $this, 'force_inactive_module' ) );
+		remove_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 
 		$this->assertEmpty( $this->instance->get_overrides( false ) );
 	}
 
-	public function test_get_overrides_cache() {
+	/**
+	 * @dataProvider get_supported_filters
+	 */
+	public function test_get_overrides_cache( $filter_name ) {
 		$this->assertEmpty( $this->instance->get_overrides() );
 
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_active_modules' ) );
+		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
 		$expected = array(
 			'photon' => 'active',
 			'lazy-images' => 'active',
 		);
 		$this->assertSame( $expected, $this->instance->get_overrides() );
 
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_inactive_module' ) );
+		add_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 
 		$this->assertSame( $expected, $this->instance->get_overrides() );
 	}
 
-	public function test_get_module_override() {
+	/**
+	 * @dataProvider get_supported_filters
+	 */
+	public function test_get_module_override( $filter_name ) {
 		$this->assertFalse( $this->instance->get_module_override( 'photon' ) );
 		$this->assertFalse( $this->instance->get_module_override( 'lazy-images' ) );
 		$this->assertFalse( $this->instance->get_module_override( 'sitemaps' ) );
 
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_active_modules' ) );
-		add_filter( 'option_jetpack_active_modules', array( $this, 'force_inactive_module' ) );
+		add_filter( $filter_name, array( $this, 'force_active_modules' ) );
+		add_filter( $filter_name, array( $this, 'force_inactive_module' ) );
 
 		$this->assertSame( 'active', $this->instance->get_module_override( 'photon' ) );
 		$this->assertSame( 'active', $this->instance->get_module_override( 'lazy-images' ) );
@@ -95,5 +108,16 @@ class WP_Test_Jetpack_Modules_Overrides extends WP_UnitTestCase {
 		}
 
 		return $modules;
+	}
+
+	public function get_supported_filters() {
+		return array(
+			'option_jetpack_active_modules' => array( // Case for filtering the option via core filter.
+				'option_jetpack_active_modules'
+			),
+			'jetpack_active_modules' => array( // Case for filtering using Jetpack filter.
+				'jetpack_active_modules',
+			)
+		);
 	}
 }


### PR DESCRIPTION
After talking to @oskosk today, I realized that we weren't taking into account the `jetpack_active_modules` filters when calculating the modules that were forced active or inactive. This PR handles that.

To test:

- `phpunit --filter=WP_Test_Jetpack_Modules_Overrides`