### PR TITLE
Jetpack: Sync fix theme update test

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -247,6 +247,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_update_theme_sync() {
+
+		if ( ! method_exists(  'ReflectionClass', 'newInstanceWithoutConstructor' ) ) {
+			$this->markTestSkipped( 'See Jetpack issue #7691' );
+		}
+
 		$dummy_details = array(
 			'type' => 'theme',
 			'action' => 'update',

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -2,25 +2,6 @@
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 //Mock object requiered for test_theme_update()
-class Dummy_Sync_Test_WP_Theme {
-	public $stylesheet = 'updated-theme';
-
-	public function get( $key ) {
-		switch ( $key ) {
-			case 'Name':
-				return 'Updated Theme';
-				break;
-			case 'Version':
-				return '10.0';
-				break;
-			case 'ThemeURI':
-				return 'http://NOT!';
-				break;
-		}
-	}
-}
-
-//Mock object requiered for test_theme_update()
 class Dummy_Sync_Test_WP_Upgrader {
 	public $skin;
 
@@ -33,7 +14,14 @@ class Dummy_Sync_Test_WP_Upgrader {
 	}
 
 	function theme_info() {
-		return new Dummy_Sync_Test_WP_Theme();
+		$reflection = new ReflectionClass("WP_Theme" );
+
+		$instance = $reflection->newInstanceWithoutConstructor();
+
+		$reflectionStyleProperty = $reflection->getProperty( 'stylesheet' );
+		$reflectionStyleProperty->setAccessible( true ) ;
+		$reflectionStyleProperty->setValue( $instance, 'foobar-theme' );
+		return $instance;
 	}
 }
 
@@ -259,7 +247,6 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_update_theme_sync() {
-		$this->markTestSkipped( 'See Jetpack issue #7691' );
 		$dummy_details = array(
 			'type' => 'theme',
 			'action' => 'update',
@@ -271,16 +258,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_updated_theme' );
-
-		$expected = array(
-			'updated-theme',
-			array(
-				'name' => 'Updated Theme',
-				'version' => '10.0',
-                'uri' => 'http://NOT!',
-			)
-		);
-		$this->assertEquals( $expected, $event_data->args );
+		
+		$this->assertEquals( 'foobar-theme', $event_data->args[0] );
+		$this->assertTrue( isset( $event_data->args[1]['name'] ) );
+		$this->assertTrue( isset( $event_data->args[1]['version'] ) );
+		$this->assertTrue( isset( $event_data->args[1]['uri'] ) );
 	}
 
 	public function test_widgets_changes_get_synced() {


### PR DESCRIPTION
Make the test not skippable 
Make sure that the data that is returned is what is expected.

Fixes #7691

#### Changes proposed in this Pull Request:

* Update one test so that it passes again and is not skipped.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
