### PR TITLE
Revert: Travis not run on docs (#9677 & #9844)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,6 @@ branches:
     - master-stable
     - /^branch-.*$/
     - /^feature\/.*$/
-before_install:
-    - |
-        IGNORE_FORMAT_REGEX='(\.md$|\.txt$|\.yml$|\..*ignore$)|(^(docs|docker))\/'
-        if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-          TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-        fi
-        git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE $IGNORE_FORMAT_REGEX || {
-          echo "Only non-testable files were updated, bailing from running unit tests."
-          travis_terminate 0
-        }
 
 # Git clone depth
 # By default Travis CI clones repositories to a depth of 50 commits


### PR DESCRIPTION
Reverting failed attempt on skipping Travis builds to not to be triggered by changes in doc files 

#### Changes proposed in this Pull Request:

* Revert #9677 
* Revert #9844

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Make sure Travis doesn't have a `before_install` hook anymore

