### PR TITLE
Add blogid to the tracking object

### DIFF
--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -57,7 +57,6 @@ function buildQuerystringNoPrefix( group, name ) {
 }
 
 const analytics = {
-
 	initialize: function( userId, username, superProps ) {
 		analytics.setUser( userId, username );
 		analytics.setSuperProps( superProps );
@@ -130,7 +129,11 @@ const analytics = {
 				eventProperties = assign( eventProperties, superProperties );
 			}
 
-			debug( 'Record event "%s" called with props %s', eventName, JSON.stringify( eventProperties ) );
+			debug(
+				'Record event "%s" called with props %s',
+				eventName,
+				JSON.stringify( eventProperties )
+			);
 
 			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 		},

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -124,11 +124,9 @@ const analytics = {
 			}
 
 			if ( _superProps ) {
-				superProperties = _superProps.getAll();
-				debug( '- Super Props: %o', superProperties );
+				debug( '- Super Props: %o', _superProps );
 				eventProperties = assign( eventProperties, superProperties );
 			}
-
 			debug(
 				'Record event "%s" called with props %s',
 				eventName,

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -10,8 +10,7 @@ import assign from 'lodash/assign';
 import config from 'config';
 
 const debug = debugFactory( 'dops:analytics' );
-let _blog,
-	_superProps,
+let	_superProps,
 	_user;
 
 // Load tracking scripts
@@ -59,15 +58,11 @@ function buildQuerystringNoPrefix( group, name ) {
 }
 
 const analytics = {
-	initialize: function( blogid, userId, username, superProps ) {
-		analytics.blogId( blogid );
+
+	initialize: function( userId, username, superProps ) {
 		analytics.setUser( userId, username );
 		analytics.setSuperProps( superProps );
 		analytics.identifyUser();
-	},
-
-	blogId( blogid ) {
-		_blog = { blogid: blogid };
 	},
 
 	setUser: function( userId, username ) {
@@ -121,20 +116,13 @@ const analytics = {
 
 	tracks: {
 		recordEvent: function( eventName, eventProperties ) {
-			let blogIdProperty,
-				superProperties;
+			let superProperties;
 
 			eventProperties = eventProperties || {};
 
 			if ( eventName.indexOf( 'akismet_' ) !== 0 && eventName.indexOf( 'jetpack_' ) !== 0 ) {
 				debug( '- Event name must be prefixed by "akismet_" or "jetpack_"' );
 				return;
-			}
-
-			if ( _blog ) {
-				blogIdProperty = _blog;
-				debug( '- Blog Id: %o', _blog );
-				eventProperties = assign( eventProperties, blogIdProperty );
 			}
 
 			if ( _superProps ) {

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -10,8 +10,7 @@ import assign from 'lodash/assign';
 import config from 'config';
 
 const debug = debugFactory( 'dops:analytics' );
-let	_superProps,
-	_user;
+let _superProps, _user;
 
 // Load tracking scripts
 window._tkq = window._tkq || [];

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -114,8 +114,6 @@ const analytics = {
 
 	tracks: {
 		recordEvent: function( eventName, eventProperties ) {
-			let superProperties;
-
 			eventProperties = eventProperties || {};
 
 			if ( eventName.indexOf( 'akismet_' ) !== 0 && eventName.indexOf( 'jetpack_' ) !== 0 ) {
@@ -125,7 +123,7 @@ const analytics = {
 
 			if ( _superProps ) {
 				debug( '- Super Props: %o', _superProps );
-				eventProperties = assign( eventProperties, superProperties );
+				eventProperties = assign( eventProperties, _superProps );
 			}
 			debug(
 				'Record event "%s" called with props %s',

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -120,9 +120,9 @@ class Main extends React.Component {
 		const tracksUser = this.props.tracksUserData;
 		if ( tracksUser ) {
 			analytics.initialize(
-				tracksUser.blogid,
 				tracksUser.userid,
-				tracksUser.username
+				tracksUser.username,
+        tracksUser.blogid,
 			);
 		}
 	};

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -118,8 +118,9 @@ class Main extends React.Component {
 
 	initializeAnalyitics = () => {
 		const tracksUser = this.props.tracksUserData;
+
 		if ( tracksUser ) {
-			analytics.initialize( tracksUser.userid, tracksUser.username, tracksUser.blogid );
+			analytics.initialize( tracksUser.userid, tracksUser.username, { blogid: tracksUser.blogid } );
 		}
 	};
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -122,7 +122,7 @@ class Main extends React.Component {
 			analytics.initialize(
 				tracksUser.userid,
 				tracksUser.username,
-        tracksUser.blogid,
+				tracksUser.blogid,
 			);
 		}
 	};

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -119,11 +119,7 @@ class Main extends React.Component {
 	initializeAnalyitics = () => {
 		const tracksUser = this.props.tracksUserData;
 		if ( tracksUser ) {
-			analytics.initialize(
-				tracksUser.userid,
-				tracksUser.username,
-				tracksUser.blogid,
-			);
+			analytics.initialize( tracksUser.userid, tracksUser.username, tracksUser.blogid );
 		}
 	};
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -120,7 +120,9 @@ class Main extends React.Component {
 		const tracksUser = this.props.tracksUserData;
 
 		if ( tracksUser ) {
-			analytics.initialize( tracksUser.userid, tracksUser.username, { blogid: tracksUser.blogid } );
+			analytics.initialize( tracksUser.userid, tracksUser.username, {
+				blog_id: tracksUser.blogid,
+			} );
 		}
 	};
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -119,7 +119,11 @@ class Main extends React.Component {
 	initializeAnalyitics = () => {
 		const tracksUser = this.props.tracksUserData;
 		if ( tracksUser ) {
-			analytics.initialize( tracksUser.userid, tracksUser.username );
+			analytics.initialize(
+				tracksUser.blogid,
+				tracksUser.userid,
+				tracksUser.username
+			);
 		}
 	};
 

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -56,7 +56,6 @@ class Jetpack_Tracks_Client {
 		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
 		}
-		
 		if ( ! $event instanceof Jetpack_Tracks_Event ) {
 			$event = new Jetpack_Tracks_Event( $event );
 		}
@@ -182,8 +181,12 @@ class Jetpack_Tracks_Client {
 		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
 			return false;
 		}
+		if ( ! $blog_id = Jetpack_Options::get_option( 'id' ) ) {
+			return false;
+		}
 
 		return array(
+			'blogid' => $blog_id,
 			'userid' => $user_data['ID'],
 			'username' => $user_data['login'],
 		);

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -182,12 +182,9 @@ class Jetpack_Tracks_Client {
 		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
 			return false;
 		}
-		if ( ! $blog_id = Jetpack_Options::get_option( 'id' ) ) {
-			return false;
-		}
 
 		return array(
-			'blogid' => $blog_id,
+			'blogid' => Jetpack_Options::get_option( 'id' ),
 			'userid' => $user_data['ID'],
 			'username' => $user_data['login'],
 		);

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -56,6 +56,7 @@ class Jetpack_Tracks_Client {
 		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
 		}
+		
 		if ( ! $event instanceof Jetpack_Tracks_Event ) {
 			$event = new Jetpack_Tracks_Event( $event );
 		}

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -184,7 +184,7 @@ class Jetpack_Tracks_Client {
 		}
 
 		return array(
-			'blogid' => Jetpack_Options::get_option( 'id' ),
+			'blogid' => Jetpack_Options::get_option( 'id', 0 ),
 			'userid' => $user_data['ID'],
 			'username' => $user_data['login'],
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add `blogid` to the tracking object on the client side for events like page view and toggles. This allows to join the events triggered from the `wp-admin`  with the data about the site we record in Calypso on this id;

* extra: 
    move to the end the debug line in the `recordEvent` function called on the analytics object to enable viewing of updated object fields in their entirety;

#### Testing instructions:
* building JP off of this branch by the method of choice, verify that track events that are called via 
the `recordEvent`  function contain a `blog_id` field.

<img width="834" alt="Screenshot 2019-05-08 at 15 47 13" src="https://user-images.githubusercontent.com/13561163/57380117-9fbe3d00-71a8-11e9-830d-d7465a9c1d45.png">

The data is passed as an attribute of the event property object. It gets recorded in a respective field via Tracks ETL (which means it will land in the blogid column of the respective data tables, and seen as such in the live view).

Most notably, this fixes the blogid in:
Fixes https://github.com/Automattic/jetpack/issues/12256


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
