### PR TITLE
Protect: Revert XML RPC request should get hard blocker quicke

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -554,7 +554,7 @@ class Jetpack_Protect_Module {
 		 * @param bool true Should we fallback to the Math questions when an IP is blocked. Default to true.
 		 */
 		$allow_math_fallback_on_fail = apply_filters( 'jpp_use_captcha_when_blocked', true );
-		if ( ! $allow_math_fallback_on_fail || Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( ! $allow_math_fallback_on_fail  ) {
 			$this->kill_login();
 		}
 		include_once dirname( __FILE__ ) . '/protect/math-fallback.php';


### PR DESCRIPTION
Since a lot of third party services relied on this be able to connect and were blocked as a result of failed login attempts we decided to revert the PR. The services will still eventually get blocked but not as quickly as they were before.

If someone want to harden their XMLRPC login they can use the following code instead.

```
add_filter( 'jpp_use_captcha_when_blocked', 'jetpack_no_captia_on_xmlrpc_requests' );
function jetpack_no_captia_on_xmlrpc_requests($allow_math_fallback) {
if( Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
return false;
}
return $allow_math_fallback;
}
```

More Context: p1HpG7-51K-p2

Reverts https://github.com/Automattic/jetpack/pull/8855