### PR TITLE
Tiled Galleries: Sync tiled-gallery-item.php with WordPress.com

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -19,11 +19,10 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		}
 
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
-		// If Photon is active, use it for original
-		if ( in_array( 'photon', Jetpack::get_active_modules() ) ) {
-			$this->orig_file = jetpack_photon_url( $this->orig_file );
-		}		
-		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
+		$this->link = $needs_attachment_link
+			? get_attachment_link( $this->image->ID )
+			// The filter will photonize the URL if and only if Photon is active
+			: apply_filters( 'jetpack_photon_url', $this->orig_file );
 
 		$img_args = array(
 			'w' => $this->image->width,
@@ -33,6 +32,8 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		if ( $this->image->height == $this->image->width ) {
 			$img_args['crop'] = true;
 		}
+		// The function will always photonoize the URL (even if Photon is
+		// not active). We need to photonize the URL to set the width/height.
 		$this->img_src = jetpack_photon_url( $this->orig_file, $img_args );
 	}
 


### PR DESCRIPTION
https://github.com/Automattic/jetpack/pull/9454 implemented a fix to always link to the photonized image in a tiled gallery if Photon is active.

The code works well. This PR just makes it easier to keep Jetpack's code in sync with the code running on WordPress.com.

* Filter the link URL through the `jetpack_photon_url` filter. This filter only photonizes the URL if Photon is active:
  https://github.com/Automattic/jetpack/blob/e89efa8fe67e506071ca9e1ffca61ab587041a4f/jetpack.php#L113-L120
* Document the choice in using the filter in one place and the function in the other.
* Leave `$this->orig_file` alone in case something else depends on it being the unmodified value.

#### Testing instructions:

1. Create a new post.
2. Add a gallery
3. In the gallery options, select "Link To: Media File" and "Type: Tiled Columns".
4. Insert the gallery into the post.
5. Publish the post.
6. View the post: check that the link surrounding each <img> tag.

Both before and after applying the patch, the link should be photonized if Photon is active and not photonized if Photon is not active.

#### Proposed changelog entry for your changes:
Tiled Galleries: Use the `jetpack_photon_url` filter to use Photon if active when a Tiled Gallery links to media file

Related WordPress.com patch: D14857-code