### PR TITLE
Publicize: Fix warning showing in the backhground when connecting facebook to publicize

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -542,7 +542,7 @@ class Publicize extends Publicize_Base {
 		$page_selected   = false;
 		if ( ! empty( $connection['connection_data']['meta']['facebook_page'] ) ) {
 			$found = false;
-			if ( $pages && is_array( $pages->data ) ) {
+			if ( $pages && isset( $pages->data ) && is_array( $pages->data )  ) {
 				foreach ( $pages->data as $page ) {
 					if ( $page->id == $connection['connection_data']['meta']['facebook_page'] ) {
 						$found = true;

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -631,8 +631,6 @@ class Publicize extends Publicize_Base {
 		// Nonce check
 		check_admin_referer( 'save_fb_token_' . $_REQUEST['connection'] );
 
-		$id = $_POST['connection'];
-
 		// Check for a numeric page ID
 		$page_id = $_POST['selected_id'];
 		if ( ! ctype_digit( $page_id ) ) {
@@ -649,16 +647,7 @@ class Publicize extends Publicize_Base {
 			'facebook_profile' => null
 		);
 
-
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.setPublicizeOptions', $id, $options );
-
-		if ( ! $xml->isError() ) {
-			$response = $xml->getResponse();
-			Jetpack_Options::update_option( 'publicize_connections', $response );
-			$this->globalization();
-		}
+		$this->set_remote_publicize_options( $_POST['connection'], $options );
 	}
 
 	function options_page_tumblr() {
@@ -742,11 +731,13 @@ class Publicize extends Publicize_Base {
 	function options_save_tumblr() {
 		// Nonce check
 		check_admin_referer( 'save_tumblr_blog_' . $_REQUEST['connection'] );
-
-		$id = $_POST['connection'];
-
 		$options = array( 'tumblr_base_hostname' => $_POST['selected_id'] );
 
+		$this->set_remote_publicize_options( $_POST['connection'], $options );
+
+	}
+
+	function set_remote_publicize_options( $id, $options ) {
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.setPublicizeOptions', $id, $options );
@@ -754,9 +745,8 @@ class Publicize extends Publicize_Base {
 		if ( ! $xml->isError() ) {
 			$response = $xml->getResponse();
 			Jetpack_Options::update_option( 'publicize_connections', $response );
+			$this->globalization();
 		}
-
-		$this->globalization();
 	}
 
 	function options_page_twitter() {

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -657,9 +657,8 @@ class Publicize extends Publicize_Base {
 		if ( ! $xml->isError() ) {
 			$response = $xml->getResponse();
 			Jetpack_Options::update_option( 'publicize_connections', $response );
+			$this->globalization();
 		}
-
-		$this->globalization();
 	}
 
 	function options_page_tumblr() {

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -446,9 +446,6 @@ class Publicize extends Publicize_Base {
 	}
 
 	function test_connection( $service_name, $connection ) {
-		$connection_test_passed  = true;
-		$connection_test_message = '';
-		$user_can_refresh        = false;
 
 		$id = $this->get_connection_id( $connection );
 
@@ -456,16 +453,13 @@ class Publicize extends Publicize_Base {
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.testPublicizeConnection', $id );
 
-		if ( $xml->isError() ) {
-			$xml_response            = $xml->getResponse();
-			$connection_test_message = $xml_response['faultString'];
-			$connection_test_passed  = false;
-		}
-
 		// Bail if all is well
-		if ( $connection_test_passed ) {
+		if ( ! $xml->isError() ) {
 			return true;
 		}
+
+		$xml_response            = $xml->getResponse();
+		$connection_test_message = $xml_response['faultString'];
 
 		// Set up refresh if the user can
 		$user_can_refresh = current_user_can( $this->GLOBAL_CAP );

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -529,7 +529,14 @@ abstract class Publicize_Base {
 	}
 
 	function is_valid_facebook_connection( $connection ) {
+		if ( $this->is_connecting_connection( $connection ) ) {
+			return true;
+		}
 		return isset( $connection['connection_data']['meta']['facebook_page'] );
+	}
+
+	function is_connecting_connection( $connection ) {
+		return isset( $connection['connection_data']['meta']['options_responses'] );
 	}
 
 	/**
@@ -565,12 +572,10 @@ abstract class Publicize_Base {
 				}
 
 				// Mark facebook profiles as deprecated
-				if ( 'facebook' === $service_name ) {
-					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
-						$connection_test_passed = false;
-						$user_can_refresh = false;
-						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.', 'jetpack');
-					}
+				if ( 'facebook' === $service_name && ! $this->is_valid_facebook_connection( $connection ) ) {
+					$connection_test_passed = false;
+					$user_can_refresh = false;
+					$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.', 'jetpack');
 				}
 
 				$unique_id = null;

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -186,7 +186,7 @@ abstract class Publicize_Base {
 				return $cmeta['connection_data']['meta']['display_name'];
 			}
 
-			return __( 'Connecting Facebook...', 'jetpack' );
+			return __( 'Connecting...', 'jetpack' );
 
 		}
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -739,7 +739,11 @@ jQuery( function($) {
 						esc_html( $this->publicize->get_display_name( $name, $connection ) )
 					);
 
-					if ( $name === 'facebook' && ! $this->publicize->is_valid_facebook_connection( $connection ) ) {
+					if (
+						$name === 'facebook'
+					     && ! $this->publicize->is_valid_facebook_connection( $connection )
+					     && $this->publicize->is_connecting_connection( $connection )
+					) {
 						$skip = true;
 						$disabled = ' disabled="disabled"';
 						$checked = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Some Code clean up. 
* Removed the error showing when the we are in the middle of the connection process. 
* Made sure that the user doesn't show up when we are in the middle of the connection process.

#### Testing instructions:

* Try connecting a facebook group notice that the error in the background is not there any more. 
* Connect a tumbler account it still works as expected. 
* Start the connection process and notice that post wrote screen is working as expected. 


Before:
![screen shot 2018-07-24 at 5 47 47 pm](https://user-images.githubusercontent.com/115071/43173459-d08490c8-8f69-11e8-9323-575ff33fdb9a.png)


After:
![screen shot 2018-07-24 at 5 48 04 pm](https://user-images.githubusercontent.com/115071/43173452-ccf51914-8f69-11e8-9d59-b3df012fa480.png)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
