### PR TITLE
require-lib: Brings the file in sync with wordpress.com 

### DIFF
--- a/require-lib.php
+++ b/require-lib.php
@@ -40,6 +40,9 @@ function jetpack_require_lib( $slug ) {
 	require_lib_from_dir( $slug, WP_CONTENT_DIR . '/lib' );
 }
 
-function jetpack_require_lib( $slug ) {
-	return jetpack_require_lib( $slug );
+// Function check so we're able to sync it back to Jetpack, since it seems like a very common function name.
+if ( ! function_exists( 'require_lib' ) ) {
+	function require_lib( $slug ) {
+		return jetpack_require_lib( $slug );
+	}
 }


### PR DESCRIPTION
Related phab revision: D13756-code

- Make sure things are still getting required.
- defensive check for require_lib(). seems like a common name that other plugins/themes/hosts may use.