### PR TITLE
Comic Custom Post Type: remove omnisearch

### DIFF
--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -47,10 +47,6 @@ class Jetpack_Comic {
 		// post type needs to be registered no matter what, but none of the UI needs to be
 		// available.
 
-		// Enable Omnisearch for Comic posts.
-		if ( class_exists( 'Jetpack_Omnisearch_Posts' ) )
-			new Jetpack_Omnisearch_Posts( self::POST_TYPE );
-
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
 
 		if ( function_exists( 'queue_publish_post' ) ) {


### PR DESCRIPTION
Fixes #7590

#### Changes proposed in this Pull Request:

* Syncs r174050-wpcom by removing Omnisearch from comic custom post type 

