### PR TITLE
Module Overrides: Add support to disable backups UI

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -19,6 +19,7 @@ import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
+import { showBackups } from 'state/initial-state';
 
 /**
  * Displays a card for Backups based on the props given.
@@ -128,6 +129,10 @@ class DashBackups extends Component {
 	}
 
 	render() {
+		if ( ! this.props.showBackups ) {
+			return null;
+		}
+
 		if ( this.props.isDevMode ) {
 			return (
 				<div className="jp-dash-item__interior">
@@ -185,7 +190,8 @@ export default connect(
 			vaultPressData: getVaultPressData( state ),
 			sitePlan: getSitePlan( state ),
 			isDevMode: isDevMode( state ),
-			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' )
+			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
+			showBackups: showBackups( state ),
 		};
 	}
 )( DashBackups );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -23,6 +23,7 @@ import { isFetchingSiteData } from 'state/site';
 import DashItem from 'components/dash-item';
 import isArray from 'lodash/isArray';
 import get from 'lodash/get';
+import { showBackups } from 'state/initial-state';
 
 /**
  * Displays a card for Security Scan based on the props given.
@@ -152,6 +153,10 @@ class DashScan extends Component {
 	}
 
 	render() {
+		if ( ! this.props.showBackups ) {
+			return null;
+		}
+
 		if ( this.props.isDevMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
@@ -206,7 +211,8 @@ export default connect(
 			sitePlan: getSitePlan( state ),
 			isDevMode: isDevMode( state ),
 			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
-			fetchingSiteData: isFetchingSiteData( state )
+			fetchingSiteData: isFetchingSiteData( state ),
+			showBackups: showBackups( state ),
 		};
 	}
 )( DashScan );

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -12,6 +12,7 @@ import { translate as __ } from 'i18n-calypso';
 import ConnectButton from 'components/connect-button';
 import { getConnectUrl as getConnectUrl } from 'state/connection';
 import { imagePath } from 'constants/urls';
+import { showBackups } from 'state/initial-state';
 
 class JetpackConnect extends React.Component {
 	static displayName = 'JetpackConnect';
@@ -145,62 +146,63 @@ class JetpackConnect extends React.Component {
 					</div>
 				</Card>
 
-				<Card className="jp-jetpack-connect__feature jp-jetpack-connect__security">
+				{ this.props.showBackups &&
+					<Card className="jp-jetpack-connect__feature jp-jetpack-connect__security">
+						<header className="jp-jetpack-connect__header">
+							<h2 className="jp-jetpack-connect__container-subtitle" title={ __( 'Keep your site safe, 24/7' ) }>
+								{ __( 'Keep your site safe, 24/7' ) }
+							</h2>
+							<p className="jp-jetpack-connect__description">
+								{ __(
+									'Automatic defense against hacks, malware, spam, data loss, and downtime.'
+								) }
+							</p>
+						</header>
 
-					<header className="jp-jetpack-connect__header">
-						<h2 className="jp-jetpack-connect__container-subtitle" title={ __( 'Keep your site safe, 24/7' ) }>
-							{ __( 'Keep your site safe, 24/7' ) }
-						</h2>
-						<p className="jp-jetpack-connect__description">
-							{ __(
-								'Automatic defense against hacks, malware, spam, data loss, and downtime.'
-							) }
-						</p>
-					</header>
-
-					<div className="jp-jetpack-connect__interior-container">
-						<div className="jp-jetpack-connect__feature-list">
-							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title={ __( "Jetpack's monitor feature" ) } className="dops-section-header__label">
-									{ __( 'Monitor', { context: 'Header. Noun: Monitor is a module of Jetpack.' } ) }
-								</h3>
-								<div className="jp-jetpack-connect__feature-content">
-									<p>
-										{ __(
-											'Be alerted about any unexpected downtime the moment it happens.'
-										) }
-									</p>
+						<div className="jp-jetpack-connect__interior-container">
+							<div className="jp-jetpack-connect__feature-list">
+								<div className="jp-jetpack-connect__feature-list-column">
+									<h3 title={ __( "Jetpack's monitor feature" ) } className="dops-section-header__label">
+										{ __( 'Monitor', { context: 'Header. Noun: Monitor is a module of Jetpack.' } ) }
+									</h3>
+									<div className="jp-jetpack-connect__feature-content">
+										<p>
+											{ __(
+												'Be alerted about any unexpected downtime the moment it happens.'
+											) }
+										</p>
+									</div>
 								</div>
-							</div>
-							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title={ __( "Jetpack's Protect features" ) } className="dops-section-header__label">
-									{ __( 'Protect', { context: 'Header. Noun: Protect is a module of Jetpack.' } ) }
-								</h3>
-								<div className="jp-jetpack-connect__feature-content">
-									<p>
-										{ __(
-											'Guard your site against brute force login attacks, spam, and harmful' +
-											'malware injections.'
-										) }
-									</p>
+								<div className="jp-jetpack-connect__feature-list-column">
+									<h3 title={ __( "Jetpack's Protect features" ) } className="dops-section-header__label">
+										{ __( 'Protect', { context: 'Header. Noun: Protect is a module of Jetpack.' } ) }
+									</h3>
+									<div className="jp-jetpack-connect__feature-content">
+										<p>
+											{ __(
+												'Guard your site against brute force login attacks, spam, and harmful' +
+												'malware injections.'
+											) }
+										</p>
+									</div>
 								</div>
-							</div>
-							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's backup feature" className="dops-section-header__label">
-									{ __( 'Backup and restore' ) }
-								</h3>
-								<div className="jp-jetpack-connect__feature-content">
-									<p>
-										{ __(
-											'Automatic, real-time backups mean your entire site is always ready ' +
-											'to be restored.'
-										) }
-									</p>
+								<div className="jp-jetpack-connect__feature-list-column">
+									<h3 title="Jetpack's backup feature" className="dops-section-header__label">
+										{ __( 'Backup and restore' ) }
+									</h3>
+									<div className="jp-jetpack-connect__feature-content">
+										<p>
+											{ __(
+												'Automatic, real-time backups mean your entire site is always ready ' +
+												'to be restored.'
+											) }
+										</p>
+									</div>
 								</div>
 							</div>
 						</div>
-					</div>
-				</Card>
+					</Card>
+				}
 
 				<Card className="jp-jetpack-connect__cta">
 					<p className="jp-jetpack-connect__description">
@@ -219,7 +221,8 @@ class JetpackConnect extends React.Component {
 export default connect(
 	state => {
 		return {
-			connectUrl: getConnectUrl( state )
+			connectUrl: getConnectUrl( state ),
+			showBackups: showBackups( state ),
 		};
 	}
 )( JetpackConnect );

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -8,11 +8,13 @@ import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { imagePath } from 'constants/urls';
+import { showBackups } from 'state/initial-state';
 
 class ThemesPromoCard extends React.Component {
 	static displayName = 'ThemesPromoCard';
@@ -55,15 +57,27 @@ class ThemesPromoCard extends React.Component {
 
 					<div className="jp-apps-card__description">
 						<h3 className="jp-apps-card__header">{ __( 'Introducing Premium Themes' ) }</h3>
-						{ __(
-							'{{p}}To create a beautiful site that looks and works exactly how you want it to, Jetpack Professional gives you unlimited access to over 200 premium WordPress themes.{{/p}}' +
-							"{{p}}Jetpack Professional is about more than just finding the perfect design. It's also about total peace of mind: real-time backups, automatic malware scanning, and priority support from our global team of experts guarantee that your site will always be safe and secure.{{/p}}",
-							{
-								components: {
-									p: <p className="jp-apps-card__paragraph" />
+						{
+							this.props.showBackups
+							? __(
+								'{{p}}To create a beautiful site that looks and works exactly how you want it to, Jetpack Professional gives you unlimited access to over 200 premium WordPress themes.{{/p}}' +
+								"{{p}}Jetpack Professional is about more than just finding the perfect design. It's also about total peace of mind: real-time backups, automatic malware scanning, and priority support from our global team of experts guarantee that your site will always be safe and secure.{{/p}}",
+								{
+									components: {
+										p: <p className="jp-apps-card__paragraph" />
+									}
 								}
-							}
-						) }
+							)
+							: __(
+								'{{p}}To create a beautiful site that looks and works exactly how you want it to, Jetpack Professional gives you unlimited access to over 200 premium WordPress themes.{{/p}}' +
+								"{{p}}Jetpack Professional is about more than just finding the perfect design. It's also about total peace of mind knowing knowing that you'll have priority support from our global team of experts should the need arise.{{/p}}",
+								{
+									components: {
+										p: <p className="jp-apps-card__paragraph" />
+									}
+								}
+							)
+						}
 
 						<p>
 							<Button
@@ -91,4 +105,11 @@ ThemesPromoCard.propTypes = {
 	plan: PropTypes.string
 };
 
-export default ThemesPromoCard;
+export default connect(
+	( state ) => {
+		return {
+			showBackups: showBackups( state ),
+		};
+	}
+)( ThemesPromoCard );
+

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -30,6 +30,7 @@ import {
 	getModuleOverride
 } from 'state/modules';
 import QuerySitePlugins from 'components/data/query-site-plugins';
+import { showBackups } from 'state/initial-state';
 
 class PlanBody extends React.Component {
 	static propTypes = {
@@ -89,7 +90,7 @@ class PlanBody extends React.Component {
 			: 'dev';
 		const premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
-			hideVaultPressCard = ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false );
+			hideVaultPressCard = ! this.props.showBackups || ( ! rewindActive && 'unavailable' !== get( this.props.rewindStatus, [ 'state' ], false ) );
 
 		const getRewindVaultPressCard = () => {
 			if ( hideVaultPressCard ) {
@@ -458,7 +459,8 @@ export default connect(
 			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
 			isModuleActivated: ( module_slug ) => _isModuleActivated( state, module_slug ),
 			isActivatingModule: ( module_slug ) => isActivatingModule( state, module_slug ),
-			getModuleOverride: ( module_slug ) => getModuleOverride( state, module_slug )
+			getModuleOverride: ( module_slug ) => getModuleOverride( state, module_slug ),
+			showBackups: showBackups( state ),
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -352,7 +352,7 @@ class PlanBody extends React.Component {
 					}
 
 					{
-						'is-personal-plan' === planClass && (
+						this.props.showBackups && 'is-personal-plan' === planClass && (
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Three great reasons to go Pro' ) }</h3>
 								<p>{ __( 'Design the perfect site with unlimited access to hundreds of themes and unlimited, high-speed, and ad-free video hosting.' ) }</p>
@@ -368,7 +368,7 @@ class PlanBody extends React.Component {
 					}
 
 					{
-						'is-premium-plan' === planClass && (
+						( ! this.props.showBackups && 'is-personal-plan' === planClass ) || 'is-premium-plan' === planClass && (
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Two great reasons to go Pro' ) }</h3>
 								<p>{ __( 'Unlimited access to hundreds of premium WordPress themes with dedicated support directly from the theme authors.' ) }</p>
@@ -399,10 +399,13 @@ class PlanBody extends React.Component {
 							<p>{ __( 'Reach more people and earn money with automated social media scheduling, better search results, SEO preview tools, PayPal payments, and an ad program.' ) }</p>
 						</div>
 
-						<div className="jp-landing__plan-features-card">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Always-on Security' ) }</h3>
-							<p>{ __( 'Automatic defense against hacks, malware, spam, data loss, and downtime with automated backups, unlimited storage, and malware scanning.' ) }</p>
-						</div>
+						{
+							this.props.showBackups &&
+							<div className="jp-landing__plan-features-card">
+								<h3 className="jp-landing__plan-features-title">{ __( 'Always-on Security' ) }</h3>
+								<p>{ __( 'Automatic defense against hacks, malware, spam, data loss, and downtime with automated backups, unlimited storage, and malware scanning.' ) }</p>
+							</div>
+						}
 
 						<div className="jp-landing__plan-features-card">
 							<h3 className="jp-landing__plan-features-title">{ __( 'Enjoy priority support' ) }</h3>

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -17,6 +17,7 @@ import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
 import analytics from 'lib/analytics';
 import { getPlanClass } from 'lib/plans/constants';
 import { translate as __ } from 'i18n-calypso';
+import { showBackups } from 'state/initial-state';
 
 class PlanGrid extends React.Component {
 
@@ -331,8 +332,19 @@ class PlanGrid extends React.Component {
 		const plan = this.getPlans()[ planType ];
 		const item = plan.features[ rowIndex ];
 		const key = planType + '-row-' + rowIndex;
+		const backupFeatureIds = [
+			'backups',
+			'malware-scan',
+			'real-time-backups',
+		];
+		const hideBackupFeature = (
+			! this.props.showBackups &&
+			item &&
+			-1 !== backupFeatureIds.indexOf( item.id )
+		);
+
 		// empty?
-		if ( typeof item === 'undefined' ) {
+		if ( typeof item === 'undefined' || hideBackupFeature ) {
 			return (
 				<td key={ key } className="plan-features__table-item" />
 			);
@@ -366,5 +378,6 @@ export default connect( ( state ) => {
 		siteRawUrl: getSiteRawUrl( state ),
 		sitePlan: getSitePlan( state ),
 		userId: getUserId( state ),
+		showBackups: showBackups( state ),
 	};
 }, null, )( PlanGrid );

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -340,7 +340,7 @@ class PlanGrid extends React.Component {
 		const hideBackupFeature = (
 			! this.props.showBackups &&
 			item &&
-			-1 !== backupFeatureIds.indexOf( item.id )
+			includes( backupFeatureIds, item.id )
 		);
 
 		// empty?

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -6,11 +6,13 @@ import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import { getPlanClass } from 'lib/plans/constants';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { imagePath } from 'constants/urls';
+import { showBackups } from 'state/initial-state';
 
 class PlanHeader extends React.Component {
 	trackLearnMore = () => {
@@ -29,37 +31,39 @@ class PlanHeader extends React.Component {
 			: 'dev';
 		switch ( planClass ) {
 			case 'is-free-plan':
-				starrySky = (
-					<div className="jp-landing-plans__header">
-						<h2 className="jp-landing-plans__header-title">
-							{ __( 'Jetpack Premium now includes our full security suite' ) }
-						</h2>
-						<p className="jp-landing-plans__header-description">
-							{ __( 'Automated backups, one-click restores, spam filtering, and malware scanning.' ) }
-						</p>
-						<div className="jp-landing-plans__header-img-container">
-							<div className="jp-landing-plans__header-col-left">
-								<h3 className="jp-landing-plans__header-subtitle">{ __( 'How much is your website worth?' ) }</h3>
-								<p className="jp-landing-plans__header-text">
-									{ __( 'For less than the price of a coffee a month you can rest easy knowing your hard work (or livelihood) is backed up.' ) }
-									<br /><br />
-									{ __( 'Upgrade to a weekly coffee and fully protect your site from malware, infiltrations, and security loopholes with automated malware scanning.' ) }
-								</p>
-								<p className="jp-landing-plans__header-btn-container">
-									<Button href={ 'https://jetpack.com/redirect/?source=plans-main-top&site=' + this.props.siteRawUrl } className="is-primary">
-										{ __( 'Learn more' ) }
-									</Button>
-								</p>
+				if ( this.props.showBackups ) {
+					starrySky = (
+						<div className="jp-landing-plans__header">
+							<h2 className="jp-landing-plans__header-title">
+								{ __( 'Jetpack Premium now includes our full security suite' ) }
+							</h2>
+							<p className="jp-landing-plans__header-description">
+								{ __( 'Automated backups, one-click restores, spam filtering, and malware scanning.' ) }
+							</p>
+							<div className="jp-landing-plans__header-img-container">
+								<div className="jp-landing-plans__header-col-left">
+									<h3 className="jp-landing-plans__header-subtitle">{ __( 'How much is your website worth?' ) }</h3>
+									<p className="jp-landing-plans__header-text">
+										{ __( 'For less than the price of a coffee a month you can rest easy knowing your hard work (or livelihood) is backed up.' ) }
+										<br /><br />
+										{ __( 'Upgrade to a weekly coffee and fully protect your site from malware, infiltrations, and security loopholes with automated malware scanning.' ) }
+									</p>
+									<p className="jp-landing-plans__header-btn-container">
+										<Button href={ 'https://jetpack.com/redirect/?source=plans-main-top&site=' + this.props.siteRawUrl } className="is-primary">
+											{ __( 'Learn more' ) }
+										</Button>
+									</p>
+								</div>
+								<div className="jp-landing-plans__header-col-right">
+									<svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="335" height="233" viewBox="0 0 1005 700" version="1.1" aria-labelledby="wpcomLogin" role="img"><title id="wpcomLogin">{ __( 'Image of WordPress login screen protected by Jetpack' ) }</title><defs><rect id="path-1" x="0" y="0" width="1005" height="700" rx="8" /><polygon id="path-3" points="0 80 80 80 80 0 0 0 0 80" /><rect id="path-5" x="22" y="154" width="280" height="35" /><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="280" height="35" fill="white"><use xlinkHref="#path-5" /></mask><rect id="path-7" x="22" y="234" width="280" height="35" /><mask id="mask-8" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="280" height="35" fill="white"><use xlinkHref="#path-7" /></mask><rect id="path-9" x="22" y="291" width="15" height="15" /><mask id="mask-10" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="15" height="15" fill="white"><use xlinkHref="#path-9" /></mask><rect id="path-11" x="230" y="289" width="71" height="30" rx="3" /><filter x="-50" y="-50" width="200" height="200" filterUnits="objectBoundingBox" id="filter-12"><feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1" /><feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1" /><feColorMatrix values="0" type="matrix" in="shadowOffsetOuter1" /></filter><filter x="-50" y="-50" width="200" height="200" filterUnits="objectBoundingBox" id="filter-13"><feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetInner1" /><feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1" /><feColorMatrix values="0" type="matrix" in="shadowInnerInner1" /></filter><mask id="mask-14" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="71" height="30" fill="white"><use xlinkHref="#path-11" /></mask><polygon id="path-15" points="54 33.75 54 0 0 0 0 33.75 0 67.5 54 67.5" /></defs><g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"><g id="Plans---wp-login-stripped" transform="translate(-197.000000, -136.000000)"><g id="Editor-Container" transform="translate(197.000000, 136.000000)"><g id="Simple-Layout"><g id="bg"><mask id="mask-2" fill="white"><use xlinkHref="#path-1" /></mask><use id="content-bg-mask" fill="#F1F1F1" xlinkHref="#path-1" /></g><g id="chrome"><rect fill="#FEFEFE" x="0" y="0" width="1005" height="53" rx="8" /><rect id="Rectangle" fill="#F1F1F1" x="0" y="46" width="1005" height="38" /><path d="M27.5 31C23.36 31 20 27.64 20 23.5 20 19.36 23.36 16 27.5 16 31.64 16 35 19.36 35 23.5 35 27.64 31.64 31 27.5 31L27.5 31ZM77.5 31C73.36 31 70 27.64 70 23.5 70 19.36 73.36 16 77.5 16 81.64 16 85 19.36 85 23.5 85 27.64 81.64 31 77.5 31L77.5 31ZM52.5 31C48.36 31 45 27.64 45 23.5 45 19.36 48.36 16 52.5 16 56.64 16 60 19.36 60 23.5 60 27.64 56.64 31 52.5 31L52.5 31Z" id="Shape" fill="#8D8D8D" /></g></g><g id="login-form" opacity="0.5" transform="translate(340.000000, 156.000000)"><rect id="log-bg" fill="#FFFFFF" x="0" y="110" width="325" height="243" /><g id="wplogo" transform="translate(123.000000, 0.000000)"><mask id="mask-4" fill="white"><use xlinkHref="#path-3" /></mask><g id="Clip-2" /><path d="M57.09 69.39L67.48 39.36C69.42 34.51 70.07 30.63 70.07 27.18 70.07 25.93 69.98 24.77 69.84 23.69 72.49 28.53 74 34.09 74 40 74 52.54 67.2 63.5 57.09 69.39L57.09 69.39ZM44.69 24.06C46.73 23.95 48.58 23.74 48.58 23.74 50.41 23.52 50.19 20.82 48.36 20.93 48.36 20.93 42.85 21.36 39.3 21.36 35.96 21.36 30.35 20.93 30.35 20.93 28.51 20.82 28.29 23.63 30.13 23.74 30.13 23.74 31.86 23.95 33.69 24.06L38.99 38.57 31.55 60.89 19.17 24.06C21.22 23.95 23.06 23.74 23.06 23.74 24.89 23.52 24.67 20.82 22.84 20.93 22.84 20.93 17.34 21.36 13.78 21.36 13.14 21.36 12.39 21.35 11.59 21.32 17.67 12.1 28.12 6 40 6 48.85 6 56.91 9.38 62.96 14.93 62.81 14.92 62.67 14.9 62.52 14.9 59.18 14.9 56.81 17.81 56.81 20.93 56.81 23.74 58.43 26.1 60.15 28.91 61.44 31.17 62.95 34.08 62.95 38.28 62.95 41.2 61.83 44.57 60.37 49.28L56.97 60.61 44.69 24.06ZM40 74C36.66 74 33.44 73.51 30.39 72.62L40.6 42.97 51.05 71.61C51.12 71.78 51.2 71.93 51.29 72.08 47.76 73.32 43.96 74 40 74L40 74ZM6 40C6 35.07 7.06 30.39 8.95 26.16L25.16 70.6C13.82 65.09 6 53.46 6 40L6 40ZM40 0C17.91 0 0 17.91 0 40 0 62.09 17.91 80 40 80 62.09 80 80 62.09 80 40 80 17.91 62.09 0 40 0L40 0Z" id="Fill-1" fill="#0072AC" mask="url(#mask-4)" /></g><use id="input" stroke="#DEDEDE" mask="url(#mask-6)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-5" /><use id="input" stroke="#DEDEDE" mask="url(#mask-8)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-7" /><use id="checkbox" stroke="#DEDEDE" mask="url(#mask-10)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-9" /><g id="btn"><use fill="black" fillOpacity="1" filter="url(#filter-12)" xlinkHref="#path-11" /><use fill="#36A3CA" fillRule="evenodd" xlinkHref="#path-11" /><use fill="black" fillOpacity="1" filter="url(#filter-13)" xlinkHref="#path-11" /><use stroke="#1075A0" mask="url(#mask-14)" strokeWidth="2" xlinkHref="#path-11" /></g></g><g id="security" transform="translate(428.000000, 275.000000)"><circle id="Oval" fill="#3D596D" cx="75" cy="75" r="75" /><g id="Page-1" transform="translate(48.000000, 37.500000)"><mask id="mask-16" fill="white"><use xlinkHref="#path-15" /></mask><g id="Clip-2" /><path d="M30.38 46.31L30.38 54 23.63 54 23.63 46.31C21.62 45.15 20.25 42.99 20.25 40.5 20.25 36.77 23.27 33.75 27 33.75 30.73 33.75 33.75 36.77 33.75 40.5 33.75 42.99 32.38 45.15 30.38 46.31L30.38 46.31ZM16.88 16.87C16.88 11.29 21.42 6.75 27 6.75 32.58 6.75 37.13 11.29 37.13 16.87L37.13 20.25 16.88 20.25 16.88 16.87ZM47.25 20.25L43.88 20.25 43.88 16.87C43.88 7.57 36.3 0 27 0 17.7 0 10.13 7.57 10.13 16.87L10.13 20.25 6.75 20.25C3.02 20.25 0 23.27 0 27L0 60.75C0 64.48 3.02 67.5 6.75 67.5L47.25 67.5C50.98 67.5 54 64.48 54 60.75L54 27C54 23.27 50.98 20.25 47.25 20.25L47.25 20.25Z" id="Fill-1" fill="#FFFFFF" mask="url(#mask-16)" /></g></g></g></g></g></svg>
+								</div>
 							</div>
-							<div className="jp-landing-plans__header-col-right">
-								<svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="335" height="233" viewBox="0 0 1005 700" version="1.1" aria-labelledby="wpcomLogin" role="img"><title id="wpcomLogin">{ __( 'Image of WordPress login screen protected by Jetpack' ) }</title><defs><rect id="path-1" x="0" y="0" width="1005" height="700" rx="8" /><polygon id="path-3" points="0 80 80 80 80 0 0 0 0 80" /><rect id="path-5" x="22" y="154" width="280" height="35" /><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="280" height="35" fill="white"><use xlinkHref="#path-5" /></mask><rect id="path-7" x="22" y="234" width="280" height="35" /><mask id="mask-8" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="280" height="35" fill="white"><use xlinkHref="#path-7" /></mask><rect id="path-9" x="22" y="291" width="15" height="15" /><mask id="mask-10" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="15" height="15" fill="white"><use xlinkHref="#path-9" /></mask><rect id="path-11" x="230" y="289" width="71" height="30" rx="3" /><filter x="-50" y="-50" width="200" height="200" filterUnits="objectBoundingBox" id="filter-12"><feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1" /><feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1" /><feColorMatrix values="0" type="matrix" in="shadowOffsetOuter1" /></filter><filter x="-50" y="-50" width="200" height="200" filterUnits="objectBoundingBox" id="filter-13"><feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetInner1" /><feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1" /><feColorMatrix values="0" type="matrix" in="shadowInnerInner1" /></filter><mask id="mask-14" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="71" height="30" fill="white"><use xlinkHref="#path-11" /></mask><polygon id="path-15" points="54 33.75 54 0 0 0 0 33.75 0 67.5 54 67.5" /></defs><g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"><g id="Plans---wp-login-stripped" transform="translate(-197.000000, -136.000000)"><g id="Editor-Container" transform="translate(197.000000, 136.000000)"><g id="Simple-Layout"><g id="bg"><mask id="mask-2" fill="white"><use xlinkHref="#path-1" /></mask><use id="content-bg-mask" fill="#F1F1F1" xlinkHref="#path-1" /></g><g id="chrome"><rect fill="#FEFEFE" x="0" y="0" width="1005" height="53" rx="8" /><rect id="Rectangle" fill="#F1F1F1" x="0" y="46" width="1005" height="38" /><path d="M27.5 31C23.36 31 20 27.64 20 23.5 20 19.36 23.36 16 27.5 16 31.64 16 35 19.36 35 23.5 35 27.64 31.64 31 27.5 31L27.5 31ZM77.5 31C73.36 31 70 27.64 70 23.5 70 19.36 73.36 16 77.5 16 81.64 16 85 19.36 85 23.5 85 27.64 81.64 31 77.5 31L77.5 31ZM52.5 31C48.36 31 45 27.64 45 23.5 45 19.36 48.36 16 52.5 16 56.64 16 60 19.36 60 23.5 60 27.64 56.64 31 52.5 31L52.5 31Z" id="Shape" fill="#8D8D8D" /></g></g><g id="login-form" opacity="0.5" transform="translate(340.000000, 156.000000)"><rect id="log-bg" fill="#FFFFFF" x="0" y="110" width="325" height="243" /><g id="wplogo" transform="translate(123.000000, 0.000000)"><mask id="mask-4" fill="white"><use xlinkHref="#path-3" /></mask><g id="Clip-2" /><path d="M57.09 69.39L67.48 39.36C69.42 34.51 70.07 30.63 70.07 27.18 70.07 25.93 69.98 24.77 69.84 23.69 72.49 28.53 74 34.09 74 40 74 52.54 67.2 63.5 57.09 69.39L57.09 69.39ZM44.69 24.06C46.73 23.95 48.58 23.74 48.58 23.74 50.41 23.52 50.19 20.82 48.36 20.93 48.36 20.93 42.85 21.36 39.3 21.36 35.96 21.36 30.35 20.93 30.35 20.93 28.51 20.82 28.29 23.63 30.13 23.74 30.13 23.74 31.86 23.95 33.69 24.06L38.99 38.57 31.55 60.89 19.17 24.06C21.22 23.95 23.06 23.74 23.06 23.74 24.89 23.52 24.67 20.82 22.84 20.93 22.84 20.93 17.34 21.36 13.78 21.36 13.14 21.36 12.39 21.35 11.59 21.32 17.67 12.1 28.12 6 40 6 48.85 6 56.91 9.38 62.96 14.93 62.81 14.92 62.67 14.9 62.52 14.9 59.18 14.9 56.81 17.81 56.81 20.93 56.81 23.74 58.43 26.1 60.15 28.91 61.44 31.17 62.95 34.08 62.95 38.28 62.95 41.2 61.83 44.57 60.37 49.28L56.97 60.61 44.69 24.06ZM40 74C36.66 74 33.44 73.51 30.39 72.62L40.6 42.97 51.05 71.61C51.12 71.78 51.2 71.93 51.29 72.08 47.76 73.32 43.96 74 40 74L40 74ZM6 40C6 35.07 7.06 30.39 8.95 26.16L25.16 70.6C13.82 65.09 6 53.46 6 40L6 40ZM40 0C17.91 0 0 17.91 0 40 0 62.09 17.91 80 40 80 62.09 80 80 62.09 80 40 80 17.91 62.09 0 40 0L40 0Z" id="Fill-1" fill="#0072AC" mask="url(#mask-4)" /></g><use id="input" stroke="#DEDEDE" mask="url(#mask-6)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-5" /><use id="input" stroke="#DEDEDE" mask="url(#mask-8)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-7" /><use id="checkbox" stroke="#DEDEDE" mask="url(#mask-10)" strokeWidth="2" fill="#FBFBFB" xlinkHref="#path-9" /><g id="btn"><use fill="black" fillOpacity="1" filter="url(#filter-12)" xlinkHref="#path-11" /><use fill="#36A3CA" fillRule="evenodd" xlinkHref="#path-11" /><use fill="black" fillOpacity="1" filter="url(#filter-13)" xlinkHref="#path-11" /><use stroke="#1075A0" mask="url(#mask-14)" strokeWidth="2" xlinkHref="#path-11" /></g></g><g id="security" transform="translate(428.000000, 275.000000)"><circle id="Oval" fill="#3D596D" cx="75" cy="75" r="75" /><g id="Page-1" transform="translate(48.000000, 37.500000)"><mask id="mask-16" fill="white"><use xlinkHref="#path-15" /></mask><g id="Clip-2" /><path d="M30.38 46.31L30.38 54 23.63 54 23.63 46.31C21.62 45.15 20.25 42.99 20.25 40.5 20.25 36.77 23.27 33.75 27 33.75 30.73 33.75 33.75 36.77 33.75 40.5 33.75 42.99 32.38 45.15 30.38 46.31L30.38 46.31ZM16.88 16.87C16.88 11.29 21.42 6.75 27 6.75 32.58 6.75 37.13 11.29 37.13 16.87L37.13 20.25 16.88 20.25 16.88 16.87ZM47.25 20.25L43.88 20.25 43.88 16.87C43.88 7.57 36.3 0 27 0 17.7 0 10.13 7.57 10.13 16.87L10.13 20.25 6.75 20.25C3.02 20.25 0 23.27 0 27L0 60.75C0 64.48 3.02 67.5 6.75 67.5L47.25 67.5C50.98 67.5 54 64.48 54 60.75L54 27C54 23.27 50.98 20.25 47.25 20.25L47.25 20.25Z" id="Fill-1" fill="#FFFFFF" mask="url(#mask-16)" /></g></g></g></g></g></svg>
+							<div className="jp-landing-plans__clouds jp-clouds-top">
+								<img src={ imagePath + '/white-clouds.svg' } alt="" />
 							</div>
 						</div>
-						<div className="jp-landing-plans__clouds jp-clouds-top">
-							<img src={ imagePath + '/white-clouds.svg' } alt="" />
-						</div>
-					</div>
-				);
+					);
+				}
 				planCard = (
 					<div className="jp-landing__plan-card">
 						<div className="jp-landing__plan-card-img">
@@ -81,7 +85,15 @@ class PlanHeader extends React.Component {
 						</div>
 						<div className="jp-landing__plan-card-current">
 							<h3 className="jp-landing__plan-features-title">{ __( 'Welcome to Jetpack Personal' ) }</h3>
-							<p className="jp-landing__plan-features-text">{ __( 'Daily backups, spam filtering, and priority support.' ) }</p>
+							{
+								this.props.showBackups
+								? (
+									<p className="jp-landing__plan-features-text">{ __( 'Daily backups, spam filtering, and priority support.' ) }</p>
+								)
+								: (
+									<p className="jp-landing__plan-features-text">{ __( 'Spam filtering and priority support.' ) }</p>
+								)
+							}
 						</div>
 					</div>
 				);
@@ -150,5 +162,10 @@ class PlanHeader extends React.Component {
 		);
 	}
 }
-
-export default PlanHeader;
+export default connect(
+	( state ) => {
+		return {
+			showBackups: showBackups( state ),
+		};
+	}
+)( PlanHeader );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -26,6 +26,7 @@ import {
 import { getSitePlan } from 'state/site';
 import includes from 'lodash/includes';
 import { isModuleActivated } from 'state/modules';
+import { showBackups } from 'state/initial-state';
 
 class LoadingCard extends Component {
 	render() {
@@ -150,6 +151,10 @@ export const BackupsScan = moduleSettingsForm(
 		}
 
 		render() {
+			if ( ! this.props.showBackups ) {
+				return null;
+			}
+
 			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
 			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
 			const hasRewindData = false !== get( this.props.rewindStatus, [ 'state' ], false );
@@ -199,5 +204,6 @@ export default connect( state => {
 		vaultPressData: getVaultPressData( state ),
 		hasThreats: getVaultPressScanThreatCount( state ),
 		vaultPressActive: isModuleActivated( state, 'vaultpress' ),
+		showBackups: showBackups( state ),
 	};
 } )( BackupsScan );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -233,3 +233,14 @@ export function isAtomicSite( state ) {
 export function currentThemeSupports( state, feature ) {
 	return get( state.jetpack.initialState.themeData, [ 'support', feature ], false );
 }
+
+/**
+ * Check if backups UI should be displayed.
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {boolean} True if backups UI should be displayed.
+ */
+export function showBackups( state ) {
+	return get( state.jetpack.initialState.siteData, 'showBackups', true );
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -296,7 +296,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 *
 				 * @param bool $show_backups Should UI for backups be displayed? True by default.
 				 */
-				'showBackups' => is_plugin_active( 'vaultpress/vaultpress.php' ) || apply_filters( 'jetpack_show_backups', true ),
+				'showBackups' => Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) || apply_filters( 'jetpack_show_backups', true ),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -289,6 +289,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 				'isAtomicSite' => jetpack_is_atomic_site(),
 				'plan' => Jetpack::get_active_plan(),
+				/**
+				 * Whether UI for backups should be displayed.
+				 *
+				 * @since 6.5.0
+				 *
+				 * @param bool $show_backups Should UI for backups be displayed? True by default.
+				 */
+				'showBackups' => is_plugin_active( 'vaultpress/vaultpress.php' ) || apply_filters( 'jetpack_show_backups', true ),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -289,14 +289,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 				'isAtomicSite' => jetpack_is_atomic_site(),
 				'plan' => Jetpack::get_active_plan(),
-				/**
-				 * Whether UI for backups should be displayed.
-				 *
-				 * @since 6.5.0
-				 *
-				 * @param bool $show_backups Should UI for backups be displayed? True by default.
-				 */
-				'showBackups' => Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) || apply_filters( 'jetpack_show_backups', true ),
+				'showBackups' => Jetpack::show_backups_ui(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -357,14 +357,16 @@ class Jetpack_Connection_Banner {
 							?>
 						</p>
 
-						<p>
-							<?php
-							esc_html_e(
-								'Customers on paid plans also benefit from unlimited backups of your entire site, spam protection, malware scanning, and automated fixes.',
-								'jetpack'
-							);
-							?>
-						</p>
+						<?php if ( Jetpack::show_backups_ui() ): ?>
+							<p>
+								<?php
+								esc_html_e(
+									'Customers on paid plans also benefit from unlimited backups of your entire site, spam protection, malware scanning, and automated fixes.',
+									'jetpack'
+								);
+								?>
+							</p>
+						<?php endif; ?>
 
 						<p>
 							<?php
@@ -802,13 +804,15 @@ class Jetpack_Connection_Banner {
 							?>
 						</p>
 
-						<p>
-							<?php
-							esc_html_e(  'Paying customers also benefit from automated backups, malware scans, and priority support.',
-								'jetpack'
-							);
-							?>
-						</p>
+						<?php if ( Jetpack::show_backups_ui() ): ?>
+							<p>
+								<?php
+								esc_html_e(  'Paying customers also benefit from automated backups, malware scans, and priority support.',
+									'jetpack'
+								);
+								?>
+							</p>
+						<?php endif; ?>
 
 						<p class="jp-banner__button-container">
 							<span class="jp-banner__tos-blurb">
@@ -939,12 +943,14 @@ class Jetpack_Connection_Banner {
 							'jetpack'
 						);
 					?></p>
-					<p><?php
-						esc_html_e(
-							'Backup & Restore: Rest assured with real-time site backups and easy roll-back site restores.',
-							'jetpack'
-						);
-					?></p>
+					<?php if ( Jetpack::show_backups_ui() ) : ?>
+						<p><?php
+							esc_html_e(
+								'Backup & Restore: Rest assured with real-time site backups and easy roll-back site restores.',
+								'jetpack'
+							);
+						?></p>
+					<?php endif; ?>
 				</div>
 				<div class="jp-connect-full__slide-card illustration">
 					<img
@@ -954,7 +960,7 @@ class Jetpack_Connection_Banner {
 				</div>
 			</div>
 
-			
+
 			<img
 				class="support-characters"
 				src="<?php echo plugins_url( 'images/characters.svg', JETPACK__PLUGIN_FILE ); ?>"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7263,6 +7263,7 @@ p {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * Check if Gutenberg editor is available
 	 *
 	 * @since 6.5.0
@@ -7363,5 +7364,21 @@ p {
 				'editor_script' => 'jetpack-blocks-editor',
 				'editor_style'  => 'jetpack-blocks-editor',
 		) );
+	}
+
+	/**
+	 * Returns a boolean for whether backups UI should be displayed or not.
+	 *
+	 * @return bool Should backups UI be displayed?
+	 */
+	public static function show_backups_ui() {
+		/**
+		 * Whether UI for backups should be displayed.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param bool $show_backups Should UI for backups be displayed? True by default.
+		 */
+		return Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) || apply_filters( 'jetpack_show_backups', true );
 	}
 }


### PR DESCRIPTION
Currently, our module overrides functionality does not allow disabling UI relating to VaultPress or Backups. This is an issue for some of our partnerships where hosting partners need the ability to disable that UI.

#### Changes proposed in this Pull Request:

* Add ability to disable backups related UI.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

- Checkout branch
- In an integration plugin, add `add_filter( 'jetpack_show_backups', '__return_false' );`
- Load Jetpack admin page
- Ensure that backups and scanning are not mentioned in UI
- Install and activate VaultPress
- Ensure that backups and scanning are mentioned


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Adds ability to disable backups UI by filter when VaultPress is not activated.

#### Screenshots

**After**

![after_dashboard](https://user-images.githubusercontent.com/1126811/43922842-8e101f86-9be5-11e8-9d9c-2442f1ef0660.png)
![after_plan](https://user-images.githubusercontent.com/1126811/43922849-91b89f28-9be5-11e8-82d2-b2cd2fe9bf8d.png)
![after_security_settings](https://user-images.githubusercontent.com/1126811/43922858-973fc728-9be5-11e8-944b-56e00599ac87.png)
![after_backups_search](https://user-images.githubusercontent.com/1126811/43922864-9975c358-9be5-11e8-858a-e973b5899362.png)

**Before**

![before_dashboard](https://user-images.githubusercontent.com/1126811/43922873-9e611c28-9be5-11e8-902c-bc8f0fefb0f7.png)
![before_plan](https://user-images.githubusercontent.com/1126811/43922879-a2a035bc-9be5-11e8-9ad2-3d012f0cbf99.png)
![before_security_settings](https://user-images.githubusercontent.com/1126811/43922883-a4cf6c5e-9be5-11e8-9e32-e242acff99c0.png)
![before_backups_search](https://user-images.githubusercontent.com/1126811/43922886-a7255d60-9be5-11e8-9ada-297d17813b98.png)
