### PR TITLE
Connection Splash Screen: Replace OSX for macOS in connection banner

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -883,7 +883,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							'Publish: Post on the go from any device using the WordPress apps for iOS, Android, Windows, Linux, and OSX.',
+							'Publish: Post on the go from any device using the WordPress apps for iOS, Android, Windows, Linux, and macOS.',
 							'jetpack'
 						);
 					?></p>


### PR DESCRIPTION
Fixes p8oabR-fb-p2 #comment-1839

#### Changes proposed in this Pull Request:

* Replaces mention of `OSX` for `macOS`. 

This was observed during the Jetpack 6.3 call for testing, but will be punted to 6.4 as the translations are already done including `OSX`.

#### Testing instructions:

