### PR TITLE
Sharing: provide path instead of URL to fix errors loading js/css

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -808,7 +808,7 @@ function sharing_display( $text = '', $echo = false ) {
 				'sharing-js',
 				Jetpack::get_file_url_for_environment(
 					'_inc/build/sharedaddy/sharing.min.js',
-					WP_SHARING_PLUGIN_URL . 'sharing.js'
+					'modules/sharedaddy/sharing.js'
 				),
 				array( 'jquery' ),
 				$ver

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -26,7 +26,7 @@ class Sharing_Admin {
 			'sharing-js',
 			Jetpack::get_file_url_for_environment(
 				'_inc/build/sharedaddy/admin-sharing.min.js',
-				WP_SHARING_PLUGIN_URL . 'admin-sharing.js'
+				'modules/sharedaddy/admin-sharing.js'
 			),
 			array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
 			2


### PR DESCRIPTION
Fixes #9470

`Jetpack::get_file_url_for_environment()` accepts paths, not full URLs,
but in #9238 we updated it to use full URLs for the sharing module.

That does not cause any issues in production environments, as the bug only appears when `SCRIPT_DEBUG` is set to true,
thus forcing `Jetpack::get_file_url_for_environment()` to use the full, unminified path.

#### Testing instructions:

* Set `define( 'SCRIPT_DEBUG', true );` in you site's `wp-config.php` file.
* Activate sharing.
* Check Settings > Sharing as well as your site's frontend; sharing.js and admin-sharing.js should have correct URLs.

#### Proposed changelog entry for your changes:
* Sharing: make sure JS files can be loaded on development sites.