### PR TITLE
Markdown: Added 'language-' prefix to the class name of fenced <code> block.

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -36,7 +36,7 @@ define( 'MARKDOWNEXTRA_VERSION',  "1.2.8" ); # 29 Nov 2013
 @define( 'MARKDOWN_FN_BACKLINK_CLASS',     "" );
 
 # Optional class prefix for fenced code block.
-@define( 'MARKDOWN_CODE_CLASS_PREFIX',     "" );
+@define( 'MARKDOWN_CODE_CLASS_PREFIX',     "language-" );
 
 # Class attribute for code blocks goes on the `code` tag;
 # setting this to true will put attributes on the `pre` tag instead.


### PR DESCRIPTION
Fixes #7293

#### Changes proposed in this Pull Request:

* Added `language-` prefix so `<code class="[language_name]">` becomes `<code class="language-[language_name]">` in the resulting html.

#### Testing instructions:

1. Use the code base of a test site and open the file `wp-content/plugins/jetpack/_inc/lib/markdown/extra.php`.

2. Modify the line in question in the commit.

3. Go to `wp-admin` of the test site -> Plugins -> Jetpack -> Settings -> `Writing` tab -> `Composing` section: enable  `Write posts or pages in plain-text Markdown syntax`.

4. Write a test post with a Markdown syntax code block.

5. Click `Preview` button to the right, then view source code of the preview post. The post content shall show `<code class="language-[language_name]">`

6. After done testing:
i.) Delete the test post.
ii.) Reset the Jetpack setting above if applicable.
iii.) Change the line in question in file `wp-content/plugins/jetpack/_inc/lib/markdown/extra.php` back to the original.

#### Sample Results:

Editor Box:
![editor box](https://user-images.githubusercontent.com/5837391/39875853-50bd95ec-54a4-11e8-9f15-ba1b759136da.png)

Source Code:
![post content source code](https://user-images.githubusercontent.com/5837391/39875858-54bf2ffc-54a4-11e8-8ebf-46ba93f9497e.png)