### PR TITLE
Sync: Do not sync failed login attempts that happen via xml-rpc.

### DIFF
--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -16,7 +16,7 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 
 	function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = Jetpack_Protect_Module::instance();
-		if ( $protect->has_login_ability() ) {
+		if ( $protect->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -22,6 +22,20 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $user->user_email, $action->args[0]['login'] );
 	}
 
+	function test_do_not_send_failed_login_message() {
+		$user_id = $this->factory->user->create();
+
+		$user = get_userdata( $user_id );
+		Jetpack_Constants::set_constant( 'XMLRPC_REQUEST', true ); // fake xmlrpc request
+		Jetpack_Protect_Module::instance()->log_failed_attempt( $user->user_email );
+		Jetpack_Constants::clear_single_constant( 'XMLRPC_REQUEST' );
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );
+
+		$this->assertFalse( $action );
+	}
+
 	function test_sends_failed_login_empty_message() {
 		Jetpack_Protect_Module::instance()->log_failed_attempt();
 


### PR DESCRIPTION
We get too many of failed login attems and this will make the Activity log more meaningful for the user by only showing the ones that are not done via xml-rpc. 

#### Changes proposed in this Pull Request:

* prevents the logging of the failed login attempts when done via xmlrpc requests. 

#### Testing instructions:

* Make a login request to the xmlrpc make sure that it doesn't appear in the activity log.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
