### PR TITLE
Customizer: keep Simple Payments Widget Customizer in sync between instances

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -60,6 +60,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
 
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
+				add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-delete', array( $this, 'ajax_delete_payment_button' ) );
 			}
@@ -119,6 +120,39 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				wp_localize_script( 'jetpack-simple-payments-widget-customizer', 'jpSimplePaymentsStrings', array(
 					'deleteConfirmation' => __( 'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.', 'jetpack' )
 				) );
+		}
+
+		public function ajax_get_payment_buttons() {
+			if ( ! check_ajax_referer( 'customize-jetpack-simple-payments', 'customize-jetpack-simple-payments-nonce', false ) ) {
+				wp_send_json_error( 'bad_nonce', 400 );
+			}
+
+			if ( ! current_user_can( 'customize' ) ) {
+				wp_send_json_error( 'customize_not_allowed', 403 );
+			}
+
+			$post_type_object = get_post_type_object( Jetpack_Simple_Payments::$post_type_product );
+			if ( ! current_user_can( $post_type_object->cap->create_posts ) || ! current_user_can( $post_type_object->cap->publish_posts ) ) {
+				wp_send_json_error( 'insufficient_post_permissions', 403 );
+			}
+
+			$product_posts = get_posts( array(
+				'numberposts' => 100,
+				'orderby' => 'date',
+				'post_type' => Jetpack_Simple_Payments::$post_type_product,
+				'post_status' => 'publish',
+			 ) );
+
+			 $formatted_products = array_map( array( $this, 'format_product_post_for_ajax_reponse' ), $product_posts );
+
+			 wp_send_json_success( $formatted_products );
+		}
+
+		public function format_product_post_for_ajax_reponse( $product_post ) {
+			return array(
+				'ID' => $product_post->ID,
+				'post_title' => $product_post->post_title,
+			);
 		}
 
 		public function ajax_save_payment_button() {

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -18,6 +18,9 @@
 			}
 
 			event.preventDefault();
+
+			syncProductLists();
+
 			var widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' );
 
 			if ( ! widgetForm.find( '.jetpack-simple-payments-form' ).is( ':visible' ) ) {
@@ -68,6 +71,31 @@
 		widgetForm.find( '.jetpack-simple-payments-cancel-form' ).on( 'click', clearForm( widgetForm ) );
 		//Delete Selected Product
 		widgetForm.find( '.jetpack-simple-payments-delete-product' ).on( 'click', deleteProduct( widgetForm ) );
+	}
+
+	function syncProductLists() {
+		var request = wp.ajax.post( 'customize-jetpack-simple-payments-buttons-get', {
+			'customize-jetpack-simple-payments-nonce': api.settings.nonce[ 'customize-jetpack-simple-payments' ],
+			'customize_changeset_uuid': api.settings.changeset.uuid,
+		} );
+
+		request.done( function( data ) {
+			var selectedProduct = 0;
+
+			$( document ).find( 'select.jetpack-simple-payments-products' ).each( function( index, select ) {
+				var $select = $( select );
+				selectedProduct = $select.val();
+
+				$select
+					.find( 'option' )
+					.remove()
+					.end()
+					.append( $.map( data, function( product ) {
+						return $( '<option>', { value: product.ID, text: product.post_title } );
+					} ) )
+					.val( selectedProduct );
+			} );
+		} );
 	}
 
 	function showForm( widgetForm ) {

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -86,14 +86,11 @@
 				var $select = $( select );
 				selectedProduct = $select.val();
 
-				$select
-					.find( 'option' )
-					.remove()
-					.end() //cancels the find operation and returns the original <select /> element.
-					.append( $.map( data, function( product ) {
-						return $( '<option>', { value: product.ID, text: product.post_title } );
-					} ) )
-					.val( selectedProduct );
+				$select.find( 'option' ).remove();
+				$select.append( $.map( data, function( product ) {
+					return $( '<option>', { value: product.ID, text: product.post_title } );
+				} ) );
+				$select.val( selectedProduct );
 			} );
 		} );
 	}

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -76,7 +76,7 @@
 	function syncProductLists() {
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-buttons-get', {
 			'customize-jetpack-simple-payments-nonce': api.settings.nonce[ 'customize-jetpack-simple-payments' ],
-			'customize_changeset_uuid': api.settings.changeset.uuid,
+			'customize_changeset_uuid': api.settings.changeset.uuid
 		} );
 
 		request.done( function( data ) {

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -89,7 +89,7 @@
 				$select
 					.find( 'option' )
 					.remove()
-					.end()
+					.end() //cancels the find operation and returns the original <select /> element.
 					.append( $.map( data, function( product ) {
 						return $( '<option>', { value: product.ID, text: product.post_title } );
 					} ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Keeps all the instances of the Simple Payments Widget Customizer in sync by observing the `widget-synced` and  `widget-updated` events, querying the server for the updated list of products.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/41804978-b74f26b0-7676-11e8-9283-bedc6c981cdb.gif) | ![after](https://user-images.githubusercontent.com/233601/41804983-d6ea75ba-7676-11e8-8f06-cfd6fea3171a.gif) |

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

Starting with a Jetpack Professional site with at least one product loaded (two for dramatic effect):

* Add a Simple Payments Widget to the site sidebar or footer.
* Add a new Product by clicking _Add New_ and filling the form.
* Add a second Simple Payments Widget to the site sidebar or footer.
* Expand the list of products on the second widget.

The list of products should show the newly added product on the correct position.

* Add a new Product by clicking _Add New_ and filling the form on the second widget.
* Expand the first widget.
* Expand the list of products on the first widget.

The list of products should show the newly created product on the second widget on the product list on the correct position.

* On the first widget, edit the currently selected product name.
* Expand the second widget.
* Expand the list of products on the second widget.

The edited product should have the new name.