### PR TITLE
Support info component: use sentence case in links

### DIFF
--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -96,7 +96,7 @@ export default class SupportInfo extends Component {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ __( 'Privacy Information' ) }
+							{ __( 'Privacy information' ) }
 						</ExternalLink>
 					</span>
 				</InfoPopover>


### PR DESCRIPTION
"Privacy info" links to support pages (e.g. https://jetpack.com/support/monitor/#privacy).

Chatted with @benhuberman earlier about this:
> sentence case looks like the way to go.
> on the linked page, Privacy Information is an actual title, and so capitalizing makes sense. otherwise, these are generically used terms here.

This was left out from https://github.com/Automattic/jetpack/pull/9715