### PR TITLE
General: Remove unneeded function jetpack_get_user_local now that it duplicates get_user_locale behaviour since WordPress 4.7

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -149,7 +149,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function get_i18n_data() {
 
-		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . jetpack_get_user_locale() . '.json';
+		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_user_locale() . '.json';
 
 		if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
 			$locale_data = @file_get_contents( $i18n_json );
@@ -312,7 +312,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 			),
 			'locale' => $this->get_i18n_data(),
-			'localeSlug' => join( '-', explode( '_', jetpack_get_user_locale() ) ),
+			'localeSlug' => join( '-', explode( '_', get_user_locale() ) ),
 			'jetpackStateNotices' => array(
 				'messageCode' => Jetpack::state( 'message' ),
 				'errorCode' => Jetpack::state( 'error' ),
@@ -413,22 +413,3 @@ function jetpack_current_user_data() {
 	return $current_user_data;
 }
 
-/**
- * Set the admin language, based on user language.
- *
- * @since 4.5.0
- *
- * @return string
- *
- * @todo Remove this function when WordPress 4.8 is released
- * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
- */
-function jetpack_get_user_locale() {
-	$locale = get_locale();
-
-	if ( function_exists( 'get_user_locale' ) ) {
-		$locale = get_user_locale();
-	}
-
-	return $locale;
-}

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -597,7 +597,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 	
 	public function get_user_locale( $user_id ) {
-		return jetpack_get_user_locale( $user_id );
+		return get_user_locale( $user_id );
 	}
 
 	public function get_allowed_mime_types( $user_id ) {


### PR DESCRIPTION

Fixes a TO-DO comment present in the removed code.

```
- * @todo Remove this function when WordPress 4.8 is released
- * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
```
#### Changes proposed in this Pull Request:

* Removes the `jetpack_get_user_locale()` function an replaces all usages for `get_user_locale()`.

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

None needed
