### PR TITLE
Likes: Bust the likes iframe cache

### DIFF
--- a/modules/likes/jetpack-likes-master-iframe.php
+++ b/modules/likes/jetpack-likes-master-iframe.php
@@ -4,7 +4,7 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version = '20171126';
+	$version = '20180418';
 	$in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
 
 	$_locale = get_locale();


### PR DESCRIPTION
The style.css loaded from the widgets.wp.com Likes iframe was cached with an outdated version, resulting in a duplication of the "Like" star (see screenshot).

The issue is already resolved on widgets.wp.com, but Jetpack keeps loading an older version.

Testing Plan:
* Load a post with Likes on, observe the double-star.
* Apply patch.
* Reload and confirm no double-stars.

h/t Cody in 1096146-z for the report.

![ote7pjg](https://user-images.githubusercontent.com/88897/38944351-458f63ba-42f9-11e8-9eed-c5eaabf0f50f.png)
