### PR TITLE
Fix personal data eraser so it works with latest core

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -863,10 +863,10 @@ class Grunion_Contact_Form_Plugin {
 		}
 
 		return array(
-			'num_items_removed'  => $removed,
-			'num_items_retained' => $retained,
-			'messages'           => $messages,
-			'done'               => count( $post_ids ) < $per_page,
+			'items_removed'  => $removed,
+			'items_retained' => $retained,
+			'messages'       => $messages,
+			'done'           => count( $post_ids ) < $per_page,
 		);
 	}
 


### PR DESCRIPTION
**Fixes a bug reported in p8oabR-cR-p2**

> An error occurred while attempting to find and erase personal data.

![2018-05-22_04-13-14](https://user-images.githubusercontent.com/1563559/40361650-8aa1f66a-5d76-11e8-8134-d38a7b8675cf.png)

This PR updates the array keys returned by the eraser so they match those found in WP core's latest [comment data eraser](https://github.com/WordPress/WordPress/blob/fc800115a76c461cd3c5527a1fd1289bd8498795/wp-includes/comment.php#L3499-L3500); i.e., I'm simply removing the `num_` prefixes.

- Enable Jetpack Contact Forms.
- Create a page and add a Jetpack Contact Form.
- Submit the form a couple of times with a test email address.
- Test both of these upcoming tools in core.
  - **Dashboard -> Tools -> Export Personal Data**
  - **Dashboard -> Tools -> Erase Personal Data**

Expect to find that exporting personal data includes a “Feedback” group containing the personal data that you submitted with the test email address. Erasing personal data should remove the Feedback posts associated with the test email address.