### PR TITLE
Protect: fix layout of "Prove your humanity" label

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -123,9 +123,21 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$ans  = sha1( $salt . $sum );
 			?>
 			<div style="margin: 5px 0 20px;">
-				<strong><?php esc_html_e( 'Prove your humanity:', 'jetpack' ); ?> </strong>
-				<?php echo $num1 ?> &nbsp; + &nbsp; <?php echo $num2 ?> &nbsp; = &nbsp;
-				<input type="input" name="jetpack_protect_num" value="" size="2" />
+				<label for="jetpack_protect_answer">
+					<?php esc_html_e( 'Prove your humanity', 'jetpack' ); ?>
+				</label>
+				<br/>
+				<span style="vertical-align:super;">
+					<?php echo "$num1 &nbsp; + &nbsp; $num2 &nbsp; = &nbsp;"; ?>
+				</span>
+				<input
+					type="text"
+					id="jetpack_protect_answer"
+					name="jetpack_protect_num"
+					value=""
+					size="2"
+					style="width:30px;height:25px;vertical-align:middle;font-size:13px;"
+					class="input" />
 				<input type="hidden" name="jetpack_protect_answer" value="<?php echo $ans; ?>" />
 			</div>
 		<?php


### PR DESCRIPTION
This PR seeks to solve a layout issue that was originally found in japanese. Note how the translation of the string "Prove your humanity" is long and causes the math question to be splitted in two lines.

<img width="342" alt="captura de pantalla 2018-07-02 a la s 23 05 16" src="https://user-images.githubusercontent.com/1041600/42198227-197c667a-7e5d-11e8-8df5-871dd89d497e.png">

After a discussion with @naokomc where she stated that this could cause issues in other languages and pointed to 

<img width="549" alt="captura de pantalla 2018-07-03 a la s 01 04 01" src="https://user-images.githubusercontent.com/1041600/42198210-07158d86-7e5d-11e8-9fdd-462354ab2f26.png">

https://translate.wordpress.org/projects/wp-plugins/jetpack/dev/nl/default?filters%5Bterm%5D=Prove+your+humanity%3A&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc

<img width="555" alt="captura de pantalla 2018-07-03 a la s 01 04 09" src="https://user-images.githubusercontent.com/1041600/42198211-0746d206-7e5d-11e8-8bb1-7342b92a2678.png">

https://translate.wordpress.org/projects/wp-plugins/jetpack/dev/ru/default?filters%5Bterm%5D=Prove+your+humanity%3A&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc

it became clear that this was an issue that needed to be solved by adapting the layout.

In addition, the text is now a label pointing to the field, and the style follows the WP core style of other fields in the page.

The math fallback now looks like

<img width="335" alt="captura de pantalla 2018-07-03 a la s 00 58 41" src="https://user-images.githubusercontent.com/1041600/42198507-b131572c-7e5e-11e8-936a-4fcd478d8e9c.png">


#### Changes proposed in this Pull Request:

* changes field type from `input` to `text`
* adds the `input` CSS class, which is from WP core
* wraps the text in a label pointing to the answer field
* adds a line break after the label, so the math question is now on a new line

#### Testing instructions:

Enable Protect and in WP login, ensure the layout is correct and everything works.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Protect: fix layout of legend that prompts the user to solve the math fallback so it works better in all languages.