### PR TITLE
Sync: add wordads options to the whitelist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -130,6 +130,12 @@ class Jetpack_Sync_Defaults {
 		'mailserver_pass', // Not syncing contents, only the option name
 		'mailserver_port',
 		'wp_page_for_privacy_policy',
+		'enable_header_ad',
+		'wordads_second_belowpost',
+		'wordads_display_front_page',
+		'wordads_display_post',
+		'wordads_display_page',
+		'wordads_display_archive',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -189,6 +189,12 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_pass'                      => '',
 			'mailserver_port'                      => 1,
 			'wp_page_for_privacy_policy'           => false,
+			'enable_header_ad'                     => '1',
+			'wordads_second_belowpost'             => '1',
+			'wordads_display_front_page'           => '1',
+			'wordads_display_post'                 => '1',
+			'wordads_display_page'                 => '1',
+			'wordads_display_archive'              => '1',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Adds word-ads related settings to the sync whitelist:

- `enable_header_ad`
- `wordads_second_belowpost`
- `wordads_display_front_page`
- `wordads_display_post`
- `wordads_display_page`
- `wordads_display_archive`

### Testing

- You'll need Jetpack pro plan.
- At wpcom or wp-admin enable word-ads
- At wp-admin adjust word-ads settings and observe options get synced
