### PR TITLE
Indicate when user email changes via Jetpack sync

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -254,6 +254,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			$this->flags[ $user_id ]['email_changed'] = true;
 		}
 
+		$flags = $this->get_flags( $user_id );
+		error_log('flags are ' . print_r( $flags , true));
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -41,7 +41,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'jetpack_deleted_user', $callable, 10, 3 );
 		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
 		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
-		
+
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
 		add_action( 'set_user_role', array( $this, 'save_user_role_handler' ), 10, 3 );
@@ -242,8 +242,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		}
 		if ( $old_user !== null && $user->data->user_email !== $old_user->user_email ) {
 			// The '_new_email' user meta is deleted right after the call to wp_update_user
-			// that got us to this point, https://opengrok.a8c.com/source/xref/trunk/wp-admin/user-edit.php#101
-			// so if it's still set then this was a user confirming their new email address
+			// that got us to this point so if it's still set then this was a user confirming
+			// their new email address
 			if ( 1 === intval( get_user_meta( $user->ID, '_new_email', true ) ) ) {
 				$this->flags[ $user_id ]['email_changed'] = true;
 			}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -80,13 +80,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'expand_users' ) );
 	}
 
-	public function deleted_user_meta_handler( $meta_ids, $object_id, $meta_key, $_meta_value ) {
-		error_log(print_r( $meta_ids, true ));
-		error_log($object_id);
-		error_log( $meta_key);
-		error_log( $_meta_value );
-	}
-
 	private function get_user( $user ) {
 		if ( is_numeric( $user ) ) {
 			$user = get_user_by( 'id', $user );
@@ -146,7 +139,6 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_action( $args ) {
-		error_log("EXPAND CALLED WITH" . print_r( $args, true));
 		// the first argument is always the user
 		list( $user ) = $args;
 		if ( $user ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -259,7 +259,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			$this->flags[ $user_id ]['email_changed'] = true;
 		}
 
-		error_log(print_r( $this->flags[ $user_id ], true) );
+		//error_log(print_r( $this->flags[ $user_id ], true) );
 
 		$flags = $this->get_flags( $user_id );
 		error_log('flags are ' . print_r( $flags , true));

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -249,7 +249,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
-		error_log(print_r( $old_user, true));
+		if ( $old_user !== null && $user->user_email !== $old_user->user_email ) {
+			$this->flags[ $user_id ]['email_changed'] = true;
+		}
 
 		/**
 		 * Fires when the client needs to sync an updated user

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -247,22 +247,19 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		} else {
 			$old_user = $old_user_data;
 		}
-		error_log("Old user is: " . print_r($old_user, true));
-		error_log("New user is: " . print_r($user, true));
 
 		if ( $old_user !== null && $user->data->user_pass !== $old_user->user_pass ) {
-			error_log("SETTING PASSWORD CHANGED");
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
 		if ( $old_user !== null && $user->data->user_email !== $old_user->user_email ) {
-			error_log("SETTING EMAIL CHANGED");
-			$this->flags[ $user_id ]['email_changed'] = true;
+			// The '_new_email' user meta is deleted right after the call to wp_update_user
+			// that got us to this point, https://opengrok.a8c.com/source/xref/trunk/wp-admin/user-edit.php#101
+			// so if it's still set then this was a user confirming their new email address
+			if ( 1 === intval( get_user_meta( $user->ID, '_new_email', true ) ) ) {
+				$this->flags[ $user_id ]['email_changed'] = true;
+			}
 		}
 
-		//error_log(print_r( $this->flags[ $user_id ], true) );
-
-		$flags = $this->get_flags( $user_id );
-		error_log('flags are ' . print_r( $flags , true));
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -42,6 +42,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
 		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
 
+		//Confirmed new email address
+		add_action( 'deleted_user_meta', array( $this, 'deleted_user_meta_handler' ), 10, 4 );
+
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
 		add_action( 'set_user_role', array( $this, 'save_user_role_handler' ), 10, 3 );
@@ -75,6 +78,13 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'expand_users' ) );
+	}
+
+	public function deleted_user_meta_handler( $meta_ids, $object_id, $meta_key, $_meta_value ) {
+		error_log(print_r( $meta_ids, true ));
+		error_log($object_id);
+		error_log( $meta_key);
+		error_log( $_meta_value );
 	}
 
 	private function get_user( $user ) {
@@ -239,6 +249,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
+		error_log(print_r( $old_user, true));
 
 		/**
 		 * Fires when the client needs to sync an updated user

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -248,7 +248,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			$old_user = $old_user_data;
 		}
 
-		if ( $old_user !== null && $user->data->user_pass !== $old_user->user_pass ) {
+		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
 		if ( $old_user !== null && $user->data->user_email !== $old_user->user_email ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -248,13 +248,15 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			$old_user = $old_user_data;
 		}
 		error_log("Old user is: " . print_r($old_user, true));
-		
+
 		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
 		if ( $old_user !== null && $user->user_email !== $old_user->user_email ) {
 			$this->flags[ $user_id ]['email_changed'] = true;
 		}
+
+		error_log(print_r( $this->flags[ $user_id ], true) );
 
 		$flags = $this->get_flags( $user_id );
 		error_log('flags are ' . print_r( $flags , true));

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -146,6 +146,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_action( $args ) {
+		error_log("EXPAND CALLED WITH" . print_r( $args, true));
 		// the first argument is always the user
 		list( $user ) = $args;
 		if ( $user ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -248,11 +248,14 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			$old_user = $old_user_data;
 		}
 		error_log("Old user is: " . print_r($old_user, true));
+		error_log("New user is: " . print_r($user, true));
 
 		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
+			error_log("SETTING PASSWORD CHANGED");
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
 		if ( $old_user !== null && $user->user_email !== $old_user->user_email ) {
+			error_log("SETTING EMAIL CHANGED");
 			$this->flags[ $user_id ]['email_changed'] = true;
 		}
 

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -247,6 +247,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		} else {
 			$old_user = $old_user_data;
 		}
+		error_log("Old user is: " . print_r($old_user, true));
+		
 		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -250,11 +250,11 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		error_log("Old user is: " . print_r($old_user, true));
 		error_log("New user is: " . print_r($user, true));
 
-		if ( $old_user !== null && $user->user_pass !== $old_user->user_pass ) {
+		if ( $old_user !== null && $user->data->user_pass !== $old_user->user_pass ) {
 			error_log("SETTING PASSWORD CHANGED");
 			$this->flags[ $user_id ]['password_changed'] = true;
 		}
-		if ( $old_user !== null && $user->user_email !== $old_user->user_email ) {
+		if ( $old_user !== null && $user->data->user_email !== $old_user->user_email ) {
 			error_log("SETTING EMAIL CHANGED");
 			$this->flags[ $user_id ]['email_changed'] = true;
 		}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -41,10 +41,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'jetpack_deleted_user', $callable, 10, 3 );
 		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
 		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
-
-		//Confirmed new email address
-		add_action( 'deleted_user_meta', array( $this, 'deleted_user_meta_handler' ), 10, 4 );
-
+		
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
 		add_action( 'set_user_role', array( $this, 'save_user_role_handler' ), 10, 3 );


### PR DESCRIPTION
Indicate via Jetpack sync when user confirms email address change for display in the Activity Log.

Testing instructions: 
Change your super admin email address and confirm via email. Confirm sync payload indicates email changed.