### PR TITLE
Admin Page: pass object instead of string to SettingsGroup component for custom content-types settings

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -61,12 +61,21 @@ export class CustomContentTypes extends React.Component {
 				{ ...this.props }
 				module="custom-content-types"
 				hideButton>
-				<SettingsGroup hasChild module={ module } support={ module.learn_more_button }>
+				<SettingsGroup
+					hasChild
+					module={ module }
+					support={ {
+						text: __( 'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+							'and display testimonials on your site.' ),
+						link: 'https://jetpack.com/support/custom-content-types/',
+					} }
+					>
 					<CompactFormToggle
-								checked={ this.state.testimonial }
-								disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) || disabledByOverride }
-								onChange={ this.handleTestimonialToggleChange }
-								disabledReason={ disabledReason }>
+						checked={ this.state.testimonial }
+						disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) || disabledByOverride }
+						onChange={ this.handleTestimonialToggleChange }
+						disabledReason={ disabledReason }
+						>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Testimonials' )
@@ -86,11 +95,21 @@ export class CustomContentTypes extends React.Component {
 							}
 						</p>
 					</FormFieldset>
+				</SettingsGroup>
+				<SettingsGroup
+					hasChild
+					module={ module }
+					support={ {
+						text: __( 'Adds the Portfolio custom post type, allowing you to manage and showcase projects on your site.' ),
+						link: 'https://jetpack.com/support/custom-content-types/',
+					} }
+					>
 					<CompactFormToggle
-								checked={ this.state.portfolio }
-								disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) || disabledByOverride }
-								onChange={ this.handlePortfolioToggleChange }
-								disabledReason={ disabledReason }>
+						checked={ this.state.portfolio }
+						disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) || disabledByOverride }
+						onChange={ this.handlePortfolioToggleChange }
+						disabledReason={ disabledReason }
+						>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Portfolios' )


### PR DESCRIPTION
Fixes PropTypes  warning: ` Invalid prop `support` of type `string` supplied to `SettingsGroup`, expected `object`.`

#### Changes proposed in this Pull Request:

* Reverts a consequence of merging #8934 which stepped over changes introduced by #9137

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Check this branch
* Build admin page
* Visit Settings.
* Confirm no red warning is shown.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
