### PR TITLE
Related posts settings: move configure link to card's footer

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -77,7 +77,7 @@ export class RelatedPostsSettings extends React.Component {
 			<div className="jp-related-posts-preview">
 				{
 					show_headline
-						? <div className="jp-related-posts-preview__title">{ __( 'Related', { context: 'A header for a block of related posts.' } ) }</div>
+						? <div className="jp-related-posts-preview__title">{ __( 'Related', { context: 'A heading for a block of related posts.' } ) }</div>
 						: ''
 				}
 				{
@@ -113,7 +113,7 @@ export class RelatedPostsSettings extends React.Component {
 					}
 					<ModuleSettingCheckbox
 						name={ 'show_headline' }
-						label={ __( 'Highlight related content with a header' ) }
+						label={ __( 'Highlight related content with a heading' ) }
 						{ ...this.props } />
 					<ModuleSettingCheckbox
 						name={ 'show_thumbnails' }

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -113,7 +113,7 @@ export class RelatedPostsSettings extends React.Component {
 					}
 					<ModuleSettingCheckbox
 						name={ 'show_headline' }
-						label={ __( 'Show a "Related" header to more clearly separate the related section from posts' ) }
+						label={ __( 'Highlight related content with a header' ) }
 						{ ...this.props } />
 					<ModuleSettingCheckbox
 						name={ 'show_thumbnails' }

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
 import Card from 'components/card';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 
@@ -20,7 +20,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 class RelatedPostsComponent extends React.Component {
-    /**
+	/**
 	 * Get options for initial state.
 	 *
 	 * @returns {{show_headline: Boolean, show_thumbnails: Boolean}} Initial state object.
@@ -50,6 +50,10 @@ class RelatedPostsComponent extends React.Component {
 
 	handleShowThumbnailsToggleChange = () => {
 		this.updateOptions( 'show_thumbnails' );
+	};
+
+	trackConfigureClick = () => {
+		analytics.tracks.recordJetpackClick( 'configure-related-posts' );
 	};
 
 	render() {
@@ -103,16 +107,6 @@ class RelatedPostsComponent extends React.Component {
 										}
 									</span>
 						</CompactFormToggle>
-						{
-							__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
-								components: {
-									span: <span className="jp-form-setting-explanation" />,
-									ExternalLink: <ExternalLink
-										className="jp-module-settings__external-link"
-										href={ this.props.configureUrl } />
-								}
-							} )
-						}
 						<FormLabel className="jp-form-label-wide">
 							{ __( 'Preview', { context: 'A header for a preview area in the configuration screen.' } ) }
 						</FormLabel>
@@ -162,6 +156,13 @@ class RelatedPostsComponent extends React.Component {
 						</Card>
 					</FormFieldset>
 				</SettingsGroup>
+				{
+					! this.props.isUnavailableInDevMode( 'related-posts' ) && (
+						<Card compact className="jp-settings-card__configure-link" onClick={ this.trackConfigureClick } href={ this.props.configureUrl }>
+							{ __( 'Configure related posts in the Customizer' ) }
+						</Card>
+					)
+				}
 			</SettingsCard>
 		);
 	}

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -93,7 +93,7 @@ class RelatedPostsComponent extends React.Component {
 									onChange={ this.handleShowHeadlineToggleChange }>
 									<span className="jp-form-toggle-explanation">
 										{
-											__( 'Show a "Related" header to more clearly separate the related section from posts' )
+											__( 'Separate related content from blog posts with a header.' )
 										}
 									</span>
 						</CompactFormToggle>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -93,7 +93,7 @@ class RelatedPostsComponent extends React.Component {
 									onChange={ this.handleShowHeadlineToggleChange }>
 									<span className="jp-form-toggle-explanation">
 										{
-											__( 'Highlight related content with a header' )
+											__( 'Highlight related content with a heading' )
 										}
 									</span>
 						</CompactFormToggle>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -93,7 +93,7 @@ class RelatedPostsComponent extends React.Component {
 									onChange={ this.handleShowHeadlineToggleChange }>
 									<span className="jp-form-toggle-explanation">
 										{
-											__( 'Separate related content from blog posts with a header.' )
+											__( 'Highlight related content with a header' )
 										}
 									</span>
 						</CompactFormToggle>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -69,7 +69,6 @@ class RelatedPostsComponent extends React.Component {
 					disableInDevMode
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
-						text: __( 'Automatically displays similar content at the end of each post.' ),
 						link: 'https://jetpack.com/support/related-posts/',
 					} }
 					>

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1717,7 +1717,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 			// Related Posts
 			'show_headline' => array(
-				'description'       => esc_html__( 'Highlight related content with a header', 'jetpack' ),
+				'description'       => esc_html__( 'Highlight related content with a heading', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1717,7 +1717,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 			// Related Posts
 			'show_headline' => array(
-				'description'       => esc_html__( 'Show a "Related" header to more clearly separate the related section from posts', 'jetpack' ),
+				'description'       => esc_html__( 'Highlight related content with a header', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -384,7 +384,7 @@ EOT;
 		$ui_settings = sprintf(
 			$ui_settings_template,
 			checked( $options['show_headline'], true, false ),
-			esc_html__( 'Highlight related content with a header', 'jetpack' ),
+			esc_html__( 'Highlight related content with a heading', 'jetpack' ),
 			checked( $options['show_thumbnails'], true, false ),
 			esc_html__( 'Show a thumbnail image where available', 'jetpack' ),
 			checked( $options['show_date'], true, false ),

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -384,7 +384,7 @@ EOT;
 		$ui_settings = sprintf(
 			$ui_settings_template,
 			checked( $options['show_headline'], true, false ),
-			esc_html__( 'Show a "Related" header to more clearly separate the related section from posts', 'jetpack' ),
+			esc_html__( 'Highlight related content with a header', 'jetpack' ),
 			checked( $options['show_thumbnails'], true, false ),
 			esc_html__( 'Show a thumbnail image where available', 'jetpack' ),
 			checked( $options['show_date'], true, false ),


### PR DESCRIPTION
Move _"try it out!"_ link in Related posts settings to card's footer.

The config link was quite unnoticeable and not in line with other sections.

Fixes #8736

Before:

<img width="736" alt="image" src="https://user-images.githubusercontent.com/87168/40970976-724558b8-68bc-11e8-9392-720a006b0415.png">


After:

<img width="738" alt="screen shot 2018-06-05 at 11 39 24" src="https://user-images.githubusercontent.com/87168/40970047-be6a0d22-68b9-11e8-906c-b6b885522a43.png">


#### Testing instructions:

- Go to `/wp-admin/admin.php?page=jetpack#/traffic`
- Enable feature
- Test link works
- Test closing customizer and ensure you come back to where you left