### PR TITLE
Linting: Enable WP_Test_Jetpack_PHP_Lint for all PHP versions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
 			<file>tests/php/test_class.jetpack-options.php</file>
 		</testsuite>
 		<testsuite name="php-lint">
-			<file phpVersion="5.3.0" phpVersionOperator="<=">tests/php/test_php-lint.php</file>
+			<file phpVersion="5.3.0" phpVersionOperator="&lt;=">tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
 			<file>tests/php/test_class.jetpack-options.php</file>
 		</testsuite>
 		<testsuite name="php-lint">
-			<file phpVersion="5.3.0" phpVersionOperator="lte">tests/php/test_php-lint.php</file>
+			<file phpVersion="5.3.0" phpVersionOperator="<=">tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
 			<file>tests/php/test_class.jetpack-options.php</file>
 		</testsuite>
 		<testsuite name="php-lint">
-			<file phpVersion="5.3.0" phpVersionOperator="&lt;=">tests/php/test_php-lint.php</file>
+			<file>tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -13,6 +13,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 			. 'do php -l "$file" | '
 			. 'grep -v "No syntax errors detected" | '
 			. 'grep -v "./tools/" | '
+			. 'grep -v "./tests/" | '
 			. 'grep -v "jetpack-cli.php" | '
 			. 'grep -v -e \'^$\'; '
 			. 'done';

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -15,6 +15,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 			. 'grep -v "./tools/" | '
 			. 'grep -v "./tests/" | '
 			. 'grep -v "jetpack-cli.php" | '
+			. 'grep -v "./_inc/class.jetpack-provision.php" | '
 			. 'grep -v -e \'^$\'; '
 			. 'done';
 


### PR DESCRIPTION
Fixes: #9862

#### Changes proposed in this Pull Request:

* Enable WP_Test_Jetpack_PHP_Lint for all PHP versions

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

Make sure that `WP_Test_Jetpack_PHP_Lint` is running for every PHP version and CI builds is passing

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* run `php -l` on every supported PHP version