### PR TITLE
WordAds: rename tracks event to use underscores over hyphens

### DIFF
--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -32,7 +32,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 	};
 
 	trackConfigureWidgetClick = () => {
-		analytics.tracks.recordJetpackClick( 'place-ad-widget' );
+		analytics.tracks.recordJetpackClick( 'place_ad_widget' );
 	}
 
 	handleChange = setting => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/9310#discussion_r183578279

#### Changes proposed in this Pull Request:

* Switch tracks event to use underscores instead of hyphens.
Tracks event was added in https://github.com/Automattic/jetpack/pull/9310 (6.1)