### PR TITLE
Contact Form: Only optimize tables via a filter

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2962,21 +2962,18 @@ function grunion_delete_old_spam() {
 		wp_delete_post( $post_id, true );
 	}
 
-	// Arbitrary check points for running OPTIMIZE
-	// nothing special about 5000 or 11
-	// just trying to periodically recover deleted rows
-	$random_num = mt_rand( 1, 5000 );
 	if (
 		/**
-		 * Filter how often the module run OPTIMIZE TABLE on the core WP tables.
+		 * Filter if the module run OPTIMIZE TABLE on the core WP tables.
 		 *
 		 * @module contact-form
 		 *
 		 * @since 1.3.1
+		 * @since 6.4.0 Set to false by default.
 		 *
-		 * @param int $random_num Random number.
+		 * @param bool $filter Should Jetpack optimize the table, defaults to false.
 		 */
-		apply_filters( 'grunion_optimize_table', ( $random_num == 11 ) )
+		apply_filters( 'grunion_optimize_table', false )
 	) {
 		$wpdb->query( "OPTIMIZE TABLE $wpdb->posts" );
 	}


### PR DESCRIPTION
Fixes #2734

#### Changes proposed in this Pull Request:

* Only optimize tables upon specific intent. 

As described in 2734, Core restricts this type of activities behind a repair flag. All in all, either way, this is relatively safe since it runs on the daily cron and, even then, very randomly.

If we want to assist with optimization items like this, we should do it more intentionally than just within the contact form module.