### PR TITLE
Comments: Fix counts endpoint's response format

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
@@ -17,15 +17,13 @@ new WPCOM_JSON_API_GET_Comment_Counts_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comment-counts',
 
 	'response_format' => array(
-		'comment_counts' => array(
-			'all'            => '(int) Combined number of approved and unapproved comments',
-			'approved'       => '(int) Number of approved comments',
-			'pending'        => '(int) Number of unapproved comments',
-			'trash'          => '(int) Number of trash comments',
-			'spam'           => '(int) Number of spam comments',
-			'post_trashed'   => '(int) Number of comments whose parent post has been trashed',
-			'total_comments' => '(int) Combined number of comments in each category',
-		)
+		'all'            => '(int) Combined number of approved and unapproved comments',
+		'approved'       => '(int) Number of approved comments',
+		'pending'        => '(int) Number of unapproved comments',
+		'trash'          => '(int) Number of trash comments',
+		'spam'           => '(int) Number of spam comments',
+		'post_trashed'   => '(int) Number of comments whose parent post has been trashed',
+		'total_comments' => '(int) Combined number of comments in each category',
 	)
 ) );
 


### PR DESCRIPTION
The response is a "bare" object - no nesting.

This also brings the code inline with the code running on WordPress.com.

Example response:

```
{
 "all": 0,
 "approved": 0,
 "pending": 0,
 "trash": 0,
 "spam": 0,
 "post_trashed": 4,
 "total_comments": 0
}
```
#### Testing instructions:

1. `curl --dump-header /dev/stderr -H "Authorization: Bearer $YOUR_BEARER_TOKEN" "https://public-api.wordpress.com/rest/v1/sites/$YOUR_SITE_ID/comment-counts?pretty=1"`
2. Verify the output doesn't change between patched and unpatched :)

Because of how the `response_format` is used in Jetpack code, there should be no change in behavior.