### PR TITLE
DashItem - fixes count to wrap when numbers are too long or on smaller screen sizes

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -50,11 +50,14 @@
 	@include breakpoint( "<660px" ) {
 		font-size: rem( 23px );
 	}
+
+	+ .jp-dash-item__description {
+		max-width: 61%;
+	}
 }
 
 .jp-dash-item__description {
 	margin: 0;
-	max-width: 61%;
 	font-size: rem( 14px );
 }
 

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -22,22 +22,27 @@
 	}
 }
 
+.jp-dash-item__content {
+	flex-grow: 1;
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .jp-dash-item__card {
 	margin: 0;
 }
 
 .jp-dash-item__count {
 	margin-top: 0;
-	margin-bottom: 0;
+	margin-bottom: 6px;
 	margin-right: 8px;
 	color: $blue-medium;
 	font-weight: 500;
 	font-size: rem( 32px );
-	display: inline;
+	display: inline-block;
 	border: 1px solid $dashboard-number-border;
 	border-radius: 4px;
 	padding: 0px 4px;
-	float: left;
 	min-width: 36px;
 	text-align: center;
 
@@ -48,7 +53,7 @@
 
 .jp-dash-item__description {
 	margin: 0;
-	width: 90%; // Room for support info icon on right.
+	max-width: 60%;
 	font-size: rem( 14px );
 }
 

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -26,6 +26,7 @@
 	flex-grow: 1;
 	display: flex;
 	flex-wrap: wrap;
+	align-items: flex-start;
 }
 
 .jp-dash-item__card {
@@ -53,7 +54,7 @@
 
 .jp-dash-item__description {
 	margin: 0;
-	max-width: 60%;
+	max-width: 61%;
 	font-size: rem( 14px );
 }
 


### PR DESCRIPTION
@rickybanister this is about the best I can do here. If we want this to look good on all screen sizes, we'll need to stack the number like before. With this rendition the label is capped at 60% width and will wrap when the number is too big. It's not ideal, but I'm not sure what else to do. This might look not great on tiny screens. Let me know what you think.

#### Before
![image](https://user-images.githubusercontent.com/1123119/39217971-859476ea-47df-11e8-978a-7f247cfc39a3.png)
![image](https://user-images.githubusercontent.com/1123119/39218033-c0ee2128-47df-11e8-902f-541267086e30.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/39217878-2715d438-47df-11e8-8a64-aa46a14263a8.png)

![image](https://user-images.githubusercontent.com/1123119/39217896-36998d00-47df-11e8-9e7a-d80585a25a58.png)
