### PR TITLE
Update Travis success email notifications stop emailing success notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,13 @@ script:
 sudo: false
 
 notifications:
-   webhooks: https://betadownload.jetpack.me/travis.php
+   webhooks:
+     urls:
+       - https://betadownload.jetpack.me/travis.php
      on_success: always # Beta builder needs notifications for successful builds
    email:
      on_success: never # default: change
+     recipients:
        - enej.bajgoric@automattic.com
        - georgestephanis@automattic.com
        - jeremy@automattic.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ notifications:
      on_success: always # Beta builder needs notifications for successful builds
    email:
      on_success: never # default: change
-     recipients:
        - enej.bajgoric@automattic.com
        - georgestephanis@automattic.com
        - jeremy@automattic.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,12 @@ script:
 
 sudo: false
 
-# We need notifications for successful builds
-
 notifications:
    webhooks: https://betadownload.jetpack.me/travis.php
+     on_success: always # Beta builder needs notifications for successful builds
    email:
+     on_success: never # default: change
+     recipients:
        - enej.bajgoric@automattic.com
        - georgestephanis@automattic.com
        - jeremy@automattic.com


### PR DESCRIPTION
Successful builds are not important enough to email. 