### PR TITLE
Likes: Automatically bust the likes iframe cache weekly

### DIFF
--- a/modules/likes/jetpack-likes-master-iframe.php
+++ b/modules/likes/jetpack-likes-master-iframe.php
@@ -4,7 +4,7 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version = '20180503';
+	$version = gmdate( 'YW' );
 	$in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
 
 	$_locale = get_locale();


### PR DESCRIPTION
We've had a few recent issues regarding stale caching of the likes iframe assets. Instead of busting the cache when we realize something is broken and having to wait for the next release, what about switching to weekly automatically like the stats js?

If there is bad code, we can fix it and, worst case, tell folks that it'll be fixed for them the following Monday?

See issue #9377 which was fixed by #9475 and #9347 which busted the cache based on a support request reporting bad styling.