### PR TITLE
Jetpack: Add wp_cli indictator to sync action actor

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -268,6 +268,7 @@ class Jetpack_Sync_Listener {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_wp_admin'      => is_admin(),
+			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
 		);
 
 		if ( $this->should_send_user_data_with_actor( $current_filter ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -99,6 +99,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_xmlrpc'        => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
+			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
 		);
 
 		$all = $queue->get_all();
@@ -132,6 +133,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'ip'               => jetpack_protect_get_ip(),
 			'user_agent'       => 'Jetpack Unit Tests',
+			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
 		);
 
 		$all = $queue->get_all();
@@ -163,7 +165,8 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,
 			'is_xmlrpc'        => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
-			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false
+			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
+			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
 		);
 
 		$all = $queue->get_all();


### PR DESCRIPTION
This change indicates whether the current action was triggered via the WordPress command line interface