### PR TITLE
Docker: fix env variables in phpunit setup

### DIFF
--- a/docker/config/wp-tests-config.php
+++ b/docker/config/wp-tests-config.php
@@ -31,10 +31,10 @@ define( 'WP_DEBUG', true );
 // These tests will DROP ALL TABLES in the database with the prefix named below.
 // DO NOT use a production database or one that is shared with something else.
 
-define( 'DB_NAME', 'wordpress' );
-define( 'DB_USER', getenv( 'WORDPRESS_DB_USER' ) );
-define( 'DB_PASSWORD', getenv( 'WORDPRESS_DB_PASSWORD' ) );
-define( 'DB_HOST', getenv( 'WORDPRESS_DB_HOST' ) );
+define( 'DB_NAME', getenv( 'MYSQL_DATABASE' ) );
+define( 'DB_USER', getenv( 'MYSQL_USER' ) );
+define( 'DB_PASSWORD', getenv( 'MYSQL_PASSWORD' ) );
+define( 'DB_HOST', getenv( 'MYSQL_HOST' ) );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 


### PR DESCRIPTION
Fixes database env vars to correct ones in wp-config used by phpunit.

Change that broke these was introduced with `.env` file in https://github.com/Automattic/jetpack/pull/9149

Note that `phpunit` uses `docker/wordpress-develop/wp-tests-config.php` — file I'm modifying is used as a template to create that file.

### Test
Run:
```
yarn docker:phpunit
```

Previously phpunit would fail. With the fix all good again!
```
yarn docker:phpunit
yarn run v1.3.2
$ yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist
$ docker-compose -f docker/docker-compose.yml exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist
Using test root /tmp/wordpress-develop/tests/phpunit
To run Jetpack woocommerce tests, prefix phpunit with JETPACK_TEST_WOOCOMMERCE=1

wp_die called
Message : <h1>Error establishing a database connection</h1>
<p>This either means that the username and password information in your <code>wp-config.php</code> file is incorrect or we can&#8217;t contact the database server at <code></code>. This could mean your host&#8217;s database server is down.</p>
<ul>
<li>Are you sure you have the correct username and password?</li>
<li>Are you sure that you have typed the correct hostname?</li>
<li>Are you sure that the database server is running?</li>
</ul>
<p>If you&#8217;re unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="https://wordpress.org/support/">WordPress Support Forums</a>.</p>

Title :
error Command failed with exit code 1.
```