### PR TITLE
Build. Remove yarn cache clean command from yarn distclean

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
     "clean-client": "rm -rf _inc/build/ _inc/blocks/ css/",
     "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
-    "distclean": "rm -rf node_modules && yarn cache clean",
+    "distclean": "rm -rf node_modules",
     "build": "yarn install-if-deps-outdated && yarn clean-client && yarn build-client",
     "build-client": "gulp",
     "build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",


### PR DESCRIPTION
Cleaning the whole yarn cache everytime we want to remove local node_modules results in disabling the offline experience and also makes the running of `yarn` take a lot of time.

Given that `yarn.lock` keeps track of specific versions of packages referred to in the package.json, cleaning the cache does not result in a better management of dependencies if we're wanting to update a dependency version

This behaviour was introduced in #6363 .

> This came up in slack: the addition of lib/accessible-focus to dops-components wasn't picked up because of yarn caching, and distclean alone wasn't enough to refresh the cached modules. 

We're no longer depending on dops-components and I'm inclined to think that what happened here was that dops-component was not being referred as a dependency to a specific commit, but to `master` in a github repo source.

> Since distclean should reset the environment back to "new", we should also clear the yarn caches.

The problem here is that `yarn cache clean` cleans the whole yarn cache and not just for the `jetpack` source code project.

#### Changes proposed in this Pull Request:

* Remove `yarn cache clean` command from the `yarn distclean` command.

#### Testing instructions:

* Run `yarn`.
* Checkout to this branch and run `yarn distclean`.
* Run `yarn` and expect this to work and be fast.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

None needed