### PR TITLE
Fix saving rss_use_expert as an integer.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -769,6 +769,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					break;
 
+				case 'rss_use_excerpt':
+					update_option( 'rss_use_excerpt', (int)(bool) $value );
+					break;
+
 				default:
 					//allow future versions of this endpoint to support additional settings keys
 					if ( has_filter( 'site_settings_endpoint_update_' . $key ) ) {


### PR DESCRIPTION
Currently, we save the value of `rss_use_excerpt` as a boolean which stores false-values as an empty string.

Bug's result is visible in the wp-admin:

![image](https://user-images.githubusercontent.com/87168/41339161-d95a6f2a-6efc-11e8-8854-c75b856e01ca.png)

WP core expects this option value to be integer (`0` or `1`).

This PR fixes it.

#### Changes proposed in this Pull Request:

* Always save `rss_use_excerpt` as an integer via the settings API.

#### Testing instructions:
- Update your sandbox with this PR. 
- Make sure to set Feed settings from `/wp-admin/options-reading.php` to "full"
- Go to Calypso _Settings > Reading > Feed Settings_ and press "save" without touching anything
- The new setting is reflected as expected on the wp-admin dashboard

Related D14755-code
