### PR TITLE
Fusion: responsive-videos.php

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -20,6 +20,9 @@ function jetpack_responsive_videos_init() {
 
 	/* Wrap videos in Buddypress */
 	add_filter( 'bp_embed_oembed_html', 'jetpack_responsive_videos_embed_html' );
+
+    /* Wrap Slideshare shortcodes */
+    add_filter( 'jetpack_slideshare_shortcode', 'jetpack_responsive_videos_embed_html' );
 }
 add_action( 'after_setup_theme', 'jetpack_responsive_videos_init', 99 );
 
@@ -46,9 +49,9 @@ function jetpack_responsive_videos_embed_html( $html ) {
 	}
 
 	if ( defined( 'SCRIPT_DEBUG' ) && true == SCRIPT_DEBUG ) {
-		wp_enqueue_script( 'jetpack-responsive-videos-script', plugins_url( 'responsive-videos/responsive-videos.js', __FILE__ ), array( 'jquery' ), '1.2', true );
+		wp_enqueue_script( 'jetpack-responsive-videos-script', plugins_url( 'responsive-videos/responsive-videos.js', __FILE__ ), array( 'jquery' ), '1.3', true );
 	} else {
-		wp_enqueue_script( 'jetpack-responsive-videos-min-script', plugins_url( 'responsive-videos/responsive-videos.min.js', __FILE__ ), array( 'jquery' ), '1.2', true );
+		wp_enqueue_script( 'jetpack-responsive-videos-min-script', plugins_url( 'responsive-videos/responsive-videos.min.js', __FILE__ ), array( 'jquery' ), '1.3', true );
 	}
 
 	// Enqueue CSS to ensure compatibility with all themes
@@ -58,11 +61,11 @@ function jetpack_responsive_videos_embed_html( $html ) {
 }
 
 /**
- * Check if oEmbed is a `$video_patterns` provider video before wrapping.
+ * Check if oEmbed is YouTube or Vimeo before wrapping..
  *
  * @return string
  */
-function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url = null ) {
+function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 		return $html;
 	}


### PR DESCRIPTION
This PR updates Jetpack to match WPCOM side with following changes:

- Slideshare shortcodes are wrapped as a responsive video embed.
- `responsive-videos.js` version bumped from `1.2` to `1.3`.

## Test Plan

- Test responsive video embedding in general
- Test Slideshare shortcode
