### PR TITLE
Fix PHP notice when image width/height not available in Jetpack_AMP_Support::add_image_to_metadata()

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -217,11 +217,15 @@ class Jetpack_AMP_Support {
 		}
 
 		$metadata['image'] = array(
-			'@type'  => 'ImageObject',
-			'url'    => $image['src'],
-			'width'  => $image['src_width'],
-			'height' => $image['src_height'],
+			'@type' => 'ImageObject',
+			'url'   => $image['src'],
 		);
+		if ( isset( $image['src_width'] ) ) {
+			$metadata['image']['width'] = $image['src_width'];
+		}
+		if ( isset( $image['src_width'] ) ) {
+			$metadata['image']['height'] = $image['src_height'];
+		}
 
 		return $metadata;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This fixes an issue I saw in my PHP error log:

> Undefined index: src_width in wp-content/plugins/jetpack/3rd-party/class.jetpack-amp-support.php on line 224

#### Testing instructions:

The issue occurs on a post that has no featured image set, but which does have an embedded `gallery` shortcode, where the underlying image files have been deleted for the attachments in that gallery.

True this is an edge case, but this hardening seems it can't hurt.