### PR TITLE
Widgets: Gravatar Profile - Remove trailing comma from last function call parameter in Gravatar Profile Widget

### DIFF
--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -352,7 +352,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			$expire = 300;
 			$response = wp_remote_get(
 				esc_url_raw( $profile_url ),
-				array( 'User-Agent' => 'WordPress.com Gravatar Profile Widget' ),
+				array( 'User-Agent' => 'WordPress.com Gravatar Profile Widget' )
 			);
 			$response_code = wp_remote_retrieve_response_code( $response );
 			if ( 200 == $response_code ) {


### PR DESCRIPTION

Fixes A small syntax thing that was introduced in #8976. 


#### Changes proposed in this Pull Request:

* Removes trailing comman from line 355 of `modules/widgets/gravatar-profile.php`.

#### Testing instructions:

* A site with current master and should be WSODing right now.
* Checkout this branch.
* Confirm that this fix brings it back.
