### PR TITLE
Put the checkboxes to subscribe to comments above post comment button.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -89,7 +89,7 @@ class Jetpack_Subscriptions {
 			add_action( 'template_redirect', array( $this, 'widget_submit' ) );
 
 		// Set up the comment subscription checkboxes
-		add_action( 'comment_form', array( $this, 'comment_subscribe_init' ) );
+		add_action( 'comment_form_after_fields', array( $this, 'comment_subscribe_init' ) );
 
 		// Catch comment posts and check for subscriptions.
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Moves the subscription checkboxes from after the submit button to before the submit button

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* When viewing the subscription options underneath the comments box on a site, the checkboxes should be over the Post Comment button.
![image](https://user-images.githubusercontent.com/44990/43659234-37cad834-9710-11e8-83fd-7b3661bf927d.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Moves the subscription checkboxes from after the submit comment button to before the submit button.