### PR TITLE
Added a listener for WooCommerce fragment update event.

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -20,6 +20,9 @@ var jetpackLazyImagesModule = function( $ ) {
 
 		// Add event to provide optional compatibility for other code.
 		$( 'body' ).bind( 'jetpack-lazy-images-load', lazy_load_init );
+
+		// WooCommerce updates the cart with new HTML, we need to trigger init when it's done
+		$( 'body' ).bind( 'wc_fragments_refreshed', lazy_load_init );
 	} );
 
 	function lazy_load_init() {


### PR DESCRIPTION
Before with Lazy Loading Images enabled the images updated from received fragments wouldn't load because Jetpack doesn't know to reinit them. This change adds a listener to a specific WooCommerce event that gets triggered on cart refresh. See: https://github.com/woocommerce/woocommerce/blob/d3b98d88f245814797f7426dccece1cbb623dfcd/assets/js/frontend/cart-fragments.js#L57

Fixes #9914 

#### Changes proposed in this Pull Request:
* Adds an event that allows Jetpack to load images on cart refresh.

#### Testing instructions:
* Get a WooCommerce testing store with Salient theme.
* Add some items into the cart, go to the cart.
* Update the quantity and save.
* See that images do not load.
* Use this PR and see that images start loading fine after quantity update.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed a compatibility issue between Lazy Images and WooCommerce cart page.