### PR TITLE
Publicize: Return out early for non-Publicize CPTs

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -395,6 +395,10 @@ class Publicize extends Publicize_Base {
 	}
 
 	function flag_post_for_publicize( $new_status, $old_status, $post ) {
+		if ( ! $this->post_type_is_publicizeable( $post->post_type ) ) {
+			return;
+		}
+
 		if ( 'publish' == $new_status && 'publish' != $old_status ) {
 			/**
 			 * Determines whether a post being published gets publicized.


### PR DESCRIPTION
Fixes https://github.com/Automattic/msm-sitemap/issues/118

When a post transitions to `publish`, Jetpack adds Publicize post meta to all posts, whether or not it is a publicize-able post type.

Testing:
* Setup Jetpack + Publicize
* Add a new CPT that is not able to be Publicized (e.g. lacking `post_type_support('publicize')`).
* Publish a post.
* Inspect the post meta and see `_publicize_pending` with value of 1.
* Apply patch and repeat. No `_publicize_pending` present.