### PR TITLE
Improve AMP compatibility for Comments iframe

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -310,18 +310,20 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				</h3>
 			<?php endif; ?>
 			<form id="commentform" class="comment-form">
-				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>
-				<!--[if !IE]><!-->
-				<script>
-					document.addEventListener('DOMContentLoaded', function () {
-						var commentForms = document.getElementsByClassName('jetpack_remote_comment');
-						for (var i = 0; i < commentForms.length; i++) {
-							commentForms[i].allowTransparency = <?php echo $transparent; ?>;
-							commentForms[i].scrolling = 'no';
-						}
-					});
-				</script>
-				<!--<![endif]-->
+				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-scripts allow-top-navigation-by-user-activation allow-forms"></iframe>
+				<?php if ( ! Jetpack_AMP_Support::is_amp_request() ) : ?>
+					<!--[if !IE]><!-->
+					<script>
+						document.addEventListener('DOMContentLoaded', function () {
+							var commentForms = document.getElementsByClassName('jetpack_remote_comment');
+							for (var i = 0; i < commentForms.length; i++) {
+								commentForms[i].allowTransparency = <?php echo $transparent; ?>;
+								commentForms[i].scrolling = 'no';
+							}
+						});
+					</script>
+					<!--<![endif]-->
+				<?php endif; ?>
 			</form>
 		</div>
 


### PR DESCRIPTION
When `amp` theme support is present and the Comments module is active, attempting to submit a comment through the iframed form results in `sandbox` security errors. To get around these, adding the explicitly-required sandbox permissions is needed.

For more, see https://www.ampproject.org/docs/reference/components/amp-iframe#sandbox

This change also removes a `script`, since it is disallowed by AMP. Maybe there is another/better way to achieve `allowTransparency` and `scrolling=no`?

How to reproduce the issue:

1. Install [AMP v1.0-beta1](https://github.com/Automattic/amp-wp/releases/tag/1.0-beta1).
2. In the admin, go to AMP > General settings and enable Native template mode.
3. Activate the comments module in Jetpack.
4. Navigate to a post and attempt to leave a comment.

Upon clicking the “Post Comment” button, an error in the console appears:

> Blocked form submission to 'https://jetpack.wordpress.com/jetpack-comment/' because the form's frame is sandboxed and the 'allow-forms' permission is not set.

![image](https://user-images.githubusercontent.com/134745/42658387-ffc42946-85d9-11e8-81b4-cdd4bfa249ef.png)
