### PR TITLE
Revert "Update site settings enpoints to support Google My Business integration (#9322)"

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -80,8 +80,6 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'twitter_via'                  => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag' => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'         => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
-		'google_my_business_keyring_id' => '(int) The Keyring token ID for a Google My Business token to associate with the site',
-		'google_my_business_location_id' => '(string) The Keyring external user ID representing the associated Google My Business location for this site',
 		'timezone_string'              => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                   => '(int) Site offset from UTC in hours',
 		'date_format'                  => '(string) PHP Date-compatible date format',
@@ -367,8 +365,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'twitter_via'             => (string) get_option( 'twitter_via' ),
 					'jetpack-twitter-cards-site-tag' => (string) get_option( 'jetpack-twitter-cards-site-tag' ),
 					'eventbrite_api_token'    => $this->get_cast_option_value_or_null( 'eventbrite_api_token', 'intval' ),
-					'google_my_business_keyring_id' => $this->get_cast_option_value_or_null( 'google_my_business_keyring_id', 'intval' ),
-					'google_my_business_location_id' => (string) get_option( 'google_my_business_location_id' ),
 					'gmt_offset'              => get_option( 'gmt_offset' ),
 					'timezone_string'         => get_option( 'timezone_string' ),
 					'date_format'             => get_option( 'date_format' ),
@@ -635,26 +631,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						} else if ( update_option( $key, $value ) ) {
 							$updated[ $key ] = (int) $value;
 						}
-					}
-					break;
-
-				case 'google_my_business_keyring_id':
-					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
-						if ( delete_option( $key ) ) {
-							$updated[ $key ] = null;
-						}
-					} else if ( update_option( $key, $value ) ) {
-						$updated[ $key ] = (int) $value;
-					}
-					break;
-
-				case 'google_my_business_location_id':
-					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
-						if ( delete_option( $key ) ) {
-							$updated[ $key ] = null;
-						}
-					} else if ( update_option( $key, $value ) ) {
-						$updated[ $key ] = (string) $value;
 					}
 					break;
 

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -79,8 +79,6 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
-		'google_my_business_keyring_id'        => '(int) The Keyring token ID for a Google My Business token to associate with the site',
-		'google_my_business_location_id'       => '(string) The Keyring external user ID representing the associated Google My Business location for this site',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -86,8 +86,6 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
-		'google_my_business_keyring_id'        => '(int) The Keyring token ID for a Google My Business token to associate with the site',
-		'google_my_business_location_id'       => '(string) The Keyring external user ID representing the associated Google My Business location for this site',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -86,8 +86,6 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'twitter_via'                          => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag'       => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'                 => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
-		'google_my_business_keyring_id'        => '(int) The Keyring token ID for a Google My Business token to associate with the site',
-		'google_my_business_location_id'       => '(string) The Keyring external user ID representing the associated Google My Business location for this site',
 		'timezone_string'                      => '(string) PHP-compatible timezone string like \'UTC-5\'',
 		'gmt_offset'                           => '(int) Site offset from UTC in hours',
 		'date_format'                          => '(string) PHP Date-compatible date format',


### PR DESCRIPTION
This reverts PR #9322.

Google My Business integration with Jetpack sites has taken a new approach (See https://github.com/Automattic/wp-calypso/pull/24815 and D13317) which makes #9322 useless now.