### PR TITLE
Jetpack Sync: remove recursion from checksum call

### DIFF
--- a/functions.global.php
+++ b/functions.global.php
@@ -182,7 +182,7 @@ function jetpack_json_wrap( &$any, $seen_nodes = array() ) {
 				if ( in_array( $v, $seen_nodes, true ) ) {
 					continue;
 				}
-				$return[ $k ] = $this->json_wrap( $v, $seen_nodes );
+				$return[ $k ] = jetpack_json_wrap( $v, $seen_nodes );
 			} else {
 				$return[ $k ] = $v;
 			}

--- a/functions.global.php
+++ b/functions.global.php
@@ -152,3 +152,44 @@ function jetpack_upgrader_pre_download( $reply ) {
 }
 
 add_filter( 'upgrader_pre_download', 'jetpack_upgrader_pre_download' );
+
+
+/**
+ * Wraps data in a way so that we can distinguish between objects and array and also prevent object recursion.
+ *
+ * @since 6.1.0
+ *
+ * @param $any
+ * @param array $seen_nodes
+ *
+ * @return array
+ */
+function jetpack_json_wrap( &$any, $seen_nodes = array() ) {
+	if ( is_object( $any ) ) {
+		$input = get_object_vars( $any );
+		$input['__o'] = 1;
+	} else {
+		$input = &$any;
+	}
+
+	if ( is_array( $input ) ) {
+		$seen_nodes[] = &$any;
+
+		$return = array();
+
+		foreach ( $input as $k => &$v ) {
+			if ( ( is_array( $v ) || is_object( $v ) ) ) {
+				if ( in_array( $v, $seen_nodes, true ) ) {
+					continue;
+				}
+				$return[ $k ] = $this->json_wrap( $v, $seen_nodes );
+			} else {
+				$return[ $k ] = $v;
+			}
+		}
+
+		return $return;
+	}
+
+	return $any;
+}

--- a/sync/class.jetpack-sync-json-deflate-array-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-array-codec.php
@@ -8,11 +8,11 @@ require_once dirname( __FILE__ ) . '/interface.jetpack-sync-codec.php';
  */
 class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 	const CODEC_NAME = "deflate-json-array";
-	
+
 	public function name() {
 		return self::CODEC_NAME;
 	}
-	
+
 	public function encode( $object ) {
 		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) );
 	}
@@ -23,7 +23,7 @@ class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 
 	// @see https://gist.github.com/muhqu/820694
 	private function json_serialize( $any ) {
-		return wp_json_encode( $this->json_wrap( $any ) );
+		return wp_json_encode( jetpack_json_wrap( $any ) );
 	}
 
 	private function json_unserialize( $str ) {
@@ -47,10 +47,10 @@ class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 				if ( ( is_array( $v ) || is_object( $v ) ) ) {
 					if ( in_array( $v, $seen_nodes, true ) ) {
 						continue;
-					} 
+					}
 					$return[ $k ] = $this->json_wrap( $v, $seen_nodes );
 				} else {
-					$return[ $k ] = $v;	
+					$return[ $k ] = $v;
 				}
 			}
 

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -47,36 +47,7 @@ abstract class Jetpack_Sync_Module {
 	}
 
 	protected function get_check_sum( $values ) {
-		return crc32( wp_json_encode( $this->json_encode( $values ) ) );
-	}
-
-	private function json_encode( &$any, $seen_nodes = array() ) {
-		if ( is_object( $any ) ) {
-			$input = get_object_vars( $any );
-		} else {
-			$input = &$any;
-		}
-
-		if ( is_array( $input ) ) {
-			$seen_nodes[] = &$any;
-
-			$return = array();
-
-			foreach ( $input as $k => &$v ) {
-				if ( ( is_array( $v ) || is_object( $v ) ) ) {
-					if ( in_array( $v, $seen_nodes, true ) ) {
-						continue;
-					}
-					$return[ $k ] = $this->json_encode( $v, $seen_nodes );
-				} else {
-					$return[ $k ] = $v;
-				}
-			}
-
-			return $return;
-		}
-
-		return $any;
+		return crc32( wp_json_encode( jetpack_json_wrap( $values ) ) );
 	}
 
 	protected function still_valid_checksum( $sums_to_check, $name, $new_sum ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -27,7 +27,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_white_listed_function_is_synced() {
-
 		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
 
 		$this->sender->do_sync();
@@ -963,6 +962,22 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		update_option( 'gmt_offset', '-1' );
 		$this->assertEquals( 'UTC-1', Jetpack_Sync_Functions::get_timezone() );
 	}
+
+	public function test_sync_callable_recursive_gets_checksum() {
+
+		$this->callable_module->set_callable_whitelist( array( 'jetpack_banana' => 'jetpack_recursive_banana' ) );
+		$this->sender->do_sync();
+		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_banana' );
+		$this->assertTrue( ! empty( $synced_value ), 'We couldn\'t synced a value!' );
+	}
+
+}
+
+function jetpack_recursive_banana() {
+	$banana = new StdClass;
+	$banana->arr = array();
+	$banana->arr[] = $banana;
+	return $banana;
 }
 
 function jetpack_foo_is_callable_random() {


### PR DESCRIPTION
Lets add recusion proteccion to our get_checksum call.

Fixes #7501

#### Changes proposed in this Pull Request:
* We removed most of the calls functions that return in whole objects ( get_post_types ) so this shouldn't in theory be needed. 

#### Testing instructions:
Do the tests pass?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: