### PR TITLE
Fix: add text domains where missing

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -274,7 +274,7 @@ class Jetpack_Provision { //phpcs:ignore
 			if ( isset( $body_json->error ) ) {
 				return new WP_Error( $body_json->error, $body_json->message );
 			} else {
-				return new WP_Error( 'server_error', sprintf( __( "Request failed with code %s" ), $response_code ) );
+				return new WP_Error( 'server_error', sprintf( __( 'Request failed with code %s', 'jetpack' ), $response_code ) );
 			}
 		}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1447,11 +1447,9 @@ function jetpack_cli_are_you_sure( $flagged = false, $error_msg = false ) {
 	}
 
 	if ( ! $flagged ) {
-		/* translators: Don't translate the word yes here. */
-		$prompt_message = __( 'Are you sure? This cannot be undone. Type "yes" to continue:', 'jetpack' );
+		$prompt_message = _x( 'Are you sure? This cannot be undone. Type "yes" to continue:', '"yes" is a command - do not translate.', 'jetpack' );
 	} else {
-		/* translators: Don't translate the word yes here. */
-		$prompt_message = __( 'Are you sure? Modifying this option may disrupt your Jetpack connection.  Type "yes" to continue.', 'jetpack' );
+		$prompt_message = _x( 'Are you sure? Modifying this option may disrupt your Jetpack connection.  Type "yes" to continue.', '"yes" is a command - do not translate.', 'jetpack' );
 	}
 
 	WP_CLI::line( $prompt_message );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1447,7 +1447,8 @@ function jetpack_cli_are_you_sure( $flagged = false, $error_msg = false ) {
 	}
 
 	if ( ! $flagged ) {
-		$prompt_message = __( 'Are you sure? This cannot be undone. Type "yes" to continue:', '"yes" is a command.  Do not translate that.', 'jetpack' );
+		/* translators: Don't translate the word yes here. */
+		$prompt_message = __( 'Are you sure? This cannot be undone. Type "yes" to continue:', 'jetpack' );
 	} else {
 		/* translators: Don't translate the word yes here. */
 		$prompt_message = __( 'Are you sure? Modifying this option may disrupt your Jetpack connection.  Type "yes" to continue.', 'jetpack' );

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -193,7 +193,7 @@ class Jetpack_Subscriptions {
 
 		$view_post_link_html = sprintf( ' <a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post ) ),
-			__( 'View post' ) // intentinally omitted domain
+			__( 'View post', 'jetpack' )
 		);
 
 		$messages['post'][6] = sprintf(

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -382,6 +382,6 @@ class Jetpack_Sync_Functions {
 		);
 
 		/* translators: %s is UTC offset, e.g. "+1" */
-		return sprintf( __( 'UTC%s' ), $formatted_gmt_offset );
+		return sprintf( __( 'UTC%s', 'jetpack' ), $formatted_gmt_offset );
 	}
 }


### PR DESCRIPTION
Tested a new version of `yarn add-textdomain` (https://github.com/Automattic/jetpack/pull/9200) and it found out these issues.
