### PR TITLE
WordAds: Update ad calls to pass consent values to ad server

### DIFF
--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -54,9 +54,6 @@ class WordAds_Params {
 			'LangId'    => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?
 			'AdSafe'    => 1, // TODO
 		);
-
-		$this->ad_consent_required = $this->is_eu_visitor() || apply_filters( 'personalized_ads_consent_requirement', false );
-		$this->ad_consent_obtained = isset( $_COOKIE['personalized-ads-consent'] );
 	}
 
 	/**
@@ -174,74 +171,6 @@ class WordAds_Params {
 		$this->page_type_ipw = $page_type_ipw;
 		return $page_type_ipw;
 	}
-
-	/**
-	 * Get the status flag for gdpr compliance to pass to the ad server.
-	 *
-	 * @return int 1 if it's safe to use ad targeting, 2 if it's not.
-	 *
-	 * @since
-	 */
-	function get_consent_status() {
-		if (
-			( $this->ad_consent_required && $this->ad_consent_obtained )
-			|| ! $this->ad_consent_required
-		) {
-			return 1;
-		} else {
-			return 2;
-		}
-	}
-
-	function is_eu_visitor() {
-		if ( isset( $_SERVER['GEOIP_COUNTRY_CODE'] ) ) {
-			$eu_countries = array(
-				// European Member countries
-				'AT', // Austria
-				'BE', // Belgium
-				'BG', // Bulgaria
-				'CY', // Cyprus
-				'CZ', // Czech Republic
-				'DE', // Germany
-				'DK', // Denmark
-				'EE', // Estonia
-				'ES', // Spain
-				'FI', // Finland
-				'FR', // France
-				'GR', // Greece
-				'HR', // Croatia
-				'HU', // Hungary
-				'IE', // Ireland
-				'IT', // Italy
-				'LT', // Lithuania
-				'LU', // Luxembourg
-				'LV', // Latvia
-				'MT', // Malta
-				'NL', // Netherlands
-				'PL', // Poland
-				'PT', // Portugal
-				'RO', // Romania
-				'SE', // Sweden
-				'SI', // Slovenia
-				'SK', // Slovakia
-				'GB', // United Kingdom
-				// Single Market Countries that GDPR applies to
-				'CH', // Switzerland
-				'IS', // Iceland
-				'LI', // Liechtenstein
-				'NO', // Norway
-			);
-
-			if (
-				! isset( $_SERVER['GEOIP_COUNTRY_CODE'] )
-				|| ! in_array( $_SERVER['GEOIP_COUNTRY_CODE'], $eu_countries )
-			) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 
 	/**
 	 * Returns true if page is static home

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -16,8 +16,8 @@ class WordAds {
 	public $params = null;
 
 	/**
-	 * The different supported ad types.
-	 * v0.1 - mrec only for now
+	 * Array of supported ad types.
+	 *
 	 * @var array
 	 */
 	public static $ad_tag_ids = array(
@@ -45,6 +45,7 @@ class WordAds {
 
 	/**
 	 * Convenience function for grabbing options from params->options
+	 *
 	 * @param  string $option the option to grab
 	 * @param  mixed  $default (optional)
 	 * @return option or $default if not set
@@ -96,6 +97,7 @@ class WordAds {
 
 	/**
 	 * Check for Jetpack's The_Neverending_Home_Page and use got_infinity
+	 *
 	 * @return boolean true if load came from infinite scroll
 	 *
 	 * @since 4.5.0
@@ -110,9 +112,9 @@ class WordAds {
 	 * @since 4.5.0
 	 */
 	private function insert_adcode() {
-		add_action( 'wp_head', array( $this, 'insert_head_meta' ), 20 );
-		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_head',              array( $this, 'insert_head_meta' ), 20 );
+		add_action( 'wp_head',              array( $this, 'insert_head_iponweb' ), 30 );
+		add_action( 'wp_enqueue_scripts',   array( $this, 'enqueue_scripts' ) );
 
 		/**
 		 * Filters enabling ads in `the_content` filter
@@ -181,9 +183,10 @@ class WordAds {
 		$pagetype = intval( $this->params->get_page_type_ipw() );
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
 		$site_id = $this->params->blog_id;
+		$consent = intval( $this->params->get_consent_status() );
 		echo <<<HTML
 		<script$data_tags type="text/javascript">
-			var __ATA_PP = { pt: $pagetype, ht: 2, tn: '$themename', amp: false, siteid: $site_id };
+			var __ATA_PP = { pt: $pagetype, ht: 2, tn: '$themename', amp: false, siteid: $site_id, consent: $consent };
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};
@@ -319,24 +322,30 @@ HTML;
 		$snippet = '';
 		$blocker_unit = 'mrec';
 		if ( 'iponweb' == $type ) {
-			$section_id = WORDADS_API_TEST_ID;
+			// Default to mrec
 			$width = 300;
 			$height = 250;
+
+			$section_id = WORDADS_API_TEST_ID;
 			$second_belowpost = '';
 			$snippet = '';
 			if ( 'top' == $spot ) {
-				// mrec for mobile, leaderboard for desktop
-				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '2';
-				$width = $this->params->mobile_device ? 300 : 728;
-				$height = $this->params->mobile_device ? 250 : 90;
-				$blocker_unit = $this->params->mobile_device ? 'top_mrec' : 'top';
-				$snippet = $this->get_ad_snippet( $section_id, $height, $width, $blocker_unit );
+				// Switch to leaderboard on desktop
+				if ( ! $this->params->mobile_device ) {
+					$width = 728;
+					$height = 90;
+				}
+
+				$section_id     = 0 === $this->params->blog_id  ? WORDADS_API_TEST_ID   : $this->params->blog_id . '2';
+				$blocker_unit   = $this->params->mobile_device  ? 'top_mrec'            : 'top';
+				$snippet        = $this->get_ad_snippet( $section_id, $height, $width, $blocker_unit );
+
 			} else if ( 'belowpost' == $spot ) {
-				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '1';
+				$section_id     = 0 === $this->params->blog_id	? WORDADS_API_TEST_ID   : $this->params->blog_id . '1';
+				$snippet = $this->get_ad_snippet( $section_id, $height, $width, 'mrec', 'float:left;margin-right:5px;margin-top:0px;' );
 				$width = 300;
 				$height = 250;
 
-				$snippet = $this->get_ad_snippet( $section_id, $height, $width, 'mrec', 'float:left;margin-right:5px;margin-top:0px;' );
 				if ( $this->option( 'wordads_second_belowpost', true ) ) {
 					$section_id2 = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID2 : $this->params->blog_id . '4';
 					$snippet .= $this->get_ad_snippet( $section_id2, $height, $width, 'mrec2', 'float:left;margin-top:0px;' );
@@ -451,18 +460,21 @@ HTML;
 	 * @since 4.7.0
 	 */
 	public function get_house_ad( $unit = 'mrec' ) {
-		if ( ! in_array( $unit, array( 'mrec', 'widesky', 'leaderboard' ) ) ) {
-			$unit = 'mrec';
-		}
 
-		$width  = 300;
-		$height = 250;
-		if ( 'widesky' == $unit ) {
-			$width  = 160;
-			$height = 600;
-		} else if ( 'leaderboard' == $unit ) {
-			$width  = 728;
-			$height = 90;
+		switch ( $unit ) {
+			case 'widesky':
+				$width  = 160;
+				$height = 600;
+				break;
+			case 'leaderboard':
+				$width  = 728;
+				$height = 90;
+				break;
+			case 'mrec':
+			default:
+				$width  = 300;
+				$height = 250;
+				break;
 		}
 
 		return <<<HTML

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -183,7 +183,7 @@ class WordAds {
 		$pagetype = intval( $this->params->get_page_type_ipw() );
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
 		$site_id = $this->params->blog_id;
-		$consent = intval( $this->params->get_consent_status() );
+		$consent = isset( $_COOKIE['personalized-ads-consent'] );
 		echo <<<HTML
 		<script$data_tags type="text/javascript">
 			var __ATA_PP = { pt: $pagetype, ht: 2, tn: '$themename', amp: false, siteid: $site_id, consent: $consent };


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds detection for EU users and passes cookie consent data (acquired via #9373) to the ad server. This will notify the ad server whether targeted advertising is allowed for the current visitor.
  * The intended behavior is that the ad server defaults to serving non-targeted (generic) ads to all users located in the EU until there is a consent cookie present (proposed in #9373).
* Adds a `personalized_ads_consent_requirement` filter, allowing site owners to extend the non-targeted ads default to users outside the EU.

#### Testing instructions:

* Apply the patch on a site using Jetpack Ads. Inspect the ad code and make sure the `consent` flag has been added.