### PR TITLE
Customizer: Simple Payments Widget breaks when starting without products

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -266,7 +266,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 						'post_status' => 'publish',
 					 ) );
 	
-					$attrs = array( 'id' => $product_posts[0]->ID );
+					$attrs = array( 'id' => ! empty( $product_posts ) ? $product_posts[0]->ID : null );
 				}
 
 				$jsp = Jetpack_Simple_Payments::getInstance();

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -78,10 +78,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 */
 		private function defaults() {
 			$current_user = wp_get_current_user();
+			$default_product_id = $this->get_first_product_id();
 
 			return array(
 				'title' => '',
-				'product_post_id' => 0,
+				'product_post_id' => $default_product_id,
 				'form_action' => '',
 				'form_product_id' => 0,
 				'form_product_title' => '',
@@ -232,6 +233,18 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 			return $errors;
 		}
+
+		function get_first_product_id() {
+			$product_posts = get_posts( array(
+				'numberposts' => 1,
+				'orderby' => 'date',
+				'post_type' => Jetpack_Simple_Payments::$post_type_product,
+				'post_status' => 'publish',
+			 ) );
+
+			return ! empty( $product_posts ) ? $product_posts[0]->ID : null;
+		}
+
 		/**
 		 * Front-end display of widget.
 		 *
@@ -256,26 +269,14 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			if ( ! empty( $instance['form_action'] ) && in_array( $instance['form_action'], array( 'add', 'edit' ) ) && is_customize_preview() ) {
 				require( dirname( __FILE__ ) . '/simple-payments/widget.php' );
 			} else {
-				if ( ! empty( $instance['product_post_id'] ) ) {
-					$attrs = array( 'id' => $instance['product_post_id'] );
-				} else {
-					$product_posts = get_posts( array(
-						'numberposts' => 1,
-						'orderby' => 'date',
-						'post_type' => Jetpack_Simple_Payments::$post_type_product,
-						'post_status' => 'publish',
-					 ) );
-	
-					$attrs = array( 'id' => ! empty( $product_posts ) ? $product_posts[0]->ID : null );
-				}
-
 				$jsp = Jetpack_Simple_Payments::getInstance();
-				$simple_payments_button = $jsp->parse_shortcode( $attrs );
-				if ( is_null( $simple_payments_button ) && ! is_customize_preview() ) {
-					return;
-				}
+				$simple_payments_button = $jsp->parse_shortcode( array(
+					'id' => $instance['product_post_id'],
+				) );
 
-				echo $simple_payments_button;
+				if ( ! is_null( $simple_payments_button ) || is_customize_preview() ) {
+					echo $simple_payments_button;
+				}
 			}
 
 			echo '</div><!--simple-payments-->';
@@ -339,8 +340,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @return array Updated safe values to be saved.
 		 */
 		function update( $new_instance, $old_instance ) {
-			$new_instance = wp_parse_args( $new_instance, $this->defaults() );
-			$old_instance = wp_parse_args( $old_instance, $this->defaults() );
+			$defaults = $this->defaults();
+			//do not overrite `product_post_id` for `$new_instance` with the defaults
+			$new_instance = wp_parse_args( $new_instance, array_diff_key( $defaults, array( 'product_post_id' => 0 ) ) );
+			$old_instance = wp_parse_args( $old_instance, $defaults );
 
 			$required_widget_props = array(
 				'title' => $this->get_latest_field_value( $new_instance, $old_instance, 'title' ),

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -291,7 +291,7 @@
 				productList.remove( productList.selectedIndex );
 				productList.dispatchEvent( new Event( 'change' ) );
 
-				if ( widgetForm.find( 'select.jetpack-simple-payments-products' ).has( 'option' ).length > 0 ) {
+				if ( widgetForm.find( 'select.jetpack-simple-payments-products' ).has( 'option' ).length === 0 ) {
 					widgetForm.find( '.jetpack-simple-payments-products-fieldset' ).hide();
 					widgetForm.find( '.jetpack-simple-payments-products-warning' ).show();
 				}

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -241,6 +241,10 @@
 					);
 					select.val( data.product_post_id ).change();
 				}
+
+				widgetForm.find( '.jetpack-simple-payments-products-fieldset' ).show();
+				widgetForm.find( '.jetpack-simple-payments-products-warning' ).hide();
+
 				changeFormAction( widgetForm, 'clear' );
 				hideForm( widgetForm );
 			} );
@@ -286,6 +290,12 @@
 				var productList = widgetForm.find( 'select.jetpack-simple-payments-products' )[ 0 ];
 				productList.remove( productList.selectedIndex );
 				productList.dispatchEvent( new Event( 'change' ) );
+
+				if ( widgetForm.find( 'select.jetpack-simple-payments-products' ).has( 'option' ).length > 0 ) {
+					widgetForm.find( '.jetpack-simple-payments-products-fieldset' ).hide();
+					widgetForm.find( '.jetpack-simple-payments-products-warning' ).show();
+				}
+
 				changeFormAction( widgetForm, 'clear' );
 				hideForm( widgetForm );
 			} );

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -7,8 +7,10 @@
 		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
 		value="<?php echo esc_attr( $instance['title'] ); ?>" />
 </p>
-<?php if ( ! empty( $product_posts ) ) { ?>
-<p>
+<p class="jetpack-simple-payments-products-warning" <?php if ( ! empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
+	<?php echo __( 'Looks like you don\'t have any products. You can create one using the Add New button below.' ) ?>
+</p>
+<p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
 	<label for="<?php echo $this->get_field_id('product_post_id'); ?>"><?php _e( 'Select a Simple Payment Button:', 'jetpack' ); ?></label>
 	<select
 		class="widefat jetpack-simple-payments-products"
@@ -21,7 +23,6 @@
 		<?php } ?>
 	</select>
 </p>
-<?php } ?>
 <p>
 	<div class="alignleft">
 		<button class="button jetpack-simple-payments-edit-product"><?php esc_html_e( 'Edit Selected' ); ?></button>

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -17,7 +17,7 @@
 		id="<?php echo $this->get_field_id('product_post_id'); ?>"
 		name="<?php echo $this->get_field_name('product_post_id'); ?>">
 		<?php foreach ( $product_posts as $product_post ) { ?>
-			<option value="<?php echo esc_attr( $product_post->ID ) ?>"<?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
+			<option value="<?php echo esc_attr( $product_post->ID ) ?>" <?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
 				<?php echo esc_attr( get_the_title( $product_post ) ) ?>
 			</option>
 		<?php } ?>


### PR DESCRIPTION
This PR fixes a number of issues with the Simple Payments Widget Customizer when the user has either a single product, or no product at all, including:

- Showing a message when the user has no products.
- Correctly loading the product information on the _Edit_ form when there's a single product.
- Correctly loading the product information on the _Edit_ form after creating the first product.
- Preserving the product drop down list selection after a _Edit_ action when the list has more than one product.
- Fixing some PHP warnings present on some themes.

#### Changes proposed in this Pull Request:

The customizer tool now shows a message when the user has no products loaded.

| Before | After |
| - | - |
| ![screen shot 2018-06-21 at 15 43 31](https://user-images.githubusercontent.com/233601/41739012-27ae362a-756a-11e8-93c6-f1bd1f30ea21.png) | ![screen shot 2018-06-21 at 15 46 45](https://user-images.githubusercontent.com/233601/41739087-6072ad2e-756a-11e8-841d-2a04c90a749b.png) |

It also makes the first product the explicit default on `$instance` when the widget is first added, instead of having the `widget` function make the choice.

It also adds logic to `customizer.js` to manage the visibility of the new message and the product drop down list.

#### Testing instructions:

For all cases, please start with an Professional Jetpack site with no previously created Simple Payment products. If you have some, please delete them on Calypso's Editor before testing this PR.

##### PHP Warnings

Adding a widget when the user has no products fires this PHP warning (as seen on the error log):

```bash
PHP Notice:  Trying to get property of non-object in /var/www/html/wp-content/plugins/jetpack/modules/widgets/simple-payments.php on line 269
PHP Stack trace:
PHP   1. {main}() /var/www/html/index.php:0
PHP   2. require() /var/www/html/index.php:17
PHP   3. require_once() /var/www/html/wp-blog-header.php:19
PHP   4. include() /var/www/html/wp-includes/template-loader.php:74
PHP   5. get_footer() /var/www/html/wp-content/themes/twentyseventeen/index.php:71
PHP   6. locate_template() /var/www/html/wp-includes/general-template.php:76
PHP   7. load_template() /var/www/html/wp-includes/template.php:647
PHP   8. require_once() /var/www/html/wp-includes/template.php:688
PHP   9. get_template_part() /var/www/html/wp-content/themes/twentyseventeen/footer.php:22
PHP  10. locate_template() /var/www/html/wp-includes/general-template.php:155
PHP  11. load_template() /var/www/html/wp-includes/template.php:647
PHP  12. require() /var/www/html/wp-includes/template.php:690
PHP  13. dynamic_sidebar() /var/www/html/wp-content/themes/twentyseventeen/template-parts/footer/footer-widgets.php:23
PHP  14. WP_Widget->display_callback() /var/www/html/wp-includes/widgets.php:742
PHP  15. Jetpack_Simple_Payments_Widget->widget() /var/www/html/wp-includes/class-wp-widget.php:372
```

That may show on some themes:

![screen shot 2018-06-21 at 15 56 34](https://user-images.githubusercontent.com/233601/41739655-1c2f8b1c-756c-11e8-87e8-a76783c3664c.png)

To verify that this is no longer the case, just add a SP Widget to a sidebar/footer on a site with no previous products and verify that the warning is now present on the `error_log` or in the page itself.

##### Edit a Product after adding it

* Add a SP Widget to a sidebar/footer on a site with no previously created products.
  * it should show the new message
* Click _Add New_ and create a new product by filling the form.
* Click _Edit Selected_ without interacting with any other element on the page.

The form should load with the correct information of the recently added product. The Customizer preview should update any changes live, and the changes should be persisted without problems.

Repeat for as many products as you'd like.

##### Edit a Single Product

* Add a SP Widget to a sidebar/footer on a site with only one product
  * the only product should load on the customizer preview correctly.
* Click _Edit Selected_ without interacting with any other element on the page.

The form should load with the correct information of the single product. The Customizer preview should update any changes live, and the changes should be persisted without problems.

##### Delete all Products

* Add a SP Widget to a sidebar/footer on a site with multiple products.
* Click _Edit Selected_ and then _Delete_. Confirm the action.
* Repeat for all products on the drop down list.

When no more products are present, the _empty list_ message should be displayed and the drop down list is no longer visible.

* Add a new product by clicking _Add New_ and filling the form.

The drop down list should be restored, the _empty list_ message hidden and the new product should load correctly on the customizer preview.

* Click _Edit Selected_

The form should load the newly created product, and changes should be correctly saved.

<!-- Add the following only if this is meant to be in changelog -->
#### Known issues:

- The _Edit Selected_ button is not disabled when the user has no products
- The _Delete_ button is not disabled when the user is adding a new product.
