### PR TITLE
Remove .widget class from selector used in EU Cookie Law Widget styles

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -1,4 +1,4 @@
-.widget_eu_cookie_law_widget.widget {
+.widget_eu_cookie_law_widget {
 	border: none;
 	bottom: 1em;
 	display: none;


### PR DESCRIPTION
Fixes #8166

#### Changes proposed in this Pull Request:

Removes `.widget` class from selector in EU Cookie Law Widget styles, since `.widget` is not used in every theme.

#### Testing instructions:

* Apply one of the themes mentioned in #8166 (Graphene or Kahuna) to a test site
* Add the EU Cookie Law Widget to the footer widget area
* View the site from the front-end. Rather than being fixed to the bottom of the screen, the widget message will be at the very bottom of the site:

![](https://cldup.com/zbqdSXHavV-3000x3000.png)

* Apply PR to the test site
* View the site from the front-end. The widget message should now be fixed to the bottom of the screen, and stay with you when you scroll:

![](https://cldup.com/sOKjg9qNne-3000x3000.png)

(Unfortunately this issue doesn't screenshot very meaningfully).

This may not fix all individual clashes between theme styles and the EU Widget, but should help those described in the ticket!
