### PR TITLE
Sync: Extract Import sync events into its own module.

### DIFF
--- a/sync/class.jetpack-sync-module-import.php
+++ b/sync/class.jetpack-sync-module-import.php
@@ -1,0 +1,84 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+
+class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
+
+	private $import_end = false;
+
+	public function name() {
+		return 'import';
+	}
+
+	public function init_listeners( $callable ) {
+		add_action( 'export_wp', $callable );
+		add_action( 'jetpack_sync_import_end', $callable, 10, 2 );
+
+		// Movable type, RSS, Livejournal
+		add_action( 'import_done', array( $this, 'sync_import_done' ) );
+
+		// WordPress, Blogger, Livejournal, woo tax rate
+		add_action( 'import_end', array( $this, 'sync_import_end' ) );
+	}
+
+	public function sync_import_done( $importer ) {
+		// We already ran an send the import
+		if ( $this->import_end ) {
+			return;
+		}
+
+		$importer_name = $this->get_importer_name( $importer );
+
+		/**
+		 * Sync Event that tells that the import is finished
+		 *
+		 * @since 5.0.0
+		 *
+		 * $param string $importer
+		 */
+		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
+		$this->import_end = true;
+	}
+
+	public function sync_import_end() {
+		// We already ran an send the import
+		if ( $this->import_end ) {
+			return;
+		}
+
+		$this->import_end = true;
+		$importer         = 'unknown';
+		$backtrace        = wp_debug_backtrace_summary( null, 0, false );
+		if ( $this->is_importer( $backtrace, 'Blogger_Importer' ) ) {
+			$importer = 'blogger';
+		}
+
+		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WC_Tax_Rate_Importer' ) ) {
+			$importer = 'woo-tax-rate';
+		}
+
+		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WP_Import' ) ) {
+			$importer = 'wordpress';
+		}
+
+		$importer_name = $this->get_importer_name( $importer );
+
+		/** This filter is already documented in sync/class.jetpack-sync-module-posts.php */
+		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
+	}
+
+	private function get_importer_name( $importer ) {
+		$importers = get_importers();
+		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
+	}
+
+	private function is_importer( $backtrace, $class_name ) {
+		foreach ( $backtrace as $trace ) {
+			if ( strpos( $trace, $class_name ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/sync/class.jetpack-sync-module-import.php
+++ b/sync/class.jetpack-sync-module-import.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
-
 class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 
 	private $import_end = false;
@@ -19,6 +17,10 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 
 		// WordPress, Blogger, Livejournal, woo tax rate
 		add_action( 'import_end', array( $this, 'sync_import_end' ) );
+	}
+
+	public function set_defaults() {
+		$this->import_end = false;
 	}
 
 	public function sync_import_done( $importer ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -23,10 +23,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		return false;
 	}
 
-	public function set_defaults() {
-		$this->import_end = false;
-	}
-
 	public function init_listeners( $callable ) {
 		$this->action_handler = $callable;
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -51,34 +51,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'jetpack_daily_akismet_meta_cleanup_after', array( $this, 'daily_akismet_meta_cleanup_after' ) );
 		add_action( 'jetpack_post_meta_batch_delete', $callable, 10, 2 );
 
-		add_action( 'export_wp', $callable );
-		add_action( 'jetpack_sync_import_end', $callable, 10, 2 );
-
-		// Movable type, RSS, Livejournal
-		add_action( 'import_done', array( $this, 'sync_import_done' ) );
-
-		// WordPress, Blogger, Livejournal, woo tax rate
-		add_action( 'import_end', array( $this, 'sync_import_end' ) );
 	}
 
-	public function sync_import_done( $importer ) {
-		// We already ran an send the import
-		if ( $this->import_end ) {
-			return;
-		}
-
-		$importer_name = $this->get_importer_name( $importer );
-
-		/**
-		 * Sync Event that tells that the import is finished
-		 *
-		 * @since 5.0.0
-		 *
-		 * $param string $importer
-		 */
-		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
-		$this->import_end = true;
-	}
 
 	public function daily_akismet_meta_cleanup_before( $feedback_ids ) {
 		remove_action( 'deleted_post_meta', $this->action_handler );
@@ -97,48 +71,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function daily_akismet_meta_cleanup_after( $feedback_ids ) {
 		add_action( 'deleted_post_meta', $this->action_handler );
-	}
-
-	public function sync_import_end() {
-		// We already ran an send the import
-		if ( $this->import_end ) {
-			return;
-		}
-
-		$this->import_end = true;
-		$importer         = 'unknown';
-		$backtrace        = wp_debug_backtrace_summary( null, 0, false );
-		if ( $this->is_importer( $backtrace, 'Blogger_Importer' ) ) {
-			$importer = 'blogger';
-		}
-
-		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WC_Tax_Rate_Importer' ) ) {
-			$importer = 'woo-tax-rate';
-		}
-
-		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WP_Import' ) ) {
-			$importer = 'wordpress';
-		}
-
-		$importer_name = $this->get_importer_name( $importer );
-
-		/** This filter is already documented in sync/class.jetpack-sync-module-posts.php */
-		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
-	}
-
-	private function get_importer_name( $importer ) {
-		$importers = get_importers();
-		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
-	}
-
-	private function is_importer( $backtrace, $class_name ) {
-		foreach ( $backtrace as $trace ) {
-			if ( strpos( $trace, $class_name ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -7,6 +7,7 @@
 
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-posts.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-import.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-comments.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-constants.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-callables.php';
@@ -36,6 +37,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Menus',
 		'Jetpack_Sync_Module_Users',
 		'Jetpack_Sync_Module_Posts',
+		'Jetpack_Sync_Module_Import',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Updates',

--- a/tests/php/sync/test_class.jetpack-sync-import.php
+++ b/tests/php/sync/test_class.jetpack-sync-import.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Testing CRUD on Posts
+ */
+class WP_Test_Jetpack_Sync_Import extends WP_Test_Jetpack_Sync_Base {
+
+	public function test_sync_export_content_event() {
+		// Can't call export_wp directly since it require no headers to be set...
+		do_action( 'export_wp', array( 'content' => 'all' ) );
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'export_wp' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $event->args[0]['content'], 'all' );
+	}
+
+	function test_import_done_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_done', 'test' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertEquals( 'test', $event->args[0] );
+		$this->assertEquals( 'Unknown Importer', $event->args[1] );
+	}
+
+	function test_import_end_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_end' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertEquals( 'unknown', $event->args[0] );
+		$this->assertEquals( 'Unknown Importer', $event->args[1] );
+	}
+
+	function test_import_end_and_import_done_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_end' );
+		do_action( 'import_done', 'test' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertEquals( 'unknown', $event->args[0] );
+	}
+
+	function test_import_done_and_import_end_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_done', 'test' );
+		do_action( 'import_end' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertEquals( 'test', $event->args[0] );
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1028,43 +1028,7 @@ That was a cool video.';
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0]['content'], 'all' );
 	}
-
-	function test_import_done_action_syncs_jetpack_sync_import_end() {
-		do_action( 'import_done', 'test' );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertEquals( 'test', $event->args[0] );
-		$this->assertEquals( 'Unknown Importer', $event->args[1] );
-	}
-
-	function test_import_end_action_syncs_jetpack_sync_import_end() {
-		do_action( 'import_end' );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertEquals( 'unknown', $event->args[0] );
-		$this->assertEquals( 'Unknown Importer', $event->args[1] );
-	}
-
-	function test_import_end_and_import_done_action_syncs_jetpack_sync_import_end() {
-		do_action( 'import_end' );
-		do_action( 'import_done', 'test' );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertEquals( 'unknown', $event->args[0] );
-	}
-
-	function test_import_done_and_import_end_action_syncs_jetpack_sync_import_end() {
-		do_action( 'import_done', 'test' );
-		do_action( 'import_end' );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertEquals( 'test', $event->args[0] );
-	}
-
+	
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1020,15 +1020,6 @@ That was a cool video.';
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 
-	public function test_sync_export_content_event() {
-		// Can't call export_wp directly since it require no headers to be set...
-		do_action( 'export_wp', array( 'content' => 'all' ) );
-		$this->sender->do_sync();
-		$event = $this->server_event_storage->get_most_recent_event( 'export_wp' );
-		$this->assertTrue( (bool) $event );
-		$this->assertEquals( $event->args[0]['content'], 'all' );
-	}
-	
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Extact the import and export sync events into its own module
This will make the curreny sync module easier to understand.

#### Testing instructions:
Do the tests pass? 
- Create an export, 
- Create an import 
do the events show up as expected on the .com side? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
