### PR TITLE
Fix: When we update core in using calypso we wouldn't send the event as a core autoupdate

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -87,7 +87,10 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		}
 
 		// Core was autoudpated
-		if ( 'update-core.php' !== $pagenow ) {
+		if (
+			'update-core.php' !== $pagenow &&
+			Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com api request do should not autoupdate core
+		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful
 			 *

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -89,7 +89,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		// Core was autoudpated
 		if (
 			'update-core.php' !== $pagenow &&
-			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com api request do should not autoupdate core
+			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
 		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -89,7 +89,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		// Core was autoudpated
 		if (
 			'update-core.php' !== $pagenow &&
-			Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com api request do should not autoupdate core
+			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com api request do should not autoupdate core
 		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -37,7 +37,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
 		$theme = reset( $updates->response );
-		
+
 		$this->assertTrue( (bool) $theme['name'] );
 		$this->assertTrue( is_int( $updates->last_checked ) );
 	}
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertTrue( is_int( $updates->last_checked ) );
-		
+
 		// Since the transient gets updates twice and we only care about the
 		// last update we only want to see 1 sync event.
 		$events = $this->server_event_storage->get_all_events( 'jetpack_update_core_change' );
@@ -136,6 +136,24 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // Old Version
+		$this->assertEquals( $event->args[1], $wp_version ); // New version
+	}
+
+	public function test_update_core_successfully_sync_action_using_wpcom_rest_api() {
+		global $wp_version, $pagenow;
+
+		$this->assertFalse( $pagenow === 'update-core.php' );
+		Jetpack_Constants::set_constant( 'REST_API_REQUEST', false );
+		Jetpack_Sync_Modules::get_module( "updates" )->update_core( 'new_version' );
+		$this->sender->do_sync();
+
+		Jetpack_Constants::clear_single_constant( 'REST_API_REQUEST' );
+
+		$autoupdate_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_autoupdated_successfully' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_updated_successfully' );
+		$this->assertFalse( (bool) $autoupdate_event );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $event->args[0], 'new_version' ); // Old Version
 		$this->assertEquals( $event->args[1], $wp_version ); // New version
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -143,7 +143,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		global $wp_version, $pagenow;
 
 		$this->assertFalse( $pagenow === 'update-core.php' );
-		Jetpack_Constants::set_constant( 'REST_API_REQUEST', false );
+		Jetpack_Constants::set_constant( 'REST_API_REQUEST', true );
 		Jetpack_Sync_Modules::get_module( "updates" )->update_core( 'new_version' );
 		$this->sender->do_sync();
 


### PR DESCRIPTION
This Pr makes sure that we do not mark updating core via calypso as a autoupdate in the Activity log.



#### Changes proposed in this Pull Request:

* Check that the constant REST_API_REQUEST is not defined or set to false. 

#### Testing instructions:
Set your site to need an update. By changing $wp_version in wp-include/version.php
use the core/update api endpoint to update the site to the latest version. 

Notice in the activity log we say who updated the core in the activity log as expected.
