### PR TITLE
Docker: disable Jetpack update notices

### DIFF
--- a/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/docker/mu-plugins/avoid-plugin-deletion.php
@@ -35,6 +35,7 @@ add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link'
  * Fail deletion attempts of our important plugins
  */
 function jetpack_docker_disable_delete_plugin( $plugin_file ) {
+	global $jetpack_docker_avoided_plugins;
 	if ( in_array( $plugin_file, $jetpack_docker_avoided_plugins ) ) {
 		wp_die(
 			'Deleting plugin "' . $plugin_file . '" is diabled at mu-plugins/avoid-plugin-deletion.php',

--- a/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/docker/mu-plugins/avoid-plugin-deletion.php
@@ -38,7 +38,7 @@ function jetpack_docker_disable_delete_plugin( $plugin_file ) {
 	global $jetpack_docker_avoided_plugins;
 	if ( in_array( $plugin_file, $jetpack_docker_avoided_plugins ) ) {
 		wp_die(
-			'Deleting plugin "' . $plugin_file . '" is diabled at mu-plugins/avoid-plugin-deletion.php',
+			'Deleting plugin "' . $plugin_file . '" is disabled at mu-plugins/avoid-plugin-deletion.php',
 			403
 		);
 	}

--- a/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/docker/mu-plugins/avoid-plugin-deletion.php
@@ -1,36 +1,59 @@
 <?php
 
 /*
-Plugin Name: Remove delete link for Jetpack
-Description: Removes the Delete link from your plugins list for the current Jetpack directory
-Version: 1.0
+Plugin Name: Disable deleting and updating Jetpack
+Description: Disable deleting and updating -actions for Jetpack plugin. Being able to delete your local development directory from WordPress is catastrophic and you can lose your git history in the process.
+Version: 2.0
 Author: Automattic
 Author URI: http://automattic.com/
 */
 
+// These are the plugins we don't want to update or delete
+$jetpack_docker_avoided_plugins = array(
+	'jetpack/jetpack.php',
+);
+
 /**
- * avoid-plugin-deletion.php
- *
- * This file contains a hook that removes the Delete link from your plugins list for the current Jetpack directory.
- *
- * It was added because the effect of being able to delete your local development directory from WordPress is catastrophic and you can lose
- * your git history in the process.
+ * Remove the Delete link from your plugins list for important plugins
  */
-add_filter( 'plugin_action_links', 'disable_plugin_deletion', 10, 4 );
-
-function disable_plugin_deletion( $actions, $plugin_file, $plugin_data, $context ) {
-
-	// Remove delete link for important plugins
+function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file, $plugin_data, $context ) {
+	global $jetpack_docker_avoided_plugins;
 	if (
 		array_key_exists( 'delete', $actions ) &&
 		in_array(
 			$plugin_file,
-			array(
-				'jetpack/jetpack.php',
-			)
+			$jetpack_docker_avoided_plugins
 		)
 	) {
 		unset( $actions['delete'] );
 	}
 	return $actions;
 }
+add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link', 10, 4 );
+
+/**
+ * Fail deletion attempts of our important plugins
+ */
+function jetpack_docker_disable_delete_plugin( $plugin_file ) {
+	if ( in_array( $plugin_file, $jetpack_docker_avoided_plugins ) ) {
+		wp_die(
+			'Deleting plugin "' . $plugin_file . '" is diabled at mu-plugins/avoid-plugin-deletion.php',
+			403
+		);
+	}
+}
+add_action( 'delete_plugin', 'jetpack_docker_disable_delete_plugin', 10, 2 );
+
+/**
+ * Stop WordPress noticing plugin updates for important plugins
+ */
+function jetpack_docker_disable_plugin_update( $plugins ) {
+	global $jetpack_docker_avoided_plugins;
+	foreach( $jetpack_docker_avoided_plugins as $avoided_plugin ) {
+		if ( isset( $plugins->response[ $avoided_plugin ] ) ) {
+			unset( $plugins->response[ $avoided_plugin ] );
+		}
+	}
+	return $plugins;
+}
+add_filter( 'site_transient_update_plugins', 'jetpack_docker_disable_plugin_update' );


### PR DESCRIPTION
- Disables notices for Jetpack plugin in Docker environment.
- Disables plugin deletions

Deleting or updating the plugin would cause your complete development folder being erased. _Not cool._

Previous version of the plugin was already removing the delete link but this disables the actual deletion.


# Testing

Probably the easiest way to test is to download older version of Gutenberg: https://downloads.wordpress.org/plugin/gutenberg.2.7.0.zip

...and add it to the list at `docker/mu-plugins/avoid-plugin-deletion.php`:
```php
$jetpack_docker_avoided_plugins = array(
	'jetpack/jetpack.php',
	'gutenberg/gutenberg.php',
);
```

Just ensure your gutenberg folder is `gutenberg`,  not `gutenberg-2.7.0`

Confirm that:

- Update notice dissapears from wp-admin and the Activity log:
    ![screen shot 2018-05-07 at 10 25 06](https://user-images.githubusercontent.com/87168/39692326-39eac7ee-51e9-11e8-924f-a8e3949b02dc.png)
    ![screen shot 2018-05-07 at 10 30 11](https://user-images.githubusercontent.com/87168/39692329-3c34982c-51e9-11e8-9744-f3d8e8ea90cf.png)
- Bring back plugin deletion link by commenting out `unset( $actions['delete'] );` in the code and press delete Gutenberg from `/wp-admin/plugins.php`. You should see this error:
    ![screen shot 2018-05-07 at 11 07 00](https://user-images.githubusercontent.com/87168/39692388-62466acc-51e9-11e8-8d25-4eea70a8d32c.png)


## CLI

Sadly deleting the plugin via cli still works: `yarn docker:wp plugin delete gutenberg`

Notes for future reference:
```php
if ( class_exists( 'WP_CLI' ) && method_exists( 'WP_CLI', 'add_hook' ) ) {
	WP_CLI::add_hook( 'before_invoke:plugin delete', function () {
			// How to recognize which plugin is about to be deleted?
			WP_CLI::error( 'Nope!' );
	} );
}
```