### PR TITLE
Add changelog for 6.4.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack by WordPress.com ===
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
-Stable tag: 6.4
+Stable tag: 6.4.1
 Requires at least: 4.7
 Tested up to: 4.9
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,15 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 
 == Changelog ==
 
+= 6.4.2 =
+
+* Release date: August 10, 2018
+* Release post: 
+
+**Bug fixes**
+
+Comments: We fixed an error that broke functionality of Social Login for comments.
+
 = 6.4.1 =
 
 * Release date: August 8, 2018

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 = 6.4.2 =
 
 * Release date: August 10, 2018
-* Release post: 
+* Release post: https://wp.me/p1moTy-9pL
 
 **Bug fixes**
 


### PR DESCRIPTION
This adds a changelog entry for #10006.

#### Changes proposed in this Pull Request:

* Updates readme.txt to include changelog for 6.4.2
* Bumps stable tag to `6.4.1`

#### Testing instructions

none needed