### PR TITLE
General: Add gulp jshint to the yarn lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
     "docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
     "docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
-    "lint": "eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
+    "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",


### PR DESCRIPTION
We were missing this...

#### Changes proposed in this Pull Request:

*  Makes the `yarn lint` script run  `gulp jshint` before eslint

#### Testing instructions:

* Run `yarn lint`. Confirm that two types of linting are run on JavaScript. One based on jshint (with rules related to core's style). Another one based on eslint (with rules similar to Calypso's).