### PR TITLE
Docker: create log file before tail

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -259,8 +259,6 @@ To `tail -f` the PHP error log, run:
 yarn docker:tail
 ```
 
-**Note:** this command does not work in Windows.
-
 ### Debugging emails
 
 Emails don’t leave your WordPress and are caught by [MailDev](http://danfarrelly.nyc/MailDev/) SMTP server container instead.
@@ -338,7 +336,7 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 1. Name your debug configuration whatever you like.
 
 1. Check the 'Filter debug connection by IDE key', and enter 'PHPSTORM' for 'IDE Key ( Session ID )'.
- 
+
 1. Click the '...' on the 'Server' line to configure your remote server.
 
 1. In the server configuration window, click the '+' icon to create a new server configuration. Name it whatever you like.
@@ -354,7 +352,3 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 1. Back in the main configuration window, click 'Apply' then 'Ok'.
 
 1. You can now start a debug session by clicking 'Run -> Debug' in the main menu
-
-
-
-

--- a/docker/bin/tail.sh
+++ b/docker/bin/tail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+WP_DEBUG_LOG=/var/www/html/wp-content/debug.log
+
+if [ ! -e "$WP_DEBUG_LOG" ] ; then
+	touch "$WP_DEBUG_LOG"
+fi
+
+tail -F --lines 100 "$WP_DEBUG_LOG"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docker:multisite-convert": "yarn docker:compose exec wordpress bash -c \"/var/scripts/multisite-convert.sh\"",
     "docker:sh": "yarn docker:compose exec wordpress bash",
     "docker:phpunit": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist",
-    "docker:tail": "yarn docker:compose exec wordpress bash -c \"tail -f /var/www/html/wp-content/debug.log\"",
+    "docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
     "docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
     "lint": "eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",


### PR DESCRIPTION
Creates the log file before attempting to `tail` it, preventing confusing errors.

### Test

Run:
```bash
rm -f ./docker/wordpress/wp-content/debug.log
yarn docker:tail
```

#### Before
→ 💥 
> tail: cannot open '/var/www/html/wp-content/debug.log' for reading: No such file or directory
> tail: no files remaining

#### After
→  🕊 ✌️ 