### PR TITLE
Performance Settings: Verbiage adjustments

### DIFF
--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -8,8 +8,6 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import decodeEntities from 'lib/decode-entities';
-import { FormFieldset } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -46,7 +44,7 @@ const SpeedUpSite = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Speed up your site' ) }
+					header={ __( 'Performance & speed' ) }
 					hideButton>
 
 					{ foundPhoton &&
@@ -59,6 +57,15 @@ const SpeedUpSite = moduleSettingsForm(
 								link: 'https://jetpack.com/support/photon/',
 							} }
 							>
+							<p>
+								{ __(
+									"Jetpack's global Content Delivery Network (CDN) optimizes " +
+										'images so your visitors enjoy the fastest experience ' +
+										'regardless of device or location. It also helps you ' +
+										'save space on your hosting plan, since images are ' +
+										'stored on our servers.'
+								) }
+							</p>
 							<ModuleToggle
 								slug="photon"
 								disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
@@ -67,14 +74,9 @@ const SpeedUpSite = moduleSettingsForm(
 								toggleModule={ this.toggleModule }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ decodeEntities( photon.description ) }
+									{ __( 'Serve images from our global CDN' ) }
 								</span>
 							</ModuleToggle>
-							<FormFieldset>
-								<span className="jp-form-setting-explanation">
-									{ decodeEntities( photon.long_description ) }
-								</span>
-							</FormFieldset>
 						</SettingsGroup>
 					}
 
@@ -87,6 +89,13 @@ const SpeedUpSite = moduleSettingsForm(
 								link: 'https://jetpack.com/support/lazy-images/',
 							} }
 							>
+							<p>
+								{ __(
+									"Lazy-loading images improve your site's speed and create a " +
+										'smoother viewing experience. Images will load as visitors ' +
+										'scroll down the screen, instead of all at once.'
+								) }
+							</p>
 							<ModuleToggle
 								slug="lazy-images"
 								disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
@@ -95,14 +104,9 @@ const SpeedUpSite = moduleSettingsForm(
 								toggleModule={ this.toggleModule }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ decodeEntities( lazyImages.description ) }
+									{ __( 'Enable Lazy Loading for images' ) }
 								</span>
 							</ModuleToggle>
-							<FormFieldset>
-								<span className="jp-form-setting-explanation">
-									{ decodeEntities( lazyImages.long_description ) }
-								</span>
-							</FormFieldset>
 						</SettingsGroup>
 					}
 				</SettingsCard>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -53,7 +53,6 @@ const SpeedUpSite = moduleSettingsForm(
 							disableInDevMode
 							module={ photon }
 							support={ {
-								text: __( 'Hosts your image files on the global WordPress.com servers.' ),
 								link: 'https://jetpack.com/support/photon/',
 							} }
 							>
@@ -85,7 +84,6 @@ const SpeedUpSite = moduleSettingsForm(
 							hasChild
 							module={ lazyImages }
 							support={ {
-								text: __( "Delays the loading of images until they are visible in the visitor's browser." ),
 								link: 'https://jetpack.com/support/lazy-images/',
 							} }
 							>


### PR DESCRIPTION
Resolves #9709

### Before

<img width="741" alt="screen shot 2018-06-08 at 18 21 04" src="https://user-images.githubusercontent.com/87168/41169267-bc885e78-6b48-11e8-9f47-a9993325954a.png">


### After

<img width="736" alt="screen shot 2018-06-08 at 18 12 07" src="https://user-images.githubusercontent.com/87168/41168877-7f49456e-6b47-11e8-9810-b50643e5a476.png">

### Testing

Test "Performance & speed" section works at `/wp-admin/admin.php?page=jetpack#/settings`