### PR TITLE
WooCommerce Analytics: support product bundles add to carts

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -33,6 +33,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 		// Capture cart events
 		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_add_to_cart' ), 10, 6 );
+		add_action( 'woocommerce_bundled_item_before_add_to_cart', array( $this, 'capture_bundle_add_to_cart' ), 10, 6 );
 
 		// single product page view
 		add_action( 'woocommerce_after_single_product', array( $this, 'capture_product_view' ) );
@@ -40,7 +41,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'wcct_before_cart_widget', array( $this, 'remove_from_cart' ) );
-		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+		add_filter( 'woocommerce_cart_item_remove', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
 
 		// cart checkout
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
@@ -312,7 +313,28 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		* @param $cart_item_data
 		*/
 	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) {
+		$this->capture_cart_event( $product_id, $quantity );
+	}
+
+	/**
+		* @param $product_id
+		* @param $quantity
+		* @param $variation_id
+		* @param $variations
+		* @param $bundled_item_cart_data
+		*/
+	public function capture_bundle_add_to_cart( $product_id, $quantity, $variation_id, $variations, $bundled_item_cart_data ) {
+		$this->capture_cart_event( $product_id, $quantity );
+	}
+
+	/**
+	 * @param $product_id
+	 * @param $quantity
+	 * @param $event
+	 */
+	public function capture_cart_event ( $product_id, $quantity ) {
 		$referer_postid = isset( $_SERVER['HTTP_REFERER'] ) ? url_to_postid( $_SERVER['HTTP_REFERER'] ) : 0;
+
 		// if the referring post is not a product OR the product being added is not the same as post
 		// (eg. related product list on single product page) then include a product view event
 		if ( ! wc_get_product( $referer_postid ) || $product_id != $referer_postid ) {

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -41,7 +41,9 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'wcct_before_cart_widget', array( $this, 'remove_from_cart' ) );
-		add_filter( 'woocommerce_cart_item_remove', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+
+		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+		add_action( 'woocommerce_cart_item_removed', array( $this, 'remove_bundle_items_from_cart' ), 10, 2 );
 
 		// cart checkout
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
@@ -157,6 +159,19 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		);
 		$url = str_replace( 'href=', $new_attributes, $url );
 		return $url;
+	}
+
+	/**
+	 * Queue remove from cart events for each item in a bundle
+	 *
+	 * @param string $removed_cart_item_key cart item key
+	 * @param object $cart cart
+	 */
+	public function remove_bundle_items_from_cart( $removed_cart_item_key, $cart ) {
+		$cart_item = $cart->removed_cart_contents[ $removed_cart_item_key ];
+		$product_id = $cart_item[ 'product_id' ];
+		$quantity = $cart_item[ 'quantity' ];
+		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
 	}
 
 	/**


### PR DESCRIPTION
IN PROGRESS

Fixes #

#### Changes proposed in this Pull Request:

* 

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Add WooCommerce Product Bundles plugin and create at least one product bundle as per instructions here - https://docs.woocommerce.com/document/bundles/bundles-configuration/#getting-started
* Make sure the carts events fire for each product in the bundle both from the lists. You need to go to the cart after adding it and should see a `product_view` and an `add_to_cart` event for each product and the bundle.
* Make sure the carts events fire for each product in the bundle from the product bundle page. You should see an `add_to_cart` event for each product and the bundle.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
