### PR TITLE
WordAds: promote Ad widget within WordAds settings card

### DIFF
--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -134,7 +134,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 							</span>
 						</CompactFormToggle>
 						<small className="jp-form-setting-explanation">
-							{ __( 'You can now also place additional ads using the Ad widget. {{link}}Try it out!{{/link}}', {
+							{ isAdsActive && __( 'You can place additional ads using the Ad widget. {{link}}Try it out!{{/link}}', {
 								components: {
 									link: <a
 										className="jp-module-settings__external-link"

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -133,6 +133,15 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 								{ __( 'Second ad below post' ) }
 							</span>
 						</CompactFormToggle>
+						<small className="jp-form-setting-explanation">
+							{ __( 'You can now also place additional ads using the Ad widget. {{link}}Try it out!{{/link}}', {
+								components: {
+									link: <a
+										className="jp-module-settings__external-link"
+										href="customize.php?autofocus[panel]=widgets" />
+								}
+							} ) }
+						</small>
 					</FormFieldset>
 				</SettingsGroup>
 				{

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -31,6 +31,10 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 		analytics.tracks.recordJetpackClick( 'view-earnings' );
 	};
 
+	trackConfigureWidgetClick = () => {
+		analytics.tracks.recordJetpackClick( 'place-ad-widget' );
+	}
+
 	handleChange = setting => {
 		return () => this.updateOptions( setting );
 	};
@@ -64,7 +68,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 						<small className="jp-form-setting-explanation">
 							{ __( 'By activating ads, you agree to the Automattic Ads {{link}}Terms of Service{{/link}}.', {
 								components: {
-									link: <a href="https://wordpress.com/automattic-ads-tos/" target="_blank" rel="noopener noreferrer" />
+									link: <a href="https://wordpress.com/automattic-ads-tos/" target="_blank" rel="noopener noreferrer" onClick={ this.trackConfigureWidgetClick } />
 								}
 							} ) }
 						</small>


### PR DESCRIPTION
The purpose of this PR is to make sure Jetpack ads module users know they can place additional ads via the Ads widget.

#### Changes proposed in this Pull Request:

* Adds help text below the `Additional ad placements` header alerting them that the Ads widget is an available option. This will only display when the Ads module is turned on - otherwise the Ads widget is not available, and users clicking the CTA would result in a poor ux.

#### Testing instructions:

* Using a Jetpack site with premium or pro plan, enable the Ads module and make sure the Ad widget message displays. A sample of what this should look like is shown below.
<img width="734" alt="screen shot 2018-04-13 at 4 11 20 pm" src="https://user-images.githubusercontent.com/2522431/38736958-5f60e1b8-3f36-11e8-8032-4f129f4c207d.png">