### PR TITLE
WordAds: Don't insert ads unless this is the main query within the loop.

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -249,8 +249,8 @@ HTML;
 	 * @since 4.5.0
 	 */
 	function insert_ad( $content ) {
-		// Ad JS won't work in XML feeds.
-		if ( is_feed() ) {
+		// Don't insert ads in feeds, or for anything but the main display. (This is required for compatibility with the Publicize module).
+		if ( is_feed() || ! is_main_query() || ! in_the_loop() ) {
 			return $content;
 		}
 		/**


### PR DESCRIPTION
This fixes an incompatibility issue with the publicize module.

The `Jetpack_Media_Summary` class used by the Publicize module applies filters for [get_the_excerpt](https://github.com/Automattic/jetpack/blob/master/_inc/lib/class.media-summary.php#L331
), which the WordAds module uses to insert ads.

Combined with the [5-6 ad limit](https://github.com/Automattic/jetpack/blob/master/modules/wordads/wordads.php#L439) we introduced in 6.1, this had led to lots of issues.

Ads are being placed in the Publicize filter calls, which is using up to 4 of the available 5-6 ad slots.
This means that Jetpack sites that once had 5 ads on their posts may now only have 1.

#### Changes proposed in this Pull Request:

* When filtering the content & excerpts, only proceed if `is_main_query()` and `is_the_loop()` are both true - otherwise bail for safety.

#### Testing instructions:

* Setup a test Jetpack site and sign up for WordAds
* Wait 48hrs (or ping me for quicker access)
* Enable all of the automatic ad placements in Jetpack > Settings > Traffic. Place 4 ad widgets in a sidebar (for good measure).
* Without this patch, view the page and you'll find you have < 5 ads showing (probably 1-2). View the page source and search for `atatags-`. Each ad rendered includes this ID, followed by the # of the ad rendered. You should find that the first few numbers are skipped and only the 4th or 5th ad are printed in the source.

* Apply this patch, then view the same page and page source. You should find that 5-6 ads are showing, and the `atatags-` ids show sequential numbers in the source.