### PR TITLE
Allow empty texts for support info bubbles

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -135,7 +135,7 @@ export class DashItem extends Component {
 				<Card className="jp-dash-item__card" href={ this.props.href }>
 					<div className="jp-dash-item__content">
 						{
-							this.props.support.text && this.props.support.link &&
+							this.props.support.link &&
 								<SupportInfo
 									module={ module }
 									{ ...this.props.support }

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -42,7 +42,7 @@ export const SettingsGroup = props => {
 			} ) }>
 				{ displayFadeBlock && <div className="jp-form-block-fade" /> }
 				{
-					props.support.text && props.support.link &&
+					props.support.link &&
 						<SupportInfo
 							module={ module }
 							{ ...props.support }

--- a/_inc/client/components/support-info/README.md
+++ b/_inc/client/components/support-info/README.md
@@ -25,6 +25,6 @@ render() {
 You must set either: `module`, or: `text` and `link`.
 
 - `module` - *optional* (object) A module's info object.
-- `text` - *optional* (string) A brief description of a module|feature. If empty, `module.long_description` is used, if possible.
-- `link` - *optional* (string) A URL leading to an overview of a module|feature. If empty, `module.learn_more_button` is used, if possible.
+- `text` - *optional* (string) A brief description of a module|feature.
+- `link` - *optional* (string) A URL leading to an overview of a module|feature.
 - `privacyLink` - *optional* (string) A URL leading to the privacy information for a module|feature. If empty, defaults to `[link]#privacy`.

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -64,11 +64,8 @@ export default class SupportInfo extends Component {
 	}
 
 	render() {
-		const module = this.getModule();
-		let { text, link, privacyLink } = this.props;
-
-		text = text || module.long_description || '';
-		link = link || module.learn_more_button || '';
+		const { text, link } = this.props;
+		let { privacyLink } = this.props;
 
 		if ( ! privacyLink && link ) {
 			privacyLink = link + '#privacy';

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -86,7 +86,8 @@ export default class SupportInfo extends Component {
 						<ExternalLink
 							href={ link }
 							onClick={ this.trackLearnMoreClick }
-							target="_blank" rel="noopener noreferrer"
+							target="_blank"
+							rel="noopener noreferrer"
 						>
 							{ __( 'Learn more' ) }
 						</ExternalLink>
@@ -95,7 +96,8 @@ export default class SupportInfo extends Component {
 						<ExternalLink
 							href={ privacyLink }
 							onClick={ this.trackPrivacyInfoClick }
-							target="_blank" rel="noopener noreferrer"
+							target="_blank"
+							rel="noopener noreferrer"
 						>
 							{ __( 'Privacy Information' ) }
 						</ExternalLink>

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -99,7 +99,7 @@ export default class SupportInfo extends Component {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ __( 'Privacy Information' ) }
+							{ __( 'Privacy information' ) }
 						</ExternalLink>
 					</span>
 				</InfoPopover>

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -96,7 +96,7 @@ export default class SupportInfo extends Component {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ __( 'Privacy information' ) }
+							{ __( 'Privacy Information' ) }
 						</ExternalLink>
 					</span>
 				</InfoPopover>

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -112,10 +112,7 @@ class ActiveCard extends Component {
 				<SettingsGroup
 					disableInDevMode={ devMode }
 					module={ { module: m.module } }
-					support={ {
-						text: m.long_description,
-						link: m.learn_more_button,
-					} }
+					support={ { link: m.learn_more_button } }
 				>
 					{ m.description }
 				</SettingsGroup>

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -112,7 +112,10 @@ class ActiveCard extends Component {
 				<SettingsGroup
 					disableInDevMode={ devMode }
 					module={ { module: m.module } }
-					support={ { link: m.learn_more_button } }
+					support={ {
+						text: m.long_description,
+						link: m.learn_more_button,
+					} }
 				>
 					{ m.description }
 				</SettingsGroup>

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -30,8 +30,6 @@ export const Masterbar = moduleSettingsForm(
 						disableInDevMode
 						module={ { module: 'masterbar' } }
 						support={ {
-							text: __( 'Adds a toolbar with links to all your sites, notifications, ' +
-								'your WordPress.com profile, and the Reader.' ),
 							link: 'https://jetpack.com/support/masterbar/',
 						} }
 						>


### PR DESCRIPTION
Allow info bubbles have no text if needed and not to default on module description texts when text is missing.

### Changes

- Previously `support-info` component would default to `module.long_description` when `text` is empty and to `module.learn_more_button` when `link` is empty. Moved these features out since the feature doesn't seem to be used anywhere.

    It's simpler to have clarity for components: no surprise texts when no text isn't defined. If info bubble should show module description, it should explicitly be passed to it.

   I found that [`searchable-modules`](https://github.com/Automattic/jetpack/blob/aa233aa9683cb4f923688a02898939dd7fc3a858/_inc/client/searchable-modules/index.jsx#L115) component is missing `text` but I didn't notice any differences in info-bubble texts when searching for settings. That component is used for settings that don't normally have UI in settings tabs. Check e.g. "Math" module.

- Change `settings-group` component to render `support-info` component even if `text` prop is not set.

- As an example, remove redundant info text from wp.com toolbar setting (in `/wp-admin/admin.php?page=jetpack#/writing`)

#### Testing instructions
- Test Jetpack dash and settings: do info bubbles show up with texts
- Use search feature at settings page and ensure info-bubbles work
- Check that WordPress.com toolbar toggle (under Writing tab in settings) does not have text:
    <img width="221" alt="screen shot 2018-06-08 at 11 10 50" src="https://user-images.githubusercontent.com/87168/41159551-2ceab2cc-6b2d-11e8-9262-d8602ea73e46.png">
