### PR TITLE
Lazy Images: Fix typo in attributes filter name

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6633,6 +6633,7 @@ p {
 			'jetpack_sso_auth_cookie_expirtation'                    => 'jetpack_sso_auth_cookie_expiration',
 			'jetpack_cache_plans'                                    => null,
 			'jetpack_updated_theme'                                  => 'jetpack_updated_themes',
+			'jetpack_lazy_images_skip_image_with_atttributes'        => 'jetpack_lazy_images_skip_image_with_attributes',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -209,12 +209,29 @@ class Jetpack_Lazy_Images {
 		 *
 		 * @module-lazy-images
 		 *
+		 * @deprecated 6.5.0 Use jetpack_lazy_images_skip_image_with_attributes instead.
+		 *
 		 * @since 5.9.0
 		 *
 		 * @param bool  Default to not skip processing the current image.
 		 * @param array An array of attributes via wp_kses_hair() for the current image.
 		 */
 		if ( apply_filters( 'jetpack_lazy_images_skip_image_with_atttributes', false, $attributes ) ) {
+			return $attributes;
+		}
+
+		/**
+		 * Allow plugins and themes to conditionally skip processing an image via its attributes.
+		 *
+		 * @module-lazy-images
+		 *
+		 * @since 6.5.0 Filter name was updated from jetpack_lazy_images_skip_image_with_atttributes to correct typo.
+		 * @since 5.9.0
+		 *
+		 * @param bool  Default to not skip processing the current image.
+		 * @param array An array of attributes via wp_kses_hair() for the current image.
+		 */
+		if ( apply_filters( 'jetpack_lazy_images_skip_image_with_attributes', false, $attributes ) ) {
 			return $attributes;
 		}
 

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -313,20 +313,34 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 		);
 	}
 
-	function test_jetpack_lazy_images_skip_image_with_atttributes_filter() {
+	/**
+	 * @dataProvider get_skip_image_with_attributes_data
+	 */
+	function test_jetpack_lazy_images_skip_image_with_attributes_filter( $filter_name ) {
 		$instance = Jetpack_Lazy_Images::instance();
 		$src = '<img src="image.jpg" srcset="medium.jpg 1000w, large.jpg 2000w" class="wp-post-image"/>';
 
 		$this->assertContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
 
-		add_filter( 'jetpack_lazy_images_skip_image_with_atttributes', '__return_true' );
+		add_filter( 'jetpack_lazy_images_skip_image_with_attributes', '__return_true' );
 		$this->assertNotContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
-		remove_filter( 'jetpack_lazy_images_skip_image_with_atttributes', '__return_true' );
+		remove_filter( 'jetpack_lazy_images_skip_image_with_attributes', '__return_true' );
 
-		add_filter( 'jetpack_lazy_images_skip_image_with_atttributes', array( $this, '__skip_if_srcset' ), 10, 2 );
+		add_filter( 'jetpack_lazy_images_skip_image_with_attributes', array( $this, '__skip_if_srcset' ), 10, 2 );
 		$this->assertNotContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( $src ) );
 		$this->assertContains( 'src="placeholder.jpg"', $instance->add_image_placeholders( '<img src="image.jpg" />' ) );
-		remove_filter( 'jetpack_lazy_images_skip_image_with_atttributes', array( $this, '__skip_if_srcset' ), 10, 2 );
+		remove_filter( 'jetpack_lazy_images_skip_image_with_attributes', array( $this, '__skip_if_srcset' ), 10, 2 );
+	}
+
+	function get_skip_image_with_attributes_data() {
+		return array(
+			'deprecated_filter_name_with_typo' => array(
+				'jetpack_lazy_images_skip_image_with_atttributes'
+			),
+			'correct_filter_name' => array(
+				'jetpack_lazy_images_skip_image_with_attributes'
+			),
+		);
 	}
 
 	/*


### PR DESCRIPTION
Fixes an issue that a user pointed out in this comment:

https://github.com/Automattic/jetpack/pull/8787#issuecomment-411196808

#### Changes proposed in this Pull Request:

* Fix a typo in `jetpack_lazy_images_skip_image_with_atttributes` so that the filter is `jetpack_lazy_images_skip_image_with_attributes`.
* Deprecates `jetpack_lazy_images_skip_image_with_atttributes` filter

#### Testing instructions:

* `phpunit --filter=WP_Test_Lazy_Images` to ensure that both filters work

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Deprecates `jetpack_lazy_images_skip_image_with_atttributes` filter in favor of `jetpack_lazy_images_skip_image_with_attributes` to address typo.