### PR TITLE
Docker README: Fix minor typo

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,7 +55,7 @@ WordPress’ `WP_SITEURL` and `WP_HOME` constants are configured to be dynamic i
 
 ### Quick install WordPress
 
-You can to just quickly install WordPress and activate Jetpack via command line. Ensure you have your domain modified in `.env` file, spin up the containers and then run:
+You can just quickly install WordPress and activate Jetpack via command line. Ensure you have your domain modified in `.env` file, spin up the containers and then run:
 
 ```sh
 yarn docker:install


### PR DESCRIPTION
In the [`Working with containers | Quick install WordPress` section](https://github.com/Automattic/jetpack/tree/1e60685fc6a3c60b1f0b91a11cdeaeaa86691c9f/docker#quick-install-wordpress), fix a minor typo.

#### Changes proposed in this Pull Request:

* Correct `You can to just quickly...` to `You can just quickly...`

#### Testing instructions:

Ensure it reads appropriately.