### PR TITLE
Docs: Partners: Fix /provision examples to send form data

### DIFF
--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -123,11 +123,11 @@ Here's an example using cURL in shell.
 ```shell
 curl --request POST \
   --url https://public-api.wordpress.com/rest/v1.3/jpphp/provision \
-  --header 'authorization: Bearer access_token_here' \
+  --header "authorization: Bearer $ACCESS_TOKEN" \
   --header 'cache-control: no-cache' \
-  --header 'local_username: local_username_here' \
-  --header 'plan: plan_here' \
-  --header 'siteurl: siteurl_here'
+  --form plan=plan_here \
+  --form siteurl=siteurl_here \
+  --form local_username=local_username_here
 ```
 
 Here's an example using the request module in NodeJS.
@@ -145,9 +145,11 @@ var options = {
     headers: {
         'cache-control': 'no-cache',
         authorization: 'Bearer ' + accessToken,
-        plan: plan,
+    },
+    formData: {
+        local_username: local_username,
         siteurl: siteurl,
-        local_username: local_username
+        plan: plan
     }
 };
 


### PR DESCRIPTION
The documentation added in #9243 was incorrect in that it suggested passing `local_username`, `siteurl`, and `plan` as headers when they should be sent in as form input. This PR corrects that.

To test:
- You'll need to create a partner key. See PCYsg-emq-p2
- You can then use the cURL example immediately by substituting in values
- To use the Node JS example:
    - you'll see to create a directory 
    - put the example in an `index.js` file in that directory
    - `npm init`
    - `npm install --save-dev request`
    - `node index.js`

