### PR TITLE
General: Update PHP Codesniffer configuration to include the PHPCompatibility standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,9 @@
         "wp-coding-standards/wpcs": "^0.14.0",
         "sirbrillig/phpcs-variable-analysis": "^2.0",
         "wimg/php-compatibility": "^8.1"
+    },
+    "scripts": {
+      "php:5.2-compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-'  --standard=PHPCompatibility --ignore=docker,tools,tests,node_modules,vendor --extensions=php .",
+      "php:lint": "composer install && vendor/bin/phpcs -p"
     }
 }

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -150,6 +150,56 @@ We strongly recommend that you install tools to review your code in your IDE. It
 - You can find [Code Sniffer rules for WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation) here. Once you've installed these rulesets, you can [follow the instructions here](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use) to configure your IDE.
 - For JavaScript, we recommend installing ESLint. Most IDEs come with an ESLint plugin that you can use. Jetpack includes a `.eslintrc` file that defines our coding standards.
 
+### Linting Jetpack's PHP
+
+You can easily run these commands to set up all the rulesets and then lint Jetpack's PHP code:
+
+This will install all the CodeSniffer rulesets we need for linting Jetpack's PHP code. You may need to do this only once.
+
+```sh
+$ composer install
+```
+
+This runs the actual linting task.
+
+```sh
+$ composer php:lint
+```
+
+_There's also a handy `yarn php:lint` that will run `composer php:lint` if you prefer_.
+
+```sh
+$ yarn php:lint
+```
+
+### Checking Jetpack's PHP for PHP 5.2 Compatibility
+
+We have a handy `composer` script that will just run the PHP CodeSniffer `PHPCompatibility` ruleset checking for code not compatible with PHP 5.2
+
+```sh
+$ composer php:5.2-compatibility
+```
+
+_There's also a handy `yarn php:5.2-compatibility` that will run `composer php:5.2-compatibility` if you prefer_.
+
+```sh
+$ yarn php:5.2-compatibility
+```
+
+
+### Linting Jetpack's JavaScript
+
+`yarn lint` will check syntax and style in the following JavaScript pieces:
+
+* All the frontend JavaScript that Jetpack relies on.
+* All the JavaScript present in the Admin Page Single Page App for Jetpack.
+
+```sh
+$ yarn lint
+```
+
+_If you haven't done it yet, you may need to run `yarn` before `yarn lint` for installing node modules for this task_.
+
 ## Developing and contributing code to Jetpack from a Windows machine
 
 When working on a Windows machine, you can use [Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux). You may, however, run into issues when you want to commit your changes. In this case, and if you use an IDE like PHPStorm, you can follow the recommendations in [this post](https://alex.blog/2018/02/21/guide-to-having-phpstorm-use-windows-subsystem-for-linux-git/) to have PhpStorm Use Windows Subsystem For Linux’s Git.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
     "php:5.2-compatibility": "composer php:5.2-compatibility",
     "php:lint": "composer php:lint",
+    "test-adminpage": "yarn test-client && yarn test-gui",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
     "docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
     "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
+    "php:5.2-compatibility": "composer php:5.2-compatibility",
+    "php:lint": "composer php:lint",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<config name="minimum_supported_wp_version" value="4.7" />
 	<config name="testVersion" value="5.2-"/>
 
+	<rule ref="PHPCompatibility" />
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />


### PR DESCRIPTION
We had the PHP Codesniffer standard `PHPCompatibility` already be installed by composer but not declared in the `phpcs.xml' file. 


#### Changes proposed in this Pull Request:

* Updates `phpcs.xml` to use `PHPCompatibility` as a rule.
* Introduces two `composer` scripts:
  * `composer php:5.2-compatibility`.
  * `composer php:lint`.
  * Updates `development-environment.md` to mention these commands.
* Introduces three `yarn`/`npm` scripts:
  * `yarn php:5.2-compatibility`. Wrapper for `composer php:5.2-compatibility`. 
  * `yarn php:lint`. Wrapper for `composer php:lint`.
  * `test-adminpage`. Wrapper for `yarn test-client && yarn test-gui`.

#### Testing instructions:

* Checkout this branch
* Run `yarn php:5.2-compatibility` and expect to see a lot of errors only related to the Jetpack PHP code being not fully compatible with PHP 5.x versions.
* Run `yarn php:lint` and expect to see a lot of errors. (The ones you saw with the command above and a lot more).
* Run `yarn test-adminpage` and expect to see the linting tasks run but no errors.