### PR TITLE
Update WordAds shortcode name

### DIFF
--- a/modules/shortcodes/wordads.php
+++ b/modules/shortcodes/wordads.php
@@ -25,7 +25,7 @@ class Jetpack_WordAds_Shortcode {
 	}
 
 	/**
-	 * Our [wordad] shortcode.
+	 * Our [wordads] shortcode.
 	 * Prints a WordAds Ad.
 	 *
 	 * @param array  $atts    Array of shortcode attributes.

--- a/modules/shortcodes/wordads.php
+++ b/modules/shortcodes/wordads.php
@@ -21,7 +21,7 @@ class Jetpack_WordAds_Shortcode {
 		if ( empty( $wordads ) ) {
 			return null;
 		}
-		add_shortcode( 'wordad', array( $this, 'wordads_shortcode' ) );
+		add_shortcode( 'wordads', array( $this, 'wordads_shortcode' ) );
 	}
 
 	/**
@@ -34,10 +34,7 @@ class Jetpack_WordAds_Shortcode {
 	 * @return string HTML for WordAds shortcode.
 	 */
 	static function wordads_shortcode( $atts, $content = '' ) {
-		$atts = shortcode_atts(
-			array(
-			), $atts, 'wordads'
-		);
+		$atts = shortcode_atts( array(), $atts, 'wordads');
 
 		return self::wordads_shortcode_html( $atts, $content );
 	}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -269,7 +269,7 @@ HTML;
 
 	/**
 	 * Insert an inline ad into a post content
-	 * Used for rendering the `wordad` shortcode.
+	 * Used for rendering the `wordads` shortcode.
 	 *
 	 * @since 6.1.0
 	 */


### PR DESCRIPTION
This PR updates the Jetpack Ads shortcode name from `[wordad]` to `[wordads]`.