### PR TITLE
Adds a build step to WordPress core.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ branches:
 
 # Clones WordPress and configures our testing environment.
 before_script:
+    - npm install grunt-cli -g
     - phpenv config-rm xdebug.ini
     - export PLUGIN_SLUG=$(basename $(pwd))
     - source ~/.nvm/nvm.sh

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -37,6 +37,9 @@ for WP_SLUG in 'master' 'latest' 'previous'; do
 	sed -i "s/yourusernamehere/root/" wp-tests-config.php
 	sed -i "s/yourpasswordhere//" wp-tests-config.php
 
+	npm install
+	grunt build
+
 	echo "Done!";
 done
 


### PR DESCRIPTION
Core has recently introduced a new file structure and now relies on the build step before it can run unit tests. We need to adapt, hence we are building WordPress before running our own unit tests. See more: https://core.trac.wordpress.org/changeset/43310

Fixes Travis failures.