### PR TITLE
Publicize: Remove the ability to select personal facebook page from the overlay

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -572,7 +572,7 @@ class Publicize extends Publicize_Base {
 			$update_notice = ob_get_clean();
 
 			if ( ! empty( $update_notice ) ) {
-			 	echo $update_notice;
+				echo $update_notice;
 			}
 
 			if ( $pages ) : ?>

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -539,12 +539,9 @@ class Publicize extends Publicize_Base {
 		// Nonce check
 		check_admin_referer( 'options_page_facebook_' . $_REQUEST['connection'] );
 
-		$me    = ( ! empty( $options_to_show[0] ) ? $options_to_show[0] : false );
 		$pages = ( ! empty( $options_to_show[1]['data'] ) ? $options_to_show[1]['data'] : false );
 
-		$profile_checked = true;
 		$page_selected   = false;
-
 		if ( ! empty( $connection['connection_data']['meta']['facebook_page'] ) ) {
 			$found = false;
 			if ( $pages && is_array( $pages->data ) ) {
@@ -557,7 +554,6 @@ class Publicize extends Publicize_Base {
 			}
 
 			if ( $found ) {
-				$profile_checked = false;
 				$page_selected   = $connection['connection_data']['meta']['facebook_page'];
 			}
 		}
@@ -637,24 +633,16 @@ class Publicize extends Publicize_Base {
 			die( 'Security check' );
 		}
 
-		if ( isset( $_POST['selected_id'] ) && 'profile' == $_POST['type'] ) {
-			// Publish to User Wall/Profile
-			$options = array(
-				'facebook_page'    => null,
-				'facebook_profile' => true
-			);
-
-		} else {
-			if ( 'page' != $_POST['type'] || ! isset( $_POST['selected_id'] ) ) {
-				return;
-			}
-
-			// Publish to Page
-			$options = array(
-				'facebook_page'    => $page_id,
-				'facebook_profile' => null
-			);
+		if ( 'page' != $_POST['type'] || ! isset( $_POST['selected_id'] ) ) {
+			return;
 		}
+
+		// Publish to Page
+		$options = array(
+			'facebook_page'    => $page_id,
+			'facebook_profile' => null
+		);
+
 
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client();

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -570,6 +570,10 @@ class Publicize extends Publicize_Base {
 			if ( ! empty( $update_notice ) ) {
 				echo $update_notice;
 			}
+			$page_info_message = sprintf(
+				__( 'Facebook supports Publicize connections to Facebook Pages, but not to Facebook Profiles. <a href="%s">Learn More about Publicize for Facebook</a>', 'jetpack' ),
+				'https://jetpack.com/support/publicize/facebook'
+			);
 
 			if ( $pages ) : ?>
 				<p><?php _e( 'Publicize to my <strong>Facebook Page</strong>:', 'jetpack' ); ?></p>
@@ -600,23 +604,21 @@ class Publicize extends Publicize_Base {
 
 					</tbody>
 				</table>
+
+				<?php Publicize_UI::global_checkbox( 'facebook', $_REQUEST['connection'] ); ?>
+				<p style="text-align: center;">
+					<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>"
+					       class="button fb-options save-options" name="save"
+					       data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>"
+					       rel="<?php echo wp_create_nonce( 'save_fb_token_' . $_REQUEST['connection'] ) ?>"/>
+				</p><br/>
+				<p><?php echo $page_info_message; ?></p>
 			<?php else: ?>
 				<div>
-					<p><?php printf( __( 'Facebook only supports Publicize for Facebook Pages. Publicize for Facebook Profiles is not possible. <a href="%s">Learn More about Publicize for Facebook</a>', 'jetpack' ), 'https://jetpack.com/support/publicize/facebook' ); ?></p>
+					<p><?php echo $page_info_message; ?></p>
 					<p><?php printf( __( '<a class="button" href="%s" target="%s">Create a Facebook page</a> to get started.', 'jetpack' ), 'https://www.facebook.com/pages/creation/', '_blank noopener noreferrer' ); ?></p>
 				</div>
-			<?php
-				die();
-			endif; ?>
-
-			<?php Publicize_UI::global_checkbox( 'facebook', $_REQUEST['connection'] ); ?>
-
-			<p style="text-align: center;">
-				<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>"
-				       class="button fb-options save-options" name="save"
-				       data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>"
-				       rel="<?php echo wp_create_nonce( 'save_fb_token_' . $_REQUEST['connection'] ) ?>"/>
-			</p><br/>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -572,31 +572,10 @@ class Publicize extends Publicize_Base {
 			$update_notice = ob_get_clean();
 
 			if ( ! empty( $update_notice ) ) {
-				echo $update_notice;
+			 	echo $update_notice;
 			}
-			?>
 
-			<?php if ( ! empty( $me['name'] ) ) : ?>
-				<p><?php _e( 'Publicize to my <strong>Facebook Wall</strong>:', 'jetpack' ); ?></p>
-				<table id="option-profile">
-					<tbody>
-					<tr>
-						<td class="radio"><input type="radio" name="option" data-type="profile"
-						                         id="<?php echo esc_attr( $me['id'] ) ?>"
-						                         value="" <?php checked( $profile_checked, true ); ?> /></td>
-						<td class="thumbnail"><label for="<?php echo esc_attr( $me['id'] ) ?>"><img
-									src="<?php echo esc_url( $me['picture']['data']['url'] ) ?>" width="50"
-									height="50"/></label></td>
-						<td class="details"><label
-								for="<?php echo esc_attr( $me['id'] ) ?>"><?php echo esc_html( $me['name'] ) ?></label>
-						</td>
-					</tr>
-					</tbody>
-				</table>
-			<?php endif; ?>
-
-			<?php if ( $pages ) : ?>
-
+			if ( $pages ) : ?>
 				<p><?php _e( 'Publicize to my <strong>Facebook Page</strong>:', 'jetpack' ); ?></p>
 				<table id="option-fb-fanpage">
 					<tbody>
@@ -625,8 +604,14 @@ class Publicize extends Publicize_Base {
 
 					</tbody>
 				</table>
-
-			<?php endif; ?>
+			<?php else: ?>
+				<div>
+					<p><?php _e( sprintf( 'Only Facebook pages are now supported by Publicize. <a href="%s">Learn more about this change</a>', 'https://jetpack.com/support/publicize/facebook' ), 'jetpack' ); ?></p>
+					<p><?php _e( sprintf( '<a class="button" href="%s" target="_blank">Create a Facebook page</a> to get started.', 'https://www.facebook.com/pages/creation/'), 'jetpack' ); ?></p>
+				</div>
+			<?php
+				die();
+			endif; ?>
 
 			<?php Publicize_UI::global_checkbox( 'facebook', $_REQUEST['connection'] ); ?>
 
@@ -637,7 +622,6 @@ class Publicize extends Publicize_Base {
 				       rel="<?php echo wp_create_nonce( 'save_fb_token_' . $_REQUEST['connection'] ) ?>"/>
 			</p><br/>
 		</div>
-
 		<?php
 	}
 

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -606,8 +606,8 @@ class Publicize extends Publicize_Base {
 				</table>
 			<?php else: ?>
 				<div>
-					<p><?php _e( sprintf( 'Only Facebook pages are now supported by Publicize. <a href="%s">Learn more about this change</a>', 'https://jetpack.com/support/publicize/facebook' ), 'jetpack' ); ?></p>
-					<p><?php _e( sprintf( '<a class="button" href="%s" target="_blank">Create a Facebook page</a> to get started.', 'https://www.facebook.com/pages/creation/'), 'jetpack' ); ?></p>
+					<p><?php printf( __( 'Facebook only supports Publicize for Facebook Pages. Publicize for Facebook Profiles is not possible. <a href="%s">Learn More about Publicize for Facebook</a>', 'jetpack' ), 'https://jetpack.com/support/publicize/facebook' ); ?></p>
+					<p><?php printf( __( '<a class="button" href="%s" target="%s">Create a Facebook page</a> to get started.', 'jetpack' ), 'https://www.facebook.com/pages/creation/', '_blank noopener noreferrer' ); ?></p>
 				</div>
 			<?php
 				die();

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -186,7 +186,7 @@ abstract class Publicize_Base {
 				return $cmeta['connection_data']['meta']['display_name'];
 			}
 
-			return __( 'Connecting facebook...', 'jetpack' );
+			return __( 'Connecting Facebook...', 'jetpack' );
 
 		}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -181,6 +181,15 @@ abstract class Publicize_Base {
 	function get_display_name( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
+		if ( 'facebook' === $service_name ) {
+			if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
+				return $cmeta['connection_data']['meta']['display_name'];
+			}
+
+			return __( 'Connecting facebook...', 'jetpack' );
+
+		}
+
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
 			return $cmeta['connection_data']['meta']['display_name'];
 		} elseif ( $service_name == 'tumblr' && isset( $cmeta['connection_data']['meta']['tumblr_base_hostname'] ) ) {


### PR DESCRIPTION
This change removed the ability for users to select personal pages from the facebook selection. 
Before:
![screen shot 2018-07-17 at 10 34 18 am](https://user-images.githubusercontent.com/115071/42835940-dba8ac20-89ae-11e8-94ba-4e8f6278717e.png)


After:
if the user has 1 page to select
<img width="629" alt="screen shot 2018-07-20 at 8 53 52 am" src="https://user-images.githubusercontent.com/115071/43020903-82458d14-8c16-11e8-94bf-81281c97ac31.png">


If the user has no pages to select.
<img width="639" alt="screen shot 2018-07-20 at 8 54 32 am" src="https://user-images.githubusercontent.com/115071/43020904-827935ec-8c16-11e8-9701-3a3acf2bc572.png">


Another minor fix:
<img width="590" alt="screen shot 2018-07-20 at 12 18 00 pm" src="https://user-images.githubusercontent.com/115071/43021013-fe04aa52-8c16-11e8-8d24-c9c5f5fa6636.png">

This gets display to the user after they connect Facebook but haven't selected the account just yet to which they want to publish to. Before it used to show the users name. 

#### Testing instructions:
Connect your facebook account. 
Does the dialog make sense?
