### PR TITLE
Add missing support info icon for Downtime Monitoring

### DIFF
--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -32,7 +32,15 @@ export const Monitor = moduleSettingsForm(
 					module="monitor"
 					header={ __( 'Downtime monitoring', { context: 'Settings header' } ) }
 				>
-					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'monitor' ) }>
+					<SettingsGroup
+						hasChild
+						disableInDevMode
+						module={ this.props.getModule( 'monitor' ) }
+						support={ {
+							text: __( 'Keep tabs on your site and receive alerts the moment downtime is detected.' ),
+							link: 'https://jetpack.com/support/monitor/',
+						} }
+					>
 						<ModuleToggle
 							slug="monitor"
 							disabled={ unavailableInDevMode }


### PR DESCRIPTION
This is a follow-up to work already merged in https://github.com/Automattic/jetpack/pull/9199. This adds the missing support info icon for Downtime Monitoring -- reported in p8oabR-c9-p2

#### Changes proposed in this Pull Request:

* Adds missing support info icon for Downtime Monitoring.

#### Testing instructions:

* Check for the existence of this icon for Downtime Monitoring.
  * Screenshot below.

![2018-04-26_16-49-26](https://user-images.githubusercontent.com/1563559/39339023-ee5adcc0-4972-11e8-9bb9-88d26f38fc20.png)

