### PR TITLE
jetpack_woocommerce_remove_share function to remove sharing display on cart pages.

### DIFF
--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -46,10 +46,10 @@ function jetpack_woocommerce_remove_share() {
 	}
 
 	if ( is_cart() || is_checkout() || is_account_page() ) {
-	    remove_filter( 'the_content', 'sharing_display', 19 );
-	    if ( class_exists( 'Jetpack_Likes' ) ) {
-	        remove_filter( 'the_content', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );
-	    }
+		remove_filter( 'the_content', 'sharing_display', 19 );
+		if ( class_exists( 'Jetpack_Likes' ) ) {
+			remove_filter( 'the_content', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );
+		}
 	}
 }
 add_action( 'loop_start', 'jetpack_woocommerce_remove_share' );

--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -35,6 +35,26 @@ function jetpack_woocommerce_social_share_icons() {
 }
 
 /**
+ * Remove sharing display from account, cart, and checkout pages in WooCommerce.
+ */
+function jetpack_woocommerce_remove_share() {
+	/**
+	 * Double check WooCommerce exists - unlikely to fail due to the hook being used but better safe than sorry.
+	 */
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		return;
+	}
+
+	if ( is_cart() || is_checkout() || is_account_page() ) {
+	    remove_filter( 'the_content', 'sharing_display', 19 );
+	    if ( class_exists( 'Jetpack_Likes' ) ) {
+	        remove_filter( 'the_content', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );
+	    }
+	}
+}
+add_action( 'loop_start', 'jetpack_woocommerce_remove_share' );
+
+/**
  * Add a callback for WooCommerce product rendering in infinite scroll.
  *
  * @param array $callbacks


### PR DESCRIPTION
This PR removes the sharing and like display functionality from CART, CHECKOUT, and ACCOUNT pages which are pretty much useless in these contexts.

Based on code in the 2016 theme file within Jetpack, and with the woocommerce compatibility file.

Requested here: https://github.com/woocommerce/woocommerce/issues/19687

To test:

1. Enable sharing and/or like buttons on a site running WooCommerce.
2. Go to a regular page. Confirm sharing is displayed.
3. Add something to cart. Go to cart. Confirm sharing is NOT displayed.
4. Proceed to checkout, again sharing should be hidden.