### PR TITLE
Privacy Settings: Update the accompanying copy.

### DIFF
--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -102,8 +102,8 @@ class Privacy extends React.Component {
 							}
 							<br />
 							{ __(
-								'Read about how Jetpack uses your data in {{pp}}Automattic Privacy Policy{{/pp}} ' +
-								'and {{js}}What Data Does Jetpack Sync{{/js}}?', {
+								'Read about how Jetpack uses your data in the {{pp}}Automattic Privacy Policy{{/pp}} ' +
+								'and our {{js}}What Data Does Jetpack Sync?{{/js}} support document.', {
 									components: {
 										pp: <ExternalLink
 												href="https://automattic.com/privacy/"


### PR DESCRIPTION
This change reflects some minor copy updates.

Details:
* Add “the” in front of “Automatic Privacy Policy”.
* Note that the “What Data Does Jetpack Sync” is a support document.
* Move the “?” character into the linked area, since it’s part of the
document’s title.

Testing:
* Go to the Privacy section in the dashboard of any Jetpack site.
* Confirm that the updated copy appears and that both links work as
before.