### PR TITLE
Widgets: using `const` causes build to fail

### DIFF
--- a/modules/widgets/customizer-utils.js
+++ b/modules/widgets/customizer-utils.js
@@ -67,7 +67,7 @@ wp.isJetpackWidgetPlaced = function( placement, widgetName ) {
 					} else if ( wp.isJetpackWidgetPlaced( placement, 'jetpack_simple_payments_widget' ) ) {
 						// Refresh Simple Payments Widget
 						try {
-							const buttonId = $( '.jetpack-simple-payments-button', placement.container ).attr( 'id' ).replace( '_button', '' );
+							var buttonId = $( '.jetpack-simple-payments-button', placement.container ).attr( 'id' ).replace( '_button', '' );
 							PaypalExpressCheckout.renderButton( null, null, buttonId, null );
 						} catch ( e ) {
 							// PaypalExpressCheckout may fail.


### PR DESCRIPTION
From @dereksmart:

"`gulp js:hint` runs on all of the .js files which aren't compiled, so can't use es6 directly in those"

