### PR TITLE
WordAds: Add ads.txt support

### DIFF
--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -44,10 +44,10 @@ class WordAds_API {
 	}
 
 	/**
-	 * Returns site's WordAds status
-	 * @return array boolean values for 'approved' and 'active'
+	 * Returns the ads.txt content needed to run WordAds.
+	 * @return array string contents of the ads.txt file.
 	 *
-	 * @since 4.5.0
+	 * @since 6.1.0
 	 */
 	public static function get_wordads_ads_txt() {
 		$endpoint = sprintf( '/sites/%d/wordads/ads-txt', Jetpack::get_option( 'id' ) );

--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -44,6 +44,24 @@ class WordAds_API {
 	}
 
 	/**
+	 * Returns site's WordAds status
+	 * @return array boolean values for 'approved' and 'active'
+	 *
+	 * @since 4.5.0
+	 */
+	public static function get_wordads_ads_txt() {
+		$endpoint = sprintf( '/sites/%d/wordads/ads-txt', Jetpack::get_option( 'id' ) );
+		$wordads_status_response = $response = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint );
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error( 'api_error', __( 'Error connecting to API.', 'jetpack' ), $response );
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+		$ads_txt = str_replace( '\\n', PHP_EOL, $body->adstxt );
+		return $ads_txt;
+	}
+
+	/**
 	 * Returns status of WordAds approval.
 	 * @return boolean true if site is WordAds approved
 	 *

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -94,7 +94,7 @@ class WordAds {
 		$this->insert_adcode();
 
 		if ( '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
-			header( 'Content-Type: text/plain; charset=utf-8' );
+			$ads_txt_server_contents = ! is_wp_error( WordAds_API::get_wordads_ads_txt() ) ? WordAds_API::get_wordads_ads_txt() : '';
 
 			/**
 			 * Provide plugins a way of modifying the contents of the automatically-generated ads.txt file.
@@ -105,7 +105,9 @@ class WordAds {
 			 *
 			 * @param string WordAds_API::get_wordads_ads_txt() The contents of the ads.txt file.
 			 */
-			$ads_txt_content = apply_filters( 'wordads_ads_txt', WordAds_API::get_wordads_ads_txt() );
+			$ads_txt_content = apply_filters( 'wordads_ads_txt', $ads_txt_server_contents );
+
+			header( 'Content-Type: text/plain; charset=utf-8' );
 			echo esc_html( $ads_txt_content );
 			die();
 		}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -95,6 +95,16 @@ class WordAds {
 
 		if ( '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
 			header( 'Content-Type: text/plain; charset=utf-8' );
+
+			/**
+			 * Provide plugins a way of modifying the contents of the automatically-generated ads.txt file.
+			 *
+			 * @module wordads
+			 *
+			 * @since 6.1.0
+			 *
+			 * @param string WordAds_API::get_wordads_ads_txt() The contents of the ads.txt file.
+			 */
 			$ads_txt_content = apply_filters( 'wordads_ads_txt', WordAds_API::get_wordads_ads_txt() );
 			echo esc_html( $ads_txt_content );
 			die();

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -92,6 +92,13 @@ class WordAds {
 		}
 
 		$this->insert_adcode();
+
+		if ( '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
+			header( 'Content-Type: text/plain; charset=utf-8' );
+			$ads_txt_content = apply_filters( 'wordads_ads_txt', WordAds_API::get_wordads_ads_txt() );
+			echo esc_html( $ads_txt_content );
+			die();
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* On Jetpack Ads sites, automatically build an ads.txt file using content from the API.

#### How to test:
* Apply the patch in D12055-code to your sandbox and sandbox the api
* Before applying this patch
  * visit `/ads.txt`. You should see a 404.
* After applying this patch
  * Turn on the Jetpack Ads module
  * Visit `/ads.txt`. You should now see a text file.

#### Proposed changelog entry for your changes:
* Adds ads.txt support to the Ads module.