### PR TITLE
PHPBrew: Activate the hash variant in our 5.2 test environment

### DIFF
--- a/tests/install-php-phpunit.sh
+++ b/tests/install-php-phpunit.sh
@@ -43,14 +43,8 @@ if [[ ${SWITCH_TO_PHP:0:3} == "5.2" ]]; then
 	export PATH=$HOME/php-utils-bin:$PATH
 
   # php and phpunit3.6 installs should be cached, only build if they're not there.
-
-# Temporarily defeat the cached 5.2 build
-# See: https://github.com/Automattic/jetpack/pull/9616#issuecomment-391256715
-# TODO: Remove this before merge!
-rm -rf $HOME/.phpbrew
-
   if [ ! -f $PHPBREW_BUILT_CHECK ]; then
-
+    
     # init with known --old to get 5.2 and 5.3
     $HOME/php-utils-bin/phpbrew init
     $HOME/php-utils-bin/phpbrew known --old

--- a/tests/install-php-phpunit.sh
+++ b/tests/install-php-phpunit.sh
@@ -43,8 +43,14 @@ if [[ ${SWITCH_TO_PHP:0:3} == "5.2" ]]; then
 	export PATH=$HOME/php-utils-bin:$PATH
 
   # php and phpunit3.6 installs should be cached, only build if they're not there.
+
+# Temporarily defeat the cached 5.2 build
+# See: https://github.com/Automattic/jetpack/pull/9616#issuecomment-391256715
+# TODO: Remove this before merge!
+rm -rf $HOME/.phpbrew
+
   if [ ! -f $PHPBREW_BUILT_CHECK ]; then
-    
+
     # init with known --old to get 5.2 and 5.3
     $HOME/php-utils-bin/phpbrew init
     $HOME/php-utils-bin/phpbrew known --old

--- a/tests/install-php-phpunit.sh
+++ b/tests/install-php-phpunit.sh
@@ -52,7 +52,7 @@ if [[ ${SWITCH_TO_PHP:0:3} == "5.2" ]]; then
     # build PHP5.2
     tail -F $HOME/.phpbrew/build/php-5.2.17/build.log &
     TAIL_PID=$!
-    $HOME/php-utils-bin/phpbrew install --patch ${THIS_DIR}/patches/node.patch --patch ${THIS_DIR}/patches/openssl.patch 5.2 +default +mysql +pdo \
+    $HOME/php-utils-bin/phpbrew install --patch ${THIS_DIR}/patches/node.patch --patch ${THIS_DIR}/patches/openssl.patch 5.2 +default +mysql +pdo +hash \
     +gettext +phar +openssl -- --with-openssl-dir=/usr/include/openssl --enable-spl --with-mysql --with-mysqli=/usr/bin/mysql_config --with-pdo-mysql=/usr
     kill -TERM $TAIL_PID
 

--- a/tests/php/test_class.functions.compat.php
+++ b/tests/php/test_class.functions.compat.php
@@ -150,4 +150,8 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_id, $youtube_id );
 	}
+
+	function test_jetpack_hash_function_is_defined() {
+		$this->assertTrue( function_exists( 'hash' ) );
+	}
 } // end class


### PR DESCRIPTION
While working on #9561, I'm getting an error in the 5.2 environment:
`Fatal error: Call to undefined function hash()`

According to the [PHP Docs](http://php.net/manual/en/hash.installation.php):

>  As of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
> It may be explicitly disabled by using the --disable-hash switch to configure.

So, it seems safe to assume it's available for unit testing purposes.

I'll add a check to the other PR that the function exists so on the off chance someone's host has disabled `hash` support, it won't cause a fatal.

#### Changes proposed in this Pull Request:

* Enable the `hash` variant in the PHPBrew-built 5.2 test environment
* Add a compat test to make sure the function is defined

#### Testing instructions:

* Automated tests pass in all envs