### PR TITLE
Jetpack: Disconnect site if the site receives an unknown_token error

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -305,15 +305,7 @@ class Jetpack_Client {
 			$body = wp_json_encode( $body );
 		}
 
-		$response = self::remote_request( $args, $body );
-
-		$result = json_decode( wp_remote_retrieve_body( $response ) );
-		if ( ! empty( $result ) && isset( $result->error ) ) {
-			if ( 'unknown_token' === $response->error ) {
-				Jetpack::unlink_user_on_unknown_token( get_current_user_id() );
-			}
-		}
-		return $response;
+		return self::remote_request( $args, $body );
 	}
 
 	/**
@@ -350,16 +342,8 @@ class Jetpack_Client {
 			'blog_id' => (int) Jetpack_Options::get_option( 'id' ),
 			'method'  => $request_method,
 		) );
-		$response = Jetpack_Client::remote_request( $validated_args, $body );
 
-		$result = json_decode( wp_remote_retrieve_body( $response ) );
-		if ( ! empty( $result ) && isset( $result->error ) ) {
-			if ( 'unknown_token' === $result->error ) {
-				Jetpack::unlink_user_on_unknown_token( Jetpack_Options::get_option('master_user' ) );
-			}
-			return $response;
-		}
-		return $response;
+		return Jetpack_Client::remote_request( $validated_args, $body );
 	}
 
 	/**

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -166,7 +166,13 @@ class Jetpack_Connection_Banner {
 	 *
 	 * @since 4.4.0
 	 */
-	function render_banner() { ?>
+	function render_banner() {
+		$disconnection_notice = Jetpack_Options::get_option( 'disconnection_notice', array() );
+		$notice = sprintf( __( 'Your connection to WordPress.com broken please try reconnecting!', 'jetpack' ) );
+		if ( in_array( get_current_user_id(), $disconnection_notice ) ) {
+			echo '<div class="updated" style="border-color: #f0821e;"><p>' . $notice . '</p></div>';
+		} ?>
+
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__inner-container">
 				<span

--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -62,7 +62,12 @@ class Jetpack_IXR_Client extends IXR_Client {
 
 		// Is the message a fault?
 		if ( $this->message->messageType == 'fault' ) {
+
 			$this->error = new IXR_Error( $this->message->faultCode, $this->message->faultString );
+			$error = $this->get_jetpack_error();
+			if ( 'unknown_token' === $error->get_error_code() && isset( $this->jetpack_args['user_id'] ) ) {
+				Jetpack::unlink_user_on_unknown_token($this->jetpack_args['user_id']);
+			}
 			return false;
 		}
 

--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -62,11 +62,11 @@ class Jetpack_IXR_Client extends IXR_Client {
 
 		// Is the message a fault?
 		if ( $this->message->messageType == 'fault' ) {
-
 			$this->error = new IXR_Error( $this->message->faultCode, $this->message->faultString );
 			$error = $this->get_jetpack_error();
+
 			if ( 'unknown_token' === $error->get_error_code() && isset( $this->jetpack_args['user_id'] ) ) {
-				Jetpack::unlink_user_on_unknown_token($this->jetpack_args['user_id']);
+				Jetpack::unlink_user_on_unknown_token( $this->jetpack_args['user_id'] );
 			}
 			return false;
 		}

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -207,7 +207,7 @@ class Jetpack_JITM {
 			$hide_jitm[ $feature_class ] = array( 'last_dismissal' => 0, 'number' => 0 );
 		}
 
-		$number = $hide_jitm[ $feature_class ][ 'number' ];
+		$number = $hide_jitm[ $feature_class ]['number'];
 
 		$hide_jitm[ $feature_class ] = array( 'last_dismissal' => time(), 'number' => $number + 1 );
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -54,6 +54,7 @@ class Jetpack_Options {
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
+				'disconnection_notice',        // (array) Whether or not to show the notice to the user that the disconnection was made for them automatically
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -54,7 +54,7 @@ class Jetpack_Options {
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
-				'disconnection_notice',        // (array) Whether or not to show the notice to the user that the disconnection was made for them automatically
+				'disconnection_notice',        // (array) Array of user ids that have been automatically disconnected
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3241,7 +3241,7 @@ p {
 	/**
 	 * Unlinks the current user from the linked WordPress.com user
 	 */
-	public static function unlink_user( $user_id = null ) {
+	public static function unlink_user( $user_id = null, $bypass_wpcom ) {
 		if ( ! $tokens = Jetpack_Options::get_option( 'user_tokens' ) )
 			return false;
 
@@ -3253,14 +3253,14 @@ p {
 		if ( ! isset( $tokens[ $user_id ] ) )
 			return false;
 
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
-		$xml->query( 'jetpack.unlink_user', $user_id );
+		if ( $bypass_wpcom ) {
+			Jetpack::load_xml_rpc_client();
+			$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
+			$xml->query( 'jetpack.unlink_user', $user_id );
+		}
 
 		unset( $tokens[ $user_id ] );
-
 		Jetpack_Options::update_option( 'user_tokens', $tokens );
-
 		/**
 		 * Fires after the current user has been unlinked from WordPress.com.
 		 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3241,7 +3241,7 @@ p {
 	/**
 	 * Unlinks the current user from the linked WordPress.com user
 	 */
-	public static function unlink_user( $user_id = null, $bypass_wpcom ) {
+	public static function unlink_user( $user_id = null, $bypass_wpcom = false ) {
 		if ( ! $tokens = Jetpack_Options::get_option( 'user_tokens' ) )
 			return false;
 
@@ -3271,6 +3271,24 @@ p {
 		do_action( 'jetpack_unlinked_user', $user_id );
 
 		return true;
+	}
+
+	public static function unlink_user_on_unknown_token( $user_id ) {
+		l( 'UNLLINKED USER' );
+		$user_id = intval( $user_id );
+		$master_user = (int) Jetpack_Options::get_option( 'master_user' );
+		if ( (int) $user_id !== $master_user ) {
+			Jetpack::unlink_user( $user_id, true );
+			return;
+		}
+
+		Jetpack::unlink_user( $master_user, true );
+
+		require_once( JETPACK__PLUGIN_DIR .'sync/class.jetpack-sync-users.php' );
+		Jetpack_sync_users::maybe_demote_master_user( $master_user );
+		if ( $master_user == Jetpack_Options::get_option( 'master_user' ) ) {
+			Jetpack_Options::delete_option( 'master_user' );
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3241,7 +3241,7 @@ p {
 	/**
 	 * Unlinks the current user from the linked WordPress.com user
 	 */
-	public static function unlink_user( $user_id = null, $bypass_wpcom = false ) {
+	public static function unlink_user( $user_id = null ) {
 		if ( ! $tokens = Jetpack_Options::get_option( 'user_tokens' ) )
 			return false;
 
@@ -3253,11 +3253,9 @@ p {
 		if ( ! isset( $tokens[ $user_id ] ) )
 			return false;
 
-		if ( $bypass_wpcom ) {
-			Jetpack::load_xml_rpc_client();
-			$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
-			$xml->query( 'jetpack.unlink_user', $user_id );
-		}
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
+		$xml->query( 'jetpack.unlink_user', $user_id );
 
 		unset( $tokens[ $user_id ] );
 		Jetpack_Options::update_option( 'user_tokens', $tokens );
@@ -3274,11 +3272,17 @@ p {
 	}
 
 	public static function update_disconnection_notice( $user_id ) {
-		$notice = (array) Jetpack_Options::get_option( 'disconnection_notice' );
-		$notice = array_merge( $notice, array( $user_id ) );
+		$notice = Jetpack_Options::get_option( 'disconnection_notice' );
+		$notice = ! empty( $notice ) && is_array( $notice ) ? array_merge( $notice, array( $user_id ) ) : array( $user_id );
 		Jetpack_Options::update_option( 'disconnection_notice', $notice );
 	}
 
+	/**
+	 * Removes a user's tokens that was already been removed on the .com but not yet on the Jetpack side
+	 * Disconnects the site if the master tokens are deleted
+	 *
+	 * @param $user_id
+	 */
 	public static function unlink_user_on_unknown_token( $user_id ) {
 		$master_user = (int) Jetpack_Options::get_option( 'master_user' );
 		if ( $user_id == 0 || $user_id == JETPACK_MASTER_USER ) {
@@ -3302,9 +3306,10 @@ p {
 			self::update_disconnection_notice( $user_id );
 			return;
 		}
+		var_dump( array_merge( array( $user_id ), array_keys( $tokens ) ) );
 
 		// Delete Everything - disconnect the site
-		Jetpack_Options::update_option( 'disconnection_notice', $tokens );
+		Jetpack_Options::update_option( 'disconnection_notice', array_merge( array( $user_id ), array_keys( $tokens ) ) );
 		Jetpack_Options::delete_option( 'user_tokens' );
 		Jetpack_Options::delete_option( 'master_user' );
 		Jetpack_Options::delete_option( 'blog_token' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
 			<file>tests/php/test_class.functions.compat.php</file>
 			<file>tests/php/test_class.jetpack-network.php</file>
 			<file>tests/php/test_class.jetpack-client-server.php</file>
+			<file>tests/php/test_class.jetpack-ixr-client.php</file>
 			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
 			<file>tests/php/test_class.jetpack-constants.php</file>

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -147,7 +147,7 @@ class Jetpack_Sync_Actions {
 		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
 
 		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );
-
+		Jetpack::load_xml_rpc_client();
 		$rpc = new Jetpack_IXR_Client( array(
 			'url'     => $url,
 			'user_id' => JETPACK_MASTER_USER,
@@ -157,8 +157,7 @@ class Jetpack_Sync_Actions {
 		$result = $rpc->query( 'jetpack.syncActions', $data );
 
 		if ( ! $result ) {
-			$error = $rpc->get_jetpack_error();
-			return $error;
+			return $rpc->get_jetpack_error();
 		}
 
 		$response = $rpc->getResponse();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -158,21 +158,6 @@ class Jetpack_Sync_Actions {
 
 		if ( ! $result ) {
 			$error = $rpc->get_jetpack_error();
-
-			if ( $error->get_error_code() === 'unknown_token' ) {
-				if ( $master_user = Jetpack_Options::get_option( 'master_user' ) ) {
-					Jetpack::unlink_user( $master_user, true );
-					Jetpack_sync_users::maybe_demote_master_user( $master_user );
-					if ( $master_user == Jetpack_Options::get_option( 'master_user') ) {
-						// Demotion didn't work!
-						Jetpack_Options::delete_option( 'master_user' );
-					}
-				}
-				return new WP_Error(
-					'unknown_token',
-					esc_html__( 'Sync has been blocked from WordPress.com because the site\s token is unknown', 'jetpack' )
-				);
-			}
 			return $error;
 		}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -157,7 +157,23 @@ class Jetpack_Sync_Actions {
 		$result = $rpc->query( 'jetpack.syncActions', $data );
 
 		if ( ! $result ) {
-			return $rpc->get_jetpack_error();
+			$error = $rpc->get_jetpack_error();
+
+			if ( $error->get_error_code() === 'unknown_token' ) {
+				if ( $master_user = Jetpack_Options::get_option( 'master_user' ) ) {
+					Jetpack::unlink_user( $master_user, true );
+					Jetpack_sync_users::maybe_demote_master_user( $master_user );
+					if ( $master_user == Jetpack_Options::get_option( 'master_user') ) {
+						// Demotion didn't work!
+						Jetpack_Options::delete_option( 'master_user' );
+					}
+				}
+				return new WP_Error(
+					'unknown_token',
+					esc_html__( 'Sync has been blocked from WordPress.com because the site\s token is unknown', 'jetpack' )
+				);
+			}
+			return $error;
 		}
 
 		$response = $rpc->getResponse();

--- a/sync/class.jetpack-sync-users.php
+++ b/sync/class.jetpack-sync-users.php
@@ -49,10 +49,10 @@ class Jetpack_Sync_Users {
 		Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
 	}
 
-	static function maybe_demote_master_user( $user_id ) {
+	static function maybe_demote_master_user( $user_id, $skip_role_test = false ) {
 		$master_user_id = Jetpack_Options::get_option( 'master_user' );
 		$role           = self::get_role( $user_id );
-		if ( $user_id == $master_user_id && 'administrator' != $role ) {
+		if ( $user_id == $master_user_id && ( $skip_role_test || 'administrator' != $role ) ) {
 			$query      = new WP_User_Query(
 				array(
 					'fields'  => array( 'id' ),

--- a/tests/php/test_class.jetpack-ixr-client.php
+++ b/tests/php/test_class.jetpack-ixr-client.php
@@ -1,0 +1,94 @@
+<?php
+
+class WP_Test_Jetpack_IXR_Client extends WP_UnitTestCase {
+
+	public function tearDown() {
+		parent::tearDown();
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+
+	public function test_jetpack_client_recieves_unknown_token_disconnect_blog() {
+
+		add_filter( 'http_response', array( $this, 'return_unknown_token_error' ) );
+		$master_user = $this->create_and_set_master_user( false );
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( array(
+			'user_id' => get_current_user_id()
+		) );
+		$xml->query( 'jetpack.monitor.isActive' );
+		remove_filter('http_response', array( $this, 'return_unknown_token_error' ) );
+
+		$this->assertFalse( Jetpack_Options::get_option( 'master_user' ) , 'Master user present' );
+		$this->assertFalse( Jetpack_Options::get_option( 'user_tokens' ), 'User Tokens Present' );
+		$this->assertFalse( Jetpack_Options::get_option( 'blog_token' ), 'Blog Token Present');
+	}
+
+	public function test_jetpack_client_recieves_unknown_token_demote_master_user() {
+
+		add_filter( 'http_response', array( $this, 'return_unknown_token_error' ) );
+		$master_user = $this->create_and_set_master_user( true );
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( array(
+			'user_id' => get_current_user_id()
+		) );
+		$xml->query( 'jetpack.monitor.isActive' );
+		remove_filter('http_response', array( $this, 'return_unknown_token_error' ) );
+
+		$master_user_new = Jetpack_Options::get_option( 'master_user' );
+		$this->assertTrue(  $master_user !== $master_user_new , 'Master Not switched present' );
+		$tokens = Jetpack_Options::get_option( 'user_tokens' );
+
+		$this->assertFalse( isset( $tokens[$master_user] ), 'Master Token Present');
+		$this->assertTrue(  isset( $tokens[$master_user_new] ), 'New Master Token Present' );
+		$this->assertTrue( (bool)Jetpack_Options::get_option( 'blog_token' ), 'Blog Token Not Present' );
+
+	}
+
+	public function create_and_set_master_user( $another_connected_admin ) {
+		$master_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$tokens = array(
+			$master_user     => 'kiwi.a.' . $master_user
+		);
+		if ( $another_connected_admin ) {
+			$other_connected_admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+			$tokens[$other_connected_admin] = 'apple.a.' . $other_connected_admin;
+		}
+
+		Jetpack_Options::update_option( 'master_user', $master_user );
+		Jetpack_Options::update_option( 'user_tokens', $tokens );
+		Jetpack_Options::update_option( 'blog_token', 'kiwi.banana' );
+		return $master_user;
+	}
+
+	public function return_unknown_token_error( $response ) {
+
+		$rr = new Requests_Response();
+		return array(
+			'headers' => new Requests_Utility_CaseInsensitiveDictionary( $response, null ),
+			'body' => '<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <fault>
+    <value>
+      <struct>
+        <member>
+          <name>faultCode</name>
+          <value><int>401</int></value>
+        </member>
+        <member>
+          <name>faultString</name>
+          <value><string>Jetpack: [unknown_token] It looks like your Jetpack connection is broken.  Try disconnecting from WordPress.com then reconnecting.</string></value>
+        </member>
+      </struct>
+    </value>
+  </fault>
+</methodResponse>',
+			'response' => array(
+				'code' => 200,
+				'message' => 'OK',
+			),
+			'cookies' => array(),
+			'http_response' => new WP_HTTP_Requests_Response( $rr ),
+		);
+	}
+}

--- a/tests/php/test_class.jetpack-ixr-client.php
+++ b/tests/php/test_class.jetpack-ixr-client.php
@@ -63,7 +63,7 @@ class WP_Test_Jetpack_IXR_Client extends WP_UnitTestCase {
 
 	public function return_unknown_token_error( $response ) {
 
-		$rr = new Requests_Response();
+		$requests_response = new Requests_Response();
 		return array(
 			'headers' => new Requests_Utility_CaseInsensitiveDictionary( $response, null ),
 			'body' => '<?xml version="1.0" encoding="UTF-8"?>
@@ -88,7 +88,7 @@ class WP_Test_Jetpack_IXR_Client extends WP_UnitTestCase {
 				'message' => 'OK',
 			),
 			'cookies' => array(),
-			'http_response' => new WP_HTTP_Requests_Response( $rr ),
+			'http_response' => new WP_HTTP_Requests_Response( $requests_response ),
 		);
 	}
 }

--- a/tests/php/test_class.jetpack-ixr-client.php
+++ b/tests/php/test_class.jetpack-ixr-client.php
@@ -22,6 +22,7 @@ class WP_Test_Jetpack_IXR_Client extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_Options::get_option( 'master_user' ) , 'Master user present' );
 		$this->assertFalse( Jetpack_Options::get_option( 'user_tokens' ), 'User Tokens Present' );
 		$this->assertFalse( Jetpack_Options::get_option( 'blog_token' ), 'Blog Token Present');
+		$this->assertEquals( array( $master_user ), Jetpack_Options::get_option( 'disconnection_notice' ) );
 	}
 
 	public function test_jetpack_client_recieves_unknown_token_demote_master_user() {
@@ -42,6 +43,7 @@ class WP_Test_Jetpack_IXR_Client extends WP_UnitTestCase {
 		$this->assertFalse( isset( $tokens[$master_user] ), 'Master Token Present');
 		$this->assertTrue(  isset( $tokens[$master_user_new] ), 'New Master Token Present' );
 		$this->assertTrue( (bool)Jetpack_Options::get_option( 'blog_token' ), 'Blog Token Not Present' );
+		$this->assertEquals( array( $master_user ), Jetpack_Options::get_option( 'disconnection_notice' ) );
 
 	}
 


### PR DESCRIPTION
Currently if the Jetpack site is syncing data with us with broken tokens, the sync just fails but the site keeps trying to sync the data. 

This change tries to change the master user since the current master user has broken tokens. 
If it is not able to change the master user it disconnects the site.
Which will require the site to connect again to fix the issue. 

#### Testing instructions:
1. temporarly break your site. ( remove ngrok, move the jetpack folder)
2. disconnect jetpack from .com
3. Notice that the site gets disconnected.
4. Notice that the master user gets switched to another admin.

#### Proposed changelog entry for your changes:

<img width="1505" alt="screen shot 2018-05-11 at 3 29 43 pm" src="https://user-images.githubusercontent.com/115071/39949553-3e3f25a2-5530-11e8-8233-02720f1a271b.png">

