### PR TITLE
Simple Payments: adds plan support check for Jetpack and WordPress.com.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1502,6 +1502,7 @@ class Jetpack {
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
 			$supports[] = 'akismet';
+			$supports[] = 'simple-payments';
 			$supports[] = 'vaultpress';
 			$plan['class'] = 'premium';
 		}
@@ -1516,6 +1517,7 @@ class Jetpack {
 
 		if ( in_array( $plan['product_slug'], $business_plans ) ) {
 			$supports[] = 'akismet';
+			$supports[] = 'simple-payments';
 			$supports[] = 'vaultpress';
 			$plan['class'] = 'business';
 		}

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -76,7 +76,7 @@ var PaypalExpressCheckout = {
 		var cssClasses = PaypalExpressCheckout.messageCssClassName + ' show ';
 		cssClasses += isError ? 'error' : 'success';
 
-		// show message 1s after Paypal popup is closed
+		// show message 1s after PayPal popup is closed
 		setTimeout( function() {
 			domEl.innerHTML = message;
 			domEl.setAttribute( 'class', cssClasses );
@@ -140,9 +140,9 @@ var PaypalExpressCheckout = {
 
 			style: {
 				label: 'pay',
-				fundingicons: true,
 				shape: 'rect',
-				color: 'silver'
+				color: 'silver',
+				fundingicons: true,
 			},
 
 			payment: function() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -86,7 +86,7 @@ class Jetpack_Simple_Payments {
 		/**
 		 * Can be used by plugin authors to disable the conflicting output of Simple Payments.
 		 *
-		 * @since 6.2.0
+		 * @since 6.3.0
 		 *
 		 * @param bool True if Simple Payments should be disabled, false otherwise.
 		 */

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -27,7 +27,7 @@ class Jetpack_Simple_Payments {
 		return self::$instance;
 	}
 
-	private function register_scripts() {
+	private function register_scripts_and_styles() {
 		/**
 		 * Paypal heavily discourages putting that script in your own server:
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
@@ -35,6 +35,7 @@ class Jetpack_Simple_Payments {
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
 		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ),
 			array( 'jquery', 'paypal-checkout-js' ), self::$version );
+		wp_register_style( 'jetpack-simple-payments', plugins_url( '/simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 	}
 
 	private function register_init_hook() {
@@ -53,7 +54,7 @@ class Jetpack_Simple_Payments {
 
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
-		$this->register_scripts();
+		$this->register_scripts_and_styles();
 		$this->register_shortcode();
 		$this->setup_cpts();
 
@@ -134,11 +135,13 @@ class Jetpack_Simple_Payments {
 		);
 
 		$data['id'] = $attrs['id'];
+
+		if( ! wp_style_is( 'jetpack-simple-payments', 'enqueue' ) ) {
+			wp_enqueue_style( 'jetpack-simple-payments' );
+		}
+
 		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
 			wp_enqueue_script( 'paypal-express-checkout' );
-		}
-		if ( ! wp_style_is( 'simple-payments', 'enqueued' ) ) {
-			wp_enqueue_style( 'simple-payments', plugins_url( 'simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 		}
 
 		wp_add_inline_script( 'paypal-express-checkout', sprintf(
@@ -249,7 +252,7 @@ class Jetpack_Simple_Payments {
 			'read_private_posts'    => 'read_private_posts',
 		);
 		$order_args = array(
-			'label'                 => esc_html__( 'Order', 'jetpack' ),
+			'label'                 => esc_html_x( 'Order', 'noun: a quantity of goods or items purchased or sold', 'jetpack' ),
 			'description'           => esc_html__( 'Simple Payments orders', 'jetpack' ),
 			'supports'              => array( 'custom-fields', 'excerpt' ),
 			'hierarchical'          => false,


### PR DESCRIPTION
This is blocking #9577

#### Changes proposed in this Pull Request:

Adds plan check for the Simple Payments shortcode. To prevent breaking the site if a user downgrades and has active Simple Payments buttons, the shortcode is ignored and removed from the post or page output.

#### Testing instructions:

* Apply this branch on a Jetpack site with a Premium or Business Subscriptions.
* Using Calypso, add a Simple Payment button to a page or post.
* Navigate to the page or post where the button was added.

The Simple Payment button should display without regressions on the page or post it was added to.

* Downgrade the site to the Free plan without deleting the SP button.
* Navigate to the Jetpack dashboard to refresh the site's settings.
* Navigate to the page or post where the SP button was added.

The page should not show a SP Button, nor it should display the unprocessed shortcode.