### PR TITLE
General: Remove the word fascinating from the text that clarifies when TOS agreement begins

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -138,7 +138,7 @@ export class ConnectButton extends React.Component {
 				{ ! this.props.isSiteConnected &&
 					<p className="jp-banner__tos-blurb">
 					{ __(
-						'By clicking the button below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
+						'By clicking the button below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com.',
 						{
 							components: {
 								tosLink: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank" />,

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -138,7 +138,7 @@ export class ConnectButton extends React.Component {
 				{ ! this.props.isSiteConnected &&
 					<p className="jp-banner__tos-blurb">
 					{ __(
-						'By clicking the button below, you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
+						'By clicking the button below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
 						{
 							components: {
 								tosLink: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank" />,

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);

--- a/functions.global.php
+++ b/functions.global.php
@@ -118,7 +118,7 @@ function jetpack_get_migration_data( $option_name ) {
  */
 function jetpack_render_tos_blurb() {
 	printf(
-		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com.', 'jetpack' ),
 		'https://wordpress.com/tos',
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates the Connect Button component in the Jetpack Admin page to not include the word `fascinating`.
* Updates the Jetpack connection banner and Splash screen to not include the word either.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Checkout this branch on a non-connected Jetpack site. 
* Confirm that the connect banner lacks the word `fascinating`. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
