### PR TITLE
Don't set data-* attributes if the ID in the HTML isn't for an attachment on this site.

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -398,6 +398,10 @@ class Jetpack_Carousel {
 
 	function add_data_to_images( $attr, $attachment = null ) {
 		$attachment_id   = intval( $attachment->ID );
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+			return $attr;
+		}
+
 		$orig_file       = wp_get_attachment_image_src( $attachment_id, 'full' );
 		$orig_file       = isset( $orig_file[0] ) ? $orig_file[0] : wp_get_attachment_url( $attachment_id );
 		$meta            = wp_get_attachment_metadata( $attachment_id );


### PR DESCRIPTION
If we set data-* attributes from a different ID we end up setting them with random incorrect data, and break new post notifications.

Test Plan: Make sure we still get the data- when we expect it

Reviewers: georgestephanis, dereksmart

Reviewed By: dereksmart

Differential Revision: D11942-code

This commit syncs r174008-wpcom.