### PR TITLE
WordPress.com toolbar settings: Verbiage adjustments

### DIFF
--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -35,6 +35,15 @@ export const Masterbar = moduleSettingsForm(
 							link: 'https://jetpack.com/support/masterbar/',
 						} }
 						>
+						<p>
+							{ __(
+								'The WordPress.com toolbar replaces the default WordPress ' +
+									'admin toolbar and streamlines your WordPress experience. ' +
+									'It offers one-click access to manage all your sites, ' +
+									'update your WordPress.com profile, view notifications, ' +
+									'and catch up on the sites you follow in the Reader.'
+							) }
+						</p>
 						<ModuleToggle
 							slug="masterbar"
 							disabled={ unavailableInDevMode || ! isLinked }
@@ -42,13 +51,6 @@ export const Masterbar = moduleSettingsForm(
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
 							{ __( 'Enable the WordPress.com toolbar' ) }
-							<span className="jp-form-setting-explanation">
-							{
-								__( 'The WordPress.com toolbar replaces the default admin bar and offers quick links to ' +
-									'the Reader, all your sites, your WordPress.com profile, and notifications. ' +
-									'Centralize your WordPress experience with a single global toolbar.' )
-							}
-						</span>
 						</ModuleToggle>
 					</SettingsGroup>
 					{


### PR DESCRIPTION
Update verbiage for WordPress.com toolbar settings.

Resolves #9695

### Before
<img width="773" alt="screen shot 2018-06-06 at 12 27 18 pm" src="https://user-images.githubusercontent.com/214813/41051911-71579276-6985-11e8-8458-f46e4338ee50.png">


### After
<img width="735" alt="screen shot 2018-06-07 at 12 40 36" src="https://user-images.githubusercontent.com/87168/41094925-37387e2c-6a50-11e8-8188-2246badfa41f.png">


### Testing

See masterbar settings toggle form `/wp-admin/admin.php?page=jetpack#/writing`