### PR TITLE
Attempt at fixing Hulu Shortocde tests "once and for all"

### DIFF
--- a/tests/php/modules/shortcodes/test_class.hulu.php
+++ b/tests/php/modules/shortcodes/test_class.hulu.php
@@ -63,15 +63,27 @@ class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
 		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
 	}
 
+	/**
+	 * Using $this->video_id requires a (cached) HTTP lookup:
+	 * @see modules/shortcodes/hulu.php:jetpack_hulu_shortcode()
+	 * Running these tests in parallel means we send many of the same requests
+	 * to Hulu before we have a chance to cache the response.
+	 * Flag all tests that use $this->video_id as dependent on
+	 * self::test_shortcodes_hulu_id() so that the response is made once, cached,
+	 * and pulled from the cache for subsequent uses.
+	 *
+	 * @depends test_shortcodes_hulu_id
+	 */
 	public function test_shortcodes_hulu_url() {
 		$content  = "[hulu http://www.hulu.com/watch/$this->video_id]";
 		$shortcode_content = do_shortcode( $content );
 
-		if ( false === stripos( $shortcode_content, 'Hulu Error' ) ) {
-			$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
-		}
+		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
 	}
 
+	/**
+	 * @depends test_shortcodes_hulu_id
+	 */
 	public function test_shortcodes_hulu_width_height() {
 		$width    = '350';
 		$height   = '500';
@@ -86,6 +98,9 @@ class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
 		$this->assertContains( 'height="197"', $shortcode_content );
 	}
 
+	/**
+	 * @depends test_shortcodes_hulu_id
+	 */
 	public function test_shortcodes_hulu_start_end_time_thumbnail() {
 		$start     = '10';
 		$end       = '20';


### PR DESCRIPTION
This is a guess - I have no idea if it is right or if my attempt at fixing the problem will work :)

My theory is that TravisCI is sending too many requests to Hulu at once. (This theory only really makes sense if we're running the Hulu shortcode tests in parallel with one another.)

Most of the tests each do something like `[hulu $this->video_id]`, which generates a request to Hulu's oEmbed API endpoint, so that we can turn the ID (human readable) into an "EID" (Hulu's internal id). If we do all those tests in parallel (across all our different test environments), Hulu may be throttling us.

To reduce the number requests per test run, flag each test that would normally require a request as dependent on `::test_shortcodes_hulu_id()`, which allows `::test_shortcodes_hulu_id()` to run first and cache the result from Hulu.

#### Testing instructions:

Let TravisCI do its thing :)