### PR TITLE
Remove local DNS check

### DIFF
--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -99,16 +99,6 @@ class Jetpack_Data {
 			return true;
 		}
 
-		// Check the IP to make sure it's pingable.
-		$ip = gethostbyname( $domain );
-
-		// Doing this again as I was getting some false positives when gethostbyname() flaked out and returned the domain.
-		$ip = filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ? $ip : gethostbyname( $ip );
-
-		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_IPV4 ) && ! self::php_bug_66229_check( $ip ) ) {
-			return new WP_Error( 'fail_domain_bad_ip_range', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as its IP `%2$s` is either invalid, or in a reserved or private range.', 'jetpack' ), $domain, $ip ) );
-		}
-
 		return true;
 	}
 


### PR DESCRIPTION
This check is redundant and also doesn't work on some hosts due to differences in local address and external address, particularly for newly-created sites.

This was attempted previously in #7319, which includes a pure-PHP DNS client so we could verify DNS externally, but after some criticism @kraftbj said:

> I think removing the check outright (and relying on WordPress.com to verify it can reach the site) is better than trying to make this check do hoops to verify the site is externally accessible.

So this PR just removes the check. We do the same check (more reliably) from WPCOM during registration anyway.

Side note: This fixes connection issues for developers using VVV with ngrok.io (i.e. me) 