### PR TITLE
Tiled Galleries: Use Photon for linked media file

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -19,12 +19,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		}
 
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
-		// If Photon is active, use it for original
-		if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
-			$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : jetpack_photon_url( $this->orig_file );
-		} else {
-			$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
-		}
+		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
 		$img_args = array(
 			'w' => $this->image->width,

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -19,6 +19,10 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		}
 
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
+		// If Photon is active, use it for original
+		if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+			$this->orig_file = jetpack_photon_url( $this->orig_file );
+		}		
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
 		$img_args = array(

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -19,7 +19,12 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		}
 
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
-		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
+		// If Photon is active, use it for original
+		if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+			$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : jetpack_photon_url( $this->orig_file );
+		} else {
+			$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
+		}
 
 		$img_args = array(
 			'w' => $this->image->width,

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -20,7 +20,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
 		// If Photon is active, use it for original
-		if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( in_array( 'photon', Jetpack::get_active_modules() ) ) {
 			$this->orig_file = jetpack_photon_url( $this->orig_file );
 		}		
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;


### PR DESCRIPTION
Fixes #9202

#### Changes proposed in this Pull Request:

If Photon is active and a Tiled Gallery links to media file, then use Photon for the link
