### PR TITLE
Lazy Images: Fix bug where images would disappear when scrolling

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -119,7 +119,7 @@ var jetpackLazyImagesModule = function( $ ) {
 
 		// Add the attributes we want on the finished image.
 		theClone.addClass( 'jetpack-lazy-image--handled' );
-		theClone.attr( 'data-lazy-src', 1 );
+		theClone.attr( 'data-lazy-loaded', 1 );
 		theClone.attr( 'src', src );
 
 		if ( srcset ) {


### PR DESCRIPTION
The `data-lazy-src` attribute was being set to `1` when an image was lazy
loaded causing the script to trigger again as the viewport was scrolled.
This appears to have been a typo in a recent change and was meant to set
`data-lazy-loaded` to `1`.

Fixes #9527

#### Changes proposed in this Pull Request:

* Lazy Images: Fix bug where images would disappear when scrolling

#### Testing instructions:

1. Install Jetpack 6.1
2. Enable Lazy Images
3. View a page with many images that go past the viewport height
4. Scroll up and down repeatedly
5. See that images that have been lazy loaded disappear
6. Check inspector to see that `src` has been set to `1`
7. When scrolling see that `data-lazy-src` is set to `1` when image is lazy loaded

#### Proposed changelog entry for your changes:

* Lazy Images: Fix bug where images would disappear when scrolling