### PR TITLE
Widgets: Make the Simple Payments button compatible with Selective Refresh

### DIFF
--- a/modules/widgets/customizer-utils.js
+++ b/modules/widgets/customizer-utils.js
@@ -1,4 +1,4 @@
-/* global wp, gapi, FB, twttr */
+/* global wp, gapi, FB, twttr, PaypalExpressCheckout */
 
 /**
  * Utilities to work with widgets in Customizer.
@@ -59,6 +59,12 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 					} else if ( wp.isJetpackWidgetPlaced( placement, 'eu_cookie_law_widget' ) ) {
 						// Refresh EU Cookie Law
 						placement.container.fadeIn();
+					} else if ( wp.isJetpackWidgetPlaced( placement, 'jetpack_simple_payments_widget' ) ) {
+						// Refresh Simple Payments Widget
+						try {
+							const buttonId = $( '.jetpack-simple-payments-button', placement.container ).attr( 'id' ).replace( '_button', '' );
+							PaypalExpressCheckout.renderButton( null, null, buttonId, null );
+						} catch ( e ) {}
 					}
 				}
 			} );
@@ -70,10 +76,12 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 					// Refresh Twitter timeline iframe, since it has to be re-built.
 					if ( wp.isJetpackWidgetPlaced( placement, 'twitter_timeline' ) && placement.container.find( 'iframe.twitter-timeline:not([src]):first' ).length ) {
 						placement.partial.refresh();
+					} else if ( wp.isJetpackWidgetPlaced( placement, 'jetpack_simple_payments_widget' ) ) {
+						// Refresh Simple Payments Widget
+						placement.partial.refresh();
 					}
 				}
 			} );
 		}
-	});
-
-})(jQuery);
+	} );
+} )( jQuery );


### PR DESCRIPTION
Require #9577 

The Simple Payments module works basically like this: whenever the Simple Payments button is rendered, it calls a JS script that in turns renders a PayPal button.
This doesn't happen with the Simple Payments widget, when the Customizer _selectively refreshes_ it.

#### Changes proposed in this Pull Request:

* Add the Simple Payments widget to the widgets that support Selective Refresh.
* Upon widget change or move, trigger a new PayPal button render on the updated widget button.

#### Testing instructions:

* Pick a Premium/Business site with one or more Simple Payments button already created.
* Open the Customizer and add a Simple Payments widget.
* Edit the widget, wait for the Customizer to refresh it, and make sure its PayPal button is still visible.
* Move the widget, and again check if the PayPal button is there.