### PR TITLE
REST-API: Categories: Document `feed_url` in category documentation

### DIFF
--- a/json-endpoints/class.wpcom-json-api-taxonomy-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-taxonomy-endpoint.php
@@ -6,6 +6,7 @@ abstract class WPCOM_JSON_API_Taxonomy_Endpoint extends WPCOM_JSON_API_Endpoint 
 		'slug'        => "(string) The slug of the category.",
 		'description' => '(string) The description of the category.',
 		'post_count'  => "(int) The number of posts using this category.",
+		'feed_url'    => '(string) The URL of the feed for this category.',
 		'parent'	  => "(int) The parent ID for the category.",
 		'meta'        => '(object) Meta data',
 	);


### PR DESCRIPTION
Summary: In rWP176103 we added `feed_url` to the response. This Diff documents that addition to the response.

Test Plan:
* Sandbox `[private link]`
* Apply Diff
* Verify that `feed_url` is documented [here](https://[private link].1/get/sites/%24site/categories/slug:%24category/#apidoc-response)

Differential Revision: D14406-code

This commit syncs r176710-wpcom.