### PR TITLE
Simple Payments Widget: Adds precision validation for the price field.

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -273,12 +273,12 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @return number number of decimal places.
 		 */
 		private function get_decimal_places( $number ) {
-			preg_match( '/(?:\.(\d+))/', $number, $match );
-			if ( count( $match ) <= 1 ) {
-				return 0;
+			$parts = explode( '.', $number );
+			if ( count( $parts ) > 2 ) {
+				return null;
 			}
 
-			return isset( $match[1] ) ? strlen( $match[1] ) : 0;
+			return isset( $parts[1] ) ? strlen( $parts[1] ) : 0;
 		}
 
 		public function validate_ajax_params( $params ) {
@@ -293,12 +293,14 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				$errors->add( 'post_title', __( "People need to know what they're paying for! Please add a brief title.", 'jetpack' ) );
 			}
 
-			if ( empty( $params['price'] ) || floatval( $params['price'] ) <= 0 ) {
+			if ( empty( $params['price'] ) || ! is_numeric( $params['price'] ) || floatval( $params['price'] ) <= 0 ) {
 				$errors->add( 'price', __( 'Everything comes with a price tag these days. Please add a your product price.', 'jetpack' ) );
 			}
 
+			// Japan's Yen is the only supported currency with a zero decimal precision.
 			$precision = strcmp( $params['currency'], 'JPY' ) === 0 ? 0 : 2;
-			if ( $this->get_decimal_places( $params['price'] ) > $precision ) {
+			$price_decimal_places = $this->get_decimal_places( $params['price'] );
+			if ( is_null( $price_decimal_places ) || $price_decimal_places > $precision ) {
 				$errors->add( 'price', __( 'Invalid price', 'jetpack' ) );
 			}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -266,6 +266,21 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			wp_send_json_success( $return );
 		}
 
+		/**
+		 * Returns the number of decimal places on string representing a price.
+		 *
+		 * @param string $number Price to check.
+		 * @return number number of decimal places.
+		 */
+		private function get_decimal_places( $number ) {
+			preg_match( '/(?:\.(\d+))/', $number, $match );
+			if ( count( $match ) <= 1 ) {
+				return 0;
+			}
+
+			return isset( $match[1] ) ? strlen( $match[1] ) : 0;
+		}
+
 		public function validate_ajax_params( $params ) {
 			$errors = new WP_Error();
 
@@ -280,6 +295,11 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 			if ( empty( $params['price'] ) || floatval( $params['price'] ) <= 0 ) {
 				$errors->add( 'price', __( 'Everything comes with a price tag these days. Please add a your product price.', 'jetpack' ) );
+			}
+
+			$precision = strcmp( $params['currency'], 'JPY' ) === 0 ? 0 : 2;
+			if ( $this->get_decimal_places( $params['price'] ) > $precision ) {
+				$errors->add( 'price', __( 'Invalid price', 'jetpack' ) );
 			}
 
 			if ( empty( $params['email'] ) || ! is_email( $params['email'] ) ) {

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -298,7 +298,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			}
 
 			// Japan's Yen is the only supported currency with a zero decimal precision.
-			$precision = strcmp( $params['currency'], 'JPY' ) === 0 ? 0 : 2;
+			$precision            = strtoupper( $params['currency'] ) === 'JPY' ? 0 : 2;
 			$price_decimal_places = $this->get_decimal_places( $params['price'] );
 			if ( is_null( $price_decimal_places ) || $price_decimal_places > $precision ) {
 				$errors->add( 'price', __( 'Invalid price', 'jetpack' ) );

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -4,15 +4,6 @@
 ( function( api, wp, $ ) {
 	var $document = $( document );
 
-	// based on https://stackoverflow.com/a/10454560/59752
-	function decimalPlaces( number ) {
-		var match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
-		if ( ! match ) {
-			return 0;
-		}
-		return Math.max( 0, ( match[ 1 ] ? match[ 1 ].length : 0 ) - ( match[ 2 ] ? +match[ 2 ] : 0 ) );
-	}
-
 	$document.ready( function() {
 		$document.on( 'widget-added', function( event, widgetContainer ) {
 			if ( widgetContainer.is( '[id*="jetpack_simple_payments_widget"]' ) ) {
@@ -241,6 +232,15 @@
 		}
 	}
 
+	function decimalPlaces( number ) {
+		var parts = number.split( '.' );
+		if ( parts.length > 2 ) {
+			return null;
+		}
+
+		return parts[ 1 ] ? parts[ 1 ].length : 0;
+	}
+
 	function isFormValid( widgetForm ) {
 		widgetForm.find( '.invalid' ).removeClass( 'invalid' );
 
@@ -253,14 +253,15 @@
 		}
 
 		var productPrice = widgetForm.find( '.jetpack-simple-payments-form-product-price' ).val();
-		if ( ! productPrice || isNaN( parseFloat( productPrice ) ) || parseFloat( productPrice ) <= 0 ) {
+		if ( ! productPrice || isNaN( productPrice ) || parseFloat( productPrice ) <= 0 ) {
 			widgetForm.find( '.jetpack-simple-payments-form-product-price' ).addClass( 'invalid' );
 			errors = true;
 		}
 
 		// Japan's Yen is the only supported currency with a zero decimal precision.
 		var precision = widgetForm.find( '.jetpack-simple-payments-form-product-currency' ).val() === 'JPY' ? 0 : 2;
-		if ( decimalPlaces( productPrice ) > precision ) {
+		var priceDecimalPlaces = decimalPlaces( productPrice );
+		if ( priceDecimalPlaces === null || priceDecimalPlaces > precision ) {
 			widgetForm.find( '.jetpack-simple-payments-form-product-price' ).addClass( 'invalid' );
 			errors = true;
 		}

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -4,6 +4,15 @@
 ( function( api, wp, $ ) {
 	var $document = $( document );
 
+	// based on https://stackoverflow.com/a/10454560/59752
+	function decimalPlaces( number ) {
+		const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
+		if ( ! match ) {
+			return 0;
+		}
+		return Math.max( 0, ( match[ 1 ] ? match[ 1 ].length : 0 ) - ( match[ 2 ] ? +match[ 2 ] : 0 ) );
+	}
+
 	$document.ready( function() {
 		$document.on( 'widget-added', function( event, widgetContainer ) {
 			if ( widgetContainer.is( '[id*="jetpack_simple_payments_widget"]' ) ) {
@@ -245,6 +254,13 @@
 
 		var productPrice = widgetForm.find( '.jetpack-simple-payments-form-product-price' ).val();
 		if ( ! productPrice || isNaN( parseFloat( productPrice ) ) || parseFloat( productPrice ) <= 0 ) {
+			widgetForm.find( '.jetpack-simple-payments-form-product-price' ).addClass( 'invalid' );
+			errors = true;
+		}
+
+		// Japan's Yen is the only supported currency with a zero decimal precision.
+		var precision = widgetForm.find( '.jetpack-simple-payments-form-product-currency' ).val() === 'JPY' ? 0 : 2;
+		if ( decimalPlaces( productPrice ) > precision ) {
 			widgetForm.find( '.jetpack-simple-payments-form-product-price' ).addClass( 'invalid' );
 			errors = true;
 		}

--- a/modules/widgets/simple-payments/customizer.js
+++ b/modules/widgets/simple-payments/customizer.js
@@ -6,7 +6,7 @@
 
 	// based on https://stackoverflow.com/a/10454560/59752
 	function decimalPlaces( number ) {
-		const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
+		var match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
 		if ( ! match ) {
 			return 0;
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/26394

Companion diff: D16745-code

#### Changes proposed in this Pull Request:

Adds a Precision check to the Price field on the Customizer. All currencies have a precision of `2`, except `JPY` that does not support decimals.

#### Testing instructions:

* Apply this branch on a Jetpack site with a Premium or Professional Plan.
* On the Customizer, navigate to Widgets and select a sidebar or a footer.
* Click on Add a Widget and search for Simple Payments.
* Click on Add New to create a new Product.
* Using an invalid precision, click _Save_

The system shouldn't allow the creation of Products with an invalid precision. For all currencies the allowed decimal precision is `2`, except for `JPY` that does not allow decimals.

![screen shot 2018-08-01 at 00 13 42](https://user-images.githubusercontent.com/233601/43499000-d3820dee-951f-11e8-86ec-869164345cd6.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Fixes a bug that allows the creation of Simple Payment Products with the wrong number of decimals.