### PR TITLE
Fix/multiple themes

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6588,7 +6588,7 @@ p {
 			'jetpack_holiday_snowing'                                => null,
 			'jetpack_sso_auth_cookie_expirtation'                    => 'jetpack_sso_auth_cookie_expiration',
 			'jetpack_cache_plans'                                    => null,
-			'jetpack_updated_themes'                                 => 'jetpack_updated_themes',
+			'jetpack_updated_theme'                                  => 'jetpack_updated_themes',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6588,6 +6588,7 @@ p {
 			'jetpack_holiday_snowing'                                => null,
 			'jetpack_sso_auth_cookie_expirtation'                    => 'jetpack_sso_auth_cookie_expiration',
 			'jetpack_cache_plans'                                    => null,
+			'jetpack_updated_themes'                                 => 'jetpack_updated_themes',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -483,7 +483,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		 * @module json-api
 		 *
 		 * @since 3.6.0
-		 * @since 6.2.0 Added $unfiltered_input parameter.
+		 * @since 6.1.1 Added $unfiltered_input parameter.
 		 *
 		 * @param array $input              Associative array of site settings to be updated.
 		 *                                  Cast and filtered based on documentation.

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -286,41 +286,51 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$theme = $upgrader->theme_info();
-		if ( ! $theme instanceof WP_Theme ) {
-			return;
+		$themes = array();
+		foreach ( $details['themes'] as $theme_slug ) {
+			$theme = wp_get_theme( $theme_slug );
+
+			if ( ! $theme instanceof WP_Theme ) {
+				continue;
+			}
+
+			$themes[ $theme_slug ] = array(
+				'name' => $theme->get( 'Name' ),
+				'version' => $theme->get( 'Version' ),
+				'uri' => $theme->get( 'ThemeURI' ),
+				'stylesheet' => $theme->stylesheet,
+			);
 		}
-		$theme_info = array(
-			'name' => $theme->get( 'Name' ),
-			'version' => $theme->get( 'Version' ),
-			'uri' => $theme->get( 'ThemeURI' ),
-		);
+
+		if ( empty( $themes ) ) {
+				return;
+		}
 
 		if ( 'install' === $details['action'] ) {
 			/**
-			 * Signals to the sync listener that a theme was installed and a sync action
+			 * Signals to the sync listener that one or more themes was installed and a sync action
 			 * reflecting the installation and the theme info should be sent
 			 *
-			 * @since 4.9.0
+			 * @since 6.2.0
 			 *
-			 * @param string $theme->theme_root Text domain of the theme
-			 * @param mixed $theme_info Array of abbreviated theme info
+			 * @param mixed $themes Array of abbreviated theme info
 			 */
-			do_action( 'jetpack_installed_theme', $theme->stylesheet, $theme_info );
+			do_action( 'jetpack_installed_themes', $themes );
 		}
 
 		if ( 'update' === $details['action'] ) {
 			/**
-			 * Signals to the sync listener that a theme was updated and a sync action
+			 * Signals to the sync listener that one or more themes was updated and a sync action
 			 * reflecting the update and the theme info should be sent
 			 *
-			 * @since 4.9.0
+			 * @since 6.2.0
 			 *
-			 * @param string $theme->theme_root Text domain of the theme
-			 * @param mixed $theme_info Array of abbreviated theme info
+			 * @param mixed $themes Array of abbreviated theme info
 			 */
-			do_action( 'jetpack_updated_theme', $theme->stylesheet, $theme_info );
+			do_action( 'jetpack_updated_themes', $themes );
 		}
+
+
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'switch_theme', array( $this, 'sync_theme_support' ) );
 		add_action( 'jetpack_sync_current_theme_support', $callable );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
-		add_action( 'jetpack_installed_themes', $callable, 10, 2 );
+		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_themes', $callable, 10, 2 );
 		add_action( 'delete_site_transient_update_themes', array( $this, 'detect_theme_deletion') );
 		add_action( 'jetpack_deleted_theme', $callable, 10, 2 );
@@ -286,39 +286,50 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$themes = array();
-		foreach ( $details['themes'] as $theme_slug ) {
-			$theme = wp_get_theme( $theme_slug );
-
+		if ( 'install' === $details['action'] ) {
+			$theme = $upgrader->theme_info();
 			if ( ! $theme instanceof WP_Theme ) {
-				continue;
+				return;
 			}
-
-			$themes[ $theme_slug ] = array(
+			$theme_info = array(
 				'name' => $theme->get( 'Name' ),
 				'version' => $theme->get( 'Version' ),
 				'uri' => $theme->get( 'ThemeURI' ),
-				'stylesheet' => $theme->stylesheet,
 			);
-		}
 
-		if ( empty( $themes ) ) {
-				return;
-		}
-
-		if ( 'install' === $details['action'] ) {
 			/**
-			 * Signals to the sync listener that one or more themes was installed and a sync action
+			 * Signals to the sync listener that a theme was installed and a sync action
 			 * reflecting the installation and the theme info should be sent
 			 *
-			 * @since 6.2.0
+			 * @since 4.9.0
 			 *
-			 * @param mixed $themes Array of abbreviated theme info
+			 * @param string $theme->theme_root Text domain of the theme
+			 * @param mixed $theme_info Array of abbreviated theme info
 			 */
-			do_action( 'jetpack_installed_themes', $themes );
+			do_action( 'jetpack_installed_theme', $theme->stylesheet, $theme_info );
 		}
 
 		if ( 'update' === $details['action'] ) {
+			$themes = array();
+			foreach ( $details['themes'] as $theme_slug ) {
+				$theme = wp_get_theme( $theme_slug );
+
+				if ( ! $theme instanceof WP_Theme ) {
+					continue;
+				}
+
+				$themes[ $theme_slug ] = array(
+					'name' => $theme->get( 'Name' ),
+					'version' => $theme->get( 'Version' ),
+					'uri' => $theme->get( 'ThemeURI' ),
+					'stylesheet' => $theme->stylesheet,
+				);
+			}
+
+			if ( empty( $themes ) ) {
+				return;
+			}
+
 			/**
 			 * Signals to the sync listener that one or more themes was updated and a sync action
 			 * reflecting the update and the theme info should be sent

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -9,8 +9,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'switch_theme', array( $this, 'sync_theme_support' ) );
 		add_action( 'jetpack_sync_current_theme_support', $callable );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
-		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
-		add_action( 'jetpack_updated_theme', $callable, 10, 2 );
+		add_action( 'jetpack_installed_themes', $callable, 10, 2 );
+		add_action( 'jetpack_updated_themes', $callable, 10, 2 );
 		add_action( 'delete_site_transient_update_themes', array( $this, 'detect_theme_deletion') );
 		add_action( 'jetpack_deleted_theme', $callable, 10, 2 );
 		add_filter( 'wp_redirect', array( $this, 'detect_theme_edit' ) );

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -259,10 +259,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_update_theme_sync() {
-		$this->markTestSkipped( 'See Jetpack issue #7691' );
 		$dummy_details = array(
 			'type' => 'theme',
 			'action' => 'update',
+			'themes' => array(
+				'twentyseventeen',
+				'twentysixteen',
+			)
 		);
 
 		/** This action is documented in /wp-admin/includes/class-wp-upgrader.php */
@@ -270,17 +273,16 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_updated_theme' );
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_updated_themes' );
+		$themes = $event_data->args[0];
 
-		$expected = array(
-			'updated-theme',
-			array(
-				'name' => 'Updated Theme',
-				'version' => '10.0',
-                'uri' => 'http://NOT!',
-			)
-		);
-		$this->assertEquals( $expected, $event_data->args );
+		//Not testing versions since they are subject to change
+		$this->assertEquals( 'Twenty Seventeen', $themes['twentyseventeen']['name'] );
+		$this->assertEquals( 'https://wordpress.org/themes/twentyseventeen/', $themes['twentyseventeen']['uri'] );
+		$this->assertEquals( 'twentyseventeen', $themes['twentyseventeen']['stylesheet'] );
+		$this->assertEquals( 'Twenty Sixteen', $themes['twentysixteen']['name'] );
+		$this->assertEquals( 'https://wordpress.org/themes/twentysixteen/', $themes['twentysixteen']['uri'] );
+		$this->assertEquals( 'twentysixteen', $themes['twentysixteen']['stylesheet'] );
 	}
 
 	public function test_widgets_changes_get_synced() {


### PR DESCRIPTION
https://github.com/Automattic/jetpack/issues/9516

Only a single theme update was synced, even when bulk updating.

#### Changes proposed in this Pull Request:

We were calling the [`theme_info()`](https://github.com/WordPress/WordPress/blob/1b5d6c6971c158e38b2f7c4ac6acfa19276aa5df/wp-admin/includes/class-theme-upgrader.php#L629) method on the Theme_Upgrader class, which returns the last theme it processed by default.

We wanted all of the themes it processed, so rather than using this function, I iterate over all of the themes the Theme_Upgrader processed, call `wp_get_theme()` on them myself, and assemble an array of the data we're interested in syncing.

Sample sync output:
```
[09-May-2018 21:17:04 UTC] jetpack_updated_themes
[09-May-2018 21:17:04 UTC] Array
(
    [0] => Array
        (
            [hestia] => Array
                (
                    [name] => Hestia
                    [version] => 1.1.73
                    [uri] => https://themeisle.com/themes/hestia/
                    [stylesheet] => hestia
                )

            [twentyseventeen] => Array
                (
                    [name] => Twenty Seventeen
                    [version] => 1.5
                    [uri] => https://wordpress.org/themes/twentyseventeen/
                    [stylesheet] => twentyseventeen
                )

            [twentysixteen] => Array
                (
                    [name] => Twenty Sixteen
                    [version] => 1.4
                    [uri] => https://wordpress.org/themes/twentysixteen/
                    [stylesheet] => twentysixteen
                )

        )

)
```




#### Testing instructions:

Go to WP Admin -> Appearance -> Edit. Lower the version number for several themes. Refresh the page, you should see a circular arrow on the left of the menu bar at the top of WP Admin. When you click it, you can select multiple themes to update at once. Update multiple themes, and you should see a sync action with data about each updated theme come through on your wpcom sandbox.

phpunit runs new test.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
