### PR TITLE
Decouple Publicize connection list access from UI scripts.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -420,7 +420,7 @@ class Publicize extends Publicize_Base {
 	 * data directly as array so it can be retrieved for static HTML generation
 	 * or JSON consumption.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 *
 	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
 	 *
@@ -586,7 +586,7 @@ class Publicize extends Publicize_Base {
 	 * far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
 	 * have Publicize disabled.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 *
 	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
 	 *
@@ -606,7 +606,7 @@ class Publicize extends Publicize_Base {
 	 * Retrieves current available publicize service connections
 	 * with associated labels and URLs.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 *
 	 * @return array {
 	 *     Array of UI service connection data for all services

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -420,7 +420,7 @@ class Publicize extends Publicize_Base {
 	 * data directly as array so it can be retrieved for static HTML generation
 	 * or JSON consumption.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 *
 	 * @param integer $selected_post_id Optional. Post ID to query connection status for.
 	 *
@@ -606,7 +606,7 @@ class Publicize extends Publicize_Base {
 	 * far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
 	 * have Publicize disabled.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 *
 	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
 	 *
@@ -629,7 +629,7 @@ class Publicize extends Publicize_Base {
 	 * Retrieves current available publicize service connections
 	 * with associated labels and URLs.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 *
 	 * @return array {
 	 *     Array of UI service connection data for all services

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -436,24 +436,25 @@ class Publicize extends Publicize_Base {
 	 *     @type string 'display_name'    Username for sharing account.
 	 * }
 	 */
-	function get_filtered_connection_data( $post_id = null ) {
+	public function get_filtered_connection_data( $post_id = null ) {
 		$connection_list = array();
 
-		$post = get_post( $post_id ); // Defaults to current post if $post_id is null
+		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
 
 		$services = $this->get_services( 'connected' );
 		$all_done = $this->done_sharing_post( $post_id );
 
-		// We don't allow Publicizing to the same external id twice, to prevent spam
+		// We don't allow Publicizing to the same external id twice, to prevent spam.
 		$service_id_done = (array) get_post_meta( $post->ID, $this->POST_SERVICE_DONE, true );
 
 		foreach ( $services as $name => $connections ) {
 			foreach ( $connections as $connection ) {
 				$connection_data = '';
-				if ( method_exists( $connection, 'get_meta' ) )
+				if ( method_exists( $connection, 'get_meta' ) ) {
 					$connection_data = $connection->get_meta( 'connection_data' );
-				elseif ( ! empty( $connection['connection_data'] ) )
+				} elseif ( ! empty( $connection['connection_data'] ) ) {
 					$connection_data = $connection['connection_data'];
+				}
 
 				/**
 				 * Filter whether a post should be publicized to a given service.
@@ -467,13 +468,13 @@ class Publicize extends Publicize_Base {
 				 * @param string $name Service name.
 				 * @param array $connection_data Array of information about all Publicize details for the site.
 				 */
-				if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
+				if ( ! apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
 					continue;
 				}
 
 				if ( ! empty( $connection->unique_id ) ) {
 					$unique_id = $connection->unique_id;
-				} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
+				} elseif ( ! empty( $connection['connection_data']['token_id'] ) ) {
 					$unique_id = $connection['connection_data']['token_id'];
 				}
 

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -422,7 +422,7 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
+	 * @param integer $selected_post_id Optional. Post ID to query connection status for.
 	 *
 	 * @return array {
 	 *     Array of UI setup data for connection list form.
@@ -436,16 +436,22 @@ class Publicize extends Publicize_Base {
 	 *     @type string 'display_name'    Username for sharing account.
 	 * }
 	 */
-	public function get_filtered_connection_data( $post_id = null ) {
+	public function get_filtered_connection_data( $selected_post_id = null ) {
 		$connection_list = array();
 
-		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
+		$post = get_post( $selected_post_id ); // Defaults to current post if $post_id is null.
+		// Handle case where there is no current post.
+		if ( ! empty( $post ) ) {
+			$post_id = $post->ID;
+		} else {
+			$post_id = null;
+		}
 
 		$services = $this->get_services( 'connected' );
 		$all_done = $this->done_sharing_post( $post_id );
 
 		// We don't allow Publicizing to the same external id twice, to prevent spam.
-		$service_id_done = (array) get_post_meta( $post->ID, $this->POST_SERVICE_DONE, true );
+		$service_id_done = (array) get_post_meta( $post_id, $this->POST_SERVICE_DONE, true );
 
 		foreach ( $services as $name => $connections ) {
 			foreach ( $connections as $connection ) {
@@ -464,11 +470,11 @@ class Publicize extends Publicize_Base {
 				 * @since 2.0.0
 				 *
 				 * @param bool true Should the post be publicized to a given service? Default to true.
-				 * @param int $post->ID Post ID.
+				 * @param int $post_id Post ID.
 				 * @param string $name Service name.
 				 * @param array $connection_data Array of information about all Publicize details for the site.
 				 */
-				if ( ! apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
+				if ( ! apply_filters( 'wpas_submit_post?', true, $post_id, $name, $connection_data ) ) {
 					continue;
 				}
 
@@ -481,9 +487,11 @@ class Publicize extends Publicize_Base {
 				// Should we be skipping this one?
 				$skip = (
 					(
+						! empty( $post )
+						&&
 						in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
 						&&
-						get_post_meta( $post->ID, $this->POST_SKIP . $unique_id, true )
+						get_post_meta( $post_id, $this->POST_SKIP . $unique_id, true )
 					)
 					||
 					(
@@ -499,7 +507,7 @@ class Publicize extends Publicize_Base {
 				);
 
 				// Was this connections (OR, old-format service) already Publicized to.
-				$done = ( 1 == get_post_meta( $post->ID, $this->POST_DONE . $unique_id, true ) || 1 == get_post_meta( $post->ID, $this->POST_DONE . $name, true ) ); // New and old style flags
+				$done = ( 1 == get_post_meta( $post_id, $this->POST_DONE . $unique_id, true ) || 1 == get_post_meta( $post_id, $this->POST_DONE . $name, true ) ); // New and old style flags.
 
 				// If this one has already been publicized to, don't let it happen again.
 				$disabled = false;
@@ -523,11 +531,11 @@ class Publicize extends Publicize_Base {
 					 * @since 3.7.0
 					 *
 					 * @param bool   $checked Indicates if this connection should be enabled. Default true.
-					 * @param int    $post->ID ID of the current post
+					 * @param int    $post_id ID of the current post
 					 * @param string $name Name of the connection (Facebook, Twitter, etc)
 					 * @param array  $connection Array of data about the connection.
 					 */
-					$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
+					$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post_id, $name, $connection );
 				}
 
 				// Determine the state of the checkbox (on/off) and allow filtering.
@@ -540,11 +548,11 @@ class Publicize extends Publicize_Base {
 				 * @since 2.0.1
 				 *
 				 * @param bool $checked Should the Publicize checkbox be enabled for a given service.
-				 * @param int $post->ID Post ID.
+				 * @param int $post_id Post ID.
 				 * @param string $name Service name.
 				 * @param array $connection Array of connection details.
 				 */
-				$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
+				$checked = apply_filters( 'publicize_checkbox_default', $checked, $post_id, $name, $connection );
 
 				// Force the checkbox to be checked if the post was DONE, regardless of what the filter does.
 				if ( $done ) {
@@ -597,6 +605,9 @@ class Publicize extends Publicize_Base {
 	public function done_sharing_post( $post_id = null ) {
 		global $publicize_ui;
 		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
+		if ( is_null( $post ) ) {
+			return false;
+		}
 		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $publicize_ui->in_jetpack && 'publish' == $post->post_status );
 	}
 

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -498,16 +498,28 @@ class Publicize extends Publicize_Base {
 						is_array( $connection )
 						&&
 						(
-							( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] ) )
+							(
+									isset( $connection['meta']['external_id'] )
+									&&
+									! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] )
+							)
 							||
 							// Jetpack's connection data looks a little different.
-							( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['external_id'] ] ) )
+							(
+									isset( $connection['external_id'] )
+									&&
+									! empty( $service_id_done[ $name ][ $connection['external_id'] ] )
+							)
 						)
 					)
 				);
 
 				// Was this connections (OR, old-format service) already Publicized to.
-				$done = ( 1 == get_post_meta( $post_id, $this->POST_DONE . $unique_id, true ) || 1 == get_post_meta( $post_id, $this->POST_DONE . $name, true ) ); // New and old style flags.
+				$done = (
+							( 1 == get_post_meta( $post_id, $this->POST_DONE . $unique_id, true ) )
+							||
+							( 1 == get_post_meta( $post_id, $this->POST_DONE . $name, true ) )
+				); // New and old style flags.
 
 				// If this one has already been publicized to, don't let it happen again.
 				$disabled = false;

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -568,7 +568,7 @@ class Publicize extends Publicize_Base {
 					'active'          => $active,
 					'hidden_checkbox' => $hidden_checkbox,
 					'label'           => esc_html( $label ),
-					'display_name'    => $this->publicize->get_display_name( $name, $connection ),
+					'display_name'    => $this->get_display_name( $name, $connection ),
 				);
 			}
 		}
@@ -585,14 +585,17 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @since 5.9.1
 	 *
+	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
+	 *
 	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
 	function done_sharing_post( $post_id = null )
 	{
+		global $publicize_ui;
 		$post = get_post( $post_id ); // Defaults to current post if $post_id is null
-		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $this->in_jetpack && 'publish' == $post->post_status );
+		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $publicize_ui->in_jetpack && 'publish' == $post->post_status );
 	}
 
 	/**

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -498,20 +498,22 @@ class Publicize extends Publicize_Base {
 					)
 				);
 
-				// Was this connections (OR, old-format service) already Publicized to?
-				$done = ( 1 == get_post_meta( $post->ID, $this->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->POST_DONE . $name, true ) ); // New and old style flags
+				// Was this connections (OR, old-format service) already Publicized to.
+				$done = ( 1 == get_post_meta( $post->ID, $this->POST_DONE . $unique_id, true ) || 1 == get_post_meta( $post->ID, $this->POST_DONE . $name, true ) ); // New and old style flags
 
-				// If this one has already been publicized to, don't let it happen again
+				// If this one has already been publicized to, don't let it happen again.
 				$disabled = false;
 				if ( $done ) {
 					$disabled = true;
 				}
 
-				// If this is a global connection and this user doesn't have enough permissions to modify
-				// those connections, don't let them change it
-				$cmeta = $this->get_connection_meta( $connection );
+				/**
+				 * If this is a global connection and this user doesn't have enough permissions to modify
+				 * those connections, don't let them change it.
+				 */
+				$cmeta           = $this->get_connection_meta( $connection );
 				$hidden_checkbox = false;
-				if ( !$done && ( 0 == $cmeta['connection_data']['user_id'] && !current_user_can( $this->GLOBAL_CAP ) ) ) {
+				if ( ! $done && ( 0 == $cmeta['connection_data']['user_id'] && ! current_user_can( $this->GLOBAL_CAP ) ) ) {
 					$disabled = true;
 					/**
 					 * Filters the checkboxes for global connections with non-prilvedged users.
@@ -528,8 +530,8 @@ class Publicize extends Publicize_Base {
 					$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
 				}
 
-				// Determine the state of the checkbox (on/off) and allow filtering
-				$checked = $skip != 1 || $done;
+				// Determine the state of the checkbox (on/off) and allow filtering.
+				$checked = ( ( 1 != $skip ) || $done );
 				/**
 				 * Filter the checkbox state of each Publicize connection appearing in the post editor.
 				 *
@@ -544,22 +546,22 @@ class Publicize extends Publicize_Base {
 				 */
 				$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
 
-				// Force the checkbox to be checked if the post was DONE, regardless of what the filter does
+				// Force the checkbox to be checked if the post was DONE, regardless of what the filter does.
 				if ( $done ) {
 					$checked = true;
 				}
 
-				// This post has been handled, so disable everything
+				// This post has been handled, so disable everything.
 				if ( $all_done ) {
 					$disabled = true;
 				}
 
-				$label = sprintf(
+				$label  = sprintf(
 					_x( '%1$s: %2$s', 'Service: Account connected as', 'jetpack' ),
 					esc_html( $this->get_service_label( $name ) ),
 					esc_html( $this->get_display_name( $name, $connection ) )
 				);
-				$active =  !$skip || $done;
+				$active = ! $skip || $done;
 
 				$connection_list[] = array(
 					'unique_id'       => $unique_id,
@@ -592,10 +594,9 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	function done_sharing_post( $post_id = null )
-	{
+	public function done_sharing_post( $post_id = null ) {
 		global $publicize_ui;
-		$post = get_post( $post_id ); // Defaults to current post if $post_id is null
+		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
 		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $publicize_ui->in_jetpack && 'publish' == $post->post_status );
 	}
 
@@ -616,7 +617,7 @@ class Publicize extends Publicize_Base {
 	 * }
 	 */
 	function get_available_service_data() {
-		$available_services = $this->get_services( 'all' );
+		$available_services     = $this->get_services( 'all' );
 		$available_service_data = array();
 
 		foreach ( $available_services as $service_name => $service ) {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -606,64 +606,63 @@ jQuery( function($) {
 	 */
 	private function get_metabox_form_connected() {
 		global $post;
-		$active = array();
-		$connection_list = $this->publicize->get_filtered_connection_data();
-		ob_start();
-		?> <div id="publicize-form" class="hide-if-js">
-			<ul>
+		$active_list = array();
 
-			<?php
-			// We can set an _all flag to indicate that this post is completely done as
-			// far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
-			// have Publicize disabled.
-			$all_done = $this->publicize->done_sharing_post();
+		$all_done = $this->publicize->done_sharing_post();
+		$connection_list = $this->publicize->get_filtered_connection_data();
+
+		ob_start();
+		?>
+			<div id="publicize-form" class="hide-if-js">
+				<ul>
+		<?php
+
 		foreach ( $connection_list as $c ) {
 			if ( $c['active'] ) {
-				$active[] = $c['label'];
+				$active_list[] = $c['label'];
 			}
 			?>
-					<li>
-						<label for="wpas-submit-<?php echo esc_attr( $c['unique_id'] ); ?>">
-							<input type="checkbox" name="wpas[submit][<?php echo $c['unique_id']; ?>]" id="wpas-submit-<?php echo $c['unique_id']; ?>" class="wpas-submit-<?php echo $c['name']; ?>" value="1" <?php
-								checked( true, $c['checked'] );
-								echo $c['disabled'];
-							?> />
-							<?php
-							if ( $c['hidden_checkbox'] ) {
-								// Need to submit a value to force a global connection to post
-								echo '<input type="hidden" name="wpas[submit][' . $c['unique_id'] . ']" value="1" />';
-							}
-							echo esc_html( $c['label'] );
-							?>
-						</label>
-					</li>
-					<?php
-				}
+				<li>
+					<label for="wpas-submit-<?php echo esc_attr( $c['unique_id'] ); ?>">
+						<input type="checkbox" name="wpas[submit][<?php echo $c['unique_id']; ?>]" id="wpas-submit-<?php echo $c['unique_id']; ?>" class="wpas-submit-<?php echo $c['name']; ?>" value="1" <?php
+						checked( true, $c['checked'] );
+						echo $c['disabled'];
+						?> />
+						<?php
+						if ( $c['hidden_checkbox'] ) {
+							// Need to submit a value to force a global connection to post
+							echo '<input type="hidden" name="wpas[submit][' . $c['unique_id'] . ']" value="1" />';
+						}
+						echo esc_html( $c['label'] );
+						?>
+					</label>
+				</li>
+			<?php
+		}
 
-			if ( $title = get_post_meta( $post->ID, $this->publicize->POST_MESS, true ) ) {
-				$title = esc_html( $title );
-			} else {
-				$title = '';
-			}
-			?>
+		if ( $title = get_post_meta( $post->ID, $this->publicize->POST_MESS, true ) ) {
+			$title = esc_html( $title );
+		} else {
+			$title = '';
+		}
 
-			</ul>
+		?>
+				</ul>
 
-			<label for="wpas-title"><?php _e( 'Custom Message:', 'jetpack' ); ?></label>
-			<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
+				<label for="wpas-title"><?php _e( 'Custom Message:', 'jetpack' ); ?></label>
+				<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
 
-			<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
+				<textarea name="wpas_title" id="wpas-title"<?php disabled( $all_done ); ?>><?php echo $title; ?></textarea>
 
-			<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
-			<input type="hidden" name="wpas[0]" value="1" />
+				<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
+				<input type="hidden" name="wpas[0]" value="1" />
 
-		</div>
+			</div>
 		<?php if ( ! $all_done ) : ?>
 			<div id="pub-connection-tests"></div>
 		<?php endif; ?>
 		<?php // #publicize-form
-
-		return array( ob_get_clean(), $active );
+		return array( ob_get_clean(), $active_list );
 	}
 
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -556,7 +556,7 @@ jQuery( function($) {
 			<span id="publicize-title">
 				<?php esc_html_e( 'Publicize:', 'jetpack' ); ?>
 				<?php if ( 0 < count( $services ) ) : ?>
-					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected( $services ); ?>
+					<?php list( $publicize_form, $active ) = $this->get_metabox_form_connected(); ?>
 					<span id="publicize-defaults">
 						<?php foreach ( $active as $item ) : ?>
 							<strong><?php echo esc_html( $item ); ?></strong>
@@ -584,9 +584,30 @@ jQuery( function($) {
 		</div> <?php // #publicize
 	}
 
-	private function get_metabox_form_connected( $services ) {
+	/**
+	 * Generates HTML content for connections form.
+	 *
+	 * Retrieves current connection list and generates HTML form.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @global WP_Post $post The current post instance being published.
+	 *
+	 * @return array {
+	 *     Array of content for generating connection form.
+	 *
+	 *     @type string HTML content of form
+	 *     @type array {
+	 *     		Array of connection labels for active connections only.
+	 *
+	 *          @type string Connection label string.
+	 *     }
+	 * }
+	 */
+	private function get_metabox_form_connected() {
 		global $post;
 		$active = array();
+		$connection_list = $this->publicize->get_filtered_connection_data();
 		ob_start();
 		?> <div id="publicize-form" class="hide-if-js">
 			<ul>
@@ -595,144 +616,29 @@ jQuery( function($) {
 			// We can set an _all flag to indicate that this post is completely done as
 			// far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
 			// have Publicize disabled.
-			$all_done = get_post_meta( $post->ID, $this->publicize->POST_DONE . 'all', true ) || ( $this->in_jetpack && 'publish' == $post->post_status );
-
-			// We don't allow Publicizing to the same external id twice, to prevent spam
-			$service_id_done = (array) get_post_meta( $post->ID, $this->publicize->POST_SERVICE_DONE, true );
-
-			foreach ( $services as $name => $connections ) {
-				foreach ( $connections as $connection ) {
-					$connection_data = '';
-					if ( method_exists( $connection, 'get_meta' ) )
-						$connection_data = $connection->get_meta( 'connection_data' );
-					elseif ( ! empty( $connection['connection_data'] ) )
-						$connection_data = $connection['connection_data'];
-
-					/**
-					 * Filter whether a post should be publicized to a given service.
-					 *
-					 * @module publicize
-					 *
-					 * @since 2.0.0
-					 *
-					 * @param bool true Should the post be publicized to a given service? Default to true.
-					 * @param int $post->ID Post ID.
-					 * @param string $name Service name.
-					 * @param array $connection_data Array of information about all Publicize details for the site.
-					 */
-					if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
-						continue;
-					}
-
-					if ( ! empty( $connection->unique_id ) ) {
-						$unique_id = $connection->unique_id;
-					} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
-						$unique_id = $connection['connection_data']['token_id'];
-					}
-
-					// Should we be skipping this one?
-					$skip = (
-						(
-							in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
-							&&
-							get_post_meta( $post->ID, $this->publicize->POST_SKIP . $unique_id, true )
-						)
-						||
-						(
-							is_array( $connection )
-							&&
-							(
-								( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] ) )
-								||
-								// Jetpack's connection data looks a little different.
-								( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['external_id'] ] ) )
-							)
-						)
-					);
-
-					// Was this connections (OR, old-format service) already Publicized to?
-					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags
-
-					// If this one has already been publicized to, don't let it happen again
-					$disabled = '';
-					if ( $done ) {
-						$disabled = ' disabled="disabled"';
-					}
-
-					// If this is a global connection and this user doesn't have enough permissions to modify
-					// those connections, don't let them change it
-					$cmeta = $this->publicize->get_connection_meta( $connection );
-					$hidden_checkbox = false;
-					if ( !$done && ( 0 == $cmeta['connection_data']['user_id'] && !current_user_can( $this->publicize->GLOBAL_CAP ) ) ) {
-						$disabled = ' disabled="disabled"';
-						/**
-						 * Filters the checkboxes for global connections with non-prilvedged users.
-						 *
-						 * @module publicize
-						 *
-						 * @since 3.7.0
-						 *
-						 * @param bool   $checked Indicates if this connection should be enabled. Default true.
-						 * @param int    $post->ID ID of the current post
-						 * @param string $name Name of the connection (Facebook, Twitter, etc)
-						 * @param array  $connection Array of data about the connection.
-						 */
-						$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
-					}
-
-					// Determine the state of the checkbox (on/off) and allow filtering
-					$checked = $skip != 1 || $done;
-					/**
-					 * Filter the checkbox state of each Publicize connection appearing in the post editor.
-					 *
-					 * @module publicize
-					 *
-					 * @since 2.0.1
-					 *
-					 * @param bool $checked Should the Publicize checkbox be enabled for a given service.
-					 * @param int $post->ID Post ID.
-					 * @param string $name Service name.
-					 * @param array $connection Array of connection details.
-					 */
-					$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
-
-					// Force the checkbox to be checked if the post was DONE, regardless of what the filter does
-					if ( $done ) {
-						$checked = true;
-					}
-
-					// This post has been handled, so disable everything
-					if ( $all_done ) {
-						$disabled = ' disabled="disabled"';
-					}
-
-					$label = sprintf(
-						_x( '%1$s: %2$s', 'Service: Account connected as', 'jetpack' ),
-						esc_html( $this->publicize->get_service_label( $name ) ),
-						esc_html( $this->publicize->get_display_name( $name, $connection ) )
-					);
-					if ( !$skip || $done ) {
-						$active[] = $label;
-					}
-					?>
+			$all_done = $this->publicize->done_sharing_post();
+		foreach ( $connection_list as $c ) {
+			if ( $c['active'] ) {
+				$active[] = $c['label'];
+			}
+			?>
 					<li>
-						<label for="wpas-submit-<?php echo esc_attr( $unique_id ); ?>">
-							<input type="checkbox" name="wpas[submit][<?php echo $unique_id; ?>]" id="wpas-submit-<?php echo $unique_id; ?>" class="wpas-submit-<?php echo $name; ?>" value="1" <?php
-								checked( true, $checked );
-								echo $disabled;
+						<label for="wpas-submit-<?php echo esc_attr( $c['unique_id'] ); ?>">
+							<input type="checkbox" name="wpas[submit][<?php echo $c['unique_id']; ?>]" id="wpas-submit-<?php echo $c['unique_id']; ?>" class="wpas-submit-<?php echo $c['name']; ?>" value="1" <?php
+								checked( true, $c['checked'] );
+								echo $c['disabled'];
 							?> />
 							<?php
-							if ( $hidden_checkbox ) {
+							if ( $c['hidden_checkbox'] ) {
 								// Need to submit a value to force a global connection to post
-								echo '<input type="hidden" name="wpas[submit][' . $unique_id . ']" value="1" />';
+								echo '<input type="hidden" name="wpas[submit][' . $c['unique_id'] . ']" value="1" />';
 							}
-							echo esc_html( $label );
+							echo esc_html( $c['label'] );
 							?>
 						</label>
 					</li>
 					<?php
 				}
-			}
 
 			if ( $title = get_post_meta( $post->ID, $this->publicize->POST_MESS, true ) ) {
 				$title = esc_html( $title );

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -626,7 +626,9 @@ jQuery( function($) {
 					<label for="wpas-submit-<?php echo esc_attr( $c['unique_id'] ); ?>">
 						<input type="checkbox" name="wpas[submit][<?php echo $c['unique_id']; ?>]" id="wpas-submit-<?php echo $c['unique_id']; ?>" class="wpas-submit-<?php echo $c['name']; ?>" value="1" <?php
 						checked( true, $c['checked'] );
-						echo $c['disabled'];
+						if ( $c['disabled'] ) {
+							echo 'disabled="disabled"';
+						}
 						?> />
 						<?php
 						if ( $c['hidden_checkbox'] ) {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -589,7 +589,7 @@ jQuery( function($) {
 	 *
 	 * Retrieves current connection list and generates HTML form.
 	 *
-	 * @since 5.9.1
+	 * @since Unknown
 	 *
 	 * @global WP_Post $post The current post instance being published.
 	 *

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -447,8 +447,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		// First connection should be 'facebook' for unfiltered list.
 		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
-		$this->assertEquals(
-			'',
+		$this->assertFalse(
 			$facebook_connection['disabled'],
 			'Facebook connection should not be disabled if the post is not \'done\'.'
 		);
@@ -462,8 +461,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
-		$this->assertEquals(
-			' disabled="disabled"',
+		$this->assertTrue(
 			$facebook_connection['disabled'],
 			'Facebook connection should be disabled if the post is \'done\'.'
 		);

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -12,7 +12,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Current test user id produced by factory method.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 * @var integer $user_id ID of current user.
 	 */
 	private $user_id;
@@ -20,7 +20,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Facebook connection.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 * @var integer FACEBOOK_CONNECTION_INDEX index number of facebook connection.
 	 */
 	const FACEBOOK_CONNECTION_INDEX = 0;
@@ -28,7 +28,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Tumblr connection.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 * @var integer TUMBLR_CONNECTION_INDEX index number of Tumblr connection.
 	 */
 	const TUMBLR_CONNECTION_INDEX = 1;
@@ -243,7 +243,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * of already shared post.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_done_sharing_post_for_done_all() {
 		$this->assertFalse(
@@ -262,7 +262,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * that already published post is correctly reported as 'done'.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_done_sharing_post_for_published() {
 		$this->assertFalse(
@@ -285,7 +285,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * connections that are valid for the current user.
 	 *
 	 * @covers Publicize::get_services_connected()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_get_services_connected() {
 		$connected_services = $this->publicize->get_services( 'connected' );
@@ -299,7 +299,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * has not been shared yet.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_get_filtered_connection_data_no_filters() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -347,7 +347,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * so a new post will not have connections disabled.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_done_sharing_post_null_post() {
 		/**
@@ -367,7 +367,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * through without disabling connections.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_get_filtered_connection_data_null_post() {
 		/**
@@ -388,7 +388,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * been applied.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_filter_wpas_submit_post() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -426,7 +426,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can be used to cause such a connection to be shown.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_filter_publicize_checkbox_global_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -455,7 +455,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can correctly set default value to unchecked.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_filter_publicize_checkbox_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -482,7 +482,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * its checkbox should be disabled.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 */
 	public function test_get_filtered_connection_data_disabled_done_all() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -515,7 +515,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * get_filtered_connection_data so this callback can be reused
 	 * for all filter test cases.
 	 *
-	 * @since 6.2.0
+	 * @since 6.5.0
 	 *
 	 * @param bool   $enabled         Should the connection be enabled.
 	 * @param int    $post_id         Post ID.

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -342,6 +342,47 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify case where no post id is provided and there is
+	 * no current post. 'Done' return value should be false
+	 * so a new post will not have connections disabled.
+	 *
+	 * @covers Publicize::done_sharing_post()
+	 * @since 6.2.0
+	 */
+	public function test_done_sharing_post_null_post() {
+		/**
+		 * Simulate null post by not providing post_id argument and
+		 * when current $post value is unset.
+		 */
+		$done_sharing = $this->publicize->done_sharing_post();
+		$this->assertFalse(
+			$done_sharing,
+			'Done sharing value should be false for null post id'
+		);
+	}
+
+	/**
+	 * Verify case where no post id is provided and there is
+	 * no current post. Connections data should be passed
+	 * through without disabling connections.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.2.0
+	 */
+	public function test_get_filtered_connection_data_null_post() {
+		/**
+		 * Simulate null post by not providing post_id argument and
+		 * when current $post value is unset.
+		 */
+		$connection_list   = $this->publicize->get_filtered_connection_data();
+		$tumblr_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$tumblr_connection['disabled'],
+			'All connections should be enabled for null post id'
+		);
+	}
+
+	/**
 	 * Verify 'wpas_submit_post?' filter functionality by checking
 	 * connection list before and after a 'no facebook' filter has
 	 * been applied.

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -12,7 +12,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Current test user id produced by factory method.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 * @var integer $user_id ID of current user.
 	 */
 	private $user_id;
@@ -20,7 +20,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Facebook connection.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 * @var integer FACEBOOK_CONNECTION_INDEX index number of facebook connection.
 	 */
 	const FACEBOOK_CONNECTION_INDEX = 0;
@@ -28,7 +28,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Tumblr connection.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 * @var integer TUMBLR_CONNECTION_INDEX index number of Tumblr connection.
 	 */
 	const TUMBLR_CONNECTION_INDEX = 1;
@@ -243,7 +243,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * of already shared post.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_done_sharing_post_for_done_all() {
 		$this->assertFalse(
@@ -262,7 +262,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * that already published post is correctly reported as 'done'.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_done_sharing_post_for_published() {
 		$this->assertFalse(
@@ -285,7 +285,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * connections that are valid for the current user.
 	 *
 	 * @covers Publicize::get_services_connected()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_get_services_connected() {
 		$connected_services = $this->publicize->get_services( 'connected' );
@@ -299,7 +299,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * has not been shared yet.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_get_filtered_connection_data_no_filters() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -347,7 +347,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * been applied.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_filter_wpas_submit_post() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -385,7 +385,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can be used to cause such a connection to be shown.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_filter_publicize_checkbox_global_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -414,7 +414,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can correctly set default value to unchecked.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_filter_publicize_checkbox_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -441,7 +441,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * its checkbox should be disabled.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 */
 	public function test_get_filtered_connection_data_disabled_done_all() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -474,7 +474,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * get_filtered_connection_data so this callback can be reused
 	 * for all filter test cases.
 	 *
-	 * @since 5.9.1
+	 * @since 6.2.0
 	 *
 	 * @param bool   $enabled         Should the connection be enabled.
 	 * @param int    $post_id         Post ID.

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -242,19 +242,17 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * the helper method that checks post flags to prevent re-sharing
 	 * of already shared post.
 	 *
-	 * @covers Publicize_UI::done_sharing_post()
+	 * @covers Publicize::done_sharing_post()
 	 * @since 5.9.1
-	 * @global Publicize_UI $publicize_ui instance of class that contains helper methods for ui generation.
 	 */
 	public function test_done_sharing_post_for_done_all() {
-		global $publicize_ui;
 		$this->assertFalse(
-			$publicize_ui->done_sharing_post( $this->post->ID ),
+			$this->publicize->done_sharing_post( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 		update_post_meta( $this->post->ID, $this->publicize->POST_DONE . 'all', true );
 		$this->assertTrue(
-			$publicize_ui->done_sharing_post( $this->post->ID ),
+			$this->publicize->done_sharing_post( $this->post->ID ),
 			'Posts flagged as \'done\' should return true done sharing'
 		);
 	}
@@ -263,14 +261,12 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that "done sharing post" logic is correct. Checks
 	 * that already published post is correctly reported as 'done'.
 	 *
-	 * @covers Publicize_UI::done_sharing_post()
+	 * @covers Publicize::done_sharing_post()
 	 * @since 5.9.1
-	 * @global Publicize_UI $publicize_ui instance of class that contains helper methods for ui generation.
 	 */
 	public function test_done_sharing_post_for_published() {
-		global $publicize_ui;
 		$this->assertFalse(
-			$publicize_ui->done_sharing_post( $this->post->ID ),
+			$this->publicize->done_sharing_post( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 
@@ -279,7 +275,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		wp_insert_post( $this->post->to_array() );
 
 		$this->assertTrue(
-			$publicize_ui->done_sharing_post( $this->post->ID ),
+			$this->publicize->done_sharing_post( $this->post->ID ),
 			'Published post should be flagged as \'done\''
 		);
 	}
@@ -288,7 +284,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that get_services_connected returns all test
 	 * connections that are valid for the current user.
 	 *
-	 * @covers Publicize_UI::get_services_connected()
+	 * @covers Publicize::get_services_connected()
 	 * @since 5.9.1
 	 */
 	public function test_get_services_connected() {
@@ -302,12 +298,11 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * when there are no connection filters and the post
 	 * has not been shared yet.
 	 *
-	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 5.9.1
 	 */
 	public function test_get_filtered_connection_data_no_filters() {
-		global $publicize_ui;
-		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$test_c          = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
 		$this->assertEquals(
 			'test-unique-id456',
@@ -351,12 +346,11 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * connection list before and after a 'no facebook' filter has
 	 * been applied.
 	 *
-	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 5.9.1
 	 */
 	public function test_filter_wpas_submit_post() {
-		global $publicize_ui;
-		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		// Second connection should be 'tumblr' for unfiltered list.
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertEquals(
@@ -367,7 +361,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		add_filter( 'wpas_submit_post?', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
 		// Get connection list again now that filter has been added.
-		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 
 		$this->assertEquals(
 			1,
@@ -390,12 +384,11 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * 'publicize_checkbox_global_default' filter
 	 * can be used to cause such a connection to be shown.
 	 *
-	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 5.9.1
 	 */
 	public function test_filter_publicize_checkbox_global_default() {
-		global $publicize_ui;
-		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertTrue(
 			$facebook_connection['hidden_checkbox'],
@@ -405,7 +398,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		add_filter( 'publicize_checkbox_global_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
 
 		// Get connection list again now that filter has been added.
-		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertFalse(
 			$facebook_connection['hidden_checkbox'],
@@ -420,12 +413,11 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * This test confirms that the 'publicize_checkbox_default'
 	 * can correctly set default value to unchecked.
 	 *
-	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 5.9.1
 	 */
 	public function test_filter_publicize_checkbox_default() {
-		global $publicize_ui;
-		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertTrue(
 			$facebook_connection['checked'],
@@ -433,7 +425,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		);
 
 		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
-		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertFalse(
@@ -448,12 +440,11 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * If a post has already been published (and is this 'done' sharing),
 	 * its checkbox should be disabled.
 	 *
-	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 5.9.1
 	 */
 	public function test_get_filtered_connection_data_disabled_done_all() {
-		global $publicize_ui;
-		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		// First connection should be 'facebook' for unfiltered list.
 		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
 		$this->assertEquals(
@@ -469,7 +460,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$this->post->post_status = 'publish';
 		wp_insert_post( $this->post->to_array() );
 
-		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
 		$this->assertEquals(
 			' disabled="disabled"',

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -17,6 +17,22 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 */
 	private $user_id;
 
+	/**
+	 * Index in 'publicize_connections' test data of Facebook connection.
+	 *
+	 * @since 5.9.1
+	 * @var integer FACEBOOK_CONNECTION_INDEX index number of facebook connection.
+	 */
+	const FACEBOOK_CONNECTION_INDEX = 0;
+
+	/**
+	 * Index in 'publicize_connections' test data of Tumblr connection.
+	 *
+	 * @since 5.9.1
+	 * @var integer TUMBLR_CONNECTION_INDEX index number of Tumblr connection.
+	 */
+	const TUMBLR_CONNECTION_INDEX = 1;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -292,8 +308,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	public function test_get_filtered_connection_data_no_filters() {
 		global $publicize_ui;
 		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
-		// Get 'tumblr' test connection entry.
-		$test_c = $connection_list[1];
+		$test_c          = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
 		$this->assertEquals(
 			'test-unique-id456',
 			$test_c['unique_id']
@@ -329,5 +344,162 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			'test-display-name456',
 			$test_c['display_name']
 		);
+	}
+
+	/**
+	 * Verify 'wpas_submit_post?' filter functionality by checking
+	 * connection list before and after a 'no facebook' filter has
+	 * been applied.
+	 *
+	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @since 5.9.1
+	 */
+	public function test_filter_wpas_submit_post() {
+		global $publicize_ui;
+		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		// Second connection should be 'tumblr' for unfiltered list.
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertEquals(
+			'facebook',
+			$facebook_connection['name'],
+			'Facebook connection should be available prior to filtering'
+		);
+
+		add_filter( 'wpas_submit_post?', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+		// Get connection list again now that filter has been added.
+		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+
+		$this->assertEquals(
+			1,
+			count( $connection_list ),
+			'Connection list should be 1 long after \'facebook\' connection removed.'
+		);
+		// First and only connection should be 'tumblr' for unfiltered list.
+		$tumblr_connection = $connection_list[0];
+		$this->assertEquals(
+			'tumblr',
+			$tumblr_connection['name'],
+			'Tumblr connection should still be available after filtering out facebook connection.'
+		);
+	}
+
+	/**
+	 * By default, global connections (where user_id == 0)
+	 * are hidden for users that do not have the appropriate
+	 * capability. This test verifies that the
+	 * 'publicize_checkbox_global_default' filter
+	 * can be used to cause such a connection to be shown.
+	 *
+	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @since 5.9.1
+	 */
+	public function test_filter_publicize_checkbox_global_default() {
+		global $publicize_ui;
+		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertTrue(
+			$facebook_connection['hidden_checkbox'],
+			'Facebook connection checkbox should be hidden by default since test user does not have capability.'
+		);
+
+		add_filter( 'publicize_checkbox_global_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+
+		// Get connection list again now that filter has been added.
+		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$facebook_connection['hidden_checkbox'],
+			'Facebook connection checkbox should not be set to hidden since filter set hidden to false.'
+		);
+
+	}
+
+	/**
+	 *
+	 * By default, all connection checkboxes are 'checked'.
+	 * This test confirms that the 'publicize_checkbox_default'
+	 * can correctly set default value to unchecked.
+	 *
+	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @since 5.9.1
+	 */
+	public function test_filter_publicize_checkbox_default() {
+		global $publicize_ui;
+		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertTrue(
+			$facebook_connection['checked'],
+			'Facebook connection should be checked by default with no filtering applied.'
+		);
+
+		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$facebook_connection['checked'],
+			'Facebook connection should be un-checked by default after filtering applied.'
+		);
+	}
+
+	/**
+	 * Confirms that a connection will be disabled after post is 'done.'
+	 *
+	 * If a post has already been published (and is this 'done' sharing),
+	 * its checkbox should be disabled.
+	 *
+	 * @covers Publicize_UI::get_filtered_connection_data()
+	 * @since 5.9.1
+	 */
+	public function test_get_filtered_connection_data_disabled_done_all() {
+		global $publicize_ui;
+		$connection_list = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		// First connection should be 'facebook' for unfiltered list.
+		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertEquals(
+			'',
+			$facebook_connection['disabled'],
+			'Facebook connection should not be disabled if the post is not \'done\'.'
+		);
+
+		/**
+		 * Publish post so the post will be considered 'done' publicizing
+		 * all connections should be disabled.
+		 */
+		$this->post->post_status = 'publish';
+		wp_insert_post( $this->post->to_array() );
+
+		$connection_list     = $publicize_ui->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertEquals(
+			' disabled="disabled"',
+			$facebook_connection['disabled'],
+			'Facebook connection should be disabled if the post is \'done\'.'
+		);
+	}
+
+	/**
+	 * Filter callback to uncheck checkbox for 'faceboook' connection.
+	 *
+	 * Filter callback interface is the same for all filters within
+	 * get_filtered_connection_data so this callback can be reused
+	 * for all filter test cases.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param bool   $enabled         Should the connection be enabled.
+	 * @param int    $post_id         Post ID.
+	 * @param string $service_name    Name of social service to share to.
+	 * @param array  $connection_data Array of information about all Publicize details for the site.
+	 *
+	 * @return bool Whether or not the connection is enabled for the filter.
+	 */
+	public function publicize_connection_filter_no_facebook( $enabled, $post_id, $service_name, $connection_data ) {
+		// Block 'facebook' connection and let all others pass through.
+		if ( 'facebook' === $service_name ) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #9039 (along with PR #9144)

Replaces the original #9466 by @c-shultz , thanks for all the effort!

**Note**: These changes are standalone but they are a dependency of #9144. They were originally contained in #9144, but are being pulled out for for clarity/organization because that PR was getting too large and complex.

#### Changes proposed in this Pull Request:
This PR separates the Publicize connection list processing from the HTML generation for the UI form.

##### Before this PR:
The method `Publicize_UI::get_metabox_form_connected()` in `ui.php` retrieved and filtered the connection list and then also generated the HTML form. 

##### After this PR:
This PR leaves the HTML generation in `Publicize_UI::get_metabox_form_connected()` but moves the connection gathering/filtering to new method `Publicize::get_filtered_connection_data()` in `publicize-jetpack.php`.

##### Why this is needed:
PR #9144 needs to access the connection list so it can be JSON encoded and utilized in new React-based frontend for Gutenberg. Splitting the connection list retrieval to a separate method allows code reuse between the classic editor HTML generation and the Gutenberg front-end to gather.

The final diff view of these changes looks a little muddled, but the [first commit](https://github.com/Automattic/jetpack/pull/9466/commits/6658192891d80a2f120304f80c5341efe7ff1f1a) pretty effectively shows the basics of what's being moved where in this PR.

This PR should not affect the Classic Editor in any way.

Unit tests have been added to test connection data fields and to test the three potentially affected filters:
 - `'wpas_submit_post?'`
 - `'publicize_checkbox_global_default'`
 - `'publicize_checkbox_default'`

#### Testing instructions:
Checkout and test Publicize in Classic Editor to confirm there are no functional changes.
See #9144 for additional testing instructions.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

props to @ehg for the design suggestions!