### PR TITLE
Add warning about privacy policy in EU cookie widget

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -151,6 +151,17 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		 */
 		public function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
+
+			wp_enqueue_script(
+				'eu-cookie-law-widget-admin',
+				Jetpack::get_file_url_for_environment(
+					'_inc/build/widgets/eu-cookie-law/eu-cookie-law-admin.min.js',
+					'modules/widgets/eu-cookie-law/eu-cookie-law-admin.js'
+				),
+				array( 'jquery' ),
+				20180417
+			);
+
 			require( dirname( __FILE__ ) . '/eu-cookie-law/form.php' );
 		}
 

--- a/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
@@ -1,0 +1,28 @@
+
+/* eslint no-var: 0 */
+
+( function( $ ) {
+	var $document = $( document );
+
+	$document.on( 'ready', function() {
+		var maybeShowNotice = function( e, policyUrl ) {
+			var $policyUrl = $( policyUrl || this )
+				.closest( '.eu-cookie-law-widget-policy-url' );
+
+			if ( $policyUrl.find( 'input[type="radio"][value="default"]' ).is( ':checked' ) ) {
+				$policyUrl.find( '.notice' ).css( 'display', 'block' );
+			} else {
+				$policyUrl.find( '.notice' ).hide();
+			}
+		};
+
+		$document.on( 'click', '.eu-cookie-law-widget-policy-url input[type="radio"]', maybeShowNotice );
+		$document.on( 'widget-updated widget-added', function( e, widget ) {
+			var widgetId = $( widget ).attr( 'id' );
+			if ( widgetId.indexOf( 'eu_cookie_law_widget' ) !== -1 ) {
+				maybeShowNotice( null, $( '#' + widgetId + ' .eu-cookie-law-widget-policy-url' ) );
+			}
+		} );
+		$( '.eu-cookie-law-widget-policy-url' ).each( maybeShowNotice );
+	} );
+} )( jQuery );

--- a/modules/widgets/eu-cookie-law/form.php
+++ b/modules/widgets/eu-cookie-law/form.php
@@ -154,11 +154,11 @@
 				value="<?php echo esc_url( $instance['custom-policy-url'] ); ?>"
 			/>
 			<span class="notice notice-warning" style="display: none;">
-        		<span style="display: block; margin: .5em 0;">
+				<span style="display: block; margin: .5em 0;">
 					<strong><?php esc_html_e( 'Caution:' ); ?></strong>
 					<?php esc_html_e( 'The default policy URL only covers cookies set by Jetpack. If you’re running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement.' ); ?>
 				</span>
-    		</span>
+			</span>
 		</li>
 	</ul>
 </p>

--- a/modules/widgets/eu-cookie-law/form.php
+++ b/modules/widgets/eu-cookie-law/form.php
@@ -123,7 +123,7 @@
 	<strong>
 		<?php esc_html_e( 'Policy URL', 'jetpack' ); ?>
 	</strong>
-	<ul>
+	<ul class="eu-cookie-law-widget-policy-url">
 		<li>
 			<label>
 				<input
@@ -153,6 +153,12 @@
 				type="text"
 				value="<?php echo esc_url( $instance['custom-policy-url'] ); ?>"
 			/>
+			<span class="notice notice-warning" style="display: none;">
+        		<span style="display: block; margin: .5em 0;">
+					<strong><?php esc_html_e( 'Caution:' ); ?></strong>
+					<?php esc_html_e( 'The default policy URL only covers cookies set by Jetpack. If you’re running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement.' ); ?>
+				</span>
+    		</span>
 		</li>
 	</ul>
 </p>

--- a/modules/widgets/eu-cookie-law/form.php
+++ b/modules/widgets/eu-cookie-law/form.php
@@ -155,8 +155,8 @@
 			/>
 			<span class="notice notice-warning" style="display: none;">
 				<span style="display: block; margin: .5em 0;">
-					<strong><?php esc_html_e( 'Caution:' ); ?></strong>
-					<?php esc_html_e( 'The default policy URL only covers cookies set by Jetpack. If you’re running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement.' ); ?>
+					<strong><?php esc_html_e( 'Caution:', 'jetpack' ); ?></strong>
+					<?php esc_html_e( 'The default policy URL only covers cookies set by Jetpack. If you’re running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement.', 'jetpack' ); ?>
 				</span>
 			</span>
 		</li>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* GDPR: A new warning is displayed while configuring an instance of the EU Cookie Law widget: "_Caution: The default policy URL only covers cookies set by Jetpack. If you're running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement._"

#### Testing instructions:

* Be sure 'Extra Sidebar Widgets' are enabled in Jetpack.  
  See: `/wp-admin/admin.php?page=jetpack_modules` to review.
  ![2018-04-17_17-56-10](https://user-images.githubusercontent.com/1563559/38907770-caeb4910-4269-11e8-8a4f-cee00adaa312.png)

* Add the EU Cookie Law Banner widget.
  ![2018-04-17_17-53-30](https://user-images.githubusercontent.com/1563559/38907487-7119b03a-4268-11e8-9f28-0a654a87686b.png)

* It should be using our cookies statement as a default setting, which will generate this notice.
  ![privacy-s1](https://user-images.githubusercontent.com/1563559/38907502-7c86dc36-4268-11e8-9671-a05ce0a81f4c.png)

* Using a custom URL should automatically disable the notice.
  ![privacy-s2](https://user-images.githubusercontent.com/1563559/38907599-edee40f8-4268-11e8-8bc3-13ce737a8d90.png)

* Save the widget, try with multiple EU widget instances in a single sidebar, and try multiple instances across multiple sidebars; i.e., do your best to break it and report any issues.

#### Proposed changelog entry for your changes:

* GDPR: A new warning is displayed while configuring an instance of the EU Cookie Law widget: "_Caution: The default policy URL only covers cookies set by Jetpack. If you're running other plugins, custom cookies, or third-party tracking technologies, you should create and link to your own cookie statement._"