### PR TITLE
Code Sync:  Upload Media v1.1 endpoint - was wpcom-ahead

### DIFF
--- a/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -159,6 +159,10 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 		$input = $this->input( true );
 		$media_files = ! empty( $input['media'] ) ? $input['media'] : array();
 
+		if ( empty( $media_files ) ) {
+			return false;
+		}
+
 		foreach ( $media_files as $media_item ) {
 			if ( ! preg_match( '@^video/@', $media_item['type'] ) ) {
 				return false;


### PR DESCRIPTION
Duplicates work of #9177.

#### Changes proposed in this Pull Request:

* Syncs the `json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php` file from wpcom to Jetpack.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
