### PR TITLE
Bring Jetpack Sitemaps in sync w/ upcoming dotcom changes

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -604,10 +604,11 @@ class Jetpack_Sitemap_Builder {
 
 			// Add as many items to the buffer as possible.
 			while ( false === $buffer->is_full() ) {
-				$last_post_id_index = abs( $last_post_id );
-				$urls               = array_slice(
+				$last_post_id_index       = abs( $last_post_id );
+				$start_from_post_id_index = $last_post_id_index ? $last_post_id_index + 1 : 0;
+				$urls                     = array_slice(
 					$other_urls,
-					$last_post_id_index + 1,
+					$start_from_post_id_index,
 					JP_SITEMAP_BATCH_SIZE,
 					true
 				);

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -130,7 +130,9 @@ class Jetpack_Sitemap_Builder {
 		}
 
 		for ( $i = 1; $i <= JP_SITEMAP_UPDATE_SIZE; $i++ ) {
-			$this->build_next_sitemap_file();
+			if ( true === $this->build_next_sitemap_file() ) {
+				break; // All finished!
+			}
 		}
 
 		if ( $this->logger ) {
@@ -146,14 +148,18 @@ class Jetpack_Sitemap_Builder {
 	 * constructs the next file, and updates the state.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @return bool True when finished.
 	 */
 	private function build_next_sitemap_file() {
+		$finished = false; // Initialize finished flag.
+
 		// Get the most recent state, and lock the state.
 		$state = Jetpack_Sitemap_State::check_out();
 
 		// Do nothing if the state was locked.
 		if ( false === $state ) {
-			return;
+			return false;
 		}
 
 		// Otherwise, branch on the sitemap-type key of $state.
@@ -218,19 +224,23 @@ class Jetpack_Sitemap_Builder {
 					$this->logger->report( '-- Finished.' );
 					$this->logger->time();
 				}
+				$finished = true;
 
-				die();
+				break;
 
 			default:
-				// Otherwise, reset the state.
 				Jetpack_Sitemap_State::reset(
 					JP_PAGE_SITEMAP_TYPE
 				);
-				die();
+				$finished = true;
+
+				break;
 		} // End switch().
 
 		// Unlock the state.
 		Jetpack_Sitemap_State::unlock();
+
+		return $finished;
 	}
 
 	/**
@@ -510,7 +520,7 @@ class Jetpack_Sitemap_Builder {
 	 * }
 	 */
 	public function build_one_page_sitemap( $number, $from_id ) {
-		$last_post_id = $from_id;
+		$last_post_id   = $from_id;
 		$any_posts_left = true;
 
 		if ( $this->logger ) {
@@ -547,7 +557,7 @@ class Jetpack_Sitemap_Builder {
 		}
 
 		// Add as many items to the buffer as possible.
-		while ( false === $buffer->is_full() ) {
+		while ( $last_post_id >= 0 && false === $buffer->is_full() ) {
 			$posts = $this->librarian->query_posts_after_id(
 				$last_post_id, JP_SITEMAP_BATCH_SIZE
 			);
@@ -565,6 +575,59 @@ class Jetpack_Sitemap_Builder {
 					$buffer->view_time( $current_item['last_modified'] );
 				} else {
 					break;
+				}
+			}
+		}
+
+		// Handle other page sitemap URLs.
+		if ( false === $any_posts_left || $last_post_id < 0 ) {
+			// Negative IDs are used to track URL indexes.
+			$last_post_id   = min( 0, $last_post_id );
+			$any_posts_left = true; // Reinitialize.
+
+			/**
+			 * Filter other page sitemap URLs.
+			 *
+			 * @module sitemaps
+			 *
+			 * @since 6.1.0
+			 *
+			 * @param array $urls An array of other URLs.
+			 */
+			$other_urls = apply_filters( 'jetpack_page_sitemap_other_urls', array() );
+
+			if ( $other_urls ) { // Start with index [1].
+				$other_urls = array_values( $other_urls );
+				array_unshift( $other_urls, $other_urls[0] );
+				unset( $other_urls[0] );
+			}
+
+			// Add as many items to the buffer as possible.
+			while ( false === $buffer->is_full() ) {
+				$last_post_id_index = abs( $last_post_id );
+				$urls               = array_slice(
+					$other_urls,
+					$last_post_id_index + 1,
+					JP_SITEMAP_BATCH_SIZE,
+					true
+				);
+
+				if ( ! $urls ) {
+					$any_posts_left = false;
+					break;
+				}
+
+				foreach ( $urls as $index => $url ) {
+					if ( ! is_array( $url ) ) {
+						$url = array( 'loc' => $url );
+					}
+					$item = array( 'xml' => compact( 'url' ) );
+
+					if ( true === $buffer->append( $item['xml'] ) ) {
+						$last_post_id = -$index;
+					} else {
+						break;
+					}
 				}
 			}
 		}

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -325,10 +325,11 @@ class Jetpack_Sitemap_Librarian {
 				"SELECT *
 					FROM $wpdb->posts
 					WHERE post_type='attachment'
-						AND post_mime_type IN ('image/jpeg','image/png','image/gif')
+						AND post_mime_type LIKE %s
 						AND ID>%d
 					ORDER BY ID ASC
 					LIMIT %d;",
+				'image/%',
 				$from_id,
 				$num_posts
 			)
@@ -357,10 +358,11 @@ class Jetpack_Sitemap_Librarian {
 				"SELECT *
 					FROM $wpdb->posts
 					WHERE post_type='attachment'
-						AND post_mime_type IN ('video/mpeg','video/wmv','video/mov','video/avi','video/ogg')
+						AND post_mime_type LIKE %s
 						AND ID>%d
 					ORDER BY ID ASC
 					LIMIT %d;",
+				'video/%',
 				$from_id,
 				$num_posts
 			)

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -87,7 +87,8 @@ class Jetpack_Sitemap_Manager {
 		// Add callback for sitemap URL handler.
 		add_action(
 			'init',
-			array( $this, 'callback_action_catch_sitemap_urls' )
+			array( $this, 'callback_action_catch_sitemap_urls' ),
+			defined( 'IS_WPCOM' ) && IS_WPCOM ? 100 : 10
 		);
 
 		// Add generator to wp_cron task list.


### PR DESCRIPTION
Sorry to lump what is three different changes into a single PR. I can break these apart if that's preferable. However, for the sake of clarity I wanted to first show how this syncs with upcoming changes in D11614-code. See References below.

### References

- D11614-code (diff pending review)
  - D11616-code (depends on these changes)
- p9f5aF-ud-p2 (requested here)

### Changes proposed in this Pull Request:

- For video sitemaps, pull all attachments with a MIME type that begins
with `video/`, instead of specific MIME types. We were currently missing
`video/mp4` and `video/quicktime`, so this fixes that by including
all `video/*` MIME types.

- ☝️ The same for `image/*` MIME types.

- Fixes: https://github.com/Automattic/jetpack/issues/9254 by returning `true` when finished, instead of `die()`ing.

- Adds a new filter: `jetpack_page_sitemap_other_urls` together with a new subroutine in `Jetpack_Sitemap_Builder::build_one_page_sitemap()`

  This allows a developer to inject arbitrary/dynamic URLs
  that are not necessarily a Post/Page and would otherwise
  be orphaned; i.e., not included in any sitemap.

- Whenever `IS_WPCOM` is true, switch hook priority to `100` for `Jetpack_Sitemap_Manager::callback_action_catch_sitemap_urls`. This gives us a chance to detect use of the following constants on the dotcom side, which are often set by other plugins:

  - `WPCOM_SKIP_DEFAULT_SITEMAP`
  - `WPCOM_SKIP_DEFAULT_NEWS_SITEMAP`

---

### How can I test this PR?

#### Testing `die()` fix in `Jetpack_Sitemap_Builder`

- Enable Jetpack Sitemaps
- Using WP-CLI, run the following commands:
  ```bash
  wp shell --url=[YOURSITE.com goes here]
  wp> $sitemap_builder = new Jetpack_Sitemap_Builder();
  wp> $sitemap_builder->update_sitemap();
  # Should return instead of `die()`ing.
  ```

#### Testing Image/Video Fixes

- Add at least one `.mp4` and `.mov` file to your media library.
- Add some images of different types to your media library.
- Enable Jetpack Sitemaps, rebuild sitemap from instructions above, and confirm all videos and images are present, see: `https://YOURSITE.com/sitemap.xml`

#### Testing New Filter `jetpack_page_sitemap_other_urls`

- Create the following directory and file:
  `wp-content/mu-plugins/test.php`

  ```php
  <?php
  add_filter( 'jetpack_page_sitemap_other_urls', function( $urls ) {
      return array_merge( $urls, [
          'https://example.com/other',
          'https://example.com/another',
     ] );
  } );
  ```

  Also works with associative arrays that include more URL-specific data:

  ```php
  <?php
  add_filter( 'jetpack_page_sitemap_other_urls', function( $urls ) {
      return array_merge( $urls, [
          [
              'loc' => 'https://example.com/other',
              'lastmod' => '2018-01-01',
              'priority' => '0.2',
          ],
          [
              'loc' => 'https://example.com/another',
              'lastmod' => '2018-01-01',
              'priority' => '0.6',
          ],
     ] );
  } );
  ```

- Enable Jetpack Sitemaps, rebuild sitemap from instructions above, and confirm both of these _other_ URLs are present, see: `https://YOURSITE.com/sitemap.xml`
  - Bonus points for testing a list that includes hundreds or thousands of additional URLs. They should be paginated automatically.

---

### Proposed changelog entries:

- Adds a new filter: `jetpack_page_sitemap_other_urls`, which allows a developer to inject arbitrary/dynamic URLs that are not necessarily a Post/Page and would otherwise be orphaned; i.e., not included in any sitemap.

- FIX: For video sitemaps, include all attachments with a MIME type that begins with `video/`, instead of specific MIME types. We were previously missing `video/mp4` and `video/quicktime`, so this fixes that by including all `video/*` MIME types.
