### PR TITLE
Fix user currency

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -374,33 +374,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	public static function get_plans( $request ) {
-		/**
-		 * Filter to turn off caching of Jetpack plans
-		 *
-		 * @since 5.9.0
-		 *
-		 * @param bool true Whether to cache Jetpack plans locally
-		 */
-		$use_cache = apply_filters( 'jetpack_cache_plans', true );
+		$request = Jetpack_Client::wpcom_json_api_request_as_user(
+			'/plans?_locale=' . get_user_locale(),
+			'2',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			)
+		);
 
-		$data = $use_cache ? get_transient( 'jetpack_plans' ) : false;
-
-		if ( false === $data ) {
-			$path = '/plans?_locale=' . get_user_locale();
-			// passing along from client to help geolocate currency
-			$ip = Jetpack::current_user_ip( true );
-			$request = Jetpack_Client::wpcom_json_api_request_as_blog( $path, '2', array( 'headers' => array( 'X-Forwarded-For' => $ip ) ), null, 'wpcom' );
-			$body = wp_remote_retrieve_body( $request );
-			if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
-				$data = $body;
-			} else {
-				// something went wrong so we'll just return the response without caching
-				return $body;
-			}
-
-			if ( true === $use_cache ) {
-				set_transient( 'jetpack_plans', $data, DAY_IN_SECONDS );
-			}
+		$body = wp_remote_retrieve_body( $request );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			$data = $body;
+		} else {
+			// something went wrong so we'll just return the response without caching
+			return $body;
 		}
 
 		return $data;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6568,6 +6568,7 @@ p {
 			'jetpack_holiday_snow_option_updated'                    => null,
 			'jetpack_holiday_snowing'                                => null,
 			'jetpack_sso_auth_cookie_expirtation'                    => 'jetpack_sso_auth_cookie_expiration',
+			'jetpack_cache_plans'                                    => null,
 		);
 
 		// This is a silly loop depth. Better way?


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/9169

This PR changes how we retrieve the plans tab info, so it has the connected WordPress.com user into account when dealing with localization. Up to this point, we were trying to use IP geolocalization and it wasn't working so well.

It also removes the plans info caching: If the user changed their WordPress language, we were still showing the cached plans info in the previous language.

How to test:
=========

1. go to your Jetpack dashboard and click on plans
2. You should get the plans' prices in the same currency your connected wpcom user gets the prices in the wpcom store
3. Change your WordPress language 
4. Go back to your jetpack dashboard and select 'plans' ... you should get the plans info in the new language.