### PR TITLE
WordAds: don't show ads on unsafe sites

### DIFF
--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -110,7 +110,7 @@ class WordAds_API {
 	 * Returns whether or not this site is safe to run ads on.
 	 * @return boolean true if ads shown not be shown on this site.
 	 *
-	 * @since @next @TODO
+	 * @since 6.5.0
 	 */
 	public static function is_wordads_unsafe() {
 		if ( is_null( self::$wordads_status ) ) {

--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -22,6 +22,7 @@ class WordAds_API {
 				'approved' => true,
 				'active'   => true,
 				'house'    => true,
+				'unsafe'   => false,
 			);
 
 			return self::$wordads_status;
@@ -38,6 +39,7 @@ class WordAds_API {
 			'approved' => $body->approved,
 			'active'   => $body->active,
 			'house'    => $body->house,
+			'unsafe'   => $body->unsafe,
 		);
 
 		return self::$wordads_status;
@@ -103,6 +105,21 @@ class WordAds_API {
 		return self::$wordads_status['house'] ? '1' : '0';
 	}
 
+
+	/**
+	 * Returns whether or not this site is safe to run ads on.
+	 * @return boolean true if ads shown not be shown on this site.
+	 *
+	 * @since @next @TODO
+	 */
+	public static function is_wordads_unsafe() {
+		if ( is_null( self::$wordads_status ) ) {
+			self::get_wordads_status();
+		}
+
+		return self::$wordads_status['unsafe'] ? '1' : '0';
+	}
+
 	/**
 	 * Grab WordAds status from WP.com API and store as option
 	 *
@@ -114,6 +131,7 @@ class WordAds_API {
 			update_option( 'wordads_approved', self::is_wordads_approved(), true );
 			update_option( 'wordads_active', self::is_wordads_active(), true );
 			update_option( 'wordads_house', self::is_wordads_house(), true );
+			update_option( 'wordads_unsafe', self::is_wordads_unsafe(), true );
 		}
 	}
 }

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -13,6 +13,7 @@ class WordAds_Params {
 			'wordads_approved'           => false,
 			'wordads_active'             => false,
 			'wordads_house'              => true,
+			'wordads_unsafe'             => false,
 			'enable_header_ad'           => true,
 			'wordads_second_belowpost'   => true,
 			'wordads_display_front_page' => true,
@@ -25,6 +26,7 @@ class WordAds_Params {
 		$this->options = array();
 		foreach ( $settings as $setting => $default ) {
 			$option = get_option( $setting, null );
+
 			if ( is_null( $option ) ) {
 				update_option( $setting, $default, true );
 				$option = $default;

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -472,7 +472,7 @@ HTML;
 	 * @since 4.5.0
 	 */
 	public function should_bail() {
-		return ! $this->option( 'wordads_approved' );
+		return ! $this->option( 'wordads_approved' ) || !! $this->option( 'wordads_unsafe' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Prevents ads from showing on sites marked as unsafe (fetched daily via api)

#### Testing instructions:

Follow the testing instructions in D17303-code, using the new corresponding api work.

#### Proposed changelog entry:

Proposing no changelog entry.