### PR TITLE
REST API: Add term feed URL to terms API endpoints

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1441,6 +1441,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$response['slug']        = (string) $taxonomy->slug;
 		$response['description'] = (string) $taxonomy->description;
 		$response['post_count']  = (int) $taxonomy->count;
+		$response['feed_url']    = get_term_feed_link( $taxonomy->term_id, $taxonomy_type );
 
 		if ( is_taxonomy_hierarchical( $taxonomy_type ) ) {
 			$response['parent'] = (int) $taxonomy->parent;

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -522,6 +522,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				'slug'        => '(string)',
 				'description' => '(HTML)',
 				'post_count'  => '(int)',
+				'feed_url'    => '(string)',
 				'meta'        => '(object)',
 			);
 			if ( 'category' === $type['type'] ) {


### PR DESCRIPTION
This diff adds a new property `feed_url` to responses for the API endpoints to list terms and get a single term.

The new property uses the [`get_term_feed_link`](https://developer.wordpress.org/reference/functions/get_term_feed_link/) function from WP core, which has different behavior depending on the current permalink setting and is filterable various ways by plugins, so we shouldn't make any assumptions about the format of feed URLs.

This commit was generated from D13871-code.

Still left to do:

- [ ] ~Add Jetpack automated tests, ideally with a couple of different permalink settings because the feed URLs can look very different based on this.  (WP.com automated tests are in place but they can't cover this case.)~ We'll track and address this separately.
- [x] Decide whether to go ahead and HTML-decode feed URLs - they may include `&amp;`, which will make them harder to use in Calypso, but many other parts of the API have the same issue and don't do this decoding.