### PR TITLE
SSO: Renamed 'Single Sign On' to 'Secure Sign On' for the rest of the files

### DIFF
--- a/languages/jetpack-af.po
+++ b/languages/jetpack-af.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ary.po
+++ b/languages/jetpack-ary.po
@@ -6621,7 +6621,7 @@ msgid "Require Two-Step Authentication"
 msgstr "يلزم إجراء مصادقة من خطوتين"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "تسجيل الدخول الموحد"
 
 #: modules/shortcodes/wufoo.php:31
@@ -7714,7 +7714,7 @@ msgstr "يتيح لك تسجيل الدخول إلى كل المواقع الت�
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "تسجيل الدخول الموحد"
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-az.po
+++ b/languages/jetpack-az.po
@@ -6557,7 +6557,7 @@ msgid "Require Two-Step Authentication"
 msgstr "İki Mərhələli Təsdiqləmə İstə"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7646,7 +7646,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-bg_BG.po
+++ b/languages/jetpack-bg_BG.po
@@ -8311,7 +8311,7 @@ msgid "Require Two-Step Authentication"
 msgstr "Изискване на двустъпкова автентикация"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Една регистрация"
 
 #: modules/shortcodes/wufoo.php:31
@@ -9291,7 +9291,7 @@ msgstr "Позволява ви да влизате във всичките си
 
 #: modules/module-headings.php:189
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Една регистрация"
 
 #: modules/module-headings.php:179

--- a/languages/jetpack-bs_BA.po
+++ b/languages/jetpack-bs_BA.po
@@ -6559,7 +6559,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7649,7 +7649,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ca.po
+++ b/languages/jetpack-ca.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ckb.po
+++ b/languages/jetpack-ckb.po
@@ -6553,7 +6553,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7642,7 +7642,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-cs_CZ.po
+++ b/languages/jetpack-cs_CZ.po
@@ -6571,7 +6571,7 @@ msgid "Require Two-Step Authentication"
 msgstr "Vyžadovat dvoufázové ověřování"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Jednotné přihlašování"
 
 #: modules/shortcodes/wufoo.php:31
@@ -7663,7 +7663,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Jednotné přihlašování"
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-cy.po
+++ b/languages/jetpack-cy.po
@@ -6575,7 +6575,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7666,7 +7666,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-da_DK.po
+++ b/languages/jetpack-da_DK.po
@@ -6553,7 +6553,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7642,7 +7642,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-gd.po
+++ b/languages/jetpack-gd.po
@@ -6575,7 +6575,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7666,7 +7666,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-gl_ES.po
+++ b/languages/jetpack-gl_ES.po
@@ -8393,7 +8393,7 @@ msgid "Require Two-Step Authentication"
 msgstr "A autenticación en dous pasos é obrigatoria"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Acceso Único"
 
 #: modules/shortcodes/wufoo.php:31
@@ -9377,7 +9377,7 @@ msgstr "Permíteche acceder cun só clic a todos os teus sitios con Jetpack usan
 
 #: modules/module-headings.php:189
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Acceso Único"
 
 #: modules/module-headings.php:179

--- a/languages/jetpack-hu_HU.po
+++ b/languages/jetpack-hu_HU.po
@@ -6567,7 +6567,7 @@ msgid "Require Two-Step Authentication"
 msgstr "Kétlépcsős hitelesítés"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Egyszerűsített bejelentkezés"
 
 #: modules/shortcodes/wufoo.php:31
@@ -7658,7 +7658,7 @@ msgstr "Lehetővé teszi, hogy minden Jetpackot bekapcsolt és csatlakoztatott h
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Egyszeri bejelentkezés"
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-is_IS.po
+++ b/languages/jetpack-is_IS.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Miðlæg innskráning"
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Miðlæg innskráning"
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ka_GE.po
+++ b/languages/jetpack-ka_GE.po
@@ -6527,7 +6527,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7615,7 +7615,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-lt_LT.po
+++ b/languages/jetpack-lt_LT.po
@@ -6559,7 +6559,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7649,7 +7649,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-lv.po
+++ b/languages/jetpack-lv.po
@@ -6559,7 +6559,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7649,7 +7649,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-mk_MK.po
+++ b/languages/jetpack-mk_MK.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ms_MY.po
+++ b/languages/jetpack-ms_MY.po
@@ -6527,7 +6527,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7615,7 +7615,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-my_MM.po
+++ b/languages/jetpack-my_MM.po
@@ -125,7 +125,7 @@ msgstr ""
 
 #: modules/module-headings.php:127
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:132
@@ -288,7 +288,7 @@ msgid "RSS Links"
 msgstr ""
 
 #: modules/sso.php:150 modules/sso.php:984
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-info.php:1009
@@ -3024,7 +3024,7 @@ msgid "We couldn't find any account on <strong>%2$s</strong> that is linked to y
 msgstr ""
 
 #: modules/sso.php:985
-msgid "Connecting with Single Sign On enables you to log in via your WordPress.com account."
+msgid "Connecting with Secure Sign On enables you to log in via your WordPress.com account."
 msgstr ""
 
 #: modules/sso.php:1008
@@ -4306,7 +4306,7 @@ msgid "With the VideoPress module you can easily upload videos to your WordPress
 msgstr ""
 
 #: modules/module-info.php:829
-msgid "With Single Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
+msgid "With Secure Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
 msgstr ""
 
 #: modules/module-info.php:830

--- a/languages/jetpack-nb_NO.po
+++ b/languages/jetpack-nb_NO.po
@@ -6573,7 +6573,7 @@ msgid "Require Two-Step Authentication"
 msgstr "Forlang tofaktor.autensering"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Engangspålogging (SSO)"
 
 #: modules/shortcodes/wufoo.php:31
@@ -7662,7 +7662,7 @@ msgstr "Lar deg logge inn på alle dine Jetpack-drevne nettsteder med ett klikk,
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr "Engangspålogging (SSO)"
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-nn_NO.po
+++ b/languages/jetpack-nn_NO.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-pl_PL.po
+++ b/languages/jetpack-pl_PL.po
@@ -8336,7 +8336,7 @@ msgid "Require Two-Step Authentication"
 msgstr "Wymagaj dwuetapowego uwierzytelniania"
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -9317,7 +9317,7 @@ msgstr ""
 
 #: modules/module-headings.php:189
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:179

--- a/languages/jetpack-pt_PT.po
+++ b/languages/jetpack-pt_PT.po
@@ -6553,7 +6553,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7642,7 +7642,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-sa_IN.po
+++ b/languages/jetpack-sa_IN.po
@@ -125,7 +125,7 @@ msgstr ""
 
 #: modules/module-headings.php:127
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:132
@@ -288,7 +288,7 @@ msgid "RSS Links"
 msgstr ""
 
 #: modules/sso.php:150 modules/sso.php:984
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-info.php:1009
@@ -3018,7 +3018,7 @@ msgid "We couldn't find any account on <strong>%2$s</strong> that is linked to y
 msgstr ""
 
 #: modules/sso.php:985
-msgid "Connecting with Single Sign On enables you to log in via your WordPress.com account."
+msgid "Connecting with Secure Sign On enables you to log in via your WordPress.com account."
 msgstr ""
 
 #: modules/sso.php:1008
@@ -4300,7 +4300,7 @@ msgid "With the VideoPress module you can easily upload videos to your WordPress
 msgstr ""
 
 #: modules/module-info.php:829
-msgid "With Single Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
+msgid "With Secure Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
 msgstr ""
 
 #: modules/module-info.php:830

--- a/languages/jetpack-si_LK.po
+++ b/languages/jetpack-si_LK.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-sl_SI.po
+++ b/languages/jetpack-sl_SI.po
@@ -1394,7 +1394,7 @@ msgstr ""
 
 #: modules/module-headings.php:127
 msgctxt "Module Name"
-msgid "Jetpack Single Sign On"
+msgid "Jetpack Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:132
@@ -1917,7 +1917,7 @@ msgid "You are not supposed to be here!"
 msgstr ""
 
 #: modules/sso.php:140
-msgid "Jetpack Single Sign On"
+msgid "Jetpack Secure Sign On"
 msgstr ""
 
 #: modules/sso.php:211
@@ -1961,7 +1961,7 @@ msgid "We couldn't find any account on <strong>%2$s</strong> that is linked to y
 msgstr ""
 
 #: modules/sso.php:905
-msgid "WordPress.com Single Sign On"
+msgid "WordPress.com Secure Sign On"
 msgstr ""
 
 #: modules/sso.php:906
@@ -3131,7 +3131,7 @@ msgid "With the VideoPress module you can easily upload videos to your WordPress
 msgstr ""
 
 #: modules/module-info.php:822
-msgid "With WordPress.com Single Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
+msgid "With WordPress.com Secure Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It's safe and secure."
 msgstr ""
 
 #: modules/module-info.php:823

--- a/languages/jetpack-sr_RS.po
+++ b/languages/jetpack-sr_RS.po
@@ -6573,7 +6573,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7663,7 +7663,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-te.po
+++ b/languages/jetpack-te.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-th.po
+++ b/languages/jetpack-th.po
@@ -6527,7 +6527,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7615,7 +7615,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-uk.po
+++ b/languages/jetpack-uk.po
@@ -6559,7 +6559,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7649,7 +7649,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-ur.po
+++ b/languages/jetpack-ur.po
@@ -6543,7 +6543,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7632,7 +7632,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack-vi.po
+++ b/languages/jetpack-vi.po
@@ -6527,7 +6527,7 @@ msgid "Require Two-Step Authentication"
 msgstr ""
 
 #: modules/sso.php:207
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/shortcodes/wufoo.php:31
@@ -7615,7 +7615,7 @@ msgstr ""
 
 #: modules/module-headings.php:174
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:164

--- a/languages/jetpack.pot
+++ b/languages/jetpack.pot
@@ -4432,7 +4432,7 @@ msgstr ""
 
 #: modules/module-info.php:829
 msgid ""
-"With Single Sign On, your users will be able to log in to or register for "
+"With Secure Sign On, your users will be able to log in to or register for "
 "your WordPress site with the same credentials they use on WordPress.com.  "
 "It's safe and secure."
 msgstr ""
@@ -5649,7 +5649,7 @@ msgid "You are not supposed to be here!"
 msgstr ""
 
 #: modules/sso.php:150 modules/sso.php:984
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/sso.php:221
@@ -5703,7 +5703,7 @@ msgstr ""
 
 #: modules/sso.php:985
 msgid ""
-"Connecting with Single Sign On enables you to log in via your WordPress.com "
+"Connecting with Secure Sign On enables you to log in via your WordPress.com "
 "account."
 msgstr ""
 
@@ -7878,7 +7878,7 @@ msgstr ""
 
 #: modules/module-headings.php:127
 msgctxt "Module Name"
-msgid "Single Sign On"
+msgid "Secure Sign On"
 msgstr ""
 
 #: modules/module-headings.php:132

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -186,7 +186,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'sso' => array(
-				'name' => _x( 'Single Sign On', 'Module Name', 'jetpack' ),
+				'name' => _x( 'Secure Sign On', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Allow users to log into this site using WordPress.com accounts', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' ),
 			),

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -3,7 +3,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' 
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' );
 
 /**
- * Module Name: Single Sign On
+ * Module Name: Secure Sign On
  * Module Description: Allow users to log into this site using WordPress.com accounts
  * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
@@ -13,7 +13,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' 
  * Auto Activate: No
  * Module Tags: Developers
  * Feature: Security, Jumpstart
- * Additional Search Queries: sso, single sign on, login, log in
+ * Additional Search Queries: sso, Secure Sign On, login, log in
  */
 
 class Jetpack_SSO {
@@ -195,7 +195,7 @@ class Jetpack_SSO {
 	}
 
 	/**
-	 * Adds settings fields to Settings > General > Single Sign On that allows users to
+	 * Adds settings fields to Settings > General > Secure Sign On that allows users to
 	 * turn off the login form on wp-login.php
 	 *
 	 * @since 2.7
@@ -204,13 +204,13 @@ class Jetpack_SSO {
 
 		add_settings_section(
 			'jetpack_sso_settings',
-			__( 'Single Sign On' , 'jetpack' ),
+			__( 'Secure Sign On' , 'jetpack' ),
 			'__return_false',
 			'jetpack-sso'
 		);
 
 		/*
-		 * Settings > General > Single Sign On
+		 * Settings > General > Secure Sign On
 		 * Require two step authentication
 		 */
 		register_setting(
@@ -228,7 +228,7 @@ class Jetpack_SSO {
 		);
 
 		/*
-		 * Settings > General > Single Sign On
+		 * Settings > General > Secure Sign On
 		 */
 		register_setting(
 			'jetpack-sso',

--- a/modules/sso/class.jetpack-sso-notices.php
+++ b/modules/sso/class.jetpack-sso-notices.php
@@ -135,7 +135,7 @@ class Jetpack_SSO_Notices {
 
 	/**
 	 * Message displayed when the site admin has disabled the default WordPress
-	 * login form in Settings > General > Single Sign On
+	 * login form in Settings > General > Secure Sign On
 	 *
 	 * @since 2.7
 	 * @param string $message


### PR DESCRIPTION
Fixes #5957

Renamed 'Single Sign On' to 'Secure Sign On' for the rest of the files due to module name change.