### PR TITLE
Unit Tests: Fail immediately if we cannot clone WordPress

### DIFF
--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -29,6 +29,12 @@ for WP_SLUG in 'master' 'latest' 'previous'; do
 		;;
 	esac
 
+	clone_exit_code=$?
+	if [ $clone_exit_code -ne 0 ]; then
+		echo "Failed to clone WordPress from develop.git.wordpress.org"
+		exit -1
+	fi
+
 	cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
 	cd /tmp/wordpress-$WP_SLUG
 

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -32,7 +32,7 @@ for WP_SLUG in 'master' 'latest' 'previous'; do
 	clone_exit_code=$?
 	if [ $clone_exit_code -ne 0 ]; then
 		echo "Failed to clone WordPress from develop.git.wordpress.org"
-		exit -1
+		exit 1
 	fi
 
 	cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"


### PR DESCRIPTION

Prevents further errors after cloning WordPress and failing.

#### Changes proposed in this Pull Request:

* Maxie the `tests/prepare-wordpress.sh` fail immediately if there was a problem attempting to clone WordPress.

#### Before

![image](https://user-images.githubusercontent.com/746152/43795771-b74a7e16-9a58-11e8-9f1d-1161ab72c664.png)

#### After

![image](https://user-images.githubusercontent.com/746152/43795902-1b0eef40-9a59-11e8-8986-527dcb1fec04.png)


#### Testing instructions:

1. Check the Travis runs and see how it currently fails earlier than attempting to copy Jetpack over the cloned WordPress source codel.


