### PR TITLE
Register personal data exporter & eraser for feedback (i.e., contact form submissions)

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -742,7 +742,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data exporter.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  array $exporters An array of personal data exporters.
 	 *
@@ -760,7 +760,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Registers the personal data eraser.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  array $erasers An array of personal data erasers.
 	 *
@@ -778,7 +778,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Exports personal data.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  string $email  Email address.
 	 * @param  int    $page   Page to export.
@@ -835,7 +835,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Erases personal data.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  string $email Email address.
 	 * @param  int    $page  Page to erase.
@@ -873,7 +873,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Queries personal data by email address.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  string $email    Email address.
 	 * @param  int    $per_page Post IDs per page. Default is `250`.
@@ -904,7 +904,7 @@ class Grunion_Contact_Form_Plugin {
 	/**
 	 * Filters searches by email address.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param  string $search SQL where clause.
 	 *

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -136,6 +136,10 @@ class Grunion_Contact_Form_Plugin {
 		add_action( 'wp_ajax_grunion-contact-form', array( $this, 'ajax_request' ) );
 		add_action( 'wp_ajax_nopriv_grunion-contact-form', array( $this, 'ajax_request' ) );
 
+		// GDPR: personal data exporter & eraser.
+		add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_personal_data_exporter' ) );
+		add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_personal_data_eraser' ) );
+
 		// Export to CSV feature
 		if ( is_admin() ) {
 			add_action( 'admin_init',            array( $this, 'download_feedback_as_csv' ) );
@@ -735,6 +739,195 @@ class Grunion_Contact_Form_Plugin {
 		return $mapped_fields;
 	}
 
+	/**
+	 * Registers the personal data exporter.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  array $exporters An array of personal data exporters.
+	 *
+	 * @return array $exporters An array of personal data exporters.
+	 */
+	public function register_personal_data_exporter( $exporters ) {
+		$exporters[] = array(
+			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
+			'callback'               => array( $this, 'personal_data_exporter' ),
+		);
+
+		return $exporters;
+	}
+
+	/**
+	 * Registers the personal data eraser.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  array $erasers An array of personal data erasers.
+	 *
+	 * @return array $erasers An array of personal data erasers.
+	 */
+	public function register_personal_data_eraser( $erasers ) {
+		$erasers[] = array(
+			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
+			'callback'             => array( $this, 'personal_data_eraser' ),
+		);
+
+		return $erasers;
+	}
+
+	/**
+	 * Exports personal data.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  string $email  Email address.
+	 * @param  int    $page   Page to export.
+	 *
+	 * @return array  $return Associative array with keys expected by core.
+	 */
+	public function personal_data_exporter( $email, $page = 1 ) {
+		$per_page    = 250;
+		$export_data = array();
+		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
+
+		foreach ( $post_ids as $post_id ) {
+			$post_fields = $this->get_parsed_field_contents_of_post( $post_id );
+
+			if ( ! is_array( $post_fields ) || empty( $post_fields['_feedback_subject'] ) ) {
+				continue; // Corrupt data.
+			}
+
+			$post_fields['_feedback_main_comment'] = $this->get_post_content_for_csv_export( $post_id );
+			$post_fields                           = $this->map_parsed_field_contents_of_post_to_field_names( $post_fields );
+
+			if ( ! is_array( $post_fields ) || empty( $post_fields ) ) {
+				continue; // No fields to export.
+			}
+
+			$post_meta   = $this->get_post_meta_for_csv_export( $post_id );
+			$post_meta   = is_array( $post_meta ) ? $post_meta : array();
+
+			$post_export_data = array();
+			$post_data        = array_merge( $post_fields, $post_meta );
+			ksort( $post_data );
+
+			foreach ( $post_data as $post_data_key => $post_data_value ) {
+				$post_export_data[] = array(
+					'name'  => preg_replace( '/^[0-9]+_/', '', $post_data_key ),
+					'value' => $post_data_value,
+				);
+			}
+
+			$export_data[] = array(
+				'group_id'    => 'feedback',
+				'group_label' => __( 'Feedback', 'jetpack' ),
+				'item_id'     => 'feedback-' . $post_id,
+				'data'        => $post_export_data,
+			);
+		}
+
+		return array(
+			'data' => $export_data,
+			'done' => count( $post_ids ) < $per_page,
+		);
+	}
+
+	/**
+	 * Erases personal data.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  string $email Email address.
+	 * @param  int    $page  Page to erase.
+	 *
+	 * @return array         Associative array with keys expected by core.
+	 */
+	public function personal_data_eraser( $email, $page = 1 ) {
+		$per_page = 250;
+		$removed  = 0;
+		$retained = 0;
+		$messages = array();
+		$post_ids = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
+
+		foreach ( $post_ids as $post_id ) {
+			if ( wp_delete_post( $post_id, true ) ) {
+				$removed++;
+			} else {
+				$retained++;
+				$messages[] = sprintf(
+					// translators: %d: Post ID.
+					__( 'Feedback ID %d could not be removed at this time.', 'jetpack' ),
+					$post_id
+				);
+			}
+		}
+
+		return array(
+			'num_items_removed'  => $removed,
+			'num_items_retained' => $retained,
+			'messages'           => $messages,
+			'done'               => count( $post_ids ) < $per_page,
+		);
+	}
+
+	/**
+	 * Queries personal data by email address.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  string $email    Email address.
+	 * @param  int    $per_page Post IDs per page. Default is `250`.
+	 * @param  int    $page     Page to query. Default is `1`.
+	 *
+	 * @return array            An array of post IDs.
+	 */
+	public function personal_data_post_ids_by_email( $email, $per_page = 250, $page = 1 ) {
+		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
+
+		$post_ids = get_posts( array(
+			'post_type'        => 'feedback',
+			'post_status'      => 'publish',
+			's'                => 'AUTHOR EMAIL: ' . $email,
+			'sentence'         => true,
+			'order'            => 'ASC',
+			'fields'           => 'ids',
+			'posts_per_page'   => $per_page,
+			'paged'            => $page,
+			'suppress_filters' => false,
+		) );
+
+		remove_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
+
+		return $post_ids;
+	}
+
+	/**
+	 * Filters searches by email address.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param  string $search SQL where clause.
+	 *
+	 * @return array          Filtered SQL where clause.
+	 */
+	public function personal_data_search_filter( $search ) {
+		global $wpdb;
+
+		/*
+		 * Limits search to `post_content` only, and we only match the
+		 * author's email address whenever it's on a line by itself.
+		 * `CHAR(13)` = `\r`, `CHAR(10)` = `\n`
+		 */
+		if ( preg_match( '/AUTHOR EMAIL\: ([^{\s]+)/', $search, $m ) ) {
+			$esc_like_email = esc_sql( $wpdb->esc_like( 'AUTHOR EMAIL: ' . $m[1] ) );
+			$search         = " AND (
+				{$wpdb->posts}.post_content LIKE CONCAT('%', CHAR(13), '{$esc_like_email}', CHAR(13), '%')
+				OR {$wpdb->posts}.post_content LIKE CONCAT('%', CHAR(10), '{$esc_like_email}', CHAR(10), '%')
+			)";
+		}
+
+		return $search;
+	}
 
 	/**
 	 * Prepares feedback post data for CSV export.


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/8799

Uses upcoming changes in core:
- https://core.trac.wordpress.org/ticket/43546
- https://core.trac.wordpress.org/ticket/43438
- https://core.trac.wordpress.org/ticket/43440

#### Changes proposed in this Pull Request:

* Registers and implements a core data exporter.
* Registers and implements a core data eraser.
* Adds unit tests for the exporter and eraser.

#### Does this work in current versions of WordPress?

Not yet, but it attaches through filters, so in current versions of WordPress it's simply not enabled, because the filters do not exist yet. To clarify further, this works with [upcoming tools in core](https://core.trac.wordpress.org/ticket/43546) that allow site owners to export personal data and/or remove personal data by email address.

#### Testing instructions:

* I suggest testing with [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV) using `wordpress-develop`, which already has some of the above patches. Just add: https://core.trac.wordpress.org/attachment/ticket/43546/43546.5.diff (e.g., `patch -p0 43546.5.diff`

* Enable Jetpack Contact Forms.
* Create a page and add a Jetpack Contact Form.
* Submit the form a couple of times with a test email address.
* Then test both of these upcoming tools in core.
  - Export Personal Data
  - Remove Personal Data

  ![2018-04-23_12-02-57](https://user-images.githubusercontent.com/1563559/39150338-7c4bd890-46ee-11e8-8517-474bf553c6b2.png)

You should find that exporting personal data includes a "Feedback" group containing the personal data that you submitted with the test email address. Removing personal data should remove the Feedback posts associated with the test email address.

#### Proposed changelog entry for your changes:

* GDPR: Adds Feedback data (i.e., Contact Form Submissions) to the Personal Data exported and/or erased by the latest version of WordPress core.