### PR TITLE
Comments: Add `allow-popups` to iframe so that social logins work.

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -314,7 +314,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				</h3>
 			<?php endif; ?>
 			<form id="commentform" class="comment-form">
-				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms"></iframe>
+				<iframe title="<?php esc_attr_e( 'Comment Form' , 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"></iframe>
 				<?php if ( ! Jetpack_AMP_Support::is_amp_request() ) : ?>
 					<!--[if !IE]><!-->
 					<script>


### PR DESCRIPTION
Fixes #10005

See #9681

#### Changes proposed in this Pull Request:

* Add `allow-popups` to `sandbox` attribute. The social login buttons depend on it.

#### Testing instructions:

1. Click each of the social login buttons. Do they work? :)
2. Leave a comment using each method:
   * Logged out completely
   * Logged in to WordPress.com
   * Using each of the Social Login options
   * Logged in to the local Jetpack site

#### Proposed changelog entry for your changes:

Fix an error that broke social login buttons when commenting.