### PR TITLE
General: Remove fusion directory from .svnignore

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -39,5 +39,4 @@ yarn.lock
 docker
 bin/pre-commit-hook.js
 bin/travis_install.sh
-fusion
 yarn-error.log


### PR DESCRIPTION
The fusion directory is no longer present so it can be removed from svnignore.

#### Changes proposed in this Pull Request:

* Removes the line reading `fusion` from `.svnignore`.

#### Testing instructions:

None needed