### PR TITLE
EU Cookie Law Widget: Update cookie banner text.

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -121,11 +121,11 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 				'customtext'         => '',
 				'color-scheme'       => $this->color_scheme_options[0],
 				'policy-url'         => $this->policy_url_options[0],
-				'default-policy-url' => 'https://jetpack.com/support/cookies/',
+				'default-policy-url' => 'https://automattic.com/cookies/',
 				'custom-policy-url'  => '',
-				'policy-link-text'   => esc_html__( 'Our Cookie Policy', 'jetpack' ),
+				'policy-link-text'   => esc_html__( 'Cookie Policy', 'jetpack' ),
 				'button'             => esc_html__( 'Close and accept', 'jetpack' ),
-				'default-text'       => esc_html__( 'Privacy & Cookies: This site uses cookies.', 'jetpack' ),
+				'default-text'       => esc_html__( 'Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use.', 'jetpack' ),
 			);
 		}
 

--- a/modules/widgets/eu-cookie-law/widget.php
+++ b/modules/widgets/eu-cookie-law/widget.php
@@ -13,7 +13,7 @@
 		?>
 		<br />
 		<?php
-		esc_html_e( 'To find out more, as well as how to remove or block these, see here:', 'jetpack' );
+		esc_html_e( 'To find out more, including how to control cookies, see here:', 'jetpack' );
 	} else {
 		echo esc_html( $instance['customtext'] );
 	} ?>


### PR DESCRIPTION
Updates the default contents (text, link) of the EU Cookie Law widget's banner.

Requested in p4H3ND-Hx-p2

#### Testing instructions:

* Make sure the new default text for the widget matches the changes here.