### PR TITLE
Added a filter for the AT is_automated_transfer state flag.

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -108,7 +108,21 @@ abstract class SAL_Site {
 	abstract protected function is_a8c_publication( $post_id );
 
 	public function is_automated_transfer() {
-		return false;
+		/**
+		 * Filter if a site is an automated-transfer site.
+		 *
+		 * @module json-api
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param bool is_automated_transfer( $this->blog_id )
+		 * @param int  $blog_id Blog identifier.
+		 */
+		return apply_filters(
+			'jetpack_site_automated_transfer',
+			false,
+			$this->blog_id
+		);
 	}
 
 	public function is_wpcom_store() {


### PR DESCRIPTION
This PR adds a filter which allows setting the `is_automated_transfer` site option.
The SAL method `is_automated_transfer()` is called by the `/rest/v1.2/sites$site` endpoint.

### Testing instructions
The filter will be used later, so the testing instructions simply reduce to check that everything is ok.