### PR TITLE
Adds a filter that switches minified assets on or off.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -42,6 +42,26 @@ function jetpack_require_lib_dir() {
 }
 add_filter( 'jetpack_require_lib_dir', 'jetpack_require_lib_dir' );
 
+/**
+ * Checks if the code debug mode turned on, and returns false if it is. When Jetpack is in
+ * code debug mode, it shouldn't use minified assets. Note that this filter is not being used
+ * in every place where assets are enqueued. The filter is added at priority 9 to be overridden
+ * by any default priority filter that runs after it.
+ *
+ * @since 6.2.0
+ *
+ * @return boolean
+ *
+ * @filter jetpack_should_use_minified_assets
+ */
+function jetpack_should_use_minified_assets() {
+	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		return false;
+	}
+	return true;
+}
+add_filter( 'jetpack_should_use_minified_assets', 'jetpack_should_use_minified_assets', 9 );
+
 // @todo: Abstract out the admin functions, and only include them if is_admin()
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack.php'               );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-network.php'       );

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -31,7 +31,16 @@ class Sharing_Admin {
 			array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
 			2
 		);
-		$postfix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		/**
+		 * Filters the switch that if set to true allows Jetpack to use minified assets. Defaults to true
+		 * if the SCRIPT_DEBUG constant is not set or set to false. The filter overrides it.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param boolean $var should Jetpack use minified assets.
+		 */
+		$postfix = apply_filters( 'jetpack_should_use_minified_assets', true ) ? '.min' : '';
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'sharing-admin', WP_SHARING_PLUGIN_URL . 'admin-sharing-rtl' . $postfix . '.css', false, JETPACK__VERSION );
 		} else {


### PR DESCRIPTION
This syncs changes introduced in r174775-wpcom that synchronised Sharing code. This is the first place where we use the new filter instead of directly checking for SCRIPT_DEBUG constant.
<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Adds a filter to switch minified assets on or off in places in code that currently support it.