### PR TITLE
Comments: Tell Comment Form Iframe about Cookie Consent Status

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -270,6 +270,10 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			if ( current_user_can( 'unfiltered_html' ) ) {
 				$params['_wp_unfiltered_html_comment'] = wp_create_nonce( 'unfiltered-html-comment_' . get_the_ID() );
 			}
+		} else {
+			$commenter = wp_get_current_commenter();
+			$params['show_cookie_consent'] = (int) has_action( 'set_comment_cookies', 'wp_set_comment_cookies' );
+			$params['has_cookie_consent'] = (int) ! empty( $commenter['comment_author_email'] );
 		}
 
 		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, Jetpack_Options::get_option( 'blog_token' ) );


### PR DESCRIPTION
If the core's "Save my name, email, and website in this browser for the next time I comment." checkbox is enabled on a WP 4.9.6+ site, tell Jetpack's comment form iframe about the checkbox and its checked state.

With this change:
* When a commenter opts-in (checks the checkbox), we recover the original behavior (and core's current behavior for opt-inners): the commenter sees their newly submitted comment in the comments list flagged as awaiting moderation.
* When a commenter does not opt-in (leaves the checkbox unchecked), we still have the bad UX (and core's current behavior for non-opt-inners): the commenter does not receive any feedback that their comment was successfully submitted.

Fixes #9808 

#### Testing instructions:

This PR can only be tested in combination with WP.com's D15393-code. See testing instructions there.

(It requires these changes to the Jetpack plugin and other changes to WordPress.com's code that handles Jetpack Comments.)

#### Proposed changelog entry for your changes:

Implement Core WordPress' Comment Cookie Consent Checkbox in Jetpack Comments