### PR TITLE
Detect /amp/ suffix when determining AMP request

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -74,7 +74,7 @@ class Jetpack_AMP_Support {
 				||
 					isset( $_GET[ amp_get_slug() ] )
 				||
-					( version_compare( AMP__VERSION, '1.0', '<' ) && self::has_amp_suffix() )
+					( version_compare( AMP__VERSION, '1.0', '<' ) && self::has_amp_suffix() ) // after AMP 1.0, the amp suffix will no longer be supported
 				);
 
 		/**

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -66,7 +66,7 @@ class Jetpack_AMP_Support {
 			&&
 				function_exists( 'amp_is_canonical' ) // this is really just testing if the plugin exists
 			&&
-				( amp_is_canonical() || isset( $_GET[ amp_get_slug() ] ) );
+				( amp_is_canonical() || isset( $_GET[ amp_get_slug() ] ) || self::has_amp_suffix() );
 
 		/**
 		 * Returns true if the current request should return valid AMP content.
@@ -76,6 +76,11 @@ class Jetpack_AMP_Support {
 		 * @param boolean $is_amp_request Is this request supposed to return valid AMP content?
 		 */
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
+	}
+
+	static function has_amp_suffix() {
+		$request_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+		return $request_path && substr_compare( $request_path, '/amp/', -4, 5, true );
 	}
 
 	static function filter_available_widgets( $widgets ) {

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -79,8 +79,8 @@ class Jetpack_AMP_Support {
 	}
 
 	static function has_amp_suffix() {
-		$request_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
-		return $request_path && substr_compare( $request_path, '/amp/', -4, 5, true );
+		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+		return $request_path && preg_match( '#/amp/?$#i', $request_path );
 	}
 
 	static function filter_available_widgets( $widgets ) {

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -62,11 +62,20 @@ class Jetpack_AMP_Support {
 		// can't use is_amp_endpoint() since it's not ready early enough in init.
 		// is_amp_endpoint() implementation calls is_feed, which bails with a notice if plugins_loaded isn't finished
 		// "Conditional query tags do not work before the query is run"
-		$is_amp_request = ! is_admin() // this is necessary so that modules can still be enabled/disabled/configured as per normal via Jetpack admin
+		$is_amp_request =
+				defined( 'AMP__VERSION' )
+			&&
+				! is_admin() // this is necessary so that modules can still be enabled/disabled/configured as per normal via Jetpack admin
 			&&
 				function_exists( 'amp_is_canonical' ) // this is really just testing if the plugin exists
 			&&
-				( amp_is_canonical() || isset( $_GET[ amp_get_slug() ] ) || self::has_amp_suffix() );
+				(
+					amp_is_canonical()
+				||
+					isset( $_GET[ amp_get_slug() ] )
+				||
+					( version_compare( AMP__VERSION, '1.0', '<' ) && self::has_amp_suffix() )
+				);
 
 		/**
 		 * Returns true if the current request should return valid AMP content.


### PR DESCRIPTION
Most AMP sites are currently configured to use the `/amp/` suffix as the canonical path to AMP content.

In Jetpack's AMP support code, we need to hook earlier than `parse_query` in order to properly intercept and modify Jetpack's output, however this means we can't use the standard means to detect `/amp/` from WP_Query and must roll out own solution that assumes that `/amp/` is truly the AMP path for the site.

The downside is that if the site has changed it to something else, e.g. `/mobile/` or `/lite/`, we won't detect it. The upside is that 99% of sites just go with the default, so this provides a workable solution for them.

cc @westonruter