### PR TITLE
Jetpack Sync: setup_post instead of overwritting the global post object

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -246,7 +246,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	// Expands wp_insert_post to include filtered content
 	function filter_post_content_and_add_links( $post_object ) {
-		global $post;
+		setup_postdata( $post_object );
 		$post = $post_object;
 
 		// return non existant post


### PR DESCRIPTION
Summary:
This was done so that the core tests pass as expected on .com.
The code will still need to be updated on the Jetpack side.

Test Plan: Do the tests pass?

Reviewers: migueluy, jollycoder

Reviewed By: jollycoder

Differential Revision: D12211-code

This commit syncs r174037-wpcom.