### PR TITLE
Open Graph: Add closing comment to OG tags

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -257,6 +257,7 @@ function jetpack_og_tags() {
 			}
 		}
 	}
+	$og_output .= "\n<!-- End Jetpack Open Graph Tags -->\n";
 	echo $og_output;
 }
 


### PR DESCRIPTION
Fixes #9302 

#### Changes proposed in this Pull Request:

* Adds a closing HTML comment to help readability of what plugin added what to a page's head.

#### Testing instructions:

* Apply patch with Jetpack active and the Sharing module enabled (as one that would enable Jetpack OG tags).
* View Source and confirm both an opening and closing html comment surrounding the OG tags.