### PR TITLE
Comments: Fix values used on sandbox attribute for comments iframe

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -314,7 +314,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				</h3>
 			<?php endif; ?>
 			<form id="commentform" class="comment-form">
-				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-forms"></iframe>
+				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms"></iframe>
 				<?php if ( ! Jetpack_AMP_Support::is_amp_request() ) : ?>
 					<!--[if !IE]><!-->
 					<script>

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -314,7 +314,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				</h3>
 			<?php endif; ?>
 			<form id="commentform" class="comment-form">
-				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-scripts allow-top-navigation-by-user-activation allow-forms"></iframe>
+				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-forms"></iframe>
 				<?php if ( ! Jetpack_AMP_Support::is_amp_request() ) : ?>
 					<!--[if !IE]><!-->
 					<script>


### PR DESCRIPTION
Fixes #10000 

Changes introduced in #9681 were bringing issues with comments on non AMP environments. 

#### Changes proposed in this Pull Request:

* Updates the `sandbox` attribute to read `allow-same-origin allow-top-navigation` and thus allowing the functions needed by the remote JS file loaded for comments

#### Testing instructions:

* Check this branch with a theme that has styles for threaded comments. like Storefront .
* Reply to a comment on a post, in the front-end.
* Open the dev console. Expect no erros coming from the browser blocking requests or actions
* Expect to see the comment threaded

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->
 
<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Comments: We fixed an error that broke functionality of nested comments.