### PR TITLE
Jetpack Twitter Cards: fix open graph tags

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -208,7 +208,9 @@ class Jetpack_Twitter_Cards {
 	}
 
 	static function site_tag() {
-		$site_tag = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack-twitter-cards-site-tag', '' );
+		$site_tag = ( defined( 'IS_WPCOM' ) && IS_WPCOM  ) ?
+            trim( get_option( 'twitter_via' ) ) :
+            Jetpack_Options::get_option_and_ensure_autoload( 'jetpack-twitter-cards-site-tag', '' );
 		if ( empty( $site_tag ) ) {
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 				return 'wordpressdotcom';


### PR DESCRIPTION
Yesterday, this deployment r176550-wpcom
caused a regression in the way we generate open graph Twitter tags.

This diff attempts to fix it by using the correct twitter setting based on `IS_WPCOM`

Jetpack and WPCOM sites use different options for twitter site tag.

Test Plan:
On site running this branch, update your twitter handle.
Ensure that twitter sharing buttons continue to use your chosen Twitter handle.
