### PR TITLE
Sharing: Make via/related functions static for outside use

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -572,7 +572,13 @@ class Share_Twitter extends Sharing_Source {
 		return __( 'Twitter', 'jetpack' );
 	}
 
-	function sharing_twitter_via( $post ) {
+	/**
+	 * Determine the Twitter 'via' value for a post.
+	 *
+	 * @param  WP_Post $post Post object.
+	 * @return string Twitter handle without the preceding @.
+	 **/
+	public static function sharing_twitter_via( $post ) {
 		/**
 		 * Allow third-party plugins to customize the Twitter username used as "twitter:site" Twitter Card Meta Tag.
 		 *
@@ -611,7 +617,13 @@ class Share_Twitter extends Sharing_Source {
 		return preg_replace( '/[^\da-z_]+/i', '', $twitter_site_tag_value );
 	}
 
-	public function get_related_accounts( $post ) {
+	/**
+	 * Determine the 'related' Twitter accounts for a post.
+	 *
+	 * @param  WP_Post $post Post object.
+	 * @return string Comma-separated list of Twitter handles.
+	 **/
+	public static function get_related_accounts( $post ) {
 		/**
 		 * Filter the list of related Twitter accounts added to the Twitter sharing button.
 		 *

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -575,10 +575,11 @@ class Share_Twitter extends Sharing_Source {
 	/**
 	 * Determine the Twitter 'via' value for a post.
 	 *
-	 * @param  WP_Post $post Post object.
+	 * @param  WP_Post|int $post Post object or post ID.
 	 * @return string Twitter handle without the preceding @.
 	 **/
 	public static function sharing_twitter_via( $post ) {
+		$post = get_post( $post );
 		/**
 		 * Allow third-party plugins to customize the Twitter username used as "twitter:site" Twitter Card Meta Tag.
 		 *
@@ -620,10 +621,11 @@ class Share_Twitter extends Sharing_Source {
 	/**
 	 * Determine the 'related' Twitter accounts for a post.
 	 *
-	 * @param  WP_Post $post Post object.
+	 * @param  WP_Post|int $post Post object or post ID.
 	 * @return string Comma-separated list of Twitter handles.
 	 **/
 	public static function get_related_accounts( $post ) {
+		$post = get_post( $post );
 		/**
 		 * Filter the list of related Twitter accounts added to the Twitter sharing button.
 		 *


### PR DESCRIPTION
The Sharing module includes handy functions for determining the 'via' and 'related' Twitter accounts. By making these functions static, we can allow other plugins to utilize these functions.

Example: https://github.com/automattic/co-authors-plus-social-pack filters both the via and related values. Twitter will only show two related accounts after submitting a tweet via the Sharing module, which if the `via` and the first value of `related` are the same account will then show the same account twice.

The most straightforward way to avoid this is to check what is being used as the "via" and to be sure to exclude that from the "related" set, which would be great to do via the same functionality Jetpack is using.

Additionally, accept a post ID in addition to a post object.