### PR TITLE
Stats page: update background to match Jetpack

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -471,7 +471,7 @@ function stats_reports_css() {
 	padding-left: 0 !important;
 }
 
-#jp-plugin-container {
+.jetpack_page_stats {
 	background-color: #f3f6f8;
 }
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -471,6 +471,10 @@ function stats_reports_css() {
 	padding-left: 0 !important;
 }
 
+#jp-plugin-container {
+	background-color: #f3f6f8;
+}
+
 #jp-stats-wrap {
 	max-width: 720px;
 	margin: 0 auto;


### PR DESCRIPTION
#9517 added headers and footers, this just updates the container background to match Jetpack admin. 

![screencapture-dereksmart-wpsandbox-me-wp-admin-admin-php-2018-05-09-16_27_52](https://user-images.githubusercontent.com/7129409/39837973-f36d393c-53a5-11e8-91da-99a1487c664c.png)

