### PR TITLE
Sharing: Scope the check for a valid and active Akismet key only to wp-admin

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7098,18 +7098,33 @@ p {
 	}
 
 	/**
-	 * Checks if Akismet is active and working.
-	 * 
+	 * Checks if Akismet is active.
+	 *
 	 * We dropped support for Akismet 3.0 with Jetpack 6.1.1 while introducing a check for an Akismet valid key
 	 * that implied usage of methods present since more recent version.
 	 * See https://github.com/Automattic/jetpack/pull/9585
 	 *
 	 * @since  5.1.0
-	 * 
+	 *
 	 * @return bool True = Akismet available. False = Aksimet not available.
 	 */
 	public static function is_akismet_active() {
 		if ( method_exists( 'Akismet' , 'http_post' ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if Akismet is active and functional.
+	 * Because sometimes checking if the Akismet plugin is active is not enough.
+	 *
+	 * @since  6.2.0
+	 *
+	 * @return bool True = Akismet available and functional. False = Aksimet not available and functional.
+	 */
+	public static function is_akismet_active_and_has_valid_key() {
+		if ( self::is_akismet_active() ) {
 			$akismet_key = Akismet::get_api_key();
 			if ( ! $akismet_key ) {
 				return false;

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -70,7 +70,7 @@ function sharing_email_send_post( $data ) {
 /* Return $data as it if email about to be send out is not spam. */
 function sharing_email_check_for_spam_via_akismet( $data ) {
 
-	if ( ! Jetpack::is_akismet_active() )
+	if ( ! Jetpack::is_akismet_active_and_has_valid_key() )
 		return $data;
 
 	// Prepare the body_request for akismet


### PR DESCRIPTION
Alternative to #9669.

in #9585 we updated `Jetpack::is_akismet_active` to always check if the plugin is active and with a valid key. This had implications for:

1. When we were deciding whether to render or not the Share by Email Button in Settings -> Sharing. So users without a valid Akismet key can't configure the Share by Email Button.
2. Everytime `Jetpack::get_all_services` is called, because there we decide whether to show the Share by Email button in the **frontend**. 

Fixes multiple calls to Akismet's service from the sites' frontend.

#### Changes proposed in this Pull Request:

* Introduces `Jetpack:: is_akismet_active_and_has_valid_key` for checking if the Akismet plugin is active on the site and configured with a valid key.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->


