### PR TITLE
Fix Activity Log Customizer Widget Title Edit Activities

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -372,6 +372,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 'customize_changeset' == $post->post_type ) {
 			$post_content = json_decode( $post->post_content, true );
 			foreach ( $post_content as $key => $value ) {
+				//Skip if it isn't a widget
+				if ( 'widget_' != substr( $key, 0, strlen( 'widget_' ) ) ) {
+					continue;
+				}
 				// Change key from "widget_archives[2]" to "archives-2"
 				$key = str_replace( 'widget_', '', $key );
 				$key = str_replace( '[', '-', $key );
@@ -383,7 +387,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 						'name'    => $wp_registered_widgets[ $key ]['name'],
 						'id'      => $key,
 						'title'   => $value['value']['title'],
-						'is_save' => true,
 					);
 					do_action( 'jetpack_widget_edited', $widget_data );
 				}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -365,6 +365,30 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_published_post', $post_ID, $flags );
 		unset( $this->just_published[ $post_ID ] );
+
+		/**
+		 * Send additional sync action for Activity Log when post is a Customizer publish
+		 */
+		if ( 'customize_changeset' == $post->post_type ) {
+			$post_content = json_decode( $post->post_content, true );
+			foreach ( $post_content as $key => $value ) {
+				// Change key from "widget_archives[2]" to "archives-2"
+				$key = str_replace( 'widget_', '', $key );
+				$key = str_replace( '[', '-', $key );
+				$key = str_replace( ']', '', $key );
+
+				global $wp_registered_widgets;
+				if ( isset( $wp_registered_widgets[ $key ] ) ) {
+					$widget_data = array(
+						'name'    => $wp_registered_widgets[ $key ]['name'],
+						'id'      => $key,
+						'title'   => $value['value']['title'],
+						'is_save' => true,
+					);
+					do_action( 'jetpack_widget_edited', $widget_data );
+				}
+			}
+		}
 	}
 
 	public function expand_post_ids( $args ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -38,7 +38,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		// Don't trigger sync action if this is an ajax request, because Customizer makes them during preview before saving changes
-		if ( is_ajax() ) {
+		if ( is_ajax() && isset( $_POST['customized'] ) ) {
 			return $instance;
 		}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -38,7 +38,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		// Don't trigger sync action if this is an ajax request, because Customizer makes them during preview before saving changes
-		if ( is_ajax() && isset( $_POST['customized'] ) ) {
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_POST['customized'] ) ) {
 			return $instance;
 		}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -37,6 +37,11 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return $instance;
 		}
 
+		// Don't trigger sync action if this is an ajax request, because Customizer makes them during preview before saving changes
+		if ( is_ajax() ) {
+			return $instance;
+		}
+
 		$widget = array(
 			'name' => $widget_object->name,
 			'id' => $widget_object->id,

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -805,6 +805,8 @@ POST_CONTENT;
 
 		//Mock registered widgets to get widget Name from
 		global $wp_registered_widgets;
+		$original_registered_widgets = $wp_registered_widgets;
+
 		$wp_registered_widgets = array(
 			'archives-2' => array(
 				'name' => 'Archives',
@@ -827,6 +829,8 @@ POST_CONTENT;
 		$this->assertEquals( 'Search', $events[1]->args[0]['name'] );
 		$this->assertEquals( 'search-2', $events[1]->args[0]['id'] );
 		$this->assertEquals( 'I am a Search widget', $events[1]->args[0]['title'] );
+
+		$wp_registered_widgets = $original_registered_widgets;
 	}
 
 	function test_that_we_apply_the_right_filters_to_post_content_and_excerpt() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -766,6 +766,69 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( "\n", $synced_post->post_content_filtered );
 	}
 
+	function test_customizer_changeset_to_widget_edited() {
+		$post_content = <<<POST_CONTENT
+{
+    "widget_archives[2]": {
+        "value": {
+            "encoded_serialized_instance": "YTozOntzOjU6InRpdGxlIjtzOjg6IkkgbG92ZSBDIjtzOjU6ImNvdW50IjtpOjA7czo4OiJkcm9wZG93biI7aTowO30=",
+            "title": "I am an Archive widget",
+            "is_widget_customizer_js_value": true,
+            "instance_hash_key": "cada21c4bae5635f7943a0c6cf41e5c3"
+        },
+        "type": "option",
+        "user_id": 1,
+        "date_modified_gmt": "2018-06-18 19:42:36"
+    },
+    "widget_search[2]": {
+        "value": {
+            "encoded_serialized_instance": "YToyOntzOjU6InRpdGxlIjtzOjg6IkkgbG92ZSBEIjtzOjEwOiJjb25kaXRpb25zIjthOjM6e3M6NjoiYWN0aW9uIjtzOjQ6ImhpZGUiO3M6OToibWF0Y2hfYWxsIjtzOjE6IjAiO3M6NToicnVsZXMiO2E6MTp7aTowO2E6Mzp7czo1OiJtYWpvciI7czo4OiJsb2dnZWRpbiI7czo1OiJtaW5vciI7czowOiIiO3M6MTI6Imhhc19jaGlsZHJlbiI7YjowO319fX0=",
+            "title": "I am a Search widget",
+            "is_widget_customizer_js_value": true,
+            "instance_hash_key": "20bf20f6d7d4ecae9092f7d3850387f1"
+        },
+		"type": "option",
+        "user_id": 1,
+        "date_modified_gmt": "2018-06-18 19:42:36"
+	}
+}
+POST_CONTENT;
+
+		// create a post
+		$user_id = $this->factory->user->create();
+		$post_id    = $this->factory->post->create( array(
+			'post_author' => $user_id,
+			'post_type' => 'customize_changeset',
+			'post_content' => $post_content
+		) );
+		$post = get_post( $post_id );
+
+		//Mock registered widgets to get widget Name from
+		global $wp_registered_widgets;
+		$wp_registered_widgets = array(
+			'archives-2' => array(
+				'name' => 'Archives',
+			),
+			'search-2' => array(
+				'name' => 'Search',
+			)
+		);
+
+		wp_update_post( $post );
+		$this->sender->do_sync();
+		$events = $this->server_event_storage->get_all_events( 'jetpack_widget_edited' );
+
+		$this->assertEquals( 'jetpack_widget_edited', $events[0]->action );
+		$this->assertEquals( 'Archives', $events[0]->args[0]['name'] );
+		$this->assertEquals( 'archives-2', $events[0]->args[0]['id'] );
+		$this->assertEquals( 'I am an Archive widget', $events[0]->args[0]['title'] );
+
+		$this->assertEquals( 'jetpack_widget_edited', $events[1]->action );
+		$this->assertEquals( 'Search', $events[1]->args[0]['name'] );
+		$this->assertEquals( 'search-2', $events[1]->args[0]['id'] );
+		$this->assertEquals( 'I am a Search widget', $events[1]->args[0]['title'] );
+	}
+
 	function test_that_we_apply_the_right_filters_to_post_content_and_excerpt() {
 		// this only applies to rendered content, which is off by default
 		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );


### PR DESCRIPTION
Customizer makes ajax requests as you change widget titles in order to preview them. They trigger sync actions which can result in many activities for the same title change. What's more, these changes aren't actually saved until you hit Publish in Customizer, which makes the activities invalid.

This change paired with a change on wpcom will ensure that Widget Modified activities are only added to the Activity Log once the changes are published in Customizer.