### PR TITLE
Fix: update ensure autoloading to use add option

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -191,9 +191,9 @@ class Jetpack_Options {
 
 		if ( false === $value && false !== $default ) {
 			if ( $is_network_option ) {
-				update_site_option( $name, $default );
+				add_site_option( $name, $default );
 			} else {
-				update_option( $name, $default );
+				add_option( $name, $default );
 			}
 			$value = $default;
 		}


### PR DESCRIPTION
Currently, we use the `update_option` when ensuring that an option is set.

With `update_option` we get a sync event:
```js
[ 
  option_name
  old_value // which in the case of non-existing option would always be null
  new_value
] 
```

With `add_option` we would get more truthy sync event (there never was any "old value" after all):
```js
[ 
  option_name
  new_value
] 
```

In the activity log API better able to distinguish how an option gets set, which is important for detecting if we should discard an event or not.

https://github.com/Automattic/jetpack/blob/6c20cae769e9c5741789d5c3841160b70a18f276/class.jetpack-options.php#L175-L202

In `get_option_and_ensure_autoload()` we first check does the option exist in the DB.

If it doesn’t exist _and_ default value is not `false` → store option in the db.

*Before the change:*
by using `update_option` we put the option in the DB cleanly without additional SQL queries. That's great apart from that it syncs those two values (null + “new value”) mentioned earlier.

*Suggested change:*
By using `add_option` we end up doing yet another check if option already exists but at least it syncs correctly (just “new value”). The overhead of additional SQL query will happen just once during the option’s lifecycle.

Because of this additional SQL query, WP core docs suggest using `update_option` instead: https://codex.wordpress.org/add_option#vs._update_option.28.29

...but our case is little different since we already do our own `get_option() === false` check.

#### Changes proposed in this Pull Request:
* Update the way an option get set initially.

#### Testing instructions:
- Create a new jurassic ninja site. 
- Switch to this branch. 

- Do you see any errors? 
- Does data get synced as expected on the .com side?