### PR TITLE
Docs: Partners: Add sh to sample commands in case scripts are not executable

### DIFF
--- a/docs/partners/plan-provisioning.md
+++ b/docs/partners/plan-provisioning.md
@@ -41,7 +41,7 @@ We like to think that integrating with Jetpack Start is fairly easy. From beginn
 2. Ensure Jetpack is installed on the WordPress site:
     - `wp plugin install jetpack`
 3. Run the following script with the Jetpack Partner ID and token that were provided to you
-    - `./wp-content/plugins/jetpack/bin/partner-provision.sh --partner_id={partner_id} --partner_secret={partner_secret} --user={id_or_email} --plan={plan_slug} [--url=http://example.com]`
+    - `sh ./wp-content/plugins/jetpack/bin/partner-provision.sh --partner_id={partner_id} --partner_secret={partner_secret} --user={id_or_email} --plan={plan_slug} [--url=http://example.com]`
     - The script makes a call to our servers to register the site (if necessary) and provision the requested plan and any additional plugins such as VaultPress and Akismet
 4. If the script is successful, it will exit with code 0, and a JSON string. If any next steps are required in the browser, the JSON will include a URL to send your user to. E.g
     - `{ success: true, next_url: "http://wordpress.com/start/plans?foo=bar" }`
@@ -57,7 +57,7 @@ The process for cancelling a single plan is just as simple as provisioning a pla
 2. Ensure Jetpack is installed on site
     - `wp plugin install jetpack`
 3. Run the following script with the Jetpack Partner ID and token that were provided to you
-    - `./wp-content/plugins/jetpack/bin/partner-cancel.sh --partner_id={partner_id} --partner_secret={partner_secret} [--url=http://example.com]`
+    - `sh ./wp-content/plugins/jetpack/bin/partner-cancel.sh --partner_id={partner_id} --partner_secret={partner_secret} [--url=http://example.com]`
 4. If the script is successful, it will exit with code 0, and a JSON string.
     - `{ success: true }`
 5. If the script is unsuccessful, it will exit with code 1, and some text describing the error, like this:


### PR DESCRIPTION
A partner reported that the `partner-provision.sh` and `partner-cancel.sh` scripts were no longer executable, which means that our sample commands that treated the scripts as executable would not work.

When I tested the last two version of Jetpack, `wp plugin install jetpack --version=6.0` and `wp plugin install jetpack --version=5.9`, the scripts weren't executable in those versions either. My guess is that the scripts were previously executable as a byproduct of how Jetpack had been installed.

For example, when I `git clone git@github.com:Automattic/jetpack.git` down to my local machine and then run `ls -lah`, I get the following:

```
-rwxr-xr-x   1 user  group   1.8K May 10 16:39 partner-cancel.sh
-rwxr-xr-x   1 user  group   5.7K May 10 16:39 partner-provision.sh
-rw-r--r--   1 user  group   798B May 10 16:39 pre-commit-hook.js
-rwxr-xr-x   1 user  group   513B May 10 16:39 travis_install.sh
```

The `x` in the left signifies that the scripts are executable.

Since running the script with `sh` will work whether the script is executable or not, we should update the examples in our docs to use `sh`.