### PR TITLE
General: Fix error when jetpack_active_plan is empty

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1472,6 +1472,9 @@ class Jetpack {
 				'product_slug' => 'jetpack_free',
 				'supports'     => array(),
 				'class'        => 'free',
+				'features'     => array(
+					'active' => array()
+				),
 			) );
 		}
 


### PR DESCRIPTION

Fixes error on fresh sites when plan data is not loaded yet on the site

#### Changes proposed in this Pull Request:

* Adds the keys `feature` and `[feature][active]` to the boilerplate array returned by `Jetpack::get_active_plan()`

#### Testing instructions:

* Start with a fresh site and before connecting Jetpack:
  * Enable `WP_DEBUG` and `WP_DEBUG_LOG` so you can make sure you see errors being logged if any.
* Connect Jetpack and get a paid plan
* When getting back to the wp-admin of your site, check the `debug.log` file and confirm you don't see an error coming from line `1552` of `class.jetpack.php` 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
