### PR TITLE
Lazy Images: Add jetpack-lazy-loaded-image event

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -93,30 +93,34 @@ var jetpackLazyImagesModule = function( $ ) {
 	 * @param {object} image The image object.
 	 */
 	function applyImage( image ) {
-		var src = image.getAttribute( 'data-lazy-src' ),
-			srcset = image.getAttribute( 'data-lazy-srcset' ),
-			sizes = image.getAttribute( 'data-lazy-sizes' );
+		var theImage = $( image ),
+			src = theImage.attr( 'data-lazy-src' ),
+			srcset = theImage.attr( 'data-lazy-srcset' ),
+			sizes = theImage.attr( 'data-lazy-sizes' ),
+			theClone;
 
-		if ( ! src ) {
+		if ( ! theImage.length || ! src ) {
 			return;
 		}
 
-		// Prevent this from being lazy loaded a second time.
-		image.classList && image.classList.add( 'jetpack-lazy-image--handled' );
-		image.setAttribute( 'data-lazy-loaded', '1' );
+		theClone = theImage.clone();
 
-		image.setAttribute( 'src', src );
-		image.removeAttribute( 'data-lazy-src' );
+		// Remove lazy attributes from the clone.
+		theClone.removeAttr( 'data-lazy-src' ),
+		theClone.removeAttr( 'data-lazy-srcset' ),
+		theClone.removeAttr( 'data-lazy-sizes' );
 
-		if ( srcset ) {
-			image.setAttribute( 'srcset', srcset );
-			image.removeAttribute( 'data-lazy-srcset' );
-		}
+		// Add the attributes we want on the finished image.
+		theClone.addClass( 'jetpack-lazy-image--handled' ),
+		theClone.attr( 'data-lazy-src', 1 ),
+		theClone.attr( 'src', src ),
+		theClone.attr( 'srcset', srcset ),
+		theClone.attr( 'sizes', sizes );
 
-		if ( sizes ) {
-			image.setAttribute( 'sizes', sizes );
-			image.removeAttribute( 'data-lazy-sizes' );
-		}
+		theImage.replaceWith( theClone );
+
+		// Fire an event so that third-party code can perform actions after an image is loaded.
+		theClone.trigger( 'jetpack-lazy-loaded-image' );
 	}
 };
 

--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -94,15 +94,22 @@ var jetpackLazyImagesModule = function( $ ) {
 	 */
 	function applyImage( image ) {
 		var theImage = $( image ),
-			src = theImage.attr( 'data-lazy-src' ),
-			srcset = theImage.attr( 'data-lazy-srcset' ),
-			sizes = theImage.attr( 'data-lazy-sizes' ),
+			src,
+			srcset,
+			sizes,
 			theClone;
 
-		if ( ! theImage.length || ! src ) {
+		if ( ! theImage.length ) {
 			return;
 		}
 
+		src = theImage.attr( 'data-lazy-src' );
+		if ( ! src ) {
+			return;
+		}
+
+		srcset = theImage.attr( 'data-lazy-srcset' );
+		sizes = theImage.attr( 'data-lazy-sizes' );
 		theClone = theImage.clone();
 
 		// Remove lazy attributes from the clone.
@@ -111,11 +118,16 @@ var jetpackLazyImagesModule = function( $ ) {
 		theClone.removeAttr( 'data-lazy-sizes' );
 
 		// Add the attributes we want on the finished image.
-		theClone.addClass( 'jetpack-lazy-image--handled' ),
-		theClone.attr( 'data-lazy-src', 1 ),
-		theClone.attr( 'src', src ),
-		theClone.attr( 'srcset', srcset ),
-		theClone.attr( 'sizes', sizes );
+		theClone.addClass( 'jetpack-lazy-image--handled' );
+		theClone.attr( 'data-lazy-src', 1 );
+		theClone.attr( 'src', src );
+
+		if ( srcset ) {
+			theClone.attr( 'srcset', srcset );
+		}
+		if ( sizes ) {
+			theClone.attr( 'sizes', sizes );
+		}
 
 		theImage.replaceWith( theClone );
 

--- a/modules/theme-tools/compat/twentysixteen.php
+++ b/modules/theme-tools/compat/twentysixteen.php
@@ -49,3 +49,19 @@ function twentysixteen_remove_share() {
 	}
 }
 add_action( 'loop_start', 'twentysixteen_remove_share' );
+
+function twentysixteen_jetpack_lazy_images_compat() {
+	if ( ! function_exists( 'wp_add_inline_script' ) ) {
+		return;
+	}
+
+	// Since TwentySixteen outdents when window is resized, let's trigger a window resize
+	// every time we lazy load an image on the TwentySixteen theme.
+	wp_add_inline_script(
+		'jetpack-lazy-images',
+		"jQuery( document.body ).on( 'jetpack-lazy-loaded-image', function () { jQuery( window ).trigger( 'resize' ); } );"
+	);
+}
+
+// Priority needs to be 11 here so that we have already enqueued jetpack-lazy-images.
+add_action( 'wp_enqueue_scripts', 'twentysixteen_jetpack_lazy_images_compat', 11 );


### PR DESCRIPTION
In #8879 it was reported that outdented images were broken in cases where the CSS class was applied after the initial page loading. In TwentySixteen, this seems to be because when the initial `1x1` image loads, it wasn't meeting the condition that it be below the entry meta content.

The first part of a fix here is to fire an event when we lazy load an image, which will allow themes and plugins to better integrate with Lazy Images.

I wasn't able to reproduce the multiple network requests that @PatTheMav reported in that issue. Based on his testing though, it seems possible that the issue was because we were calling `image.setAttribute()` on the image in the dom. What I've tried to do in this PR is to clone the original image, update the attributes, and THEN replace the original image with the new one. I hope this fixes the issue. 🤞 

To test:

- Checkout branch
- Ensure lazy images is turned on
- Create a post with several paragraphs and images
- In console add the following:
    ```js
    jQuery( document.body ).on( 'jetpack-lazy-loaded-image', function( e ) {
    	console.log( e.target );
    } );
    ```
- Ensure that images load as you scroll and that the images get logged in the console
- Test the above in TwentySixteen and ensure that images are outdented after they are lazy loaded.

Here's an example of an outdented image in TwentySixteen:

<img width="984" alt="screen shot 2018-04-30 at 7 59 59 pm" src="https://user-images.githubusercontent.com/1126811/39457128-3005461a-4cb1-11e8-8346-3a47463fc903.png">

Here's the same image not outdented:

<img width="994" alt="screen shot 2018-04-30 at 8 00 23 pm" src="https://user-images.githubusercontent.com/1126811/39457136-36562d40-4cb1-11e8-988e-ae2999ab4d5d.png">
