### PR TITLE
Add option for top of page position for the cookie widget

### DIFF
--- a/modules/widgets/customizer-utils.js
+++ b/modules/widgets/customizer-utils.js
@@ -58,6 +58,11 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 						twttr.widgets.load( placement.container[0] );
 					} else if ( wp.isJetpackWidgetPlaced( placement, 'eu_cookie_law_widget' ) ) {
 						// Refresh EU Cookie Law
+						if ( $( '#eu-cookie-law' ).hasClass( 'top' ) ) {
+							$( '.widget_eu_cookie_law_widget' ).addClass( 'top' );
+						} else {
+							$( '.widget_eu_cookie_law_widget' ).removeClass( 'top' );
+						}
 						placement.container.fadeIn();
 					}
 				}
@@ -66,7 +71,6 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 			// Refresh widgets when they're moved.
 			wp.customize.selectiveRefresh.bind( 'partial-content-moved', function( placement ) {
 				if ( placement.container ) {
-
 					// Refresh Twitter timeline iframe, since it has to be re-built.
 					if ( wp.isJetpackWidgetPlaced( placement, 'twitter_timeline' ) && placement.container.find( 'iframe.twitter-timeline:not([src]):first' ).length ) {
 						placement.partial.refresh();
@@ -74,6 +78,5 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 				}
 			} );
 		}
-	});
-
-})(jQuery);
+	} );
+} )( jQuery );

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -63,6 +63,16 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		);
 
 		/**
+		 * Widget position options.
+		 *
+		 * @var array
+		 */
+		private $position_options = array(
+			'bottom',
+			'top',
+		);
+
+		/**
 		 * Constructor.
 		 */
 		function __construct() {
@@ -117,6 +127,7 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 				'policy-url'         => get_option( 'wp_page_for_privacy_policy' ) ? $this->policy_url_options[1] : $this->policy_url_options[0],
 				'default-policy-url' => 'https://automattic.com/cookies/',
 				'custom-policy-url'  => get_option( 'wp_page_for_privacy_policy' ) ? get_permalink( (int) get_option( 'wp_page_for_privacy_policy' ) ) : '',
+				'position'           => $this->position_options[0],
 				'policy-link-text'   => esc_html__( 'Cookie Policy', 'jetpack' ),
 				'button'             => esc_html__( 'Close and accept', 'jetpack' ),
 				'default-text'       => esc_html__( "Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use. \r\nTo find out more, including how to control cookies, see here:", 'jetpack' ),
@@ -147,6 +158,10 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 			$classes['hide'] = 'hide-on-' . esc_attr( $instance['hide'] );
 			if ( 'negative' === $instance['color-scheme'] ) {
 				$classes['negative'] = 'negative';
+			}
+
+			if ( 'top' === $instance['position'] ) {
+				$classes['top'] = 'top';
 			}
 
 			if ( Jetpack::is_module_active( 'wordads' ) ) {
@@ -200,6 +215,7 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 			$instance['text']         = $this->filter_value( isset( $new_instance['text'] ) ? $new_instance['text'] : '', $this->text_options );
 			$instance['color-scheme'] = $this->filter_value( isset( $new_instance['color-scheme'] ) ? $new_instance['color-scheme'] : '', $this->color_scheme_options );
 			$instance['policy-url']   = $this->filter_value( isset( $new_instance['policy-url'] ) ? $new_instance['policy-url'] : '', $this->policy_url_options );
+			$instance['position']     = $this->filter_value( isset( $new_instance['position'] ) ? $new_instance['position'] : '', $this->position_options );
 
 			if ( isset( $new_instance['hide-timeout'] ) ) {
 				// Time can be a value between 3 and 1000 seconds.

--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -4,6 +4,10 @@
 		initialScrollPosition,
 		scrollFunction;
 
+	if ( overlay.hasClass( 'top' ) ) {
+		$( '.widget_eu_cookie_law_widget' ).addClass( 'top' );
+	}
+
 	if ( overlay.hasClass( 'ads-active' ) ) {
 		var adsCookieValue = document.cookie.replace( /(?:(?:^|.*;\s*)personalized-ads-consent\s*\=\s*([^;]*).*$)|^.*$/, '$1' );
 		if ( '' !== cookieValue && '' !== adsCookieValue ) {

--- a/modules/widgets/eu-cookie-law/form.php
+++ b/modules/widgets/eu-cookie-law/form.php
@@ -237,6 +237,38 @@
 
 <hr />
 
+<p>
+	<strong>
+		<?php _e( 'Position', 'jetpack' ); ?>
+	</strong>
+	<ul>
+		<li>
+			<label>
+				<input
+					<?php checked( $instance['position'], 'bottom' ); ?>
+					name="<?php echo esc_attr( $this->get_field_name( 'position' ) ); ?>"
+					type="radio"
+					value="bottom"
+				/>
+				<?php esc_html_e( 'Bottom', 'jetpack' ); ?>
+			</label>
+		</li>
+		<li>
+			<label>
+				<input
+					<?php checked( $instance['position'], 'top' ); ?>
+					name="<?php echo esc_attr( $this->get_field_name( 'position' ) ); ?>"
+					type="radio"
+					value="top"
+				/>
+				<?php esc_html_e( 'Top', 'jetpack' ); ?>
+			</label>
+		</li>
+	</ul>
+</p>
+
+<hr />
+
 <p class="small">
 	<?php esc_html_e( 'It is your own responsibility to ensure that your site complies with the relevant laws.', 'jetpack' ); ?>
 	<a href="https://jetpack.com/support/extra-sidebar-widgets/eu-cookie-law-widget/">

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -11,6 +11,11 @@
 	z-index: 50001;
 }
 
+.widget_eu_cookie_law_widget.widget.top {
+	bottom: auto;
+	top: 1em;
+}
+
 #eu-cookie-law {
 	background-color: #fff;
 	border: 1px solid #dedede;

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -16,6 +16,10 @@
 	top: 1em;
 }
 
+.admin-bar .widget_eu_cookie_law_widget.widget.top {
+	top: 3em;
+}
+
 #eu-cookie-law {
 	background-color: #fff;
 	border: 1px solid #dedede;


### PR DESCRIPTION
Fixes #9634

#### Changes proposed in this Pull Request:

* Adds a "top" option for the cookie widget position. The existing bottom of the screen position is the default.

#### Testing instructions:

* Test both the top and bottom for existing and new instances of the widget. Test with and without the admin bar present. 
* To test in development mode, you'll need to force the widgets module active, e.g. using https://github.com/allendav/jetpack-force-widgets-active

#### Proposed changelog entry for your changes:

* Adds a "top" option for the cookie widget position. The existing bottom of the screen position is the default.
