### PR TITLE
Protect: Improve Accessibility for Math Fallback.

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -124,11 +124,19 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			?>
 			<div style="margin: 5px 0 20px;">
 				<strong><?php esc_html_e( 'Prove your humanity:', 'jetpack' ); ?> </strong>
-				<?php echo $num1 ?> &nbsp; + &nbsp; <?php echo $num2 ?> &nbsp; = &nbsp;
-				<input type="input" name="jetpack_protect_num" value="" size="2" />
-				<input type="hidden" name="jetpack_protect_answer" value="<?php echo $ans; ?>" />
+				<label for="sum">
+					<?php echo esc_html( $num1 ); ?>
+					<span class="a11y-visually-hidden"><?php esc_html_e( 'plus', 'jetpack' ); ?></span>
+					<span aria-hidden="true"> + </span>
+					<?php echo esc_html( $num2 ); ?>
+					<span class="a11y-visually-hidden"><?php esc_html_e( 'equals', 'jetpack' ); ?></span>
+					<span aria-hidden="true"> = </span>
+				</label>
+				<input type="number" id="sum" name="jetpack_protect_num" value="" size="2" />
+				<input type="hidden" name="jetpack_protect_answer" value="<?php echo esc_attr( $ans ); ?>" />
 			</div>
 		<?php
+			return void;
 		}
 
 	}

--- a/modules/protect/protect-dashboard-widget.css
+++ b/modules/protect/protect-dashboard-widget.css
@@ -114,3 +114,15 @@
 	margin-top: -30px;
 	padding: 0 12px;
 }
+
+.a11y-visually-hidden { 
+	position: absolute;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	padding: 0;
+	border: 0;
+	white-space: nowrap;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+}


### PR DESCRIPTION
Fixes #6714

#### Changes proposed in this Pull Request:

* Made the math question contain inside a html `<label>` element.
* Made the `<label>` tied to the `<input>` field for the answer via `for="sum"`.
* The math operators were also implemented with the plain text equivalent for people using assistive technologies since those operators are not always supported by screen readers.
* The `<input type="">` is changed to `number`.

#### Testing instructions:
1.) Checkout the code on a WP test site that you've admin access to

2.) Make sure "Protect" is enabled under WP-Admin (Jetpack -> Settings -> Security)
https://jetpack.com/support/security-features/#protect

3.) Test login with a test user. Trigger the Math captcha by attempting a fixed number of failed login using the correct username, but with the wrong password.

4.) Use a screen reader to test the reader reads out the math equation properly. Enter the right and wrong numbers to make sure the results are as intended.

5.) Once done testing, make sure the test user can login normally, then revert the test site code to its previous state.