### PR TITLE
Classic Stats - widen width a bit to match Calypso stats

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -500,7 +500,7 @@ function stats_reports_css() {
 }
 
 #jp-stats-wrap {
-	max-width: 720px;
+	max-width: 1040px;
 	margin: 0 auto;
 	overflow: hidden;
 }


### PR DESCRIPTION
Fixes #9700 

#### Changes proposed in this Pull Request:

* widen max width

#### Before
![image](https://user-images.githubusercontent.com/1123119/41251969-ec1c505e-6d78-11e8-85b0-cd2aab128bbf.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/41251944-d749d606-6d78-11e8-86f5-076040fd2217.png)
