### PR TITLE
Update/sharing links to redirect to calypso

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6929,6 +6929,28 @@ p {
 		$url = str_replace( '/', '::', $url );
 		return $url;
 	}
+	/*
+	 * link to the calypso section
+	 * $link is expected to be the url starting from the root and the %site% will be replaced with the url of the site as expected.
+	 *
+	 * $param string
+	 * @return string
+	 */
+	public static function calyps_url( $path, $from = null ) {
+		$host = 'https://wordpress.com';
+
+		if ( $path[0] !== '/' ) {
+			$path = '/' . $path;
+		}
+		$site_suffix = self::build_raw_urls( home_url() );
+		$path_with_site = str_replace( '%site%', $site_suffix, $path );
+
+		if ( self::is_user_connected() ) {
+			return $host . $path_with_site;
+		}
+
+		self::$instance->build_connect_url( true, $host . $path_with_site, $from );
+	}
 
 	/**
 	 * Stores and prints out domains to prefetch for page speed optimization.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -615,18 +615,3 @@ abstract class Publicize_Base {
 		return str_replace( $search, $replace, $string );
 	}
 }
-
-function publicize_calypso_url() {
-	$calypso_sharing_url = 'https://wordpress.com/sharing/';
-	if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'build_raw_urls' ) ) {
-		$site_suffix = Jetpack::build_raw_urls( home_url() );
-	} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
-		$site_suffix = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
-	}
-
-	if ( $site_suffix ) {
-		return $calypso_sharing_url . $site_suffix;
-	} else {
-		return $calypso_sharing_url;
-	}
-}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -51,7 +51,15 @@ class Publicize_UI {
 	* If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
 	*/
 	function sharing_menu() {
-		add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
+		$page_hook = add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
+		add_action( "load-{$page_hook}", array( &$this, 'redirect_to_calypso' ) );
+	}
+
+	public function redirect_to_calypso() {
+		if ( empty( $_GET['action'] ) ) { // this is done so that we support the refresh links.
+			wp_redirect( Jetpack::calyps_url( '/sharing/%site%' ) );
+			die();
+		}
 	}
 
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -79,13 +79,26 @@ class Sharing_Admin {
 
 	public function subscription_menu( $user ) {
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$active = Jetpack::get_active_modules();
-			if ( ! in_array( 'publicize', $active ) && ! current_user_can( 'manage_options' ) ) {
+			if ( ! Jetpack::is_module_active( 'publicize' ) && ! current_user_can( 'manage_options' ) ) {
 				return;
 			}
 		}
 
-		add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
+		$page_hook = add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
+		add_action( "load-{$page_hook}", array( &$this, 'redirect_to_calypso' ) );
+	}
+
+	public function redirect_to_calypso() {
+		$path = '/sharing/buttons/%site%';
+		if ( Jetpack::is_module_active( 'publicize' ) ) {
+			if ( isset( $_GET['action'] ) ) { // do not redirect if action is set.
+				return;
+			}
+			$path = '/sharing/%site%';
+		}
+
+		wp_redirect( Jetpack::calyps_url( $path ) );
+		die();
 	}
 
 	public function ajax_save_services() {


### PR DESCRIPTION
When a user tries to go to Sharing Section in the wp-admin 
they will not get redirected to calypso. 

If the user doesn't have a Jetpack connection already they should be sent through the connection flow instead of the settings page. 
They should eventually be redirected to the expected settings screen. 

#### Changes proposed in this Pull Request:
*  Redirect the user to calypso when they try to edit the sharing settings. 
#### Testing instructions:
Go to the wp-admin. Does the navigation to the sharing settings work as expected? 

When clicking the reload connection links do they work as expected. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
