### PR TITLE
Widgets: Make the Simple Payments button compatible with Selective Refresh

### DIFF
--- a/modules/widgets/customizer-utils.js
+++ b/modules/widgets/customizer-utils.js
@@ -1,4 +1,4 @@
-/* global wp, gapi, FB, twttr */
+/* global wp, gapi, FB, twttr, PaypalExpressCheckout */
 
 /**
  * Utilities to work with widgets in Customizer.
@@ -64,6 +64,16 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 							$( '.widget_eu_cookie_law_widget' ).removeClass( 'top' );
 						}
 						placement.container.fadeIn();
+					} else if ( wp.isJetpackWidgetPlaced( placement, 'jetpack_simple_payments_widget' ) ) {
+						// Refresh Simple Payments Widget
+						try {
+							const buttonId = $( '.jetpack-simple-payments-button', placement.container ).attr( 'id' ).replace( '_button', '' );
+							PaypalExpressCheckout.renderButton( null, null, buttonId, null );
+						} catch ( e ) {
+							// PaypalExpressCheckout may fail.
+							// For the same usage, see also:
+							// https://github.com/Automattic/jetpack/blob/6c1971e6bed7d3df793392a7a58ffe0afaeeb5fe/modules/simple-payments/simple-payments.php#L111
+						}
 					}
 				}
 			} );
@@ -73,6 +83,9 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 				if ( placement.container ) {
 					// Refresh Twitter timeline iframe, since it has to be re-built.
 					if ( wp.isJetpackWidgetPlaced( placement, 'twitter_timeline' ) && placement.container.find( 'iframe.twitter-timeline:not([src]):first' ).length ) {
+						placement.partial.refresh();
+					} else if ( wp.isJetpackWidgetPlaced( placement, 'jetpack_simple_payments_widget' ) ) {
+						// Refresh Simple Payments Widget
 						placement.partial.refresh();
 					}
 				}


### PR DESCRIPTION
Replace #9668
Required by #9577

The Simple Payments module works basically like this: whenever the Simple Payments button is rendered, it calls a JS script that in turns renders a PayPal button.
This doesn't happen with the Simple Payments widget, when the Customizer _selectively refreshes_ it.

#### Changes proposed in this Pull Request:

* Add the Simple Payments widget to the widgets that support Selective Refresh.
* Upon widget change or move, trigger a new PayPal button render on the updated widget button.

#### Testing instructions:

* `git checkout fix/simple-payment-widget-customizer-reload-script`: it's the branch of #9668, and it contains exactly the same changes as this PR, but it's branched off #9577 which introduces the Simple Payments widget, so it's easier to test.
* Pick a Premium/Business site with one or more Simple Payments button already created.
* Open the Customizer and add a Simple Payments widget.
* Edit the widget, wait for the Customizer to refresh it, and make sure its PayPal button is still visible.
* Move the widget, and again check if the PayPal button is there.