### PR TITLE
Reset bottom margin for eu cookie law form in case theme changed it

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -42,6 +42,14 @@
 }
 
 /**
+ * Using a highly-specific rule to make sure that certain form styles
+ * will be reset
+ */
+#eu-cookie-law form {
+	margin-bottom: 0;
+}
+
+/**
  * Using a highly-specific rule to make sure that all button styles
  * will be reset
  */


### PR DESCRIPTION
Fixes #9632

#### Changes proposed in this Pull Request:

* Adds a specific bottom margin to the cookie widget

#### Testing instructions:

* Install and activate Storefront theme
* Enable the cookie widget
* Verify the margins are consistent within the widget
