### PR TITLE
Fix rel issue - move noopener and noreferrer tags into existing rel tag

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -201,11 +201,12 @@ abstract class Sharing_Source {
 		$text = apply_filters( 'jetpack_sharing_display_text', $text, $this, $id, $args );
 
 		return sprintf(
-			'<a rel="nofollow" data-shared="%s" class="%s" href="%s"%s title="%s"><span%s>%s</span></a>',
+			'<a rel="nofollow%s" data-shared="%s" class="%s" href="%s"%s title="%s"><span%s>%s</span></a>',
+			( true == $this->open_link_in_new ) ? ' noopener noreferrer' : '',
 			( $id ? esc_attr( $id ) : '' ),
 			implode( ' ', $klasses ),
 			$url,
-			( true == $this->open_link_in_new ) ? ' rel="noopener noreferrer" target="_blank"' : '',
+			( true == $this->open_link_in_new ) ? ' target="_blank"' : '',
 			$title,
 			( 'icon' == $this->button_style ) ? '></span><span class="sharing-screen-reader-text"' : '',
 			$text


### PR DESCRIPTION
### Summary
_Fixes an issue introduced in https://github.com/Automattic/jetpack/pull/9644 where Google would crawl sharing links, because a duplicate rel tag meant the first rel="nofollow" was ignored. After this fix, the additional rel tags are combined with the first._

### Changes
* move noopener and noreferrer tags into existing rel tag

### Testing instructions
* Install Jetpack and enable sharing.
* Inspect the sharing links, there should only be one rel tag. 

[Status] Needs Review

See https://github.com/Automattic/jetpack/pull/9644#issuecomment-411115258