### PR TITLE
Fix: double-domain in translation function

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -723,7 +723,7 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_background_color_callback() {
-		$this->settings_select( 'carousel_background_color', array( 'black' => __( 'Black', 'jetpack' ), 'white' => __( 'White', 'jetpack', 'jetpack' ) ) );
+		$this->settings_select( 'carousel_background_color', array( 'black' => __( 'Black', 'jetpack' ), 'white' => __( 'White', 'jetpack' ) ) );
 	}
 
 	function carousel_background_color_sanitize( $value ) {


### PR DESCRIPTION
Remove double-domain in: `__( string, 'jetpack', 'jetpack' )`

https://codex.wordpress.org/Function_Reference/_2#Parameters

## Testing

Nothing much to test:

"Background colour" drop-down in `/wp-admin/options-media.php` translates well with or without the change — no warnings in PHP log neither.

![image](https://user-images.githubusercontent.com/87168/41915939-993b9668-795f-11e8-9a3b-0043c9883ed3.png)
