### PR TITLE
Make Gutenberg be checked by default in Jetpack Live branches

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.4
+// @version      1.5
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -16,7 +16,7 @@
 		const branch = jQuery( '.head-ref' ).text();
 		const branchIsForked = branch.includes( ':' );
 		const branchIsMerged = $( '.gh-header-meta .State' ).text().trim() === 'Merged';
-		const query = 'jetpack-beta&branch=' + branch + '&shortlived&wp-debug-log';
+		const query = 'jetpack-beta&branch=' + branch + '&shortlived&wp-debug-log&gutenberg';
 		const base = 'https://jurassic.ninja/create?';
 		let link = base + query;
 		const canLiveTestText =
@@ -26,7 +26,7 @@
 			'<ul>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" class="task-list-item-checkbox">Launch with Gutenberg installed</li>' +
+			'<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>' +
 			'<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>' +


### PR DESCRIPTION
Updates the Jetpack Live Branches Tampermonkey script to have Gutenberg checked by default.


#### Changes proposed in this Pull Request:

* Updates the `jetpack-live-branches.user.js` Tampermonkey script to have Gutenberg checked by default.

#### Testing instructions:

* Install ths `1.5` version of the script by [clicking here](https://github.com/Automattic/jetpack/raw/update/jetpack-live-branches-gutenberg-checked-by-default/tools/jetpack-live-branches/jetpack-live-branches.user.js).
* visit a Pull Request.
* Expect Gutenberg to be checked by default

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->




#### Before

![image](https://user-images.githubusercontent.com/746152/42762588-19866fe6-88e7-11e8-87cf-889c435c89b7.png)


#### After

![image](https://user-images.githubusercontent.com/746152/42762604-2163c858-88e7-11e8-8ee8-1eb5aba70322.png)
