### PR TITLE
Markdown: fix jetpack_utf8_strlen regex

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -73,7 +73,7 @@ function Markdown($text) {
  *
  */
 function jetpack_utf8_strlen( $text ) {
-	return preg_match_all( "/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", $text, $m );
+	return preg_match_all( "/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/", $text, $m );
 }
 
 #


### PR DESCRIPTION
This regex does not work properly. 

Reported by @mdawaffe  in D11859-code

> Inside the create_function() call, there needs to be an extra level of slashes. That level was not removed when the function was pulled out of the create_function() call.

To Test: 
```
php > var_dump( preg_match_all( "/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", 'hello', $m ) );
int(0)
php > var_dump( preg_match_all( "/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/", 'hello', $m ) );
int(5)
```
or 
```
<?php

function jetpack_utf8_strlen( $text ) {
        return preg_match_all( "/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", $text, $m );
}

var_dump( jetpack_utf8_strlen( "Hello" ) ); // should be 5
```