### PR TITLE
Related Posts: Only attempt to grab related posts for Published posts.

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -591,11 +591,13 @@ EOT;
 	public function get_for_post_id( $post_id, array $args ) {
 		$options = $this->get_options();
 
-		if ( ! empty( $args['size'] ) )
+		if ( ! empty( $args['size'] ) ) {
 			$options['size'] = $args['size'];
+		}
 
-		if ( ! $options['enabled'] || 0 == (int)$post_id || empty( $options['size'] ) )
+		if ( ! $options['enabled'] || 0 == (int)$post_id || empty( $options['size'] ) || get_post_status( $post_id) !== 'publish' ) {
 			return array();
+		}
 
 		$defaults = array(
 			'size' => (int)$options['size'],


### PR DESCRIPTION
Fixes #9494

Attempting to grab Related Posts for an unpublished post doesn't really make sense for our use case as we could cache the result for a post that changes drastically before publishing.