### PR TITLE
Widgets: Record events for the Simple Payments widget

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -259,63 +259,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		}
 
 		/**
-		 * Return an associative array of default values.
-		 *
-		 * These values are used in new widgets.
-		 *
-		 * @return array Default values for the widget options.
-		 */
-		private function defaults() {
-			return array(
-				'title' => '',
-				'product_post_id' => 0,
-				'form_action' => '',
-				'form_product_id' => 0,
-				'form_product_title' => '',
-				'form_product_description' => '',
-				'form_product_image_id' => 0,
-				'form_product_image_src' => '',
-				'form_product_currency' => '',
-				'form_product_price' => '',
-				'form_product_multiple' => '',
-				'form_product_email' => '',
-			);
-		}
-
-		/**
-		 * Adds a nonce for customizing menus.
-		 *
-		 * @param array $nonces Array of nonces.
-		 * @return array $nonces Modified array of nonces.
-		 */
-		function widget( $args, $instance ) {
-			$instance = wp_parse_args( $instance, $this->defaults() );
-
-			if ( empty( $_POST['params'] ) || ! is_array( $_POST['params'] ) ) {
-				wp_send_json_error( 'missing_params', 400 );
-			}
-
-			$params = wp_unslash( $_POST['params'] );
-			$illegal_params = array_diff( array_keys( $params ), array( 'product_post_id' ) );
-			if ( ! empty( $illegal_params ) ) {
-				wp_send_json_error( 'illegal_params', 400 );
-			}
-
-			$product_id = ( int ) $params['product_post_id'];
-			$product_post = get_post( $product_id );
-
-			$return = array( 'status' => $product_post->post_status );
-
-			wp_delete_post( $product_id, true );
-			$status = get_post_status( $product_id );
-			if ( false === $status ) {
-				$return['status'] = 'deleted';
-			}
-
-			wp_send_json_success( $return );
-		}
-
-		/**
 		 * Front-end display of widget.
 		 *
 		 * @see WP_Widget::widget()

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -352,16 +352,20 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		private function record_event( $stat_name, $event_action, $event_properties = array() ) {
 			$current_user = wp_get_current_user();
 
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// `bumps_stats_extra` only exists on .com
+			if ( function_exists( 'bump_stats_extras' ) ) {
 				require_lib( 'tracks/client' );
 				tracks_record_event( $current_user, 'simple_payments_button_' . $event_action, $event_properties );
-				bump_stats_extras( 'simple_payments', $stat_name );
+				/** This action is documented in modules/widgets/social-media-icons.php */
+				do_action( 'jetpack_bump_stats_extra', 'jetpack-simple_payments', $stat_name );
 				return;
 			}
 
 			jetpack_tracks_record_event( $current_user, 'jetpack_wpa_simple_payments_button_' . $event_action, $event_properties );
-			/** This action is documented in modules/widgets/social-media-icons.php */
-			do_action( 'jetpack_bump_stats_extras', 'simple_payments', $stat_name );
+			$jetpack = Jetpack::init();
+			// $jetpack->stat automatically prepends the stat group with 'jetpack-'
+			$jetpack->stat( 'simple_payments', $stat_name ) ;
+			$jetpack->do_stats( 'server_side' );
 		}
 
 		/**

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -246,6 +246,20 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		}
 
 		/**
+		 * Return an associative array of default values.
+		 *
+		 * These values are used in new widgets.
+		 *
+		 * @return array Default values for the widget options.
+		 */
+		public function defaults() {
+			return array(
+				'title' => '',
+				'product_post_id' => 0,
+			);
+		}
+
+		/**
 		 * Front-end display of widget.
 		 *
 		 * @see WP_Widget::widget()

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -407,15 +407,16 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @param array $event_properties
 		 */
 		private function record_event( $stat_name, $event_action, $event_properties = array() ) {
+			$current_user = wp_get_current_user();
+
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 				require_lib( 'tracks/client' );
-				$current_user = wp_get_current_user();
 				tracks_record_event( $current_user, 'simple_payments_button_' . $event_action, $event_properties );
 				bump_stats_extras( 'simple_payments', $stat_name );
 				return;
 			}
 
-			JetpackTracking::record_user_event( 'wpa_simple_payments_button_' . $event_action, $event_properties );
+			jetpack_tracks_record_event( $current_user, 'jetpack_wpa_simple_payments_button_' . $event_action, $event_properties );
 			/** This action is documented in modules/widgets/social-media-icons.php */
 			do_action( 'jetpack_bump_stats_extras', 'simple_payments', $stat_name );
 		}

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -252,11 +252,54 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 *
 		 * @return array Default values for the widget options.
 		 */
-		public function defaults() {
+		private function defaults() {
 			return array(
 				'title' => '',
 				'product_post_id' => 0,
+				'form_action' => '',
+				'form_product_id' => 0,
+				'form_product_title' => '',
+				'form_product_description' => '',
+				'form_product_image_id' => 0,
+				'form_product_image_src' => '',
+				'form_product_currency' => '',
+				'form_product_price' => '',
+				'form_product_multiple' => '',
+				'form_product_email' => '',
 			);
+		}
+
+		/**
+		 * Adds a nonce for customizing menus.
+		 *
+		 * @param array $nonces Array of nonces.
+		 * @return array $nonces Modified array of nonces.
+		 */
+		function widget( $args, $instance ) {
+			$instance = wp_parse_args( $instance, $this->defaults() );
+
+			if ( empty( $_POST['params'] ) || ! is_array( $_POST['params'] ) ) {
+				wp_send_json_error( 'missing_params', 400 );
+			}
+
+			$params = wp_unslash( $_POST['params'] );
+			$illegal_params = array_diff( array_keys( $params ), array( 'product_post_id' ) );
+			if ( ! empty( $illegal_params ) ) {
+				wp_send_json_error( 'illegal_params', 400 );
+			}
+
+			$product_id = ( int ) $params['product_post_id'];
+			$product_post = get_post( $product_id );
+
+			$return = array( 'status' => $product_post->post_status );
+
+			wp_delete_post( $product_id, true );
+			$status = get_post_status( $product_id );
+			if ( false === $status ) {
+				$return['status'] = 'deleted';
+			}
+
+			wp_send_json_success( $return );
 		}
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25484

Add metrics for the Simple Payments widget.

#### Changes proposed in this Pull Request:

* Add three new Tracks event:
  - `jetpack_wpa_simple_payments_button_create`
  - `jetpack_wpa_simple_payments_button_update`
  - `jetpack_wpa_simple_payments_button_delete`

The extra event properties are the same as in Calypso: id, price, and currency for create and update; only id for delete.

* Add three new MC stats to the `simple_payments` group:
  - `button_created`
  - `button_updated`
  - `button_deleted`

#### Testing instructions:

I'm not sure how to properly test this on WPCOM while it's still a PR to be merged into a feature branch.