### PR TITLE
Replace -'s with _'s

### DIFF
--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import get from 'lodash/get';
+import each from 'lodash/each';
 import analytics from 'lib/analytics';
 
 /**
@@ -113,7 +114,15 @@ export function ModuleSettingsForm( InnerComponent ) {
 			this.props.updateOptions( this.state.options )
 				.then( () => {
 					// Track it
-					this.trackFormSubmission( this.state.options );
+
+					const saneOptions = {};
+
+					each( this.state.options, ( value, key ) => {
+						key = key.replace( /\-/, '_' );
+						saneOptions[ key ] = value;
+					} );
+
+					this.trackFormSubmission( saneOptions );
 
 					this.setState( { options: {} } );
 				} )


### PR DESCRIPTION
Fixes where we send some props with `-` in them, where it's required they be snake_case. I'm not sure this is the *best* approach, but I didn't want to change a bunch of things to expect snake_case. This seems like the *best low-impact* change and the performance hit is negligible.

Please cherry pick into a release if possible. Currently, this event is being rejected in some cases: see p4qSXL-2De-p2 comment-7252 for more information.

#### Changes proposed in this Pull Request:

* Do not send `-` in a prop.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Ensure when toggling the Infinite Scroll setting, that it sends an event with snake_case.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
N/A