### PR TITLE
Add option `wp_page_for_privacy_policy` to sync

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -129,6 +129,7 @@ class Jetpack_Sync_Defaults {
 		'mailserver_login', // Not syncing contents, only the option name
 		'mailserver_pass', // Not syncing contents, only the option name
 		'mailserver_port',
+		'wp_page_for_privacy_policy',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -188,6 +188,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_login'                     => '',
 			'mailserver_pass'                      => '',
 			'mailserver_port'                      => 1,
+			'wp_page_for_privacy_policy'           => 3,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -188,7 +188,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_login'                     => '',
 			'mailserver_pass'                      => '',
 			'mailserver_port'                      => 1,
-			'wp_page_for_privacy_policy'           => 3,
+			'wp_page_for_privacy_policy'           => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Adds new `wp_page_for_privacy_policy` option to the sync options white-list.

`wp_page_for_privacy_policy` is a new option introduced in WordPress 4.9.6 ([in RC1](https://make.wordpress.org/core/2018/05/10/wordpress-4-9-6-release-candidate/) as of 11 May 2018):
- https://core.trac.wordpress.org/ticket/43491
- https://github.com/WordPress/WordPress/commit/f1e065b13bdf21cf246302216e15ac8e4efdbe45#diff-edf10fb2833dc3fa63e4d9879ce60bfdR346
and:
- https://core.trac.wordpress.org/ticket/43435
- https://github.com/WordPress/WordPress/commit/9af2f7cd35c05a6e0a7e1ae0938236efcdbf571a

The official 4.9.6 release is scheduled for Thursday, May 17th.

wpcom side: D13136-code

## Testing

1) Use WP 4.9.6 beta:
    - https://wordpress.org/wordpress-4.9.6-RC1.zip
    - https://make.wordpress.org/core/handbook/testing/beta/

2) Go to `/wp-admin/privacy.php` (**Settings** → **Privacy**)

3) Choose a page as a privacy page or create new one
    ![image](https://user-images.githubusercontent.com/87168/39914551-020740b4-550e-11e8-99a8-17736a8bd945.png)

4) Ensure `wp_page_for_privacy_policy` gets synced 👍