### PR TITLE
Docker: add note about yarn version in readme.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ _**All commands mentioned in this document should be run from the base Jetpack d
 #### Prerequisites:
 - [Docker](https://www.docker.com/community-edition)
 - [NodeJS](https://nodejs.org)
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://yarnpkg.com/) — please make sure your version is higher than v1.3: `yarn --version`
 - Optionally [Ngrok](https://ngrok.com) client and account or some other service for creating a local HTTP tunnel. It’s fine to stay on the free pricing tier with Ngrok.
 
 Install prerequisites and clone the repository:


### PR DESCRIPTION
Adds note about `yarn` version in Docker-readme since there have been already two cases where v0.x versions were causing issues.

p7rcWF-MA-p2