### PR TITLE
CI: testing php linting in Travis

### DIFF
--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -3,12 +3,20 @@
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
 		echo "Linting PHP files..."
-		find . \
+		if find . \
 			-not -path "./node_modules*" \
 			-not -path "./tools*" \
 			-not -path "./docker*" \
+			-not -path "./languages*" \
+			-not -path "./scss*" \
+			-not -path "./docs*" \
+			-not -path "./images*" \
 			-name \*.php \
-			-exec php -l "{}" \;
+			-exec php -l "{}" \; | grep "Parse error";
+		then
+			echo "Linting errors found: see above."
+			exit 1;
+		fi
 
     echo "Testing on WordPress master..."
     cd /tmp/wordpress-master/src/wp-content/plugins/$PLUGIN_SLUG

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -2,6 +2,14 @@
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
+		echo "Linting PHP files..."
+		find . \
+			-not -path "./node_modules*" \
+			-not -path "./tools*" \
+			-not -path "./docker*" \
+			-name \*.php \
+			-exec php -l "{}" \;
+
     echo "Testing on WordPress master..."
     cd /tmp/wordpress-master/src/wp-content/plugins/$PLUGIN_SLUG
     if $WP_TRAVISCI; then


### PR DESCRIPTION
Runs `php -l` on all php files and fails Travis if it finds any problems.

![image](https://user-images.githubusercontent.com/87168/42281664-eb100a70-7fac-11e8-9653-c37095c222d1.png)

![image](https://user-images.githubusercontent.com/87168/42282209-6c11a4e8-7fae-11e8-8f84-5a86ef9fe76a.png)


## Testing 

This branch has code that should fail on PHP 5.2 (fixed in https://github.com/Automattic/jetpack/pull/9863), so until this branch is rebased, Travis will fail here. 

_Does this PR catch them errors?_ 