### PR TITLE
Docs: Partners: Mention the ability to use free plan

### DIFF
--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -102,7 +102,7 @@ Plans can be provisioned by making a request using your partner token from the s
 
 - __local_user__:     The username, ID or email on the local website (not the WordPress.com username) that should own the plan. The corresponding user _must_ already exist.
 - __siteurl__:        The URL where the WordPress core files reside.
-- __plan__:           A slug representing which plan to provision. One of `personal`, `premium`, or `professional`.
+- __plan__:           A slug representing which plan to provision. One of `free`, `personal`, `premium`, or `professional`.
 - __force_register__: (optional) A true/false value indicating whether to re-register a site even if we already have tokens for it. Useful for sites that have gotten into a bad state.
 - __force_connect__:  (optional) A true/false value indicating whether to re-connect a user even if we already have tokens for them. Useful for sites that have gotten into a bad state.
 - __onboarding__:     (optional) If true, put the user through our onboarding wizard for new sites.

--- a/docs/partners/plan-provisioning.md
+++ b/docs/partners/plan-provisioning.md
@@ -26,7 +26,7 @@ Further in this document, you will find a few CLI commands with various argument
 - `partner_id`            : Provided to you when we provision your partner account.
 - `partner_secret`        : Provided to you when we provision your partner account.
 - `user`                  : The ID, email address, or login of a valid user on the WordPress installation hosted by the partner. See: https://make.wordpress.org/cli/handbook/config/#global-parameters.
-- `plan`                  : One of `personal`, `premium`, or `professional`. The partner's account will need to have this type of plan allowed.
+- `plan`                  : One of `free`, `personal`, `premium`, or `professional`. The partner's account will need to have this type of plan allowed.
 - `url`                   : This optional URL value is used to select a specific subsite in a network. See: https://make.wordpress.org/cli/handbook/config/#global-parameters.
 - `onboarding`            : This optional value can be set to `1` to enabled an onboarding wizard.
 - `partner_tracking_id`   : This optional value allows us to attach specific actions to a specific site on the partner's side. This has proved useful in cases where users had multiple staging sites.


### PR DESCRIPTION
Previously, we allowed hosts to use the Jetpack Start API to provision a site without a plan, called a Jetpack Free plan from here on out. This worked by leaving off the `plan` argument. Now, the API has been changed to allow sending `free` as a plan so we should update our docs to reflect that.

#### Changes proposed in this Pull Request:

* Expand the allowed plans mentioned in the partner provisioning docs to include free.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Ensure that changes make sense

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Updated partner documentation to mention free plan as a provision option.