### PR TITLE
Check if lint errors would have been caught with 5.3 running in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ cache:
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.
 
-# Test WP trunk/master and two latest versions on minimum (5.2).
-# Test WP latest two versions (4.5, 4.3) on most popular (5.6, 7.0).
-# Test WP trunk/master on edge platforms (PHP 7.2).
+# Test WP trunk/master and two latest versions on minimum (5.3).
+# Test WP latest two versions (4.5, 4.3) on most popular (5.5, 5.6).
+# Test WP latest stable (4.5) on other supported PHP (5.3, 5.4).
+# Test WP trunk/master on edge platforms (7.0, PHP nightly).
 
 # WP_VERSION specifies the tag to use. The way these tests are configured to run
 # requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
@@ -36,9 +37,12 @@ matrix:
   - env: WP_TRAVISCI="yarn danger ci"
   - php: "7.0"
     env: "SWITCH_TO_PHP=5.2"
+  - php: "5.3"
     dist: precise
+  - php: "5.5"
   - php: "5.6"
   - php: "7.0"
+  - php: "7.1"
   - php: "7.2"
 
 # whitelist branches for the "push" build check.

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -217,10 +217,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				$this->record_event( 'updated', 'update', $tracks_properties );
 			}
 
-			wp_send_json_success( array(
+			wp_send_json_success( [
 				'product_post_id' => $product_post_id,
 				'product_post_title' => $params['post_title'],
-			) );
+			] );
 		}
 
 		public function ajax_delete_payment_button() {
@@ -438,7 +438,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 			$form_product_email = ! empty( $new_instance['form_product_email'] )
 				? sanitize_text_field( $new_instance['form_product_email'] )
-				: $defaults['form_product_email'];
+				: $this->defaults()['form_product_email'];
 
 			return array_merge( $required_widget_props, array(
 				'form_product_id' => ( int ) $new_instance['form_product_id'],


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Reverts 071912304b61e264751beb67c6fa34c04e02a468
* Reverts 8697b273e28ff38a01feec69a1fbb00a33f32be5.

#### Testing instructions:

Check the Travis runs
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
