### PR TITLE
Lazy Images: WooCommerce: Adds compat for lazy images when updating cart quantity

### DIFF
--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -93,3 +93,13 @@ function jetpack_woocommerce_infinite_scroll_style() {
 	}";
 	wp_add_inline_style( 'woocommerce-layout', $custom_css );
 }
+
+function jetpack_woocommerce_lazy_images_compat() {
+	wp_add_inline_script( 'wc-cart-fragments', "
+		jQuery( 'body' ).bind( 'wc_fragments_refreshed', function() {
+			jQuery( 'body' ).trigger( 'jetpack-lazy-images-load' );
+		} );
+	" );
+}
+
+add_action( 'wp_enqueue_scripts', 'jetpack_woocommerce_lazy_images_compat', 11 );


### PR DESCRIPTION
Fixes #9914

In testing, I noticed that the images returned from the AJAX request are not processed by the lazy images module. You can see this yourself by adding a `console.log( data );` around this line: https://github.com/woocommerce/woocommerce/blob/387093cd27f097c71b2fcb4bfd73362d058c3ed9/assets/js/frontend/cart-fragments.js#L42

Note, you'll also need to set `define( 'SCRIPT_DEBUG', true);` in `wp-config.php` to load the non-minified file.

This makes me think that the initial lazy loaded image, that is set when the page initially loads, is being stored somewhere in the Woo script. We should probably find that. Perhaps @coderkevin or @mikejolley can help explain why that is happening and or correct me if I'm wrong.

That being said, this PR does fix the reported issue.

#### Changes proposed in this Pull Request:

* Add a listener for when WooCommerce shopping cart fragments are loaded that triggers loading lazy images.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->
* Get a WooCommerce testing store with Salient theme.
* Add some items into the cart, go to the cart.
* Update the quantity and save.
* See that images do not load.
* Use this PR and see that images start loading fine after quantity update.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
