### PR TITLE
Docker: hide installed site from search engines

### DIFF
--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -18,6 +18,10 @@ wp --allow-root core install \
 	--admin_email=${WP_ADMIN_EMAIL} \
 	--skip-email
 
+# Set the site hidden from search engines
+# https://codex.wordpress.org/Option_Reference#Privacy
+wp --allow-root option update blog_public 0
+
 # Install Query Monitor plugin
 # https://wordpress.org/plugins/query-monitor/
 wp --allow-root plugin install query-monitor --activate


### PR DESCRIPTION
Hide WordPress site from search engines during install.

_"Block search engines, but allow normal visitors"_ seems like a sensible default for development sites.

https://codex.wordpress.org/Option_Reference#Privacy
