### PR TITLE
WordAds: remove dns prefetch for scripts that are no longer used

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -214,9 +214,6 @@ HTML;
 		<link rel='dns-prefetch' href='//ad.doubleclick.net' />
 		<link rel='dns-prefetch' href='//googleads.g.doubleclick.net' />
 		<link rel='dns-prefetch' href='//www.googletagservices.com' />
-		<link rel='dns-prefetch' href='//cdn.switchadhub.com' />
-		<link rel='dns-prefetch' href='//delivery.g.switchadhub.com' />
-		<link rel='dns-prefetch' href='//delivery.swid.switchadhub.com' />
 		<script$data_tags async type="text/javascript" src="//s.pubmine.com/head.js"></script>
 HTML;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Remove dns prefetch for scripts that are no longer used on the ad server.