### PR TITLE
Simple Payments Widget: Add missing class_exists check

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -476,6 +476,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 	// Register Jetpack_Simple_Payments_Widget widget.
 	function register_widget_jetpack_simple_payments() {
+		if ( ! class_exists( 'Jetpack_Simple_Payments' ) ) {
+			return;
+		}
+
 		$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
 		if ( ! $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
 			return;


### PR DESCRIPTION
Fixes a `CRITICAL Call to undefined method Jetpack_Simple_Payments::is_enabled_jetpack_simple_payments()` error (reported by @madeincosmos).

#### Changes proposed in this Pull Request:

* Add a missing `class_exists` check.

For some reasons, this check already exists in the WPCOM version of the file, so this change also puts the two versions in sync.

#### Testing instructions:

- Smoke test sites on any plans and make sure they don't throw that error.