### PR TITLE
WooCommerce Analytics: always return a properly formatted URL.

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -262,12 +262,12 @@ class Jetpack_Google_Analytics_Universal {
 		$product = $item['data'];
 
 		$new_attributes = sprintf(
-			' data-product_id="%1$s" data-product_sku="%2$s">',
+			'" data-product_id="%1$s" data-product_sku="%2$s">',
 			esc_attr( $product->get_id() ),
 			esc_attr( $product->get_sku() )
 		);
 
-		$url = str_replace( '>', $new_attributes, $url );
+		$url = str_replace( '">', $new_attributes, $url );
 		return $url;
 	}
 

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -248,22 +248,26 @@ class Jetpack_Google_Analytics_Universal {
 	}
 
 	/**
-	* Adds the product ID and SKU to the remove product link (for use by remove_from_cart above) if not present
-	*/
+	 * Adds the product ID and SKU to the remove product link (for use by remove_from_cart above) if not present
+	 *
+	 * @param string $url Full HTML a tag of the link to remove an item from the cart.
+	 * @param string $key Unique Key ID for a cart item.
+	 */
 	public function remove_from_cart_attributes( $url, $key ) {
 		if ( false !== strpos( $url, 'data-product_id' ) ) {
 			return $url;
 		}
 
-		$item = WC()->cart->get_cart_item( $key );
-		$product = $item[ 'data' ];
+		$item    = WC()->cart->get_cart_item( $key );
+		$product = $item['data'];
 
-		$new_attributes = sprintf( 'href="%s" data-product_id="%s" data-product_sku="%s"',
-			esc_attr( $url ),
+		$new_attributes = sprintf(
+			' data-product_id="%1$s" data-product_sku="%2$s">',
 			esc_attr( $product->get_id() ),
 			esc_attr( $product->get_sku() )
-			);
-		$url = str_replace( 'href=', $new_attributes, $url );
+		);
+
+		$url = str_replace( '>', $new_attributes, $url );
 		return $url;
 	}
 

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -136,8 +136,9 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	/**
 	 * Adds the product ID to the remove product link (for use by remove_from_cart above) if not present
 	 *
-	 * @param string $url url.
-	 * @param string $key key.
+	 * @param string $url Full HTML a tag of the link to remove an item from the cart.
+	 * @param string $key Unique Key ID for a cart item.
+	 *
 	 * @return mixed.
 	 */
 	public function remove_from_cart_attributes( $url, $key ) {
@@ -149,12 +150,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$product = $item['data'];
 
 		$new_attributes = sprintf(
-			'href="%s" data-product_id="%s" data-product_sku="%s"',
-			esc_attr( $url ),
-			esc_attr( $product->get_id() ),
-			esc_attr( $product->get_sku() )
+			' data-product_id="%s">',
+			esc_attr( $product->get_id() )
 		);
-		$url = str_replace( 'href=', $new_attributes, $url );
+
+		$url = str_replace( '>', $new_attributes, $url );
 		return $url;
 	}
 

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -150,11 +150,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$product = $item['data'];
 
 		$new_attributes = sprintf(
-			' data-product_id="%s">',
+			'" data-product_id="%s">',
 			esc_attr( $product->get_id() )
 		);
 
-		$url = str_replace( '>', $new_attributes, $url );
+		$url = str_replace( '">', $new_attributes, $url );
 		return $url;
 	}
 


### PR DESCRIPTION
When filtering the remove cart URL, we don't want to make any changes to the URL itself; we only want to add additional attributes if needed.

Fixes issues when the remove cart link was broken when the Product ID was missing from the cart item and Woo Analytics was adding it.

#### Testing instructions:

1. Start with a Woo site with a Jetpack Professional plan.
2. In Calypso > Settings > Traffic, enable Google Analytics and all its options.
3. On your site, add products to your cart.
4. Go to the cart page.
5. Make sure that all remove from cart icons work, and include the product ID attribute.

#### Proposed changelog entry for your changes:
* WooCommerce Analytics: fix broken remove from cart link.