### PR TITLE
General: Move jetpack_get_user_locale to functions.global.php so it's more widely available

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -398,23 +398,3 @@ function jetpack_current_user_data() {
 
 	return $current_user_data;
 }
-
-/**
- * Set the admin language, based on user language.
- *
- * @since 4.5.0
- *
- * @return string
- *
- * @todo Remove this function when WordPress 4.8 is released
- * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
- */
-function jetpack_get_user_locale() {
-	$locale = get_locale();
-
-	if ( function_exists( 'get_user_locale' ) ) {
-		$locale = get_user_locale();
-	}
-
-	return $locale;
-}

--- a/functions.global.php
+++ b/functions.global.php
@@ -17,6 +17,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Set the admin language, based on user language.
+ *
+ * @since 4.5.0
+ *
+ * @return string
+ *
+ * @todo Remove this function when WordPress 4.8 is released
+ * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
+ */
+function jetpack_get_user_locale() {
+	$locale = get_locale();
+
+	if ( function_exists( 'get_user_locale' ) ) {
+		$locale = get_user_locale();
+	}
+
+	return $locale;
+}
+
+/**
  * Determine if this site is an Atomic site or not looking first at the 'at_options' option.
  * As a fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
  *


### PR DESCRIPTION
Fixes fatal when using the Gutenberg editor in the Frontend introduced by #9560.

#### Changes proposed in this Pull Request:

* Moves the function `jetpack_get_user_locale()` from `_inc/lib/admin-pages/class.jetpack-react-page.php` to `functions.global.php`
 
#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Check this branch
* Install and activate the Frontenberg Editor:
    ```
       wp theme install https://github.com/tomjn/Frontenberg/archive/master.zip --activate
    ```
* Visit the site's home and expect it to not throw a fatal error
* Visit Jetpack's admin page and expect the same.
<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Shortcodes: Fixed a fatal coming form the VR shortcode when using the Gutenberg editor in the frontend