### PR TITLE
REST API: Change blog owner when changing the connection owner

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -881,11 +881,22 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 
+		// Update the master user in Jetpack
 		$updated = Jetpack_Options::update_option( 'master_user', $new_owner_id );
-		if ( $updated ) {
+
+		// Notify WPCOM about the master user change
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( array(
+			'user_id' => get_current_user_id(),
+		) );
+		$xml->query( 'jetpack.switchBlogOwner', array(
+			'new_blog_owner' => $new_owner_id,
+		) );
+
+		if ( $updated && ! $xml->isError() ) {
 			return rest_ensure_response(
 				array(
-					'code' => 'success'
+					'code' => 'success',
 				)
 			);
 		}


### PR DESCRIPTION
Currently, when we change the connection owner of a Jetpack site in Calypso (AKA "Site Owner" in the Calypso UI), this only changes the master user, but doesn't actually change the site ownership. As consulted earlier with @kraftbj and @dereksmart, master user and site ownership must be the same.

#### Changes proposed in this Pull Request:

* Update the `/connection/owner` REST API endpoint to change the blog owner when the connection owner is changed.
* Update tests to skip the XML-RPC request as it's beyond our testing capabilities.

#### Testing instructions:

* Checkout this branch on your Jetpack site.
* Make sure you're admin in the site, you're connected and you're the connection/site owner.
* Make sure you're proxied, as the feature is available only in Calypso staging.
* Make sure there is at least 1 more connected admin user in your Jetpack site.
* Go to https://wordpress.com/settings/manage-connection/:site, where `:site` is the slug of your Jetpack site.
* Transfer the site ownership to the other user. 
* Go to the blog RC, and verify that the site owner has been updated to the new one properly.
* Verify the tests pass.