### PR TITLE
Changes the way Jetpack handles asset paths based on environment.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7096,11 +7096,16 @@ p {
 	 * @return string The URL to the file
 	 */
 	public static function get_file_url_for_environment( $min_path, $non_min_path ) {
-		$path = ( Jetpack_Constants::is_defined( 'SCRIPT_DEBUG' ) && Jetpack_Constants::get_constant( 'SCRIPT_DEBUG' ) )
-			? $non_min_path
-			: $min_path;
+		/**
+		 * Filters whether Jetpack should use minified assets such as CSS and JavaScript files.
+		 *
+		 * @module general
+		 *
+		 * @since 6.1
+		 */
+		$minify = apply_filters( 'jetpack_should_use_minified_assets', true );
 
-		return plugins_url( $path, JETPACK__PLUGIN_FILE );
+		return plugins_url( $minify ? $min_path : $non_min_path, JETPACK__PLUGIN_FILE );
 	}
 
 	/**

--- a/jetpack.php
+++ b/jetpack.php
@@ -89,6 +89,10 @@ add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );
 add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
+// Disable minified assets loading in development mode
+if ( Jetpack_Constants::is_defined( 'SCRIPT_DEBUG' ) && Jetpack_Constants::get_constant( 'SCRIPT_DEBUG' ) ) {
+	add_filter( 'jetpack_should_use_minified_assets', '__return_false' );
+}
 
 /**
  * Add an easy way to photon-ize a URL that is safe to call even if Jetpack isn't active.

--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -13,6 +13,11 @@
  * Additional Search Queries: shortcodes, shortcode, embeds, media, bandcamp, dailymotion, facebook, flickr, google calendars, google maps, google+, polldaddy, recipe, recipes, scribd, slideshare, slideshow, slideshows, soundcloud, ted, twitter, vimeo, vine, youtube
  */
 
+if ( ! defined( 'JETPACK_SHORTCODES_PLUGIN_URL' ) ) {
+	define( 'JETPACK_SHORTCODES_PLUGIN_URL', 'modules/shortcodes/' );
+	define( 'JETPACK_SHORTCODES_PLUGIN_DIR', plugin_dir_path( __FILE__ ) . 'shortcodes/' );
+}
+
 /**
  * Transforms the $atts array into a string that the old functions expected
  *

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -273,7 +273,10 @@ class Jetpack_Slideshow_Shortcode {
 		wp_enqueue_script( 'jquery-cycle', plugins_url( '/js/jquery.cycle.min.js', __FILE__ ), array( 'jquery' ), '20161231', true );
 		wp_enqueue_script(
 			'jetpack-slideshow',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/slideshow-shortcode.min.js', 'modules/shortcodes/js/slideshow-shortcode.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/slideshow-shortcode.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/slideshow-shortcode.js'
+			),
 			array( 'jquery-cycle' ),
 			'20160119.1',
 			true

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -693,7 +693,7 @@ EXPECTED;
 	 * @dataProvider get_file_url_for_environment_data_provider
 	 */
 	function test_get_file_url_for_environment( $min_path, $non_min_path, $is_script_debug, $expected, $not_expected ) {
-		Jetpack_Constants::set_constant( 'SCRIPT_DEBUG', $is_script_debug );
+		add_filter( 'jetpack_should_use_minified_assets', $is_script_debug ? '__return_false' : '__return_true' );
 		$file_url = Jetpack::get_file_url_for_environment( $min_path, $non_min_path );
 
 		$this->assertContains( $$expected, $file_url );


### PR DESCRIPTION
This introduces a filter that can be used to override Jetpack trying to load minified assets. It also introduces a constant that replaces the path used to enqueue assets for shortcodes. This is the proposed approach to handle other assets as well.
