### PR TITLE
Debug: Do not enqueue Jetpack Search debug bar scripts unless necessary

### DIFF
--- a/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
+++ b/3rd-party/debug-bar/class.jetpack-search-debug-bar.php
@@ -26,6 +26,8 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 		$this->title( esc_html__( 'Jetpack Search', 'jetpack' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'login_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'enqueue_embed_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -46,6 +48,11 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
+		// Do not enqueue scripts if we haven't already enqueued Debug Bar or Query Monitor styles.
+		if ( ! wp_style_is( 'debug-bar' ) && ! wp_style_is( 'query-monitor' ) ) {
+			return;
+		}
+
 		wp_enqueue_style(
 			'jetpack-search-debug-bar',
 			plugins_url( '3rd-party/debug-bar/debug-bar.css', JETPACK__PLUGIN_FILE )


### PR DESCRIPTION
During testing today, I noticed that a CSS and JS file from Jetpack for Debug Bar integration were being loaded on all visits to my personal site, even when I was logged out. This didn't happen when I only used Debug Bar, but when I was using Query Monitor, which support Debug Bar panels, the CSS and JS files were loaded unnecessarily.

We shouldn't load those files unless necessary.

#### Changes proposed in this Pull Request:

* Do not load CSS and JS file for Debug Bar integration unless Query Monitor or Debug Bar CSS has already been enqueued.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

- Checkout branch
- Purchase Jetpack Professional plan
- Ensure Search module is on
- Install and activate Debug Bar
- While logged in, perform a search on frontend of site and ensure Jetpack Search debug panel shows
- Ensure that you can prettify JSON output in panel
- In an incognito, or logged out tab, perform search on the frontend, and ensure that you don't see files like this in the source: `jetpack/3rd-party/debug-bar/debug-bar.css`
- Deactivate Debug Bar plugin
- Follow steps above for Query Monitor plugin

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes an issue where a CSS and JavaScript file could be enqueued unnecessarily the Search module was activated and if the site was using the Query Monitor plugin.