### PR TITLE
Dashboard cards: remove paid labels

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -2,14 +2,6 @@
 	.jp-dash-item__content a {
 		font-style: italic;
 	}
-	.dops-section-header__card-badge .dops-button {
-		background: none;
-		border-bottom-width: 1px;
-
-		&:hover {
-			background: $white;
-		}
-	}
 	.dops-section-header__actions {
 		.form-toggle__label {
 			position: relative;

--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -16,17 +16,11 @@ export default class SectionHeader extends React.Component {
 	static displayName = 'SectionHeader';
 
 	static propTypes = {
-		label: PropTypes.string,
-		cardBadge: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.element,
-			PropTypes.object
-		] )
+		label: PropTypes.string
 	};
 
 	static defaultProps = {
-		label: '',
-		cardBadge: ''
+		label: ''
 	};
 
 	render() {
@@ -35,15 +29,10 @@ export default class SectionHeader extends React.Component {
 			'dops-section-header'
 		);
 
-		const maybeShowCardBadge = this.props.cardBadge !== ''
-			? <span className="dops-section-header__card-badge">{ this.props.cardBadge }</span>
-			: '';
-
 		return (
-			<Card compact className={ classNames( classes, { 'has-card-badge': this.props.cardBadge !== '' } ) }>
+			<Card compact className={ classes }>
 				<div className="dops-section-header__label">
 					<span className="dops-section-header__label-text">{ this.props.label }</span>
-					{ maybeShowCardBadge }
 				</div>
 				<div className="dops-section-header__actions">
 					{ this.props.children }


### PR DESCRIPTION
This PR removes the paid labels from all cards in the Dashboard.

Details as described in #9299 :

> As part of Jetpack dashboard improvement initiative (p6TEKc-1WA-p2), we decided to remove the "PAID" labels from Jetpack dashboard cards. We are going to improve the upgrade badge (now it looks like alert) and removing the PAID label is the first step.

Fixes #9299

### Before

![image](https://user-images.githubusercontent.com/390760/41295649-004ffa1e-6e53-11e8-9e08-8e3846eae7b9.png)

### After

![image](https://user-images.githubusercontent.com/390760/41295683-12d03b22-6e53-11e8-86e4-d18e6fc66b9b.png)