### PR TITLE
Revert "Code Sync: sync easy-markdown.php - was divergent (#9366)"

### DIFF
--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -115,8 +115,6 @@ class WPCom_Markdown {
 	 * @return null
 	 */
 	public function load_markdown_for_posts() {
-		add_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ), 10, 2 );
-		add_action( 'after_wp_tiny_mce', array( $this, 'after_wp_tiny_mce' ) );
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ), 10, 2 );
 		add_filter( 'edit_post_content', array( $this, 'edit_post_content' ), 10, 2 );
@@ -135,8 +133,6 @@ class WPCom_Markdown {
 	 * @return null
 	 */
 	public function unload_markdown_for_posts() {
-		remove_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ) );
-		remove_action( 'after_wp_tiny_mce', array( $this, 'after_wp_tiny_mce' ) );
 		remove_action( 'wp_insert_post', array( $this, 'wp_insert_post' ) );
 		remove_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ), 10, 2 );
 		remove_filter( 'edit_post_content', array( $this, 'edit_post_content' ), 10, 2 );
@@ -417,50 +413,6 @@ class WPCom_Markdown {
 				$content = '';
 		}
 		return $content;
-	}
-
-	/**
-	 * Some tags are allowed to have a 'markdown' attribute, allowing them to contain Markdown.
-	 * We need to tell KSES about those tags.
-	 * @param  array $tags     List of tags that KSES allows.
-	 * @param  string $context The context that KSES is allowing these tags.
-	 * @return array           The tags that KSES allows, with our extra 'markdown' parameter where necessary.
-	 */
-	public function wp_kses_allowed_html( $tags, $context ) {
-		if ( 'post' !== $context ) {
-			return $tags;
-		}
-
-		$re = '/' . $this->get_parser()->contain_span_tags_re . '/';
-		foreach ( $tags as $tag => $attributes ) {
-			if ( preg_match( $re, $tag ) ) {
-				$attributes['markdown'] = true;
-				$tags[ $tag ] = $attributes;
-			}
-		}
-
-		return $tags;
-	}
-
-	/**
-	 * TinyMCE needs to know not to strip the 'markdown' attribute. Unfortunately, it doesn't
-	 * really offer a nice API for whitelisting attributes, so we have to manually add it
-	 * to the schema instead.
-	 */
-	public function after_wp_tiny_mce() {
-?>
-<script type="text/javascript">
-tinymce.on( 'AddEditor', function( event ) {
-	event.editor.on( 'BeforeSetContent', function( event ) {
-		var editor = event.target;
-		Object.keys( editor.schema.elements ).forEach( function( key, index ) {
-			editor.schema.elements[ key ].attributes['markdown'] = {};
-			editor.schema.elements[ key ].attributesOrder.push( 'markdown' );
-		} );
-	} );
-}, true );
-</script>
-<?php
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit dc18c8453d744548efb42682bc1fc606e2e9780f.

This last minute revert fixes error in console (`tinymce is not defined` )

![image](https://user-images.githubusercontent.com/746152/39494913-8e0ce49e-4d6e-11e8-9480-62cf1c42abed.png)

coming from the changes introduced in #9366 with  https://github.com/Automattic/jetpack/pull/9366/files#diff-c8a16334ab363043643dab428095f818R453

