### PR TITLE
Widgets: shows a warning for Admin users when Simple Payments is not enabled.

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -47,11 +47,6 @@ class Jetpack_Simple_Payments {
 	}
 
 	public function init_hook_action() {
-		if ( ! $this->is_enabled_jetpack_simple_payments() ) {
-			add_shortcode( self::$shortcode, array( $this, 'ignore_shortcode' ) );
-			return;
-		}
-
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
 		$this->register_scripts_and_styles();
@@ -140,6 +135,10 @@ class Jetpack_Simple_Payments {
 			wp_enqueue_style( 'jetpack-simple-payments' );
 		}
 
+		if ( ! $this->is_enabled_jetpack_simple_payments() ) {
+			return $this->output_admin_warning( $data );
+		}
+
 		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
 			wp_enqueue_script( 'paypal-express-checkout' );
 		}
@@ -155,7 +154,28 @@ class Jetpack_Simple_Payments {
 		return $this->output_shortcode( $data );
 	}
 
-	function ignore_shortcode() { return; }
+	function output_admin_warning( $data ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		$css_prefix = self::$css_classname_prefix;
+
+		return "
+<div class='{$data['class']} ${css_prefix}-wrapper'>
+	<div class='${css_prefix}-product'>
+		<div class='${css_prefix}-details'>
+			<div class='${css_prefix}-purchase-message show error' id='{$data['dom_id']}-message-container'>
+				<p>" . sprintf(
+					__( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" target="_blank">these resources</a>.', 'jetpack' ),
+					esc_url( "https://jetpack.com/support/simple-payment-button/" )
+				 ) . "</p>
+				<p>" . esc_html__( '(Only administrators will see this message.)', 'jetpack' ) . "</p>
+			</div>
+		</div>
+	</div>
+</div>
+		";
+	}
 
 	function output_shortcode( $data ) {
 		$items = '';

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -160,15 +160,26 @@ class Jetpack_Simple_Payments {
 		}
 		$css_prefix = self::$css_classname_prefix;
 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$message = __( 'Simple Payments is not supported by your current Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
+			$support_url = 'https://support.wordpress.com/simple-payments/';
+		} else {
+			$message = __( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
+			$support_url = 'https://jetpack.com/support/simple-payment-button/';
+		}
+
+		$warning = sprintf(
+			wp_kses( $message, array( 'a' => array( 'href' => array(), 'target' => array() ) ) ),
+			esc_url( $support_url ),
+			'target="_blank"'
+		);
+
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
 	<div class='${css_prefix}-product'>
 		<div class='${css_prefix}-details'>
 			<div class='${css_prefix}-purchase-message show error' id='{$data['dom_id']}-message-container'>
-				<p>" . sprintf(
-					__( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" target="_blank">these resources</a>.', 'jetpack' ),
-					esc_url( "https://jetpack.com/support/simple-payment-button/" )
-				 ) . "</p>
+				<p>${warning}</p>
 				<p>" . esc_html__( '(Only administrators will see this message.)', 'jetpack' ) . "</p>
 			</div>
 		</div>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -167,7 +167,7 @@ class Jetpack_Simple_Payments {
 		$warning = sprintf(
 			wp_kses(
 				__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-				array( 'a' => array( 'href' => array(), 'target' => array() ) )
+				array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
 			),
 			esc_url( $support_url )
 		);

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -160,18 +160,12 @@ class Jetpack_Simple_Payments {
 		}
 		$css_prefix = self::$css_classname_prefix;
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$message = __( 'Simple Payments is not supported by your current Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
-			$support_url = 'https://support.wordpress.com/simple-payments/';
-		} else {
-			$message = __( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
-			$support_url = 'https://jetpack.com/support/simple-payment-button/';
-		}
-
 		$warning = sprintf(
-			wp_kses( $message, array( 'a' => array( 'href' => array(), 'target' => array() ) ) ),
-			esc_url( $support_url ),
-			'target="_blank"'
+			wp_kses(
+				__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+				array( 'a' => array( 'href' => array(), 'target' => array() ) )
+			),
+			esc_url( $support_url )
 		);
 
 		return "

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -160,6 +160,10 @@ class Jetpack_Simple_Payments {
 		}
 		$css_prefix = self::$css_classname_prefix;
 
+		$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			? 'https://support.wordpress.com/simple-payments/'
+			: 'https://jetpack.com/support/simple-payment-button/';
+
 		$warning = sprintf(
 			wp_kses(
 				__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -56,9 +56,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
+
 			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
 			if ( is_customize_preview() && $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
@@ -113,9 +115,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			wp_enqueue_style( 'jetpack-simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
 		}
 
-		function admin_enqueue_styles_and_scripts(){
-				wp_enqueue_style( 'jetpack-simple-payments-widget-customizer', plugins_url( 'simple-payments/customizer.css', __FILE__ ) );
+		function admin_enqueue_styles() {
+			wp_enqueue_style( 'jetpack-simple-payments-widget-customizer', plugins_url( 'simple-payments/customizer.css', __FILE__ ) );
+		}
 
+		function admin_enqueue_scripts() {
 				wp_enqueue_media();
 				wp_enqueue_script( 'jetpack-simple-payments-widget-customizer', plugins_url( '/simple-payments/customizer.js', __FILE__ ), array( 'jquery' ), false, true );
 				wp_localize_script( 'jetpack-simple-payments-widget-customizer', 'jpSimplePaymentsStrings', array(
@@ -462,21 +466,22 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @param array $instance Previously saved values from database.
 		 */
 		function form( $instance ) {
+			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
+			if ( ! $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
+				require dirname( __FILE__ ) . '/simple-payments/admin-warning.php';
+				return;
+			}
+
 			$instance = wp_parse_args( $instance, $this->defaults() );
 
-			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
-			if ( $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
-				$product_posts = get_posts( array(
-					'numberposts' => 100,
-					'orderby' => 'date',
-					'post_type' => Jetpack_Simple_Payments::$post_type_product,
-					'post_status' => 'publish',
-				) );
+			$product_posts = get_posts( array(
+				'numberposts' => 100,
+				'orderby' => 'date',
+				'post_type' => Jetpack_Simple_Payments::$post_type_product,
+				'post_status' => 'publish',
+			) );
 
-				require( dirname( __FILE__ ) . '/simple-payments/form.php' );
-			} else {
-				require( dirname( __FILE__ ) . '/simple-payments/admin-warning.php' );
-			}
+			require dirname( __FILE__ ) . '/simple-payments/form.php';
 		}
 	}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -56,7 +56,8 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
-			if ( is_customize_preview() ) {
+			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
+			if ( is_customize_preview() && $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
 
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
@@ -463,14 +464,19 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 
-			$product_posts = get_posts( array(
-				'numberposts' => 100,
-				'orderby' => 'date',
-				'post_type' => Jetpack_Simple_Payments::$post_type_product,
-				'post_status' => 'publish',
-			 ) );
+			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
+			if ( $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
+				$product_posts = get_posts( array(
+					'numberposts' => 100,
+					'orderby' => 'date',
+					'post_type' => Jetpack_Simple_Payments::$post_type_product,
+					'post_status' => 'publish',
+				) );
 
-			require( dirname( __FILE__ ) . '/simple-payments/form.php' );
+				require( dirname( __FILE__ ) . '/simple-payments/form.php' );
+			} else {
+				require( dirname( __FILE__ ) . '/simple-payments/admin-warning.php' );
+			}
 		}
 	}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -56,7 +56,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
+			global $pagenow;
+			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
+			}
 
 			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
 			if ( is_customize_preview() && $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -1,0 +1,6 @@
+<div class='error'>
+	<p><?php echo sprintf(
+		__( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" target="_blank">these resources</a>.', 'jetpack' ),
+		esc_url( "https://jetpack.com/support/simple-payment-button/" )
+	); ?></p>
+</div>

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -1,6 +1,20 @@
-<div class='error'>
-	<p><?php echo sprintf(
-		__( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" target="_blank">these resources</a>.', 'jetpack' ),
-		esc_url( "https://jetpack.com/support/simple-payment-button/" )
-	); ?></p>
+<?php
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	$message     = __( 'Simple Payments is not supported by your current Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
+	$support_url = 'https://support.wordpress.com/simple-payments/';
+} else {
+	$message     = __( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
+	$support_url = 'https://jetpack.com/support/simple-payment-button/';
+}
+?>
+<div class='jetpack-simple-payments error'>
+	<p>
+	<?php
+	printf(
+		wp_kses( $message, array( 'a' => array( 'href' => array(), 'target' => array() ) ) ),
+		esc_url( $support_url ),
+		'target="_blank"'
+	);
+	?>
+	</p>
 </div>

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -1,13 +1,16 @@
 <div class='jetpack-simple-payments-disabled-error'>
 	<p>
-	<?php
-	printf(
-		wp_kses(
-			__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-			array( 'a' => array( 'href' => array(), 'target' => array() ) )
-		),
-		esc_url( $support_url )
-	);
-	?>
+		<?php
+			$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+				? 'https://support.wordpress.com/simple-payments/'
+				: 'https://jetpack.com/support/simple-payment-button/';
+			printf(
+				wp_kses(
+					__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+					array( 'a' => array( 'href' => array(), 'target' => array() ) )
+				),
+				esc_url( $support_url )
+			);
+		?>
 	</p>
 </div>

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -1,19 +1,12 @@
-<?php
-if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-	$message     = __( 'Simple Payments is not supported by your current Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
-	$support_url = 'https://support.wordpress.com/simple-payments/';
-} else {
-	$message     = __( 'Simple Payments is not supported by your Jetpack Plan. To learn more, and to upgrade to a supported plan, visit <a href="%s" %s>these resources</a>.', 'jetpack' );
-	$support_url = 'https://jetpack.com/support/simple-payment-button/';
-}
-?>
 <div class='jetpack-simple-payments-disabled-error'>
 	<p>
 	<?php
 	printf(
-		wp_kses( $message, array( 'a' => array( 'href' => array(), 'target' => array() ) ) ),
-		esc_url( $support_url ),
-		'target="_blank"'
+		wp_kses(
+			__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+			array( 'a' => array( 'href' => array(), 'target' => array() ) )
+		),
+		esc_url( $support_url )
 	);
 	?>
 	</p>

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -7,7 +7,7 @@
 			printf(
 				wp_kses(
 					__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-					array( 'a' => array( 'href' => array(), 'target' => array() ) )
+					array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
 				),
 				esc_url( $support_url )
 			);

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -7,7 +7,7 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	$support_url = 'https://jetpack.com/support/simple-payment-button/';
 }
 ?>
-<div class='jetpack-simple-payments error'>
+<div class='jetpack-simple-payments-disabled-error'>
 	<p>
 	<?php
 	printf(

--- a/modules/widgets/simple-payments/customizer.css
+++ b/modules/widgets/simple-payments/customizer.css
@@ -3,6 +3,10 @@
 	clear: both;
 }
 
+.widget-content .jetpack-simple-payments.error p {
+	color: initial;
+}
+
 .widget-content .jetpack-simple-payments-form .invalid {
 	border: 1px solid #dc3232;
 }

--- a/modules/widgets/simple-payments/customizer.css
+++ b/modules/widgets/simple-payments/customizer.css
@@ -3,8 +3,12 @@
 	clear: both;
 }
 
-.widget-content .jetpack-simple-payments.error p {
-	color: initial;
+.widget-content .jetpack-simple-payments-disabled-error {
+	background: #fff;
+	border-left: 4px solid #dc3232;
+	box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+	margin: 5px 0 15px;
+	padding: 1px 12px;
 }
 
 .widget-content .jetpack-simple-payments-form .invalid {


### PR DESCRIPTION
Fixes #9777

#### Changes proposed in this Pull Request:

Adds a warning for admin users when there are Simple Payments products published on pages/posts or as a Widget and Simple Payments is disabled.

| Admins | Non-Admins |
| - | - |
| ![screen shot 2018-07-01 at 11 56 26](https://user-images.githubusercontent.com/233601/42135832-28e73cfc-7d27-11e8-8dad-8c5b188097c7.png) | ![screen shot 2018-07-01 at 11 57 05](https://user-images.githubusercontent.com/233601/42135834-2ed5cf52-7d27-11e8-963d-3bfa396a8344.png) |

The same warning appears on the Customizer when the user wants to add or edit a Simple Payments Widget. The user is not allowed to edit or add new products, but the Widget itself can be removed.

![screen shot 2018-07-01 at 11 58 01](https://user-images.githubusercontent.com/233601/42135841-4f2951a2-7d27-11e8-9fa0-743c647cbb7e.png)

If for some reason the user bypasses this restrictions to show the product, it will still fail due to WordPress.com backend checks.

![screen shot 2018-07-01 at 12 15 09](https://user-images.githubusercontent.com/233601/42135914-a7c448b6-7d28-11e8-887b-9bef9630c845.png)

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Get a Professional Subscription on a Jetpack site.
* Add a Simple Payment Product to a Page/Post and as a Widget, and publish the changes.
* Navigate to the page/post: the site should show the product and the widget for both admin, non-admins and logged out users.
* Cancel the Professional Subscription
* Navigate to the page/post: the site should show the warning for admin users, and for non-admin and anonymous users it shouldn't show a warning nor the product.

Also, some scripts should not load when the warning is shown.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Adds a Admin only warning when Simple Payments is disabled, but there are products published.