### PR TITLE
CLI: Publicize: Adds publicize command for listing connections

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -138,6 +138,27 @@ class Publicize extends Publicize_Base {
 		return false;
 	}
 
+	function get_all_connections_for_user() {
+		$connections = Jetpack_Options::get_option( 'publicize_connections' );
+
+		$connections_to_return = array();
+		if ( ! empty( $connections ) ) {
+			foreach ( (array) $connections as $service_name => $connections_for_service ) {
+				foreach ( $connections_for_service as $id => $connection ) {
+					$user_id = intval( $connection['connection_data']['user_id'] );
+					// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
+					if ( $user_id === 0 || $this->user_id() === $user_id ) {
+						$connections_to_return[ $service_name ][ $id ] = $connection;
+					}
+				}
+			}
+
+			return $connections_to_return;
+		}
+
+		return false;
+	}
+
 	function get_connection_id( $connection ) {
 		return $connection['connection_data']['id'];
 	}


### PR DESCRIPTION
This pull request seeks to add some CLI commands for managing Publicize. Specifically for listing connections and disconnecting connections.

This is currently useful for a partner that is integrating deeply with Jetpack, but it can be used by any Jetpack user that uses Publicize.

To test:

- Connect several accounts
- Run commands from the examples section (replacing the ID with your own connection IDs) and ensure the commands work
- When specifying `all` or a service for disconnection you should be asked to confirm the action and progress bar should be displayed
- When specifying a specific connection to disconnect, no prompt should be displayed