### PR TITLE
Admin Page: Correct plan icon in upgade nudges

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -161,7 +161,7 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Integrate easily with Google Analytics.' ) }
-						plan={ PLAN_JETPACK_BUSINESS }
+						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-ga&site=' + siteRawUrl }
@@ -176,7 +176,7 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Help your content get found and shared with SEO tools.' ) }
-						plan={ PLAN_JETPACK_BUSINESS }
+						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
 						href={ 'https://jetpack.com/redirect/?source=settings-seo&site=' + siteRawUrl }


### PR DESCRIPTION
The upgrade nudges for the SEO Tools and Google Analytics features show the plan icon for the professional plan, which is incorrect since those features require the premium plan. This PR fixes that.

Expand the code below each diff below and note that the conditional looks like this:

```php
if ( 'is-business-plan' === planClass || 'is-premium-plan' === planClass )
```

This logic is checking for whether we have a premium or professional. In other words, whether we have _at least_ a premium plan.

To test:

- On a site with the latest master and no plan, go to the `Traffic` tab of the settings page.
- Ensure that you see something like this:
    <img width="745" alt="screen shot 2018-04-10 at 5 14 08 pm" src="https://user-images.githubusercontent.com/1126811/38586351-0943f66c-3ce3-11e8-92df-5780fbf8f2ed.png">
- Checkout this branch on a site with no plan, then go to the `Traffic` tab of the settings page
- Ensure that you see something like this:
    <img width="759" alt="screen shot 2018-04-10 at 5 13 22 pm" src="https://user-images.githubusercontent.com/1126811/38586388-254b7df8-3ce3-11e8-9345-db2f7f8fa60c.png">

