### PR TITLE
Code Sync: Autosave Post v1.1 endpoint - was wpcom-ahead

### DIFF
--- a/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
@@ -58,6 +58,11 @@ class WPCOM_JSON_API_Autosave_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_
 			return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 		}
 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// Make sure Custom Post Types, etc. get registered.
+			$this->load_theme_functions();
+		}
+
 		$post = get_post( $post_id );
 
 		if ( ! $post || is_wp_error( $post ) ) {


### PR DESCRIPTION
Merges r172745-wpcom.

Summary:
When editing a published custom post type like portfolios the preview would break on autosave. This was due to the wrong preview URL being sent to the front end which this change resolves.
Without the appropriate theme functions, the custom post types (& their redirects) do not get registered.

Further details: https://github.com/Automattic/wp-calypso/issues/22645

Test Plan was:
1. Starting at URL: https://wordpress.com/types/jetpack-portfolio
2. Select a site with Portfolios enabled (or enable them in the Writing settings on your site).
3. If you don't have any portfolio projects yet, create and publish one.
4. In the list of portfolio projects, select one to open it in the editor.
5. Before making any changes, select "Preview" to preview the project.
6. Make any edit to the project.
7. Select "Preview" again to try to preview your changes.
8. Without this patch applied the Preview should 404. With this patch applied the Preview should work as expected.

Reviewers: mppfeiffer

Reviewed By: mppfeiffer

Differential Revision: https://[private link]


#### Testing instructions:

None are needed

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
