### PR TITLE
Widgets: Add jetpack_top_posts_widget_layout filter

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -328,8 +328,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 * @param array $posts IDs of the posts to be displayed
 		 * @param array $display Display option from widget form
 		 */
-		$layout = apply_filters('jetpack_top_posts_widget_layout', '', $posts, $display );
-		if (!empty($layout)) {
+		$layout = apply_filters( 'jetpack_top_posts_widget_layout', '', $posts, $display );
+		if ( ! empty( $layout ) ) {
 			echo $layout;
 			echo $args['after_widget'];
 			return;

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -324,7 +324,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 *
 		 * @module widgets
 		 * 
-		 * @since 4.5.0 
+		 * @since 6.4.0 
 		 *
 		 * @param string $layout layout of the Top Posts Widget (empty string)
 		 * @param array $posts IDs of the posts to be displayed

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -319,6 +319,13 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			return;
 		}
 
+		$layout = apply_filters('jetpack_top_posts_widget_layout', '', $posts, $display );
+		if (!empty($layout)) {
+			echo $layout;
+			echo $args['after_widget'];
+			return;
+		}
+
 		switch ( $display ) {
 		case 'list' :
 		case 'grid' :

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -319,6 +319,15 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			return;
 		}
 
+		/**
+		 * Filter the layout of the Top Posts Widget
+		 *
+		 * @module widgets
+		 * 
+		 * @param string $layout layout of the Top Posts Widget (empty string)
+		 * @param array $posts IDs of the posts to be displayed
+		 * @param array $display Display option from widget form
+		 */
 		$layout = apply_filters('jetpack_top_posts_widget_layout', '', $posts, $display );
 		if (!empty($layout)) {
 			echo $layout;

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -324,6 +324,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 *
 		 * @module widgets
 		 * 
+		 * @since 4.5.0 
+		 *
 		 * @param string $layout layout of the Top Posts Widget (empty string)
 		 * @param array $posts IDs of the posts to be displayed
 		 * @param array $display Display option from widget form


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* A `jetpack_top_posts_widget_layout` filter has been added that allows you to create a custom display layout for the <b>Top posts</b> widget

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Everything should work as before