### PR TITLE
Infinite Scroll: Add privacy policy link

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1542,11 +1542,7 @@ class The_Neverending_Home_Page {
 	 */
 	private function default_footer() {
 		if ( get_privacy_policy_url() !== '' ) {
-			$credits = sprintf(
-				'<a href="%1$s" rel="noopener noreferrer" target="_blank">%2$s</a><span role="separator" aria-hidden="true"> / </span>',
-				get_privacy_policy_url(),
-				__( 'Privacy Policy', 'jetpack' )
-			);
+			$credits = get_the_privacy_policy_link() . ' / ';
 		} else {
 			$credits = '';
 		}

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1541,7 +1541,7 @@ class The_Neverending_Home_Page {
 	 *
 	 */
 	private function default_footer() {
-		if ( function_exists( 'get_privacy_policy_url' ) && (get_privacy_policy_url() !== '') ) {
+		if ( function_exists( 'get_privacy_policy_url' ) && ( '' !== get_privacy_policy_url() ) ) {
 			$credits = get_the_privacy_policy_link() . '<span role="separator" aria-hidden="true"> / </span>';
 		} else {
 			$credits = '';

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1545,7 +1545,7 @@ class The_Neverending_Home_Page {
 			$credits = sprintf(
 				'<a href="%1$s" rel="noopener noreferrer" target="_blank">%2$s</a><span role="separator" aria-hidden="true"> / </span>',
 				get_privacy_policy_url(),
-				__('Privacy Policy', 'jetpack' )
+				__( 'Privacy Policy', 'jetpack' )
 			);
 		} else {
 			$credits = '';

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1538,12 +1538,14 @@ class The_Neverending_Home_Page {
 	 *
 	 * @uses __, wp_get_theme, apply_filters, home_url, esc_attr, get_bloginfo, bloginfo
 	 * @return string
+	 *
 	 */
 	private function default_footer() {
-		if ( function_exists( 'the_privacy_policy_link' ) ) {
+		if ( get_privacy_policy_url() !== '' ) {
 			$credits = sprintf(
-				__( '%1$s / ', 'jetpack' ),
-				the_privacy_policy_link()
+				'<a href="%1$s" rel="noopener noreferrer" target="_blank">%2$s</a><span role="separator" aria-hidden="true"> / </span>',
+				get_privacy_policy_url(),
+				__('Privacy Policy', 'jetpack' )
 			);
 		} else {
 			$credits = '';
@@ -1557,7 +1559,6 @@ class The_Neverending_Home_Page {
 			__( 'Theme: %1$s.', 'jetpack' ),
 			wp_get_theme()->Name
 		);
-
 		/**
 		 * Filter Infinite Scroll's credit text.
 		 *

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1541,8 +1541,8 @@ class The_Neverending_Home_Page {
 	 *
 	 */
 	private function default_footer() {
-		if ( get_privacy_policy_url() !== '' ) {
-			$credits = get_the_privacy_policy_link() . ' / ';
+		if ( function_exists( 'get_privacy_policy_url' ) && (get_privacy_policy_url() !== '') ) {
+			$credits = get_the_privacy_policy_link() . '<span role="separator" aria-hidden="true"> / </span>';
 		} else {
 			$credits = '';
 		}

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1540,7 +1540,15 @@ class The_Neverending_Home_Page {
 	 * @return string
 	 */
 	private function default_footer() {
-		$credits = sprintf(
+		if ( function_exists( 'the_privacy_policy_link' ) ) {
+			$credits = sprintf(
+				__( '%1$s / ', 'jetpack' ),
+				the_privacy_policy_link()
+			);
+		} else {
+			$credits = '';
+		}
+		$credits .= sprintf(
 			'<a href="https://wordpress.org/" rel="noopener noreferrer" target="_blank" rel="generator">%1$s</a> ',
 			__( 'Proudly powered by WordPress', 'jetpack' )
 		);
@@ -1549,6 +1557,7 @@ class The_Neverending_Home_Page {
 			__( 'Theme: %1$s.', 'jetpack' ),
 			wp_get_theme()->Name
 		);
+
 		/**
 		 * Filter Infinite Scroll's credit text.
 		 *


### PR DESCRIPTION
Fixes #9435 

WP bundled themes now have a privacy policy link in their footer, which
is helpful for complying with GDPR rules, but users who enable the infinite
footer lose that link. This adds a similar link to the infinity footer $credits.

#### Changes proposed in this Pull Request:

* Add a privacy policy link to `$credits` to mimic the new WP bundled theme link

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Publish the privacy policy page on test site
* Enable infinite scroll with this patch applied
* Scroll down to display the infinite footer
* Confirm that it now includes a link to the privacy policy page

(Edit: Added extra step for testing.)

