### PR TITLE
Contact form: Fix undefined variables.

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -244,7 +244,7 @@ add_filter( 'views_edit-feedback', 'grunion_admin_view_tabs' );
 function grunion_admin_view_tabs( $views ) {
 	global $current_screen;
 	if ( 'edit-feedback' != $current_screen->id )
-		return $actions;
+		return $views;
 
 	unset( $views['publish'] );
 
@@ -873,7 +873,7 @@ function grunion_recheck_queue() {
 		if ( $is_spam ) {
 			wp_update_post( array( 'ID' => $feedback->ID, 'post_status' => 'spam' ) );
 			/** This action is already documented in modules/contact-form/admin.php */
-			do_action( 'contact_form_akismet', 'spam', $akismet_values );
+			do_action( 'contact_form_akismet', 'spam', $meta );
 		}
 	}
 


### PR DESCRIPTION
Hi  @georgestephanis ,

Could you use this PR which fixes #8796 ?

#### Changes proposed in this Pull Request:

* Return` $views` instead of `$actions`, taking as an example` grunion_admin_bulk_actions()`
* Use `$meta` which is defined and contains akismet data, instead of `$akismet_values` which does not, taking as an example `grunion_ajax_spam()` and `grunion_handle_bulk_spam()`

I'm not sure if the variable name should be renamed as `$akismet_values` instead of meta, which may not fit well. Thanks, any feedback is gladly appreciated