### PR TITLE
Sharing Recaptcha: manual Domain/Package validation 

### DIFF
--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -61,6 +61,7 @@ class Jetpack_ReCaptcha {
 			'invalid-input-response' => __( 'The response parameter is invalid or malformed', 'jetpack' ),
 			'invalid-json'           => __( 'Invalid JSON', 'jetpack' ),
 			'unexpected-response'    => __( 'Unexpected response', 'jetpack' ),
+			'unexpected-hostname'    => __( 'Unexpected hostname', 'jetpack' ),
 		);
 	}
 
@@ -126,6 +127,14 @@ class Jetpack_ReCaptcha {
 
 		if ( true !== $resp_decoded['success'] ) {
 			return new WP_Error( $error_code, $error_message );
+		}
+
+		// Validate the hostname matches expected source
+		if ( isset( $resp_decoded['hostname'] ) ) {
+			$url = wp_parse_url( get_home_url() );
+			if ( $url['host'] !== $resp_decoded['hostname'] ) {
+				return new WP_Error( 'unexpected-host', $this->error_codes['unexpected-hostname'] );
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Merges changes from .com that added more support for Recatpcha v2. 

This specific changes makes sure that the requests are actually coming from the site they're filling out the recatpcha on. It shouldn't affect behavior, but it allows people to set domain wildcards like *.wordpress.com 

Read more here https://developers.google.com/recaptcha/docs/domain_validation

To Test: 
- Make sure recaptcha still works as expected