### PR TITLE
Sharing: Cache the result of verification of the akismet key in a transient

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7117,17 +7117,17 @@ p {
 			$cached_key_verification = get_transient( 'jetpack_akismet_key_is_valid' );
 
 			// We cache the result of the Akismet key verification for ten minutes.
-			if ( in_array( $cached_key_verification, array( 'valid', 'invalid', 'failed' ) ) ) {
+			if ( in_array( $cached_key_verification, array( 'valid', 'invalid' ) ) ) {
 				$akismet_key_state = $cached_key_verification;
 			} else {
 				$akismet_key_state = Akismet::verify_key( $akismet_key );
+				if ( 'failed' === $akismet_key_state ) {
+					return false;
+				}
 				set_transient( 'jetpack_akismet_key_is_valid', $akismet_key_state, 10 * MINUTE_IN_SECONDS );
 			}
 
-			if ( 'invalid' === $akismet_key_state || 'failed' === $akismet_key_state ) {
-				return false;
-			}
-			return true;
+			return ( 'valid' === $akismet_key_state );
 		}
 		return false;
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7099,13 +7099,13 @@ p {
 
 	/**
 	 * Checks if Akismet is active and working.
-	 * 
+	 *
 	 * We dropped support for Akismet 3.0 with Jetpack 6.1.1 while introducing a check for an Akismet valid key
 	 * that implied usage of methods present since more recent version.
 	 * See https://github.com/Automattic/jetpack/pull/9585
 	 *
 	 * @since  5.1.0
-	 * 
+	 *
 	 * @return bool True = Akismet available. False = Aksimet not available.
 	 */
 	public static function is_akismet_active() {
@@ -7114,7 +7114,16 @@ p {
 			if ( ! $akismet_key ) {
 				return false;
 			}
-			$akismet_key_state = Akismet::verify_key( $akismet_key );
+			$cached_key_verification = get_transient( 'jetpack_akismet_key_is_valid' );
+
+			// We cache the result of the Akismet key verification for ten minutes.
+			if ( in_array( $cached_key_verification, array( 'valid', 'invalid', 'failed' ) ) ) {
+				$akismet_key_state = $cached_key_verification;
+			} else {
+				$akismet_key_state = Akismet::verify_key( $akismet_key );
+				set_transient( 'jetpack_akismet_key_is_valid', $akismet_key_state, 10 * MINUTE_IN_SECONDS );
+			}
+
 			if ( 'invalid' === $akismet_key_state || 'failed' === $akismet_key_state ) {
 				return false;
 			}


### PR DESCRIPTION
Alternative to #9667

in #9585 we updated `Jetpack::is_akismet_active` to always check if the plugin is active and with a valid key. This had implications for:

1. When we were deciding whether to render or not the Share by Email Button in Settings -> Sharing. So users without a valid Akismet key can't configure the Share by Email Button.
2. Everytime `Jetpack::get_all_services` is called, because there we decide whether to show the Share by Email button in the **frontend**. 

#### Changes proposed in this Pull Request:

* Caches the result of verifying the Akismet for ten minutes so we don't request it a lot of times in the frontend.

#### Testing instructions:

* **Start with Akismet being active but without a key set**
* Connect Jetpack and activate recommended features
* Visit Sharing -> Settings
* Confirm that you don’t see the Share by Email button
* **Enter a valid key for Akismet**
* Visit Sharing -> Settings
* Confirm that you see the Share by Email button
* Add the Share by Email Button
* Visit the frontend, a post
* Confirm that you see the Share by Email button
* **Visit `/wp-admin/options.php` and update the value of the option `ossdl_off_include_dirs` to be invalid (just appending a new character will do).**
* Visit the frontend, a post
* Confirm that you don't see the Share by Email button
* Visit Sharing -> Settings
* Confirm that you don’t see the Share by Email button
#### Changelog entry

Fixed the way we check if akismet is active and has a valid key by caching the result of the verification.