### PR TITLE
PHP 7.3: Use break instead of continue within a switch case

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -74,7 +74,7 @@ class Jetpack_Media_Summary {
 						if ( 0 == $return['count']['video'] ) {
 							// If there is no id on the video, then let's just skip this
 							if ( ! isset ( $data['id'][0] ) ) {
-								continue;
+								break;
 							}
 
 							$guid = $data['id'][0];
@@ -84,7 +84,7 @@ class Jetpack_Media_Summary {
 							if ( $video_info instanceof stdClass ) {
 								// Continue early if we can't find a Video slug.
 								if ( empty( $video_info->files->std->mp4 ) ) {
-									continue;
+									break;
 								}
 
 								$url = sprintf(


### PR DESCRIPTION
Starting in PHP 7.3 (currently in Beta 2), PHP will throw a warning when using `continue` within a `switch` to confirm intent. In PHP, within `switch`, `break` and `continue` do the same thing while in other languages `continue` would behave like PHP's `continue 2`.

This would preserve the same behavior and avoid the warning. See https://github.com/php/php-src/blob/php-7.3.0beta2/UPGRADING

Based on the current timeline, this would need to land no later than our December release (6.8 based on our monthly clip). PHP 7.3 is expected to go into GA on December 13th. Since this is a backwards compatible change, no reason to wait though.

#### Testing instructions:

1. Before patch, run something via PHP 7.3. See warning.
2. Apply patch, repeat, see no error.

#### Proposed changelog entry for your changes:
* Improves compatibility with the upcoming PHP 7.3
