### PR TITLE
Added a check to see if tinymce is defined.

### DIFF
--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -451,7 +451,7 @@ class WPCom_Markdown {
 ?>
 <script type="text/javascript">
 jQuery( function() {
-	tinymce.on( 'AddEditor', function( event ) {
+	( 'undefined' !== typeof tinymce ) && tinymce.on( 'AddEditor', function( event ) {
 		event.editor.on( 'BeforeSetContent', function( event ) {
 			var editor = event.target;
 			Object.keys( editor.schema.elements ).forEach( function( key, index ) {


### PR DESCRIPTION
It looks like recently WordPress has changed the way TinyMCE is loading on various pages. We can no longer rely on tinymce object being present, and we can check to see if it is before registering event handlers. This lets us avoid fatal errors while remaining backwards compatible.

Fixes #9761 

#### Changes proposed in this Pull Request:
* Adds a TinyMCE check to avoid fatal errors.

#### Testing instructions:
* Try to load WordPress admin dashboard with Jetpack Markdown enabled. See the fatal error and not loading Stats Widget.
* Roll this PR on.
* Try step 1, see that the widget loads OK.
* Try creating posts and pages in TinyMCE using markdown, see that it works fine as usual.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed a compatibility problem between WordPress TinyMCE and Jetpack Markdown.