### PR TITLE
Masterbar: Remove the Next Steps link

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -509,17 +509,7 @@ class A8C_WPCOM_Masterbar {
 				'class' => 'mb-icon user-info-item',
 			),
 		) );
-
-		$wp_admin_bar->add_menu( array(
-			'parent' => $id,
-			'id'     => 'next-steps',
-			'title'  => esc_html__( 'Next Steps', 'jetpack' ),
-			'href'   => 'https://wordpress.com/me/next',
-			'meta'   => array(
-				'class' => 'mb-icon user-info-item',
-			),
-		) );
-
+		
 		$help_link = 'https://jetpack.com/support/';
 
 		if ( jetpack_is_atomic_site() ) {


### PR DESCRIPTION
Firest removed in Calypso in https://github.com/Automattic/wp-calypso/pull/23952
Then removed on .com in D11711-code

This PR brings things in line.
#### Changes proposed in this Pull Request:
Before:
<img width="295" alt="screen shot 2018-04-13 at 11 36 09 am" src="https://user-images.githubusercontent.com/115071/38752096-e59dbca6-3f0e-11e8-8c27-d703ef135fc6.png">

After:
<img width="299" alt="screen shot 2018-04-13 at 11 35 47 am" src="https://user-images.githubusercontent.com/115071/38752115-ecf71cae-3f0e-11e8-9f63-a8af75b6074c.png">



#### Testing instructions:
load jetpack with the mastebar
Notive that the section Next Steps is gone.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
