### PR TITLE
Fixed missing expected plan properties.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1460,23 +1460,20 @@ class Jetpack {
 		global $active_plan_cache;
 
 		// this can be expensive to compute so we cache for the duration of a request
-		if ( $active_plan_cache ) {
+		if ( is_array( $active_plan_cache ) && ! empty( $active_plan_cache ) ) {
 			return $active_plan_cache;
 		}
 
 		$plan = get_option( 'jetpack_active_plan', array() );
 
 		// Set the default options
-		if ( empty( $plan ) || ( isset( $plan['product_slug'] ) && 'jetpack_free' === $plan['product_slug'] ) ) {
-			$plan = wp_parse_args( $plan, array(
-				'product_slug' => 'jetpack_free',
-				'supports'     => array(),
-				'class'        => 'free',
-				'features'     => array(
-					'active' => array()
-				),
-			) );
-		}
+		$plan = wp_parse_args( $plan, array(
+			'product_slug' => 'jetpack_free',
+			'class'        => 'free',
+			'features'     => array(
+				'active' => array()
+			),
+		) );
 
 		$supports = array();
 


### PR DESCRIPTION
Previously the stored plan could have been restored improperly from cache, or did not have an expected property because it was retrieved before WordPress.com changes took effect.

This PR introduces defaults for every plan, not just free, plus fixes a problem when the global plan cache was incorrectly populated.

#### Changes proposed in this Pull Request:
* Properly checks the global variable where the plan cache was stored.
* Introduces defaults for every plan, not just free plan.

#### Testing instructions:
* Sandbox your site, make sure you're receiving the old plan without the features array. To do that you can comment out the line in the `get_plan` method of the `trait.json-api-site-wpcom.php` file.
* Observe warnings.
* Roll this PR on, see no more warnings.
* Make sure the site works properly with paid plans - i.e. all promoted features should be available.
