### PR TITLE
Allows to run tests for modules Javascript code

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -6,6 +6,7 @@ modules/custom-css/custom-css/js/codemirror.min.js
 modules/shortcodes/js/jmpress.js
 modules/shortcodes/js/jquery.cycle.min.js
 modules/theme-tools/responsive-videos/responsive-videos.min.js
+modules/**/test-*.js
 
 todo:
 modules/infinite-scroll/infinity.js

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -109,7 +109,7 @@ If you're not familiar with PHP Unit Testing, you can also check [this tutorial]
 
 ## Unit-testing the JS Admin Page
 
-You can run [Mocha](https://mochajs.org/) based tests for the Admin Page source code.
+You can run [Mocha](https://mochajs.org/) based tests for the Admin Page source code and the modules Javascript code.
 
 Standing on your jetpack directory, run
 
@@ -117,6 +117,7 @@ Standing on your jetpack directory, run
 $ yarn
 $ yarn test-client
 $ yarn test-gui
+$ yarn test-modules
 ```
 
 ## Use PHP CodeSniffer and ESLint to make sure your code respects coding standards

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -107,9 +107,12 @@ phpunit --filter my_test_name
 
 If you're not familiar with PHP Unit Testing, you can also check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/)
 
-## Unit-testing the JS Admin Page
+## Unit-testing the JS code
 
-You can run [Mocha](https://mochajs.org/) based tests for the Admin Page source code and the modules Javascript code.
+Jetpack includes also several [Mocha](https://mochajs.org/) based unit tests.
+To execute them in your local environment, you can use the following commands.
+
+### Admin Page unit tests
 
 Standing on your jetpack directory, run
 
@@ -117,7 +120,27 @@ Standing on your jetpack directory, run
 $ yarn
 $ yarn test-client
 $ yarn test-gui
+```
+
+### Jetpack modules unit tests
+
+Standing on your jetpack directory, run
+
+```
+$ yarn
 $ yarn test-modules
+```
+
+You can also only run tests matching a specific pattern. To do that, use the argument `-g, --grep <pattern>`:
+
+```
+$ yarn test-gui -g 'my custom pattern to filter tests'
+```
+
+To use a custom reporter, pass the argument `-R, --reporter <name>`:
+
+```
+$ yarn test-client -R 'my_reporter'
 ```
 
 ## Use PHP CodeSniffer and ESLint to make sure your code respects coding standards

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -112,9 +112,11 @@ function onBuild( done ) {
 		const supportedModulesSource = `modules/@(${ supportedModules.join( '|' ) })/**/*.js`;
 
 		// Uglify other JS from _inc and supported modules
+		// Skipping module unit test files.
 		const sources = [
 			'_inc/*.js',
-			supportedModulesSource
+			supportedModulesSource,
+			'!modules/**/test-*.js',
 		];
 
 		// Don't process minified JS in _inc or modules directories
@@ -368,7 +370,8 @@ gulp.task( 'eslint', function() {
 	return gulp.src( [
 		'_inc/client/**/*.js',
 		'_inc/client/**/*.jsx',
-		'!_inc/client/**/test/*.js'
+		'!_inc/client/**/test/*.js',
+		'modules/**/*.jsx',
 	] )
 		.pipe( eslint() )
 		.pipe( eslint.format() )

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",
     "test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js gui",
-    "precommit": "node bin/pre-commit-hook.js"
+    "precommit": "node bin/pre-commit-hook.js",
+    "test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js modules"
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
+
 require( 'babel-register' )( {
-        ignore: /\/node_modules\/(?!@automattic\/dops-components\/)/
+	ignore: /\/node_modules\/(?!@automattic\/dops-components\/)/
 } );
 
 const program = require( 'commander' ),
 	glob = require( 'glob' ),
 	Mocha = require( 'mocha' ),
-	path = require( 'path' ),
 	boot = require( './boot-test' );
 
 program
-	.usage( '[options] [files]' )
-	.option( '-R, --reporter <name>', 'specify the reporter to use', 'spec' )
-	.option( '-g, --grep <pattern>', 'only run tests matching <pattern>' );
+    .usage( '[options] [files]' )
+    .option( '-R, --reporter <name>', 'specify the reporter to use', 'spec' )
+    .option( '-g, --grep <pattern>', 'only run tests matching <pattern>' );
 
 program.name = 'runner';
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -31,26 +31,34 @@ mocha.suite.beforeAll( boot.before );
 mocha.suite.afterAll( boot.after );
 
 if ( program.args.length ) {
-
 	// Test interface components
-	if ( 1 === program.args.length && 'gui' === program.args[0] ) {
+	if ( 1 === program.args.length ) {
 		// Don't load styles for testing
-		require.extensions['.scss'] = () => false;
-		require.extensions['.css'] = require.extensions['.scss'];
+		require.extensions[ '.scss' ] = () => false;
+		require.extensions[ '.css' ] = require.extensions[ '.scss' ];
 
 		// Define a dom so we can have window and all else
-		require('jsdom-global')();
+		require( 'jsdom-global' )();
 
 		window.Initial_State = {
 			userData: {},
 			dismissedNotices: {}
 		};
-		mocha.addFile( '_inc/client/test/main.js' );
 
-		glob.sync( '_inc/client/**/test/component.js' ).forEach( file => {
-			mocha.addFile( file );
-		});
+		switch ( program.args[ 0 ] ) {
+			case 'gui':
+				mocha.addFile( '_inc/client/test/main.js' );
 
+				glob.sync( '_inc/client/**/test/component.js' ).forEach( file => {
+					mocha.addFile( file );
+				} );
+				break;
+			case 'modules':
+				glob.sync( 'modules/**/test-*.js' ).forEach( file => {
+					mocha.addFile( file );
+				} );
+				break;
+		}
 	} else {
 		program.args.forEach( function( file ) {
 			mocha.addFile( file );
@@ -59,7 +67,7 @@ if ( program.args.length ) {
 } else {
 	glob.sync( '_inc/client/state/**/test/*.js' ).forEach( file => {
 		mocha.addFile( file );
-	});
+	} );
 }
 
 mocha.run( function( failures ) {


### PR DESCRIPTION
Allows executing unit tests for Javascript code within modules. All javascript unit tests inside any of Jetpack modules will be run after calling the command 'yarn test-modules` in the terminal.

This PR is a suggestion from @ehg, and the code is based on the work done by @c-shultz in the PR #9144 (thanks!)

#### Changes proposed in this Pull Request:

* Added a new script entry to `package.json` to run modules Javascript unit tests.

#### Testing instructions:

* Just execute `yarn test-modules` in Jetpack base folder.
* The command shouldn't fail (command exit status should be 0).
* The output should be:

  ```  0 passing (1ms)```

  since there aren't any Javascript unit tests inside any modules yet.
* You can also add a dummy test to a folder within the modules folder and after running `yarn test-modules` again the test should be executed.