### PR TITLE
Fix Widget Visibility Condition Actions for Edge

### DIFF
--- a/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -71,6 +71,7 @@
 .widget-conditional .condition-control a:before {
 	position: absolute;
 	text-indent: 0;
+	top: 0;
 	left: 0;
 }
 .widget-conditional .condition-control .delete-condition {


### PR DESCRIPTION
The layout for the delete and add action icons was broken in Edge. Each button was shifted down by 100% of their height.

The root cause is unknown :) But this fixes the issue and causes no problems in IE, Chrome, Firefox, Safari, or Safari iOS.

#### Testing instructions:

1. In MS Edge, open wp-admin/widgets.php and look at a widget's Visibility settings.
2. In MS Edge, open wp-admin/widgets.php, click "Manage with Live Preview" to open the Customizer, and look at a widget's Visibility settings.

Tested in Microsoft Edge 42.17134.1.0

Before in wp-admin/:
<img width="406" alt="before - wp-admin" src="https://user-images.githubusercontent.com/125994/40207870-885484ce-59eb-11e8-94d2-7adee712be40.png">
Before in Customizer:
<img width="280" alt="before - customizer" src="https://user-images.githubusercontent.com/125994/40207880-96de9a7a-59eb-11e8-9737-3ab72a5f2930.png">

After in wp-admin/:
<img width="406" alt="after - wp-admin" src="https://user-images.githubusercontent.com/125994/40207886-9e186154-59eb-11e8-838d-cd5d46195760.png">
After in Customizer:
<img width="282" alt="after - customizer" src="https://user-images.githubusercontent.com/125994/40207894-a4f0246c-59eb-11e8-90ec-d950ab02bd98.png">

#### Proposed changelog entry for your changes:

Fix Widget Visibility styling in MS Edge.