### PR TITLE
Simple Payments Widget: Add style overrides

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -58,7 +58,8 @@ class Jetpack {
 		'wordads',
 		'eu-cookie-law-style',
 		'flickr-widget-style',
-		'jetpack-search-widget'
+		'jetpack-search-widget',
+		'simple-payments-widget-style',
 	);
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -59,7 +59,7 @@ class Jetpack {
 		'eu-cookie-law-style',
 		'flickr-widget-style',
 		'jetpack-search-widget',
-		'simple-payments-widget-style',
+		'jetpack-simple-payments-widget-style',
 	);
 
 	/**

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -27,6 +27,16 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 					'customize_selective_refresh' => true,
 				)
 			);
+
+			parent::__construct( 'Jetpack_Simple_Payments_Widget', __( 'Simple Payments', 'jetpack' ), $widget );
+
+			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
+			}
+		}
+
+		function enqueue_style() {
+			wp_enqueue_style( 'simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
 		}
 
 		/**
@@ -121,7 +131,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			require( dirname( __FILE__ ) . '/simple-payments/form.php' );
 		}
 	}
-	
+
 	// Register Jetpack_Simple_Payments_Widget widget.
 	function register_widget_jetpack_simple_payments() {
 		// || ! Jetpack::active_plan_supports( 'simple-payment' )

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		}
 
 		function enqueue_style() {
-			wp_enqueue_style( 'simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
+			wp_enqueue_style( 'jetpack-simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
 		}
 
 		/**

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -28,8 +28,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
-			parent::__construct( 'Jetpack_Simple_Payments_Widget', __( 'Simple Payments', 'jetpack' ), $widget );
-
 			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 			}

--- a/modules/widgets/simple-payments/style.css
+++ b/modules/widgets/simple-payments/style.css
@@ -1,0 +1,8 @@
+@media screen and (min-width: 400px) {
+	.widget.simple-payments .jetpack-simple-payments-product {
+		flex-direction: column;
+	}
+	.widget.simple-payments .jetpack-simple-payments-details {
+		padding-left: 0;
+	}
+}

--- a/modules/widgets/simple-payments/style.css
+++ b/modules/widgets/simple-payments/style.css
@@ -1,8 +1,8 @@
 @media screen and (min-width: 400px) {
-	.widget.simple-payments .jetpack-simple-payments-product {
+	.widget.jetpack-simple-payments .jetpack-simple-payments-product {
 		flex-direction: column;
 	}
-	.widget.simple-payments .jetpack-simple-payments-details {
+	.widget.jetpack-simple-payments .jetpack-simple-payments-details {
 		padding-left: 0;
 	}
 }

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -44,7 +44,8 @@ const concat_list = [
 	'modules/wordads/css/style.css',
 	'modules/widgets/eu-cookie-law/style.css',
 	'modules/widgets/flickr/style.css',
-	'modules/search/css/search-widget-frontend.css'
+	'modules/search/css/search-widget-frontend.css',
+	'modules/widgets/simple-payments/style.css',
 ];
 
 /**


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/24902

Originally Simple Payments buttons were designed for being displayed in the post content, but we're recently working to also display them in the sidebars as widgets.

Currently we have a media query that handles how Simple Payments buttons with images are displayed:
- As a single column on small screens (`<400px`).
- As two columns (1 for the image, and the other for everything else) on large screens.

This doesn't scale well for widgets, since most often sidebars `<400px` wide.

#### Changes proposed in this Pull Request:

Override the media query and ensure that Simple Payments widgets are always displayed as a single column.

| Before | After |
| --- | --- |
| <img width="325" alt="screen_shot_2018-05-14_at_11 12 34" src="https://user-images.githubusercontent.com/233601/40123688-2c496148-58fd-11e8-857d-c5bf266db026.png"> | <img width="325" alt="screen_shot_2018-05-14_at_11 37 57" src="https://user-images.githubusercontent.com/233601/40123589-ee977b32-58fc-11e8-9064-ef8cd55f032b.png"> |

#### Testing instructions:

- On a site on a Premium or higher plan, edit a post/page and insert a Simple Payments button with an image.

- Add a Simple Payments widget selecting the SP button with an image.
Make sure that the widget is displayed as a single column at any width.

- Add the same SP button in a post.
Make sure that it's still displayed as a single column on small screens and as two columns on large ones.
