### PR TITLE
Enables PHP error logging for the Jetpack test suite

### DIFF
--- a/docker/config/wp-tests-config.php
+++ b/docker/config/wp-tests-config.php
@@ -22,6 +22,9 @@ define( 'WP_DEFAULT_THEME', 'default' );
 // Test with WordPress debug mode (default).
 define( 'WP_DEBUG', true );
 
+// Enable error logging for tests
+define( 'WP_DEBUG_LOG', true );
+
 // ** MySQL settings ** //
 
 // This configuration file will be used by the copy of WordPress being tested.


### PR DESCRIPTION
Enables PHP error logging for the Jetpack test suite. You can now add error_log() or l() statements to unit tests for debugging purposes and see them in wp-content/debug.log