### PR TITLE
Media endpoint: Rename class - Media not defined in Jetpack

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-media-v1-2-endpoint.php
@@ -66,8 +66,8 @@ class WPCOM_JSON_API_List_Media_v1_2_Endpoint extends WPCOM_JSON_API_List_Media_
 		foreach ( $media_list as $index => $media_item ) {
 			// expose `revision_history` object for each image
 			$media_item->revision_history = (object) array(
-				'items'       => (array) Media::get_revision_history( $media_item->ID ),
-				'original'    => (object) Media::get_original_media( $media_item->ID )
+				'items'       => (array) Jetpack_Media::get_revision_history( $media_item->ID ),
+				'original'    => (object) Jetpack_Media::get_original_media( $media_item->ID )
 			);
 		}
 


### PR DESCRIPTION
I'm not sure how/if this is used, but if it was it definitely wasn't working because `Media` is not defined in Jetpack.