### PR TITLE
General: SVN ignore dangerfile.js

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -14,6 +14,7 @@
 readme.md
 .github
 phpunit.xml.dist
+dangerfile.js
 docs
 tests
 tools


### PR DESCRIPTION
Adds `dangerfile.js` to `.svnignore`.

#### Changes proposed in this Pull Request:

* Adds a line mentioning `dangerfile.js` to .svnignore. We don't need the file published in the plugin directory.

#### Testing instructions:

None needed