### PR TITLE
Move set_plugin_action_links() to be run on current_screen instead of on on admin_init

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
-		add_action( 'admin_init', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
+		add_action( 'current_screen', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
 
 		// For some options, we should always send the change right away!
 		$always_send_updates_to_these_options = array(
@@ -122,7 +122,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_check_and_send_callables', '__return_true' );
 	}
 
-	public function set_plugin_action_links() {
+	public function set_plugin_action_links( $current_screen ) {
 		if (
 			! class_exists( 'DOMDocument' ) ||
 			! function_exists ( 'libxml_use_internal_errors' ) ||

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -720,7 +720,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'plugin_action_links_jetpack/jetpack.php', array( $helper_jetpack, 'filter_override_array' ), 10 );
 
 		$callables_module = new Jetpack_Sync_Module_Callables(); // Do the admin init here so that we calculate the plugin links
-		$callables_module->set_plugin_action_links();
+		set_current_screen( 'plugins' );
+		$callables_module->set_plugin_action_links( get_current_screen() );
 		// Let's see if the original values get synced
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -777,10 +778,11 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		delete_transient( 'jetpack_plugin_api_action_links_refresh' );
 		add_filter( 'plugin_action_links', array( $this, 'cause_fatal_error' ) );
 		$callables_module = new Jetpack_Sync_Module_Callables(); // Do the admin init here so that we calculate the plugin links
-		$callables_module->set_plugin_action_links();
+		set_current_screen( 'plugins' );
+		$callables_module->set_plugin_action_links( get_current_screen() );
 
 		$this->resetCallableAndConstantTimeouts();
-		$callables_module->set_plugin_action_links();
+		$callables_module->set_plugin_action_links( get_current_screen() );
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
 		$this->assertTrue( isset( $plugins_action_links['hello.php']['world'] ) );


### PR DESCRIPTION
Fixes #9959.
Fixes #8164

#### Changes proposed in this Pull Request:
Don't hook `set_plugin_action_links()` to `admin_init`, but to `current_screen`.

#### Testing instructions:
Load admin pages (in particular plugins page).
