### PR TITLE
JPS: XML-RPC: Require authentication of jetpack.remoteProvision when site connected

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -37,6 +37,7 @@ class Jetpack_XMLRPC_Server {
 				'jetpack.unlinkUser'        => array( $this, 'unlink_user' ),
 				'jetpack.syncObject'        => array( $this, 'sync_object' ),
 				'jetpack.idcUrlValidation'  => array( $this, 'validate_urls_for_idc_mitigation' ),
+				'jetpack.remoteProvision'   => array( $this, 'remote_provision' ),
 			) );
 
 			if ( isset( $core_methods['metaWeblog.editPost'] ) ) {
@@ -81,7 +82,6 @@ class Jetpack_XMLRPC_Server {
 	function authorize_xmlrpc_methods() {
 		return array(
 			'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ),
-			'jetpack.remoteProvision' => array( $this, 'remote_provision' ),
 		);
 	}
 


### PR DESCRIPTION
Currently, the `jetpack.remoteProvision` XML-RPC method is guarded by a nonce that is verified by calling back to WordPress.com. This PR seeks to add an extra layer of security by forcing the XML-RPC request to be authenticated when this site is connected to WordPress.com. 

This patch requires D11321

To test:

- Follow testing instructions on D11780 and D11321