### PR TITLE
Lazy Images: Do not change image display for no JS support

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -263,16 +263,13 @@ class Jetpack_Lazy_Images {
 	public function add_nojs_fallback() {
 		?>
 			<style type="text/css">
-				.jetpack-lazy-image {
+				html:not( .jetpack-lazy-images-js-enabled ) .jetpack-lazy-image {
 					display: none;
-				}
-				.jetpack-lazy-images-js .jetpack-lazy-image {
-					display: block;
 				}
 			</style>
 			<script>
 				document.documentElement.classList.add(
-					'jetpack-lazy-images-js'
+					'jetpack-lazy-images-js-enabled'
 				);
 			</script>
 		<?php

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -267,7 +267,7 @@ class Jetpack_Lazy_Images {
 					display: none;
 				}
 				.jetpack-lazy-images-js .jetpack-lazy-image {
-					display: inline-block;
+					display: block;
 				}
 			</style>
 			<script>


### PR DESCRIPTION
To support browsers without JavaScript enabled, we made a change to hide lazily loaded images by default and then add a class with JavaScript which would show the lazy loaded image. This was done in #9780.

When released, at least two users reported issues with their images no longer being centered. This is because we were setting the display to `inline-block` when we decided to show the image. This PR changes that behavior so that we set display to `block` instead.

~Ideally, we would hide the lazily loaded images by appending a class to the HTML element when the post is rendered. Then, we could just remove the class with JavaScript. That being said, I am not aware of a great way to do this in WordPress.~ I just pushed a second commit to do just that. Essentially, I use a `not` selector on the `html` element to hide the image, and then use JavaScript to set the class on the `html` element which will show the lazy loaded image.

To test:

- Checkout branch
- Ensure lazy images module is on
- Load a post with images in it, with at least one image being centered
- Ensure the centered image does not fill the post content. If it does, crop it
- Reload post and ensure that image is properly centered

Before:

![before 9872](https://user-images.githubusercontent.com/5654161/42458823-31f09a50-83a3-11e8-8541-f953936c0a1f.png)

After:

![after 9872](https://user-images.githubusercontent.com/5654161/42458837-3bdc4aaa-83a3-11e8-86f5-0f125f47e3e6.png)


Fixes: #9879