### PR TITLE
Comments: Add Bulk Update/Delete Endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -42,6 +42,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-roles-endpoint.ph
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-terms-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-users-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-user-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-bulk-update-comments-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-comment-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-endpoint.php' );

--- a/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
@@ -70,9 +70,9 @@ class WPCOM_JSON_API_Bulk_Update_Comments_Endpoint extends WPCOM_JSON_API_Endpoi
 
 		$input = $this->input();
 
-		if ( is_array( $input['comment_ids'] ) ) {
+		if ( isset( $input['comment_ids'] ) && is_array( $input['comment_ids'] ) ) {
 			$comment_ids = $input['comment_ids'];
-		} else if ( ! empty( $input['comment_ids'] ) ) {
+		} else if ( isset( $input['comment_ids'] ) && ! empty( $input['comment_ids'] ) ) {
 			$comment_ids = explode( ',', $input['comment_ids'] );
 		} else {
 			$comment_ids = array();
@@ -85,12 +85,12 @@ class WPCOM_JSON_API_Bulk_Update_Comments_Endpoint extends WPCOM_JSON_API_Endpoi
 		wp_defer_comment_counting( true );
 
 		if ( $this->api->ends_with( $path, '/delete' ) ) {
-			if ( $this->validate_empty_status_param( $input['empty_status'] ) ) {
+			if ( isset( $input['empty_status'] ) && $this->validate_empty_status_param( $input['empty_status'] ) ) {
 				$result['results'] = $this->delete_all( $input['empty_status'] );
 			} else {
 				$result['results'] = $this->bulk_delete_comments( $comment_ids );
 			}
-		} else {
+		} else if ( isset( $input['status'] ) ) {
 			$result['results'] = $this->bulk_update_comments_status( $comment_ids, $input['status'] );
 		}
 

--- a/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
@@ -1,0 +1,223 @@
+<?php
+
+new WPCOM_JSON_API_Bulk_Update_Comments_Endpoint( array(
+	'description'          => 'Update multiple comment\'s status.',
+	'group'                => 'comments',
+	'stat'                 => 'comments:1:bulk-update-status',
+	'min_version'          => '1',
+	'max_version'          => '1',
+	'method'               => 'POST',
+	'path'                 => '/sites/%s/comments/status',
+	'path_labels'          => array(
+		'$site' => '(int|string) Site ID or domain',
+	),
+	'request_format'       => array(
+		'comment_ids' => '(array|string) An array, or comma-separated list, of Comment IDs to update.',
+		'status'      => '(string) The new status value. Allowed values: approved, unapproved, spam, trash',
+	),
+	'response_format'      => array(
+		'results' => '(array) An array of updated Comment IDs.'
+	),
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/comments/status',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'comment_ids' => array( 881, 882 ),
+			'status'      => 'approved',
+		),
+	)
+) );
+
+new WPCOM_JSON_API_Bulk_Update_Comments_Endpoint( array(
+	'description'          => 'Permanently delete multiple comments. Note: this request will send non-trashed comments to the trash. Trashed comments will be permanently deleted.',
+	'group'                => 'comments',
+	'stat'                 => 'comments:1:bulk-delete',
+	'min_version'          => '1',
+	'max_version'          => '1',
+	'method'               => 'POST',
+	'path'                 => '/sites/%s/comments/delete',
+	'path_labels'          => array(
+		'$site' => '(int|string) Site ID or domain',
+	),
+	'request_format'       => array(
+		'comment_ids'  => '(array|string) An array, or comma-separated list, of Comment IDs to delete or trash. (optional)',
+		'empty_status' => '(string) Force to permanently delete all spam or trash comments. (optional). Allowed values: spam, trash',
+	),
+	'response_format'      => array(
+		'results' => '(array) An array of deleted or trashed Comment IDs.'
+	),
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/comments/delete',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'comment_ids' => array( 881, 882 ),
+		),
+	)
+) );
+
+class WPCOM_JSON_API_Bulk_Update_Comments_Endpoint extends WPCOM_JSON_API_Endpoint {
+	// /sites/%s/comments/status
+	// /sites/%s/comments/delete
+	function callback( $path = '', $blog_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$input = $this->input();
+
+		if ( is_array( $input['comment_ids'] ) ) {
+			$comment_ids = (array) $input['comment_ids'];
+		} else if ( ! empty( $input['comment_ids'] ) ) {
+			$comment_ids = explode( ',', $input['comment_ids'] );
+		} else {
+			$comment_ids = array();
+		}
+
+		$result = array(
+			'results' => array(),
+		);
+
+		wp_defer_comment_counting( true );
+
+		if ( $this->api->ends_with( $path, '/delete' ) ) {
+			if ( ! empty( $input['empty_status'] ) ) {
+				$empty_status = $input['empty_status'];
+				$result['results'] = $this->delete_all( $empty_status );
+			} else {
+				$result['results'] = $this->bulk_delete_comments( $comment_ids );
+			}
+		} else {
+			$status = $input['status'];
+			$result['results'] = $this->bulk_update_comments_status( $comment_ids, $status );
+		}
+
+		wp_defer_comment_counting( false );
+
+		return $result;
+	}
+
+	/**
+	 * Determine if the passed comment status is valid or not.
+	 *
+	 * @param string $status
+	 *
+	 * @return boolean
+	 */
+	function validate_status_param( $status ) {
+		return in_array( $status, array( 'approved', 'unapproved', 'pending', 'spam', 'trash' ) );
+	}
+
+	/**
+	 * Determine if the passed empty status is valid or not.
+	 *
+	 * @param string $empty_status
+	 *
+	 * @return boolean
+	 */
+	function validate_empty_status_param( $empty_status ) {
+		return in_array( $empty_status, array( 'spam', 'trash' ) );
+	}
+
+	/**
+	 * Update the status of multiple comments.
+	 *
+	 * @param array $comment_ids Comments to update.
+	 * @param string $status New status value.
+	 *
+	 * @return array Updated comments IDs.
+	 */
+	function bulk_update_comments_status( $comment_ids, $status ) {
+		if ( count( $comment_ids ) < 1 ) {
+			return new WP_Error( 'empty_comment_ids', 'The request must include comment_ids' );
+		}
+		if ( ! $this->validate_status_param( $status ) ) {
+			return new WP_Error( 'invalid_status', "Invalid comment status value provided: '$status'.", 400 );
+		}
+		$results = array();
+		foreach( $comment_ids as $comment_id ) {
+			if ( ! current_user_can( 'edit_comment', $comment_id ) ) {
+				continue;
+			}
+			$result = false;
+			switch( $status ) {
+				case 'approved':
+					$result = wp_set_comment_status( $comment_id, 'approve' );
+					break;
+				case 'unapproved':
+				case 'pending':
+					$result = wp_set_comment_status( $comment_id, 'hold' );
+					break;
+				case 'spam':
+					$result = wp_spam_comment( $comment_id );
+					break;
+				case 'trash':
+					$result = wp_trash_comment( $comment_id );
+					break;
+			}
+			if ( $result ) {
+				$results[] = $comment_id;
+			}
+		}
+		return $results;
+	}
+
+	/**
+	 * Permanenty delete multiple comments.
+	 *
+	 * Comments are only permanently deleted if trash is disabled or their status is `trash` or `spam`.
+	 * Otherwise they are moved to trash.
+	 *
+	 * @param array $comment_ids Comments to trash or delete.
+	 *
+	 * @return array Deleted comments IDs.
+	 */
+	function bulk_delete_comments( $comment_ids ) {
+		if ( count( $comment_ids ) < 1 ) {
+			return new WP_Error( 'empty_comment_ids', 'The request must include comment_ids' );
+		}
+		$results = array();
+		foreach( $comment_ids as $comment_id ) {
+			if ( ! current_user_can( 'edit_comment', $comment_id ) ) {
+				continue;
+			}
+			if ( wp_delete_comment( $comment_id ) ) {
+				$results[] = $comment_id;
+			}
+		}
+		return $results;
+	}
+
+	/**
+	 * Delete all spam or trash comments.
+	 *
+	 * Comments are only permanently deleted if trash is disabled or their status is `trash` or `spam`.
+	 * Otherwise they are moved to trash.
+	 *
+	 * @param string $status Can be `spam` or `trash`.
+	 *
+	 * @return array Deleted comments IDs.
+	 */
+	function delete_all( $status ) {
+		if ( ! $this->validate_empty_status_param( $status ) ) {
+			return array();
+		}
+		global $wpdb;
+		// This could potentially take a long time, so we only want to delete comments created
+		// before this operation.
+		// Comments marked `spam` or `trash` after this moment won't be touched.
+		// Core uses the `pagegen_timestamp` hidden field for this same reason.
+		$delete_time = gmdate('Y-m-d H:i:s');
+		$comment_ids = $wpdb->get_col( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = %s AND %s > comment_date_gmt", $status, $delete_time ) );
+
+		if ( count( $comment_ids ) < 1 ) {
+			return array();
+		}
+
+		return $this->bulk_delete_comments( $comment_ids );
+	}
+}


### PR DESCRIPTION
Contributes to fixing https://github.com/Automattic/wp-calypso/issues/20299

WPCOM diff: D13678-code

I'm not exactly sure how to do this from a Fusion standpoint.
I've (accidentally) created the WPCOM diff first, which has been thoroughly reviewed and approved, and then realized that it contains: 1 file already synced, and 1 completely new file.
What would be the best practice here?

#### Changes proposed in this Pull Request:

This diff proposes the introduction of several new bulk endpoints:

`POST /sites/{site}/comments/status`: update multiple comments statuses (also useful because currently we do this with a frontend loop).
`POST /sites/{site}/comments/delete`: delete multiple comments or, in alternative, all spam or trash comments.

Most of the logic here is inspired by how Core handles all of this: https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-comments.php

#### Testing instructions:

- Checkout this branch on a Jetpack site.
- Head over to https://developer.wordpress.com/docs/api/console/ and select WP.COM API v1.
- Search for the new endpoints and try them on the Jetpack site, making sure the outcome is what is expected.

Notes: a comment cannot be permanently deleted unless it's `spam` or `trash`, but it's moved to `trash` instead.