### PR TITLE
Code Sync: Bring wpcom changes to class json endpoints: Add Site keyrings endpoint

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -721,6 +721,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 			);
 			$return[$key] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
 			break;
+		case 'site_keyring':
+			$docs = array(
+				'keyring_id'       => '(int) Keyring ID',
+				'service'          => '(string) The service name',
+				'external_user_id' => '(string) External user id for the service'
+			);
+			$return[$key] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
+			break;
 		case 'taxonomy':
 			$docs = array(
 				'name'         => '(string) The taxonomy slug',


### PR DESCRIPTION
This commit adds a site keyrings endpoint
to manage site<->keyring relationship.

Currently that being used only for Google My Business

Differential revision: D13317

Merges r175707-wpcom.

#### Changes proposed in this Pull Request:

* adds a site keyrings case

#### Testing instructions:

* Check that r175707-wpcom matches this diff

