### PR TITLE
Connection Splash Screen: Update agreement text to specify that consent is granted by clicking the Set up Jetpack button

### DIFF
--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By connecting your site you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By setting up Jetpack, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By setting up Jetpack, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);


### PR DESCRIPTION
Updates the agreement text on the new Connection Splash screen to be consistent with the text present in the Jetpack connection screen (Jetpack dashboard) and on the Jetpack banner present in the WordPress Dashboard.

#### Testing instructions

1. Checkout this PR.
3. Deactivate Jetpack and reactivate
4. Expect to be shown the following text: 
    By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com
   
**Before**

![image](https://user-images.githubusercontent.com/746152/42048524-e59fc6ac-7ad9-11e8-8dd6-6837b4fa2eea.png)

**After**

![image](https://user-images.githubusercontent.com/746152/42247109-b875b518-7ef5-11e8-98e0-80ccaa59fc01.png)

#### Other connection prompts for reference

**Jetpack connection card:**

![image](https://user-images.githubusercontent.com/746152/42048346-66127c2c-7ad9-11e8-8dad-160502405a45.png)

**WordPress Dashboard banner for Jetpack**

![image](https://user-images.githubusercontent.com/746152/42048373-73f988a8-7ad9-11e8-9324-418a30a739da.png)

