### PR TITLE
Fix EU cookie banner `E_NOTICE` on missing array index

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -196,10 +196,10 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 			$instance = array();
 			$defaults = $this->defaults();
 
-			$instance['hide']           = $this->filter_value( $new_instance['hide'], $this->hide_options );
-			$instance['text']           = $this->filter_value( $new_instance['text'], $this->text_options );
-			$instance['color-scheme']   = $this->filter_value( $new_instance['color-scheme'], $this->color_scheme_options );
-			$instance['policy-url']     = $this->filter_value( $new_instance['policy-url'], $this->policy_url_options );
+			$instance['hide']         = $this->filter_value( isset( $new_instance['hide'] ) ? $new_instance['hide'] : '', $this->hide_options );
+			$instance['text']         = $this->filter_value( isset( $new_instance['text'] ) ? $new_instance['text'] : '', $this->text_options );
+			$instance['color-scheme'] = $this->filter_value( isset( $new_instance['color-scheme'] ) ? $new_instance['color-scheme'] : '', $this->color_scheme_options );
+			$instance['policy-url']   = $this->filter_value( isset( $new_instance['policy-url'] ) ? $new_instance['policy-url'] : '', $this->policy_url_options );
 
 			if ( isset( $new_instance['hide-timeout'] ) ) {
 				// Time can be a value between 3 and 1000 seconds.


### PR DESCRIPTION
Fixes the following `E_NOTICE` by checking if each `isset()` during validation.

> Undefined index: hide in wp-content/plugins/jetpack/modules/widgets/eu-cookie-law.php on line 199

@oskosk I took a slightly different approach than what I suggested in chat because merging with defaults would have altered the way other things work in this function, based on later assumptions.

#### Testing instructions

* Check this branch and enable WP_DEBUG_LOG
* Remove any EU Cookie law widget present.
* Add a Cookies & Consent Banner Widget.
* Expect to see no warning logged.
