### PR TITLE
Add REST API endpoint to allow changing the connection owner

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -122,6 +122,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::get_user_connection_data_permission_callback',
 		) );
 
+		// Set the connection owner
+		register_rest_route( 'jetpack/v4', '/connection/owner', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::set_connection_owner',
+			'permission_callback' => __CLASS__ . '::set_connection_owner_permission_callback',
+		) );
+
 		// Current user: get or set tracking settings.
 		register_rest_route( 'jetpack/v4', '/tracking/settings', array(
 			array(
@@ -559,6 +566,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Check that user has permission to change the master user.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @return bool|WP_Error True if user is able to change master user.
+	 */
+	public static function set_connection_owner_permission_callback() {
+		if ( get_current_user_id() === Jetpack_Options::get_option( 'master_user' ) ) {
+			return true;
+		}
+
+		return new WP_Error( 'invalid_user_permission_set_connection_owner', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
+	}
+
+	/**
 	 * Verify that a user can use the /connection/user endpoint. Has to be a registered user and be currently linked.
 	 *
 	 * @since 4.3.0
@@ -814,6 +836,64 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'currentUser'  => jetpack_current_user_data(),
 		);
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Change the master user.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return bool|WP_Error True if owner successfully changed.
+	 */
+	public static function set_connection_owner( $request ) {
+		if ( ! isset( $request['owner'] ) ) {
+			return new WP_Error(
+				'invalid_param',
+				esc_html__( 'Invalid Parameter', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$new_owner_id = $request['owner'];
+		if ( ! user_can( $new_owner_id, 'jetpack_admin_page' ) ) {
+			return new WP_Error(
+				'new_owner_not_admin',
+				esc_html__( 'New owner is not admin', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( $new_owner_id === get_current_user_id() ) {
+			return new WP_Error(
+				'new_owner_is_current_user',
+				esc_html__( 'New owner is same as current user', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! Jetpack::is_user_connected( $new_owner_id ) ) {
+			return new WP_Error(
+				'new_owner_not_connected',
+				esc_htmp__( 'New owner is not connected', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$updated = Jetpack_Options::update_option( 'master_user', $new_owner_id );
+		if ( $updated ) {
+			return rest_ensure_response(
+				array(
+					'code' => 'success'
+				)
+			);
+		}
+		return new WP_Error(
+			'error_setting_new_owner',
+			esc_html__( 'Could not confirm new owner.', 'jetpack' ),
+			array( 'status' => 500 )
+		);
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -852,7 +852,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error(
 				'invalid_param',
 				esc_html__( 'Invalid Parameter', 'jetpack' ),
-				array( 'status' => 404 )
+				array( 'status' => 400 )
 			);
 		}
 
@@ -861,7 +861,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error(
 				'new_owner_not_admin',
 				esc_html__( 'New owner is not admin', 'jetpack' ),
-				array( 'status' => 404 )
+				array( 'status' => 400 )
 			);
 		}
 
@@ -869,7 +869,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error(
 				'new_owner_is_current_user',
 				esc_html__( 'New owner is same as current user', 'jetpack' ),
-				array( 'status' => 404 )
+				array( 'status' => 400 )
 			);
 		}
 
@@ -877,7 +877,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error(
 				'new_owner_not_connected',
 				esc_htmp__( 'New owner is not connected', 'jetpack' ),
-				array( 'status' => 404 )
+				array( 'status' => 400 )
 			);
 		}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -857,7 +857,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		$new_owner_id = $request['owner'];
-		if ( ! user_can( $new_owner_id, 'jetpack_admin_page' ) ) {
+		if ( ! user_can( $new_owner_id, 'administrator' ) ) {
 			return new WP_Error(
 				'new_owner_not_admin',
 				esc_html__( 'New owner is not admin', 'jetpack' ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -876,7 +876,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( ! Jetpack::is_user_connected( $new_owner_id ) ) {
 			return new WP_Error(
 				'new_owner_not_connected',
-				esc_htmp__( 'New owner is not connected', 'jetpack' ),
+				esc_html__( 'New owner is not connected', 'jetpack' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1000,8 +1000,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 404, $response );
 
 		// Create another user
-		$new_owner = $this->create_and_get_user();
-		$new_owner->add_cap( 'jetpack_admin_page' );
+		$new_owner = $this->create_and_get_user( 'administrator' );
 		Jetpack_Options::update_option( 'user_tokens', array( $new_owner->ID => "honey.badger.$new_owner->ID" ) );
 
 		// Change owner to valid user

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -993,11 +993,11 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		// Attempt owner change with bad user
 		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => 999 ), 'POST' );
-		$this->assertResponseStatus( 404, $response );
+		$this->assertResponseStatus( 400, $response );
 
 		// Attempt owner change to same user
 		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $user->ID ), 'POST' );
-		$this->assertResponseStatus( 404, $response );
+		$this->assertResponseStatus( 400, $response );
 
 		// Create another user
 		$new_owner = $this->create_and_get_user( 'administrator' );

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -969,5 +969,46 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 404, $response );
 	}
 
+	/**
+	 * Test changing the master user.
+	 *
+	 * @since 6.2.0
+	 */
+	public function test_change_owner() {
+
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user();
+		$user->add_cap( 'jetpack_connect_user' );
+		wp_set_current_user( $user->ID );
+
+		// Mock site already registered
+		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
+
+		// Attempt change, fail because not master user
+		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => 999 ), 'POST' );
+		$this->assertResponseStatus( 403, $response );
+
+		// Set up user as master user
+		Jetpack_Options::update_option( 'master_user', $user->ID );
+
+		// Attempt owner change with bad user
+		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => 999 ), 'POST' );
+		$this->assertResponseStatus( 404, $response );
+
+		// Attempt owner change to same user
+		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $user->ID ), 'POST' );
+		$this->assertResponseStatus( 404, $response );
+
+		// Create another user
+		$new_owner = $this->create_and_get_user();
+		$new_owner->add_cap( 'jetpack_admin_page' );
+		Jetpack_Options::update_option( 'user_tokens', array( $new_owner->ID => "honey.badger.$new_owner->ID" ) );
+
+		// Change owner to valid user
+		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $new_owner->ID ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
+		$this->assertEquals( $new_owner->ID, Jetpack_Options::get_option( 'master_user' ), 'Master user not changed' );
+	}
+
 
 } // class end


### PR DESCRIPTION
Part of fix for https://github.com/Automattic/wp-calypso/issues/16021. A new API is needed to change the connection owner.

#### Changes proposed in this Pull Request:

* Adds a new API endpoint `/connection/owner` to set a new master user with `owner={new owner id}`
* Only current owner has permission to call
* Supplied `owner` must be a currently admin

#### Testing instructions:

* Contains unit test for new API
* Also can be tested from js console with:
```
jQuery.ajax( {
    url: '/wp-json/jetpack/v4/connection/owner/',
    method: 'post',
    beforeSend: function ( xhr ) {
        xhr.setRequestHeader( 'X-WP-Nonce', Initial_State.WP_API_nonce );
    },
    data: JSON.stringify( {
        'owner': **** new owner id ****
    } ),
    contentType: "application/json",
    dataType: "json"
} ).done( function ( response ) {
    console.log( response );
} ).error( function ( error ) {
    console.log( error.responseText );
} );
```

