### PR TITLE
Plans: add new two year plan slugs

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1490,6 +1490,7 @@ class Jetpack {
 			'jetpack_personal',
 			'jetpack_personal_monthly',
 			'personal-bundle',
+			'personal-bundle-2y',
 		);
 
 		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
@@ -1503,7 +1504,8 @@ class Jetpack {
 			'jetpack_premium',
 			'jetpack_premium_monthly',
 			'value_bundle',
-		);
+			'value_bundle-2y',
+        );
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
 			$supports[] = 'akismet';
@@ -1517,6 +1519,7 @@ class Jetpack {
 			'jetpack_business',
 			'jetpack_business_monthly',
 			'business-bundle',
+			'business-bundle-2y',
 			'vip',
 		);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1505,7 +1505,7 @@ class Jetpack {
 			'jetpack_premium_monthly',
 			'value_bundle',
 			'value_bundle-2y',
-        );
+		);
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
 			$supports[] = 'akismet';


### PR DESCRIPTION
We recently rolled out plans that renew in 2 years instead of 1 in https://github.com/Automattic/wp-calypso/pull/25668. This PR updates a few client Jetpack checks that determine if certain modules or plugins should be loaded. Reading the code this likely affects akismet, vaultpress and simple payments. Related APIs of course check these feature capabilities on their own as well.

![screen shot 2018-07-24 at 5 00 57 pm](https://user-images.githubusercontent.com/1270189/43172401-ff207ad8-8f63-11e8-91cf-d5908d87254d.png)
![screen shot 2018-07-24 at 5 10 58 pm](https://user-images.githubusercontent.com/1270189/43172530-8dbfea6c-8f64-11e8-81d8-63fedad92a14.png)


#### To recreate the bug:
- Create a new site at WordPress.com with a custom domain
- Buy a 2 year business plan subscription at WordPress.com
- Install a plugin or custom theme
- Check if we can add a Simple Payment in the post editor or as a widget in the customizer.
Expected: Simple Payments work
Actual: Simple Payments never load, because the Custom Post Type isn't registered. 

### Testing Instructions
- Create a new site at WordPress.com with a custom domain. (If y'all are a8c folks, choose a .blog domain).
- Buy a 2 year business plan subscription at WordPress.com
- Install a plugin or custom theme
- Check if we can add a Simple Payment in the post editor or as a widget in the customizer. (Verify that this is broken)
- Then install the [Jetpack beta plugin](https://jetpack.com/download-jetpack-beta/)
- Visit /wp-admin/admin.php?page=jetpack-beta and active this branch `fix/plans-check`
- Check if we can add a Simple Payment in the post editor or as a widget in the customizer.

See also: p7jreA-1Hq-p2

cc props to @jhnstn and @donpark for helping find this. ✨

@Copons feel free to take over this PR tomorrow 👍 