### PR TITLE
Connection splash: update copy on contact us button

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -973,7 +973,7 @@ class Jetpack_Connection_Banner {
 
 			<p class="jp-connect-full__button-container">
 				<a href="https://jetpack.com/contact-support/" class="dops-button">
-					<?php esc_html_e( 'Chat with us', 'jetpack' ); ?>
+					<?php esc_html_e( 'Get in touch with us', 'jetpack' ); ?>
 				</a>
 				<a href="https://jetpack.com/support" class="dops-button">
 					<?php esc_html_e( 'Search our support site', 'jetpack' ); ?>


### PR DESCRIPTION
> Change “Chat with Us” to “Get in touch with us” since we don’t have embedded chat on the support site yet.

Reported in p6TEKc-2c8-p2

#### Testing instructions:

- Spin up a new site; jurassic.ninja is your friend.
- Confirm that the contact us (secondary) button on the connection splash shows the updated label.