### PR TITLE
Widgets: Fix the Simple Payments widget in the widgets.php page

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -56,19 +56,16 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				)
 			);
 
+			global $pagenow;
 			if ( is_customize_preview() ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
-
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
-				add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
-				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
-				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-delete', array( $this, 'ajax_delete_payment_button' ) );
-			} else {
-				global $pagenow;
-				if ( 'widgets.php' === $pagenow ) {
-					add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_scripts' ) );
-				}
+			} else if ( 'widgets.php' === $pagenow ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_scripts' ) );
 			}
+			add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
+			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
+			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-delete', array( $this, 'ajax_delete_payment_button' ) );
 
 			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
@@ -134,18 +131,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				array( 'jquery' ), false, true
 			);
 
-			$product_posts = get_posts( array(
-				'numberposts' => 100,
-				'orderby' => 'date',
-				'post_type' => Jetpack_Simple_Payments::$post_type_product,
-				'post_status' => 'publish',
-			) );
-
 			wp_localize_script(
 				'jetpack-simple-payments-widget-widgets-page',
 				'jetpackSimplePaymentsWidget',
 				array(
-					'products' => $product_posts,
+					'nonce'   => wp_create_nonce( 'customize-jetpack-simple-payments' ),
 					'strings' => array(
 						'deleteConfirmation' => __(
 							'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.',

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -133,14 +133,25 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				plugins_url( '/simple-payments/widgets-page.js', __FILE__ ),
 				array( 'jquery' ), false, true
 			);
+
+			$product_posts = get_posts( array(
+				'numberposts' => 100,
+				'orderby' => 'date',
+				'post_type' => Jetpack_Simple_Payments::$post_type_product,
+				'post_status' => 'publish',
+			) );
+
 			wp_localize_script(
 				'jetpack-simple-payments-widget-widgets-page',
-				'jpSimplePaymentsStrings',
+				'jetpackSimplePaymentsWidget',
 				array(
-					'deleteConfirmation' => __(
-						'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.',
-						'jetpack'
-					)
+					'products' => $product_posts,
+					'strings' => array(
+						'deleteConfirmation' => __(
+							'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.',
+							'jetpack'
+						),
+					),
 				)
 			);
 		}
@@ -486,14 +497,14 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 
-			if ( is_customize_preview() ) {
-				$product_posts = get_posts( array(
-					'numberposts' => 100,
-					'orderby' => 'date',
-					'post_type' => Jetpack_Simple_Payments::$post_type_product,
-					'post_status' => 'publish',
-				 ) );
+			$product_posts = get_posts( array(
+				'numberposts' => 100,
+				'orderby' => 'date',
+				'post_type' => Jetpack_Simple_Payments::$post_type_product,
+				'post_status' => 'publish',
+			) );
 
+			if ( is_customize_preview() ) {
 				require( dirname( __FILE__ ) . '/simple-payments/form.php' );
 			} else {
 				require( dirname( __FILE__ ) . '/simple-payments/form-widgets-page.php' );

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -63,6 +63,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
 				add_action( 'wp_ajax_customize-jetpack-simple-payments-button-delete', array( $this, 'ajax_delete_payment_button' ) );
+			} else {
+				global $pagenow;
+				if ( 'widgets.php' === $pagenow ) {
+					add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_scripts' ) );
+				}
 			}
 
 			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
@@ -120,6 +125,24 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				wp_localize_script( 'jetpack-simple-payments-widget-customizer', 'jpSimplePaymentsStrings', array(
 					'deleteConfirmation' => __( 'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.', 'jetpack' )
 				) );
+		}
+
+		function widgets_page_enqueue_scripts() {
+			wp_enqueue_script(
+				'jetpack-simple-payments-widget-widgets-page',
+				plugins_url( '/simple-payments/widgets-page.js', __FILE__ ),
+				array( 'jquery' ), false, true
+			);
+			wp_localize_script(
+				'jetpack-simple-payments-widget-widgets-page',
+				'jpSimplePaymentsStrings',
+				array(
+					'deleteConfirmation' => __(
+						'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.',
+						'jetpack'
+					)
+				)
+			);
 		}
 
 		public function ajax_get_payment_buttons() {
@@ -463,14 +486,18 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 
-			$product_posts = get_posts( array(
-				'numberposts' => 100,
-				'orderby' => 'date',
-				'post_type' => Jetpack_Simple_Payments::$post_type_product,
-				'post_status' => 'publish',
-			 ) );
+			if ( is_customize_preview() ) {
+				$product_posts = get_posts( array(
+					'numberposts' => 100,
+					'orderby' => 'date',
+					'post_type' => Jetpack_Simple_Payments::$post_type_product,
+					'post_status' => 'publish',
+				 ) );
 
-			require( dirname( __FILE__ ) . '/simple-payments/form.php' );
+				require( dirname( __FILE__ ) . '/simple-payments/form.php' );
+			} else {
+				require( dirname( __FILE__ ) . '/simple-payments/form-widgets-page.php' );
+			}
 		}
 	}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -57,13 +57,13 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			);
 
 			global $pagenow;
-			if ( is_customize_preview() ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
+			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+/*				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
-			} else if ( 'widgets.php' === $pagenow ) {
+			} else if ( 'widgets.php' === $pagenow ) {*/
 				add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_styles_and_scripts' ) );
 			}
-			add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
+			//add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
 			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-get', array( $this, 'ajax_get_payment_button' ) );
 			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
 			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-delete', array( $this, 'ajax_delete_payment_button' ) );
@@ -100,29 +100,8 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			);
 		}
 
-		/**
-		 * Adds a nonce for customizing menus.
-		 *
-		 * @param array $nonces Array of nonces.
-		 * @return array $nonces Modified array of nonces.
-		 */
-		function filter_nonces( $nonces ) {
-			$nonces['customize-jetpack-simple-payments'] = wp_create_nonce( 'customize-jetpack-simple-payments' );
-			return $nonces;
-		}
-
 		function enqueue_style() {
 			wp_enqueue_style( 'jetpack-simple-payments-widget-style', plugins_url( 'simple-payments/style.css', __FILE__ ), array(), '20180518' );
-		}
-
-		function admin_enqueue_styles_and_scripts(){
-				wp_enqueue_style( 'jetpack-simple-payments-widget-customizer', plugins_url( 'simple-payments/customizer.css', __FILE__ ) );
-
-				wp_enqueue_media();
-				wp_enqueue_script( 'jetpack-simple-payments-widget-customizer', plugins_url( '/simple-payments/customizer.js', __FILE__ ), array( 'jquery' ), false, true );
-				wp_localize_script( 'jetpack-simple-payments-widget-customizer', 'jpSimplePaymentsStrings', array(
-					'deleteConfirmation' => __( 'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.', 'jetpack' )
-				) );
 		}
 
 		function widgets_page_enqueue_styles_and_scripts() {
@@ -147,39 +126,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 						),
 					),
 				)
-			);
-		}
-
-		public function ajax_get_payment_buttons() {
-			if ( ! check_ajax_referer( 'customize-jetpack-simple-payments', 'customize-jetpack-simple-payments-nonce', false ) ) {
-				wp_send_json_error( 'bad_nonce', 400 );
-			}
-
-			if ( ! current_user_can( 'customize' ) ) {
-				wp_send_json_error( 'customize_not_allowed', 403 );
-			}
-
-			$post_type_object = get_post_type_object( Jetpack_Simple_Payments::$post_type_product );
-			if ( ! current_user_can( $post_type_object->cap->create_posts ) || ! current_user_can( $post_type_object->cap->publish_posts ) ) {
-				wp_send_json_error( 'insufficient_post_permissions', 403 );
-			}
-
-			$product_posts = get_posts( array(
-				'numberposts' => 100,
-				'orderby' => 'date',
-				'post_type' => Jetpack_Simple_Payments::$post_type_product,
-				'post_status' => 'publish',
-			 ) );
-
-			 $formatted_products = array_map( array( $this, 'format_product_post_for_ajax_reponse' ), $product_posts );
-
-			 wp_send_json_success( $formatted_products );
-		}
-
-		public function format_product_post_for_ajax_reponse( $product_post ) {
-			return array(
-				'ID' => $product_post->ID,
-				'post_title' => $product_post->post_title,
 			);
 		}
 
@@ -537,12 +483,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				'post_type' => Jetpack_Simple_Payments::$post_type_product,
 				'post_status' => 'publish',
 			) );
-
-			if ( is_customize_preview() ) {
-				require( dirname( __FILE__ ) . '/simple-payments/form.php' );
-			} else {
-				require( dirname( __FILE__ ) . '/simple-payments/form-widgets-page.php' );
-			}
+			require( dirname( __FILE__ ) . '/simple-payments/form-widgets-page.php' );
 		}
 	}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles_and_scripts' ) );
 				add_filter( 'customize_refresh_nonces', array( $this, 'filter_nonces' ) );
 			} else if ( 'widgets.php' === $pagenow ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_scripts' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'widgets_page_enqueue_styles_and_scripts' ) );
 			}
 			add_action( 'wp_ajax_customize-jetpack-simple-payments-buttons-get', array( $this, 'ajax_get_payment_buttons' ) );
 			add_action( 'wp_ajax_customize-jetpack-simple-payments-button-save', array( $this, 'ajax_save_payment_button' ) );
@@ -124,13 +124,16 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				) );
 		}
 
-		function widgets_page_enqueue_scripts() {
+		function widgets_page_enqueue_styles_and_scripts() {
+			wp_enqueue_style(
+				'jetpack-simple-payments-widget-customizer',
+				plugins_url( 'simple-payments/customizer.css', __FILE__ )
+			);
 			wp_enqueue_script(
 				'jetpack-simple-payments-widget-widgets-page',
 				plugins_url( '/simple-payments/widgets-page.js', __FILE__ ),
 				array( 'jquery' ), false, true
 			);
-
 			wp_localize_script(
 				'jetpack-simple-payments-widget-widgets-page',
 				'jetpackSimplePaymentsWidget',

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -211,6 +211,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			}
 
 			wp_send_json_success( array(
+				'id'          => $product_post_id,
 				'title'       => get_the_title( $product ),
 				'description' => $product->post_content,
 				'image_id'    => get_post_thumbnail_id( $product->ID ),

--- a/modules/widgets/simple-payments/form-widgets-page.php
+++ b/modules/widgets/simple-payments/form-widgets-page.php
@@ -62,6 +62,14 @@
 	<hr />
 
 	<div  class="jetpack-simple-payments-form" style="display: none;">
+		<input
+			class="jetpack-simple-payments-form-product-id"
+			id="<?php echo $this->get_field_id('form_product_id'); ?>"
+			name="<?php echo $this->get_field_name('form_product_id'); ?>"
+			type="hidden"
+			value="<?php echo esc_attr( $instance['form_product_id'] ); ?>"
+		/>
+
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>">
 				<?php esc_html_e( 'What is this payment for?', 'jetpack' ); ?>

--- a/modules/widgets/simple-payments/form-widgets-page.php
+++ b/modules/widgets/simple-payments/form-widgets-page.php
@@ -112,7 +112,7 @@
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>">
-				<?php esc_html_e( 'Description:', jetpack ); ?>
+				<?php esc_html_e( 'Description:', 'jetpack' ); ?>
 			</label>
 			<textarea
 				class="widefat jetpack-simple-payments-form-product-description"
@@ -177,7 +177,7 @@
 			/>
 			<small>
 				<?php printf( esc_html__(
-					"This is where PayPal will send your money. To claim a payment, you'll need a %1$sPayPal account%2$s connected to a bank account." ),
+					'This is where PayPal will send your money. To claim a payment, you\'ll need a %1$sPayPal account%2$s connected to a bank account.' ),
 					'<a href="https://paypal.com" target="_blank">',
 					'</a>'
 				) ?>

--- a/modules/widgets/simple-payments/form-widgets-page.php
+++ b/modules/widgets/simple-payments/form-widgets-page.php
@@ -29,7 +29,7 @@
 					value="<?php echo esc_attr( $product_post->ID ) ?>"
 					<?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>
 				>
-					<?php echo esc_attr( get_the_title( $product_post ) ) ?>
+					<?php echo esc_attr( get_the_title( $product_post ) ); ?>
 				</option>
 			<?php } ?>
 		</select>
@@ -61,13 +61,13 @@
 
 	<hr />
 
-	<div class="jetpack-simple-payments-widget-form" style="display: none;">
+	<div  class="jetpack-simple-payments-form" style="display: none;">
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>">
 				<?php esc_html_e( 'What is this payment for?', 'jetpack' ); ?>
 			</label>
 			<input
-				class="widefat jetpack-simple-payments-widget-form-product-title"
+				class="widefat jetpack-simple-payments-form-product-title"
 				id="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"
 				name="<?php echo esc_attr( $this->get_field_name( 'form_product_title' ) ); ?>"
 				type="text"
@@ -75,6 +75,104 @@
 			/>
 			<small>
 				<?php esc_html_e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.', 'jetpack' ); ?>
+			</small>
+		</p>
+
+		<div class="jetpack-simple-payments-image-fieldset">
+			<label>
+				<?php esc_html_e( 'Product image:' ); ?>
+			</label>
+			<div
+				class="jetpack-simple-payments-select-image placeholder"
+				<?php if ( ! empty( $instance['form_product_image_id'] ) ) echo 'style="display: none;"'; ?>
+			>
+				<?php esc_html_e( 'Select an image' ); ?>
+			</div>
+			<div
+				class="jetpack-simple-payments-image"
+				<?php if ( empty( $instance['form_product_image_id'] ) ) echo 'style="display: none;"'; ?>
+			>
+				<img
+					class="jetpack-simple-payments-select-image"
+					src="<?php echo esc_url( $instance['form_product_image_src'] ); ?>"
+				/>
+				<button class="button jetpack-simple-payments-remove-image">
+					<?php esc_html_e( 'Remove image' ); ?>
+				</button>
+			</div>
+		</div>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>">
+				<?php esc_html_e( 'Description:', jetpack ); ?>
+			</label>
+			<textarea
+				class="widefat jetpack-simple-payments-form-product-description"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_description' ) ); ?>"
+				rows=5
+			><?php echo esc_html( $instance['form_product_description'] ); ?></textarea>
+		</p>
+
+		<p class="cost">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>">
+				<?php esc_html_e( 'Price:', 'jetpack' ); ?>
+			</label>
+			<select
+				class="field-currency widefat jetpack-simple-payments-form-product-currency"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>"
+			>
+				<?php foreach( Jetpack_Simple_Payments_Widget::$supported_currency_list as $code => $currency ) { ?>
+					<option
+						value="<?php echo esc_attr( $code ) ?>"
+						<?php selected( $instance['form_product_currency'], $code ); ?>
+					>
+						<?php echo esc_html( $code . ' ' . $currency ); ?>
+					</option>
+				<?php } ?>
+			</select>
+			<input
+				class="field-price widefat jetpack-simple-payments-form-product-price"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_price' ) ); ?>"
+				placeholder="1.00"
+				type="text"
+				value="<?php echo esc_attr( $instance['form_product_price'] ); ?>"
+			/>
+		</p>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>">
+				<input
+					class="jetpack-simple-payments-form-product-multiple"
+					id="<?php echo esc_attr( $this->get_field_id( 'form_product_multiple' ) ); ?>"
+					name="<?php echo esc_attr( $this->get_field_name( 'form_product_multiple' ) ); ?>"
+					type="checkbox"
+					value="1"
+					<?php checked( $instance['form_product_multiple'], '1' ); ?>
+				/>
+				<?php esc_html_e( 'Allow people to buy more than one item at a time.', 'jetpack' ); ?>
+			</label>
+		</p>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>">
+				<?php esc_html_e( 'Email:', 'jetpack' ); ?>
+		</label>
+			<input
+				class="field-email widefat jetpack-simple-payments-form-product-email"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_email' ) ); ?>"
+				type="email"
+				value="<?php  echo esc_attr( $instance['form_product_email'] ); ?>"
+			/>
+			<small>
+				<?php printf( esc_html__(
+					"This is where PayPal will send your money. To claim a payment, you'll need a %1$sPayPal account%2$s connected to a bank account." ),
+					'<a href="https://paypal.com" target="_blank">',
+					'</a>'
+				) ?>
 			</small>
 		</p>
 

--- a/modules/widgets/simple-payments/form-widgets-page.php
+++ b/modules/widgets/simple-payments/form-widgets-page.php
@@ -1,0 +1,108 @@
+<div class="jetpack-simple-payments-widget-container">
+	<p>
+		<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+			<?php esc_html_e( 'Title:', 'jetpack' ); ?>
+		</label>
+		<input
+			class="widefat jetpack-simple-payments-widget-title"
+			id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+			name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+			type="text"
+			value="<?php echo esc_attr( $instance['title'] ); ?>"
+		/>
+	</p>
+
+	<p
+		class="jetpack-simple-payments-widget-products-fieldset"
+		<?php if ( empty( $product_posts ) ) { echo 'style="display: none;"'; } ?>
+	>
+		<label for="<?php echo $this->get_field_id('product_post_id'); ?>">
+			<?php esc_html_e( 'Select a Simple Payment Button:', 'jetpack' ); ?>
+		</label>
+		<select
+			class="widefat jetpack-simple-payments-products"
+			id="<?php echo $this->get_field_id('product_post_id'); ?>"
+			name="<?php echo $this->get_field_name('product_post_id'); ?>"
+		>
+			<?php foreach ( $product_posts as $product_post ) { ?>
+				<option
+					value="<?php echo esc_attr( $product_post->ID ) ?>"
+					<?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>
+				>
+					<?php echo esc_attr( get_the_title( $product_post ) ) ?>
+				</option>
+			<?php } ?>
+		</select>
+	</p>
+
+	<p
+		class="jetpack-simple-payments-products-warning"
+		<?php if ( ! empty( $product_posts ) ) { echo 'style="display: none;"'; } ?>
+	>
+		<?php esc_html_e( 'Looks like you don\'t have any products. You can create one using the Add New button below.', 'jetpack' ) ?>
+	</p>
+
+	<p>
+		<div class="alignleft">
+			<button
+				class="button jetpack-simple-payments-edit-product"
+				<?php disabled( empty( $product_posts ), true ); ?>
+			>
+				<?php esc_html_e( 'Edit Selected', 'jetpack' ); ?>
+			</button>
+		</div>
+		<div class="alignright">
+			<button class="button jetpack-simple-payments-add-product">
+				<?php esc_html_e( 'Add New', 'jetpack' ); ?>
+			</button>
+		</div>
+		<br class="clear" />
+	</p>
+
+	<hr />
+
+	<div class="jetpack-simple-payments-widget-form" style="display: none;">
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>">
+				<?php esc_html_e( 'What is this payment for?', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat jetpack-simple-payments-widget-form-product-title"
+				id="<?php echo esc_attr( $this->get_field_id( 'form_product_title' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'form_product_title' ) ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['form_product_title'] ); ?>"
+			/>
+			<small>
+				<?php esc_html_e( 'For example: event tickets, charitable donations, training courses, coaching fees, etc.', 'jetpack' ); ?>
+			</small>
+		</p>
+
+		<p>
+			<div class="alignleft">
+				<button
+					class="button-link button-link-delete jetpack-simple-payments-delete-product"
+					type="button"
+				>
+					<?php esc_html_e( 'Delete Product', 'jetpack' ); ?>
+				</button>
+			</div>
+			<div class="alignright">
+				<button
+					class="button jetpack-simple-payments-save-product"
+					name="<?php echo esc_attr( $this->get_field_name( 'save' ) ); ?>"
+				>
+					<?php esc_html_e( 'Save', 'jetpack' ); ?>
+				</button>
+				<span> | <button
+					class="button-link jetpack-simple-payments-cancel-form"
+					type="button"
+				>
+					<?php esc_html_e( 'Cancel', 'jetpack' ); ?>
+				</button></span>
+			</div>
+			<br class="clear" />
+		</p>
+		<hr />
+	</div>
+</div>

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -29,6 +29,26 @@
 		return values;
 	}
 
+	function setFormValues( $form, values ) {
+		console.log( values );
+
+		$( '.jetpack-simple-payments-form-product-title', $form ).val( values.title );
+		$( '.jetpack-simple-payments-form-product-description', $form ).val( values.description );
+		$( '.jetpack-simple-payments-form-product-currency', $form ).val( values.currency );
+		$( '.jetpack-simple-payments-form-product-price', $form ).val( values.price );
+		$( '.jetpack-simple-payments-form-product-multiple', $form ).prop( 'checked', !! values.multiple );
+		$( '.jetpack-simple-payments-form-product-email', $form ).val( values.email );
+
+		if ( !! values.image_id && !! values.image_src ) {
+			var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+
+			$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).hide();
+			$( 'img', $imageContainer ).prop( 'src', values.image_src );
+			$imageContainer.data( 'image-id', values.image_id );
+			$imageContainer.show();
+		}
+	}
+
 	function updateSelector( $widget, action, data ) {
 		var $selector = $( '.jetpack-simple-payments-products', $widget );
 
@@ -50,7 +70,9 @@
 	}
 
 	function clearForm( $form ) {
-		$( 'input', $form ).val( '' );
+		$( 'input[type="text"], textarea', $form ).val( '' );
+		$( 'input[type="checkbox"]', $form ).prop( 'checked', false );
+		$( 'option', $form ).prop( 'selected', false );
 	}
 
 	function disableWidget( $widget ) {
@@ -96,8 +118,7 @@
 
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
-		$( '.jetpack-simple-payments-delete-product', $form ).show();
-		$form.show();
+		disableWidget( $widget );
 
 		var productId = $( '.jetpack-simple-payments-products', $widget ).val();
 
@@ -109,11 +130,14 @@
 		} );
 
 		request.done( function( data ) {
-			console.log( 'DONE', data );
+			setFormValues( $form, data );
+			$( '.jetpack-simple-payments-delete-product', $form ).show();
+			$form.show();
+			enableWidget( $widget );
 		} );
 
-		request.fail( function( data ) {
-			console.log( 'FAIL', data );
+		request.fail( function() {
+			enableWidget( $widget );
 		} );
 	} );
 
@@ -207,8 +231,13 @@
 		event.preventDefault();
 
 		var $form = getForm( $( this ) );
+		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+
 		$form.hide();
 		$( '.jetpack-simple-payments-delete-product', $form ).hide();
+		$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).show();
+		$imageContainer.data( 'image-id', 0 );
+		$imageContainer.hide();
 		clearForm( $form );
 	} );
 }( jQuery ) );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -1,41 +1,131 @@
-/* global jetpackSimplePaymentsWidget */
-/* eslint no-var: 0, no-console: 0 */
+/* global wp, jetpackSimplePaymentsWidget */
+/* eslint no-var: 0 */
 
 ( function( $ ) {
-	var products = jetpackSimplePaymentsWidget.products;
-	var strings = jetpackSimplePaymentsWidget.strings;
+	var nonce = jetpackSimplePaymentsWidget.nonce;
+	//var strings = jetpackSimplePaymentsWidget.strings;
 	var $widgetsArea = $( '#widgets-right' );
+
+	function getWidgetContainer( $element ) {
+		return $element.closest( '.jetpack-simple-payments-widget-container' );
+	}
+
+	function getForm( $element ) {
+		var $widget = getWidgetContainer( $element );
+		return $( '.jetpack-simple-payments-widget-form', $widget );
+	}
+
+	function getFormValues( $form ) {
+		var values = {
+			id: 0,
+			title: $( '.jetpack-simple-payments-widget-form-product-title', $form ).val(),
+			content: '',
+			imageId: 0,
+			currency: 'USD',
+			price: '1',
+			multiple: 0,
+			email: 'example@example.org',
+		};
+		return values;
+	}
+
+	function updateSelector( $widget, action, data ) {
+		var $selector = $( '.jetpack-simple-payments-products', $widget );
+
+		switch ( action ) {
+			case 'create':
+				$selector.append(
+					$( '<option>', {
+						text: data.product_post_title,
+						value: data.product_post_id,
+					} )
+				);
+				$selector.val( data.product_post_id ).change();
+				break;
+			case 'update':
+				break;
+			case 'delete':
+				break;
+		}
+	}
+
+	function clearForm( $form ) {
+		$( 'input', $form ).val( '' );
+	}
+
+	function disableWidget( $widget ) {
+		$( 'button, input', $widget ).prop( 'disabled', true );
+	}
+
+	function enableWidget( $widget ) {
+		$( 'button, input', $widget ).prop( 'disabled', false );
+	}
 
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
 		event.preventDefault();
 
-		var $widget = getWidgetContainer( $( this ) );
-		showForm( $widget );
+		var $form = getForm( $( this ) );
+		$form.show();
 	} );
 
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
 		event.preventDefault();
 
+		var $form = getForm( $( this ) );
+		$form.show();
+	} );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
+		event.preventDefault();
+
 		var $widget = getWidgetContainer( $( this ) );
-		showForm( $widget );
+		disableWidget( $widget );
+
+		var $form = getForm( $( this ) );
+		var values = getFormValues( $form );
+
+		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-save', {
+			'customize-jetpack-simple-payments-nonce': nonce,
+			params: {
+				product_post_id: values.id,
+				post_title: values.title,
+				post_content: values.content,
+				image_id: values.imageId,
+				currency: values.currency,
+				price: values.price,
+				multiple: values.multiple,
+				email: values.email,
+			},
+		} );
+
+		request.done( function( data ) {
+			var action = !! values.id ? 'update' : 'create';
+			updateSelector( $widget, action, data );
+			enableWidget( $widget );
+			$form.hide();
+			clearForm( $form );
+		} );
+
+		request.fail( function( data ) {
+			var validCodes = {
+				post_title: 'title',
+				price: 'price',
+				email: 'email',
+			};
+			data.forEach( function( item ) {
+				if ( validCodes.hasOwnProperty( item.code ) ) {
+					$( '.jetpack-simple-payments-form-product-' + validCodes[ item.code ], $form ).addClass( 'invalid' );
+				}
+			} );
+			enableWidget( $widget );
+		} );
 	} );
 
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
 		event.preventDefault();
 
-		var $widget = getWidgetContainer( $( this ) );
-		hideForm( $widget );
+		var $form = getForm( $( this ) );
+		$form.hide();
+		clearForm( $form );
 	} );
-
-	function getWidgetContainer( element ) {
-		return element.closest( '.jetpack-simple-payments-widget-container' );
-	}
-
-	function showForm( $widget ) {
-		$( '.jetpack-simple-payments-widget-form', $widget ).show();
-	}
-
-	function hideForm( $widget ) {
-		$( '.jetpack-simple-payments-widget-form', $widget ).hide();
-	}
 }( jQuery ) );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -12,19 +12,19 @@
 
 	function getForm( $element ) {
 		var $widget = getWidgetContainer( $element );
-		return $( '.jetpack-simple-payments-widget-form', $widget );
+		return $( '.jetpack-simple-payments-form', $widget );
 	}
 
 	function getFormValues( $form ) {
 		var values = {
 			id: 0,
-			title: $( '.jetpack-simple-payments-widget-form-product-title', $form ).val(),
-			content: '',
-			imageId: 0,
-			currency: 'USD',
-			price: '1',
-			multiple: 0,
-			email: 'example@example.org',
+			title: $( '.jetpack-simple-payments-form-product-title', $form ).val(),
+			content: $( '.jetpack-simple-payments-form-product-description', $form ).val(),
+			imageId: $( '.jetpack-simple-payments-image', $form ).data( 'image-id' ),
+			currency: $( '.jetpack-simple-payments-form-product-currency', $form ).val(),
+			price: $( '.jetpack-simple-payments-form-product-price', $form ).val(),
+			multiple: $( '.jetpack-simple-payments-form-product-multiple', $form ).is( ':checked' ) ? 1 : 0,
+			email: $( '.jetpack-simple-payments-form-product-email', $form ).val(),
 		};
 		return values;
 	}
@@ -119,6 +119,42 @@
 			} );
 			enableWidget( $widget );
 		} );
+	} );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-select-image', function( event ) {
+		event.preventDefault();
+
+		var $form = getForm( $( this ) );
+		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+
+		var mediaFrame = new wp.media.view.MediaFrame.Select( {
+			title: 'Choose Product Image',
+			multiple: false,
+			library: { type: 'image' },
+			button: { text: 'Choose Image' }
+		} );
+
+		mediaFrame.on( 'select', function() {
+			var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
+
+			$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).hide();
+			$( 'img', $imageContainer ).prop( 'src', selection.url );
+			$imageContainer.data( 'image-id', selection.id );
+			$imageContainer.show();
+		} );
+
+		mediaFrame.open();
+	} );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-remove-image', function( event ) {
+		event.preventDefault();
+
+		var $form = getForm( $( this ) );
+		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+
+		$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).show();
+		$imageContainer.data( 'image-id', 0 );
+		$imageContainer.hide();
 	} );
 
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -1,5 +1,5 @@
 /* global wp, jetpackSimplePaymentsWidget */
-/* eslint no-var: 0, no-console: 0 */
+/* eslint no-var: 0 */
 
 ( function( $ ) {
 	// ELEMENTS CLASSES
@@ -26,7 +26,7 @@
 	};
 
 	var nonce = jetpackSimplePaymentsWidget.nonce;
-	//var strings = jetpackSimplePaymentsWidget.strings;
+	var strings = jetpackSimplePaymentsWidget.strings;
 	var $widgetsArea = $( '#widgets-right' );
 
 	// Get the widget parent context of an element.
@@ -93,6 +93,7 @@
 				$( 'option[value="' + data.product_post_id + '"]', $selector ).text( data.product_post_title );
 				break;
 			case 'delete':
+				$( 'option[value="' + data.product_post_id + '"]', $selector ).remove();
 				break;
 		}
 	}
@@ -223,9 +224,9 @@
 		request.done( function( data ) {
 			var action = !! values.id ? 'update' : 'create';
 			updateSelector( $widget, action, data );
-			enableWidget( $widget );
 			$form.hide();
 			clearForm( $form );
+			enableWidget( $widget );
 		} );
 
 		request.fail( function( data ) {
@@ -239,6 +240,37 @@
 					$( '.jetpack-simple-payments-form-product-' + validCodes[ item.code ], $form ).addClass( 'invalid' );
 				}
 			} );
+			enableForm( $form );
+		} );
+	} );
+
+	$widgetsArea.on( 'click', buttons.deleteProduct, function( event ) {
+		event.preventDefault();
+
+		if ( ! confirm( strings.deleteConfirmation ) ) {
+			return;
+		}
+
+		var $widget = getWidgetContainer( $( this ) );
+		var $form = getForm( $( this ) );
+		disableWidget( $widget );
+
+		var productId = $( productsSelector, $widget ).val();
+		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-delete', {
+			'customize-jetpack-simple-payments-nonce': nonce,
+			params: {
+				product_post_id: productId,
+			},
+		} );
+
+		request.done( function() {
+			updateSelector( $widget, 'delete', { product_post_id: productId } );
+			$form.hide();
+			clearForm( $form );
+			enableWidget( $widget );
+		} );
+
+		request.fail( function() {
 			enableForm( $form );
 		} );
 	} );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -34,6 +34,12 @@
 		return $element.closest( '.jetpack-simple-payments-widget-container' );
 	}
 
+	// Get the widget spinner.
+	function getSpinner( $element ) {
+		var $widgetInside = $element.closest( '.widget-inside' );
+		return $( '.spinner', $widgetInside );
+	}
+
 	// Get the product form parent context of an element.
 	function getForm( $element ) {
 		var $widget = getWidgetContainer( $element );
@@ -116,18 +122,27 @@
 	}
 
 	// Disable all fields of a widget.
-	function disableWidget( $widget ) {
+	function disableWidget( $widget, $spinner ) {
 		$( 'button, input, select, textarea', $widget ).prop( 'disabled', true );
+		if ( $spinner ) {
+			$spinner.css( 'visibility', 'visible' );
+		}
 	}
 
 	// Enable all fields of a widget.
-	function enableWidget( $widget ) {
+	function enableWidget( $widget, $spinner ) {
 		$( 'button, input, select, textarea', $widget ).prop( 'disabled', false );
+		if ( $spinner ) {
+			$spinner.css( 'visibility', 'hidden' );
+		}
 	}
 
 	// Enable all fields of a form.
-	function enableForm( $form ) {
+	function enableForm( $form, $spinner ) {
 		$( 'button, input, select, textarea', $form ).prop( 'disabled', false );
+		if ( $spinner ) {
+			$spinner.css( 'visibility', 'hidden' );
+		}
 	}
 
 	// Check if a product form's values are valid.
@@ -171,7 +186,8 @@
 
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
-		disableWidget( $widget );
+		var $spinner = getSpinner( $( this ) );
+		disableWidget( $widget, $spinner );
 
 		var productId = $( productsSelector, $widget ).val();
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-get', {
@@ -185,11 +201,11 @@
 			setFormValues( $form, data );
 			$( buttons.deleteProduct, $form ).show();
 			$form.show();
-			enableForm( $form );
+			enableForm( $form, $spinner );
 		} );
 
 		request.fail( function() {
-			enableWidget( $widget );
+			enableWidget( $widget, $spinner );
 		} );
 	} );
 
@@ -199,13 +215,14 @@
 
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
+		var $spinner = getSpinner( $( this ) );
 		var values = getFormValues( $form );
 
 		if ( ! isFormValid( $form, values ) ) {
 			return;
 		}
 
-		disableWidget( $widget );
+		disableWidget( $widget, $spinner );
 
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-save', {
 			'customize-jetpack-simple-payments-nonce': nonce,
@@ -226,7 +243,7 @@
 			updateSelector( $widget, action, data );
 			$form.hide();
 			clearForm( $form );
-			enableWidget( $widget );
+			enableWidget( $widget, $spinner );
 		} );
 
 		request.fail( function( data ) {
@@ -240,7 +257,7 @@
 					$( '.jetpack-simple-payments-form-product-' + validCodes[ item.code ], $form ).addClass( 'invalid' );
 				}
 			} );
-			enableForm( $form );
+			enableForm( $form, $spinner );
 		} );
 	} );
 
@@ -253,7 +270,8 @@
 
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
-		disableWidget( $widget );
+		var $spinner = getSpinner( $( this ) );
+		disableWidget( $widget, $spinner );
 
 		var productId = $( productsSelector, $widget ).val();
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-delete', {
@@ -267,11 +285,11 @@
 			updateSelector( $widget, 'delete', { product_post_id: productId } );
 			$form.hide();
 			clearForm( $form );
-			enableWidget( $widget );
+			enableWidget( $widget, $spinner );
 		} );
 
 		request.fail( function() {
-			enableForm( $form );
+			enableForm( $form, $spinner );
 		} );
 	} );
 
@@ -313,9 +331,10 @@
 		event.preventDefault();
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
+		var $spinner = getSpinner( $( this ) );
 		$form.hide();
 		$( buttons.deleteProduct, $form ).hide();
 		clearForm( $form );
-		enableWidget( $widget );
+		enableWidget( $widget, $spinner );
 	} );
 }( jQuery ) );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -1,0 +1,41 @@
+/* global jetpackSimplePaymentsWidget */
+/* eslint no-var: 0, no-console: 0 */
+
+( function( $ ) {
+	var products = jetpackSimplePaymentsWidget.products;
+	var strings = jetpackSimplePaymentsWidget.strings;
+	var $widgetsArea = $( '#widgets-right' );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
+		event.preventDefault();
+
+		var $widget = getWidgetContainer( $( this ) );
+		showForm( $widget );
+	} );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
+		event.preventDefault();
+
+		var $widget = getWidgetContainer( $( this ) );
+		showForm( $widget );
+	} );
+
+	$widgetsArea.on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
+		event.preventDefault();
+
+		var $widget = getWidgetContainer( $( this ) );
+		hideForm( $widget );
+	} );
+
+	function getWidgetContainer( element ) {
+		return element.closest( '.jetpack-simple-payments-widget-container' );
+	}
+
+	function showForm( $widget ) {
+		$( '.jetpack-simple-payments-widget-form', $widget ).show();
+	}
+
+	function hideForm( $widget ) {
+		$( '.jetpack-simple-payments-widget-form', $widget ).hide();
+	}
+}( jQuery ) );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -61,6 +61,29 @@
 		$( 'button, input', $widget ).prop( 'disabled', false );
 	}
 
+	function isFormValid( $form, values ) {
+		$( '.invalid', $form ).removeClass( 'invalid' );
+		var isValid = true;
+
+		if ( ! values.title ) {
+			$( '.jetpack-simple-payments-form-product-title', $form ).addClass( 'invalid' );
+			isValid = false;
+		}
+
+		if ( ! values.price || isNaN( parseFloat( values.price ) ) || parseFloat( values.price ) <= 0 ) {
+			$( '.jetpack-simple-payments-form-product-price', $form ).addClass( 'invalid' );
+			isValid = false;
+		}
+
+		var isEmailValid = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test( values.email );
+		if ( ! values.email || ! isEmailValid ) {
+			$( '.jetpack-simple-payments-form-product-email', $form ).addClass( 'invalid' );
+			isValid = false;
+		}
+
+		return isValid;
+	}
+
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
 		event.preventDefault();
 
@@ -79,10 +102,14 @@
 		event.preventDefault();
 
 		var $widget = getWidgetContainer( $( this ) );
-		disableWidget( $widget );
-
 		var $form = getForm( $( this ) );
 		var values = getFormValues( $form );
+
+		if ( ! isFormValid( $form, values ) ) {
+			return;
+		}
+
+		disableWidget( $widget );
 
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-save', {
 			'customize-jetpack-simple-payments-nonce': nonce,

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -102,6 +102,7 @@
 				$( 'option[value="' + data.product_post_id + '"]', $selector ).remove();
 				break;
 		}
+		$selector.change();
 	}
 
 	// Clear the image of a product form.

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -2,55 +2,80 @@
 /* eslint no-var: 0, no-console: 0 */
 
 ( function( $ ) {
+	// ELEMENTS CLASSES
+	var productsSelector = '.jetpack-simple-payments-products';
+	var buttons = {
+		addProduct: '.jetpack-simple-payments-add-product',
+		editProduct: '.jetpack-simple-payments-edit-product',
+		deleteProduct: '.jetpack-simple-payments-delete-product',
+		saveProduct: '.jetpack-simple-payments-save-product',
+		selectImage: '.jetpack-simple-payments-select-image',
+		removeImage: '.jetpack-simple-payments-remove-image',
+		cancelForm: '.jetpack-simple-payments-cancel-form',
+	};
+	var productForm = {
+		title: '.jetpack-simple-payments-form-product-title',
+		description: '.jetpack-simple-payments-form-product-description',
+		image: '.jetpack-simple-payments-image',
+		imagePlaceholder: '.jetpack-simple-payments-image-fieldset .placeholder',
+		currency: '.jetpack-simple-payments-form-product-currency',
+		price: '.jetpack-simple-payments-form-product-price',
+		multiple: '.jetpack-simple-payments-form-product-multiple',
+		email: '.jetpack-simple-payments-form-product-email',
+	};
+
 	var nonce = jetpackSimplePaymentsWidget.nonce;
 	//var strings = jetpackSimplePaymentsWidget.strings;
 	var $widgetsArea = $( '#widgets-right' );
 
+	// Get the widget parent context of an element.
 	function getWidgetContainer( $element ) {
 		return $element.closest( '.jetpack-simple-payments-widget-container' );
 	}
 
+	// Get the product form parent context of an element.
 	function getForm( $element ) {
 		var $widget = getWidgetContainer( $element );
 		return $( '.jetpack-simple-payments-form', $widget );
 	}
 
+	// Get the values of a product form.
 	function getFormValues( $form ) {
 		var values = {
 			id: 0,
-			title: $( '.jetpack-simple-payments-form-product-title', $form ).val(),
-			content: $( '.jetpack-simple-payments-form-product-description', $form ).val(),
-			imageId: $( '.jetpack-simple-payments-image', $form ).data( 'image-id' ),
-			currency: $( '.jetpack-simple-payments-form-product-currency', $form ).val(),
-			price: $( '.jetpack-simple-payments-form-product-price', $form ).val(),
-			multiple: $( '.jetpack-simple-payments-form-product-multiple', $form ).is( ':checked' ) ? 1 : 0,
-			email: $( '.jetpack-simple-payments-form-product-email', $form ).val(),
+			title: $( productForm.title, $form ).val(),
+			description: $( productForm.description, $form ).val(),
+			imageId: $( productForm.image, $form ).data( 'image-id' ),
+			currency: $( productForm.currency, $form ).val(),
+			price: $( productForm.price, $form ).val(),
+			multiple: $( productForm.multiple, $form ).is( ':checked' ) ? 1 : 0,
+			email: $( productForm.email, $form ).val(),
 		};
 		return values;
 	}
 
+	// Set the values of a product form.
 	function setFormValues( $form, values ) {
-		console.log( values );
-
-		$( '.jetpack-simple-payments-form-product-title', $form ).val( values.title );
-		$( '.jetpack-simple-payments-form-product-description', $form ).val( values.description );
-		$( '.jetpack-simple-payments-form-product-currency', $form ).val( values.currency );
-		$( '.jetpack-simple-payments-form-product-price', $form ).val( values.price );
-		$( '.jetpack-simple-payments-form-product-multiple', $form ).prop( 'checked', !! values.multiple );
-		$( '.jetpack-simple-payments-form-product-email', $form ).val( values.email );
+		$( productForm.title, $form ).val( values.title );
+		$( productForm.description, $form ).val( values.description );
+		$( productForm.currency, $form ).val( values.currency );
+		$( productForm.price, $form ).val( values.price );
+		$( productForm.multiple, $form ).prop( 'checked', !! values.multiple );
+		$( productForm.email, $form ).val( values.email );
 
 		if ( !! values.image_id && !! values.image_src ) {
-			var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+			var $imageContainer = $( productForm.image, $form );
 
-			$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).hide();
+			$( productForm.imagePlaceholder, $form ).hide();
 			$( 'img', $imageContainer ).prop( 'src', values.image_src );
 			$imageContainer.data( 'image-id', values.image_id );
 			$imageContainer.show();
 		}
 	}
 
+	// Update the products selector by adding, removing, or changing one of its values.
 	function updateSelector( $widget, action, data ) {
-		var $selector = $( '.jetpack-simple-payments-products', $widget );
+		var $selector = $( productsSelector, $widget );
 
 		switch ( action ) {
 			case 'create':
@@ -69,59 +94,82 @@
 		}
 	}
 
+	// Clear the image of a product form.
+	function clearFormImage( $form ) {
+		var $imageContainer = $( productForm.image, $form );
+
+		$( productForm.imagePlaceholder, $form ).show();
+		$imageContainer.data( 'image-id', 0 );
+		$imageContainer.hide();
+	}
+
+	// Clear a product form.
 	function clearForm( $form ) {
 		$( 'input[type="text"], textarea', $form ).val( '' );
 		$( 'input[type="checkbox"]', $form ).prop( 'checked', false );
 		$( 'option', $form ).prop( 'selected', false );
+		clearFormImage( $form );
 	}
 
+	// Disable all fields of a widget.
 	function disableWidget( $widget ) {
-		$( 'button, input', $widget ).prop( 'disabled', true );
+		$( 'button, input, select, textarea', $widget ).prop( 'disabled', true );
 	}
 
+	// Enable all fields of a widget.
 	function enableWidget( $widget ) {
-		$( 'button, input', $widget ).prop( 'disabled', false );
+		$( 'button, input, select, textarea', $widget ).prop( 'disabled', false );
 	}
 
+	// Enable all fields of a form.
+	function enableForm( $form ) {
+		$( 'button, input, select, textarea', $form ).prop( 'disabled', false );
+	}
+
+	// Check if a product form's values are valid.
 	function isFormValid( $form, values ) {
 		$( '.invalid', $form ).removeClass( 'invalid' );
 		var isValid = true;
 
 		if ( ! values.title ) {
-			$( '.jetpack-simple-payments-form-product-title', $form ).addClass( 'invalid' );
+			$( productForm.title, $form ).addClass( 'invalid' );
 			isValid = false;
 		}
 
 		if ( ! values.price || isNaN( parseFloat( values.price ) ) || parseFloat( values.price ) <= 0 ) {
-			$( '.jetpack-simple-payments-form-product-price', $form ).addClass( 'invalid' );
+			$( productForm.price, $form ).addClass( 'invalid' );
 			isValid = false;
 		}
 
 		var isEmailValid = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test( values.email );
 		if ( ! values.email || ! isEmailValid ) {
-			$( '.jetpack-simple-payments-form-product-email', $form ).addClass( 'invalid' );
+			$( productForm.email, $form ).addClass( 'invalid' );
 			isValid = false;
 		}
 
 		return isValid;
 	}
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-add-product', function( event ) {
+	// Show the Create Product form.
+	$widgetsArea.on( 'click', buttons.addProduct, function( event ) {
 		event.preventDefault();
 
+		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
+		disableWidget( $widget );
+		enableForm( $form );
 		$form.show();
 	} );
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
+	// Fetch the selected product values, and show the Edit Product form.
+	$widgetsArea.on( 'click', buttons.editProduct, function( event ) {
 		event.preventDefault();
 
 		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
 		disableWidget( $widget );
 
-		var productId = $( '.jetpack-simple-payments-products', $widget ).val();
-
+		var productId = $( productsSelector, $widget ).val();
 		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-get', {
 			'customize-jetpack-simple-payments-nonce': nonce,
 			params: {
@@ -131,9 +179,9 @@
 
 		request.done( function( data ) {
 			setFormValues( $form, data );
-			$( '.jetpack-simple-payments-delete-product', $form ).show();
+			$( buttons.deleteProduct, $form ).show();
 			$form.show();
-			enableWidget( $widget );
+			enableForm( $form );
 		} );
 
 		request.fail( function() {
@@ -141,7 +189,8 @@
 		} );
 	} );
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
+	// Save the values contained in a product form.
+	$widgetsArea.on( 'click', buttons.saveProduct, function( event ) {
 		event.preventDefault();
 
 		var $widget = getWidgetContainer( $( this ) );
@@ -159,7 +208,7 @@
 			params: {
 				product_post_id: values.id,
 				post_title: values.title,
-				post_content: values.content,
+				post_content: values.description,
 				image_id: values.imageId,
 				currency: values.currency,
 				price: values.price,
@@ -187,15 +236,16 @@
 					$( '.jetpack-simple-payments-form-product-' + validCodes[ item.code ], $form ).addClass( 'invalid' );
 				}
 			} );
-			enableWidget( $widget );
+			enableForm( $form );
 		} );
 	} );
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-select-image', function( event ) {
+	// Open a Media Library dialog.
+	$widgetsArea.on( 'click', buttons.selectImage, function( event ) {
 		event.preventDefault();
 
 		var $form = getForm( $( this ) );
-		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
+		var $imageContainer = $( productForm.image, $form );
 
 		var mediaFrame = new wp.media.view.MediaFrame.Select( {
 			title: 'Choose Product Image',
@@ -207,7 +257,7 @@
 		mediaFrame.on( 'select', function() {
 			var selection = mediaFrame.state().get( 'selection' ).first().toJSON();
 
-			$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).hide();
+			$( productForm.imagePlaceholder, $form ).hide();
 			$( 'img', $imageContainer ).prop( 'src', selection.url );
 			$imageContainer.data( 'image-id', selection.id );
 			$imageContainer.show();
@@ -216,28 +266,21 @@
 		mediaFrame.open();
 	} );
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-remove-image', function( event ) {
+	// Remove a selected image.
+	$widgetsArea.on( 'click', buttons.removeImage, function( event ) {
 		event.preventDefault();
-
 		var $form = getForm( $( this ) );
-		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
-
-		$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).show();
-		$imageContainer.data( 'image-id', 0 );
-		$imageContainer.hide();
+		clearFormImage( $form );
 	} );
 
-	$widgetsArea.on( 'click', '.jetpack-simple-payments-cancel-form', function( event ) {
+	// Close a product form and clear its values.
+	$widgetsArea.on( 'click', buttons.cancelForm, function( event ) {
 		event.preventDefault();
-
+		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
-		var $imageContainer = $( '.jetpack-simple-payments-image', $form );
-
 		$form.hide();
-		$( '.jetpack-simple-payments-delete-product', $form ).hide();
-		$( '.jetpack-simple-payments-image-fieldset .placeholder', $form ).show();
-		$imageContainer.data( 'image-id', 0 );
-		$imageContainer.hide();
+		$( buttons.deleteProduct, $form ).hide();
 		clearForm( $form );
+		enableWidget( $widget );
 	} );
 }( jQuery ) );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -14,6 +14,7 @@
 		cancelForm: '.jetpack-simple-payments-cancel-form',
 	};
 	var productForm = {
+		id: '.jetpack-simple-payments-form-product-id',
 		title: '.jetpack-simple-payments-form-product-title',
 		description: '.jetpack-simple-payments-form-product-description',
 		image: '.jetpack-simple-payments-image',
@@ -42,7 +43,7 @@
 	// Get the values of a product form.
 	function getFormValues( $form ) {
 		var values = {
-			id: 0,
+			id: $( productForm.id, $form ).val(),
 			title: $( productForm.title, $form ).val(),
 			description: $( productForm.description, $form ).val(),
 			imageId: $( productForm.image, $form ).data( 'image-id' ),
@@ -56,6 +57,7 @@
 
 	// Set the values of a product form.
 	function setFormValues( $form, values ) {
+		$( productForm.id, $form ).val( values.id );
 		$( productForm.title, $form ).val( values.title );
 		$( productForm.description, $form ).val( values.description );
 		$( productForm.currency, $form ).val( values.currency );
@@ -88,6 +90,7 @@
 				$selector.val( data.product_post_id ).change();
 				break;
 			case 'update':
+				$( 'option[value="' + data.product_post_id + '"]', $selector ).text( data.product_post_title );
 				break;
 			case 'delete':
 				break;
@@ -105,7 +108,7 @@
 
 	// Clear a product form.
 	function clearForm( $form ) {
-		$( 'input[type="text"], textarea', $form ).val( '' );
+		$( 'input[type="hidden"], input[type="text"], textarea', $form ).val( '' );
 		$( 'input[type="checkbox"]', $form ).prop( 'checked', false );
 		$( 'option', $form ).prop( 'selected', false );
 		clearFormImage( $form );

--- a/modules/widgets/simple-payments/widgets-page.js
+++ b/modules/widgets/simple-payments/widgets-page.js
@@ -1,5 +1,5 @@
 /* global wp, jetpackSimplePaymentsWidget */
-/* eslint no-var: 0 */
+/* eslint no-var: 0, no-console: 0 */
 
 ( function( $ ) {
 	var nonce = jetpackSimplePaymentsWidget.nonce;
@@ -94,8 +94,27 @@
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-edit-product', function( event ) {
 		event.preventDefault();
 
+		var $widget = getWidgetContainer( $( this ) );
 		var $form = getForm( $( this ) );
+		$( '.jetpack-simple-payments-delete-product', $form ).show();
 		$form.show();
+
+		var productId = $( '.jetpack-simple-payments-products', $widget ).val();
+
+		var request = wp.ajax.post( 'customize-jetpack-simple-payments-button-get', {
+			'customize-jetpack-simple-payments-nonce': nonce,
+			params: {
+				product_post_id: productId,
+			},
+		} );
+
+		request.done( function( data ) {
+			console.log( 'DONE', data );
+		} );
+
+		request.fail( function( data ) {
+			console.log( 'FAIL', data );
+		} );
 	} );
 
 	$widgetsArea.on( 'click', '.jetpack-simple-payments-save-product', function( event ) {
@@ -189,6 +208,7 @@
 
 		var $form = getForm( $( this ) );
 		$form.hide();
+		$( '.jetpack-simple-payments-delete-product', $form ).hide();
 		clearForm( $form );
 	} );
 }( jQuery ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25576

The newly introduced Simple Payments widget heavily relies on the Customizer JS API and therefore it doesn't work in the Widgets (`widgets.php`) page.

This PR is an attempt to make it work in both pages flawlessly.

My initial attempt consisted in revers engineer the Customizer itself, to figure out when and why all widget events are triggered, in order to emulate them in the Widgets page.
This was sort of possible, but required an amount of hacks and workarounds several orders of magnitude larger than what I'm comfortable with.

This is the second attempt, and it's completely independent from the Customizer JS API.
It relies entirely on the event delegation, which is easy and performant enough to pull off with jQuery.
I haven't modified the existing `form.php` and `customizer.js` files, but instead opted to write two new files from scratch in order to keep both version always open side by side, trying to stay as true to the original code as possible, while also rewriting it and learning from it.

The idea behind this attempt is that we observe the widgets container, and only react when one of the buttons in a Simple Payments widget is clicked. From there, that widget becomes the context where everything happens.

Clicking on "Add New" will simply open an empty form.
Clicking on "Edit Selected" will fetch via AJAX the details of the selected product to populate the form.
Saving will simply save via AJAX whatever is in the form, and update the products selector accordingly.
Deleting will delete the product and update the products selector.
Closing the form will simply hide and clear it.

Bar corner cases and polish, this works fine in both the Widgets page and the Customizer.

There is one gotcha that I haven't got the time to study because I caught it too late before my AFK time.
When adding a new product or editing an existing one, the Customizer does not refresh accordingly until the product is saved.
This happens because the selective refresh relies on the values returned by the `WP_Widget::update()` method. In this case, the only values actually needed for the widget are the title and a product ID.
All the product details (name, price, image, etc.) are saved via AJAX and stored in their own posts of CPT `jp_pay_product`.
I know for a fact that @rodrigoi solved this issue, but for my poor understanding of the selective refresh magic, I can't seem to figure out exactly how.

Since my AFK is near, I'm leaving this PR here hoping it will be of some inspiration to fix that nasty issue.

#### Changes proposed in this Pull Request:

* WIP

#### Testing instructions:

* On a Pro JP site, open both the Widgets page and the Customizer.
* Add multiple Simple Payments widgets to a sidebar.
* Try to add new products, and edit and deleting existing ones.
* Make sure all the operations work as expected.
* Make sure the Customizer preview updates accordingly to the edit (note: as of now, products are only updated when saving them).