### PR TITLE
Render stats footer on non-canonical AMP pages

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -12,6 +12,11 @@ class Jetpack_AMP_Support {
 			return;
 		}
 
+		// enable stats
+		if ( Jetpack::is_module_active( 'stats' ) ) {
+			add_action( 'amp_post_template_footer', array( 'Jetpack_AMP_Support', 'add_stats_pixel' ) );
+		}
+
 		// carousel
 		add_filter( 'jp_carousel_maybe_disable', '__return_true' );
 
@@ -113,6 +118,18 @@ class Jetpack_AMP_Support {
 
 		remove_filter( 'pre_kses', array( 'Filter_Embedded_HTML_Objects', 'filter' ), 11 );
 		remove_filter( 'pre_kses', array( 'Filter_Embedded_HTML_Objects', 'maybe_create_links' ), 100 );
+	}
+
+	/**
+	 * Add Jetpack stats pixel.
+	 *
+	 * @since 6.2.1
+	 */
+	static function add_stats_pixel() {
+		if ( ! has_action( 'wp_footer', 'stats_footer' ) ) {
+			return;
+		}
+		stats_render_amp_footer( stats_build_view_data() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9716

#### Changes proposed in this Pull Request:

* Render stats pixel for legacy, non-paired, non-canonical AMP pages

#### Testing instructions:

* Enable AMP plugin 0.7 or higher
* Ensure stats module is enabled
* Go to any post with `?amp` suffix
* Search page source for `<amp-pixel>` - there should be a stats pixel rendered in the footer

