### PR TITLE
Fixes the internationalization of the plans tab

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -386,13 +386,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$data = $use_cache ? get_transient( 'jetpack_plans' ) : false;
 
 		if ( false === $data ) {
-			$path = '/plans';
+			$path = '/plans?_locale=' . get_user_locale();
 			// passing along from client to help geolocate currency
-			$ip = $_SERVER['HTTP_X_FORWARDED_FOR']; // if we already have an list of forwarded ips, then just use that
-			if ( empty( $ip ) ) {
+			if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+				$ip = $_SERVER['HTTP_X_FORWARDED_FOR']; // if we
+			}
+			//already have an list of forwarded ips, then just use that
+			if ( empty( $ip ) && isset( $_SERVER['HTTP_CLIENT_IP'] )) {
 				$ip = $_SERVER['HTTP_CLIENT_IP']; // another popular one for proxy servers
 			}
-			if ( empty( $ip ) ) {
+			if ( empty( $ip ) && isset( $_SERVER['REMOTE_ADDR'] ) ) {
 				$ip = $_SERVER['REMOTE_ADDR']; // if we don't have an ip by now, take the closest node's ip (likely directly connected client)
 			}
 			$request = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -388,13 +388,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( false === $data ) {
 			$path = '/plans?_locale=' . get_user_locale();
 			// passing along from client to help geolocate currency
-			if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-				$ip = $_SERVER['HTTP_X_FORWARDED_FOR']; // if we
-			}
-			//already have an list of forwarded ips, then just use that
-			if ( empty( $ip ) && isset( $_SERVER['HTTP_CLIENT_IP'] )) {
-				$ip = $_SERVER['HTTP_CLIENT_IP']; // another popular one for proxy servers
-			}
+			$ip = Jetpack::current_user_ip( true );
 			if ( empty( $ip ) && isset( $_SERVER['REMOTE_ADDR'] ) ) {
 				$ip = $_SERVER['REMOTE_ADDR']; // if we don't have an ip by now, take the closest node's ip (likely directly connected client)
 			}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -389,9 +389,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$path = '/plans?_locale=' . get_user_locale();
 			// passing along from client to help geolocate currency
 			$ip = Jetpack::current_user_ip( true );
-			if ( empty( $ip ) && isset( $_SERVER['REMOTE_ADDR'] ) ) {
-				$ip = $_SERVER['REMOTE_ADDR']; // if we don't have an ip by now, take the closest node's ip (likely directly connected client)
-			}
 			$request = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );
 			$body = wp_remote_retrieve_body( $request );
 			if ( 200 === wp_remote_retrieve_response_code( $request ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/9279

This PR adds a locale param to the plans info request. At the moment we are not passing any locale info, so the plans tab is always being rendered in English, no matter the language of the user

#### Testing instructions:

0. Change the language of your site to any other than English
1. Clean the transients (`wp-cli transient delete-all`)
2. Go to your Jetpack dashboard and click on the plans tab. The plans information should be in the same language you selected in 0.