### PR TITLE
Danger: Update message wording & add `danger skip` check

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,12 +3,12 @@
  */
 import { danger, warn } from 'danger';
 
-// Skip danger check if "no ci" or "no danger"
-const commitMessages = danger.git.commits.map( cmt => cmt.message );
-if ( commitMessages.includes( 'no ci' ) ||
-			commitMessages.includes( 'skip ci' ) ||
-			commitMessages.includes( 'no danger' ) ||
-			commitMessages.includes( 'skip danger' ) ) {
+// Skip danger check if "no ci" or "no danger" in latest commit
+const lastCommit = danger.git.commits.slice( -1 )[ 0 ].message;
+if ( lastCommit.includes( 'no ci' ) ||
+lastCommit.includes( 'skip ci' ) ||
+lastCommit.includes( 'no danger' ) ||
+lastCommit.includes( 'skip danger' ) ) {
 	process.exit( 0 ); // eslint-disable-line no-process-exit
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,7 +3,7 @@
  */
 import { danger, warn } from 'danger';
 
-// Skip danger check if "no ci"
+// Skip danger check if "no ci" or "no danger"
 const commitMessages = danger.git.commits.map( cmt => cmt.message );
 if ( commitMessages.includes( 'no ci' ) ||
 			commitMessages.includes( 'skip ci' ) ||

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -5,10 +5,12 @@ import { danger, warn } from 'danger';
 
 // Skip danger check if "no ci" or "no danger" in latest commit
 const lastCommit = danger.git.commits.slice( -1 )[ 0 ].message;
-if ( lastCommit.includes( 'no ci' ) ||
-lastCommit.includes( 'skip ci' ) ||
-lastCommit.includes( 'no danger' ) ||
-lastCommit.includes( 'skip danger' ) ) {
+if (
+	lastCommit.includes( 'no ci' ) ||
+	lastCommit.includes( 'skip ci' ) ||
+	lastCommit.includes( 'no danger' ) ||
+	lastCommit.includes( 'skip danger' )
+) {
 	process.exit( 0 ); // eslint-disable-line no-process-exit
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,6 +3,15 @@
  */
 import { danger, warn } from 'danger';
 
+// Skip danger check if "no ci"
+const commitMessages = danger.git.commits.map( cmt => cmt.message );
+if ( commitMessages.includes( 'no ci' ) ||
+			commitMessages.includes( 'skip ci' ) ||
+			commitMessages.includes( 'no danger' ) ||
+			commitMessages.includes( 'skip danger' ) ) {
+	process.exit( 0 ); // eslint-disable-line no-process-exit
+}
+
 // No PR is too small to include a description of why you made a change
 if ( danger.github.pr.body.length < 10 ) {
 	warn( 'Please include a description of your PR changes.' );
@@ -16,5 +25,5 @@ if ( ! ghLabels.find( l => l.name.toLowerCase().includes( '[status]' ) ) ) {
 
 // Test instructions
 if ( ! danger.github.pr.body.includes( 'Testing instructions' ) ) {
-	warn( 'Test instructions are missing for this PR. Please add some' );
+	warn( '"Testing instructions" are missing for this PR. Please add some' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* update `Test instructions` => `"Testing instructions"`
* Skip Danger checks if `no ci`/`no danger`/`skip ci`/`skip danger` is present in commit message