### PR TITLE
Sitemap: Format last modified datetime for vid sitemap

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -475,13 +475,13 @@ class Jetpack_Sitemap_Builder {
 		if ( 0 < $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
 				$video['filename'] = jp_sitemap_filename( JP_VIDEO_SITEMAP_TYPE, 1 );
-				$video['last_modified'] = $max[ JP_VIDEO_SITEMAP_TYPE ]['lastmod'];
+				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_TYPE ]['lastmod'] );
 			} else {
 				$video['filename'] = jp_sitemap_filename(
 					JP_VIDEO_SITEMAP_INDEX_TYPE,
 					$max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['number']
 				);
-				$video['last_modified'] = $max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['lastmod'];
+				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['lastmod'] );
 			}
 
 			$buffer->append(


### PR DESCRIPTION
The video sitemap is not filtering the last modified datetime using the `jp_sitemap_datetime`, resulting in an invalid datetime being printed to the xmlsite map.

To test:
1. Have a site with a video that would generate a video sitemap.
2. Review sitemap.xml and see the video last mod time in the format of `2018-06-08 14:51:39`.
3. Apply patch.
4. Review sitemap.xml and see the correct format of `2018-06-08T14:51:39Z`