### PR TITLE
Sync: Check that jetpack_json_wrap exists

### DIFF
--- a/sync/class.jetpack-sync-json-deflate-array-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-array-codec.php
@@ -27,6 +27,7 @@ class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 		if ( function_exists( 'jetpack_json_wrap' ) ) {
 			return wp_json_encode( jetpack_json_wrap( $any ) );
 		}
+		// This prevents fatal error when updating pre 6.0 via the cli command
 		return wp_json_encode( $this->json_wrap( $any ) );
 	}
 

--- a/sync/class.jetpack-sync-json-deflate-array-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-array-codec.php
@@ -24,7 +24,10 @@ class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 	// @see https://gist.github.com/muhqu/820694
 
 	protected function json_serialize( $any ) {
-		return wp_json_encode( jetpack_json_wrap( $any ) );
+		if ( function_exists( 'jetpack_json_wrap' ) ) {
+			return wp_json_encode( jetpack_json_wrap( $any ) );
+		}
+		return wp_json_encode( $this->json_wrap( $any ) );
 	}
 
 	protected function json_unserialize( $str ) {


### PR DESCRIPTION
Fixes #9477 

#### Changes proposed in this Pull Request:

* use the previous version of the function if the current once doesn't exits.

#### Testing instructions:
*
Downgrade Jetpack to 6.0 use the cli command to update to the this version of Jetpack

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
