### PR TITLE
Fix: sitemap cron with custom post types

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -393,8 +393,6 @@ class Jetpack_Sitemap_Manager {
 				'jp_sitemap_cron_hook'
 			);
 		}
-
-		return;
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -360,6 +360,11 @@ class Jetpack_Sitemap_Manager {
 		return $schedules;
 	}
 
+	public function callback_sitemap_cron_hook() {
+		$sitemap_builder = new Jetpack_Sitemap_Builder();
+		$sitemap_builder->update_sitemap();
+	}
+
 	/**
 	 * Add actions to schedule sitemap generation.
 	 * Should only be called once, in the constructor.

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -381,11 +381,9 @@ class Jetpack_Sitemap_Manager {
 		// Add cron schedule.
 		add_filter( 'cron_schedules', array( $this, 'callback_add_sitemap_schedule' ) );
 
-		$sitemap_builder = new Jetpack_Sitemap_Builder();
-
 		add_action(
 			'jp_sitemap_cron_hook',
-			array( $sitemap_builder, 'update_sitemap' )
+			array( $this, 'callback_sitemap_cron_hook' )
 		);
 
 		if ( ! wp_next_scheduled( 'jp_sitemap_cron_hook' ) ) {

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -360,6 +360,11 @@ class Jetpack_Sitemap_Manager {
 		return $schedules;
 	}
 
+	/**
+	 * Callback handler for sitemap cron hook
+	 *
+	 * @access public
+	 */
 	public function callback_sitemap_cron_hook() {
 		$sitemap_builder = new Jetpack_Sitemap_Builder();
 		$sitemap_builder->update_sitemap();


### PR DESCRIPTION
We've been running into issues with custom post types not showing up in sitemaps. These custom post types are leveraging the `jetpack_sitemap_post_types` filter. Testing locally, it appeared that custom post types _do_ appear in sitemaps after running `wp jetpack sitemap rebuild  --url=URL`; however, custom post types would _not_ appear after running `wp cron event run --all --url=URL`.

Testing locally, it seemed that, for cron, the `Jetpack_Sitemap_Builder` instance was getting created too early for the theme's `jetpack_sitemap_post_types` filter to be registered. As such, the `jetpack_sitemap_post_types` WP option value, updated in the constructor method of `Jetpack_Sitemap_Builder`, is reset to the default value of `array( 'post', 'page' )`.

This PR attempts to patch this issue by delaying, for cron, the instantiation of `Jetpack_Sitemap_Builder` until a (new) callback is executed for the `jp_sitemap_cron_hook` action, allowing the theme's `jetpack_sitemap_post_types` filter to be registered successfully.

#### Changes proposed in this Pull Request:

* Creates a wrapper method for the `jp_sitemap_cron_hook` action so the `Jetpack_Sitemap_Builder` instance is created within the the cron action and _not_ before

#### Testing instructions:

* Set up 1+ custom post types
* Within a theme, use the `jetpack_sitemap_post_types` filter to add the previously created custom post type(s)
* Via the WP-CLI, run `wp jetpack sitemap rebuild  --url=URL`, replacing `URL` with an actual URL
* Check the `jetpack_sitemap_post_types` WP option (table) value; make sure it includes the previously created custom post type(s)
* Via the WP-CLI, run `wp cron event run --all --url=URL`, replacing `URL` with an actual URL
* Check the `jetpack_sitemap_post_types` WP option (table) value; make sure it includes the previously created custom post type(s) (previous to this change, this value would be reset to `array( 'post', 'page' )`)

Thanks!
