### PR TITLE
WooCommerce Anayltics: Use `Jetpack::get_active_plugins`

### DIFF
--- a/modules/woocommerce-analytics/wp-woocommerce-analytics.php
+++ b/modules/woocommerce-analytics/wp-woocommerce-analytics.php
@@ -55,7 +55,7 @@ class Jetpack_WooCommerce_Analytics {
 		 *
 		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
 		 */
-		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #9545 

#### Changes proposed in this Pull Request:

* Use `Jetpack::get_active_plugins()` instead of pulling straight from the db. The prevents issues of a non-array being returned as well as catching multisite network-activated plugins.