### PR TITLE
Update/identify broken facebook accounts

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1288,7 +1288,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				// differs from the logic in the Publicize class.
 				$option_connections = is_user_logged_in()
 					? (array) $publicize->get_all_connections_for_user()
-					: Jetpack_Options::get_option( 'publicize_connections' );
+					: (array) $publicize->get_all_connections();
 
 				foreach ( $option_connections as $service_name => $connections ) {
 					foreach ( (array) $connections as $id => $connection ) {
@@ -1355,7 +1355,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 					$option_connections = is_user_logged_in()
 						? (array) $publicize->get_all_connections_for_user()
-						: Jetpack_Options::get_option( 'publicize_connections' );
+						: (array) $publicize->get_all_connections();
 
 					if ( 'all' === $service ) {
 						foreach ( (array) $option_connections as $service_name => $service_connections ) {

--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -101,7 +101,6 @@ div.publicize-service-left {
 	min-height: 35px;
 }
 
-
 div.publicize-service-left a{
 	font-size: 18px;
 	text-decoration: none;
@@ -228,3 +227,5 @@ input.fb-options {
 .pub-connection-error {
 	color: #ff0000;
 }
+
+.pub-connection-test. test-failed p { margin-top: 0; }

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -120,8 +120,12 @@ class Publicize extends Publicize_Base {
 		) );
 	}
 
+	function get_all_connections() {
+		return Jetpack_Options::get_option( 'publicize_connections' );
+	}
+
 	function get_connections( $service_name, $_blog_id = false, $_user_id = false ) {
-		$connections           = Jetpack_Options::get_option( 'publicize_connections' );
+		$connections           = $this->get_all_connections();
 		$connections_to_return = array();
 		if ( ! empty( $connections ) && is_array( $connections ) ) {
 			if ( ! empty( $connections[ $service_name ] ) ) {
@@ -139,7 +143,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_all_connections_for_user() {
-		$connections = Jetpack_Options::get_option( 'publicize_connections' );
+		$connections = $this->get_all_connections();
 
 		$connections_to_return = array();
 		if ( ! empty( $connections ) ) {
@@ -490,7 +494,7 @@ class Publicize extends Publicize_Base {
 		}
 		// Only do this when a post transitions to being published
 		if ( get_post_meta( $post->ID, $this->PENDING ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
-			$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+			$connected_services = $this->get_all_connections();
 			if ( ! empty( $connected_services ) ) {
 				/**
 				 * Fires when a post is saved that has is marked as pending publicizing
@@ -516,7 +520,7 @@ class Publicize extends Publicize_Base {
 			return $flags;
 		}
 
-		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+		$connected_services = $this->get_all_connections();
 
 		if ( empty( $connected_services ) ) {
 			return $flags;
@@ -532,7 +536,7 @@ class Publicize extends Publicize_Base {
 	 */
 
 	function options_page_facebook() {
-		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+		$connected_services = $this->get_all_connections();
 		$connection         = $connected_services['facebook'][ $_REQUEST['connection'] ];
 		$options_to_show    = ( ! empty( $connection['connection_data']['meta']['options_responses'] ) ? $connection['connection_data']['meta']['options_responses'] : false );
 
@@ -688,7 +692,7 @@ class Publicize extends Publicize_Base {
 		// Nonce check
 		check_admin_referer( 'options_page_tumblr_' . $_REQUEST['connection'] );
 
-		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+		$connected_services = $this->get_all_connections();
 		$connection         = $connected_services['tumblr'][ $_POST['connection'] ];
 		$options_to_show    = $connection['connection_data']['meta']['options_responses'];
 		$request            = $options_to_show[0];

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -560,7 +560,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Facebook Profiles no longer support automatic sharing via Publicize.', 'jetpack');
+						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.', 'jetpack');
 					}
 				}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -560,7 +560,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Publizing to Facebook using a Personal account is not supported.' );
+						$connection_test_message = __( 'Facebook Profiles no longer support automatic sharing via Publicize.', 'jetpack');
 					}
 				}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -519,6 +519,10 @@ abstract class Publicize_Base {
 		return post_type_supports( $post_type, 'publicize' );
 	}
 
+	function is_valid_facebook_connection( $connection ) {
+		return isset( $connection['connection_data']['meta']['facebook_page'] );
+	}
+
 	/**
 	 * Runs tests on all the connections and returns the results to the caller
 	 */
@@ -551,6 +555,22 @@ abstract class Publicize_Base {
 					$refresh_url = $error_data['refresh_url'];
 				}
 
+				// Mark facebook profiles as deprecated
+				if ( 'facebook' === $service_name ) {
+					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
+						$connection_test_passed = false;
+						$user_can_refresh = false;
+						$connection_test_message = __( 'Publizing to Facebook using a Personal account is not supported.' );
+					}
+				}
+
+				$unique_id = null;
+				if ( ! empty( $connection->unique_id ) ) {
+					$unique_id = $connection->unique_id;
+				} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
+					$unique_id = $connection['connection_data']['token_id'];
+				}
+
 				$test_results[] = array(
 					'connectionID'          => $id,
 					'serviceName'           => $service_name,
@@ -558,7 +578,8 @@ abstract class Publicize_Base {
 					'connectionTestMessage' => esc_attr( $connection_test_message ),
 					'userCanRefresh'        => $user_can_refresh,
 					'refreshText'           => esc_attr( $refresh_text ),
-					'refreshURL'            => $refresh_url
+					'refreshURL'            => $refresh_url,
+					'unique_id'             => $unique_id,
 				);
 			}
 		}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -82,7 +82,7 @@ class Publicize_UI {
 				'_inc/build/publicize/assets/publicize.min.js',
 				'modules/publicize/assets/publicize.js'
 			),
-			array( 'jquery', 'thickbox' ),
+			array( 'jquery', 'F' ),
 			'20121019'
 		);
 		if ( is_rtl() ) {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -485,6 +485,7 @@ jQuery( function($) {
 				if ( ! facebookNotice ) {
 					var message = '<p>'
 						+ testResult.connectionTestMessage
+						+ '</p><p>'
 						+ ' <a class="button" href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" rel="noopener noreferrer" target="_blank">'
 						+ '<?php echo esc_html( __( 'Update Your Sharing Settings' ,'jetpack' ) ); ?>'
 						+ '</a>'

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -82,7 +82,7 @@ class Publicize_UI {
 				'_inc/build/publicize/assets/publicize.min.js',
 				'modules/publicize/assets/publicize.js'
 			),
-			array( 'jquery', 'F' ),
+			array( 'jquery', 'thickbox' ),
 			'20121019'
 		);
 		if ( is_rtl() ) {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -451,9 +451,11 @@ jQuery( function($) {
 
 		// If any of the tests failed, show some stuff
 		var somethingShownAlready = false;
+		var facebookNotice = false;
 		$.each( response.data, function( index, testResult ) {
+
 			// find the li for this connection
-			if ( ! testResult.connectionTestPassed ) {
+			if ( ! testResult.connectionTestPassed && testResult.userCanRefresh ) {
 				if ( ! somethingShownAlready ) {
 					testsSelector
 						.addClass( 'below-h2' )
@@ -476,6 +478,29 @@ jQuery( function($) {
 						.click( publicizeConnRefreshClick );
 				}
 			}
+
+			if( ! testResult.connectionTestPassed && ! testResult.userCanRefresh ) {
+
+				$( '#wpas-submit-' + testResult.unique_id ).prop( "checked", false ).prop( "disabled", true );
+				if ( ! facebookNotice ) {
+					var message = '<p>'
+						+ testResult.connectionTestMessage
+						+ ' <a class="button" href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" rel="noopener noreferrer" target="_blank">'
+						+ '<?php echo esc_html( __( 'Update Your Sharing Settings' ,'jetpack' ) ); ?>'
+						+ '</a>'
+						+ '<p>';
+
+					testsSelector
+						.addClass( 'below-h2' )
+						.addClass( 'error' )
+						.addClass( 'publicize-token-refresh-message' )
+						.append( message );
+					facebookNotice = true;
+				}
+
+			}
+
+
 		} );
 	}
 
@@ -701,7 +726,7 @@ jQuery( function($) {
 					if ( $done ) {
 						$checked = true;
 					}
-
+					$disabled = false;
 					// This post has been handled, so disable everything
 					if ( $all_done ) {
 						$disabled = ' disabled="disabled"';
@@ -712,9 +737,18 @@ jQuery( function($) {
 						esc_html( $this->publicize->get_service_label( $name ) ),
 						esc_html( $this->publicize->get_display_name( $name, $connection ) )
 					);
-					if ( !$skip || $done ) {
+
+					if ( $name === 'facebook' && ! $this->publicize->is_valid_facebook_connection( $connection ) ) {
+						$skip = true;
+						$disabled = ' disabled="disabled"';
+						$checked = false;
+						$hidden_checkbox = false;
+					}
+
+					if ( ( !$skip || $done ) && ! $disabled ) {
 						$active[] = $label;
 					}
+
 					?>
 					<li>
 						<label for="wpas-submit-<?php echo esc_attr( $unique_id ); ?>">


### PR DESCRIPTION
Fixes Facebook removing the ability to publicize to personal profiles. 

#### Changes proposed in this Pull Request:
* Remve the ability for the user to select the facebook's personal profile account. To publicize to.
* Show a notice so that the user know to disconnect the connection and set up a new one. 

UI When showing the Personal Facebook Connection on the settings screen.
<img width="592" alt="screen shot 2018-07-20 at 3 43 47 pm" src="https://user-images.githubusercontent.com/115071/43028258-ba883308-8c33-11e8-97df-5c6451735181.png">



UI when showing the Page Facebook Connection on the settings screen
<img width="600" alt="screen shot 2018-07-19 at 3 07 58 pm" src="https://user-images.githubusercontent.com/115071/42974115-d3d74ade-8b6a-11e8-91fd-21c6b705a13b.png">

UI on the new post screen showing the Broken personal Facebook connection. 
<img width="298" alt="screen shot 2018-07-20 at 1 18 49 pm" src="https://user-images.githubusercontent.com/115071/43028267-c88ae8b0-8c33-11e8-895a-35e576f38aa4.png">
<img width="286" alt="screen shot 2018-07-20 at 3 42 43 pm" src="https://user-images.githubusercontent.com/115071/43028285-e1110db0-8c33-11e8-91d4-4fc30b730151.png">

UI on the new post screen showing the Page Facebook connection. 

<img width="292" alt="screen shot 2018-07-19 at 3 46 53 pm" src="https://user-images.githubusercontent.com/115071/42974261-571ce408-8b6b-11e8-9819-16bdacb5d5f0.png">
<img width="292" alt="screen shot 2018-07-19 at 3 46 49 pm" src="https://user-images.githubusercontent.com/115071/42974262-5a26ca1a-8b6b-11e8-9ef7-9aaecee1eb1c.png">

#### Testing instructions:

Go to the WP-admin > Settings > Sharing
Does the UI make sense. 
1. Connect your personal Facebook account. 
Notice all the error messages. 
Notice that when you publish that the post doesn't go to facebook anymore.

2. Disconnect your personal account and connect a page account. 
Notice that everything works as expected/ as before. 

