### PR TITLE
WordAds: prioritize header ad display when hitting 6-ad limit

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -426,11 +426,11 @@ HTML;
 		$this->ads[] = array( 'location' => $location, 'width' => $width, 'height' => $height );
 		$ad_number = count( $this->ads );
 		// Max 6 ads per page.
-		if ( $ad_number > 6 ) {
+		if ( $ad_number > 5 && 'top' !== $location ) {
 			return;
 		}
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
-		
+
 		return <<<HTML
 		<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 			<div id="atatags-{$ad_number}">


### PR DESCRIPTION
If a site owner uses widgets or shortcodes to add more than 6 ads per page, we automatically shut off rendering after the 6th ad.

The header ad renders after any ads in the post body added via shortcodes. This PR updates the ad limit to 5, allowing for the header ad to be included as the 6th ad.

#### Changes proposed in this Pull Request:

* Update the limit to 5 ads + a header ad.

#### Testing instructions:

On a site that was approved for WordAds > 24hrs ago, add 12 wordads shortcodes to the body, and make sure that header ads are turned on in Jetpack > Settings > Traffic.

Without the patch, the header ad will be missing.
With the patch, the header ad will display.