### PR TITLE
Revert "Sync: Remove jetpack_valid_failed_login_attempt sync event"

### DIFF
--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * logs bruteprotect failed logins via sync
+ */
+class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
+
+	function name() {
+		return 'protect';
+	}
+
+	function init_listeners( $callback ) {
+		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ) );
+		add_action( 'jetpack_valid_failed_login_attempt', $callback );
+	}
+
+	function maybe_log_failed_login_attempt( $failed_attempt ) {
+		$protect = Jetpack_Protect_Module::instance();
+		if ( $protect->has_login_ability() ) {
+			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
+		}
+	}
+}

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -23,6 +23,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-terms.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-plugins.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-full-sync.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-stats.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-protect.php';
 
 class Jetpack_Sync_Modules {
 
@@ -37,6 +38,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Users',
 		'Jetpack_Sync_Module_Posts',
 		'Jetpack_Sync_Module_Import',
+		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Updates',
 		'Jetpack_Sync_Module_Attachments',

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test pluggable functionality for bruteprotect
+ */
+
+require_once dirname( __FILE__ ) . '/../../../modules/protect.php';
+
+class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
+
+	function test_sends_failed_login_message() {
+		$user_id = $this->factory->user->create();
+
+		$user = get_userdata( $user_id );
+
+		Jetpack_Protect_Module::instance()->log_failed_attempt( $user->user_email );
+
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+
+		$this->assertEquals( $user->user_email, $action->args[0]['login'] );
+	}
+
+	function test_sends_failed_login_empty_message() {
+		Jetpack_Protect_Module::instance()->log_failed_attempt();
+
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+
+		$this->assertEquals( '', $action->args[0]['login'] );
+	}
+}


### PR DESCRIPTION
Reverts Automattic/jetpack#9514

We need to only remove the failed login attempts that should happen via xml-rpc but leave the other ones as is. 

the idea is that we would only show the ones that are done by real humans. 

cc: @lezama