### PR TITLE
Revert "Sharing: Update sharing links to redirect to calypso"

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6929,28 +6929,6 @@ p {
 		$url = str_replace( '/', '::', $url );
 		return $url;
 	}
-	/*
-	 * link to the calypso section
-	 * $link is expected to be the url starting from the root and the %site% will be replaced with the url of the site as expected.
-	 *
-	 * $param string
-	 * @return string
-	 */
-	public static function calyps_url( $path, $from = null ) {
-		$host = 'https://wordpress.com';
-
-		if ( $path[0] !== '/' ) {
-			$path = '/' . $path;
-		}
-		$site_suffix = self::build_raw_urls( home_url() );
-		$path_with_site = str_replace( '%site%', $site_suffix, $path );
-
-		if ( self::is_user_connected() ) {
-			return $host . $path_with_site;
-		}
-
-		self::$instance->build_connect_url( true, $host . $path_with_site, $from );
-	}
 
 	/**
 	 * Stores and prints out domains to prefetch for page speed optimization.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -615,3 +615,18 @@ abstract class Publicize_Base {
 		return str_replace( $search, $replace, $string );
 	}
 }
+
+function publicize_calypso_url() {
+	$calypso_sharing_url = 'https://wordpress.com/sharing/';
+	if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'build_raw_urls' ) ) {
+		$site_suffix = Jetpack::build_raw_urls( home_url() );
+	} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+		$site_suffix = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+	}
+
+	if ( $site_suffix ) {
+		return $calypso_sharing_url . $site_suffix;
+	} else {
+		return $calypso_sharing_url;
+	}
+}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -51,15 +51,7 @@ class Publicize_UI {
 	* If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
 	*/
 	function sharing_menu() {
-		$page_hook = add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
-		add_action( "load-{$page_hook}", array( &$this, 'redirect_to_calypso' ) );
-	}
-
-	public function redirect_to_calypso() {
-		if ( empty( $_GET['action'] ) ) { // this is done so that we support the refresh links.
-			wp_redirect( Jetpack::calyps_url( '/sharing/%site%' ) );
-			die();
-		}
+		add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
 	}
 
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -79,26 +79,13 @@ class Sharing_Admin {
 
 	public function subscription_menu( $user ) {
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			if ( ! Jetpack::is_module_active( 'publicize' ) && ! current_user_can( 'manage_options' ) ) {
+			$active = Jetpack::get_active_modules();
+			if ( ! in_array( 'publicize', $active ) && ! current_user_can( 'manage_options' ) ) {
 				return;
 			}
 		}
 
-		$page_hook = add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
-		add_action( "load-{$page_hook}", array( &$this, 'redirect_to_calypso' ) );
-	}
-
-	public function redirect_to_calypso() {
-		$path = '/sharing/buttons/%site%';
-		if ( Jetpack::is_module_active( 'publicize' ) ) {
-			if ( isset( $_GET['action'] ) ) { // do not redirect if action is set.
-				return;
-			}
-			$path = '/sharing/%site%';
-		}
-
-		wp_redirect( Jetpack::calyps_url( $path ) );
-		die();
+		add_submenu_page( 'options-general.php', __( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'sharing', array( &$this, 'management_page' ) );
 	}
 
 	public function ajax_save_services() {

--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,6 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 **Enhancements**
 
 * Connection: Updated connect splash screen with new content.
-* Sharing: Sharing section in wp-admin will now redirect to Calypso instead.
 * Docs: Added documentation for retrieving provision status of a site.
 * Shortcodes: Added oEmbed support for flat.io.
 * Widgets: Added `jetpack_top_posts_widget_layout` filter that allows you to create a custom display layout for the Top posts widget.


### PR DESCRIPTION
* Reverts #9951
* Removes changelog entry.


Changes introduced in #9951 are not behaving as expected and expectations are not clear enough for testing. We need to revert.