### PR TITLE
Add a script to build blocks using Calypso SDK

### DIFF
--- a/bin/build-blocks.js
+++ b/bin/build-blocks.js
@@ -23,7 +23,7 @@ blocks.forEach( block => {
 	console.log( `Building ${ block }` );
 	// Relative to wp-calypso
 	const inputFile = path.join( 'client/gutenberg/extensions/', block );
-	execSync( `npx wp-calypso-sdk ${ inputFile } ${ outputDir }`, {
+	execSync( `npx calypso-gutenberg-sdk ${ inputFile } ${ outputDir }`, {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/bin/build-blocks.js
+++ b/bin/build-blocks.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/* eslint no-console: 0 */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const execSync = require( 'child_process' ).execSync;
+
+const blocks = [
+	'hello-dolly/hello-block.js',
+	// 'jetpack/tiled-gallery/tiled-gallery.jsx',
+];
+
+const outputDir = path.resolve( '_inc/build/blocks' );
+
+if ( ! fs.existsSync( outputDir ) ) {
+	fs.mkdirSync( outputDir );
+}
+
+console.log( 'Building Gutenberg blocks...' );
+
+blocks.forEach( block => {
+	console.log( `Building ${ block }` );
+	// Relative to wp-calypso
+	const inputFile = path.join( 'client/gutenberg/extensions/', block );
+	execSync( `npx wp-calypso-sdk ${ inputFile } ${ outputDir }`, {
+		shell: true,
+		stdio: 'inherit',
+	} );
+} );

--- a/bin/build-blocks.js
+++ b/bin/build-blocks.js
@@ -23,7 +23,7 @@ blocks.forEach( block => {
 	console.log( `Building ${ block }` );
 	// Relative to wp-calypso
 	const inputFile = path.join( 'client/gutenberg/extensions/', block );
-	execSync( `npx calypso-gutenberg-sdk ${ inputFile } ${ outputDir }`, {
+	execSync( `npx calypso-gutenberg-sdk build-block ${ inputFile } ${ outputDir }`, {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn install-if-deps-outdated && yarn build-client",
+    "build-blocks": "node ./bin/build-blocks.js",
     "build-client": "gulp",
     "build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
     "build-production": "yarn distclean && yarn && gulp languages:extract && yarn build-production-client",


### PR DESCRIPTION
⚠️ 🛠 **Work In Progress — Do not merge**

---

Adds a script to build all the blocks from Calypso, using Calypso as a dependency:

```
yarn build-blocks
```

Does this approach make sense regarding developer-experience?

Currently, blocks live inside Calypso codebase but as the block builder evolves, blocks could live also inside Jetpack or in a separate repository. 

This doesn't include yet anything regarding PHP, styles or i18n stuff yet since we don't have any of that in the builder neither. 

This PR is just to add the first iteration of the entry point in Jetpack for all the work that is Calypso SDK block builder. We will keep iterating on developer experience further down the road.


### Testing

Requires linking Calypso to Jetpack manually (temporarily until it can be pulled in as a dependency).

Inside Calypso folder:
```bash
npm link
```

Inside Jetpack folder:
```bash
npm link wp-calypso
```

Finally, you can run:
```
yarn build-blocks
```

You should end up with `_inc/build/blocks/hello-dolly/blocks-hello-dolly.js` -file in Jetpack.