### PR TITLE
Search: Add an experimental phrase suggester for spell correcting search queries

### DIFF
--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -338,4 +338,33 @@ class Jetpack_WPES_Query_Builder {
 		return $aggregations;
 	}
 
+	/**
+	 * Assemble the 'suggest' portion of an ES query, using a phrase suggester. Note that this is experimental and
+	 * only works with English tokens.
+	 *
+	 * @param string $query The query text being searched.
+	 *
+	 * @return array An experimental suggest query.
+	 */
+	public function build_experimental_suggest( $query ) {
+		return array(
+			'text' => $query,
+			'experimental-phrase-suggester' => array(
+				'phrase' => array(
+					'field'                      => 'title.en',
+					"max_errors"                 => 4.0,
+					'confidence'                 => .9,
+					'real_word_error_likelihood' => .9,
+					'size' => 1,
+					"direct_generator" => array(
+						array(
+							'field'           => 'content.en',
+							'suggest_mode'    => 'always',
+							'min_word_length' => 1
+						)
+					)
+				)
+			)
+		);
+	}
 }

--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -351,14 +351,14 @@ class Jetpack_WPES_Query_Builder {
 			'text' => $query,
 			'experimental-phrase-suggester' => array(
 				'phrase' => array(
-					'field'                      => 'title.en',
+					'field'                      => 'mlt_content.default',
 					"max_errors"                 => 4.0,
 					'confidence'                 => .9,
 					'real_word_error_likelihood' => .9,
 					'size' => 1,
 					"direct_generator" => array(
 						array(
-							'field'           => 'content.en',
+							'field'           => 'mlt_content.default',
 							'suggest_mode'    => 'always',
 							'min_word_length' => 1
 						)

--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -338,33 +338,4 @@ class Jetpack_WPES_Query_Builder {
 		return $aggregations;
 	}
 
-	/**
-	 * Assemble the 'suggest' portion of an ES query, using a phrase suggester. Note that this is experimental and
-	 * only works with English tokens.
-	 *
-	 * @param string $query The query text being searched.
-	 *
-	 * @return array An experimental suggest query.
-	 */
-	public function build_experimental_suggest( $query ) {
-		return array(
-			'text' => $query,
-			'experimental-phrase-suggester' => array(
-				'phrase' => array(
-					'field'                      => 'mlt_content.default',
-					"max_errors"                 => 4.0,
-					'confidence'                 => .9,
-					'real_word_error_likelihood' => .9,
-					'size' => 1,
-					"direct_generator" => array(
-						array(
-							'field'           => 'mlt_content.default',
-							'suggest_mode'    => 'always',
-							'min_word_length' => 1
-						)
-					)
-				)
-			)
-		);
-	}
 }


### PR DESCRIPTION
Prototype for fixing #7924.
More context: https://wp.me/p10gg3-8JM-p2

#### Changes proposed in this Pull Request:

* Add a phrase suggester request to Jetpack search's ElasticSearch request.
* If the original search returned no results but did return a suggestion, trigger a second search request for the suggestion.
* If the suggest finds results, show them. If not, don't change the visual result.
* Print "Did you mean, X?" if the original query had results but also returned a suggestion.
* Print "Spell Corrected to, X" if the original query had no results but the suggestion did have results.

#### Testing instructions:

* Patch this code into a Jetpack site with a plan that support Search.
* Misspell a search for an existing post (eg: "hllo world" for existing post, "hello world").
* If the misspelled query doesn't match any posts and the suggester can suggest the correct query, the result found by the suggestion should appear along with "Spell corrected to, X."
* If the misspelled query does match a post and the suggester can suggest a "better" query, it should show "Did you mean, X?". The "X?" text should be linked to the search page for X.

#### See screenshots for examples on various themes:

<img width="1680" alt="interior_list-sct-hello" src="https://user-images.githubusercontent.com/1385146/44132623-b4992be2-a00f-11e8-9662-8e8568bb4688.png">
<img width="1680" alt="interior_lite-dym-post" src="https://user-images.githubusercontent.com/1385146/44132624-b4ab5150-a00f-11e8-9626-86c67222d0c7.png">
<img width="1680" alt="stout-sct-hello" src="https://user-images.githubusercontent.com/1385146/44132629-b7876c42-a00f-11e8-8e2c-ada4106fd5d6.png">
<img width="1680" alt="stout-dym-post" src="https://user-images.githubusercontent.com/1385146/44132628-b773ebc2-a00f-11e8-83c1-071906306b2e.png">
<img width="1680" alt="twentyfifteen-sct-hello" src="https://user-images.githubusercontent.com/1385146/44132633-bb92dcd6-a00f-11e8-8f8b-36dbb0042331.png">
<img width="1680" alt="twentyfifteen-dym-post" src="https://user-images.githubusercontent.com/1385146/44132632-bb8018ee-a00f-11e8-9b4d-c71c919f432f.png">
<img width="1680" alt="twentyseventeen-sct-hello" src="https://user-images.githubusercontent.com/1385146/44132640-c0d33c72-a00f-11e8-87a8-037f92180f99.png">
<img width="1680" alt="twentyseventeen-dym-post" src="https://user-images.githubusercontent.com/1385146/44132639-c0c0dbf4-a00f-11e8-89ad-b07fa5fdf895.png">

