### PR TITLE
Widgets: fixes PHP's fatal class not found error on Simple Payments Widget

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -476,6 +476,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 	// Register Jetpack_Simple_Payments_Widget widget.
 	function register_widget_jetpack_simple_payments() {
+		if ( ! class_exists( 'Jetpack_Simple_Payments' ) ) {
+			return;
+		}
+
 		$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
 		if ( ! $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
 			return;


### PR DESCRIPTION
Fixes #9875

#### Changes proposed in this Pull Request:

* adds a existence check for the `Jetpack_Simple_Payments` class dependency on `Jetpack_Simple_Payments_Widget`.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Get this branch on a Multisite Installation
* Activate the Jetpack Plugin on the main site.
* Deactivate the Jetpack Plugin on the main site.

Previously, the site failed with a WSOD with this error:

```
PHP Fatal error:  Uncaught Error: Class 'Jetpack_Simple_Payments' not found in /var/www/html/wp-content/plugins/jetpack/modules/widgets/simple-payments.php:483
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(286): register_widget_jetpack_simple_payments('')
#1 /var/www/html/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array)
#2 /var/www/html/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#3 /var/www/html/wp-includes/widgets.php(1649): do_action('widgets_init')
#4 /var/www/html/wp-includes/class-wp-hook.php(286): wp_widgets_init('')
#5 /var/www/html/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array)
#6 /var/www/html/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#7 /var/www/html/wp-settings.php(450): do_action('init')
#8 /var/www/html/wp-config.php(83): require_once('/var/www/html/w...')
#9 /var/www/html/wp-load.php(37): require_once('/var/www/html/w...')
#10 /var/www/html/wp-admin/admin.php(31): require_once('/var/www/html/w...')
#11 /var/www/html/wp-admin/cu in /var/www/html/wp-content/plugins/jetpack/modules/widgets/simple-payments.php on line 483
```

which should no longer happen.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* fixed Fatal Error when disconnecting the main site on a multisite installation.