### PR TITLE
Widget: Added option to set DoNotTrack in Twitter Timeline Widget

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -143,7 +143,9 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		 *
 		 * @see https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference.html
 		 *
-		 * @since 6.6.0
+		 * @module widgets
+		 *
+		 * @since 6.9.0
 		 *
 		 * @param bool false Should the Twitter Timeline use the DNT attribute? Default to false.
 		 */

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -115,7 +115,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		// Start tag output
 		// This tag is transformed into the widget markup by Twitter's
 		// widgets.js code
-		echo '<a class="twitter-timeline" data-dnt="true"';
+		echo '<a class="twitter-timeline"';
 
 		$data_attribs = array(
 			'width',
@@ -306,6 +306,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			'theme'        => 'light',
 			'chrome'       => array(),
 			'tweet-limit'  => null,
+			'dnt'          => apply_filters( 'jetpack_twitter_timeline_default_dnt', false ),
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -138,6 +138,20 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo ' data-partner="' . esc_attr( $partner ) . '"';
 		}
 
+		/**
+		 * Allow the activation of Do Not Track for the Twitter Timeline Widget.
+		 *
+		 * @see https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference.html
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param bool false Should the Twitter Timeline use the DNT attribute? Default to false.
+		 */
+		$dnt = apply_filters( 'jetpack_twitter_timeline_default_dnt', false );
+		if ( true === $dnt ) {
+			echo ' data-dnt="true"';
+		}
+
 		if ( ! empty( $instance['chrome'] ) && is_array( $instance['chrome'] ) ) {
 			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}
@@ -271,12 +285,6 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			}
 		}
 
-		if ( 'true' === $new_instance['dnt'] | 'false' === $new_instance['dnt'] ) {
-				$instance['dnt'] = $new_instance['dnt'];
-		} else {
-			$instance['dnt'] = 'true';
-		}
-
 		return $instance;
 	}
 
@@ -312,7 +320,6 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			'theme'        => 'light',
 			'chrome'       => array(),
 			'tweet-limit'  => null,
-			'dnt'          => apply_filters( 'jetpack_twitter_timeline_default_dnt', false ),
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -271,6 +271,12 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			}
 		}
 
+		if ( 'true' === $new_instance['dnt'] | 'false' === $new_instance['dnt'] ) {
+				$instance['dnt'] = $new_instance['dnt'];
+		} else {
+			$instance['dnt'] = 'true';
+		}
+
 		return $instance;
 	}
 

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -115,7 +115,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		// Start tag output
 		// This tag is transformed into the widget markup by Twitter's
 		// widgets.js code
-		echo '<a class="twitter-timeline"';
+		echo '<a class="twitter-timeline" data-dnt="true"';
 
 		$data_attribs = array(
 			'width',


### PR DESCRIPTION
Fixes #6722

#### Changes proposed in this Pull Request:

* Added option to set DoNotTrack in Twitter Timeline Widget

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

1.) Checkout the code on a test WP site.
2.) Make sure Twitter Timeline Widget is displayed in one of your active sidebars.
3.) Load the site and examine the source code to determine if the hyperlinks on Twitter Timeline Widget comes with DNT attribute.
4.) After done testing, revert the code to its previous state.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Widget: Added option to set DoNotTrack in Twitter Timeline Widget