### PR TITLE
Widgets: Only render the Simple Payments widget if its button exists

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -60,16 +60,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @param array $instance Saved values from database.
 		 */
 		function widget( $args, $instance ) {
-			echo $args['before_widget'];
-
-			/** This filter is documented in core/src/wp-includes/default-widgets.php */
-			$title = apply_filters( 'widget_title', $instance['title'] );
-			if ( ! empty( $title ) ) {
-				echo $args['before_title'] . $title . $args['after_title'];
-			}
-
-			echo '<div class="jetpack-simple-payments-content">';
-
 			if( ! empty( $instance['product_post_id'] ) ) {
 				$attrs = array( 'id' => $instance['product_post_id'] );
 			} else {
@@ -83,7 +73,24 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			}
 
 			$jsp = Jetpack_Simple_Payments::getInstance();
-			echo $jsp->parse_shortcode( $attrs );
+
+			$simple_payments_button = $jsp->parse_shortcode( $attrs );
+
+			if ( is_null( $simple_payments_button ) && ! is_customize_preview() ) {
+				return;
+			}
+
+			echo $args['before_widget'];
+
+			/** This filter is documented in core/src/wp-includes/default-widgets.php */
+			$title = apply_filters( 'widget_title', $instance['title'] );
+			if ( ! empty( $title ) ) {
+				echo $args['before_title'] . $title . $args['after_title'];
+			}
+
+			echo '<div class="jetpack-simple-payments-content">';
+
+			echo $simple_payments_button;
 
 			echo '</div><!--simple-payments-->';
 


### PR DESCRIPTION
Require #9577

Currently, the Simple Payments widget renders regardless of the fact that its Simple Payments button might not exist (e.g. it has been deleted).

#### Changes proposed in this Pull Request:

* In the frontend, only show the widget if the Simple Payments shortcode is parsed successfully.
* In the customizer, show the widget regardless, so that it can be modified via the pencil icon.

#### Testing instructions:

* Pick a Premium/Business site with one or more Simple Payments button already created.
* Open the Customizer and add a Simple Payments widget.
* Head to the post/page editor (in Calypso), click on Add Content and select "Add Payment Button".
* In the dialog, delete the Simple Payments button associated to the widget created earlier.
* Open the frontend, and make sure the Simple Payments widget is not rendered at all.
* Open the Customizer, and make sure the Simple Payments widget is rendered without content.