### PR TITLE
Stats: Print stats pixel again

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -269,6 +269,7 @@ function stats_render_footer( $data ) {
 </script>
 
 END;
+	print $stats_footer;
 }
 
 function stats_render_amp_footer( $data ) {


### PR DESCRIPTION
After #9458, the pixel was not printed to the front-end.

This restores a `print` that was removed during the refactoring.