### PR TITLE
Masterbar: Invert Order of Customize and Themes buttons

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -863,14 +863,14 @@ class A8C_WPCOM_Masterbar {
 
 			$theme_title = $this->create_menu_item_pair(
 				array(
-					'url'   => 'https://wordpress.com/themes/' . esc_attr( $this->primary_site_slug ),
-					'id'    => 'wp-admin-bar-themes',
-					'label' => esc_html__( 'Themes', 'jetpack' ),
-				),
-				array(
 					'url'   => $customizer_url,
 					'id'    => 'wp-admin-bar-cmz',
 					'label' => esc_html_x( 'Customize', 'admin bar customize item label', 'jetpack' ),
+				),
+				array(
+					'url'   => 'https://wordpress.com/themes/' . esc_attr( $this->primary_site_slug ),
+					'id'    => 'wp-admin-bar-themes',
+					'label' => esc_html__( 'Themes', 'jetpack' ),
 				)
 			);
 			$meta = array( 'class' => 'mb-icon', 'class' => 'inline-action' );


### PR DESCRIPTION
This brings the Masterbar My Site(s) navigation (the frontend version of the Calypso Sidebar) in line with https://github.com/Automattic/wp-calypso/pull/24587.

#### Changes proposed in this Pull Request:

* Swap the order of the arguments passed to `A8C_WPCOM_Masterbar->create_menu_item_pair` such that the `Customizer` array is first & the `Themes` array is second

Before:
<img width="312" alt="screen shot 2018-05-01 at 4 56 40 pm" src="https://user-images.githubusercontent.com/1587282/39494854-fc8c2f1e-4d65-11e8-87c1-01ad385048ad.png">

After:
<img width="312" alt="screen shot 2018-05-01 at 4 57 03 pm" src="https://user-images.githubusercontent.com/1587282/39494837-ed840f28-4d65-11e8-911c-f64cba20fea7.png">


#### Testing instructions:

* Run this branch (the Jetpack Beta Plugin can help with this!)
* Activate the "WordPress.com Toolbar" in the Jetpack "Writing" Settings
* Click `My Sites` (or `My Site` if your test user only has one)
* You should see `Customize` as the main menu item under the `Personalize` section and `Themes` in the smaller inline button
* Clicking `Customize` should take you to the Customizer for the site
  * It should also trigger an appropriate Tracks event
* Clicking `Themes` should take you to the Themes Showcase (https://wordpress.com/themes/<SiteName>)
  * It should also trigger an appropriate Tracks event

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Masterbar: Invert Order of Customize and Themes buttons