### PR TITLE
JP dialogue component: add height to account for the rest of wp 

### DIFF
--- a/_inc/client/components/jetpack-dialogue/style.scss
+++ b/_inc/client/components/jetpack-dialogue/style.scss
@@ -9,6 +9,7 @@
 	background: rgba($gray-light, .95);
 	text-align: center;
 	padding: rem( 32px );
+	height: 100%;
 }
 
 .jp-dialogue {

--- a/_inc/client/scss/layout.scss
+++ b/_inc/client/scss/layout.scss
@@ -89,3 +89,7 @@ $breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding
 		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
 	}
 }
+
+#jp-plugin-container {
+	min-height: 100vh;
+}


### PR DESCRIPTION
Issue: The `body` is not growing along with the component, so we get issues like this: 
<img width="595" alt="screen shot 2018-05-04 at 3 11 40 pm" src="https://user-images.githubusercontent.com/7129409/39647564-7c5c6b16-4fad-11e8-9bdd-94af1000497d.png">

To Test: 
- Activate jumpstart manually: `wp jetpack options update jumpstart new_connection`
- Hover over a menu item towards the bottom
- It should hover in the correct place