### PR TITLE
Added a filter to allow for custom image dimension logic.

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -383,11 +383,28 @@ class Jetpack_PostImages {
 				'height' => (int) $image_tag->getAttribute( 'height' ),
 			);
 
+			/**
+			 * Filters the switch to ignore minimum image size requirements. Can be used
+			 * to add custom logic to image dimensions, like only enforcing one of the dimensions,
+			 * or disabling it entirely.
+			 *
+			 * @since 6.4.0
+			 *
+			 * @param bool $ignore Should the image dimensions be ignored?
+			 * @param array $meta Array containing image dimensions parsed from the markup.
+			 */
+			$ignore_dimensions = apply_filters( 'jetpack_postimages_ignore_minimum_dimensions', false, $meta );
+
 			// Must be larger than 200x200 (or user-specified).
-			if ( empty( $meta['width'] ) || $meta['width'] < $width ) {
-				continue;
-			}
-			if ( empty( $meta['height'] ) || $meta['height'] < $height ) {
+			if (
+				! $ignore_dimensions
+				&& (
+					empty( $meta['width'] )
+					|| empty( $meta['height'] )
+					|| $meta['width'] < $width
+					|| $meta['height'] < $height
+				)
+			) {
 				continue;
 			}
 


### PR DESCRIPTION
We have recently introduced a minimum 200x200 image size when extracting images from HTML markup. Unfortunately, sometimes the image has one of the dimensions slightly less than the minimum, but otherwise it fits the featured image perfectly. Or some sites do not use dimension properties at all, even though images are perfectly fine size wise. This change lets users customize size properties parsing. Related to 8081-wpcom.

#### Changes proposed in this Pull Request:
* Added a filter to allow for custom image dimension treatment.

#### Testing instructions:
The filter is currently not used anywhere in Jetpack. You can use it manually by adding a custom check and calling `Jetpack_PostImages::from_html` with an arbitrary HTML, like this:

```
add_action( 'plugins_loaded', function() {
	$html = '<img src="https://example.com/example.jpg" />';
	error_log( 'Without filter' );
	error_log( print_r( Jetpack_PostImages::from_html( $html ), true ) );

	add_filter( 'jetpack_postimages_ignore_minimum_dimensions', '__return_true' );

	error_log( 'With filter' );
	error_log( print_r( Jetpack_PostImages::from_html( $html ), true ) );
});
```
You should see an empty array in the first case, and an array with image data in the second case.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added advanced control capabilities to image extraction from posts.