### PR TITLE
Add a Jumpstart description for Lazy Images.

### DIFF
--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -3,6 +3,7 @@
 /**
  * Module Name: Lazy Images
  * Module Description: Lazy load images
+ * Jumpstart Description: Instead of waiting for the entire page to load before displaying it to a visitor, Jetpack shows the page’s non-image content as quickly as possible. Jetpack then requests and downloads images on the page when the user scrolls down, so they’ll appear right as the user gets to that point on the screen.
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0

--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -3,7 +3,7 @@
 /**
  * Module Name: Lazy Images
  * Module Description: Lazy load images
- * Jumpstart Description: Boost your site's performance by only loading images when needed as they're scrolled into view on your site's pages.
+ * Jumpstart Description: Lazy-loading images improve your site's speed and create a smoother viewing experience. Images will load as visitors scroll down the screen, instead of all at once.
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0

--- a/modules/lazy-images.php
+++ b/modules/lazy-images.php
@@ -3,7 +3,7 @@
 /**
  * Module Name: Lazy Images
  * Module Description: Lazy load images
- * Jumpstart Description: Instead of waiting for the entire page to load before displaying it to a visitor, Jetpack shows the page’s non-image content as quickly as possible. Jetpack then requests and downloads images on the page when the user scrolls down, so they’ll appear right as the user gets to that point on the screen.
+ * Jumpstart Description: Boost your site's performance by only loading images when needed as they're scrolled into view on your site's pages.
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0


### PR DESCRIPTION
Before there was no description, which resulted in an empty box showing up in the Jumpstart dialog.

#### Changes proposed in this Pull Request:
* Added Jumpstart description to Lazy Images setting.

#### Testing instructions:
* Get a site with Jumpstart prompt - like a new JN site.
* See that Lazy Images has a description in the dialog:
![image](https://user-images.githubusercontent.com/746152/42246829-7d41ebd4-7ef4-11e8-9065-f278a84c1310.png)




<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added Lazy Images description in the new user greeting dialog.