### PR TITLE
EU Cookie Law Widget: Update the title and description

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -76,9 +76,9 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 			parent::__construct(
 				'eu_cookie_law_widget',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
-				apply_filters( 'jetpack_widget_name', esc_html__( 'EU Cookie Law Banner', 'jetpack' ) ),
+				apply_filters( 'jetpack_widget_name', esc_html__( 'Cookies & Consents Banner', 'jetpack' ) ),
 				array(
-					'description' => esc_html__( 'Display a banner for compliance with the EU Cookie Law.', 'jetpack' ),
+					'description' => esc_html__( 'Display a banner for EU Cookie Law and GDPR compliance.', 'jetpack' ),
 					'customize_selective_refresh' => true,
 				),
 				array()


### PR DESCRIPTION
This change proposes an update to the title and description of the EU
Cookie Law Widget. As it will soon be updated to also handle consent
(as required by the GDPR) on sites using WordAds (9373) — and we may
very well update it in the future to handle more privacy-related things
— it makes sense to expand the title/description accordingly.

To test, simply apply this change and make sure that the widget’s title
and description are updated accordingly. Also confirm that there are no issues with adding/configuring/removing the widget. It should behave
exactly as before.