### PR TITLE
Code Sync: sync easy-markdown.php - was wpcom-ahead - will be jetpack-ahead

### DIFF
--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -116,6 +116,7 @@ class WPCom_Markdown {
 	 */
 	public function load_markdown_for_posts() {
 		add_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ), 10, 2 );
+		add_action( 'after_wp_tiny_mce', array( $this, 'after_wp_tiny_mce' ) );
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ), 10, 2 );
 		add_filter( 'edit_post_content', array( $this, 'edit_post_content' ), 10, 2 );
@@ -135,6 +136,7 @@ class WPCom_Markdown {
 	 */
 	public function unload_markdown_for_posts() {
 		remove_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ) );
+		remove_action( 'after_wp_tiny_mce', array( $this, 'after_wp_tiny_mce' ) );
 		remove_action( 'wp_insert_post', array( $this, 'wp_insert_post' ) );
 		remove_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ), 10, 2 );
 		remove_filter( 'edit_post_content', array( $this, 'edit_post_content' ), 10, 2 );
@@ -438,6 +440,27 @@ class WPCom_Markdown {
 		}
 
 		return $tags;
+	}
+
+	/**
+	 * TinyMCE needs to know not to strip the 'markdown' attribute. Unfortunately, it doesn't
+	 * really offer a nice API for whitelisting attributes, so we have to manually add it
+	 * to the schema instead.
+	 */
+	public function after_wp_tiny_mce() {
+?>
+<script type="text/javascript">
+tinymce.on( 'AddEditor', function( event ) {
+	event.editor.on( 'BeforeSetContent', function( event ) {
+		var editor = event.target;
+		Object.keys( editor.schema.elements ).forEach( function( key, index ) {
+			editor.schema.elements[ key ].attributes['markdown'] = {};
+			editor.schema.elements[ key ].attributesOrder.push( 'markdown' );
+		} );
+	} );
+}, true );
+</script>
+<?php
 	}
 
 	/**

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -450,15 +450,17 @@ class WPCom_Markdown {
 	public function after_wp_tiny_mce() {
 ?>
 <script type="text/javascript">
-tinymce.on( 'AddEditor', function( event ) {
-	event.editor.on( 'BeforeSetContent', function( event ) {
-		var editor = event.target;
-		Object.keys( editor.schema.elements ).forEach( function( key, index ) {
-			editor.schema.elements[ key ].attributes['markdown'] = {};
-			editor.schema.elements[ key ].attributesOrder.push( 'markdown' );
+jQuery( function() {
+	tinymce.on( 'AddEditor', function( event ) {
+		event.editor.on( 'BeforeSetContent', function( event ) {
+			var editor = event.target;
+			Object.keys( editor.schema.elements ).forEach( function( key, index ) {
+				editor.schema.elements[ key ].attributes['markdown'] = {};
+				editor.schema.elements[ key ].attributesOrder.push( 'markdown' );
+			} );
 		} );
-	} );
-}, true );
+	}, true );
+} );
 </script>
 <?php
 	}


### PR DESCRIPTION
Previous attempt in #9366 went wrong because the `<script>` was being executed before `window.tinymce` was declared. So it was reverted in #9366.

Now, for syncing the file, this PR will do it, but also will leave the file jp-ahead because of this wrapping.

#### Changes proposed in this Pull Request:

* Wraps the initialization code for hooking into tinymce be wrapped on a jQuery.ready call.

#### Testing instructions:

* check this PR with a connected Jetpack
* VIsit WordPress's Dashboard and confirm you get not Javascript warnings in the console
* Visit an edit post screen and confirm you're able to write markdown in the "Visual" mode of the classic editor.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
