### PR TITLE
Simple Payment Widget: Manage Products from the Customizer

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -13,6 +13,33 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 	 * Display a Simple Payment Button as a Widget.
 	 */
 	class Jetpack_Simple_Payments_Widget extends WP_Widget {
+		private static $currencie_symbols = array(
+			'USD' => '$',
+			'GBP' => '&#163;',
+			'JPY' => '&#165;',
+			'BRL' => 'R$',
+			'EUR' => '&#8364;',
+			'NZD' => 'NZ$',
+			'AUD' => 'A$',
+			'CAD' => 'C$',
+			'INR' => '₹',
+			'ILS' => '₪',
+			'RUB' => '₽',
+			'MXN' => 'MX$',
+			'SEK' => 'Skr',
+			'HUF' => 'Ft',
+			'CHF' => 'CHF',
+			'CZK' => 'Kč',
+			'DKK' => 'Dkr',
+			'HKD' => 'HK$',
+			'NOK' => 'Kr',
+			'PHP' => '₱',
+			'PLN' => 'PLN',
+			'SGD' => 'S$',
+			'TWD' => 'NT$',
+			'THB' => '฿',
+		);
+
 		/**
 		 * Constructor.
 		 */
@@ -28,6 +55,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
+<<<<<<< HEAD
 			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 			}
@@ -35,6 +63,13 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 		function enqueue_style() {
 			wp_enqueue_style( 'jetpack-simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
+=======
+			if ( is_customize_preview() ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
+
+				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
+			}
+>>>>>>> Widgets: allows users to create a new SP button from the customizer
 		}
 
 		/**
@@ -44,11 +79,36 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 *
 		 * @return array Default values for the widget options.
 		 */
-		public function defaults() {
+		private function defaults() {
 			return array(
 				'title' => '',
 				'product_post_id' => 0,
+				'form_product_title' => '',
+				'form_product_description' => '',
+				'form_product_image' => '',
+				'form_product_currency' => '',
+				'form_product_price' => '',
+				'form_product_multiple' => '',
+				'form_product_email' => '',
 			);
+		}
+
+		/**
+		 * Adds a nonce for customizing menus.
+		 *
+		 * @param array $nonces Array of nonces.
+		 * @return array $nonces Modified array of nonces.
+		 */
+		function filter_nonces( $nonces ) {
+			$nonces['customize-jetpack-simple-payments'] = wp_create_nonce( 'customize-jetpack-simple-payments' );
+			return $nonces;
+		}
+
+		function admin_enqueue_styles_and_scripts( $hook_suffix ){
+				wp_enqueue_style( 'jetpack-simple-payments-widget-customizer', plugins_url( 'simple-payments/customizer.css', __FILE__ ) );
+
+				wp_enqueue_media();
+				wp_enqueue_script( 'jetpack-simple-payments-widget-customizer', plugins_url( '/simple-payments/customizer.js', __FILE__ ), array( 'jquery' ), false, true );
 		}
 
 		/**

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -13,7 +13,8 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 	 * Display a Simple Payment Button as a Widget.
 	 */
 	class Jetpack_Simple_Payments_Widget extends WP_Widget {
-		private static $currencie_symbols = array(
+		// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+		private static $supported_currency_list = array(
 			'USD' => '$',
 			'GBP' => '&#163;',
 			'JPY' => '&#165;',

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -113,6 +113,9 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 				wp_enqueue_media();
 				wp_enqueue_script( 'jetpack-simple-payments-widget-customizer', plugins_url( '/simple-payments/customizer.js', __FILE__ ), array( 'jquery' ), false, true );
+				wp_localize_script( 'jetpack-simple-payments-widget-customizer', 'jpSimplePaymentsStrings', array(
+					'deleteConfirmation' => __( 'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.', 'jetpack' )
+				) );
 		}
 
 		public function ajax_save_payment_button() {

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -243,7 +243,12 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				}
 
 				$jsp = Jetpack_Simple_Payments::getInstance();
-				echo $jsp->parse_shortcode( $attrs );
+				$simple_payments_button = $jsp->parse_shortcode( $attrs );
+				if ( is_null( $simple_payments_button ) && ! is_customize_preview() ) {
+					return;
+				}
+
+				echo $simple_payments_button;
 			}
 
 			echo '</div><!--simple-payments-->';

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -61,6 +61,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-add-new', array( $this, 'ajax_add_new_payment_button' ) );
 			}
+
+			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
+			}
 		}
 
 		/**
@@ -95,6 +99,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		function filter_nonces( $nonces ) {
 			$nonces['customize-jetpack-simple-payments'] = wp_create_nonce( 'customize-jetpack-simple-payments' );
 			return $nonces;
+		}
+
+		function enqueue_style() {
+			wp_enqueue_style( 'jetpack-simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
 		}
 
 		function admin_enqueue_styles_and_scripts(){

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -235,18 +235,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			if ( strcmp( $new_instance['form_action'], $old_instance['form_action'] ) !== 0 ) {
 				switch ( $new_instance['form_action' ] ) {
 					case 'edit': //load the form with existing values
-						// $product_id = ! empty( $product_id ) ?: ( int ) $old_instance['product_post_id'];
-						// $product_post = get_post( $product_id );
-						// if( ! empty( $product_post ) ) {
-						// 	$widget_title = ! empty( $widget_title ) ?: $old_instance['widget_title'];
-						// 	$form_product_title = get_the_title( $product_post );
-						// 	$form_product_description = $product_post->post_content;
-						// 	$form_product_image = get_post_thumbnail_id( $product_id, 'full' );
-						// 	$form_product_currency = get_post_meta( $product_id, 'spay_currency', true );
-						// 	$form_product_price = get_post_meta( $product_id, 'spay_price', true );
-						// 	$form_product_multiple = get_post_meta( $product_id, 'spay_multiple', true ) || '0';
-						// 	$form_product_email = get_post_meta( $product_id, 'spay_email', true );
-						// }
 						break;
 					case 'clear': //clear form
 						$form_action = '';

--- a/modules/widgets/simple-payments/customizer.css
+++ b/modules/widgets/simple-payments/customizer.css
@@ -1,0 +1,57 @@
+.widget-content .jetpack-simple-payments,
+.widget-content .jetpack-simple-payments-form {
+	clear: both;
+}
+
+.widget-content .jetpack-simple-payments-form .cost label {
+	display: block;
+}
+
+.widget-content .jetpack-simple-payments-image-fieldset {
+	position: relative;
+	width: 100%;
+}
+
+.widget-content .jetpack-simple-payments-image-fieldset .placeholder {
+	border: 1px dashed #b4b9be;
+	box-sizing: border-box;
+	cursor: pointer;
+	line-height: 20px;
+	padding: 9px 0;
+	position: relative;
+	text-align: center;
+	width: 100%;
+	margin: 4px 0 1em;
+}
+
+.widget-content .jetpack-simple-payments-image {
+	max-width: 100%;
+	margin-top: 4px;
+	position: relative;
+	text-align: center;
+}
+
+.widget-content .jetpack-simple-payments-image img {
+	max-width: 100%;
+	box-sizing: border-box;
+	border: 1px dashed #b4b9be;
+	padding: 4px;
+	height: auto;
+	cursor: pointer;
+}
+
+.widget-content .jetpack-simple-payments-image img:hover {
+	border-style: solid;
+}
+
+.widget-content .jetpack-simple-payments-form .field-currency {
+	display: inline-block;
+	vertical-align: top;
+	width: 40%;
+}
+
+.widget-content .jetpack-simple-payments-form .field-price {
+	display: inline-block;
+	line-height: 20px;
+	width: 58%;
+}

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -1,0 +1,104 @@
+( function( api, wp, $ ) {
+	function getWidgetRoot() {
+		return $( this ).closest( '.widget-content' );
+	}
+
+	function showForm() {
+		var root = getWidgetRoot.apply( this );
+		root.find( '.jetpack-simple-payments-widget-title' ).attr( 'disabled', 'disabled' );
+		root.find( '.jetpack-simple-payments-products' ).attr( 'disabled', 'disabled' );
+		root.find( '.jetpack-simple-payments-add-product' ).attr( 'disabled', 'disabled' );
+		root.find( '.jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
+		root.find( '.jetpack-simple-payments-form' ).show();
+	}
+
+	function hideForm() {
+		var root = getWidgetRoot.apply( this );
+		root.find( '.jetpack-simple-payments-widget-title' ).removeAttr( 'disabled' );
+		root.find( '.jetpack-simple-payments-products' ).removeAttr( 'disabled' );
+		root.find( '.jetpack-simple-payments-add-product' ).removeAttr( 'disabled' );
+		root.find( '.jetpack-simple-payments-edit-product' ).removeAttr( 'disabled' );
+		root.find( '.jetpack-simple-payments-form' ).hide();
+	}
+
+	function changeFormAction( action ) {
+		var root = getWidgetRoot.apply( this );
+		root.find( '.jetpack-simple-payments-form-action' ).val( action ).change();
+	}
+
+	$( document ).ready( function() {
+		$( document.body ).on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
+			event.preventDefault();
+
+			showForm.apply( this );
+
+			// changeFormAction.apply( this, [ 'clear' ] );
+		} );
+
+		$( document.body ).on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
+			event.preventDefault();
+
+			showForm.apply( this );
+
+			changeFormAction.apply( this, [ 'edit' ] );
+		} );
+
+		$( document.body ).on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
+			event.preventDefault();
+
+			hideForm.apply( this );
+
+			changeFormAction.apply( this, [ 'clear' ] );
+		} );
+
+		$( document.body ).on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
+			event.preventDefault();
+
+			// request = wp.ajax.post( 'customize-jetpack-simple-payments-button-add-new', {
+			// 	'customize-jetpack-simple-payments-nonce': api.settings.nonce['customize-simple-payments'],
+			// 	'customize_changeset_uuid': api.settings.changeset.uuid,
+			// 	'params': { foo: 'bar' }
+			// } );
+
+			// request.done( function( response ) {
+			// 	console.log( response );
+
+			// 	var select = root.find( 'select.jetpack-simple-payments-products' ).append(
+			// 		$('<option>', {
+			// 			value: response.product_post_id,
+			// 			text: response.product_post_title
+			// 		} )
+			// 	);
+			// 	select.val( response.product_post_id ).change();
+			// } );
+		} );
+
+		$( document.body ).on( 'click', '.jetpack-simple-payments-image-fieldset .placeholder, .jetpack-simple-payments-image > img', function() {
+			var root = getWidgetRoot.apply( this );
+			var imageContainer = root.find( '.jetpack-simple-payments-image' );
+
+			var mediaFrame = new wp.media.view.MediaFrame.Select( {
+				title: 'Choose Product Image',
+				multiple: false,
+				library: { type: 'image' },
+				button: { text: 'Choose Image' },
+			} );
+
+			mediaFrame.on( 'select', function() {
+				var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
+
+				root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).hide();
+
+				imageContainer.find( 'img' )
+					.attr( 'src', selection.url )
+					.attr( 'title', selection.title )
+					.attr( 'alt', selection.caption );
+				imageContainer.find( 'input[type=hidden]' ).val( selection.id ).change();
+
+				imageContainer.show();
+			} );
+
+			mediaFrame.open();
+		} );
+	} );
+}( wp.customize, wp, jQuery ) );

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -14,7 +14,7 @@
 		//show form
 		root.find( '.jetpack-simple-payments-form' ).show();
 		//focus on first field
-		root.find( '.jetpack-simple-payments-form-product-title').focus();
+		root.find( '.jetpack-simple-payments-form-product-title' ).focus();
 	}
 
 	function hideForm() {

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -13,6 +13,8 @@
 		root.find( '.jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
 		//show form
 		root.find( '.jetpack-simple-payments-form' ).show();
+		//focus on first field
+		root.find( '.jetpack-simple-payments-form-product-title').focus();
 	}
 
 	function hideForm() {
@@ -108,7 +110,6 @@
 
 			mediaFrame.on( 'select', function() {
 				var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
-				console.log(selection);
 				//hide placeholder
 				root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).hide();
 
@@ -117,11 +118,29 @@
 					.attr( 'src', selection.url )
 					.show();
 
+				//show image and remove button
+				root.find( '.jetpack-simple-payments-image' ).show();
+
 				//set hidden field for the selective refresh
 				root.find( '.jetpack-simple-payments-form-image-id' ).val( selection.id ).change();
 			} );
 
 			mediaFrame.open();
+		} );
+
+		//Remove Image
+		$( document.body ).on( 'click', '.jetpack-simple-payments-remove-image', function( event ) {
+			event.preventDefault();
+			var root = getWidgetRoot.apply( this );
+
+			//show placeholder
+			root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).show();
+
+			//hide image and remove button
+			root.find( '.jetpack-simple-payments-image' ).hide();
+
+			//set hidden field for the selective refresh
+			root.find( '.jetpack-simple-payments-form-image-id' ).val( '' ).change();
 		} );
 	} );
 }( wp.customize, wp, jQuery ) );

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -5,19 +5,25 @@
 
 	function showForm() {
 		var root = getWidgetRoot.apply( this );
+		//disable widget title and product selector
 		root.find( '.jetpack-simple-payments-widget-title' ).attr( 'disabled', 'disabled' );
 		root.find( '.jetpack-simple-payments-products' ).attr( 'disabled', 'disabled' );
+		//disable add and edit buttons
 		root.find( '.jetpack-simple-payments-add-product' ).attr( 'disabled', 'disabled' );
 		root.find( '.jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
+		//show form
 		root.find( '.jetpack-simple-payments-form' ).show();
 	}
 
 	function hideForm() {
 		var root = getWidgetRoot.apply( this );
+		//enable widget title and product selector
 		root.find( '.jetpack-simple-payments-widget-title' ).removeAttr( 'disabled' );
 		root.find( '.jetpack-simple-payments-products' ).removeAttr( 'disabled' );
+		//endable add and edit buttons
 		root.find( '.jetpack-simple-payments-add-product' ).removeAttr( 'disabled' );
 		root.find( '.jetpack-simple-payments-edit-product' ).removeAttr( 'disabled' );
+		//hide the form
 		root.find( '.jetpack-simple-payments-form' ).hide();
 	}
 
@@ -27,14 +33,16 @@
 	}
 
 	$( document ).ready( function() {
+		//Add New Button
 		$( document.body ).on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
 			event.preventDefault();
 
 			showForm.apply( this );
 
-			// changeFormAction.apply( this, [ 'clear' ] );
+			changeFormAction.apply( this, [ 'add' ] );
 		} );
 
+		//Edit Button
 		$( document.body ).on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
 			event.preventDefault();
 
@@ -43,6 +51,7 @@
 			changeFormAction.apply( this, [ 'edit' ] );
 		} );
 
+		//Cancel Button
 		$( document.body ).on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
 			event.preventDefault();
 
@@ -51,28 +60,41 @@
 			changeFormAction.apply( this, [ 'clear' ] );
 		} );
 
+		//Save Product button
 		$( document.body ).on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
 			event.preventDefault();
+			var root = getWidgetRoot.apply( this );
+			var clearForm = changeFormAction.bind( this );
+			var hide = hideForm.bind( this );
 
-			// request = wp.ajax.post( 'customize-jetpack-simple-payments-button-add-new', {
-			// 	'customize-jetpack-simple-payments-nonce': api.settings.nonce['customize-simple-payments'],
-			// 	'customize_changeset_uuid': api.settings.changeset.uuid,
-			// 	'params': { foo: 'bar' }
-			// } );
+			request = wp.ajax.post( 'customize-jetpack-simple-payments-button-add-new', {
+				'customize-jetpack-simple-payments-nonce': api.settings.nonce['customize-jetpack-simple-payments'],
+				'customize_changeset_uuid': api.settings.changeset.uuid,
+				'params': { 
+					'title': root.find( '.jetpack-simple-payments-form-product-title' ).val(),
+					'description': root.find( '.jetpack-simple-payments-form-product-description' ).val(),
+					'image_id': root.find( '.jetpack-simple-payments-form-image-id' ).val(),
+					'currency': root.find( '.jetpack-simple-payments-form-product-currency' ).val(),
+					'price': root.find( '.jetpack-simple-payments-form-product-price' ).val(),
+					'multiple': root.find( '.jetpack-simple-payments-form-product-multiple' ).is(':checked'),
+					'email': root.find( '.jetpack-simple-payments-form-product-email' ).val(),
+				}
+			} );
 
-			// request.done( function( response ) {
-			// 	console.log( response );
-
-			// 	var select = root.find( 'select.jetpack-simple-payments-products' ).append(
-			// 		$('<option>', {
-			// 			value: response.product_post_id,
-			// 			text: response.product_post_title
-			// 		} )
-			// 	);
-			// 	select.val( response.product_post_id ).change();
-			// } );
+			request.done( function( response ) {
+				var select = root.find( 'select.jetpack-simple-payments-products' ).append(
+					$('<option>', {
+						value: response.product_post_id,
+						text: response.product_post_title
+					} )
+				);
+				select.val( response.product_post_id ).change();
+				clearForm( 'clear' );
+				hide();
+			} );
 		} );
 
+		//Select an Image
 		$( document.body ).on( 'click', '.jetpack-simple-payments-image-fieldset .placeholder, .jetpack-simple-payments-image > img', function() {
 			var root = getWidgetRoot.apply( this );
 			var imageContainer = root.find( '.jetpack-simple-payments-image' );
@@ -86,16 +108,17 @@
 
 			mediaFrame.on( 'select', function() {
 				var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
-
+				console.log(selection);
+				//hide placeholder
 				root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).hide();
 
+				//load image from media library
 				imageContainer.find( 'img' )
 					.attr( 'src', selection.url )
-					.attr( 'title', selection.title )
-					.attr( 'alt', selection.caption );
-				imageContainer.find( 'input[type=hidden]' ).val( selection.id ).change();
+					.show();
 
-				imageContainer.show();
+				//set hidden field for the selective refresh
+				root.find( '.jetpack-simple-payments-form-image-id' ).val( selection.id ).change();
 			} );
 
 			mediaFrame.open();

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -1,4 +1,4 @@
-/* global jQuery */
+/* global jQuery, jpSimplePaymentsStrings */
 /* eslint no-var: 0, quote-props: 0 */
 
 ( function( api, wp, $ ) {
@@ -226,6 +226,10 @@
 	function deleteProduct( widgetForm ) {
 		return function( event ) {
 			event.preventDefault();
+
+			if ( ! confirm( jpSimplePaymentsStrings.deleteConfirmation ) ) {
+				return;
+			}
 
 			var formProductId = parseInt( widgetForm.find( '.jetpack-simple-payments-form-product-id' ).val(), 10 );
 			if ( ! formProductId ) {

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -1,105 +1,143 @@
+/* global jQuery */
+/* eslint no-var: 0, quote-props: 0 */
+
 ( function( api, wp, $ ) {
-	function getWidgetRoot() {
-		return $( this ).closest( '.widget-content' );
-	}
+	var $document = $( document );
 
-	function showForm() {
-		var root = getWidgetRoot.apply( this );
-		//disable widget title and product selector
-		root.find( '.jetpack-simple-payments-widget-title' ).attr( 'disabled', 'disabled' );
-		root.find( '.jetpack-simple-payments-products' ).attr( 'disabled', 'disabled' );
-		//disable add and edit buttons
-		root.find( '.jetpack-simple-payments-add-product' ).attr( 'disabled', 'disabled' );
-		root.find( '.jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
-		//show form
-		root.find( '.jetpack-simple-payments-form' ).show();
-		//focus on first field
-		root.find( '.jetpack-simple-payments-form-product-title' ).focus();
-	}
+	$document.ready( function() {
+		$document.on( 'widget-added', function( event, widgetContainer ) {
+			if ( widgetContainer.is( '[id*="jetpack_simple_payments_widget"]' ) ) {
+				initWidget( widgetContainer );
+			}
+		} );
 
-	function hideForm() {
-		var root = getWidgetRoot.apply( this );
-		//enable widget title and product selector
-		root.find( '.jetpack-simple-payments-widget-title' ).removeAttr( 'disabled' );
-		root.find( '.jetpack-simple-payments-products' ).removeAttr( 'disabled' );
-		//endable add and edit buttons
-		root.find( '.jetpack-simple-payments-add-product' ).removeAttr( 'disabled' );
-		root.find( '.jetpack-simple-payments-edit-product' ).removeAttr( 'disabled' );
-		//hide the form
-		root.find( '.jetpack-simple-payments-form' ).hide();
-	}
+		$document.on( 'widget-synced widget-updated', function( event, widgetContainer ) {
+			//this fires for all widgets, this prevent errors for non SP widgets
+			if ( ! widgetContainer.is( '[id*="jetpack_simple_payments_widget"]' ) ) {
+				return;
+			}
 
-	function changeFormAction( action ) {
-		var root = getWidgetRoot.apply( this );
-		root.find( '.jetpack-simple-payments-form-action' ).val( action ).change();
-	}
+			event.preventDefault();
+			var widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' );
 
-	$( document ).ready( function() {
+			if ( ! widgetForm.find( '.jetpack-simple-payments-form' ).is( ':visible' ) ) {
+				widgetForm.find( '.jetpack-simple-payments-add-product' )
+					.add( '.jetpack-simple-payments-edit-product' )
+					.add( '.jetpack-simple-payments-products' )
+					.removeAttr( 'disabled' );
+			} else {
+				widgetForm.find( '.jetpack-simple-payments-save-product' )
+					.add( '.jetpack-simple-payments-cancel-form' )
+					.add( '.jetpack-simple-payments-delete-product' )
+					.removeAttr( 'disabled' );
+			}
+
+			var newImageId = parseInt( widgetForm.find( '.jetpack-simple-payments-form-image-id' ).val(), 10 );
+			var newImageSrc = widgetForm.find( '.jetpack-simple-payments-form-image-src' ).val();
+
+			var placeholder = widgetForm.find( '.jetpack-simple-payments-image-fieldset .placeholder' );
+			var image = widgetForm.find( '.jetpack-simple-payments-image > img' );
+			var imageControls = widgetForm.find( '.jetpack-simple-payments-image' );
+
+			if ( newImageId && newImageSrc ) {
+				image.attr( 'src', newImageSrc );
+				placeholder.hide();
+				imageControls.show();
+			} else {
+				placeholder.show();
+				image.removeAttr( 'src' );
+				imageControls.hide();
+			}
+		} );
+	} );
+
+	function initWidget( widgetContainer ) {
+		var widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' );
+
 		//Add New Button
-		$( document.body ).on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
-			event.preventDefault();
-
-			showForm.apply( this );
-
-			changeFormAction.apply( this, [ 'add' ] );
-		} );
-
+		widgetForm.find( '.jetpack-simple-payments-add-product' ).on( 'click', showAddNewForm( widgetForm ) );
 		//Edit Button
-		$( document.body ).on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
-			event.preventDefault();
-
-			showForm.apply( this );
-
-			changeFormAction.apply( this, [ 'edit' ] );
-		} );
-
-		//Cancel Button
-		$( document.body ).on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
-			event.preventDefault();
-
-			hideForm.apply( this );
-
-			changeFormAction.apply( this, [ 'clear' ] );
-		} );
-
-		//Save Product button
-		$( document.body ).on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
-			event.preventDefault();
-			var root = getWidgetRoot.apply( this );
-			var clearForm = changeFormAction.bind( this );
-			var hide = hideForm.bind( this );
-
-			request = wp.ajax.post( 'customize-jetpack-simple-payments-button-add-new', {
-				'customize-jetpack-simple-payments-nonce': api.settings.nonce['customize-jetpack-simple-payments'],
-				'customize_changeset_uuid': api.settings.changeset.uuid,
-				'params': { 
-					'title': root.find( '.jetpack-simple-payments-form-product-title' ).val(),
-					'description': root.find( '.jetpack-simple-payments-form-product-description' ).val(),
-					'image_id': root.find( '.jetpack-simple-payments-form-image-id' ).val(),
-					'currency': root.find( '.jetpack-simple-payments-form-product-currency' ).val(),
-					'price': root.find( '.jetpack-simple-payments-form-product-price' ).val(),
-					'multiple': root.find( '.jetpack-simple-payments-form-product-multiple' ).is(':checked'),
-					'email': root.find( '.jetpack-simple-payments-form-product-email' ).val(),
-				}
-			} );
-
-			request.done( function( response ) {
-				var select = root.find( 'select.jetpack-simple-payments-products' ).append(
-					$('<option>', {
-						value: response.product_post_id,
-						text: response.product_post_title
-					} )
-				);
-				select.val( response.product_post_id ).change();
-				clearForm( 'clear' );
-				hide();
-			} );
-		} );
-
+		widgetForm.find( '.jetpack-simple-payments-edit-product' ).on( 'click', showEditForm( widgetForm ) );
 		//Select an Image
-		$( document.body ).on( 'click', '.jetpack-simple-payments-image-fieldset .placeholder, .jetpack-simple-payments-image > img', function() {
-			var root = getWidgetRoot.apply( this );
-			var imageContainer = root.find( '.jetpack-simple-payments-image' );
+		widgetForm.find( '.jetpack-simple-payments-image-fieldset .placeholder, .jetpack-simple-payments-image > img' ).on( 'click', selectImage( widgetForm ) );
+		//Remove Image Button
+		widgetForm.find( '.jetpack-simple-payments-remove-image' ).on( 'click', removeImage( widgetForm ) );
+		//Save Product button
+		widgetForm.find( '.jetpack-simple-payments-save-product' ).on( 'click', saveChanges( widgetForm ) );
+		//Cancel Button
+		widgetForm.find( '.jetpack-simple-payments-cancel-form' ).on( 'click', clearForm( widgetForm ) );
+		//Delete Selected Product
+		widgetForm.find( '.jetpack-simple-payments-delete-product' ).on( 'click', deleteProduct( widgetForm ) );
+	}
+
+	function showForm( widgetForm ) {
+		//disable widget title and product selector
+		widgetForm.find( '.jetpack-simple-payments-widget-title' ).attr( 'disabled', 'disabled' );
+		widgetForm.find( '.jetpack-simple-payments-products' ).attr( 'disabled', 'disabled' );
+		//disable add and edit buttons
+		widgetForm.find( '.jetpack-simple-payments-add-product' ).attr( 'disabled', 'disabled' );
+		widgetForm.find( '.jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
+		//disable save, delete and cancel until the widget update event is fired
+		widgetForm.find( '.jetpack-simple-payments-save-product' )
+			.add( '.jetpack-simple-payments-cancel-form' )
+			.add( '.jetpack-simple-payments-delete-product' )
+			.attr( 'disabled', 'disabled' );
+		//show form
+		widgetForm.find( '.jetpack-simple-payments-form' ).show();
+	}
+
+	function hideForm( widgetForm ) {
+		//enable widget title and product selector
+		widgetForm.find( '.jetpack-simple-payments-widget-title' ).removeAttr( 'disabled' );
+		widgetForm.find( '.jetpack-simple-payments-products' ).removeAttr( 'disabled' );
+		//endable add and edit buttons
+		widgetForm.find( '.jetpack-simple-payments-add-product' ).removeAttr( 'disabled' );
+		widgetForm.find( '.jetpack-simple-payments-edit-product' ).removeAttr( 'disabled' );
+		//hide the form
+		widgetForm.find( '.jetpack-simple-payments-form' ).hide();
+	}
+
+	function changeFormAction( widgetForm, action ) {
+		widgetForm.find( '.jetpack-simple-payments-form-action' ).val( action ).change();
+	}
+
+	function showAddNewForm( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+
+			showForm( widgetForm );
+
+			changeFormAction( widgetForm, 'add' );
+		};
+	}
+
+	function showEditForm( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+
+			showForm( widgetForm );
+
+			changeFormAction( widgetForm, 'edit' );
+		};
+	}
+
+	function clearForm( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+
+			hideForm( widgetForm );
+
+			widgetForm.find( '.jetpack-simple-payments-add-product, .jetpack-simple-payments-edit-product' ).attr( 'disabled', 'disabled' );
+
+			changeFormAction( widgetForm, 'clear' );
+		};
+	}
+
+	function selectImage( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+
+			var imageContainer = widgetForm.find( '.jetpack-simple-payments-image' );
 
 			var mediaFrame = new wp.media.view.MediaFrame.Select( {
 				title: 'Choose Product Image',
@@ -111,7 +149,7 @@
 			mediaFrame.on( 'select', function() {
 				var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
 				//hide placeholder
-				root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).hide();
+				widgetForm.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).hide();
 
 				//load image from media library
 				imageContainer.find( 'img' )
@@ -119,28 +157,96 @@
 					.show();
 
 				//show image and remove button
-				root.find( '.jetpack-simple-payments-image' ).show();
+				widgetForm.find( '.jetpack-simple-payments-image' ).show();
 
 				//set hidden field for the selective refresh
-				root.find( '.jetpack-simple-payments-form-image-id' ).val( selection.id ).change();
+				widgetForm.find( '.jetpack-simple-payments-form-image-id' ).val( selection.id ).change();
 			} );
 
 			mediaFrame.open();
-		} );
+		};
+	}
 
-		//Remove Image
-		$( document.body ).on( 'click', '.jetpack-simple-payments-remove-image', function( event ) {
+	function removeImage( widgetForm ) {
+		return function( event ) {
 			event.preventDefault();
-			var root = getWidgetRoot.apply( this );
 
 			//show placeholder
-			root.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).show();
+			widgetForm.find( '.jetpack-simple-payments-image-fieldset .placeholder' ).show();
 
 			//hide image and remove button
-			root.find( '.jetpack-simple-payments-image' ).hide();
+			widgetForm.find( '.jetpack-simple-payments-image' ).hide();
 
 			//set hidden field for the selective refresh
-			root.find( '.jetpack-simple-payments-form-image-id' ).val( '' ).change();
-		} );
-	} );
+			widgetForm.find( '.jetpack-simple-payments-form-image-id' ).val( '' ).change();
+		};
+	}
+
+	function saveChanges( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+			var productPostId = widgetForm.find( '.jetpack-simple-payments-form-product-id' ).val();
+
+			var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-save', {
+				'customize-jetpack-simple-payments-nonce': api.settings.nonce[ 'customize-jetpack-simple-payments' ],
+				'customize_changeset_uuid': api.settings.changeset.uuid,
+				'params': {
+					'product_post_id': productPostId,
+					'post_title': widgetForm.find( '.jetpack-simple-payments-form-product-title' ).val(),
+					'post_content': widgetForm.find( '.jetpack-simple-payments-form-product-description' ).val(),
+					'image_id': widgetForm.find( '.jetpack-simple-payments-form-image-id' ).val(),
+					'currency': widgetForm.find( '.jetpack-simple-payments-form-product-currency' ).val(),
+					'price': widgetForm.find( '.jetpack-simple-payments-form-product-price' ).val(),
+					'multiple': widgetForm.find( '.jetpack-simple-payments-form-product-multiple' ).is( ':checked' ) ? 1 : 0,
+					'email': widgetForm.find( '.jetpack-simple-payments-form-product-email' ).val(),
+				}
+			} );
+
+			request.done( function( response ) {
+				var select = widgetForm.find( 'select.jetpack-simple-payments-products' );
+				var productOption = select.find( 'option[value="' + productPostId + '"]' );
+
+				if ( productOption.length > 0	) {
+					productOption.text( response.product_post_title );
+				} else {
+					select.append(
+						$( '<option>', {
+							value: response.product_post_id,
+							text: response.product_post_title
+						} )
+					);
+					select.val( response.product_post_id ).change();
+				}
+				changeFormAction( widgetForm, 'clear' );
+				hideForm( widgetForm );
+			} );
+		};
+	}
+
+	function deleteProduct( widgetForm ) {
+		return function( event ) {
+			event.preventDefault();
+
+			var formProductId = parseInt( widgetForm.find( '.jetpack-simple-payments-form-product-id' ).val(), 10 );
+			if ( ! formProductId ) {
+				return;
+			}
+
+			var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-delete', {
+				'customize-jetpack-simple-payments-nonce': api.settings.nonce[ 'customize-jetpack-simple-payments' ],
+				'customize_changeset_uuid': api.settings.changeset.uuid,
+				'params': {
+					'product_post_id': formProductId
+				}
+			} );
+
+			request.done( function() {
+				var productList = widgetForm.find( 'select.jetpack-simple-payments-products' )[ 0 ];
+				productList.remove( productList.selectedIndex );
+				productList.dispatchEvent( new Event( 'change' ) );
+				changeFormAction( widgetForm, 'clear' );
+				hideForm( widgetForm );
+			} );
+		};
+	}
 }( wp.customize, wp, jQuery ) );

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -89,7 +89,7 @@
 			class="field-currency widefat jetpack-simple-payments-form-product-currency"
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>">
-			<?php foreach( Jetpack_Simple_Payments_Widget::$currencie_symbols as $code => $currency ) {?>
+			<?php foreach( Jetpack_Simple_Payments_Widget::$supported_currency_list as $code => $currency ) {?>
 				<option value="<?php echo esc_attr( $code ) ?>"<?php selected( $instance['form_product_currency'], $code ); ?>>
 					<?php esc_html_e( $code . ' ' . $currency ) ?>
 				</option>

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -19,3 +19,99 @@
 	</select>
 </p>
 <?php } ?>
+<p>
+	<div class="alignleft">
+		<button class="button jetpack-simple-payments-edit-product"><?php esc_html_e( 'Edit' ); ?></button>
+	</div>
+	<div class="alignright">
+		<button class="button jetpack-simple-payments-add-product"><?php esc_html_e( 'Add New' ); ?></button>
+	</div>
+	<br class="clear">
+</p>
+<hr />
+<div class="jetpack-simple-payments-form" style="display: none;">
+	<input
+		type="hidden"
+		id="<?php echo $this->get_field_id('form_action'); ?>"
+		name="<?php echo $this->get_field_name('form_action'); ?>"
+		class="jetpack-simple-payments-form-action" />
+	<input
+		type="hidden"
+		id="<?php echo $this->get_field_id('form_product_id'); ?>"
+		name="<?php echo $this->get_field_name('form_product_id'); ?>"
+		class="jetpack-simple-payments-form-action" />
+	<p>
+		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"><?php esc_html_e( 'What is this payment for?' ); ?></label>
+		<input
+			type="text"
+			class="widefat field-title"
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_title' ) ); ?>"
+			value="<?php echo esc_attr( $instance['form_product_title'] ); ?>" />
+		<br />
+		<small><?php _e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.' ); ?></small>
+	</p>
+	<div class="simple-payments-image-fieldset">
+		<label><?php esc_html_e( 'Product image' ); ?></label>
+		<div class="placeholder" <?php if ( has_post_thumbnail( $instance['product_post_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
+		<div class="simple-payments-image">
+			<?php
+			if ( has_post_thumbnail( $instance['product_post_id'] ) ) {
+				$image_id = get_post_thumbnail_id( $instance['product_post_id'] );
+				error_log(wp_get_attachment_image_url( $image_id, 'full' ));
+			?>
+				<img src="<?php echo esc_url( wp_get_attachment_image_url( $image_id, 'full' ) ); ?>" />
+				<!--input
+					type="hidden"
+					id="<?php echo esc_attr( $this->get_field_id( 'form_product_image' ) ); ?>"
+					name="<?php echo esc_attr( $this->get_field_name( 'form_product_image' ) ); ?>"
+					value="<?php echo esc_attr( $image_id ); ?>" / -->
+				<button class="button simple-payments-remove-image"><?php esc_html_e( 'Remove image' ); ?></button>
+			<?php } ?>
+		</div>
+	</div>
+	<p>
+		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"><?php esc_html_e( 'Description' ); ?></label>
+		<textarea
+			class="field-description widefat"
+			rows=5
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_description' ) ); ?>"><?php  esc_html_e( $instance['form_product_description'] ); ?></textarea>
+	</p>
+	<p class="cost">
+		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>"><?php esc_html_e( 'Price' ); ?></label>
+		<select class="field-currency widefat" id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>">
+		<?php foreach( Jetpack_Simple_Payments_Widget::$currencie_symbols as $code => $currency ) {?>
+				<option value="<?php echo esc_attr( $code ) ?>"<?php selected( $instance['form_product_currency'], $code ); ?>>
+					<?php esc_html_e( $code . ' ' . $currency ) ?>
+				</option>
+			<?php } ?>
+		</select>
+		<input
+			type="text"
+			class="field-price widefat"
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_price' ) ); ?>"
+			value="<?php echo esc_attr( $instance['form_product_price'] ); ?>" />
+	</p>
+	<p>
+		<input class="field-multiple" id="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_multiple' ) ); ?>" type="checkbox" value="1"<?php checked( $instance['form_product_multiple'], '1' ); ?>/>
+		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"><?php esc_html_e( 'Allow people to buy more than one item at a time.' ); ?></label>
+	</p>
+	<p>
+		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>"><?php esc_html_e( 'Email' ); ?></label>
+		<input class="field-email widefat" id="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_email' ) ); ?>" type="email" value="<?php  echo esc_attr( $instance['form_product_email'] ); ?>" />
+		<small><?php printf( esc_html__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a %1$sPayPal account%2$s connected to a bank account.' ), '<a href="https://paypal.com" target="_blank">', '</a>' ) ?></small>
+	</p>
+	<p>
+		<div class="alignleft">
+			<span><button type="button" class="button-link button-link-delete simple-payments-delete-product"><?php _e( 'Delete' ); ?></button> | </span>
+			<button type="button" class="button-link simple-payments-cancel-form"><?php _e( 'Cancel' ); ?></button>
+		</div>
+		<div class="alignright">
+			<button name="<?php echo $this->get_field_name('save'); ?>" class="button simple-payments-save-product"><?php _e( 'Save' ); ?></button>
+		</div>
+		<br class="clear">
+	</p>
+	<hr />
+</div>

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -43,6 +43,12 @@
 		id="<?php echo $this->get_field_id('form_product_id'); ?>"
 		name="<?php echo $this->get_field_name('form_product_id'); ?>"
 		class="jetpack-simple-payments-form-product-id" />
+	<input
+		type="hidden"
+		id="<?php echo esc_attr( $this->get_field_id( 'form_product_image_id' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'form_product_image_id' ) ); ?>"
+		value="<?php echo esc_attr( $instance['form_product_image_id'] ); ?>"
+		class="jetpack-simple-payments-form-image-id" />
 	<p>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"><?php esc_html_e( 'What is this payment for?' ); ?></label>
 		<input
@@ -55,22 +61,16 @@
 		<small><?php _e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.' ); ?></small>
 	</p>
 	<div class="jetpack-simple-payments-image-fieldset">
+		<?php
+			$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
+			$image_src = '';
+			if ( ! empty( $image_id) ) {
+				$image_src = esc_url( wp_get_attachment_image_url( $image_id, 'full' ) );
+			}
+		?>
 		<label><?php esc_html_e( 'Product image' ); ?></label>
-		<div class="placeholder" <?php if ( has_post_thumbnail( $instance['form_product_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
-		<div class="jetpack-simple-payments-image">
-			<?php
-				$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
-				$image_src = '';
-				if ( ! empty( $image_id) ) {
-					$image_src = esc_url( wp_get_attachment_image_url( $image_id, 'full' ) );
-				}
-			?>
-			<input
-				type="hidden"
-				id="<?php echo esc_attr( $this->get_field_id( 'form_product_image_id' ) ); ?>"
-				name="<?php echo esc_attr( $this->get_field_name( 'form_product_image_id' ) ); ?>"
-				value="<?php echo esc_attr( $instance['form_product_image_id'] ); ?>"
-				class="jetpack-simple-payments-form-image-id" />
+		<div class="placeholder" <?php if ( ! empty( $image_id ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
+		<div class="jetpack-simple-payments-image" <?php if ( empty( $image_id ) ) echo 'style="display:none;"'; ?>>
 			<img src="<?php echo $image_src; ?>" />
 			<button class="button jetpack-simple-payments-remove-image"><?php esc_html_e( 'Remove image' ); ?></button>
 		</div>

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -2,7 +2,7 @@
 	<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Widget Title', 'jetpack' ); ?></label>
 	<input
 		type="text"
-		class="widefat"
+		class="widefat jetpack-simple-payments-widget-title"
 		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
 		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
 		value="<?php echo esc_attr( $instance['title'] ); ?>" />
@@ -10,7 +10,10 @@
 <?php if ( ! empty( $product_posts ) ) { ?>
 <p>
 	<label for="<?php echo $this->get_field_id('product_post_id'); ?>"><?php _e( 'Select a Simple Payment Button:', 'jetpack' ); ?></label>
-	<select class="widefat" id="<?php echo $this->get_field_id('product_post_id'); ?>" name="<?php echo $this->get_field_name('product_post_id'); ?>">
+	<select
+		class="widefat jetpack-simple-payments-products"
+		id="<?php echo $this->get_field_id('product_post_id'); ?>"
+		name="<?php echo $this->get_field_name('product_post_id'); ?>">
 		<?php foreach ( $product_posts as $product_post ) { ?>
 			<option value="<?php echo esc_attr( $product_post->ID ) ?>"<?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
 				<?php echo esc_attr( get_the_title( $product_post ) ) ?>
@@ -39,49 +42,54 @@
 		type="hidden"
 		id="<?php echo $this->get_field_id('form_product_id'); ?>"
 		name="<?php echo $this->get_field_name('form_product_id'); ?>"
-		class="jetpack-simple-payments-form-action" />
+		class="jetpack-simple-payments-form-product-id" />
 	<p>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"><?php esc_html_e( 'What is this payment for?' ); ?></label>
 		<input
 			type="text"
-			class="widefat field-title"
+			class="widefat field-title jetpack-simple-payments-form-product-title"
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_title' ) ); ?>"
 			value="<?php echo esc_attr( $instance['form_product_title'] ); ?>" />
 		<br />
 		<small><?php _e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.' ); ?></small>
 	</p>
-	<div class="simple-payments-image-fieldset">
+	<div class="jetpack-simple-payments-image-fieldset">
 		<label><?php esc_html_e( 'Product image' ); ?></label>
-		<div class="placeholder" <?php if ( has_post_thumbnail( $instance['product_post_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
-		<div class="simple-payments-image">
+		<div class="placeholder" <?php if ( has_post_thumbnail( $instance['form_product_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
+		<div class="jetpack-simple-payments-image">
 			<?php
-			if ( has_post_thumbnail( $instance['product_post_id'] ) ) {
-				$image_id = get_post_thumbnail_id( $instance['product_post_id'] );
-				error_log(wp_get_attachment_image_url( $image_id, 'full' ));
+				$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
+				$image_src = '';
+				if ( ! empty( $image_id) ) {
+					$image_src = esc_url( wp_get_attachment_image_url( $image_id, 'full' ) );
+				}
 			?>
-				<img src="<?php echo esc_url( wp_get_attachment_image_url( $image_id, 'full' ) ); ?>" />
-				<!--input
-					type="hidden"
-					id="<?php echo esc_attr( $this->get_field_id( 'form_product_image' ) ); ?>"
-					name="<?php echo esc_attr( $this->get_field_name( 'form_product_image' ) ); ?>"
-					value="<?php echo esc_attr( $image_id ); ?>" / -->
-				<button class="button simple-payments-remove-image"><?php esc_html_e( 'Remove image' ); ?></button>
-			<?php } ?>
+			<input
+				type="hidden"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_image_id' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_image_id' ) ); ?>"
+				value="<?php echo esc_attr( $instance['form_product_image_id'] ); ?>"
+				class="jetpack-simple-payments-form-image-id" />
+			<img src="<?php echo $image_src; ?>" />
+			<button class="button jetpack-simple-payments-remove-image"><?php esc_html_e( 'Remove image' ); ?></button>
 		</div>
 	</div>
 	<p>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"><?php esc_html_e( 'Description' ); ?></label>
 		<textarea
-			class="field-description widefat"
+			class="field-description widefat jetpack-simple-payments-form-product-description"
 			rows=5
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_description' ) ); ?>"><?php  esc_html_e( $instance['form_product_description'] ); ?></textarea>
 	</p>
 	<p class="cost">
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>"><?php esc_html_e( 'Price' ); ?></label>
-		<select class="field-currency widefat" id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>">
-		<?php foreach( Jetpack_Simple_Payments_Widget::$currencie_symbols as $code => $currency ) {?>
+		<select
+			class="field-currency widefat jetpack-simple-payments-form-product-currency"
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>">
+			<?php foreach( Jetpack_Simple_Payments_Widget::$currencie_symbols as $code => $currency ) {?>
 				<option value="<?php echo esc_attr( $code ) ?>"<?php selected( $instance['form_product_currency'], $code ); ?>>
 					<?php esc_html_e( $code . ' ' . $currency ) ?>
 				</option>
@@ -89,27 +97,37 @@
 		</select>
 		<input
 			type="text"
-			class="field-price widefat"
+			class="field-price widefat jetpack-simple-payments-form-product-price"
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_price' ) ); ?>"
 			value="<?php echo esc_attr( $instance['form_product_price'] ); ?>" />
 	</p>
 	<p>
-		<input class="field-multiple" id="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_multiple' ) ); ?>" type="checkbox" value="1"<?php checked( $instance['form_product_multiple'], '1' ); ?>/>
+		<input
+			class="field-multiple jetpack-simple-payments-form-product-multiple"
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_multiple' ) ); ?>"
+			type="checkbox"
+			value=<?php checked( $instance['form_product_multiple'], '1' ); ?>/>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"><?php esc_html_e( 'Allow people to buy more than one item at a time.' ); ?></label>
 	</p>
 	<p>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>"><?php esc_html_e( 'Email' ); ?></label>
-		<input class="field-email widefat" id="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'form_product_email' ) ); ?>" type="email" value="<?php  echo esc_attr( $instance['form_product_email'] ); ?>" />
+		<input
+			class="field-email widefat jetpack-simple-payments-form-product-email"
+			id="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_email' ) ); ?>"
+			type="email"
+			value="<?php  echo esc_attr( $instance['form_product_email'] ); ?>" />
 		<small><?php printf( esc_html__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a %1$sPayPal account%2$s connected to a bank account.' ), '<a href="https://paypal.com" target="_blank">', '</a>' ) ?></small>
 	</p>
 	<p>
 		<div class="alignleft">
-			<span><button type="button" class="button-link button-link-delete simple-payments-delete-product"><?php _e( 'Delete' ); ?></button> | </span>
-			<button type="button" class="button-link simple-payments-cancel-form"><?php _e( 'Cancel' ); ?></button>
+			<span><button type="button" class="button-link button-link-delete jetpack-simple-payments-delete-product"><?php _e( 'Delete' ); ?></button> | </span>
+			<button type="button" class="button-link jetpack-simple-payments-cancel-form"><?php _e( 'Cancel' ); ?></button>
 		</div>
 		<div class="alignright">
-			<button name="<?php echo $this->get_field_name('save'); ?>" class="button simple-payments-save-product"><?php _e( 'Save' ); ?></button>
+			<button name="<?php echo $this->get_field_name('save'); ?>" class="button jetpack-simple-payments-save-product"><?php _e( 'Save' ); ?></button>
 		</div>
 		<br class="clear">
 	</p>

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -24,7 +24,7 @@
 <?php } ?>
 <p>
 	<div class="alignleft">
-		<button class="button jetpack-simple-payments-edit-product"><?php esc_html_e( 'Edit' ); ?></button>
+		<button class="button jetpack-simple-payments-edit-product"><?php esc_html_e( 'Edit Selected' ); ?></button>
 	</div>
 	<div class="alignright">
 		<button class="button jetpack-simple-payments-add-product"><?php esc_html_e( 'Add New' ); ?></button>
@@ -37,11 +37,13 @@
 		type="hidden"
 		id="<?php echo $this->get_field_id('form_action'); ?>"
 		name="<?php echo $this->get_field_name('form_action'); ?>"
+		value="<?php echo esc_attr( $instance['form_action'] ); ?>"
 		class="jetpack-simple-payments-form-action" />
 	<input
 		type="hidden"
 		id="<?php echo $this->get_field_id('form_product_id'); ?>"
 		name="<?php echo $this->get_field_name('form_product_id'); ?>"
+		value="<?php echo esc_attr( $instance['form_product_id'] ); ?>"
 		class="jetpack-simple-payments-form-product-id" />
 	<input
 		type="hidden"
@@ -49,6 +51,12 @@
 		name="<?php echo esc_attr( $this->get_field_name( 'form_product_image_id' ) ); ?>"
 		value="<?php echo esc_attr( $instance['form_product_image_id'] ); ?>"
 		class="jetpack-simple-payments-form-image-id" />
+	<input
+		type="hidden"
+		id="<?php echo esc_attr( $this->get_field_id( 'form_product_image_src' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'form_product_image_src' ) ); ?>"
+		value="<?php echo esc_attr( $instance['form_product_image_src'] ); ?>"
+		class="jetpack-simple-payments-form-image-src" />
 	<p>
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"><?php esc_html_e( 'What is this payment for?' ); ?></label>
 		<input
@@ -61,17 +69,10 @@
 		<small><?php _e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.' ); ?></small>
 	</p>
 	<div class="jetpack-simple-payments-image-fieldset">
-		<?php
-			$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
-			$image_src = '';
-			if ( ! empty( $image_id) ) {
-				$image_src = esc_url( wp_get_attachment_image_url( $image_id, 'full' ) );
-			}
-		?>
 		<label><?php esc_html_e( 'Product image' ); ?></label>
-		<div class="placeholder" <?php if ( ! empty( $image_id ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
-		<div class="jetpack-simple-payments-image" <?php if ( empty( $image_id ) ) echo 'style="display:none;"'; ?>>
-			<img src="<?php echo $image_src; ?>" />
+		<div class="placeholder" <?php if ( ! empty( $instance['form_product_image_id'] ) ) echo 'style="display:none;"'; ?>><?php esc_html_e( 'Select an image' ); ?></div>
+		<div class="jetpack-simple-payments-image" <?php if ( empty( $instance['form_product_image_id'] ) ) echo 'style="display:none;"'; ?>>
+			<img src="<?php echo esc_url( $instance['form_product_image_src'] ); ?>" />
 			<button class="button jetpack-simple-payments-remove-image"><?php esc_html_e( 'Remove image' ); ?></button>
 		</div>
 	</div>
@@ -108,7 +109,8 @@
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_multiple' ) ); ?>"
 			type="checkbox"
-			value=<?php checked( $instance['form_product_multiple'], '1' ); ?>/>
+			value="1"
+			<?php checked( $instance['form_product_multiple'], '1' ); ?> />
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"><?php esc_html_e( 'Allow people to buy more than one item at a time.' ); ?></label>
 	</p>
 	<p>

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,0 +1,30 @@
+<p>widget template</p>
+<div class='jetpack-simple-payments-wrapper'>
+	<div class='jetpack-simple-payments-product'>
+		<div class='jetpack-simple-payments-product-image'>
+			<?php
+
+$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
+?>
+			<div class='jetpack-simple-payments-image'>
+				<?php echo wp_get_attachment_image( $image_id, 'full' ) ?>
+			</div>
+		</div>
+		<div class='jetpack-simple-payments-details'>
+			<div class='jetpack-simple-payments-title'><p><?php esc_attr_e( $instance['form_product_title'] ); ?></p></div>
+			<div class='jetpack-simple-payments-description'><p><?php  esc_html_e( $instance['form_product_description'] ); ?></p></div>
+			<div class='jetpack-simple-payments-price'><p><?php esc_attr_e( $instance['form_product_price'] ); ?> <?php esc_attr_e( $instance['form_product_currency'] ); ?></p></div>
+			<div class='jetpack-simple-payments-purchase-box'>
+				<?php if ( $instance['form_product_multiple'] ) { ?>
+					<div class='jetpack-simple-payments-items'>
+						<input
+							type='number'
+							class='jetpack-simple-payments-items-number'
+							value='1'
+							min='1' />
+					</div>
+				<?php } ?>
+			</div>
+		</div>
+	</div>
+</div>

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,11 +1,7 @@
-<p>widget template</p>
 <div class='jetpack-simple-payments-wrapper'>
 	<div class='jetpack-simple-payments-product'>
 		<div class='jetpack-simple-payments-product-image'>
-			<?php
-
-$image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id'];
-?>
+			<?php $image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id']; ?>
 			<div class='jetpack-simple-payments-image'>
 				<?php echo wp_get_attachment_image( $image_id, 'full' ) ?>
 			</div>

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,9 +1,8 @@
 <div class='jetpack-simple-payments-wrapper'>
 	<div class='jetpack-simple-payments-product'>
-		<div class='jetpack-simple-payments-product-image'>
-			<?php $image_id = has_post_thumbnail( $instance['form_product_id'] ) ? get_post_thumbnail_id( $instance['form_product_id'] ) : $instance['form_product_image_id']; ?>
+		<div class='jetpack-simple-payments-product-image' <?php if ( empty( $instance['form_product_image_id'] ) ) echo 'style="display:none;"'; ?>>
 			<div class='jetpack-simple-payments-image'>
-				<?php echo wp_get_attachment_image( $image_id, 'full' ) ?>
+				<?php echo wp_get_attachment_image( $instance['form_product_image_id'], 'full' ) ?>
 			</div>
 		</div>
 		<div class='jetpack-simple-payments-details'>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a form to manage Simple Payment Buttons from the customizer interface.

| - | - |
| - | - |
| Add New | ![my movie 1 mp4](https://user-images.githubusercontent.com/233601/41058102-4bb41be2-699f-11e8-8be6-b034a049f479.gif) |
| Edit | ![edit](https://user-images.githubusercontent.com/233601/41335035-e00442b8-6ebd-11e8-8d7f-8b79cf3f27d9.gif) |
| Delete | ![delete](https://user-images.githubusercontent.com/233601/41334902-7129293a-6ebd-11e8-8b4c-e924d6937c1d.gif) |

| Cosed | Open |
| - | - |
| ![screen shot 2018-06-06 at 15 10 32](https://user-images.githubusercontent.com/233601/41056991-3fa8a262-699c-11e8-89e4-ab28ce16e5e2.png) | ![screen shot 2018-06-06 at 15 11 15](https://user-images.githubusercontent.com/233601/41057003-466ed74c-699c-11e8-8012-2e934a2cc4e2.png) |


#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

Pre-requisites:

- apply this branch on a Jetpack site with an active Business Plan subscription and a Theme with at least one widget area
- have at least one previously created Simple Payment Button
- open the Customizer on your Jetpack Business Site
- go to Widgets and select a Widget Area
- click on Add Widget
- search on the widget panel for Simple Payment
- select the Simple Payment widget

at this point, a widget with defaulting to the first SP button should be added to the customizer sidebar.
All actions are atomic and effectively add or modify the existing products. Making a change on a product on the customizer **without publishing** affects products published on posts and pages. But changes on which product is shown on the widget only persist after being _Published_ by the user.

To **create a new product**, you'll need to:

- click on _Add New_
- fill the form. Using an image is optional, but it should open the media library if clicked.

The widget preview on the customizer should clear out, and display the entered values as they are typed on the form.

- click _Save_

the form should close, and the new SP button should be added to the drop down list. The customizer preview should show the new SP button.

- click _Cancel_

the form should clear and close, and the previously selected SP button should appear on the customizer preview.

To **edit and existing product**, you'll need to:

- Select the desired product from the drop down list
- click on _Edit Selected_

The form should load the product properties, and the widget preview on the customizer should show the correct product, and update the values as they are edited on the form.

- click _Save_

the form should close, preserving the changes on the customizer preview window and the selected item on the product drop down list.

- click _Cancel_

the form should clear and close, and the previously selected SP button should appear on the customizer preview.

To **delete an existing product**, you'll need to:

- Select the desired product from the drop down list.
- click on _Edit Selected_

The form should load the product properties, and the widget preview on the customizer should show the correct product.

- click _Delete_

After confirming the action, the selected product should disappear from the product drop down list. The first product on the list should be selected, and the customizer preview should reflect this change. 