### PR TITLE
Added a check for WordAds feature.

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -36,7 +36,8 @@ import {
 } from 'state/at-a-glance';
 import {
 	getSitePlan,
-	isFetchingSiteData
+	isFetchingSiteData,
+	getActiveFeatures,
 } from 'state/site';
 import SectionHeader from 'components/section-header';
 import ProStatus from 'pro-status';
@@ -105,7 +106,11 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_WORDADS_JETPACK:
-				if ( 'is-premium-plan' === planClass || 'is-business-plan' === planClass ) {
+				if (
+					'is-premium-plan' === planClass ||
+					'is-business-plan' === planClass ||
+					-1 !== props.activeFeatures.indexOf( FEATURE_WORDADS_JETPACK )
+				) {
 					return '';
 				}
 
@@ -235,7 +240,8 @@ export const SettingsCard = props => {
 			case FEATURE_WORDADS_JETPACK:
 				if (
 					'is-premium-plan' !== planClass &&
-					'is-business-plan' !== planClass
+					'is-business-plan' !== planClass &&
+					-1 === props.activeFeatures.indexOf( FEATURE_WORDADS_JETPACK )
 				) {
 					return false;
 				}
@@ -367,6 +373,7 @@ export default connect(
 			vaultPressData: getVaultPressData( state ),
 			getModuleOverride: module_name => getModuleOverride( state, module_name ),
 			getModule: module_name => getModule( state, module_name ),
+			activeFeatures: getActiveFeatures( state ),
 		};
 	}
 )( SettingsCard );

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -117,7 +117,7 @@ export function getAvailableFeatures( state ) {
  * @return {Object}  Features
  */
 export function getActiveFeatures( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'siteFeatures', 'active' ], {} );
+	return get( state.jetpack.siteData, [ 'data', 'siteFeatures', 'active' ], [] );
 }
 
 export function getAvailablePlans( state ) {

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -26,7 +26,7 @@ export const data = ( state = {}, action ) => {
 		case JETPACK_SITE_DATA_FETCH_RECEIVE:
 			return assign( {}, state, action.siteData );
 		case JETPACK_SITE_FEATURES_FETCH_RECEIVE:
-			return merge( {}, state, { siteFeatures: action.siteFeatures } );
+			return merge( {}, state, { site: { features: action.siteFeatures } } );
 		case JETPACK_SITE_PLANS_FETCH_RECEIVE:
 			return merge( {}, state, { sitePlans: action.plans } );
 		default:
@@ -108,7 +108,7 @@ export function getSitePlan( state ) {
  * @return {Object}  Features
  */
 export function getAvailableFeatures( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'siteFeatures', 'available' ], {} );
+	return get( state.jetpack.siteData, [ 'data', 'site', 'features', 'available' ], {} );
 }
 
 /**
@@ -117,7 +117,7 @@ export function getAvailableFeatures( state ) {
  * @return {Object}  Features
  */
 export function getActiveFeatures( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'siteFeatures', 'active' ], [] );
+	return get( state.jetpack.siteData, [ 'data', 'site', 'features', 'active' ], [] );
 }
 
 export function getAvailablePlans( state ) {

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -203,14 +203,11 @@ abstract class Jetpack_Admin_Page {
 			$to_deactivate = array_intersect( $active, $to_deactivate );
 
 			foreach ( $to_deactivate as $feature ) {
-				l( 'checking ' . $feature );
-				l( 'Plan supports: ' . Jetpack::active_plan_supports( $feature ) );
 				if ( Jetpack::active_plan_supports( $feature ) ) {
 					$to_deactivate = array_diff( $to_deactivate, array( $feature ) );
 				}
 			}
 
-			l( $to_deactivate );
 			if ( ! empty( $to_deactivate ) ) {
 				Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
 			}

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -202,11 +202,13 @@ abstract class Jetpack_Admin_Page {
 			}
 			$to_deactivate = array_intersect( $active, $to_deactivate );
 
+			$to_leave_enabled = array();
 			foreach ( $to_deactivate as $feature ) {
 				if ( Jetpack::active_plan_supports( $feature ) ) {
-					$to_deactivate = array_diff( $to_deactivate, array( $feature ) );
+					$to_leave_enabled []= $feature;
 				}
 			}
+			$to_deactivate = array_diff( $to_deactivate, $to_leave_enabled );
 
 			if ( ! empty( $to_deactivate ) ) {
 				Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -21,15 +21,6 @@ abstract class Jetpack_Admin_Page {
 	static $block_page_rendering_for_idc;
 
 	/**
-	 * Flag to know if we already checked the plan.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @var bool
-	 */
-	static $plan_checked = false;
-
-	/**
 	 * Function called after admin_styles to load any additional needed styles.
 	 *
 	 * @since 4.3.0
@@ -172,7 +163,7 @@ abstract class Jetpack_Admin_Page {
 	 *
 	 * @param $page
 	 *
-	 * @return bool|array
+	 * @return array
 	 */
 	function check_plan_deactivate_modules( $page ) {
 		if (
@@ -187,49 +178,44 @@ abstract class Jetpack_Admin_Page {
 					'jetpack_page_akismet-key-config'
 				)
 			)
-			|| true === self::$plan_checked
 		) {
 			return false;
 		}
 
-		self::$plan_checked = true;
-		$previous = get_option( 'jetpack_active_plan', '' );
-		$current = Jetpack_Core_Json_Api_Endpoints::site_data();
-		if ( ! $current || is_wp_error( $current ) ) {
-			// If we can't get information about the current plan we don't do anything
-			self::$plan_checked = true;
-			return;
-		}
+		$current = Jetpack::get_active_plan();
 
 		$to_deactivate = array();
-		if ( isset( $current->plan->product_slug ) ) {
-			if (
-				empty( $previous )
-				|| ! isset( $previous['product_slug'] )
-				|| $previous['product_slug'] !== $current->plan->product_slug
-			) {
-				$active = Jetpack::get_active_modules();
-				switch ( $current->plan->product_slug ) {
-					case 'jetpack_free':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
-						break;
-					case 'jetpack_personal':
-					case 'jetpack_personal_monthly':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
-						break;
-					case 'jetpack_premium':
-					case 'jetpack_premium_monthly':
-						$to_deactivate = array( 'seo-tools', 'google-analytics', 'search' );
-						break;
+		if ( isset( $current['product_slug'] ) ) {
+			$active = Jetpack::get_active_modules();
+			switch ( $current['product_slug'] ) {
+				case 'jetpack_free':
+					$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
+					break;
+				case 'jetpack_personal':
+				case 'jetpack_personal_monthly':
+					$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads', 'search' );
+					break;
+				case 'jetpack_premium':
+				case 'jetpack_premium_monthly':
+					$to_deactivate = array( 'seo-tools', 'google-analytics', 'search' );
+					break;
+			}
+			$to_deactivate = array_intersect( $active, $to_deactivate );
+
+			foreach ( $to_deactivate as $feature ) {
+				l( 'checking ' . $feature );
+				l( 'Plan supports: ' . Jetpack::active_plan_supports( $feature ) );
+				if ( Jetpack::active_plan_supports( $feature ) ) {
+					$to_deactivate = array_diff( $to_deactivate, array( $feature ) );
 				}
-				$to_deactivate = array_intersect( $active, $to_deactivate );
-				if ( ! empty( $to_deactivate ) ) {
-					Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
-				}
+			}
+
+			l( $to_deactivate );
+			if ( ! empty( $to_deactivate ) ) {
+				Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
 			}
 		}
 		return array(
-			'previous'   => $previous,
 			'current'    => $current,
 			'deactivate' => $to_deactivate
 		);

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -303,6 +303,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 				'isAtomicSite' => jetpack_is_atomic_site(),
+				'plan' => Jetpack::get_active_plan(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -199,8 +199,7 @@ class Jetpack_Admin {
 				return false;
 			}
 
-			$plan = Jetpack::get_active_plan();
-			return in_array( $module['module'], $plan['supports'] );
+			return Jetpack::active_plan_supports( $module['module'] );
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1543,7 +1543,23 @@ class Jetpack {
 	public static function active_plan_supports( $feature ) {
 		$plan = Jetpack::get_active_plan();
 
-		if ( in_array( $feature, $plan['supports'] ) ) {
+		// Manually mapping WordPress.com features to Jetpack module slugs
+		foreach ( $plan['features']['active'] as $wpcom_feature ) {
+			switch ( $wpcom_feature ) {
+				case 'wordads-jetpack';
+
+				// WordAds are supported for this site
+				if ( 'wordads' === $feature ) {
+					return true;
+				}
+				break;
+			}
+		}
+
+		if (
+			in_array( $feature, $plan['supports'] )
+			|| in_array( $feature, $plan['features']['active'] )
+		) {
 			return true;
 		}
 
@@ -2883,9 +2899,7 @@ class Jetpack {
 			}
 		}
 
-		$plan = Jetpack::get_active_plan();
-
-		if ( ! in_array( $module, $plan['supports'] ) ) {
+		if ( ! Jetpack::active_plan_supports( $module ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
This PR adds a check to see if WordAds are available even on the free plan based on the response we're getting from WordPress.com. Companion diff D11633-code.


#### Changes proposed in this Pull Request:
* Fixes a small reducer inconsistency in site state.
* Moves the features to be stored inside the plan state, to be consistent with the format they are now returned from WordPress.com.
* Unifies supported feature checks by using `Jetpack::active_plan_supports` where we need feature checks.
* Removes additional plan checking on every admin page load, leaves only existing heartbeat plan refreshing.
* Makes sure the WordAds module is not greyed out in the legacy settings page.
* Adds a Settings UI check for Ads feature.

#### Testing instructions:
* Use the `JETPACK__WPCOM_JSON_API_HOST` to point your Jetpack site to your sandbox for API calls.
* Use D11633-code.
* Use a free plan on your site.
* Make sure you can enable and configure WordAds.
 