### PR TITLE
Sharing: Refactor Jetpack::is_akismet_active() to also check for a valid key

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7110,8 +7110,12 @@ p {
 	 */
 	public static function is_akismet_active() {
 		if ( method_exists( 'Akismet' , 'http_post' ) ) {
-			$akismet_key = Akismet::verify_key( Akismet::get_api_key() );
-			if ( ! $akismet_key || 'invalid' === $akismet_key || 'failed' === $akismet_key ) {
+			$akismet_key = Akismet::get_api_key();
+			if ( ! $akismet_key ) {
+				return false;
+			}
+			$akismet_key_state = Akismet::verify_key( $akismet_key );
+			if ( 'invalid' === $akismet_key_state || 'failed' === $akismet_key_state ) {
 				return false;
 			}
 			return true;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7105,6 +7105,10 @@ p {
 	 */
 	public static function is_akismet_active() {
 		if ( method_exists( 'Akismet' , 'http_post' ) || function_exists( 'akismet_http_post' ) ) {
+			$akismet_key = Akismet::verify_key( Akismet::get_api_key() );
+			if ( ! $akismet_key || 'invalid' === $akismet_key || 'failed' === $akismet_key ) {
+				return false;
+			}
 			return true;
 		}
 		return false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7099,12 +7099,17 @@ p {
 
 	/**
 	 * Checks if Akismet is active and working.
+	 * 
+	 * We dropped support for Akismet 3.0 with Jetpack 6.1.1 while introducing a check for an Akismet valid key
+	 * that implied usage of methods present since more recent version.
+	 * See https://github.com/Automattic/jetpack/pull/9585
 	 *
 	 * @since  5.1.0
+	 * 
 	 * @return bool True = Akismet available. False = Aksimet not available.
 	 */
 	public static function is_akismet_active() {
-		if ( method_exists( 'Akismet' , 'http_post' ) || function_exists( 'akismet_http_post' ) ) {
+		if ( method_exists( 'Akismet' , 'http_post' ) ) {
 			$akismet_key = Akismet::verify_key( Akismet::get_api_key() );
 			if ( ! $akismet_key || 'invalid' === $akismet_key || 'failed' === $akismet_key ) {
 				return false;


### PR DESCRIPTION

More context in p1HpG7-570-p2.

#### Changes proposed in this Pull Request:

* Updates Jetpack::is_akismet_active() to also check for a valid Akismet key.


#### Testing instructions:
 
* Start with a Jetpack-connected site.
* Go to wp-admin > Jetpack > Settings > Sharing > Sharing buttons and make sure sharing buttons are enabled.
* Go to wp-admin > Plugins and make sure Akismet is activated but do not connect Akismet via Jetpack or with an API key.
* Check this branch.
* With the Akismet plugin activated but not connected, expect to not be able to add the email sharing button.

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

Sharing: Added check for validating akismet key before allowing sharing by email. 