### PR TITLE
Promo cards: fix images URLs

### DIFF
--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -51,7 +51,7 @@ class AppsCard extends React.Component {
 			<div className={ classes }>
 				<Card className="jp-apps-card__content">
 					<div className="jp-apps-card__top">
-						<img src={ imagePath + '/get-apps.svg' } alt="" />
+						<img src={ imagePath + 'get-apps.svg' } alt="" />
 					</div>
 
 					<div className="jp-apps-card__description">

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -50,7 +50,7 @@ class ThemesPromoCard extends React.Component {
 			<div className={ classes }>
 				<Card className="jp-apps-card__content">
 					<div className="jp-apps-card__top">
-						<img src={ imagePath + '/themes.svg' } alt="Premium Themes" />
+						<img src={ imagePath + 'themes.svg' } alt={ __( ' Premium Themes' ) } />
 					</div>
 
 					<div className="jp-apps-card__description">


### PR DESCRIPTION
The var `imagePath` already includes the trailing slash `images/` so let's clean up the image URLs to use just the image name and extension to avoid double forward slash `//`.

### Before

`https://sitename.com/wp-content/plugins/jetpack-dev/images//themes.svg`

### After

`https://sitename.com/wp-content/plugins/jetpack-dev/images/themes.svg`

### How to test

- Have Jetpack site on a free plan.
- Go to your site > `/wp-admin/admin.php?page=jetpack#/plans`.
- Make sure the images on the Themes and Apps promo cards have the correct URL path.