### PR TITLE
Add Jetpack branding to Gutenberg menu items

### DIFF
--- a/_inc/client/gutenberg.jsx
+++ b/_inc/client/gutenberg.jsx
@@ -1,0 +1,6 @@
+/* global wp */
+/* eslint react/react-in-jsx-scope: 0 */
+window.JetpackDashicon = ( { icon } ) => {
+	const { Dashicon } = wp.components;
+	return <span className="jetpack-icon"><Dashicon icon={ icon } /></span>;
+};

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -623,7 +623,7 @@ class Jetpack {
 		add_action( 'admin_enqueue_scripts', array( $this, 'devicepx' ) );
 
 		// gutenberg locale
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_gutenberg_locale' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_gutenberg_assets' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'extra_oembed_providers' ), 100 );
 
@@ -3843,11 +3843,22 @@ p {
 		return true;
 	}
 
-	function enqueue_gutenberg_locale() {
+	function enqueue_gutenberg_assets() {
 		wp_add_inline_script(
 			'wp-i18n',
 			'wp.i18n.setLocaleData( ' . self::get_i18n_data_json() . ', \'jetpack\' );'
 		);
+		wp_enqueue_script(
+			'jetpack-gutenberg',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/gutenberg.min.js',
+				'_inc/build/gutenberg.js'
+			),
+			array( 'wp-blocks', 'wp-element', 'wp-i18n' ),
+			JETPACK__VERSION,
+			true
+		);
+		wp_enqueue_style( 'jetpack-icons' );
 	}
 
 	function jetpack_menu_order( $menu_order ) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -72,7 +72,7 @@ function onBuild( done ) {
 
 		if ( 'production' === process.env.NODE_ENV ) {
 			log( 'Uglifying JS...' );
-			gulp.src( '_inc/build/admin.js' )
+			gulp.src( [ '_inc/build/admin.js', '_inc/build/gutenberg.js' ] )
 				.pipe( uglify() )
 				.pipe( gulp.dest( '_inc/build' ) )
 				.on( 'end', function() {

--- a/modules/shortcodes/js/blocks/vr-block.jsx
+++ b/modules/shortcodes/js/blocks/vr-block.jsx
@@ -1,4 +1,4 @@
-/* global wp */
+/* global wp, JetpackDashicon */
 /* eslint react/react-in-jsx-scope: 0 */
 
 ( function( blocks, components, i18n ) {
@@ -14,7 +14,7 @@
 
 	registerBlockType( 'jetpack/vr', {
 		title: __( 'VR Image', 'jetpack' ),
-		icon: 'embed-photo',
+		icon: <JetpackDashicon icon="embed-photo" />,
 		category: 'embed',
 		support: {
 			html: false

--- a/modules/shortcodes/vr.php
+++ b/modules/shortcodes/vr.php
@@ -139,7 +139,7 @@ function jetpack_register_block_type_vr() {
 	wp_register_script(
 		'jetpack_vr_viewer_shortcode_editor_script',
 		Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/blocks/vr-block.min.js', 'modules/shortcodes/js/blocks/vr-block.js' ),
-		array( 'wp-blocks', 'wp-element', 'wp-i18n' )
+		array( 'jetpack-gutenberg' )
 	);
 
 	wp_register_style(

--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -32,3 +32,16 @@ li.toplevel_page_jetpack .wp-menu-image:before {
 	background: none !important;
 	background-repeat: no-repeat;
 }
+/* icons for the Gutenberg editor */
+.editor-inserter__block .jetpack-icon {
+	position: relative;
+	&::before {
+		font-family: 'jetpack';
+		font-size: 13px;
+		content: '\f100';
+		color: #00BE28;
+		position: absolute;
+		top: 12px;
+		right: -10px;
+	}
+}

--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -32,16 +32,24 @@ li.toplevel_page_jetpack .wp-menu-image:before {
 	background: none !important;
 	background-repeat: no-repeat;
 }
+
 /* icons for the Gutenberg editor */
-.editor-inserter__block .jetpack-icon {
+.editor-block-list-item-jetpack-vr  {
 	position: relative;
-	&::before {
-		font-family: 'jetpack';
-		font-size: 13px;
-		content: '\f100';
-		color: #00BE28;
-		position: absolute;
-		top: 12px;
-		right: -10px;
+	.editor-inserter__item-icon {
+		background-color: #00BE28;
+		color: white;
+		&:hover {
+			color: white;
+		}
+		&::before {
+			font-family: 'jetpack';
+			font-size: 20px;
+			content: '\f100';
+			color: white;
+			position: absolute;
+			top: 9px;
+			right: 15px;
+		}
 	}
 }

--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -38,7 +38,7 @@ li.toplevel_page_jetpack .wp-menu-image:before {
 	position: relative;
 	.editor-inserter__item-icon {
 		background-color: #00BE28;
-		color: white;
+		color: white !important;
 		&:hover {
 			color: white;
 		}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ const webpackConfig = {
 	// The key is used as the name of the script.
 	entry: {
 		admin: './_inc/client/admin.js',
-		'static': './_inc/client/static.jsx'
+		'static': './_inc/client/static.jsx',
+		gutenberg: './_inc/client/gutenberg.jsx',
 	},
 	output: {
 		path: path.join( __dirname, '_inc/build' ),


### PR DESCRIPTION
Alternative to #9579

This builds on https://github.com/WordPress/gutenberg/pull/6636 to show (very amateurishly) how we can style Jetpack components so that users know they're using Jetpack features.

<img width="334" alt="jetpack-icon" src="https://user-images.githubusercontent.com/51896/40254791-b0613684-5a99-11e8-8a59-5d6a709a032e.png">
