### PR TITLE
Add changelog for 6.3.3.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 == Changelog ==
 
+= 6.3.2 =
+
+* Release date: July 4, 2018
+* Release post: https://wp.me/p1moTy-96E
+
+**Bug fixes**
+
+* Simple Payment: Fix compatibility issues with PHP versions 5.3 and below
+
 = 6.3 =
 
 * Release date: July 3, 2018

--- a/readme.txt
+++ b/readme.txt
@@ -114,12 +114,3 @@ On the 1st of August, 2018 Facebook sunsets its API allowing to post updates to 
 **Bug fixes**
 
 * General: properly handle Jetpack connection owner transition process.
-
-= 6.3.2 =
-
-* Release date: July 4, 2018
-* Release post: https://wp.me/p1moTy-96E
-
-**Bug fixes**
-
-* Simple Payment: Fix compatibility issues with PHP versions 5.3 and below

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,23 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 
 == Changelog ==
 
+= 6.3.3 =
+
+* Release date: July 30, 2018
+* Release post: https://wp.me/p1moTy-9n0
+
+**Facebook API Maintenance**
+
+On the 1st of August, 2018 Facebook sunsets its API allowing to post updates to your Profile Page. Only the API allowing to post to Facebook Pages will remain. This required several changes to Jetpack that we are presenting in this release:
+
+* Publicize: making sure we are handling existing connections gracefully.
+* Publicize: using logo font instead of images to make the UI up to date and mobile ready.
+* Publicize: removing the ability to select Facebook Profile connections in the UI.
+
+**Bug fixes**
+
+* General: properly handle Jetpack connection owner transition process.
+
 = 6.3.2 =
 
 * Release date: July 4, 2018
@@ -106,4 +123,3 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 **Bug fixes**
 
 * Simple Payment: Fix compatibility issues with PHP versions 5.3 and below
-

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack by WordPress.com ===
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
-Stable tag: 6.3
+Stable tag: 6.3.2
 Requires at least: 4.7
 Tested up to: 4.9
 


### PR DESCRIPTION
This adds changelogs entries for #9938, #9927, #9926, and #9925.

#### Changes proposed in this Pull Request:

* Updates changelog.txt to include changelog for 6.3.2
* Updates readme.txt to include changelog for 6.3.3
* Bumps stable tag to `6.3.2`
