### PR TITLE
JSON API Endpoints: Merge Changes to json-endpoints.php

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -94,9 +94,6 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-site-homepage-e
 // Widgets
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-add-widget-endpoint.php' );
 
-// Widgets
-require_once( $json_endpoints_dir . 'class.wpcom-json-api-add-widget-endpoint.php' );
-
 // **********
 // v1.2
 // **********

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -94,6 +94,9 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-site-homepage-e
 // Widgets
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-add-widget-endpoint.php' );
 
+// Widgets
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-add-widget-endpoint.php' );
+
 // **********
 // v1.2
 // **********

--- a/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
@@ -1,12 +1,5 @@
 <?php
-/*
- * WARNING: This file is distributed verbatim in Jetpack.
- * There should be nothing WordPress.com specific in this file.
- *
- * Not yet synced - but it should be :)
- *
- * @hide-in-jetpack
- */
+
 /**
  * Activate a widget on a site.
  *

--- a/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
@@ -1,9 +1,107 @@
 <?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * Not yet synced - but it should be :)
+ *
+ * @hide-in-jetpack
+ */
 /**
  * Activate a widget on a site.
  *
  * https://public-api.wordpress.com/rest/v1.1/sites/$site/widgets/new
  */
+
+new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
+	'description'      => 'Activate a widget on a site.',
+	'group'            => 'sites',
+	'stat'             => 'widgets:new',
+	'method'           => 'POST',
+	'min_version'      => '1.1',
+	'path'             => '/sites/%s/widgets/new',
+	'path_labels'      => array(
+		'$site' => '(string) Site ID or domain.'
+	),
+	'request_format' => array(
+		'id_base' => '(string) The base ID of the widget.',
+		'sidebar' => '(string) Optional. The ID of the sidebar where this widget will be active. If empty, the widget will be added in the first sidebar available.',
+		'position' => '(int) Optional. The position of the widget in the sidebar.',
+		'settings' => '(object) Optional. The settings for the new widget.',
+	),
+	'response_format'  => array(
+		'id' => '(string) The actual ID of the widget.',
+		'sidebar' => '(string) The ID of the sidebar where this widget will be active.',
+		'position' => '(int) The final position of the widget in the sidebar.',
+		'settings' => '(array) The settings for the new widget.',
+	),
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/12345678/widgets/new',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'id_base' => 'text',
+			'sidebar' => 'sidebar-2',
+			'position' => '0',
+			'settings' => array( 'title' => 'hello world' ),
+		)
+	),
+	'example_response' => '
+	{
+		"id": "text-3",
+		"id_base": "text",
+		"settings": {
+			"title": "hello world"
+		},
+		"sidebar": "sidebar-2",
+		"position": 0
+	}'
+) );
+
+
+
+new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
+	'description'      => 'Activate a group of widgets on a site. The bulk version of using the /new endpoint',
+	'group'            => '__do_not_document',
+	'stat'             => 'widgets:new:bulk',
+	'force'            => 'wpcom',
+	'method'           => 'POST',
+	'min_version'      => '1.1',
+	'path'             => '/sites/%s/widgets',
+	'path_labels'      => array(
+		'$site' => '(string) Site ID or domain.'
+	),
+	'request_format' => array(
+		'widgets' => '(array:widget) An array of widget objects to add.',
+	),
+	'response_format'  => array(
+		'widgets' => '(array:widget) An array of widget objects added.',
+	),
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/12345678/widgets',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'id_base' => 'text',
+			'sidebar' => 'sidebar-2',
+			'position' => '0',
+			'settings' => array( 'title' => 'hello world' ),
+		)
+	),
+	'example_response' => '
+	{
+		"id": "text-3",
+		"id_base": "text",
+		"settings": {
+			"title": "hello world"
+		},
+		"sidebar": "sidebar-2",
+		"position": 0
+	}'
+) );
+
 
 new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
 	'description'      => 'Activate a widget on a site.',
@@ -100,4 +198,3 @@ class WPCOM_JSON_API_Add_Widgets_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 }
-

--- a/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
@@ -1,57 +1,9 @@
 <?php
-
 /**
  * Activate a widget on a site.
  *
  * https://public-api.wordpress.com/rest/v1.1/sites/$site/widgets/new
  */
-
-new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
-	'description'      => 'Activate a widget on a site.',
-	'group'            => 'sites',
-	'stat'             => 'widgets:new',
-	'method'           => 'POST',
-	'min_version'      => '1.1',
-	'path'             => '/sites/%s/widgets/new',
-	'path_labels'      => array(
-		'$site' => '(string) Site ID or domain.'
-	),
-	'request_format' => array(
-		'id_base' => '(string) The base ID of the widget.',
-		'sidebar' => '(string) Optional. The ID of the sidebar where this widget will be active. If empty, the widget will be added in the first sidebar available.',
-		'position' => '(int) Optional. The position of the widget in the sidebar.',
-		'settings' => '(object) Optional. The settings for the new widget.',
-	),
-	'response_format'  => array(
-		'id' => '(string) The actual ID of the widget.',
-		'sidebar' => '(string) The ID of the sidebar where this widget will be active.',
-		'position' => '(int) The final position of the widget in the sidebar.',
-		'settings' => '(array) The settings for the new widget.',
-	),
-	'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/12345678/widgets/new',
-	'example_request_data' => array(
-		'headers' => array(
-			'authorization' => 'Bearer YOUR_API_TOKEN'
-		),
-		'body' => array(
-			'id_base' => 'text',
-			'sidebar' => 'sidebar-2',
-			'position' => '0',
-			'settings' => array( 'title' => 'hello world' ),
-		)
-	),
-	'example_response' => '
-	{
-		"id": "text-3",
-		"id_base": "text",
-		"settings": {
-			"title": "hello world"
-		},
-		"sidebar": "sidebar-2",
-		"position": 0
-	}'
-) );
-
 
 
 new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
@@ -146,13 +98,6 @@ new WPCOM_JSON_API_Add_Widgets_Endpoint( array (
 class WPCOM_JSON_API_Add_Widgets_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * API callback.
-	 *
-	 * @param string $path
-	 * @param int    $blog_id
-	 * @uses jetpack_require_lib
-	 * @uses Jetpack_Widgets
-	 *
-	 * @return array|WP_Error
 	 */
 	function callback( $path = '', $blog_id = 0 ) {
 		// Switch to the given blog.
@@ -165,13 +110,13 @@ class WPCOM_JSON_API_Add_Widgets_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'unauthorized', 'User is not authorized to access widgets', 403 );
 		}
 
-		jetpack_require_lib( 'widgets' );
+		require_lib( 'widgets' );
 		$args = $this->input( false, false ); // Don't filter the input
 		if ( empty( $args ) || ! is_array( $args ) ) {
 			return new WP_Error( 'no_data', 'No data was provided.', 400 );
 		}
 		if ( isset( $args['widgets'] ) || ! empty( $args['widgets'] ) ) {
-			$widgets = Jetpack_Widgets::activate_widgets( $args['widgets'] );
+			$widgets = Widgets::activate_widgets( $args['widgets'] );
 			if ( is_wp_error( $widgets ) ) {
 				return $widgets;
 			}
@@ -182,12 +127,12 @@ class WPCOM_JSON_API_Add_Widgets_Endpoint extends WPCOM_JSON_API_Endpoint {
 		}
 
 		if ( empty( $args['sidebar'] ) ) {
-			$active_sidebars = Jetpack_Widgets::get_active_sidebars();
+			$active_sidebars = Widgets::get_active_sidebars();
 			reset( $active_sidebars );
 			$args['sidebar'] = key( $active_sidebars );
 		}
 
-		return Jetpack_Widgets::activate_widget( $args['id_base'], $args['sidebar'], $args['position'], $args['settings'] );
+		return Widgets::activate_widget( $args['id_base'], $args['sidebar'], $args['position'], $args['settings'] );
 	}
 
 }


### PR DESCRIPTION
Summary:
Jetpack now includes `class.wpcom-json-api-add-widget-endpoint.php` (Add Widget Endpoint), so to sync WP.com's and Jetpack's `json-endpoints.php`, we need to move some files around.

* Moves `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-add-widget-endpoint.php` to `public.api/rest/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php`
* Moves Endpoint instantiation from `public.api/rest/wpcom-json-endpoints.php` to `public.api/rest/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php`. Previously, Jetpack only included the add-one-widget endpoint instantiation. With this patch it also includes the add-many-widgets instantiation.

{F72251}

Reviewers: #touches_jetpack_files, mdawaffe

Subscribers: roccotrip

Tags: #touches_jetpack_files

Differential Revision: D12352-code

This commit syncs r176571-wpcom.

To test: TBD
