### PR TITLE
Media Settings: Verbiage Adjustments

### DIFF
--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -65,8 +65,7 @@ class Media extends React.Component {
 			return null;
 		}
 
-		const carousel = this.props.module( 'carousel' ),
-			isCarouselActive = this.props.getOptionValue( 'carousel' ),
+		const isCarouselActive = this.props.getOptionValue( 'carousel' ),
 			videoPress = this.props.module( 'videopress' ),
 			planClass = getPlanClass( this.props.sitePlan.product_slug );
 
@@ -80,6 +79,16 @@ class Media extends React.Component {
 					link: 'https://jetpack.com/support/carousel',
 				} }
 				>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'Images' ) }
+				</FormLegend>
+				<p>
+					{ __(
+						'Create full-screen carousel slideshows for the images in your ' +
+							'posts and pages. Carousel galleries are mobile-friendly and ' +
+							'encourage site visitors to interact with your photos.'
+					) }
+				</p>
 				<ModuleToggle
 					slug="carousel"
 					activated={ isCarouselActive }
@@ -88,7 +97,7 @@ class Media extends React.Component {
 					>
 					<span className="jp-form-toggle-explanation">
 						{
-							carousel.description
+							__( 'Display images in a full-screen carousel gallery' )
 						}
 					</span>
 				</ModuleToggle>
@@ -96,16 +105,24 @@ class Media extends React.Component {
 					<CompactFormToggle
 						checked={ this.state.carousel_display_exif }
 						disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
-						onChange={ this.handleCarouselDisplayExifChange }>
+						onChange={ this.handleCarouselDisplayExifChange }
+						>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Show photo metadata (Exif) in carousel, when available' )
+								__( 'Show photo Exif metadata in carousel (when available)' )
 							}
 						</span>
 					</CompactFormToggle>
+					<FormFieldset>
+							<p className="jp-form-setting-explanation">
+								{ __(
+									'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
+								) }
+							</p>
+					</FormFieldset>
 					<FormLabel>
 						<FormLegend className="jp-form-label-wide">
-							{ __( 'Color scheme' ) }
+							{ __( 'Carousel color scheme' ) }
 						</FormLegend>
 						<FormSelect
 							name={ 'carousel_background_color' }
@@ -128,6 +145,14 @@ class Media extends React.Component {
 					link: 'https://jetpack.com/support/videopress/',
 				} }
 				>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'Video' ) }
+				</FormLegend>
+				<p> { __(
+					'Make the content you publish more engaging with high-resolution video. ' +
+						'With Jetpack Video you can customize your media player and deliver ' +
+						'high-speed, ad-free, and unbranded videos to your visitors.'
+				) } </p>
 				<ModuleToggle
 					slug="videopress"
 					disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
@@ -137,7 +162,7 @@ class Media extends React.Component {
 					>
 					<span className="jp-form-toggle-explanation">
 						{
-							videoPress.description
+							__( 'Enable high-speed, ad-free video player' )
 						}
 					</span>
 				</ModuleToggle>

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -151,7 +151,7 @@ class Media extends React.Component {
 				<p> { __(
 					'Make the content you publish more engaging with high-resolution video. ' +
 						'With Jetpack Video you can customize your media player and deliver ' +
-						'high-speed, ad-free, and unbranded videos to your visitors.'
+						'high-speed, ad-free, and unbranded videos to your visitors. Videos are hosted on our WordPress.com servers and do not subtract space from your hosting plan!'
 				) } </p>
 				<ModuleToggle
 					slug="videopress"

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -74,8 +74,6 @@ class Media extends React.Component {
 				hasChild
 				module={ { module: 'carousel' } }
 				support={ {
-					text: __( 'Replaces the standard WordPress galleries with a ' +
-						'full-screen photo browsing experience, including comments and EXIF metadata.' ),
 					link: 'https://jetpack.com/support/carousel',
 				} }
 				>
@@ -141,7 +139,6 @@ class Media extends React.Component {
 				disableInDevMode
 				module={ videoPress }
 				support={ {
-					text: __( 'Hosts your video files on the global WordPress.com servers.' ),
 					link: 'https://jetpack.com/support/videopress/',
 				} }
 				>


### PR DESCRIPTION
Resolves #9689

- Remove un-used `carousel` const
- Update labels and descriptions for media settings
- Add section titles for Video and Image settings

### Before
<img width="776" alt="screen shot 2018-06-05 at 4 29 24 pm" src="https://user-images.githubusercontent.com/214813/41002190-1074ff88-68e1-11e8-99c6-3d2363ffb5e1.png">



### After
<img width="739" alt="screen shot 2018-06-07 at 12 25 53" src="https://user-images.githubusercontent.com/87168/41094365-5deb3f48-6a4e-11e8-9ce5-aea7fa4f9112.png">


### Testing

See that Media settings in `/wp-admin/admin.php?page=jetpack#/writing` continue working.