### PR TITLE
Docker: update step when creating .env

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/Automattic/jetpack.git && cd jetpack
 
 Optionally, copy settings file to modify it:
 ```sh
-cp defaults.env .env
+cp docker/default.env docker/.env
 ```
 
 Anything you put in `.env` overrides values in `default.env`. You should modify all the password fields for security, for example.


### PR DESCRIPTION
This PR updates the documentation to specify the right directory in the step that instructs the user to copy the `default.env` file to an `.env` file to modify it, since the one mentioned previously, `defaults.env` doesn't exist, but [default.env does exist](https://github.com/Automattic/jetpack/blob/master/docker/default.env).
