### PR TITLE
Privacy Settings: Content and Copy Updates

### DIFF
--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -100,25 +100,6 @@ class Privacy extends React.Component {
 							{
 								__( 'We are committed to your privacy and security. ' )
 							}
-							<br />
-							{ __(
-								'Read about how Jetpack uses your data in the {{pp}}Automattic Privacy Policy{{/pp}} ' +
-								'and our {{js}}What Data Does Jetpack Sync?{{/js}} support document.', {
-									components: {
-										pp: <ExternalLink
-												href="https://automattic.com/privacy/"
-												onClick={ trackPrivacyPolicyView }
-												target="_blank" rel="noopener noreferrer"
-												/>,
-										js: <ExternalLink
-												href="https://jetpack.com/support/what-data-does-jetpack-sync/"
-												onClick={ trackWhatJetpackSyncView }
-												target="_blank" rel="noopener noreferrer"
-												/>
-									}
-								} )
-							}
-						</p>
 						<p>
 							<CompactFormToggle
 								compact
@@ -126,8 +107,49 @@ class Privacy extends React.Component {
 								disabled={ this.props.isFetchingTrackingSettings || this.props.isUpdatingTrackingSettings }
 								onChange={ this.togglePrivacy }
 								id="privacy-settings">
-								{ __( 'Send information to help us improve our products.' ) }
+								{ __( 
+									'Allow us to collect information about how you use your services while you are logged in to your WordPress.com account through our own first-party analytics tool. ' +
+									'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}.', {
+										components: {
+											cookiePolicyLink: <ExternalLink
+													href="https://automattic.com/cookies/"
+													onClick={ trackCookiePolicyView }
+													target="_blank" rel="noopener noreferrer"
+													/>
+											}
+									}
+
+								) }
 							</CompactFormToggle>
+
+							<br />
+
+							{ __(
+								'We use this information to improve our products, make our marketing to you more relevant, personalize your experience, and for the other purposes described in our {{pp}}privacy policy{{/pp}}.', {
+									components: {
+										pp: <ExternalLink
+												href="https://automattic.com/privacy/"
+												onClick={ trackPrivacyPolicyView }
+												target="_blank" rel="noopener noreferrer"
+												/>
+									}
+								} )
+							}
+
+							<br />
+
+							{ __(
+								'We use other tracking technologies and cookies, including some from third parties. ' +
+								'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these technologies and your options to control them.', {
+									components: {
+										cookiePolicyLink: <ExternalLink
+												href="https://automattic.com/cookies/"
+												onClick={ trackCookiePolicyView }
+												target="_blank" rel="noopener noreferrer"
+												/>
+									}
+								} )
+							}
 						</p>
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -115,7 +115,7 @@ class Privacy extends React.Component {
 								onChange={ this.togglePrivacy }
 								id="privacy-settings">
 								{ __( 
-									'Allow us to collect information about how you use your services while you are logged in to your WordPress.com account through our own first-party analytics tool. ' +
+									'Share information with our analytics tool about your use of services while logged in to your WordPress.com account. ' +
 									'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}.', {
 										components: {
 											cookiePolicyLink: <ExternalLink
@@ -131,7 +131,7 @@ class Privacy extends React.Component {
 						</p>
 						<p>
 							{ __(
-								'We use this information to improve our products, make our marketing to you more relevant, personalize your experience, and for the other purposes described in our {{pp}}privacy policy{{/pp}}.', {
+								'This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our {{pp}}privacy policy{{/pp}}.', {
 									components: {
 										pp: <ExternalLink
 												href="https://automattic.com/privacy/"
@@ -144,8 +144,8 @@ class Privacy extends React.Component {
 						</p>
 						<p>
 							{ __(
-								'We use other tracking technologies and cookies, including some from third parties. ' +
-								'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these technologies and your options to control them.', {
+								'We use other tracking tools, including some from third parties. ' +
+								'{{cookiePolicyLink}}Read about these{{/cookiePolicyLink}} and how to control them.', {
 									components: {
 										cookiePolicyLink: <ExternalLink
 												href="https://automattic.com/cookies/"

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -34,7 +34,6 @@ const trackPrivacyCenterView = () => analytics.tracks.recordJetpackClick( {
 	feature: 'privacy'
 } );
 
-
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
 
@@ -114,7 +113,7 @@ class Privacy extends React.Component {
 								disabled={ this.props.isFetchingTrackingSettings || this.props.isUpdatingTrackingSettings }
 								onChange={ this.togglePrivacy }
 								id="privacy-settings">
-								{ __( 
+								{ __(
 									'Share information with our analytics tool about your use of services while logged in to your WordPress.com account. ' +
 									'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}.', {
 										components: {
@@ -123,9 +122,8 @@ class Privacy extends React.Component {
 													onClick={ trackCookiePolicyView }
 													target="_blank" rel="noopener noreferrer"
 													/>
-											}
+										}
 									}
-
 								) }
 							</CompactFormToggle>
 						</p>

--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -24,10 +24,16 @@ const trackPrivacyPolicyView = () => analytics.tracks.recordJetpackClick( {
 	feature: 'privacy'
 } );
 
-const trackWhatJetpackSyncView = () => analytics.tracks.recordJetpackClick( {
-	target: 'what-data-jetpack-sync',
+const trackCookiePolicyView = () => analytics.tracks.recordJetpackClick( {
+	target: 'cookie-policy',
 	feature: 'privacy'
 } );
+
+const trackPrivacyCenterView = () => analytics.tracks.recordJetpackClick( {
+	target: 'privacy-center',
+	feature: 'privacy'
+} );
+
 
 class Privacy extends React.Component {
 	static displayName = 'PrivacySettings';
@@ -100,6 +106,7 @@ class Privacy extends React.Component {
 							{
 								__( 'We are committed to your privacy and security. ' )
 							}
+						</p>
 						<p>
 							<CompactFormToggle
 								compact
@@ -121,9 +128,8 @@ class Privacy extends React.Component {
 
 								) }
 							</CompactFormToggle>
-
-							<br />
-
+						</p>
+						<p>
 							{ __(
 								'We use this information to improve our products, make our marketing to you more relevant, personalize your experience, and for the other purposes described in our {{pp}}privacy policy{{/pp}}.', {
 									components: {
@@ -135,9 +141,8 @@ class Privacy extends React.Component {
 									}
 								} )
 							}
-
-							<br />
-
+						</p>
+						<p>
 							{ __(
 								'We use other tracking technologies and cookies, including some from third parties. ' +
 								'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these technologies and your options to control them.', {
@@ -145,6 +150,19 @@ class Privacy extends React.Component {
 										cookiePolicyLink: <ExternalLink
 												href="https://automattic.com/cookies/"
 												onClick={ trackCookiePolicyView }
+												target="_blank" rel="noopener noreferrer"
+												/>
+									}
+								} )
+							}
+						</p>
+						<p>
+							{ __(
+								'For more information on how specific Jetpack features use data and track activity, please refer to our {{privacyCenterLink}}Privacy Center{{/privacyCenterLink}}.', {
+									components: {
+										privacyCenterLink: <ExternalLink
+												href="https://jetpack.com/support/privacy"
+												onClick={ trackPrivacyCenterView }
 												target="_blank" rel="noopener noreferrer"
 												/>
 									}


### PR DESCRIPTION
This change updates the copy and content of the Privacy settings area within the Jetpack settings UI. This will now be in sync with the same setting on WordPress.com.

Specifically:
* Add additional copy that better explains what folks are opting out of.
* Add reference/link to the Automatic cookie policy (note that this will not be live until May 21).
* Add reference/link to the Jetpack Privacy Center.

Test Plan:
* Visit the Privacy settings page of your Jetpack site (wp-admin).
* Confirm that the content/copy has been updated, according to the changes in this PR.
* Confirm that all links work as expected and that the setting still toggles correctly.