### PR TITLE
Sitemap settings: clarify texts

### DIFF
--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -31,6 +31,10 @@
 			margin-top: rem( 16px );
 		}
 
+		&.is-warning {
+			color: $alert-red;
+		}
+
 		a {
 			text-decoration: underline;
 		}

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -44,7 +44,7 @@ export class Sitemaps extends React.Component {
 					hasChild
 					module={ { module: 'sitemaps' } }
 					support={ {
-						text: __( 'Automatically generates the files required for search engines to index your site.' ),
+						text: __( 'Jetpack will generate two different sitemaps for you: a sitemap listing all your public posts and pages, and a News sitemap built specifically for Google News.' ),
 						link: 'https://jetpack.com/support/sitemaps/',
 					} }
 					>
@@ -54,7 +54,7 @@ export class Sitemaps extends React.Component {
 						activated={ this.props.getOptionValue( 'sitemaps' ) }
 						toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
 						toggleModule={ this.props.toggleModuleNow }>
-						{ __( 'Generate XML sitemaps' ) }
+						{ __( 'Generate XML sitemaps that help search engines to index your site' ) }
 					</ModuleToggle>
 					{
 						this.props.isSiteVisibleToSearchEngines

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
@@ -34,6 +35,11 @@ export class Sitemaps extends React.Component {
 			sitemap_url = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
 			news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
 
+		const searchEngineVisibilityClasses = classNames( {
+			'jp-form-setting-explanation': true,
+			'is-warning': ! this.props.isSiteVisibleToSearchEngines && this.props.getOptionValue( 'sitemaps' )
+		} );
+
 		return (
 			<SettingsCard
 				{ ...this.props }
@@ -44,48 +50,64 @@ export class Sitemaps extends React.Component {
 					hasChild
 					module={ { module: 'sitemaps' } }
 					support={ {
-						text: __( 'Jetpack will generate two different sitemap files for you: a sitemap listing all your public posts and pages, and a News sitemap built specifically for Google News.' ),
 						link: 'https://jetpack.com/support/sitemaps/',
 					} }
-					>
-					{
-						this.props.getOptionValue( 'sitemaps' ) && (
-							<p className="jp-form-setting-explanation">
-								{ __(
-									'Sitemaps are files that search engines like Google or ' +
-										'Bing use to index your website and can help get you ' +
-										'discovered and rank higher. When this feature is enabled, ' +
-										'Jetpack will create these files for you and update them ' +
-										'automatically whenever you add new content to your site.'
-									) }
-							</p>
-						)
-					}
+				>
+					<p>
+						{ __(
+							'Sitemaps are files that search engines like Google or Bing use ' +
+								'to index your website and can help get you discovered and ' +
+								'rank higher. When this feature is enabled, Jetpack will create ' +
+								'these files for you and update them automatically whenever you ' +
+								'add new content to your site.'
+							) }
+					</p>
 					<ModuleToggle
 						slug="sitemaps"
 						compact
 						activated={ this.props.getOptionValue( 'sitemaps' ) }
 						toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
-						toggleModule={ this.props.toggleModuleNow }>
-						{ __( 'Generate XML sitemaps that help search engines to index your site' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						{ __( 'Generate XML sitemaps' ) }
 					</ModuleToggle>
 					{
 						this.props.isSiteVisibleToSearchEngines
 							? this.props.getOptionValue( 'sitemaps' ) && (
 								<FormFieldset>
 									<p className="jp-form-setting-explanation">
-										<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+										Your sitemap is automatically sent to all major search engines for indexing.
 										<br />
-										<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+										<ExternalLink
+											onClick={ this.trackSitemapUrl }
+											icon={ true }
+											target="_blank"
+											rel="noopener noreferrer"
+											href={ sitemap_url }
+										>
+											{ sitemap_url }
+										</ExternalLink>
+										<br />
+										<ExternalLink
+											onClick={ this.trackSitemapNewsUrl }
+											icon={ true }
+											target="_blank"
+											rel="noopener noreferrer"
+											href={ news_sitemap_url }
+										>
+											{ news_sitemap_url }
+										</ExternalLink>
 									</p>
 								</FormFieldset>
 							)
 							: (
 								<FormFieldset>
-										<p className="jp-form-setting-explanation">
+										<p className={ searchEngineVisibilityClasses }>
 											{
 												__(
-													'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.',
+													'Your site is not currently accessible to search engines. ' +
+														'You might have "Search Engine Visibility" disabled in ' +
+														'your {{a}}Reading Settings{{/a}}.',
 													{
 														components: {
 															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -44,10 +44,23 @@ export class Sitemaps extends React.Component {
 					hasChild
 					module={ { module: 'sitemaps' } }
 					support={ {
-						text: __( 'Jetpack will generate two different sitemaps for you: a sitemap listing all your public posts and pages, and a News sitemap built specifically for Google News.' ),
+						text: __( 'Jetpack will generate two different sitemap files for you: a sitemap listing all your public posts and pages, and a News sitemap built specifically for Google News.' ),
 						link: 'https://jetpack.com/support/sitemaps/',
 					} }
 					>
+					{
+						this.props.getOptionValue( 'sitemaps' ) && (
+							<p className="jp-form-setting-explanation">
+								{ __(
+									'Sitemaps are files that search engines like Google or ' +
+										'Bing use to index your website and can help get you ' +
+										'discovered and rank higher. When this feature is enabled, ' +
+										'Jetpack will create these files for you and update them ' +
+										'automatically whenever you add new content to your site.'
+									) }
+							</p>
+						)
+					}
 					<ModuleToggle
 						slug="sitemaps"
 						compact
@@ -60,8 +73,7 @@ export class Sitemaps extends React.Component {
 						this.props.isSiteVisibleToSearchEngines
 							? this.props.getOptionValue( 'sitemaps' ) && (
 								<FormFieldset>
-									<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-									<p>
+									<p className="jp-form-setting-explanation">
 										<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
 										<br />
 										<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
@@ -72,11 +84,14 @@ export class Sitemaps extends React.Component {
 								<FormFieldset>
 										<p className="jp-form-setting-explanation">
 											{
-												__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
-													components: {
-														a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
+												__(
+													'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.',
+													{
+														components: {
+															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
+														}
 													}
-												} )
+												)
 											}
 										</p>
 								</FormFieldset>

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -56,10 +56,10 @@ export class Sitemaps extends React.Component {
 					<p>
 						{ __(
 							'Sitemaps are files that search engines like Google or Bing use ' +
-								'to index your website and can help get you discovered and ' +
-								'rank higher. When this feature is enabled, Jetpack will create ' +
-								'these files for you and update them automatically whenever you ' +
-								'add new content to your site.'
+								'to index your website. They can help improve your ranking in ' +
+								'search results. When you enable this feature, Jetpack will ' +
+								'create sitemaps for you and update them automatically when ' +
+								'the content on your site changes.'
 							) }
 					</p>
 					<ModuleToggle
@@ -76,7 +76,10 @@ export class Sitemaps extends React.Component {
 							? this.props.getOptionValue( 'sitemaps' ) && (
 								<FormFieldset>
 									<p className="jp-form-setting-explanation">
-										Your sitemap is automatically sent to all major search engines for indexing.
+										{ __(
+											'Good news: Jetpack is sending your sitemap automatically ' +
+												'to all major search engines for indexing.'
+										) }
 										<br />
 										<ExternalLink
 											onClick={ this.trackSitemapUrl }
@@ -105,9 +108,10 @@ export class Sitemaps extends React.Component {
 										<p className={ searchEngineVisibilityClasses }>
 											{
 												__(
-													'Your site is not currently accessible to search engines. ' +
-														'You might have "Search Engine Visibility" disabled in ' +
-														'your {{a}}Reading Settings{{/a}}.',
+													"Search engines can't access your site at the moment. " +
+														"If you'd like to make your site accessible, check " +
+														'your {{a}}Reading settings{{/a}} and switch ' +
+														'"Search Engine Visibility" on.',
 													{
 														components: {
 															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />


### PR DESCRIPTION
Improve texts for sitemap settings.

### Before
<img width="737" alt="screen shot 2018-06-05 at 13 03 02" src="https://user-images.githubusercontent.com/87168/40972374-d1bb3106-68c0-11e8-9be8-5d92bae30bee.png">
<img width="743" alt="screen shot 2018-06-05 at 12 39 02" src="https://user-images.githubusercontent.com/87168/40971305-78852554-68bd-11e8-95ca-1432947366db.png">
<img width="303" alt="screen shot 2018-06-05 at 12 39 06" src="https://user-images.githubusercontent.com/87168/40971306-79c32e8e-68bd-11e8-8efe-42182f19e432.png">

### After

#### Sitemaps Disabled
![screen shot 2018-06-11 at 15 56 17](https://user-images.githubusercontent.com/87168/41232767-0f7f3c52-6d90-11e8-970d-73dda028974e.png)

#### Sitemaps Enabled
![screen shot 2018-06-11 at 15 56 11](https://user-images.githubusercontent.com/87168/41232773-1243cd22-6d90-11e8-8cab-af5303cf44f6.png)

### Alert text when _"Discourage search engines from indexing this site"_ is enabled

Warning is red when sitemaps are enabled but grey when sitemaps are disabled. That way users who want to keep the site hidden and don't want to turn sitemaps on wouldn't need to stare at warnings so much and actively keep ignoring them.

#### Sitemaps Disabled
![screen shot 2018-06-11 at 15 55 45](https://user-images.githubusercontent.com/87168/41232791-2332366e-6d90-11e8-83e7-3fb5f68bddd0.png)

#### Sitemaps Enabled
![screen shot 2018-06-11 at 15 55 51](https://user-images.githubusercontent.com/87168/41232789-216c3564-6d90-11e8-8bda-8e62acd211cd.png)

#### Info bubble
![screen shot 2018-06-11 at 15 56 22](https://user-images.githubusercontent.com/87168/41232751-082a41cc-6d90-11e8-9e1a-b001d2cd0b7a.png)

## Testing

- Go to `/wp-admin/admin.php?page=jetpack#/traffic`
- Ensure section still works