### PR TITLE
Add interface for custom ads.txt entries

### DIFF
--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -12,6 +12,7 @@ import analytics from 'lib/analytics';
  */
 import { FEATURE_WORDADS_JETPACK } from 'lib/plans/constants';
 import { FormFieldset, FormLegend } from 'components/forms';
+import Textarea from 'components/textarea';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -48,12 +49,15 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 		const wordads_display_post = this.props.getOptionValue( 'wordads_display_post', 'wordads' );
 		const wordads_display_page = this.props.getOptionValue( 'wordads_display_page', 'wordads' );
 		const wordads_display_archive = this.props.getOptionValue( 'wordads_display_archive', 'wordads' );
+		const wordads_custom_adstxt = this.props.getOptionValue( 'wordads_custom_adstxt', 'wordads' );
+		const isSubDirSite = this.props.siteRawUrl.indexOf( '::' ) !== -1;
 		return (
 			<SettingsCard
 				{ ...this.props }
 				header={ __( 'Ads', { context: 'Ads header' } ) }
 				feature={ FEATURE_WORDADS_JETPACK }
-				hideButton>
+				saveDisabled={ this.props.isSavingAnyOption( [ 'wordads_custom_adstxt' ] ) } >
+
 				<SettingsGroup
 					disableInDevMode
 					hasChild
@@ -147,6 +151,31 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 							} ) }
 						</small>
 					</FormFieldset>
+					{ ! isSubDirSite &&
+						<FormFieldset>
+							<FormLegend>{ __( 'Custom ads.txt entries' ) }</FormLegend>
+							<p>
+								{ isAdsActive && __(
+									'Jetpack automatically generates a custom {{link}}ads.txt{{/link}} tailored for your site. ' +
+									'If you need to add additional entries for other networks please add them in the space below, one per line.', {
+										components: {
+											link: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />
+										}
+									}
+								) }
+
+								{ ! isAdsActive && __(
+									'Jetpack automatically generates a custom ads.txt tailored for your site. ' +
+									'If you need to add additional entries for other networks please add them in the space below, one per line.'
+								) }
+							</p>
+							<Textarea
+								name="wordads_custom_adstxt"
+								value={ wordads_custom_adstxt }
+								disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt' ] ) }
+								onChange={ this.props.onOptionChange } />
+						</FormFieldset>
+					}
 				</SettingsGroup>
 				{
 					! unavailableInDevMode && isAdsActive && (

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -165,8 +165,7 @@ export const Ads = moduleSettingsForm( class extends React.Component {
 								) }
 
 								{ ! isAdsActive && __(
-									'Jetpack automatically generates a custom ads.txt tailored for your site. ' +
-									'If you need to add additional entries for other networks please add them in the space below, one per line.'
+									'When ads are enabled, Jetpack automatically generates a custom ads.txt tailored for your site.'
 								) }
 							</p>
 							<Textarea

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1927,6 +1927,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback'  => __CLASS__ . '::validate_boolean',
 				'jp_group'           => 'wordads',
 			),
+			'wordads_custom_adstxt' => array(
+				'description'        => esc_html__( 'Custom ads.txt entries', 'jetpack' ),
+				'type'               => 'string',
+				'default'            => '',
+				'validate_callback'  => __CLASS__ . '::validate_string',
+				'sanitize_callback'  => 'sanitize_textarea_field',
+				'jp_group'           => 'wordads',
+			),
 
 			// Google Analytics
 			'google_analytics_tracking_id' => array(

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -19,6 +19,7 @@ class WordAds_Params {
 			'wordads_display_post'       => true,
 			'wordads_display_page'       => true,
 			'wordads_display_archive'    => true,
+			'wordads_custom_adstxt'      => ''
 		);
 
 		// grab settings, or set as default if it doesn't exist
@@ -30,7 +31,7 @@ class WordAds_Params {
 				$option = $default;
 			}
 
-			$this->options[$setting] = (bool) $option;
+			$this->options[$setting] = 'wordads_custom_adstxt' !== $setting ? (bool) $option : $option;
 		}
 
 		$host = 'localhost';

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -140,6 +140,7 @@ class WordAds {
 		add_action( 'wp_head',              array( $this, 'insert_head_meta' ), 20 );
 		add_action( 'wp_head',              array( $this, 'insert_head_iponweb' ), 30 );
 		add_action( 'wp_enqueue_scripts',   array( $this, 'enqueue_scripts' ) );
+		add_filter( 'wordads_ads_txt',      array( $this, 'insert_custom_adstxt' ) );
 
 		/**
 		 * Filters enabling ads in `the_content` filter
@@ -366,6 +367,23 @@ HTML;
 			jQuery('.wpcnt-header').insertBefore('$selector');
 		</script>
 HTML;
+	}
+
+	/**
+	 * Filter the latest ads.txt to include custom user entries. Strips any tags or whitespace.
+	 * @param  string $adstxt The ads.txt being filtered
+	 * @return string         Filtered ads.txt with custom entries, if applicable
+	 *
+	 * @since 6.5.0
+	 */
+	function insert_custom_adstxt( $adstxt ) {
+		$custom_adstxt = trim( wp_strip_all_tags( $this->option( 'wordads_custom_adstxt' ) ) );
+		if ( $custom_adstxt ) {
+			$adstxt .= "\n\n#Jetpack - User Custom Entries\n";
+			$adstxt .= $custom_adstxt . "\n";
+		}
+
+		return $adstxt;
 	}
 
 	/**

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -137,6 +137,7 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_post',
 		'wordads_display_page',
 		'wordads_display_archive',
+		'wordads_custom_adstxt',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -196,6 +196,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_post'                 => '1',
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
+			'wordads_custom_adstxt'                => 'pineapple',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
There are is a small subset of advanced users that run multiple ad networks in addition to the Jetpack ads module that overrides our custom ads.txt. Since our ads.txt is frequently updated and custom tailored to the site we need a way to allow users to include custom entries.

Additionally, changes to the ads.txt should show up in Jetpack Sync (separate commit):
![screen_shot_2018-08-23_at_10 49 32_am](https://user-images.githubusercontent.com/273708/44554966-d8d08300-a6e7-11e8-8daf-76c7780f450e.png)


#### Changes proposed in this Pull Request:

* Custom ads.txt textarea w/ explanation & instructions in ads module.
* Restored `Save Settings` button to accommodate textarea entries.
* New filter to insert custom entries into latest ads.txt pulled from API.

**Admin update**

<img width="719" alt="screen shot 2018-08-07 at 1 50 22 pm" src="https://user-images.githubusercontent.com/273708/43802666-57901f2e-9a4b-11e8-8882-4756275fbf96.png">

**ads.txt update w/ `#Jetpack - User Custom Entries`**

<img width="526" alt="screen shot 2018-08-07 at 2 14 13 pm" src="https://user-images.githubusercontent.com/273708/43803018-6b8245ba-9a4c-11e8-9c2a-ee8758cda0c2.png">


#### Testing instructions:

1. Enable Jetpack ads module.
1. View `<site>/ads.txt` and verify `#Jetpack - User Custom Entries` is not present.
1. Add custom entries to `Custom ads.txt entries` textarea and save.
1. Attempt to include garbage entries w/ html markup or script tags.
1. View `<site>/ads.txt` and verify `#Jetpack - User Custom Entries` is present and that "bad" entries are stripped and only "regular" text remains.
1. On a site WP install utilizing a subdirectory (e.g. www.site.com/foo/wp-admin) check that the ads.txt portion is removed, as ads.txt requires by definition not to run under a subdirectory.

<img width="1185" alt="screen shot 2018-08-23 at 4 16 05 pm" src="https://user-images.githubusercontent.com/273708/44556846-78920f00-a6f0-11e8-8ff3-a9633684ef1a.png">

#### Proposed changelog entry for your changes:
* Added ability to include custom ads.txt entries in the ads module