### PR TITLE
Sync: add admin email options to sync whitelist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -120,6 +120,8 @@ class Jetpack_Sync_Defaults {
 		'uploads_use_yearmonth_folders',
 		'date_format',
 		'time_format',
+		'admin_email',
+		'new_admin_email',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -179,6 +179,8 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'uploads_use_yearmonth_folders'        => '0',
 			'date_format'                          => '0',
 			'time_format'                          => '0',
+			'admin_email'                          => 'banana@example.org',
+			'new_admin_email'                      => 'banana@example.net',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Adds `new_admin_email` and  `admin_email` options to sync whitelist.

These are for the "admin email address" field in `/wp-admin/options-general.php`

Not for user email of the WP account.

![image](https://user-images.githubusercontent.com/87168/38757091-6b59799c-3f74-11e8-9a3b-025f8013d14d.png)

`new_admin_email` is used temporarily when changing email:

![image](https://user-images.githubusercontent.com/87168/38757197-cc64465e-3f74-11e8-88f9-e8ff289b78cf.png)

Changing emails can sync out events like these:
```
'added_option'
(
    [0] => new_admin_email
    [1] => ipsum@example.com
)

'updated_option'
(
    [0] => new_admin_email
    [1] => ipsum@example.com
    [2] => ipsum2@example.com
)

'updated_option'
(
    [0] => admin_email
    [1] => lorem@example.com
    [2] => ipsum@example.com
)

'deleted_option'
(
    [0] => new_admin_email
)
```


## Testing

- Change site admin email from `/wp-admin/options-general.php` and confirm it.
- Observe events sync
- Tests should pass: `phpunit --filter=WP_Test_Jetpack_Sync_Options`