### PR TITLE
Sync: Add codec to the sync objects endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -148,6 +148,7 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 
 		return array(
 			'objects' => $objects,
+			'codec' => $codec->name(),
 		);
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -592,7 +592,8 @@ new Jetpack_JSON_API_Sync_Object( array(
 		'object_ids'     => '(array) The IDs of the objects',
 	),
 	'response_format' => array(
-		'objects' => '(string) The encoded objects'
+		'objects' => '(string) The encoded objects',
+		'codec'   => '(string) The codec used to encode the objects, deflate-json-array or simple'
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object?module_name=posts&object_type=post&object_ids[]=1&object_ids[]=2&object_ids[]=3'
 ) );


### PR DESCRIPTION
In 6.1 we introduced the simple codec. This will allow us to extract sync items that are not configured as expected. 

#### Changes proposed in this Pull Request:

* 

#### Testing instructions:

Apply this patch to the PR. 
Notice that you are able to retrieve the sync object via the manager when the site doesn't support the correct default codec. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
