### PR TITLE
WordAds: update ads.txt to pull from daily transient, falling back to api call

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -96,7 +96,11 @@ class WordAds {
 		$this->insert_adcode();
 
 		if ( '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
-			$ads_txt_server_contents = ! is_wp_error( WordAds_API::get_wordads_ads_txt() ) ? WordAds_API::get_wordads_ads_txt() : '';
+
+			if ( false === ( $ads_txt_transient = get_transient( 'jetpack_ads_txt' ) ) ) {
+				$ads_txt_transient = ! is_wp_error( WordAds_API::get_wordads_ads_txt() ) ? WordAds_API::get_wordads_ads_txt() : '';
+				set_transient( 'jetpack_ads_txt', $ads_txt_transient, DAY_IN_SECONDS );
+			}
 
 			/**
 			 * Provide plugins a way of modifying the contents of the automatically-generated ads.txt file.
@@ -107,7 +111,7 @@ class WordAds {
 			 *
 			 * @param string WordAds_API::get_wordads_ads_txt() The contents of the ads.txt file.
 			 */
-			$ads_txt_content = apply_filters( 'wordads_ads_txt', $ads_txt_server_contents );
+			$ads_txt_content = apply_filters( 'wordads_ads_txt', $ads_txt_transient );
 
 			header( 'Content-Type: text/plain; charset=utf-8' );
 			echo esc_html( $ads_txt_content );
@@ -430,7 +434,7 @@ HTML;
 			return;
 		}
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
-		
+
 		return <<<HTML
 		<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 			<div id="atatags-{$ad_number}">


### PR DESCRIPTION
The ads.txt file introduced in 6.1 is currently not using any sort of caching.
This PR puts the ads.txt contents into a transient expiring daily.

This will result in only 1 api call to the server for the ads.txt contents per day.

#### Changes proposed in this Pull Request:

* Set a transient `jetpack_ads_txt` containing the ads.txt contents - expires daily.

#### Testing instructions:

On a jetpack site with wordads enabled:
 * run the following wp-cli command: `wp transient get jetpack_ads_txt`. You should see a warning that the transient is not set.
 * visit `/ads.txt` on the site. You should see ads.txt contents displayed.
 * re-run the following wp-cli command: `wp transient get jetpack_ads_txt`. You should now see the same ads.txt contents echo'd in the console.
 * and for good measure, once again visit `/ads.txt` on the site. You should see ads.txt contents displayed.