### PR TITLE
Sync: add more options to the whitelist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -122,6 +122,9 @@ class Jetpack_Sync_Defaults {
 		'time_format',
 		'admin_email',
 		'new_admin_email',
+		'default_email_category',
+		'default_role',
+		'page_for_posts',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -181,9 +181,9 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'time_format'                          => '0',
 			'admin_email'                          => 'banana@example.org',
 			'new_admin_email'                      => 'banana@example.net',
-			'default_email_category'               => '1',
-			'default_role'                         => 'subscriber',
-			'page_for_posts'                       => '1',
+			'default_email_category'               => '2',
+			'default_role'                         => 'contributor',
+			'page_for_posts'                       => '2',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -181,6 +181,9 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'time_format'                          => '0',
 			'admin_email'                          => 'banana@example.org',
 			'new_admin_email'                      => 'banana@example.net',
+			'default_email_category'               => '1',
+			'default_role'                         => 'subscriber',
+			'page_for_posts'                       => '1',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Adds `default_email_category`, `page_for_posts` and `default_role` to whitelisted options to sync.

Changes will be shown at the Activity Log.

### Testing

- Modify **New User Default Role** from `/wp-admin/options-general.php`
- Modify **Default Mail Category** from `/wp-admin/options-writing.php`
- Modify **Homepage**  from `/wp-admin/options-reading.php`

→ Observer these get synced.
→ Tests pass: `yarn docker:phpunit --filter=WP_Test_Jetpack_Sync_Options`