### PR TITLE
Revert "Try: Skip TravisCI if non-testable files are updated"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,6 @@ branches:
 git:
   depth: 1
 
-# Skip Travis CI test if edited files were doc / non-testable
-before_install:
-    - |
-        git diff --name-only HEAD~1 | grep -qvE '(\.txt$|\.editorconfig$|\.md$|\.yml$|\..*ignore$)|(^docker)' || {
-          echo "Only non-testable files were updated, skipping from running tests."
-          travis_terminate 0
-        }
-
 # Clones WordPress and configures our testing environment
 before_script:
     - phpenv config-rm xdebug.ini


### PR DESCRIPTION
Reverts Automattic/jetpack#9988

This change broke TravisCI tests that run after a PR is merged into master. Tests within PR work as expected - we need to revert and fix this.