### PR TITLE
WPCOM merge: site settings endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -658,11 +658,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 
-				case 'holidaysnow':
-					// Holiday snow has been deprecated. Always turn off.
-					$updated[ $key ] = false;
-					break;
-
 				case 'api_cache':
 					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
 						if ( delete_option( 'jetpack_api_cache_enabled' ) ) {

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -475,22 +475,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	public function update_settings() {
 		// $this->input() retrieves posted arguments whitelisted and casted to the $request_format
 		// specs that get passed in when this class is instantiated
-		$input = $this->input();
-		$unfiltered_input = $this->input( false, false );
 		/**
 		 * Filters the settings to be updated on the site.
 		 *
 		 * @module json-api
 		 *
 		 * @since 3.6.0
-		 * @since 6.2.0 Added $unfiltered_input parameter.
 		 *
-		 * @param array $input              Associative array of site settings to be updated.
-		 *                                  Cast and filtered based on documentation.
-		 * @param array $unfiltered_input   Associative array of site settings to be updated.
-		 *                                  Neither cast nor filtered. Contains raw input.
+		 * @param array $input Associative array of site settings to be updated.
 		 */
-		$input = apply_filters( 'rest_api_update_site_settings', $input, $unfiltered_input );
+		$input = apply_filters( 'rest_api_update_site_settings', $this->input() );
 
 		$blog_id = get_current_blog_id();
 


### PR DESCRIPTION
This is pretty straightforward after sorting through diffs and changes, it's wpcom-specific code and the `net_neutrality` setting (also wpcom-specific).

The `net_neutrality` stuff doesn't strictly have to go into Jetpack, since it's WP.com-only.  One way to split this out better would be to use the new filter on the site settings endpoint (see #9464).  If this is something that's desired, I'd propose that we do it separately, bringing the file in sync first via this PR and #9464.