### PR TITLE
Travis: set git clone depth to 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ branches:
     - /^branch-.*$/
     - /^feature\/.*$/
 
+# Git clone depth
+# By default Travis CI clones repositories to a depth of 50 commits
+git:
+  depth: 1
+
 # Clones WordPress and configures our testing environment.
 before_script:
     - phpenv config-rm xdebug.ini


### PR DESCRIPTION
By default Travis CI clones repositories to a depth of 50 commits:
```sh
$ git clone --depth=50 https://github.com/Automattic/jetpack.git Automattic/jetpack
Cloning into 'Automattic/jetpack'...
$ cd Automattic/jetpack
From https://github.com/Automattic/jetpack
 * branch            refs/pull/9772/merge -> FETCH_HEAD
$ git checkout -qf FETCH_HEAD
```

With this setting, Jetpack will be cloned only to depth `1`.

![image](https://user-images.githubusercontent.com/87168/41469877-8f00d006-70b7-11e8-99d2-b9d8f4b29502.png)

Read more: https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth

From Travis docs:

> Note that if you use a depth of 1 and have a queue of jobs, Travis CI won’t build commits that are in the queue when you push a new commit.

I'm not 100% sure what that means. Old builds for old commits in a PR can be dropped safely when pushing new commits but what about `master` branch?