### PR TITLE
Twitter Timeline Widget: Deprecate type `widget-id`

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -82,6 +82,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	public function widget( $args, $instance ) {
+		if ( $this->is_widget_id_deprecated( $instance['type'] ) ) {
+			if ( current_user_can( 'edit_theme_options' ) ) {
+				echo $args['before_widget'];
+				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
+				echo '<div>' . esc_html__( 'Widget ID is not supported anymore. Please update your Twitter Timeline widget.', 'jetpack' );
+				echo $args['after_widget'];
+			}
+			return;
+		}
+
 		$instance['lang'] = substr( strtoupper( get_locale() ), 0, 2 );
 
 		echo $args['before_widget'];
@@ -503,5 +513,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			</select>
 		</p>
 	<?php
+	}
+
+	/**
+	 * Twitter deprecated `data-widget-id` on 2018-05-25,
+	 * with cease support deadline on 2018-07-27.
+	 */
+	public function is_widget_id_deprecated( $type ) {
+		$today = new DateTime( 'now' );
+		$deadline = new DateTime( '2018-07-26' ); // One day early
+
+		return 'widget-id' === $type && $today >= $deadline;
 	}
 }

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -82,7 +82,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	public function widget( $args, $instance ) {
-		if ( $this->is_widget_id_deprecated( $instance['type'] ) ) {
+		// Twitter deprecated `data-widget-id` on 2018-05-25,
+		// with cease support deadline on 2018-07-27.
+		// 1532563200 is 2018-07-26, one day early.
+		 if ( 'widget-id' === $instance['type'] && time() > 1532563200 ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
@@ -476,16 +479,5 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			</select>
 		</p>
 	<?php
-	}
-
-	/**
-	 * Twitter deprecated `data-widget-id` on 2018-05-25,
-	 * with cease support deadline on 2018-07-27.
-	 */
-	public function is_widget_id_deprecated( $type ) {
-		$today = new DateTime( 'now' );
-		$deadline = new DateTime( '2018-07-26' ); // One day early
-
-		return 'widget-id' === $type && $today >= $deadline;
 	}
 }

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -86,7 +86,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
-				echo '<div>' . esc_html__( 'Widget ID is not supported anymore. Please update your Twitter Timeline widget.', 'jetpack' );
+				echo '<p>' . esc_html__( 'Widget ID is not supported anymore. Please update your Twitter Timeline widget.', 'jetpack' ) . '</p>';
 				echo $args['after_widget'];
 			}
 			return;
@@ -102,6 +102,11 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title );
 		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . $title . $args['after_title'];
+		}
+
+		if ( 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
+			echo '<p>' . esc_html__( 'Widget ID is deprecated and will stop working on 27 July 2018. Please update your Twitter Timeline widget.', 'jetpack' ) . '</p>';
+
 		}
 
 		// Start tag output

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -134,17 +134,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}
 
-		$type      = ( isset( $instance['type'] ) ? $instance['type'] : '' );
 		$widget_id = ( isset( $instance['widget-id'] ) ? $instance['widget-id'] : '' );
-		switch ( $type ) {
-			case 'profile':
-				echo ' href="https://twitter.com/' . esc_attr( $widget_id ) . '"';
-				break;
-			case 'widget-id':
-			default:
-				echo ' data-widget-id="' . esc_attr( $widget_id ) . '"';
-				break;
-		}
+		echo ' href="https://twitter.com/' . esc_attr( $widget_id ) . '"';
 
 		// End tag output
 		echo '>';
@@ -240,10 +231,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		}
 
-		$instance['type'] = 'widget-id';
-		if ( in_array( $new_instance['type'], array( 'widget-id', 'profile' ) ) ) {
-			$instance['type'] = $new_instance['type'];
-		}
+		$instance['type'] = 'profile';
 
 		$instance['theme'] = 'light';
 		if ( in_array( $new_instance['theme'], array( 'light', 'dark' ) ) ) {
@@ -294,6 +282,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			'title'        => esc_html__( 'Follow me on Twitter', 'jetpack' ),
 			'width'        => '',
 			'height'       => '400',
+			'type'         => 'profile',
 			'widget-id'    => '',
 			'link-color'   => '#f96e5b',
 			'border-color' => '#e8e8e8',
@@ -304,16 +293,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
 
-		if ( empty( $instance['type'] ) ) {
-			// Decide the correct widget type.  If this is a pre-existing
-			// widget with a numeric widget ID, then the type should be
-			// 'widget-id', otherwise it should be 'profile'.
-			if ( ! empty( $instance['widget-id'] ) && is_numeric( $instance['widget-id'] ) ) {
-				$instance['type'] = 'widget-id';
-			} else {
-				$instance['type'] = 'profile';
-			}
-		}
+		$instance['type'] = 'profile';
 		?>
 
 		<p>
@@ -368,39 +348,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			/>
 		</p>
 
-		<p class="jetpack-twitter-timeline-widget-type-container">
-			<label for="<?php echo $this->get_field_id( 'type' ); ?>">
-				<?php esc_html_e( 'Widget Type:', 'jetpack' ); ?>
-				<?php echo $this->get_docs_link( '#widget-type' ); ?>
-			</label>
-			<select
-				name="<?php echo $this->get_field_name( 'type' ); ?>"
-				id="<?php echo $this->get_field_id( 'type' ); ?>"
-				class="jetpack-twitter-timeline-widget-type widefat"
-			>
-				<option value="profile"<?php selected( $instance['type'], 'profile' ); ?>>
-					<?php esc_html_e( 'Profile', 'jetpack' ); ?>
-				</option>
-				<option value="widget-id"<?php selected( $instance['type'], 'widget-id' ); ?>>
-					<?php esc_html_e( 'Widget ID', 'jetpack' ); ?>
-				</option>
-			</select>
-		</p>
-
 		<p class="jetpack-twitter-timeline-widget-id-container">
-			<label
-				for="<?php echo $this->get_field_id( 'widget-id' ); ?>"
-				data-widget-type="widget-id"
-				<?php echo ( 'widget-id' === $instance['type'] ? '' : 'style="display: none;"' ); ?>
-			>
-				<?php esc_html_e( 'Widget ID:', 'jetpack' ); ?>
-				<?php echo $this->get_docs_link( '#widget-id' ); ?>
-			</label>
-			<label
-				for="<?php echo $this->get_field_id( 'widget-id' ); ?>"
-				data-widget-type="profile"
-				<?php echo ( 'profile' === $instance['type'] ? '' : 'style="display: none;"' ); ?>
-			>
+			<label for="<?php echo $this->get_field_id( 'widget-id' ); ?>">
 				<?php esc_html_e( 'Twitter Username:', 'jetpack' ); ?>
 				<?php echo $this->get_docs_link( '#twitter-username' ); ?>
 			</label>

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -90,6 +90,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
 				echo '<p>' . esc_html__( "The Twitter Timeline widget can't display tweets based on searches or hashtags. To display a simple list of tweets instead, change the Widget ID to a Twitter username. Otherwise, delete this widget.", 'jetpack' ) . '</p>';
+				echo '<p>' . esc_html__( '(Only administrators will see this message.)', 'jetpack' ) . '</p>';
 				echo $args['after_widget'];
 			}
 			return;
@@ -109,6 +110,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		if ( 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
 			echo '<p>' . esc_html__( 'As of July 27, 2018, the Twitter Timeline widget will no longer display tweets based on searches or hashtags. To display a simple list of tweets instead, change the Widget ID to a Twitter username.', 'jetpack' ) . '</p>';
+			echo '<p>' . esc_html__( '(Only administrators will see this message.)', 'jetpack' ) . '</p>';
 		}
 
 		// Start tag output

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -86,7 +86,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
-				echo '<p>' . esc_html__( 'Widget ID is not supported anymore. Please update your Twitter Timeline widget.', 'jetpack' ) . '</p>';
+				echo '<p>' . esc_html__( "The Twitter Timeline widget can't display tweets based on searches or hashtags. To display a simple list of tweets instead, change the Widget ID to a Twitter username. Otherwise, delete this widget.", 'jetpack' ) . '</p>';
 				echo $args['after_widget'];
 			}
 			return;
@@ -105,7 +105,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		}
 
 		if ( 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
-			echo '<p>' . esc_html__( 'Widget ID is deprecated and will stop working on 27 July 2018. Please update your Twitter Timeline widget.', 'jetpack' ) . '</p>';
+			echo '<p>' . esc_html__( 'As of July 27, 2018, the Twitter Timeline widget will no longer display tweets based on searches or hashtags. To display a simple list of tweets instead, change the Widget ID to a Twitter username.', 'jetpack' ) . '</p>';
 		}
 
 		// Start tag output

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -106,7 +106,6 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		if ( 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
 			echo '<p>' . esc_html__( 'Widget ID is deprecated and will stop working on 27 July 2018. Please update your Twitter Timeline widget.', 'jetpack' ) . '</p>';
-
 		}
 
 		// Start tag output

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -138,7 +138,17 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}
 
+		$type      = ( isset( $instance['type'] ) ? $instance['type'] : '' );
 		$widget_id = ( isset( $instance['widget-id'] ) ? $instance['widget-id'] : '' );
+		switch ( $type ) {
+			case 'profile':
+				echo ' href="https://twitter.com/' . esc_attr( $widget_id ) . '"';
+				break;
+			case 'widget-id':
+			default:
+				echo ' data-widget-id="' . esc_attr( $widget_id ) . '"';
+				break;
+		}
 		echo ' href="https://twitter.com/' . esc_attr( $widget_id ) . '"';
 
 		// End tag output

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -312,6 +312,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
 
+		if ( 'widget-id' === $instance['type'] ) {
+			$instance['widget-id'] = '';
+		}
+
 		$instance['type'] = 'profile';
 		?>
 


### PR DESCRIPTION
Context: p58i-715-p2, p58i-72F-p2

[Twitter will deprecate](https://twittercommunity.com/t/deprecating-widget-settings/102295) `widget-id` on 25/05/2018 and will cease support altogether on 27/07/2018:

> On May 25, 2018, the widget settings page will no longer allow embedded timeline widgets to be created or edited. From that date, the only (and best) way to create timeline widgets will be to head to publish.twitter.com. All existing timeline widgets that rely on these settings (e.g. the ones that have data-widget-id in the markup) will continue to function until July 27.

Our Twitter Timeline widget can be used to pull tweets either from a `profile` (by feeding it a Twitter username), or from a `widget-id`.
The latter case will stop working on July 27: all Twitter Timeline widgets of type `widget-id` won't render anything anymore.

| Before | Until July 26 | After July 26 |
| --- | --- | --- |
| <img width="271" alt="screen shot 2018-05-22 at 12 05 47" src="https://user-images.githubusercontent.com/2070010/40359007-1d537096-5db9-11e8-8962-e2e381e31f94.png"> | <img width="276" alt="screen shot 2018-05-22 at 12 04 57" src="https://user-images.githubusercontent.com/2070010/40359011-233a7676-5db9-11e8-913e-4a24e8ba3e92.png"> | <img width="268" alt="screen shot 2018-05-22 at 12 04 38" src="https://user-images.githubusercontent.com/2070010/40359018-28ed84e6-5db9-11e8-8b9f-259821036b8a.png"> |

#### Next Steps

Update the support docs (both JP and .com) to remove any mentions of Widget ID.

#### Note

This widget registers a [JavaScript file](https://github.com/Automattic/jetpack/blob/master/modules/widgets/twitter-timeline-admin.js) used on the type selector.

I've decided to not remove it for now because I plan to update this widget to support the Color Picker and maybe extend it to support other Twitter Publish formats.
Though, if you prefer to remove the file for now and add it back in a second time, I'll update this PR ASAP.

#### Note (2)

This file is in the [Fusion whitelist](https://github.com/Automattic/jetpack/blob/master/fusion/whitelist.json#L377), so I assume I don't have to do anything else to sync .com, but since this is the first time I do some JP work after Fusion, please let me know if my assumption is incorrect.

#### Changes proposed in this Pull Request:

* Remove the `type` selector, forcing it to `profile`.
* Add two deprecation notices only visible to admins (`edit_theme_options` capability) and if the widget is of type `widget-id`, inviting them to update the widget.
  * One visible immediately that also informs them of the deprecation deadline.
  * The other will appear starting on July 26 (the day before the deadline).
* On July 26, stop rendering widgets of type `widget-id` for non-admin users.

#### Testing instructions:

* Before checking out this branch: add a Twitter Timeline of type `widget-id` to a sidebar (the only way to create a Twitter Widget right now is at https://twitter.com/settings/widgets/new: create a widget, edit it, and copy the ID from the URL).
* After checking out this branch: make sure that the widget will display a deprecation notice, only visible to admins.
* In the Customizer or in the Widgets dashboard, make sure there is no "Widget Type" selector anymore.
* By modifying the deadline date to the past (e.g. from `2018-07-27` to `2017-07-27`): make sure the widget only displays a deprecation notice to admins, and is not rendered at all to non-admins.