### PR TITLE
Settings: Custom content types verbiage updates

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -65,11 +65,22 @@ export class CustomContentTypes extends React.Component {
 					hasChild
 					module={ module }
 					support={ {
-						text: __( 'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
-							'and display testimonials on your site.' ),
 						link: 'https://jetpack.com/support/custom-content-types/',
 					} }
 					>
+					<p>
+						{ __(
+							'Add {{testimonialLink}}testimonials{{/testimonialLink}} to ' +
+								'your website to attract new customers. If your theme doesn’t ' +
+								'support Jetpack Testimonials, you can still use a simple ' +
+								'shortcode to display them on your site.',
+							{
+								components: {
+									testimonialLink: this.linkIfActiveCPT( 'testimonial' )
+								}
+							}
+						) }
+					</p>
 					<CompactFormToggle
 						checked={ this.state.testimonial }
 						disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) || disabledByOverride }
@@ -84,15 +95,7 @@ export class CustomContentTypes extends React.Component {
 					</CompactFormToggle>
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
-							{
-								__( 'Add, organize, and display {{testimonialLink}}testimonials{{/testimonialLink}}. If your theme doesn’t support testimonials yet, you can display them using the shortcode	( [testimonials] ).',
-									{
-										components: {
-											testimonialLink: this.linkIfActiveCPT( 'testimonial' )
-										}
-									}
-								)
-							}
+							{ __( 'Testimonials shortcode: [testimonials]' ) }
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
@@ -100,10 +103,22 @@ export class CustomContentTypes extends React.Component {
 					hasChild
 					module={ module }
 					support={ {
-						text: __( 'Adds the Portfolio custom post type, allowing you to manage and showcase projects on your site.' ),
 						link: 'https://jetpack.com/support/custom-content-types/',
 					} }
 					>
+					<p>
+						{ __(
+							'Use {{portfolioLink}}portfolios{{/portfolioLink}} on your ' +
+								'site to showcase your best work. If your theme doesn’t support ' +
+								'Jetpack Portfolios, you can still use a simple shortcode to ' +
+								'display them on your site.',
+							{
+								components: {
+									portfolioLink: this.linkIfActiveCPT( 'portfolio' )
+								}
+							}
+						) }
+					</p>
 					<CompactFormToggle
 						checked={ this.state.portfolio }
 						disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) || disabledByOverride }
@@ -119,13 +134,7 @@ export class CustomContentTypes extends React.Component {
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
 							{
-								__( 'Add, organize, and display {{portfolioLink}}portfolios{{/portfolioLink}}. If your theme doesn’t support portfolios yet, you can display them using the shortcode ( [portfolio] ).',
-									{
-										components: {
-											portfolioLink: this.linkIfActiveCPT( 'portfolio' )
-										}
-									}
-								)
+								__( 'Portfolios shortcode: [portfolio]' )
 							}
 						</p>
 					</FormFieldset>


### PR DESCRIPTION
Closes #9710

## Before
<img width="758" alt="screen shot 2018-06-07 at 5 10 27 pm" src="https://user-images.githubusercontent.com/214813/41126494-b7eaf39a-6a75-11e8-8120-ee2c49851845.png">

## After
![image](https://user-images.githubusercontent.com/87168/41228605-9dbc0266-6d81-11e8-9ad1-005fa5925d77.png)

Both info bubbles don't have description now:
![image](https://user-images.githubusercontent.com/87168/41228611-a3f19f56-6d81-11e8-9155-d17383d95e27.png)


## Testing

Go to `/wp-admin/admin.php?page=jetpack#/writing` and see "Custom content types" section.