### PR TITLE
Twitter Timeline widget: Checking 'type' is an index of $instance

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -85,7 +85,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		// Twitter deprecated `data-widget-id` on 2018-05-25,
 		// with cease support deadline on 2018-07-27.
 		// 1532563200 is 2018-07-26, one day early.
-		 if ( 'widget-id' === $instance['type'] && time() > 1532563200 ) {
+		 if ( isset( $instance['type'] ) && 'widget-id' === $instance['type'] && time() > 1532563200 ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];
@@ -108,7 +108,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
-		if ( 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
+		if ( isset( $instance['type'] ) && 'widget-id' === $instance['type'] && current_user_can( 'edit_theme_options' ) ) {
 			echo '<p>' . esc_html__( 'As of July 27, 2018, the Twitter Timeline widget will no longer display tweets based on searches or hashtags. To display a simple list of tweets instead, change the Widget ID to a Twitter username.', 'jetpack' ) . '</p>';
 			echo '<p>' . esc_html__( '(Only administrators will see this message.)', 'jetpack' ) . '</p>';
 		}


### PR DESCRIPTION
Prevents log lines being written. Fixes #9957.