### PR TITLE
wpcom merge: REST API: Roles endpoint update for JP sites

### DIFF
--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -177,6 +177,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return true;
 	}
 
+	function current_user_can( $role ) {
+		return current_user_can( $role );
+	}
+
 	/**
 	 * Post functions
 	 */

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -173,6 +173,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return null;
 	}
 
+	function is_connected_site() {
+		return true;
+	}
+
 	/**
 	 * Post functions
 	 */


### PR DESCRIPTION
Summary: Ads a 1.2 endpoint that returns roles from shadow data

Test Plan:
Check that we don't break anything.
Do the test pass?

test the api endpoint for .com sites v1, v1.1 and v1.2
test the api endpoint for a jetpack sites v1, v1.1 and v1.2
Does it return the values as expected

Do not connected sites not return data as expected.

Reviewers: migueluy
Reviewed By: migueluy

Differential Revision: https://[private link]
https://[private link]

Merges r164573-wpcom.