### PR TITLE
XML-RPC: Partners: Add jetpack.remoteconenct method for auto-connect a site

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -294,7 +294,8 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new WP_Error(
 					'already_connected',
-					__( 'Jetpack is already connected.', 'jetpack' ), 400
+					__( 'Jetpack is already connected.', 'jetpack' ),
+					400
 				),
 				'jpc_remote_register_fail'
 			);
@@ -302,11 +303,12 @@ class Jetpack_XMLRPC_Server {
 
 		$user = $this->fetch_and_verify_local_user( $request );
 
-		if ( ! $user | is_wp_error( $user ) || is_a( $user, 'IXR_Error' ) ) {
+		if ( ! $user || is_wp_error( $user ) || is_a( $user, 'IXR_Error' ) ) {
 			return $this->error(
 				new WP_Error(
 					'input_error',
-					__( 'Valid user is required.', 'jetpack' ), 400
+					__( 'Valid user is required.', 'jetpack' ),
+					400
 				),
 				'jpc_remote_connect_fail'
 			);
@@ -316,7 +318,8 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new WP_Error(
 					'input_error',
-					__( 'A non-empty nonce must be supplied.', 'jetpack' ), 400
+					__( 'A non-empty nonce must be supplied.', 'jetpack' ),
+					400
 				),
 				'jpc_remote_connect_fail'
 			);
@@ -336,7 +339,8 @@ class Jetpack_XMLRPC_Server {
 			return $this->error(
 				new WP_Error(
 					'token_fetch_failed',
-					__( 'Failed to fetch user token from WordPress.com.', 'jetpack' ), 400
+					__( 'Failed to fetch user token from WordPress.com.', 'jetpack' ),
+					400
 				),
 				'jpc_remote_connect_fail'
 			);

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -327,8 +327,8 @@ class Jetpack_XMLRPC_Server {
 			$ixr_client = new Jetpack_IXR_Client();
 		}
 		$ixr_client->query( 'jetpack.getUserAccessToken', array(
-			'nonce'   => sanitize_text_field( $request['nonce'] ),
-			'user_id' => $user->ID,
+			'nonce'            => sanitize_text_field( $request['nonce'] ),
+			'external_user_id' => $user->ID,
 		) );
 
 		$token = $ixr_client->isError() ? false : $ixr_client->getResponse();

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -88,8 +88,9 @@ class Jetpack_XMLRPC_Server {
 
 	function provision_xmlrpc_methods() {
 		return array(
-			'jetpack.remoteRegister' => array( $this, 'remote_register' ),
-			'jetpack.remoteProvision'   => array( $this, 'remote_provision' ),
+			'jetpack.remoteRegister'  => array( $this, 'remote_register' ),
+			'jetpack.remoteProvision' => array( $this, 'remote_provision' ),
+			'jetpack.remoteConnect'   => array( $this, 'remote_connect' ),
 		);
 	}
 
@@ -279,6 +280,74 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Given an array containing a local user identifier and a nonce, will attempt to fetch and set
+	 * an access token for the given user.
+	 *
+	 * @param array $request An array containing local_user and nonce keys at minimum.
+	 * @return mixed
+	 */
+	public function remote_connect( $request, $ixr_client = false ) {
+		if ( Jetpack::is_active() ) {
+			return $this->error(
+				new WP_Error(
+					'already_connected',
+					__( 'Jetpack is already connected.', 'jetpack' ), 400
+				),
+				'jpc_remote_register_fail'
+			);
+		}
+
+		$user = $this->fetch_and_verify_local_user( $request );
+
+		if ( ! $user | is_wp_error( $user ) || is_a( $user, 'IXR_Error' ) ) {
+			return $this->error(
+				new WP_Error(
+					'input_error',
+					__( 'Valid user is required.', 'jetpack' ), 400
+				),
+				'jpc_remote_connect_fail'
+			);
+		}
+
+		if ( empty( $request['nonce'] ) ) {
+			return $this->error(
+				new WP_Error(
+					'input_error',
+					__( 'A non-empty nonce must be supplied.', 'jetpack' ), 400
+				),
+				'jpc_remote_connect_fail'
+			);
+		}
+
+		if ( ! $ixr_client ) {
+			Jetpack::load_xml_rpc_client();
+			$ixr_client = new Jetpack_IXR_Client();
+		}
+		$ixr_client->query( 'jetpack.getUserAccessToken', array(
+			'nonce'   => sanitize_text_field( $request['nonce'] ),
+			'user_id' => $user->ID,
+		) );
+
+		$token = $ixr_client->isError() ? false : $ixr_client->getResponse();
+		if ( empty( $token ) ) {
+			return $this->error(
+				new WP_Error(
+					'token_fetch_failed',
+					__( 'Failed to fetch user token from WordPress.com.', 'jetpack' ), 400
+				),
+				'jpc_remote_connect_fail'
+			);
+		}
+		$token = sanitize_text_field( $token );
+
+		Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $token, $user->ID ), true );
+
+		$this->do_post_authorization();
+
+		return Jetpack::is_active();
 	}
 
 	private function fetch_and_verify_local_user( $request ) {
@@ -697,5 +766,19 @@ class Jetpack_XMLRPC_Server {
 			(string) $nonce,
 			(string) $hmac,
 		);
+	}
+
+	/**
+	 * Handles authorization actions after connecting a site, such as enabling modules.
+	 *
+	 * This do_post_authorization() is used in this class, as opposed to calling
+	 * Jetpack::handle_post_authorization_actions() directly so that we can mock this method as necessary.
+	 *
+	 * @return void
+	 */
+	public function do_post_authorization() {
+		/** This filter is documented in class.jetpack-cli.php */
+		$enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
+		Jetpack::handle_post_authorization_actions( $enable_sso, false, false );
 	}
 }

--- a/modules/contact-form.php
+++ b/modules/contact-form.php
@@ -13,7 +13,7 @@
  * Additional Search Queries: contact, form, grunion, feedback, submission
  */
 
-include dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';
+require_once dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';
 /*
  * Filters if the new Contact Form Editor View should be used.
  *
@@ -22,7 +22,7 @@ include dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';
  * Expected to be removed in Jetpack 5.8 or if a security issue merits removing the old code sooner.
  *
  * @since 5.2.0
- * 
+ *
  * @param boolean $view Use new Editor View. Default true.
  */
 if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {

--- a/tests/php/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/test_class.jetpack-xmlrpc-server.php
@@ -142,6 +142,126 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_remote_connect_error_when_site_active() {
+		// Simulate the site being active.
+		Jetpack_Options::update_options( array(
+			'blog_token'  => 1,
+			'id'          => 1001,
+		) );
+		Jetpack::update_user_token( 1, sprintf( '%s.%d', 'token', 1 ), true );
+
+		$server = new Jetpack_XMLRPC_Server();
+
+		$response = $server->remote_connect( array(
+			'nonce'      => '1234',
+			'local_user' => '1',
+		) );
+
+		$this->assertInstanceOf( 'IXR_Error', $response );
+		$this->assertObjectHasAttribute( 'code', $response );
+		$this->assertObjectHasAttribute( 'message', $response );
+		$this->assertEquals( 400, $response->code );
+		$this->assertEquals(
+			'Jetpack: [token_fetch_failed] Failed to fetch user token from WordPress.com.',
+			$response->message
+		);
+
+		foreach ( array( 'blog_token', 'id','master_user', 'user_tokens' ) as $option_name ) {
+			Jetpack_Options::delete_option( $option_name );
+		}
+	}
+
+	public function test_remote_connect_error_invalid_user() {
+		$server = new Jetpack_XMLRPC_Server();
+		$response = $server->remote_connect( array(
+			'nonce'      => '1234',
+			'local_user' => '100000000',
+		) );
+
+		$this->assertInstanceOf( 'IXR_Error', $response );
+		$this->assertObjectHasAttribute( 'code', $response );
+		$this->assertObjectHasAttribute( 'message', $response );
+		$this->assertEquals( 400, $response->code );
+		$this->assertEquals(
+			'Jetpack: [input_error] Valid user is required.',
+			$response->message
+		);
+	}
+
+	public function test_remote_connect_empty_nonce() {
+		$server = new Jetpack_XMLRPC_Server();
+		$response = $server->remote_connect( array(
+			'local_user' => '1',
+		) );
+
+		$this->assertInstanceOf( 'IXR_Error', $response );
+		$this->assertObjectHasAttribute( 'code', $response );
+		$this->assertObjectHasAttribute( 'message', $response );
+		$this->assertEquals( 400, $response->code );
+		$this->assertEquals(
+			'Jetpack: [input_error] A non-empty nonce must be supplied.',
+			$response->message
+		);
+	}
+
+	public function test_remote_connect_fails_no_blog_token() {
+		Jetpack_Options::delete_option( 'blog_token' );
+
+		$server = new Jetpack_XMLRPC_Server();
+
+		add_filter( 'pre_http_request', array( $this, '__return_token' ) );
+		$response = $server->remote_connect( array(
+			'nonce'      => '1234',
+			'local_user' => '1',
+		) );
+
+		$this->assertInstanceOf( 'IXR_Error', $response );
+		$this->assertObjectHasAttribute( 'code', $response );
+		$this->assertObjectHasAttribute( 'message', $response );
+		$this->assertEquals( 400, $response->code );
+		$this->assertEquals(
+			'Jetpack: [token_fetch_failed] Failed to fetch user token from WordPress.com.',
+			$response->message
+		);
+	}
+
+	public function test_remote_connect_nonce_validation_error() {
+		Jetpack_Options::update_options( array(
+			'id'         => 1001,
+			'blog_token' =>  '123456.123456',
+		) );
+
+		$server = $this->get_mocked_xmlrpc_server();
+		$response = $server->remote_connect( array(
+			'nonce'      => '1234',
+			'local_user' => '1',
+		), $this->get_mocked_ixr_client( true, false ) );
+
+		$this->assertInstanceOf( 'IXR_Error', $response );
+		$this->assertObjectHasAttribute( 'code', $response );
+		$this->assertObjectHasAttribute( 'message', $response );
+		$this->assertEquals( 400, $response->code );
+		$this->assertEquals(
+			'Jetpack: [token_fetch_failed] Failed to fetch user token from WordPress.com.',
+			$response->message
+		);
+	}
+
+	public function test_remote_connect_success() {
+		Jetpack_Options::update_options( array(
+			'id'         => 1001,
+			'blog_token' =>  '123456.123456',
+		) );
+
+		$server = $this->get_mocked_xmlrpc_server();
+		$response = $server->remote_connect( array(
+			'nonce'      => '1234',
+			'local_user' => '1',
+		), $this->get_mocked_ixr_client( true, 'this_is.a_token' ) );
+
+		$this->assertTrue( $response );
+	}
+
 	/*
 	 * Helpers
 	 */
@@ -174,5 +294,42 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 				'message' => '',
 			)
 		);
+	}
+
+	protected function get_mocked_ixr_client( $query_called = false, $response = '', $query_return = true, $error = null ) {
+		Jetpack::load_xml_rpc_client();
+		$xml = $this->getMockBuilder( 'Jetpack_IXR_Client' )
+			->setMethods( array(
+				'query',
+				'isError',
+				'getResponse',
+			) )
+			->getMock();
+
+		$xml->expects( $this->exactly( $query_called ? 1 : 0 ) )
+			->method( 'query' )
+			->willReturn( $query_return );
+
+		$xml->expects( $this->exactly( $query_called ? 1 : 0 ) )
+			->method( 'isError' )
+			->willReturn( empty( $error ) ? false : true );
+
+		$xml->expects( $this->exactly( empty( $error ) ? 1 : 0 ) )
+			->method( 'getResponse' )
+			->willReturn( $response );
+
+		return $xml;
+	}
+
+	protected function get_mocked_xmlrpc_server() {
+		$server = $this->getMockBuilder( 'Jetpack_XMLRPC_Server' )
+			->setMethods( array(
+				'do_post_authorization',
+			) )
+			->getMock();
+
+		$server->method( 'do_post_authorization' )->willReturn( true );
+
+		return $server;
 	}
 }

--- a/tests/php/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/test_class.jetpack-xmlrpc-server.php
@@ -328,7 +328,9 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 			) )
 			->getMock();
 
-		$server->method( 'do_post_authorization' )->willReturn( true );
+		$server->expects( $this->any() )
+			->method( 'do_post_authorization' )
+			->willReturn( true );
 
 		return $server;
 	}

--- a/tests/php/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/test_class.jetpack-xmlrpc-server.php
@@ -308,15 +308,15 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 
 		$xml->expects( $this->exactly( $query_called ? 1 : 0 ) )
 			->method( 'query' )
-			->willReturn( $query_return );
+			->will( $this->returnValue( $query_return ) );
 
 		$xml->expects( $this->exactly( $query_called ? 1 : 0 ) )
 			->method( 'isError' )
-			->willReturn( empty( $error ) ? false : true );
+			->will( $this->returnValue( empty( $error ) ? false : true ) );
 
 		$xml->expects( $this->exactly( empty( $error ) ? 1 : 0 ) )
 			->method( 'getResponse' )
-			->willReturn( $response );
+			->will( $this->returnValue( $response ) );
 
 		return $xml;
 	}
@@ -330,7 +330,7 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 
 		$server->expects( $this->any() )
 			->method( 'do_post_authorization' )
-			->willReturn( true );
+			->will( $this->returnValue( true ) );
 
 		return $server;
 	}


### PR DESCRIPTION
We are currently working on improving flows for our users that connect via hosting partners. Part of this will be auto-connecting sites/users where the user connecting does NOT have an existing WordPress.com account. In this case, we'll create a new WP.com account for the user and then auto-connect the site. See D16948 for the required WPCOM patch.

#### Changes proposed in this Pull Request:

* Add `jetpack.remoteConnect` method for automatically connecting a disconnected site, given a local user ID and a token.

#### Testing instructions:

- `phpunit --filter=WP_Test_Jetpack_XMLRPC_Server`
- Checkout `D16948` on WordPress.com
- Manually test flow
    - Ensure email address of user on does not have existing WP.com account
    - Ensure that you're sandboxing WordPress.com:
    - Use the following command, replacing partner the arguments :
        - `sh jetpack/bin/partner-provision.sh --partner_id={PARTNER_ID} --partner_secret={PARTNER_SECRET} --user={LOCAL_WP_USER_ID} --plan=professional`
        - For instructions on setting up a partner ID and secret, see: PCYsg-eDL-p2
    - Ensure that the response you get back looks like: 
    ```
    {
      "success": true,
      "auth_required": false,
      "next_url": "http:/example.com/wp-login.php?action=jetpack-sso&redirect_to=http%3A%2F%2Fexample.com%2Fwp-admin%2F"
    }
    ```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add XML-RPC method for allowing remotely connecting a site if the site has already been registered but not yet connected.