### PR TITLE
Site Logo: remove custom name for "Site Identity" section

### DIFF
--- a/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -79,9 +79,6 @@ class Site_Logo {
 		// Include our custom control.
 		require( dirname( __FILE__ ) . '/class-site-logo-control.php' );
 
-		//Update the Customizer section title for discoverability.
-		$wp_customize->get_section('title_tagline')->title = __( 'Site Title, Tagline, and Logo', 'jetpack' );
-
 		// Add a setting to hide header text if the theme isn't supporting the feature itself
 		if ( ! current_theme_supports( 'custom-header' ) ) {
 			$wp_customize->add_setting( 'site_logo_header_text', array(


### PR DESCRIPTION
> WordPress has changed that section to Site Identity since 4.3 so you shouldn't mess with it anymore as the new name is more inclusive. At least you shouldn't do this for 4.3 or newer.

This PR removes the custom name for the "Site Identity" section in the Customizer. The custom name is unnecessary, given core's updating of the section name in 4.3.

Fixes #3082. Props stalebot ;)

----

#### Testing instructions:

- Visit the Customizer with this patch applied.
- The section containing Site Title, Tagline, and Logo should be named "Site Identity"
