### PR TITLE
REST API: Add tests for term feed URL

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -112,11 +112,6 @@ function is_running_uninstall_group() {
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
 }
 
-function is_running_external_http_group() {
-	global $argv;
-	return is_array( $argv ) && in_array( '--group=external-http', $argv );
-}
-
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist
 require $test_root . '/includes/speed-trap-listener.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -90,7 +90,7 @@ function _manually_install_woocommerce() {
 }
 
 // If we are running the uninstall tests don't load jepack.
-if ( ! ( is_running_uninstall_group() ) ) {
+if ( ! ( in_running_uninstall_group() ) ) {
 	tests_add_filter( 'plugins_loaded', '_manually_load_plugin', 1 );
 	if ( '1' == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		tests_add_filter( 'setup_theme', '_manually_install_woocommerce' );	
@@ -100,15 +100,15 @@ if ( ! ( is_running_uninstall_group() ) ) {
 require $test_root . '/includes/bootstrap.php';
 
 // Load the shortcodes module to test properly.
-if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! is_running_uninstall_group() ) {
+if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! in_running_uninstall_group() ) {
 	require dirname( __FILE__ ) . '/../../modules/shortcodes.php';
 }
 
 // Load attachment helper methods.
 require dirname( __FILE__ ) . '/attachment_test_case.php';
 
-function is_running_uninstall_group() {
-	global $argv;
+function in_running_uninstall_group() {
+	global  $argv;
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
 }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -90,7 +90,7 @@ function _manually_install_woocommerce() {
 }
 
 // If we are running the uninstall tests don't load jepack.
-if ( ! ( in_running_uninstall_group() ) ) {
+if ( ! ( is_running_uninstall_group() ) ) {
 	tests_add_filter( 'plugins_loaded', '_manually_load_plugin', 1 );
 	if ( '1' == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		tests_add_filter( 'setup_theme', '_manually_install_woocommerce' );	
@@ -100,16 +100,21 @@ if ( ! ( in_running_uninstall_group() ) ) {
 require $test_root . '/includes/bootstrap.php';
 
 // Load the shortcodes module to test properly.
-if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! in_running_uninstall_group() ) {
+if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! is_running_uninstall_group() ) {
 	require dirname( __FILE__ ) . '/../../modules/shortcodes.php';
 }
 
 // Load attachment helper methods.
 require dirname( __FILE__ ) . '/attachment_test_case.php';
 
-function in_running_uninstall_group() {
-	global  $argv;
+function is_running_uninstall_group() {
+	global $argv;
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
+}
+
+function is_running_external_http_group() {
+	global $argv;
+	return is_array( $argv ) && in_array( '--group=external-http', $argv );
 }
 
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose

--- a/tests/php/modules/shortcodes/test_class.ted.php
+++ b/tests/php/modules/shortcodes/test_class.ted.php
@@ -48,7 +48,7 @@ class WP_Test_Jetpack_Shortcodes_Ted_External extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( 'ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world.html', $shortcode_content );
+		$this->assertContains( 'ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world', $shortcode_content );
 
 		unset( $GLOBALS[ 'post' ] );
 	}

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -37,12 +37,6 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
-		if ( ! is_running_external_http_group() ) {
-			$this->markTestSkipped(
-				'Use --group=external-http to run this test'
-			);
-		}
-
 		$endpoint = new Jetpack_JSON_API_Plugins_Modify_Endpoint( array(
 			'description'     => 'Update a Plugin on your Jetpack Site',
 			'group'           => 'plugins',
@@ -128,7 +122,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
-	 * @requires PHP 5.3.2
+	 * @requires PHP 5.3
 	 */
 	public function test_get_term_feed_url_pretty_permalinks() {
 		global $blog_id;
@@ -159,7 +153,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
-	 * @requires PHP 5.3.2
+	 * @requires PHP 5.3
 	 */
 	public function test_get_term_feed_url_ugly_permalinks() {
 		global $blog_id;
@@ -189,6 +183,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author tonykova
 	 * @covers Jetpack_API_Plugins_Install_Endpoint
+	 * @group external-http
 	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -37,6 +37,11 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
+		if ( ! is_running_external_http_group() ) {
+			$this->markTestSkipped(
+				'Use --group=external-http to run this test'
+			);
+		}
 
 		$endpoint = new Jetpack_JSON_API_Plugins_Modify_Endpoint( array(
 			'description'     => 'Update a Plugin on your Jetpack Site',

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -20,6 +20,12 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 
 		parent::setUp();
 
+		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
+			// Loading the API breaks in 5.2.x due to `const` declarations, and
+			// this will still happen even though all tests are skipped (why?)
+			return;
+		}
+
 		$this->set_globals();
 
 		// Force direct method. Running the upgrade via PHPUnit can't detect the correct filesystem method.

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -128,6 +128,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
+	 * @requires PHP 5.3.2
 	 */
 	public function test_get_term_feed_url_pretty_permalinks() {
 		global $blog_id;
@@ -158,6 +159,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
+	 * @requires PHP 5.3.2
 	 */
 	public function test_get_term_feed_url_ugly_permalinks() {
 		global $blog_id;

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -24,6 +24,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		// Force direct method. Running the upgrade via PHPUnit can't detect the correct filesystem method.
 		add_filter( 'filesystem_method', array( $this,  'filesystem_method_direct' ) );
 
+		require_once dirname( __FILE__ ) . '/../../modules/module-extras.php';
 		require_once dirname( __FILE__ ) . '/../../class.json-api.php';
 		require_once dirname( __FILE__ ) . '/../../class.json-api-endpoints.php';
 	}

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * @group external-http
- */
+
 class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 
 	/**
@@ -16,6 +14,9 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	}
 
 	public function setUp() {
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
 
 		parent::setUp();
 
@@ -32,6 +33,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author lezama
 	 * @covers Jetpack_JSON_API_Plugins_Modify_Endpoint
+	 * @group external-http
 	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
@@ -97,6 +99,84 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 			$this->rmdir( $the_real_folder );
 		}
 
+	}
+
+	public function create_get_category_endpoint() {
+		// From json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php :(
+		return new WPCOM_JSON_API_Get_Taxonomy_Endpoint( array(
+			'description' => 'Get information about a single category.',
+			'group'       => 'taxonomy',
+			'stat'        => 'categories:1',
+
+			'method'      => 'GET',
+			'path'        => '/sites/%s/categories/slug:%s',
+			'path_labels' => array(
+				'$site'     => '(int|string) Site ID or domain',
+				'$category' => '(string) The category slug'
+			),
+
+			'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/categories/slug:community'
+		) );
+	}
+
+	/**
+	 * @author nylen
+	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
+	 * @group json-api
+	 */
+	public function test_get_term_feed_url_pretty_permalinks() {
+		global $blog_id;
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+		// Reset taxonomy URL structure after changing permalink structure
+		create_initial_taxonomies();
+
+		$category = wp_insert_term( 'test_category', 'category' );
+
+		$endpoint = $this->create_get_category_endpoint();
+		// Initialize some missing stuff for the API
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+
+		$response = $endpoint->callback(
+			sprintf( '/sites/%d/categories/slug:test_category', $blog_id ),
+			$blog_id,
+			'test_category'
+		);
+
+		$this->assertStringEndsWith(
+			'/category/test_category/feed/',
+			$response->feed_url
+		);
+	}
+
+	/**
+	 * @author nylen
+	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
+	 * @group json-api
+	 */
+	public function test_get_term_feed_url_ugly_permalinks() {
+		global $blog_id;
+
+		$this->set_permalink_structure( '' );
+		// Reset taxonomy URL structure after changing permalink structure
+		create_initial_taxonomies();
+
+		$category = wp_insert_term( 'test_category', 'category' );
+
+		$endpoint = $this->create_get_category_endpoint();
+		// Initialize some missing stuff for the API
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+
+		$response = $endpoint->callback(
+			sprintf( '/sites/%d/categories/slug:test_category', $blog_id ),
+			$blog_id,
+			'test_category'
+		);
+
+		$this->assertStringEndsWith(
+			'/?feed=rss2&amp;cat=' . $category['term_id'],
+			$response->feed_url
+		);
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/9635:

> Add Jetpack automated tests, ideally with a couple of different permalink settings because the feed URLs can look very different based on this. (WP.com automated tests are in place but they can't cover this case.)