### PR TITLE
Try moving Danger CI into existing container to speedup TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ matrix:
   - php: "5.2"
     env: WP_MODE=multi  WP_BRANCH=master
     dist: precise
-  - env: WP_TRAVISCI="yarn test-everything"
+  - env: WP_TRAVISCI="yarn lint"
+  - env: WP_TRAVISCI="yarn test-client"
+  - env: WP_TRAVISCI="yarn test-dangerci-and-gui"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ matrix:
     dist: precise
   - env: WP_TRAVISCI="yarn lint"
   - env: WP_TRAVISCI="yarn test-client"
-  - env: WP_TRAVISCI="yarn test-gui"
-  - env: WP_TRAVISCI="yarn danger ci"
+  - env: WP_TRAVISCI="yarn danger ci && yarn test-gui"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ matrix:
     env: WP_MODE=multi  WP_BRANCH=master
     dist: precise
   - env: WP_TRAVISCI="yarn lint"
-  - env: WP_TRAVISCI="yarn test-client"
-  - env: WP_TRAVISCI="yarn test-dangerci-and-gui"
+  - env: WP_TRAVISCI="yarn test-dangerci-and-adminpage"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,7 @@ matrix:
   - php: "5.2"
     env: WP_MODE=multi  WP_BRANCH=master
     dist: precise
-  - env: WP_TRAVISCI="yarn lint"
-  - env: WP_TRAVISCI="yarn test-client"
-  - env: WP_TRAVISCI="yarn test-adminpage"
+  - env: WP_TRAVISCI="yarn test-everything"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     dist: precise
   - env: WP_TRAVISCI="yarn lint"
   - env: WP_TRAVISCI="yarn test-client"
-  - env: WP_TRAVISCI="yarn danger ci && yarn test-gui"
+  - env: WP_TRAVISCI="yarn test-adminpage"
 
 cache:
   directories:

--- a/_inc/client/test/main.js
+++ b/_inc/client/test/main.js
@@ -12,8 +12,8 @@ Enzyme.configure( { adapter: new Adapter() } );
 /**
  * Internal dependencies
  */
-import Main from '../main';
-import store from 'state/redux-store';
+//import Main from '../main';
+//import store from 'state/redux-store';
 
 describe( 'Main', () => {
 	it( 'should render the Main component', () => {

--- a/_inc/client/test/main.js
+++ b/_inc/client/test/main.js
@@ -12,8 +12,8 @@ Enzyme.configure( { adapter: new Adapter() } );
 /**
  * Internal dependencies
  */
-//import Main from '../main';
-//import store from 'state/redux-store';
+import Main from '../main';
+import store from 'state/redux-store';
 
 describe( 'Main', () => {
 	it( 'should render the Main component', () => {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js gui",
     "precommit": "node bin/pre-commit-hook.js",
     "test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js modules",
-    "test-dangerci-and-gui": "yarn danger ci && yarn test-gui"
+    "test-dangerci-and-adminpage": "yarn danger ci && yarn test-adminpage"
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "build-pot": "grunt makepot",
     "test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js gui",
     "precommit": "node bin/pre-commit-hook.js",
-    "test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js modules"
+    "test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js modules",
+    "test-everything": "yarn danger ci && yarn test-client && yarn test-gui && yarn lint"
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js gui",
     "precommit": "node bin/pre-commit-hook.js",
     "test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js modules",
-    "test-everything": "yarn danger ci && yarn test-client && yarn test-gui && yarn lint"
+    "test-dangerci-and-gui": "yarn danger ci && yarn test-gui"
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Move Danger CI from a unique container into existing container to speedup TravisCI builds. Danger CI now runs before `test-adminpage` in a shared container.
* Since Danger CI will not fail a build in any situation, this should not affect the use of `test-adminpage` (which in itself combined `test-gui` and `test-client`)
* Both are combined in `test-dangerci-and-adminpage` for running in TravisCI.

#### Testing instructions:

* `test-dangerci-and-adminpage` should be running on the last container/job in TravisCI. Confirm both Danger CI and `test-adminpage` are run inside.