### PR TITLE
Add remoteRegister to unsigned requests on active jetpacks

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -83,6 +83,7 @@ class Jetpack_XMLRPC_Server {
 	function authorize_xmlrpc_methods() {
 		return array(
 			'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ),
+			'jetpack.remoteRegister' => array( $this, 'remote_register' ),
 		);
 	}
 


### PR DESCRIPTION
Fixes an issue where `force_register=true` in Jetpack Start provisioning could cause a failure with a missing endpoint.

`requested method jetpack.remoteRegister does not exist`

#### Changes proposed in this Pull Request:

* Make remoteRegister method available for unsigned requests to active Jetpacks.

