### PR TITLE
Widgets: Add Plan Check to the Simple Payments Widget

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -259,6 +259,20 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		}
 
 		/**
+		 * Return an associative array of default values.
+		 *
+		 * These values are used in new widgets.
+		 *
+		 * @return array Default values for the widget options.
+		 */
+		public function defaults() {
+			return array(
+				'title' => '',
+				'product_post_id' => 0,
+			);
+		}
+
+		/**
 		 * Front-end display of widget.
 		 *
 		 * @see WP_Widget::widget()

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -456,7 +456,8 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 	// Register Jetpack_Simple_Payments_Widget widget.
 	function register_widget_jetpack_simple_payments() {
-		if ( ! Jetpack::is_active() ) {
+		$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
+		if ( ! $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
 			return;
 		}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -259,20 +259,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		}
 
 		/**
-		 * Return an associative array of default values.
-		 *
-		 * These values are used in new widgets.
-		 *
-		 * @return array Default values for the widget options.
-		 */
-		public function defaults() {
-			return array(
-				'title' => '',
-				'product_post_id' => 0,
-			);
-		}
-
-		/**
 		 * Front-end display of widget.
 		 *
 		 * @see WP_Widget::widget()


### PR DESCRIPTION
Depends on:

- ~Simple Payments: adds plan support check for Jetpack and WordPress.com (#9650 and D14005-code)~

Original PR (for the old feature branch) on https://github.com/Automattic/jetpack/pull/9657.

#### Changes proposed in this Pull Request:

* Adds a plan support check to the SP Widget.

#### Testing instructions:

* Apply this branch on a Jetpack site with a Premium or Business Subscriptions.
* Using the Customizer, add a Simple Payment button as a widget to the site's sidebar.
* Navigate to site's frontend.

The Simple Payment button should display as a widget on the selected sidebar and location.

* Downgrade the site to the Free plan without deleting the SP Widget from the sidebar.
* Navigate to the Jetpack dashboard to refresh the site's settings.
* Navigate to site's frontend.

The site's sidebar should no longer show the Simple Payment.