### PR TITLE
REST API: Get all custom post type labels translated

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -56,8 +56,16 @@ class WPCOM_JSON_API_List_Post_Types_Endpoint extends WPCOM_JSON_API_Endpoint {
 		 */
 		if ( apply_filters( 'rest_api_localize_response', false ) ) {
 			// API localization occurs after the initial post types have been
-			// registered, so re-register if localizing response
-			create_initial_post_types();
+			// registered, so let's get the post type labels translated
+			if ( 'en' !== get_locale() ) {
+				global $wp_post_types;
+				foreach ( $wp_post_types as $post_type_name => $post_type_object ) {
+					foreach ( array_keys( (array) $post_type_object->labels ) as $label_key ) {
+						// Direct use of translate call because this doesn't need to be extracted.
+						$post_type_object->labels->$label_key = translate( $post_type_object->labels->$label_key, 'default' );
+					}
+				}
+			}
 		}
 
 		// Get a list of available post types


### PR DESCRIPTION
Before this PR only the standard post type labels were translated as they were re-generated by re-registering them. 

#### Changes proposed in this Pull Request:

* This simply passes all the labels of all custom post tyles through the `translate()` function so that they get transformed from English to the target language.
