### PR TITLE
WordAds: Return WordAds module status through SAL

### DIFF
--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -101,8 +101,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function has_wordads() {
-		// TODO: any way to detect wordads on the site, or does it need to be modified on the way through?
-		return false;
+		return Jetpack::is_module_active( 'wordads' );
 	}
 
 	function get_frame_nonce() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update the SAL to return the current WordAds module status (instead of returning false).