### PR TITLE
JPS: Do not escape translated strings since they are not echoed

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -43,7 +43,7 @@ class Jetpack_Provision { //phpcs:ignore
 		if ( Jetpack::validate_sync_error_idc_option() ) {
 			return new WP_Error(
 				'site_in_safe_mode',
-				esc_html__( 'Can not provision a plan while in safe mode. See: https://jetpack.com/support/safe-mode/', 'jetpack' )
+				__( 'Can not provision a plan while in safe mode. See: https://jetpack.com/support/safe-mode/', 'jetpack' )
 			);
 		}
 
@@ -210,7 +210,7 @@ class Jetpack_Provision { //phpcs:ignore
 				return new WP_Error(
 					'server_error',
 					/* translators: %s is an HTTP status code retured from an API request. Ex. – 400 */
-					sprintf( esc_html__( 'Request failed with code %s', 'jetpack' ), $response_code )
+					sprintf( __( 'Request failed with code %s', 'jetpack' ), $response_code )
 				);
 			}
 		}

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -139,7 +139,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new Jetpack_Error(
 					'nonce_missing',
-					esc_html__( 'The required "nonce" parameter is missing.', 'jetpack' ),
+					__( 'The required "nonce" parameter is missing.', 'jetpack' ),
 					400
 				),
 				'jpc_remote_provision_fail'
@@ -150,7 +150,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new Jetpack_Error(
 					'local_username_missing',
-					esc_html__( 'The required "local_username" parameter is missing.', 'jetpack' ),
+					__( 'The required "local_username" parameter is missing.', 'jetpack' ),
 					400
 				),
 				'jpc_remote_provision_fail'
@@ -174,7 +174,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new Jetpack_Error(
 					'invalid_nonce',
-					esc_html__( 'There was an issue validating this request.', 'jetpack' ),
+					__( 'There was an issue validating this request.', 'jetpack' ),
 					400
 				),
 				'jpc_remote_provision_fail'
@@ -190,7 +190,7 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		if ( ! $user ) {
-			return $this->error( new Jetpack_Error( 'user_unknown', 'User not found.', 404 ) );
+			return $this->error( new Jetpack_Error( 'user_unknown', __( 'User not found.', 'jetpack' ), 404 ) );
 		}
 
 		require_once JETPACK__PLUGIN_DIR . '_inc/class.jetpack-provision.php';


### PR DESCRIPTION
Since these strings are returned in an API response, and not echoed to the browser, it's not necessary that they be escaped. Escaping these strings also results in this output in the API:

> The required &quot;siteurl&quot; argument is missing.

This PR chooses to replace `esc_html__()` with `__()` for partner provisioning of plans since those strings will be returning via the API or by WP-CLI.

To test:

- Checkout PR
- Follow the docs [here](https://github.com/Automattic/jetpack/tree/master/docs/partners) to make a request to the API, ensuring that you leave off the siteurl or local_username args
- Ensure that response comes back with `"` instead of the escaped `&quot;` equivalent