### PR TITLE
Media Summary: Setup postdata for obtaining the excerpt

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -301,6 +301,10 @@ class Jetpack_Media_Summary {
 	/**
 	 * Retrieve an excerpt for the post summary.
 	 *
+	 * This function works around a suspected problem with Core. If resolved, this function should be simplified.
+	 * @link https://github.com/Automattic/jetpack/pull/8510
+	 * @link https://core.trac.wordpress.org/ticket/42814
+	 *
 	 * @param  string  $post_content The post's content.
 	 * @param  string  $post_excerpt The post's excerpt. Empty if none was explicitly set.
 	 * @param  int     $max_words Maximum number of words for the excerpt. Used on wp.com. Default 16.

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -54,7 +54,7 @@ class Jetpack_Media_Summary {
 		);
 
 		if ( empty( $post->post_password ) ) {
-			$return['excerpt']       = self::get_excerpt( $post->post_content, $post->post_excerpt, $args['max_words'], $args['max_chars'] );
+			$return['excerpt']       = self::get_excerpt( $post->post_content, $post->post_excerpt, $args['max_words'], $args['max_chars'] , $post);
 			$return['count']['word'] = self::get_word_count( $post->post_content );
 			$return['count']['word_remaining'] = self::get_word_remaining_count( $post->post_content, $return['excerpt'] );
 			$return['count']['link'] = self::get_link_count( $post->post_content );
@@ -298,7 +298,7 @@ class Jetpack_Media_Summary {
 		);
 	}
 
-	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256 ) {
+	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $post = null ) {
 		if ( function_exists( 'wpcom_enhanced_excerpt_extract_excerpt' ) ) {
 			return self::clean_text( wpcom_enhanced_excerpt_extract_excerpt( array(
 				'text'           => $post_content,
@@ -311,7 +311,7 @@ class Jetpack_Media_Summary {
 		} else {
 
 			/** This filter is documented in core/src/wp-includes/post-template.php */
-			$post_excerpt = apply_filters( 'get_the_excerpt', $post_excerpt );
+			$post_excerpt = apply_filters( 'get_the_excerpt', $post_excerpt, $post );
 			return self::clean_text( $post_excerpt );
 		}
 	}

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -298,7 +298,9 @@ class Jetpack_Media_Summary {
 		);
 	}
 
-	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $post = null ) {
+	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $requested_post = null ) {
+		global $post;
+		$original_post = $post; // Saving the global for later use.
 		if ( function_exists( 'wpcom_enhanced_excerpt_extract_excerpt' ) ) {
 			return self::clean_text( wpcom_enhanced_excerpt_extract_excerpt( array(
 				'text'           => $post_content,
@@ -308,12 +310,16 @@ class Jetpack_Media_Summary {
 				'max_chars'      => $max_chars,
 				'read_more_threshold' => 25,
 			) ) );
-		} else {
-
+		} elseif ( $requested_post instanceof WP_Post ) {
+			$post = $requested_post; // setup_postdata does not set the global.
+			setup_postdata( $post );
 			/** This filter is documented in core/src/wp-includes/post-template.php */
 			$post_excerpt = apply_filters( 'get_the_excerpt', $post_excerpt, $post );
+			$post         = $original_post; // wp_reset_postdata uses the $post global.
+			wp_reset_postdata();
 			return self::clean_text( $post_excerpt );
 		}
+		return '';
 	}
 
 	static function get_word_count( $post_content ) {

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -298,16 +298,26 @@ class Jetpack_Media_Summary {
 		);
 	}
 
+	/**
+	 * Retrieve an excerpt for the post summary.
+	 *
+	 * @param  string  $post_content The post's content.
+	 * @param  string  $post_excerpt The post's excerpt. Empty if none was explicitly set.
+	 * @param  int     $max_words Maximum number of words for the excerpt. Used on wp.com. Default 16.
+	 * @param  int     $max_chars Maximum characters in the excerpt. Used on wp.com. Default 256.
+	 * @param  WP_Post $requested_post The post object.
+	 * @return string Post excerpt.
+	 **/
 	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $requested_post = null ) {
 		global $post;
 		$original_post = $post; // Saving the global for later use.
 		if ( function_exists( 'wpcom_enhanced_excerpt_extract_excerpt' ) ) {
 			return self::clean_text( wpcom_enhanced_excerpt_extract_excerpt( array(
-				'text'           => $post_content,
-				'excerpt_only'   => true,
-				'show_read_more' => false,
-				'max_words'      => $max_words,
-				'max_chars'      => $max_chars,
+				'text'                => $post_content,
+				'excerpt_only'        => true,
+				'show_read_more'      => false,
+				'max_words'           => $max_words,
+				'max_chars'           => $max_chars,
 				'read_more_threshold' => 25,
 			) ) );
 		} elseif ( $requested_post instanceof WP_Post ) {


### PR DESCRIPTION
Fixes #8420
Fixes #9209
Complement of #8510
Supports #8156

In PHP 7.2, warnings are thrown, in the end, because we are attempting to apply `get_the_excerpt` filters without being within the Loop. While Core makes it seem like this should work, it doesn't. (see #8510 for PR that would require Core changes to work as I think it should). 

In this PR, we override the `$post` global and setup the post data so the excerpt and underlying functions work as intended.

We're overriding the `$post` since this function does not presume to operate within the Loop, so we need to fully mock the Loop.

#### Testing instructions:
* Jetpack + Sharing (or any module that outputs OG tags) on PHP 7.2
* Open a post without an explicitly set excerpt.
* Observe PHP warnings are reported in #8420.
* Apply patch.
* Confirm excerpt is set in the og tags in head with no PHP warnings.