### PR TITLE
Tools: Add Code Snippets checkbox to Live Branches Script

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.3
+// @version      1.4
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -28,6 +28,7 @@
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" class="task-list-item-checkbox">Launch with Gutenberg installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>' +
+			'<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-downgrade" class="task-list-item-checkbox">Launch with WP Downgrade installed</li>' +
 			'</ul>' +


### PR DESCRIPTION
* The [Code Snippets](https://en-gb.wordpress.org/plugins/code-snippets/) plugin allows us to add custom code to test PRs that would require small snippets of filtering or hooking to review a PR.

#### Changes proposed in this Pull Request:

* Adds the ability to launch a Live Branch site with the [Code Snippets plugin](https://en-gb.wordpress.org/plugins/code-snippets/).


#### Testing instructions:

* Click https://github.com/Automattic/jetpack/raw/add/code-snippets-feature-to-tampermonkey-script/tools/jetpack-live-branches/jetpack-live-branches.user.js to get the new script version installed. 
* Visit a PR on this repo
* Expect to see a checkbox for Code Snippets.

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/38570787-53e2be60-3cf7-11e8-926e-c7735149ac71.png)
