### PR TITLE
Shortcodes: Update instagram, recipe, presentations shortcode file paths

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -147,7 +147,10 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	if ( ! empty( $response_body->html ) ) {
 		wp_enqueue_script(
 			'jetpack-instagram-embed',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/instagram.min.js', 'modules/shortcodes/js/instagram.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/instagram.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/instagram.js'
+			),
 			array( 'jquery' ),
 			false,
 			true

--- a/modules/shortcodes/presentations.php
+++ b/modules/shortcodes/presentations.php
@@ -121,14 +121,20 @@ class Presentations {
 		wp_enqueue_script( 'jquery' );
 		wp_enqueue_script(
 			'jmpress',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/jmpress.min.js', 'modules/shortcodes/js/jmpress.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/jmpress.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/jmpress.js'
+			),
 			array( 'jquery' ),
 			'0.4.5',
 			true
 		);
 		wp_enqueue_script(
 			'presentations',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/main.min.js', 'modules/shortcodes/js/main.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/main.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/main.js'
+			),
 			array( 'jquery', 'jmpress' ),
 			false,
 			true

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -119,14 +119,20 @@ class Jetpack_Recipes {
 
 		wp_enqueue_script(
 			'jetpack-recipes-printthis',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/recipes-printthis.min.js', 'modules/shortcodes/js/recipes-printthis.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/recipes-printthis.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/recipes-printthis.js'
+			),
 			array( 'jquery' ),
 			'20170202'
 		);
 
 		wp_enqueue_script(
 			'jetpack-recipes-js',
-			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/recipes.min.js', 'modules/shortcodes/js/recipes.js' ),
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/shortcodes/js/recipes.min.js',
+				JETPACK_SHORTCODES_PLUGIN_URL . 'js/recipes.js'
+			),
 			array( 'jquery', 'jetpack-recipes-printthis' ),
 			'20131230'
 		);


### PR DESCRIPTION
Following suit of #9324, this updates the js filepaths to use the new `JETPACK_SHORTCODES_PLUGIN_URL` constant to enqueue the js.

To test: 
- `define( 'SCRIPT_DEBUG', true );` in wp-config.php
- Insert a recipe, presentations, and instagram shortcodes
- Make sure they're all loading the un-minified versions of the files
- No JS errors in console

Example shortcodes: 
- Instagram: `https://www.instagram.com/p/BhW5dtfl-tw/?taken-by=wordpressdotcom`
- Recipe: `[recipe-notes]Add your notes, tips, etc here.[/recipe-notes]`
- Presentations: `[presentation width=600 height=375]`