### PR TITLE
General: SVN-ignore some files we do not ship

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -37,3 +37,7 @@ _inc/build/maps
 .codeclimate.yml
 yarn.lock
 docker
+bin/pre-commit-hook.js
+bin/travis_install.sh
+fusion
+yarn-error.log


### PR DESCRIPTION
This PR adds some files to svnignore so they're not shown when running `svn status` after running the tools for publishing a release.

#### Changes proposed in this Pull Request:

* Adds the following paths to `.svnignore`:

```
bin/pre-commit-hook.js
bin/travis_install.sh
fusion
yarn-error.log
```


#### Testing instructions

Just double check that these files are not needed in the final bundle.