### PR TITLE
Make Wufoo safe for https usage and async

### DIFF
--- a/modules/shortcodes/wufoo.php
+++ b/modules/shortcodes/wufoo.php
@@ -1,11 +1,11 @@
 <?php
 /*
 Plugin Name: Wufoo Shortcode Plugin
-Description: Enables shortcode to embed Wufoo forms. Usage: [wufoo username="chriscoyier" formhash="x7w3w3" autoresize="true" height="458" header="show" ssl="true"]
+Description: Enables shortcode to embed Wufoo forms. Usage: [wufoo username="chriscoyier" formhash="x7w3w3" autoresize="true" height="458" header="show"]
 Author: Chris Coyier / Wufoo, evansolomon
 
 Based on https://wordpress.org/extend/plugins/wufoo-shortcode/
-http://wufoo.com/docs/code-manager/wordpress-shortcode-plugin/
+https://wufoo.com/docs/code-manager/wordpress-shortcode-plugin/
 */
 
 
@@ -17,7 +17,6 @@ function wufoo_shortcode( $atts ) {
 			'autoresize' => true,
 			'height'     => '500',
 			'header'     => 'show',
-			'ssl'        => '',
 		), $atts
 	);
 
@@ -28,7 +27,7 @@ function wufoo_shortcode( $atts ) {
 		 * Return an error to the users with instructions if one of these params is invalid
 		 * They don't have default values because they are user/form-specific
 		 */
-		$return_error = sprintf( __( 'Something is wrong with your Wufoo shortcode. If you copy and paste it from the %sWufoo Code Manager%s, you should be golden.', 'jetpack' ), '<a href="http://wufoo.com/docs/code-manager/" target="_blank">', '</a>' );
+		$return_error = sprintf( __( 'Something is wrong with your Wufoo shortcode. If you copy and paste it from the %sWufoo Code Manager%s, you should be golden.', 'jetpack' ), '<a href="https://wufoo.com/docs/code-manager/" target="_blank">', '</a>' );
 
 		return '
 			<div style="border: 20px solid red; border-radius: 40px; padding: 40px; margin: 50px 0 70px;">
@@ -38,27 +37,24 @@ function wufoo_shortcode( $atts ) {
 	}
 
 	/**
+	 * Placeholder which will tell Wufoo where to render the form.
+	 */
+	$js_embed_placeholder = '<div id="wufoo-' . $attr['formhash'] . '"></div>';
+
+	/**
 	 * Required parameters are present.
 	 * An error will be returned inside the form if they are invalid.
 	 */
-	$js_embed = '<script type="text/javascript">var host = (("https:" == document.location.protocol) ? "https://secure." : "http://");document.write(unescape("%3Cscript src=\'" + host + "wufoo.com/scripts/embed/form.js\'  type=\'text/javascript\'%3E%3C/script%3E"));</script>';
-	$js_embed .= "<script type='text/javascript'>";
-	$js_embed .= 'var wufoo_' . $attr['formhash'] . ' = new WufooForm();';
-	$js_embed .= 'wufoo_' . $attr['formhash'] . ' .initialize({';
+	$js_embed = '(function(){try{var wufoo_' . $attr['formhash'] . ' = new WufooForm();';
+	$js_embed .= 'wufoo_' . $attr['formhash'] . '.initialize({';
 	$js_embed .= "'userName':'" . $attr['username'] . "', ";
 	$js_embed .= "'formHash':'" . $attr['formhash'] . "', ";
 	$js_embed .= "'autoResize':" . (bool) ( $attr['autoresize'] ) . ',';
 	$js_embed .= "'height':'" . (int) $attr['height'] . "',";
-	$js_embed .= "'header':'" . esc_js( $attr['header'] ) . "' ";
-
-	/**
-	 * Only output SSL value if passes as param.
-	 * Lower tier plans don't show this param (don't offer SSL).
-	 */
-	$js_embed .= ( $attr['ssl'] ) ? ",'ssl':" . (bool) $attr['ssl'] : '';
-	$js_embed .= '});';
+	$js_embed .= "'header':'" . esc_js( $attr['header'] ) . "',";
+	$js_embed .= "'ssl':true,'async':true});";
 	$js_embed .= 'wufoo_' . $attr['formhash'] . '.display();';
-	$js_embed .= '</script>';
+	$js_embed .= '}catch(e){}})();';
 
 	/**
 	 * iframe embed, loaded inside <noscript> tags.
@@ -70,13 +66,23 @@ function wufoo_shortcode( $atts ) {
 	$iframe_embed .= '<a href="https://' . $attr['username'] . '.wufoo.com/forms/' . $attr['formhash'] . '/" ';
 	$iframe_embed .= 'rel="nofollow" target="_blank">' . __( 'Fill out my Wufoo form!', 'jetpack' ) . '</a></iframe>';
 
+	wp_enqueue_script(
+		'wufoo-form',
+		'https://www.wufoo.com/scripts/embed/form.js',
+		array(),
+		false,
+		true
+	);
+
+	wp_add_inline_script( 'wufoo-form', $js_embed );
+
 	/** This action is already documented in modules/widgets/gravatar-profile.php */
 	do_action( 'jetpack_stats_extra', 'embeds', 'wufoo' );
 
 	/**
 	 * Return embed in JS and iframe.
 	 */
-	return "$js_embed <noscript> $iframe_embed </noscript>";
+	return "$js_embed_placeholder<noscript>$iframe_embed</noscript>";
 }
 
 add_shortcode( 'wufoo', 'wufoo_shortcode' );


### PR DESCRIPTION
Summary:
This removes the ssl argument of shortcode and replaces everything to work over https. SSL used to be a paid feature over at Wufoo but that changed 5 years ago https://www.wufoo.com/blog/making-wufoo-more-secure-https/

It also turns the old embed codes into their new async version and makes sure only a single `form.js` would be loaded even for multiple forms.

Testing instructions: Test with various wufoo embed shortcodes, all should work over https, regardless whether they set https argument (to true/false) or not at all.

Reviewers: paulbunkham

Reviewed By: paulbunkham

Subscribers: mdawaffe, paulbunkham, jblz

Tags: #touches_jetpack_files

Differential Revision: D16996-code

This commit syncs r179447-wpcom.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Updated Wufoo Shortcode to always load over https and use async form embed.