### PR TITLE
Fix VR Gutenberg block

### DIFF
--- a/modules/shortcodes/css/blocks/vr-block.css
+++ b/modules/shortcodes/css/blocks/vr-block.css
@@ -6,6 +6,10 @@
 	overflow: hidden;
 }
 
+.wp-block-jetpack-vr .components-placeholder__fieldset {
+	justify-content: space-around;
+}
+
 iframe.wp-block-jetpack-vr {
 	position: absolute;
 	top: 0;

--- a/modules/shortcodes/js/blocks/vr-block.jsx
+++ b/modules/shortcodes/js/blocks/vr-block.jsx
@@ -21,17 +21,19 @@
 		attributes: {
 			url: {
 				type: 'string',
+				'default': '',
 			},
 			view: {
 				type: 'string',
+				'default': '',
 			}
 		},
 
 		edit: props => {
-			const attributes = props.attributes;
+			const { attributes, setAttributes } = props;
 
-			const onSetUrl = value => props.setAttributes( { url: value } );
-			const onSetView = value => props.setAttributes( { view: value } );
+			const onChangeUrl = value => setAttributes( { url: value.trim() } );
+			const onChangeView = value => setAttributes( { view: value } );
 
 			const renderEdit = () => {
 				if ( attributes.url && attributes.view ) {
@@ -57,15 +59,19 @@
 							className={ props.className }
 						>
 							<TextControl
+								name="jetpack_vr_url"
+								type="url"
 								style={ { flex: '1 1 auto' } }
 								label={ __( 'Enter URL to VR image', 'jetpack' ) }
 								value={ attributes.url }
-								onChange={ onSetUrl }
+								onChange={ onChangeUrl }
 							/>
 							<SelectControl
+								name="jetpack_vr_view"
 								label={ __( 'View Type', 'jetpack' ) }
+								disabled={ ! attributes.url }
 								value={ attributes.view }
-								onChange={ onSetView }
+								onChange={ onChangeView }
 								options={ [
 									{ label: '', value: '' },
 									{ label: __( '360°', 'jetpack' ), value: '360' },
@@ -79,7 +85,7 @@
 
 			return renderEdit();
 		},
-		save: ( props ) => {
+		save: props => {
 			return (
 				<div className={ props.className }>
 					<iframe

--- a/modules/shortcodes/js/blocks/vr-block.jsx
+++ b/modules/shortcodes/js/blocks/vr-block.jsx
@@ -2,18 +2,17 @@
 /* eslint react/react-in-jsx-scope: 0 */
 
 ( function( blocks, components, i18n ) {
-	const {
-		registerBlockType,
-		UrlInput
-	} = blocks;
+	const { registerBlockType } = blocks;
 	const {
 		Placeholder,
-		SelectControl
+		SelectControl,
+		TextControl
 	} = components;
 	const { __ } = i18n;
 
 	registerBlockType( 'jetpack/vr', {
 		title: __( 'VR Image', 'jetpack' ),
+		description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
 		icon: 'embed-photo',
 		category: 'embed',
 		support: {
@@ -53,27 +52,26 @@
 					<div>
 						<Placeholder
 							key="placeholder"
-							instructions={ __( 'Enter URL to VR image', 'jetpack' ) }
 							icon="format-image"
 							label={ __( 'VR Image', 'jetpack' ) }
 							className={ props.className }
 						>
-							<UrlInput
+							<TextControl
+								style={ { flex: '1 1 auto' } }
+								label={ __( 'Enter URL to VR image', 'jetpack' ) }
 								value={ attributes.url }
 								onChange={ onSetUrl }
 							/>
-							<div style={ { marginTop: '10px' } }>
-								<SelectControl
-									label={ __( 'View Type', 'jetpack' ) }
-									value={ attributes.view }
-									onChange={ onSetView }
-									options={ [
-										{ label: '', value: '' },
-										{ label: __( '360', 'jetpack' ), value: '360' },
-										{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-									] }
-								/>
-							</div>
+							<SelectControl
+								label={ __( 'View Type', 'jetpack' ) }
+								value={ attributes.view }
+								onChange={ onSetView }
+								options={ [
+									{ label: '', value: '' },
+									{ label: __( '360°', 'jetpack' ), value: '360' },
+									{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+								] }
+							/>
 						</Placeholder>
 					</div>
 				);

--- a/modules/shortcodes/js/blocks/vr-block.jsx
+++ b/modules/shortcodes/js/blocks/vr-block.jsx
@@ -59,7 +59,6 @@
 							className={ props.className }
 						>
 							<TextControl
-								name="jetpack_vr_url"
 								type="url"
 								style={ { flex: '1 1 auto' } }
 								label={ __( 'Enter URL to VR image', 'jetpack' ) }
@@ -67,7 +66,6 @@
 								onChange={ onChangeUrl }
 							/>
 							<SelectControl
-								name="jetpack_vr_view"
 								label={ __( 'View Type', 'jetpack' ) }
 								disabled={ ! attributes.url }
 								value={ attributes.view }

--- a/modules/shortcodes/vr.php
+++ b/modules/shortcodes/vr.php
@@ -144,9 +144,7 @@ function jetpack_register_block_type_vr() {
 
 	wp_register_script(
 		'jetpack_vr_viewer_shortcode_editor_script',
-		// Not using `Jetpack::get_file_url_for_environment()` here because
-		// Jetpack does not generate minified files for Gutenberg blocks just yet.
-		plugins_url( 'modules/shortcodes/js/blocks/vr-block.js', JETPACK__PLUGIN_FILE ),
+		Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/blocks/vr-block.min.js', 'modules/shortcodes/js/blocks/vr-block.js' ),
 		array( 'wp-blocks', 'wp-element', 'wp-i18n' )
 	);
 

--- a/modules/shortcodes/vr.php
+++ b/modules/shortcodes/vr.php
@@ -144,7 +144,9 @@ function jetpack_register_block_type_vr() {
 
 	wp_register_script(
 		'jetpack_vr_viewer_shortcode_editor_script',
-		Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/blocks/vr-block.min.js', 'modules/shortcodes/js/blocks/vr-block.js' ),
+		// Not using `Jetpack::get_file_url_for_environment()` here because
+		// Jetpack does not generate minified files for Gutenberg blocks just yet.
+		plugins_url( 'modules/shortcodes/js/blocks/vr-block.js', JETPACK__PLUGIN_FILE ),
 		array( 'wp-blocks', 'wp-element', 'wp-i18n' )
 	);
 


### PR DESCRIPTION
Current VR block is incompatible with latest Gutenberg 3.2.0:

![block rendering error](https://user-images.githubusercontent.com/87168/42884402-e95896ca-8aa6-11e8-824e-aac5e3f1b6ac.png)

The block was originally implemented in https://github.com/Automattic/jetpack/pull/9560 

#### Changes proposed in this Pull Request:

* Most importantly; replaces deprecated `UrlInput` with `TextControl`
* Keep "type" field disabled to force users to fill "url" input first. Previously, if they would choose a value from dropdown first and start typing any text to URL input, the block would immediately render the embed with invalid URL. The solution is not ideal but helps a bit. Adding additional "embed" button would be best and make the block behave similarly with other Gutenberg embed blocks. I'll leave that for another PR.
* Add block description
* Make two inputs behave nicer on small screens

#### Testing instructions:

- Use latest Gutenberg
- Make sure you have Jetpack build done `yarn build` (or use un-minified version by setting `define ( 'SCRIPT_DEBUG', true );`)
- Add a VR block to a post or page (you can find it under "embeds")
- The block should work in different screen sizes
- Adding a valid URL _and_ type will render the embed. Here's a test URL you can use together with "360" setting: `https://en-blog.files.wordpress.com/2016/12/regents_park.jpg`

![screen shot 2018-07-19 at 11 19 03](https://user-images.githubusercontent.com/87168/42930954-0cd6095c-8b47-11e8-914c-f1aa07a7af3b.png)
![screen shot 2018-07-19 at 11 19 12](https://user-images.githubusercontent.com/87168/42930944-08e714e4-8b47-11e8-8517-e321a3b3595f.png)
![screen shot 2018-07-19 at 11 21 15](https://user-images.githubusercontent.com/87168/42930932-035a7f98-8b47-11e8-984a-fcc0e0b1f7cc.png)
![screen shot 2018-07-19 at 11 19 27](https://user-images.githubusercontent.com/87168/42930940-06b85976-8b47-11e8-9c10-5562861d6255.png)
![screen shot 2018-07-19 at 11 21 21](https://user-images.githubusercontent.com/87168/42930927-017cb51a-8b47-11e8-9c91-37b96c9a62f7.png)