### PR TITLE
Dev Mode: Force bool on is_development_mode

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1571,7 +1571,8 @@ class Jetpack {
 		 *
 		 * @param bool $development_mode Is Jetpack's development mode active.
 		 */
-		return apply_filters( 'jetpack_development_mode', $development_mode );
+		$development_mode = ( bool ) apply_filters( 'jetpack_development_mode', $development_mode );
+		return $development_mode;
 	}
 
 	/**

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -496,6 +496,12 @@ EXPECTED;
 		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
 
+	function test_is_development_mode_bool() {
+		add_filter( 'jetpack_development_mode', '__return_zero' );
+		$this->assertFalse( Jetpack::is_development_mode() );
+		remove_filter( 'jetpack_development_mode', '__return_zero' );
+	}
+
 	function test_get_sync_idc_option_sanitizes_out_www_and_protocol() {
 		$original_home    = get_option( 'home' );
 		$original_siteurl = get_option( 'siteurl' );


### PR DESCRIPTION
As reported in p73hgi-JQ-p2 , if a non-bool falsely response is returned from `is_development_mode`, Calypso will output it.

When writing `is_development_mode` the expectation was a bool response, so let's force that to prevent unintended usage of the constant/filter.