### PR TITLE
Respect JETPACK_START_API_HOST env var in partner-provision.sh

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -156,9 +156,10 @@ ACCESS_TOKEN_JSON=$(
 	curl \
 		--silent \
 		--request POST \
-		--url https://public-api.wordpress.com/oauth2/token \
+		--url https://$JETPACK_START_API_HOST/oauth2/token \
 		--header 'cache-control: no-cache' \
 		--header 'content-type: multipart/form-data;' \
+		--header "Host: public-api.wordpress.com" \
 		--form client_id="$CLIENT_ID" \
 		--form client_secret="$CLIENT_SECRET" \
 		--form grant_type=client_credentials \
@@ -196,6 +197,7 @@ PROVISION_REQUEST=$(
 		--request POST \
 		--url "$PROVISION_REQUEST_URL" \
 		--header "authorization: Bearer $ACCESS_TOKEN" \
+		--header "Host: public-api.wordpress.com" \
 		--header 'cache-control: no-cache' \
 		--header 'content-type: multipart/form-data;' \
 		$PROVISION_REQUEST_ARGS


### PR DESCRIPTION
Fixes an issue where specifying `JETPACK_START_API_HOST` on the command line (useful for development) didn't work.

Trying this:

```
JETPACK_START_API_HOST=mysandbox.wordpress.com sh bin/partner-provision.sh --partner_id=12345 --partner_secret=abcd1234
```

Would result in a 404 since the script wasn't specifying the 'host' header, meaning that a WPCOM sandbox would not recognise the incoming request as being to the `public-api.wordpress.com` virtualhost.

In addition, we weren't using the `JETPACK_START_API_HOST` var in the access token request, which meant that this wouldn't go to your sandbox.

What this added up to is that the JETPACK_START_API_HOST env var was broken, and the only way to develop against your sandbox is to modify the /etc/hosts file, which is not possible in all the environments where we want to test. With this patch, that var works again.

#### Changes proposed in this Pull Request:

* Respect JETPACK_START_API_HOST for all requests

#### Testing instructions:

* You need a WPCOM API sandbox.
* Provision a Jetpack site for a hosting partner key using something like `JETPACK_START_API_HOST=mysandbox.wordpress.com sh bin/partner-provision.sh --partner_id=12345 --partner_secret=abcd1234`
* Request should succeed, and be processed by your sandbox.