### PR TITLE
Sync: Fix single theme update

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -278,9 +278,6 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function check_upgrader( $upgrader, $details ) {
-		l( 'CHECK UPGRESADER!' );
-		l( $details );
-		l( $upgrader->theme_info() );
 		if ( ! isset( $details['type'] ) ||
 		     'theme' !== $details['type'] ||
 		     is_wp_error( $upgrader->skin->result ) ||

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -236,7 +236,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 		fclose( $file_pointer );
-		
+
 		$theme_data = array(
 			'name' => $theme->get('Name'),
 			'version' => $theme->get('Version'),
@@ -277,7 +277,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		do_action( 'jetpack_deleted_theme', $slug, $theme_data );
 	}
 
-	public function check_upgrader( $upgrader, $details) {
+	public function check_upgrader( $upgrader, $details ) {
+		l( 'CHECK UPGRESADER!' );
+		l( $details );
+		l( $upgrader->theme_info() );
 		if ( ! isset( $details['type'] ) ||
 		     'theme' !== $details['type'] ||
 		     is_wp_error( $upgrader->skin->result ) ||
@@ -311,6 +314,11 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		if ( 'update' === $details['action'] ) {
 			$themes = array();
+
+			if ( empty( $details['themes'] ) && isset ( $details['theme'] ) ) {
+				$details['themes'] = array( $details['theme'] );
+			}
+
 			foreach ( $details['themes'] as $theme_slug ) {
 				$theme = wp_get_theme( $theme_slug );
 

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -246,7 +246,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'itek', $event_data->args[0] );
 	}
 
-	public function test_update_theme_sync() {
+	public function test_update_themes_sync() {
 		$dummy_details = array(
 			'type' => 'theme',
 			'action' => 'update',
@@ -271,6 +271,27 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'Twenty Sixteen', $themes['twentysixteen']['name'] );
 		$this->assertEquals( 'https://wordpress.org/themes/twentysixteen/', $themes['twentysixteen']['uri'] );
 		$this->assertEquals( 'twentysixteen', $themes['twentysixteen']['stylesheet'] );
+	}
+
+	public function test_update_theme_sync() {
+		$dummy_details = array(
+			'type' => 'theme',
+			'action' => 'update',
+			'theme' => 'twentyseventeen'
+		);
+
+		/** This action is documented in /wp-admin/includes/class-wp-upgrader.php */
+		do_action( 'upgrader_process_complete', new Dummy_Sync_Test_WP_Upgrader(), $dummy_details );
+
+		$this->sender->do_sync();
+
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_updated_themes' );
+		$themes = $event_data->args[0];
+
+		//Not testing versions since they are subject to change
+		$this->assertEquals( 'Twenty Seventeen', $themes['twentyseventeen']['name'] );
+		$this->assertEquals( 'https://wordpress.org/themes/twentyseventeen/', $themes['twentyseventeen']['uri'] );
+		$this->assertEquals( 'twentyseventeen', $themes['twentyseventeen']['stylesheet'] );
 	}
 
 	public function test_widgets_changes_get_synced() {


### PR DESCRIPTION
When updating a theme via the new update theme UI in the activity log.
We should show the new theme updated activity.

This fixes an regression introduced in https://github.com/Automattic/jetpack/pull/9519

cc: @eliorivero 

#### Changes proposed in this Pull Request:

* Check that we show just one activity as expected.

#### Testing instructions:

Set a theme so that it needs an update. 
Update it via the activity log. 

Do you notice that the activity show up as excepted?

<img width="1191" alt="screen shot 2018-05-30 at 4 03 55 pm" src="https://user-images.githubusercontent.com/115071/40752137-22129358-6423-11e8-86e3-a33a27b3efe8.png">


