### PR TITLE
Admin Page: Check for connect permissions a bit later for hiding connection Banner

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -157,7 +157,7 @@ class Main extends React.Component {
 		// Track page views
 		this.props.isSiteConnected && analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
-		if ( ! this.props.userCanManageModules || ! this.props.userCanConnectSite ) {
+		if ( ! this.props.userCanManageModules ) {
 			if ( ! this.props.siteConnectionStatus ) {
 				return false;
 			}
@@ -168,7 +168,7 @@ class Main extends React.Component {
 			);
 		}
 
-		if ( ! this.props.siteConnectionStatus ) {
+		if ( ! this.props.siteConnectionStatus && this.props.userCanConnectSite ) {
 			return (
 				<div aria-live="assertive">
 					<JetpackConnect />


### PR DESCRIPTION
Fixes issue with Some settings tab being disallowed for users that can manage modules but cannot connect site. 

Context: p9zhOE-8J-p2

#### Changes proposed in this Pull Request:

* Moves the check for connection permissions right before we attempt to show the connect card

#### Testing instructions:
* Checkout this branch
* Either check on VIP Go sandbox or update [class.jetpack-react-page.php#L398](https://github.com/Automattic/jetpack/blob/master/_inc/lib/admin-pages/class.jetpack-react-page.php#L398) by hand to set `connect` to `false`.
* With an admin user  attempt to visit the "Discussion", "Security", or "Traffic" tabs. Confirm that you're able to do it .
* Visit Jetpack's dashboard an confirm you can't see the "Manage site connection" link on the Connection Card. Should look like:
     
    ![image](https://user-images.githubusercontent.com/746152/39438673-59a6670a-4c7b-11e8-98b3-aff0a47122ce.png)
