### PR TITLE
Shortcodes: Add flat.io oEmbed

### DIFF
--- a/modules/shortcodes/flatio.php
+++ b/modules/shortcodes/flatio.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * Flat.io embed
+ *
+ * example URL: https://flat.io/score/5a5268ed41396318cbd7772c-string-quartet-for-rainy-days
+*/
+
+// Register oEmbed provider
+wp_oembed_add_provider( 'https://flat.io/score/*', 'https://flat.io/services/oembed', false );
+wp_oembed_add_provider( 'https://*.flat.io/score/*', 'https://flat.io/services/oembed', false );


### PR DESCRIPTION
Adds oEmbed endpoint for flat.io.

To test:
1. Start a new post and paste `https://flat.io/score/5a5268ed41396318cbd7772c-string-quartet-for-rainy-days` on a new line.
2. Publish the post and see the embed.

More details about the oEmbed: https://flat.io/developers/docs/embed/oembed.html
Requested via 1253763-zen and Twitter https://twitter.com/CJRPhD/status/1013205598106800128

![2018-07-16 at 14 59](https://user-images.githubusercontent.com/88897/42780469-df868502-8908-11e8-8aa9-ddbaa7961c52.jpg)
