### PR TITLE
Ensure we are properly giving priority to creator when a site has no …

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -26,6 +26,15 @@ class Jetpack_Twitter_Cards {
 		 * These tags apply to any page (home, archives, etc)
 		 */
 
+		// If we have information on the author/creator, then include that as well
+		if ( ! empty( $post ) && ! empty( $post->post_author ) ) {
+			/** This action is documented in modules/sharedaddy/sharing-sources.php */
+			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID );
+			if ( ! empty( $handle ) && 'wordpressdotcom' != $handle && 'jetpack' != $handle ) {
+				$og_tags['twitter:creator'] = self::sanitize_twitter_user( $handle );
+			}
+		}
+
 		$site_tag = self::site_tag();
 		/** This action is documented in modules/sharedaddy/sharing-sources.php */
 		$site_tag = apply_filters( 'jetpack_sharing_twitter_via', $site_tag, ( is_singular() ? $post->ID : null ) );
@@ -107,15 +116,6 @@ class Jetpack_Twitter_Cards {
 
 		$og_tags['twitter:card'] = $card_type;
 
-		// If we have information on the author/creator, then include that as well
-		if ( ! empty( $post ) && ! empty( $post->post_author ) ) {
-			/** This action is documented in modules/sharedaddy/sharing-sources.php */
-			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID );
-			if ( ! empty( $handle ) && 'wordpressdotcom' != $handle && 'jetpack' != $handle ) {
-				$og_tags['twitter:creator'] = self::sanitize_twitter_user( $handle );
-			}
-		}
-
 		// Make sure we have a description for Twitter, their validator isn't happy without some content (single space not valid).
 		if ( ! isset( $og_tags['og:description'] ) || '' == trim( $og_tags['og:description'] ) || __('Visit the post for more.', 'jetpack') == $og_tags['og:description'] ) { // empty( trim( $og_tags['og:description'] ) ) isn't valid php
 			$has_creator = ( ! empty($og_tags['twitter:creator']) && '@wordpressdotcom' != $og_tags['twitter:creator'] ) ? true : false;
@@ -143,9 +143,13 @@ class Jetpack_Twitter_Cards {
 		return '@' . preg_replace( '/^@/', '', $str );
 	}
 
+	static function is_default_site_tag( $site_tag ) {
+	    return in_array( $site_tag, array( '@wordpressdotcom', '@jetpack', 'wordpressdotcom', 'jetpack' ) );
+    }
+
 	static function prioritize_creator_over_default_site( $site_tag, $og_tags = array() ) {
-		if ( ! empty( $og_tags['twitter:creator'] ) && in_array( $site_tag, array( '@wordpressdotcom', '@jetpack' ) ) ) {
-			$site_tag = $og_tags['twitter:creator'];
+		if ( ! empty( $og_tags['twitter:creator'] ) && self::is_default_site_tag( $site_tag ) ) {
+			return $og_tags['twitter:creator'];
 		}
 		return $site_tag;
 	}

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -30,7 +30,7 @@ class Jetpack_Twitter_Cards {
 		if ( ! empty( $post ) && ! empty( $post->post_author ) ) {
 			/** This action is documented in modules/sharedaddy/sharing-sources.php */
 			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID );
-			if ( ! empty( $handle ) && 'wordpressdotcom' != $handle && 'jetpack' != $handle ) {
+			if ( ! empty( $handle ) && ! self::is_default_site_tag( $handle ) ) {
 				$og_tags['twitter:creator'] = self::sanitize_twitter_user( $handle );
 			}
 		}
@@ -144,8 +144,8 @@ class Jetpack_Twitter_Cards {
 	}
 
 	static function is_default_site_tag( $site_tag ) {
-	    return in_array( $site_tag, array( '@wordpressdotcom', '@jetpack', 'wordpressdotcom', 'jetpack' ) );
-    }
+		return in_array( $site_tag, array( '@wordpressdotcom', '@jetpack', 'wordpressdotcom', 'jetpack' ) );
+	}
 
 	static function prioritize_creator_over_default_site( $site_tag, $og_tags = array() ) {
 		if ( ! empty( $og_tags['twitter:creator'] ) && self::is_default_site_tag( $site_tag ) ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -589,7 +589,11 @@ class Share_Twitter extends Sharing_Source {
 		 * @param string $string Twitter Username.
 		 * @param array $args Array of Open Graph Meta Tags and Twitter Cards tags.
 		 */
-		$twitter_site_tag_value = apply_filters( 'jetpack_twitter_cards_site_tag', '', array() );
+		$twitter_site_tag_value = apply_filters(
+		        'jetpack_twitter_cards_site_tag',
+                '',
+                array( 'twitter:creator' => apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID ) )
+        );
 
 		/*
 		 * Hack to remove the unwanted behavior of adding 'via @jetpack' which

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -590,12 +590,10 @@ class Share_Twitter extends Sharing_Source {
 		 * @param array $args Array of Open Graph Meta Tags and Twitter Cards tags.
 		 */
 		$twitter_site_tag_value = apply_filters(
-		        'jetpack_twitter_cards_site_tag',
-				'',
-				array( 'twitter:creator' =>
-					   /** This action is documented in modules/sharedaddy/sharing-sources.php */
-					   apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID )
-				)
+			'jetpack_twitter_cards_site_tag',
+			'',
+			/** This action is documented in modules/sharedaddy/sharing-sources.php */
+			array( 'twitter:creator' => apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID ) )
 		);
 
 		/*

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -591,9 +591,12 @@ class Share_Twitter extends Sharing_Source {
 		 */
 		$twitter_site_tag_value = apply_filters(
 		        'jetpack_twitter_cards_site_tag',
-                '',
-                array( 'twitter:creator' => apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID ) )
-        );
+				'',
+				array( 'twitter:creator' =>
+					   /** This action is documented in modules/sharedaddy/sharing-sources.php */
+					   apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID )
+				)
+		);
 
 		/*
 		 * Hack to remove the unwanted behavior of adding 'via @jetpack' which


### PR DESCRIPTION
This fixes an issue that is only affecting wordpress.com sites:

see p2EDhh-rQ-p2
and D15968-code

To test:

1. Apply this patch to your site and ensure you can still
a) set a default twitter handle for your sharing buttons, and that your default twitter handle appears when you click a share-via-twitter button
b) when you publicize a post, and no default twitter handle is set, ensure the twitter handle used in publicize is present when you click a share-via-twitter button