### PR TITLE
IDC: Clear VaultPress options when in IDC and Jetpack connection cycled

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -162,6 +162,14 @@ class Jetpack_IDC {
 	 * Clears all IDC specific options. This method is used on disconnect and reconnect.
 	 */
 	static function clear_all_idc_options() {
+		// If the site is currently in IDC, let's also clear the VaultPress connection options.
+		// We have to check if the site is in IDC, otherwise we'd be clearing the VaultPress
+		// connection any time the Jetpack connection is cycled.
+		if ( Jetpack::validate_sync_error_idc_option() ) {
+			delete_option( 'vaultpress' );
+			delete_option( 'vaultpress_auto_register' );
+		}
+
 		Jetpack_Options::delete_option(
 			array(
 				'sync_error_idc',


### PR DESCRIPTION
Since VaultPress and Jetpack both rely on the URL and key being correct, and since we're already clearing out an IDC situation when the site cycles the connection, let's go ahead and cleanup the VaultPress connection options as well.

`Jetpack_IDC::clear_all_idc_options()` is currently called whenever the site connects or disconnects, so it seems like a good place to put the VaultPress options check. But, for a Jetpack IDC, to delete the IDC options, we don't care if the site is in a current IDC. If the connection is updated, we just flush. 

So, to keep from clearing out the VaultPress connection every time the Jetpack connection is cycled, this PR also adds a check to make sure the site is in an IDC before clearing out the VaultPress connection options.

To test:

- Check this PR out on a site with a Jetpack plan and ensure that VaultPress and Jetpack are connected.
- Disconnect and reconnect Jetpack and then ensure that VaultPress is still connected
- Now, put your site in an IDC, start a fresh connection in the IDC prompt, and ensure VaultPress is disconnected

How to put your site in IDC? I usually point two domains to the same site and put something like this in the `wp-config.php`:

```
define('SP_REQUEST_URL', ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST']);

define('WP_SITEURL', SP_REQUEST_URL);
define('WP_HOME', SP_REQUEST_URL);
```

Next, connect the site with one domain. Afterwards, log out of the first domain and login to the site with the second domain. After a sync request is made from the second domain, the site should be in IDC.