### PR TITLE
Widgets: Twitter Timeline - Remove Cutoff Date that has now passed

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -84,8 +84,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		// Twitter deprecated `data-widget-id` on 2018-05-25,
 		// with cease support deadline on 2018-07-27.
-		// 1532563200 is 2018-07-26, one day early.
-		 if ( isset( $instance['type'] ) && 'widget-id' === $instance['type'] && time() > 1532563200 ) {
+		if ( isset( $instance['type'] ) && 'widget-id' === $instance['type'] ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				echo $args['before_widget'];
 				echo $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title'];


### PR DESCRIPTION
Twitter stopped supporting the `widget-id` parameter on 2018-07-27. Ahead
of time, we hardcoded a cutoff date near then as part of a warning to
folks.

That date is in the past, so we no longer need the check.

See https://github.com/Automattic/jetpack/pull/9575

#### Changes proposed in this Pull Request:

* Remove cutoff date check that is no longer necessary.

#### Testing instructions:

1. Agree that `time() > 1532563200` :)