### PR TITLE
Shortcodes: fix FB shortcode embed in wp-admin

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -44,7 +44,10 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 
 	// since Facebook is a faux embed, we need to load the JS SDK in the wpview embed iframe
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && ! empty( $_POST['action'] ) && 'parse-embed' == $_POST['action'] ) {
-		return $embed . wp_scripts()->do_items( array( 'jetpack-facebook-embed' ) );
+		ob_start();
+		wp_scripts()->do_items( array( 'jetpack-facebook-embed' ) );
+		$scripts = ob_get_clean();
+		return $embed . $scripts;
 	} else {
 		wp_enqueue_script( 'jetpack-facebook-embed' );
 		return $embed;


### PR DESCRIPTION
Introduced [two years ago](https://github.com/Automattic/jetpack/commit/8cc296561a948d541b8f6c97cf25ba7a2e418bc5#diff-acdae11434deb22407edfdf6ad6a0e9dR40), this change broke the facebook shortcode/url embeds in wp-admin. 

WP is expecting an object for the embed. This makes it so.

To Test: 
- Paste a facebook post link in wp-admin editor, like `https://www.facebook.com/WordPresscom/posts/10154113693553980`
- You should see an facebook embed in the post editor. 
- Make sure selective refresh still works for the facebook widget in the customizer. 