### PR TITLE
Likes: sync changes needed for WordPress.com

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -140,6 +140,20 @@ class Jetpack_Likes {
 		}
 	}
 
+
+	/**
+     * Stub for is_post_likeable, since some wpcom functions call this directly on the class
+	 * Are likes enabled for this post?
+     *
+     * @param int $post_id
+     * @return bool
+	 */
+	static function is_post_likeable( $post_id = 0 ) {
+		_deprecated_function( __METHOD__, 'jetpack-5.4', 'Jetpack_Likes_Settings()->is_post_likeable' );
+        $settings = new Jetpack_Likes_Settings();
+        return $settings->is_post_likeable();
+	}
+
 	/**
 	 * Stub for is_likes_visible, since some themes were calling it directly from this class
 	 *

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -150,8 +150,8 @@ class Jetpack_Likes {
 	 */
 	static function is_post_likeable( $post_id = 0 ) {
 		_deprecated_function( __METHOD__, 'jetpack-5.4', 'Jetpack_Likes_Settings()->is_post_likeable' );
-        $settings = new Jetpack_Likes_Settings();
-        return $settings->is_post_likeable();
+		$settings = new Jetpack_Likes_Settings();
+		return $settings->is_post_likeable();
 	}
 
 	/**

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -178,21 +178,6 @@ class Jetpack_Likes {
 	}
 
 	/**
-	 * WordPress.com: Metabox option for sharing (sharedaddy will handle this on the JP blog)
-	 */
-	function sharing_meta_box_content( $post ) {
-		$post_id = ! empty( $post->ID ) ? (int) $post->ID : get_the_ID();
-		$disabled = get_post_meta( $post_id, 'sharing_disabled', true ); ?>
-		<p>
-			<label for="wpl_enable_post_sharing">
-				<input type="checkbox" name="wpl_enable_post_sharing" id="wpl_enable_post_sharing" value="1" <?php checked( !$disabled ); ?>>
-				<?php _e( 'Show sharing buttons.', 'jetpack' ); ?>
-			</label>
-			<input type="hidden" name="wpl_sharing_status_hidden" value="1" />
-		</p> <?php
-	}
-
-	/**
 	  * Options to be added to the discussion page (see also admin_settings_init, etc below for Sharing settings page)
 	  */
 

--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -157,6 +157,21 @@ class Jetpack_Likes_Settings {
 	}
 
 	/**
+	 * WordPress.com: Metabox option for sharing (sharedaddy will handle this on the JP blog)
+	 */
+	public function sharing_meta_box_content( $post ) {
+		$post_id = ! empty( $post->ID ) ? (int) $post->ID : get_the_ID();
+		$disabled = get_post_meta( $post_id, 'sharing_disabled', true ); ?>
+		<p>
+			<label for="wpl_enable_post_sharing">
+				<input type="checkbox" name="wpl_enable_post_sharing" id="wpl_enable_post_sharing" value="1" <?php checked( !$disabled ); ?>>
+				<?php _e( 'Show sharing buttons.', 'jetpack' ); ?>
+			</label>
+			<input type="hidden" name="wpl_sharing_status_hidden" value="1" />
+		</p> <?php
+	}
+
+	/**
 	 * Adds the 'sharing' menu to the settings menu.
 	 * Only ran if sharedaddy and publicize are not already active.
 	 */


### PR DESCRIPTION
This adds back a stubbed version of `Jetpack_Likes::is_post_likeable()`. It's called directly on the class in wpcom.
Also moves `sharing_meta_box_content` where it can be reached in wpcom by [this](https://github.com/Automattic/jetpack/blob/23eb01b21f22d9bc25482a8dc4557b56333aff4e/modules/likes.php#L78)

**Testing**
These changes only affect wpcom   
