### PR TITLE
General: Fix check for wordads-jetpack feature availability for a plan. 

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1556,13 +1556,12 @@ class Jetpack {
 		// Manually mapping WordPress.com features to Jetpack module slugs
 		foreach ( $plan['features']['active'] as $wpcom_feature ) {
 			switch ( $wpcom_feature ) {
-				case 'wordads-jetpack';
-
-				// WordAds are supported for this site
-				if ( 'wordads' === $feature ) {
-					return true;
-				}
-				break;
+				case 'wordads-jetpack':
+					// WordAds are supported for this site
+					if ( 'wordads' === $feature ) {
+						return true;
+					}
+					break;
 			}
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Fixes a typo on a switch statement for the `Jetpack::active_plan_supports()` method.

#### Testing instructions:

_Incoming_

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

General: Fixed the way we check if a wordads is a featured supported by the plan.