### PR TITLE
Code Sync: Top Posts Widget - was divergent

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -303,10 +303,15 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			echo $args['before_title'] . $title . $args['after_title'];
 
 		if ( ! $posts ) {
+			$link = 'https://jetpack.com/support/getting-more-views-and-traffic/';
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				$link = 'http://en.support.wordpress.com/getting-more-site-traffic/';
+			}
+
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo '<p>' . sprintf(
 					__( 'There are no posts to display. <a href="%s" target="_blank">Want more traffic?</a>', 'jetpack' ),
-					'https://jetpack.com/support/getting-more-views-and-traffic/'
+					esc_url( $link )
 				) . '</p>';
 			}
 


### PR DESCRIPTION
Brings in latest changes from .com version



#### Changes proposed in this Pull Request:

* Makes the URL be either jetpack.com or wordpress.com based depending on the `IS_WPCOM` constant

#### Testing instructions:
Nothing to test. confirm the change is straightforward.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
