### PR TITLE
WP REST API: Add endpoints synced from WP.com

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -17,6 +17,9 @@ require_once ABSPATH . '/wp-includes/class-wp-error.php';
 
 // Register endpoints when WP REST API is initialized.
 add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register_endpoints' ) );
+// Load API endpoints that are synced with WP.com
+// Each of these is a class that will register its own routes on 'rest_api_init'.
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/load-wpcom-endpoints.php';
 
 /**
  * Class Jetpack_Core_Json_Api_Endpoints

--- a/_inc/lib/core-api/load-wpcom-endpoints.php
+++ b/_inc/lib/core-api/load-wpcom-endpoints.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Loader for WP REST API endpoints that are synced with WP.com.
+ *
+ * On WP.com see:
+ *  - wp-content/mu-plugins/rest-api.php
+ *  - wp-content/rest-api-plugins/jetpack-endpoints/
+ */
+
+function wpcom_rest_api_v2_load_plugin_files( $file_pattern ) {
+	$plugins = glob( dirname( __FILE__ ) . '/' . $file_pattern );
+
+	if ( ! is_array( $plugins ) ) {
+		return;
+	}
+
+	foreach ( array_filter( $plugins, 'is_file' ) as $plugin ) {
+		require_once $plugin;
+	}
+}
+
+// API v2 plugins: define a class, then call this function.
+function wpcom_rest_api_v2_load_plugin( $class_name ) {
+	global $wpcom_rest_api_v2_plugins;
+
+	if ( ! isset( $wpcom_rest_api_v2_plugins ) ) {
+		$_GLOBALS['wpcom_rest_api_v2_plugins'] = $wpcom_rest_api_v2_plugins = array();
+	}
+
+	if ( ! isset( $wpcom_rest_api_v2_plugins[ $class_name ] ) ) {
+		$wpcom_rest_api_v2_plugins[ $class_name ] = new $class_name;
+	}
+}
+
+// Now load the endpoint files.
+wpcom_rest_api_v2_load_plugin_files( 'wpcom-endpoints/*.php' );

--- a/_inc/lib/core-api/wpcom-endpoints/hello.php
+++ b/_inc/lib/core-api/wpcom-endpoints/hello.php
@@ -1,0 +1,22 @@
+<?php
+
+class WPCOM_REST_API_V2_Endpoint_Hello {
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route( 'wpcom/v2', '/hello', array(
+			array(
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => array( $this, 'get_data' ),
+			),
+		) );
+	}
+
+	public function get_data( $request ) {
+		return array( 'hello' => 'world' );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Hello' );

--- a/_inc/lib/core-api/wpcom-endpoints/sites-posts-featured-media-url.php
+++ b/_inc/lib/core-api/wpcom-endpoints/sites-posts-featured-media-url.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Plugin Name: WPCOM Add Featured Media URL
+ *
+ * Adds `jetpack_featured_media_url` to post responses
+ */
+
+class WPCOM_REST_API_V2_Sites_Posts_Add_Featured_Media_URL {
+	function __construct() {
+		add_action( 'rest_api_init', array( $this, 'add_featured_media_url' ) );
+	}
+
+	function add_featured_media_url() {
+		register_rest_field( 'post', 'jetpack_featured_media_url',
+			array(
+				'get_callback'    => array( $this, 'get_featured_media_url' ),
+				'update_callback' => null,
+				'schema'          => null,
+			)
+		);
+	}
+
+	function get_featured_media_url( $object, $field_name, $request ) {
+		$featured_media_url = '';
+		$image_attributes = wp_get_attachment_image_src(
+			get_post_thumbnail_id( $object['id'] ),
+			'full'
+		);
+		if ( is_array( $image_attributes ) && isset( $image_attributes[0] ) ) {
+			$featured_media_url = (string) $image_attributes[0];
+		}
+		return $featured_media_url;
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Sites_Posts_Add_Featured_Media_URL' );


### PR DESCRIPTION
This PR adds a folder that is designed to share WP REST API (v2 API) code between WP.com and Jetpack and keep them in sync.

This is useful now that you can access Jetpack sites via the WP REST API and public-api.wordpress.com.  The **namespaces** of new endpoints in this folder should be `wpcom/v2` so that they will also work on WP.com.

The endpoints here are just tests, one shows how you can extend the built-in `wp/v2` endpoints and another adds a new route.

To try it, apply D16735-code and this PR, and visit API URLs like the following:

- https://public-api.wordpress.com/wp/v2/sites/nylen.io::jp/posts (note communication with the Jetpack site and `jetpack_featured_media_url` property added to each post object)
- https://public-api.wordpress.com/wp/v2/sites/jnylen0.wordpress.com/posts (same, but for a regular WP.com site)
- https://public-api.wordpress.com/wpcom/v2/sites/nylen.io::jp/hello (note communication with the Jetpack site)
- https://public-api.wordpress.com/wpcom/v2/sites/jnylen0.wordpress.com/hello

If this functionality is going to be widely used, it might be better to put the new folder somewhere easier to find, but this seems like the most appropriate place at the moment.

TBD: best way to write tests for this logic.  They already exist on the WP.com side.