### PR TITLE
Options: add basic options to sync whitelist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -111,6 +111,15 @@ class Jetpack_Sync_Defaults {
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 		'jetpack_api_cache_enabled',
+		'start_of_week',
+		'blacklist_keys',
+		'posts_per_page',
+		'posts_per_rss',
+		'show_on_front',
+		'ping_sites',
+		'uploads_use_yearmonth_folders',
+		'date_format',
+		'time_format',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -170,6 +170,15 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 			'jetpack_api_cache_enabled'            => '1',
 			'sidebars_widgets'                     => array( 'array_version' => 3 ),
+			'start_of_week'                        => '0',
+			'blacklist_keys'                       => '',
+			'posts_per_page'                       => '1',
+			'posts_per_rss'                        => '1',
+			'show_on_front'                        => '0',
+			'ping_sites'                           => false,
+			'uploads_use_yearmonth_folders'        => '0',
+			'date_format'                          => '0',
+			'time_format'                          => '0',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Adds a set of basic options to whitelist that are safe to sync:
- no filters
- simple enough content

These would all be used for capturing events for the Activity Log.

## Test

Change these settings in your WP admin interface and observe them get synced.

- 'start_of_week' → In general
- 'blacklist_keys'  → In discussion
- 'posts_per_page'  → In reading
- 'posts_per_rss'  → In reading
- 'show_on_front'  → In reading (radio button)
- 'ping_sites'  → In writing ("Update services")
- 'uploads_use_yearmonth_folders'  → In media
- 'date_format' → In general
- 'time_format' → In general

Tests pass:
```
phpunit --filter=WP_Test_Jetpack_Sync_Options
```