### PR TITLE
Quick tour: don't scroll to top

### DIFF
--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -36,7 +36,9 @@
 		transitionSlideToIndex( $( this ).index() );
 	} );
 
-	nextFeatureButtons.on( 'click', function() {
+	nextFeatureButtons.on( 'click', function( e ) {
+		e.preventDefault();
+
 		var slideIndex = $( this )
 			.closest( '.jp-wpcom-connect__slide' )
 			.index();


### PR DESCRIPTION
Make sure we don't scroll users to top when clicking “Start quick tour” or “Next feature” on the quick tour banner.

Reported in p6TEKc-2c8-p2

#### Testing instructions

- Spin up a new site; jurassic.ninja is your friend.
- Make sure the “next step” links on the quick tour banner don't scroll the browser window to the top.