### PR TITLE
Lazy Images: Add jetpack-lazy-images-load event

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -17,6 +17,9 @@ var jetpackLazyImagesModule = function( $ ) {
 
 		// Lazy load images that are brought in from Infinite Scroll
 		$( 'body' ).bind( 'post-load', lazy_load_init );
+
+		// Add event to provide optional compatibility for other code.
+		$( 'body' ).bind( 'jetpack-lazy-images-load', lazy_load_init );
 	} );
 
 	function lazy_load_init() {


### PR DESCRIPTION
Partially addresses #8854 by adding a listener for the `jetpack-lazy-images-load` event that will initialize (or really just look for any lazy images that haven't been loaded) and load any in the viewport.

This is especially useful for content loaded via AJAX or some other method after document ready.

To test:

- Comment out line 16 of `lazy-images.js` so that we don't do the initial init
- Go to a post with a lazy image
- Ensure the image doesn't load by default
- Run `jQuery( 'body' ).trigger( 'jetpack_lazy_images_load' );` in the console
- Ensure image loads