### PR TITLE
Fix reliability and speed of sync queue lag test

### DIFF
--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -91,7 +91,7 @@ class Jetpack_Sync_Queue {
 
 	// lag is the difference in time between the age of the oldest item
 	// (aka first or frontmost item) and the current time
-	function lag( $now = null) {
+	function lag( $now = null ) {
 		global $wpdb;
 
 		$first_item_name = $wpdb->get_var( $wpdb->prepare(

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -91,7 +91,7 @@ class Jetpack_Sync_Queue {
 
 	// lag is the difference in time between the age of the oldest item
 	// (aka first or frontmost item) and the current time
-	function lag() {
+	function lag( $now = null) {
 		global $wpdb;
 
 		$first_item_name = $wpdb->get_var( $wpdb->prepare(
@@ -103,10 +103,14 @@ class Jetpack_Sync_Queue {
 			return 0;
 		}
 
+		if ( null === $now ) {
+			$now = microtime( true );
+		}
+
 		// break apart the item name to get the timestamp
 		$matches = null;
 		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
-			return microtime( true ) - floatval( $matches[1] );
+			return $now - floatval( $matches[1] );
 		} else {
 			return 0;
 		}
@@ -320,6 +324,17 @@ class Jetpack_Sync_Queue {
 		return $this->delete_checkout_id();
 	}
 
+	/**
+	 * This option is specifically chosen to, as much as possible, preserve time order
+	 * and minimise the possibility of collisions between multiple processes working
+	 * at the same time.
+	 *
+	 * @return string
+	 */
+	protected function generate_option_name_timestamp() {
+		return sprintf( '%.6f', microtime( true ) );
+	}
+
 	private function get_checkout_id() {
 		global $wpdb;
 		$checkout_value = $wpdb->get_var( 
@@ -382,12 +397,7 @@ class Jetpack_Sync_Queue {
 	}
 
 	private function get_next_data_row_option_name() {
-		// this option is specifically chosen to, as much as possible, preserve time order
-		// and minimise the possibility of collisions between multiple processes working
-		// at the same time
-		// TODO: confirm we only need to support PHP 5.05+ (otherwise we'll need to emulate microtime as float, and avoid PHP_INT_MAX)
-		// @see: http://php.net/manual/en/function.microtime.php
-		$timestamp = sprintf( '%.6f', microtime( true ) );
+		$timestamp = $this->generate_option_name_timestamp();
 
 		// row iterator is used to avoid collisions where we're writing data waaay fast in a single process
 		if ( $this->row_iterator === PHP_INT_MAX ) {

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -52,13 +52,25 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	}
 
 	function test_queue_lag() {
-		// lag is the difference in time between the age of the oldest item and the current time
-		$this->queue->reset();
-		$this->queue->add( 'foo' );
-		sleep( 3 );
-		$this->queue->add( 'bar' );
-		sleep( 3 );
-		$this->assertEquals( 6, intval( $this->queue->lag() ) );
+		/* @var $queue Jetpack_Sync_Queue|\PHPUnit\Framework\MockObject\MockObject */
+		$queue = $this->getMockBuilder( Jetpack_Sync_Queue::class )
+			->setMethods( array( 'generate_option_name_timestamp' ) )
+			->setConstructorArgs( array( 'my_queue' ) )
+			->getMock();
+
+		$queue->expects( $this->at( 0 ) )
+			->method( 'generate_option_name_timestamp' )
+			->will( $this->returnValue( '1527862857.091832' ) );
+
+		$queue->expects( $this->at( 1 ) )
+			->method( 'generate_option_name_timestamp' )
+			->will( $this->returnValue( '1527862860.092171' ) );
+
+		$queue->reset();
+		$queue->add( 'foo' );
+		$queue->add( 'bar' );
+
+		$this->assertEquals( 6, intval( $queue->lag( 1527862863.0946 ) ) );
 	}
 
 	function test_checkout_queue_items() {

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -60,17 +60,17 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 
 		$queue->expects( $this->at( 0 ) )
 			->method( 'generate_option_name_timestamp' )
-			->will( $this->returnValue( '1527862857.091832' ) );
+			->will( $this->returnValue( '1.5' ) );
 
 		$queue->expects( $this->at( 1 ) )
 			->method( 'generate_option_name_timestamp' )
-			->will( $this->returnValue( '1527862860.092171' ) );
+			->will( $this->returnValue( '3.0' ) );
 
 		$queue->reset();
 		$queue->add( 'foo' );
 		$queue->add( 'bar' );
 
-		$this->assertEquals( 6, intval( $queue->lag( 1527862863.0946 ) ) );
+		$this->assertEquals( 6, intval( $queue->lag( 7.5 ) ) );
 	}
 
 	function test_checkout_queue_items() {

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 
 	function test_queue_lag() {
 		/* @var $queue Jetpack_Sync_Queue|\PHPUnit\Framework\MockObject\MockObject */
-		$queue = $this->getMockBuilder( Jetpack_Sync_Queue::class )
+		$queue = $this->getMockBuilder( 'Jetpack_Sync_Queue' )
 			->setMethods( array( 'generate_option_name_timestamp' ) )
 			->setConstructorArgs( array( 'my_queue' ) )
 			->getMock();


### PR DESCRIPTION
Previously, the `test_queue_lag()` method relied on sleeping for 3 seconds after each call to the queue's `add()` method.  After sleeping for 6 seconds, it would then call `lag()` and assert that the `intval()` of the return value was 6.  This would randomly fail on Travis builds when for whatever reason the lag actually exceeded 7 seconds.

That may have been due to a slow database read or write.  The Jetpack sync engine finds relevant options by doing a LIKE query on option_name, which could have highly variable performance depending upon the number of options in the table, other queries running at that time, etc.  So, the lag goes above 6 seconds and the old test approach fails, which is very frustrating.

Beyond that, the old approach required at least 6 seconds to complete the test because of the sleep() calls.  Slow tests are generally undesirable, obviously.

This commit instead makes the test more deterministic by mocking and injecting the time values.  When adding items to the queue, the new `generate_option_name_timestamp()` method is called.  During testing, we mock this method and return predictable values.  Then in `lag()`, we allow the caller to inject a value for $now, rather than being tightly coupled to the PHP core `microtime()` function.  This allows us to also make that call predictable and deterministic.

With these changes, we're still testing the lag() function to the same extent we did previously.  The DB queries are still run and the same logic is in place.  We just don't rely on `sleep()` and `microtime()` directly during testing.