### PR TITLE
CLI: Adds an api_call command that acts as wrapper for making authed API calls

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1038,8 +1038,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * Allows calling a WordPress.com API endpoint using the current blog's token.
 	 *
 	 * ## OPTIONS
-	 * --endpoint=<endpoint>
-	 * : The endpoint to call with the current blog's token, where `%d` represents the current blog's ID.
+	 * --resource=<resource>
+	 * : The resource to call with the current blog's token, where `%d` represents the current blog's ID.
 	 *
 	 * [--api_version=<api_version>]
 	 * : The API version to query against.
@@ -1054,11 +1054,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : A JSON encoded string representing arguments to send in the body.
 	 *
 	 * [--field=<value>]
-	 * : Any number of arguments that should be passed to the endpoint.
+	 * : Any number of arguments that should be passed to the resource.
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp jetpack call_api --endpoint='/sites/%d'
+	 * wp jetpack call_api --resource='/sites/%d'
 	 */
 	public function call_api( $args, $named_args ) {
 		if ( ! Jetpack::is_active() ) {
@@ -1066,25 +1066,25 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 
 		$consumed_args = array(
-			'endpoint',
+			'resource',
 			'api_version',
 			'base_api_path',
 			'body',
 		);
 
-		// Get args that should be passed to endpoint.
+		// Get args that should be passed to resource.
 		$other_args = array_diff_key( $named_args, array_flip( $consumed_args ) );
 
 		$decoded_body = ! empty( $named_args['body'] )
 			? json_decode( $named_args['body'] )
 			: false;
 
-		$endpoint_url = ( false === strpos( $named_args['endpoint'], '%d' ) )
-			? $named_args['endpoint']
-			: sprintf( $named_args['endpoint'], Jetpack_Options::get_option( 'id' ) );
+		$resource_url = ( false === strpos( $named_args['resource'], '%d' ) )
+			? $named_args['resource']
+			: sprintf( $named_args['resource'], Jetpack_Options::get_option( 'id' ) );
 
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
-			$endpoint_url,
+			$resource_url,
 			empty( $named_args['api_version'] ) ? Jetpack_Client::WPCOM_JSON_API_VERSION : $named_args['api_version'],
 			$other_args,
 			empty( $decoded_body ) ? null : $decoded_body,
@@ -1095,7 +1095,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( sprintf(
 				/* translators: %1ds is an endpoint route (ex. /sites/123456), %2$d is an error code, %3$s is an error message. */
 				__( 'Request to %1$s returned an error: (%2$d) %3$s.', 'jetpack' ),
-				$endpoint_url,
+				$resource_url,
 				$response->get_error_code(),
 				$response->get_error_message()
 			) );
@@ -1105,7 +1105,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( sprintf(
 				/* translators: %1ds is an endpoint route (ex. /sites/123456), %2$d is an HTTP status code. */
 				__( 'Request to %1$s returned a non-200 response code: %2$d.', 'jetpack' ),
-				$endpoint_url,
+				$resource_url,
 				wp_remote_retrieve_response_code( $response )
 			) );
 		}
@@ -1144,7 +1144,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	public function get_stats( $args, $named_args ) {
 		$resource = add_query_arg( $named_args, '/visits' );
 		$endpoint = jetpack_stats_api_path( $resource );
-		WP_CLI::runcommand( sprintf( 'jetpack call_api --endpoint=%s', $endpoint ) );
+		WP_CLI::runcommand( sprintf( 'jetpack call_api --resource=%s', $endpoint ) );
 	}
 
 	private function get_api_host() {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1152,6 +1152,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *  - day
 	 *  - week
 	 *  - month
+	 *  - year
 	 * ---
 	 *
 	 * [--date=<date>]

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1172,10 +1172,12 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$named_args,
 			array_flip( array(
 				'quantity',
-				'period',
 				'date',
 			) )
 		);
+
+		// The API expects unit, but period seems to be more correct.
+		$selected_args['unit'] = $named_args['period'];
 
 		$command = sprintf(
 			'jetpack call_api --resource=/sites/%d/stats/%s',

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1142,9 +1142,16 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * wp jetpack get_stats
 	 */
 	public function get_stats( $args, $named_args ) {
-		$resource = add_query_arg( $named_args, '/visits' );
-		$endpoint = jetpack_stats_api_path( $resource );
-		WP_CLI::runcommand( sprintf( 'jetpack call_api --resource=%s', $endpoint ) );
+		WP_CLI::runcommand(
+			sprintf(
+				'jetpack call_api --resource=/sites/%d/stats/%s',
+				Jetpack_Options::get_option( 'id' ),
+				add_query_arg( $named_args, 'visits' )
+			),
+			array(
+				'launch' => false, // Use the current process.
+			)
+		);
 	}
 
 	private function get_api_host() {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1100,7 +1100,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( is_wp_error( $response ) ) {
 			WP_CLI::error( sprintf(
-				/* translators: %1ds is an endpoint route (ex. /sites/123456), %2$d is an error code, %3$s is an error message. */
+				/* translators: %1$s is an endpoint route (ex. /sites/123456), %2$d is an error code, %3$s is an error message. */
 				__( 'Request to %1$s returned an error: (%2$d) %3$s.', 'jetpack' ),
 				$resource_url,
 				$response->get_error_code(),
@@ -1110,7 +1110,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			WP_CLI::error( sprintf(
-				/* translators: %1ds is an endpoint route (ex. /sites/123456), %2$d is an HTTP status code. */
+				/* translators: %1$s is an endpoint route (ex. /sites/123456), %2$d is an HTTP status code. */
 				__( 'Request to %1$s returned a non-200 response code: %2$d.', 'jetpack' ),
 				$resource_url,
 				wp_remote_retrieve_response_code( $response )

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1113,8 +1113,38 @@ class Jetpack_CLI extends WP_CLI_Command {
 		WP_CLI::success( wp_remote_retrieve_body( $response ) );
 	}
 
+	/**
+	 * API wrapper for getting stats from the WordPress.com API for the current site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--quantity=<quantity>]
+	 * : The number of units to include.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--period=<period>]
+	 * : The unit of time to query stats for.
+	 * ---
+	 * default: day
+	 * options:
+	 *  - day
+	 *  - week
+	 *  - month
+	 * ---
+	 *
+	 * [--date=<date>]
+	 * : The latest date to return stats for. Ex. - 2018-01-01.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp jetpack get_stats
+	 */
 	public function get_stats( $args, $named_args ) {
-
+		$resource = add_query_arg( $named_args, '/visits' );
+		$endpoint = jetpack_stats_api_path( $resource );
+		WP_CLI::runcommand( sprintf( 'jetpack call_api --endpoint=%s', $endpoint ) );
 	}
 
 	private function get_api_host() {


### PR DESCRIPTION
This PR seeks to add a `wp jetpack call_api` command which is a wrapper for simplifying authenticated (with the blog token) requests to the WordPress.com API. One use case of this is to query the WordPress.com API for stats. We can make that query with the following:

```
wp jetpack call_api --endpoint='/sites/%d/stats'
```

This functional is currently available with `wp eval`, but the results are pretty rough since there is no error handling and it's quite hard to grok:

```
wp eval "echo json_encode( Jetpack_Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/stats?force=wpcom', preg_replace( '/^Success:\s+/', '', '$(wp jetpack options get id)' ) ), '1.1' )['body'] );"
```

To test:

- Test multiple API calls with the `call_api` command:
    - `wp jetpack call_api --resource='/sites/%d'`
    - `wp jetpack call_api --resource='/sites/%d/stats'`
    - `wp jetpack call_api --resource='/sites/%d/stats/visits'`
- Test the `get_stats` command:
    - `wp jetpack get_stats`
    - `wp jetpack get_stats --quantity=4`
    - `wp jetpack get_stats  --period=month`
    - `wp jetpack get_stats --date=2017-12-31` (return stats from periods before and up to 2017-12-31)
- Test `--pretty` pretty prints JSON from successful API calls above
- Test `--strip-success` remove the green `Success: ` label from successful API calls above
- Test error state.
    - I did this by sandboxing the API while not logged into sandbox