### PR TITLE
CLI: Add testing suite to cli status command

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -30,7 +30,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	public function status( $args, $assoc_args ) {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php' );
 
-		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_site_url() ) ) );
+		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_home_url() ) ) );
 
 		if ( ! Jetpack::is_active() ) {
 			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );


### PR DESCRIPTION
The `status` check provides a possibly-incorrect response in terms of if the connection with WordPress.com is functional.

This integrates the testing suite done when visiting the in-plugin debugger with the cli status command.

A future todo would be to align this suite (and which is what is used with jetpack.com/support/debug/) and the test-connection REST API endpoint. At this time, I suggest we use the test suite here since it matches what Happiness uses and contains the most accurate source of information.

Testing:
1. On a Jetpack site that is functional, check https://jetpack.com/support/debug/ and confirm the same result (everything is working) with `jetpack status full`).
2. On a Jetpack site, create some type of breakage that would impact communication only - for example, add whitespace to a plugin after a closing `?>` so that whitespace would be outputted to xmlrpc.php. Before this PR, `jetpack status` would say it is connected but https://jetpack.com/support/debug/ would indicate an issue. After this PR, run `jetpack status full` and confirm CLI informs there is an issue.