### PR TITLE
Contact Form: Updates to data exporter/eraser

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -851,13 +851,13 @@ class Grunion_Contact_Form_Plugin {
 
 		foreach ( $post_ids as $post_id ) {
 			/**
-			 * Filters whether to erase the Feedback post.
+			 * Filters whether to erase a particular Feedback post.
 			 *
-			 * @since
+			 * @since 6.3.0
 			 *
-			 * @param bool|string  Whether to apply erase the Feedback post (bool).
-			 *                     Custom prevention message (string). Default true.
-			 * @param int $post_id Feedback post ID.
+			 * @param bool|string $prevention_message Whether to apply erase the Feedback post (bool).
+			 *                                        Custom prevention message (string). Default true.
+			 * @param int         $post_id            Feedback post ID.
 			 */
 			$prevention_message = apply_filters( 'grunion_contact_form_delete_feedback_post', true, $post_id );
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -749,7 +749,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array $exporters An array of personal data exporters.
 	 */
 	public function register_personal_data_exporter( $exporters ) {
-		$exporters['jetpack-contact-form'] = array(
+		$exporters['jetpack-feedback'] = array(
 			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'               => array( $this, 'personal_data_exporter' ),
 		);
@@ -767,7 +767,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array $erasers An array of personal data erasers.
 	 */
 	public function register_personal_data_eraser( $erasers ) {
-		$erasers['jetpack-contact-form'] = array(
+		$erasers['jetpack-feedback'] = array(
 			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'             => array( $this, 'personal_data_eraser' ),
 		);

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -850,6 +850,33 @@ class Grunion_Contact_Form_Plugin {
 		$post_ids = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
 
 		foreach ( $post_ids as $post_id ) {
+			/**
+			 * Filters whether to erase the Feedback post.
+			 *
+			 * @since
+			 *
+			 * @param bool|string  Whether to apply erase the Feedback post (bool).
+			 *                     Custom prevention message (string). Default true.
+			 * @param int $post_id Feedback post ID.
+			 */
+			$prevention_message = apply_filters( 'grunion_contact_form_delete_feedback_post', true, $post_id );
+
+			if ( true !== $prevention_message ) {
+				if ( $prevention_message && is_string( $prevention_message ) ) {
+					$messages[] = esc_html( $prevention_message );
+				} else {
+					$messages[] = sprintf(
+						// translators: %d: Post ID.
+						__( 'Feedback ID %d could not be removed at this time.', 'jetpack' ),
+						$post_id
+					);
+				}
+
+				$retained = true;
+
+				continue;
+			}
+
 			if ( wp_delete_post( $post_id, true ) ) {
 				$removed = true;
 			} else {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -844,16 +844,16 @@ class Grunion_Contact_Form_Plugin {
 	 */
 	public function personal_data_eraser( $email, $page = 1 ) {
 		$per_page = 250;
-		$removed  = 0;
-		$retained = 0;
+		$removed  = false;
+		$retained = false;
 		$messages = array();
 		$post_ids = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
 
 		foreach ( $post_ids as $post_id ) {
 			if ( wp_delete_post( $post_id, true ) ) {
-				$removed++;
+				$removed = true;
 			} else {
-				$retained++;
+				$retained = true;
 				$messages[] = sprintf(
 					// translators: %d: Post ID.
 					__( 'Feedback ID %d could not be removed at this time.', 'jetpack' ),

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -749,7 +749,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array $exporters An array of personal data exporters.
 	 */
 	public function register_personal_data_exporter( $exporters ) {
-		$exporters[] = array(
+		$exporters['jetpack-contact-form'] = array(
 			'exporter_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'               => array( $this, 'personal_data_exporter' ),
 		);
@@ -767,7 +767,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array $erasers An array of personal data erasers.
 	 */
 	public function register_personal_data_eraser( $erasers ) {
-		$erasers[] = array(
+		$erasers['jetpack-contact-form'] = array(
 			'eraser_friendly_name' => __( 'Feedback', 'jetpack' ),
 			'callback'             => array( $this, 'personal_data_eraser' ),
 		);


### PR DESCRIPTION
The aim of this PR is to add a bit of flexibility to the data exporter and eraser so they can be tailored to the needs of different privacy and data retention policies. For example, on WordCamp.org, we want to retain our contact form submissions for 3 years, so any Feedback posts that are newer than that shouldn't be erased.

To this end, I'm proposing the following changes, which I will add as commits to this PR:

* Use associative strings when registering the exporter and eraser callbacks
* Allow individual items to be skipped during erasure via a filter, similar to how Core's comments eraser works
* ~Perhaps add filters to modify which individual Feedback fields get exported and erased~

#### Testing instructions:

Follow the testing steps in #9395 to get set up and confirm that data export/erasure are working. Then:

* Copy [this file](https://gist.github.com/coreymckrill/bed546ef05c9917d0d01618588a2c206) into the **wp-content/mu-plugins** folder.
* Perform the two tests separately, uncommenting the relevant lines to activate them.
* For Test 1, the result should be that the data export does _not_ include feedback posts, and during data erasure, the feedback posts are _not_ deleted.
* For Test 2, during erasure, you should see a message that personal data was found, but not erased, followed by the "because reasons" message.

#### Proposed changelog entry for your changes:

* Privacy tools: Identify the data export/erasure callbacks for Feedback posts using associative keys, to better match the convention in Core.
* Privacy tools: Added the `grunion_contact_form_delete_feedback_post` filter hook to allow specific Feedback posts to be bypassed during data erasure requests, similar to the `wp_anonymize_comment` filter in Core.
