### PR TITLE
Added a filter for the AT pending state flag.

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -585,12 +585,13 @@ abstract class SAL_Site {
 		 *
 		 * @module json-api
 		 *
-		 * @since 6.3.3
+		 * @since 6.4.0
 		 *
 		 * @param bool has_site_pending_automated_transfer( $this->blog_id )
 		 * @param int  $blog_id Blog identifier.
 		 */
-		return apply_filters( 'wpcom_json_api_site_pending_automated_transfer',
+		return apply_filters(
+			'jetpack_site_pending_automated_transfer',
 			false,
 			$this->blog_id
 		);

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -580,12 +580,20 @@ abstract class SAL_Site {
 	}
 
 	function has_pending_automated_transfer() {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_once( WP_CONTENT_DIR . '/lib/automated-transfer/utils.php' );
-			return A8C\Automated_Transfer\Utils\has_site_pending_automated_transfer( $this->blog_id ); //phpcs:ignore PHPCompatibility
-		}
-
-		return false;
+		/**
+		 * Filter if a site is in pending automated transfer state.
+		 *
+		 * @module json-api
+		 *
+		 * @since 6.3.3
+		 *
+		 * @param bool has_site_pending_automated_transfer( $this->blog_id )
+		 * @param int  $blog_id Blog identifier.
+		 */
+		return apply_filters( 'wpcom_json_api_site_pending_automated_transfer',
+			false,
+			$this->blog_id
+		);
 	}
 
 	function signup_is_store() {


### PR DESCRIPTION
Before that we were using an environment check and using a getter method that required PHP namespace syntax. This didn't work in PHP 5.2, so we are changing it to a filter call.

Fixes #9943.

Related: D16395-code