### PR TITLE
Make check for meta tag to verify site more permissive

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -12,6 +12,7 @@ import {
 	getModuleOptionValidValues
 } from 'state/modules';
 import {
+	fetchSettings,
 	getSetting,
 	updateSettings,
 	isUpdatingSetting,
@@ -65,6 +66,9 @@ export function connectModuleOptions( Component ) {
 			},
 			clearUnsavedSettingsFlag: () => {
 				return dispatch( clearUnsavedSettingsFlag() );
+			},
+			refreshSettings: () => {
+				return dispatch( fetchSettings() );
 			}
 		} )
 	)( Component );

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -127,6 +127,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					this.setState( { options: {} } );
 				} )
 				.then( () => {
+					this.props.refreshSettings();
 					this.props.clearUnsavedSettingsFlag();
 				} );
 		};

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
 import ExternalLink from 'components/external-link';
+import get from 'lodash/get';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -19,9 +21,48 @@ import SettingsGroup from 'components/settings-group';
 import JetpackBanner from 'components/jetpack-banner';
 
 class VerificationServicesComponent extends React.Component {
+	static serviceIds = {
+		google: 'google-site-verification',
+		bing: 'msvalidate.01',
+		pinterest: 'p:domain_verify',
+		yandex: 'yandex-verification',
+	};
+
 	activateVerificationTools = () => {
 		return this.props.updateOptions( { 'verification-tools': true } );
 	};
+
+	getMetaTag( serviceName = '', content = '' ) {
+		if ( ! content ) {
+			return '';
+		}
+
+		if ( ! /^[a-z0-9_-]+$/i.test( content ) ) {
+			// User is probably editing the content
+			return content;
+		}
+
+		if ( includes( content, '<meta' ) ) {
+			// We were passed a meta tag already!
+			return content;
+		}
+
+		return `<meta name="${ get(
+			VerificationServicesComponent.serviceIds,
+			serviceName,
+			''
+		) }" content="${ content }" />`;
+	}
+
+	getSiteVerificationValue( service ) {
+		const optionValue = this.props.getOptionValue( service );
+		// if current value is equal to the initial value, update format for display
+		if ( ! this.props.isDirty() ) {
+			return this.getMetaTag( service, optionValue );
+		}
+
+		return optionValue;
+	}
 
 	render() {
 		const verification = this.props.getModule( 'verification-tools' );
@@ -106,43 +147,54 @@ class VerificationServicesComponent extends React.Component {
 						) }
 					</p>
 					<FormFieldset>
-						{
-							[
-								{
-									id: 'google',
-									label: __( 'Google' ),
-									placeholder: '<meta name="google-site-verification" content="1234" />'
-								},
-								{
-									id: 'bing',
-									label: __( 'Bing' ),
-									placeholder: '<meta name="msvalidate.01" content="1234" />'
-								},
-								{
-									id: 'pinterest',
-									label: __( 'Pinterest' ),
-									placeholder: '<meta name="p:domain_verify" content="1234" />'
-								},
-								{
-									id: 'yandex',
-									label: __( 'Yandex' ),
-									placeholder: '<meta name="yandex-verification" content="1234" />'
-								}
-							].map( item => (
-								<FormLabel
-									className="jp-form-input-with-prefix"
-									key={ `verification_service_${ item.id }` }>
-									<span>{ item.label }</span>
-									<TextInput
-										name={ item.id }
-										value={ this.props.getOptionValue( item.id ) }
-										placeholder={ item.placeholder }
-										className="code"
-										disabled={ this.props.isUpdating( item.id ) }
-										onChange={ this.props.onOptionChange } />
-								</FormLabel>
-							) )
-						}
+						<FormLabel
+							className="jp-form-input-with-prefix"
+							key="verification_service_google">
+							<span>{ __( 'Google' ) }</span>
+							<TextInput
+								name="google"
+								value={ this.getSiteVerificationValue( 'google' ) }
+								placeholder={ this.getMetaTag( 'google', '1234' ) }
+								className="code"
+								disabled={ this.props.isUpdating( 'google' ) }
+								onChange={ this.props.onOptionChange } />
+						</FormLabel>
+						<FormLabel
+							className="jp-form-input-with-prefix"
+							key="verification_service_bing">
+							<span>{ __( 'Bing' ) }</span>
+							<TextInput
+								name="bing"
+								value={ this.getSiteVerificationValue( 'bing' ) }
+								placeholder={ this.getMetaTag( 'bing', '1234' ) }
+								className="code"
+								disabled={ this.props.isUpdating( 'bing' ) }
+								onChange={ this.props.onOptionChange } />
+						</FormLabel>
+						<FormLabel
+							className="jp-form-input-with-prefix"
+							key="verification_service_pinterest">
+							<span>{ __( 'Pinterest' ) }</span>
+							<TextInput
+								name="pinterest"
+								value={ this.getSiteVerificationValue( 'pinterest' ) }
+								placeholder={ this.getMetaTag( 'pinterest', '1234' ) }
+								className="code"
+								disabled={ this.props.isUpdating( 'pinterest' ) }
+								onChange={ this.props.onOptionChange } />
+						</FormLabel>
+						<FormLabel
+							className="jp-form-input-with-prefix"
+							key="verification_service_yandex">
+							<span>{ __( 'Yandex' ) }</span>
+							<TextInput
+								name="yandex"
+								value={ this.getSiteVerificationValue( 'yandex' ) }
+								placeholder={ this.getMetaTag( 'yandex', '1234' ) }
+								className="code"
+								disabled={ this.props.isUpdating( 'yandex' ) }
+								onChange={ this.props.onOptionChange } />
+						</FormLabel>
 					</FormFieldset>
 				</SettingsGroup>
 			</SettingsCard>

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2264,7 +2264,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_verification_service( $value = '', $request, $param ) {
-		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || preg_match( '#^<meta[^<>]+content=["\']?([^"\' <>]*)[^<>]*/?>$#i', $value ) ) ) ) {
+		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || jetpack_verification_get_code( $value ) !== false ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an alphanumeric string or a verification tag.', 'jetpack' ), $param ) );
 		}
 		return true;

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2264,7 +2264,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_verification_service( $value = '', $request, $param ) {
-		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $value ) ) ) ) {
+		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || preg_match( '#^<meta[^<>]+content=["\']?([^"\' <>]*)[^<>]*/?>$#i', $value ) ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an alphanumeric string or a verification tag.', 'jetpack' ), $param ) );
 		}
 		return true;

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -30,9 +30,12 @@ function jetpack_verification_services() {
 	);
 }
 
-
 function jetpack_verification_options_init() {
-	register_setting( 'verification_services_codes_fields', 'verification_services_codes', 'jetpack_verification_validate' );
+	register_setting(
+		'verification_services_codes_fields',
+		'verification_services_codes',
+		[ 'sanitize_callback' => 'jetpack_verification_validate' ]
+	);
 }
 add_action( 'admin_init', 'jetpack_verification_options_init' );
 

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -3,7 +3,7 @@
 // Edit here to add new services
 function jetpack_verification_services() {
 	return array(
-			'google' => array(
+		'google' => array(
 			'name'   =>'Google Search Console',
 			'key'    =>'google-site-verification',
 			'format' =>'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8',

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -34,7 +34,7 @@ function jetpack_verification_options_init() {
 	register_setting(
 		'verification_services_codes_fields',
 		'verification_services_codes',
-		[ 'sanitize_callback' => 'jetpack_verification_validate' ]
+		array( 'sanitize_callback' => 'jetpack_verification_validate' )
 	);
 }
 add_action( 'admin_init', 'jetpack_verification_options_init' );

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -38,6 +38,7 @@ function jetpack_verification_options_init() {
 	);
 }
 add_action( 'admin_init', 'jetpack_verification_options_init' );
+add_action( 'rest_api_init', 'jetpack_verification_options_init' );
 
 function jetpack_verification_print_meta() {
 	$verification_services_codes =  Jetpack_Options::get_option_and_ensure_autoload( 'verification_services_codes', '0' );

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -7,9 +7,10 @@
 
 function jetpack_verification_validate( $verification_services_codes ) {
 	foreach ( $verification_services_codes as $key => $code ) {
-		// Parse html meta tags if present
-		if ( stripos( $code, 'meta' ) )
-			$code = jetpack_verification_get_code( $code );
+		// Parse html meta tag if it does not look like a valid code
+		if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
+			$code = jetpack_verification_get_code($code);
+		}
 
 		$code = esc_attr( trim( $code ) );
 

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -5,7 +5,7 @@
  * This file will be included in module-extras.php.
  */
 
-function jetpack_verification_validate( &$verification_services_codes ) {
+function jetpack_verification_validate( $verification_services_codes ) {
 	foreach ( $verification_services_codes as $key => $code ) {
 		// Parse html meta tags if present
 		if ( stripos( $code, 'meta' ) )

--- a/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
+++ b/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
@@ -4,27 +4,41 @@ require dirname( __FILE__ ) . '/../../../../modules/verification-tools/verificat
 class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 
 	/**
-	 * @author zinigor
+	 * @author cbauerman
 	 * @covers jetpack_verification_validate
-	 * @since 5.5.0
+	 * @since 6.5.0
 	 */
-	public function test_jetpack_verification_validate_processes_and_returns_codes() {
-		$codes = array(
-			'google' => '         untrimmed code      ',
-			'bing' => 'some code that is going to be longer than 100 chars in order to test the trimming'
-			. ' some code that isgoing to be longer than 100 chars in order to test the trimming'
-			. ' some code that isgoing to be longer than 100 chars in order to test the trimming',
-			'yandex' => 'some regular string with nothing special in it'
+	public function test_jetpack_verification_validate_google_raw_code() {
+		$this->assertEquals(
+			jetpack_verification_validate( array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ) ),
+			array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ),
+			'raw code should be accepeted'
 		);
+	}
 
-		$processed_codes = jetpack_verification_validate( $codes );
+	/**
+	 * @author cbauerman
+	 * @covers jetpack_verification_validate
+	 * @since 6.5.0
+	 */
+	public function test_jetpack_verification_validate_google_code_in_meta_double_quotes() {
+		$this->assertEquals(
+			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content="bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr" />' ) ),
+			array( 'test' => 'bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr' ),
+			'google-style meta tag with double quotes should be accepeted'
+		);
+	}
 
-		foreach( array( 'google', 'bing', 'yandex' ) as $key ) {
-			$this->assertEquals(
-				substr( esc_attr( trim( $codes[ $key ] ) ), 0, 100 ),
-				$processed_codes[ $key ],
-				'the code should be processed'
-			);
-		}
+	/**
+	 * @author cbauerman
+	 * @covers jetpack_verification_validate
+	 * @since 6.5.0
+	 */
+	public function test_jetpack_verification_validate_google_code_in_meta_single_quotes() {
+		$this->assertEquals(
+			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content=\'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub\' />' ) ),
+			array( 'test' => 'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub' ),
+			'google-style meta tag with single quotes should be accepeted'
+		);
 	}
 }

--- a/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
+++ b/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
@@ -19,7 +19,7 @@ class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 
 		$processed_codes = jetpack_verification_validate( $codes );
 
-		foreach( [ 'google', 'bing', 'yandex' ] as $key ) {
+		foreach( array( 'google', 'bing', 'yandex' ) as $key ) {
 			$this->assertEquals(
 				substr( esc_attr( trim( $codes[ $key ] ) ), 0, 100 ),
 				$processed_codes[ $key ],

--- a/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
+++ b/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
@@ -10,19 +10,19 @@ class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 	 */
 	public function test_jetpack_verification_validate_processes_and_returns_codes() {
 		$codes = array(
-			'         untrimmed code      ',
-			'some code that is going to be longer than 100 chars in order to test the trimming'
+			'google' => '         untrimmed code      ',
+			'bing' => 'some code that is going to be longer than 100 chars in order to test the trimming'
 			. ' some code that isgoing to be longer than 100 chars in order to test the trimming'
 			. ' some code that isgoing to be longer than 100 chars in order to test the trimming',
-			'some regular string with nothing special in it'
+			'yandex' => 'some regular string with nothing special in it'
 		);
 
 		$processed_codes = jetpack_verification_validate( $codes );
 
-		foreach( array_merge( $codes, $processed_codes ) as $code ) {
+		foreach( [ 'google', 'bing', 'yandex' ] as $key ) {
 			$this->assertEquals(
-				substr( esc_attr( trim( $code ) ), 0, 100 ),
-				$code,
+				substr( esc_attr( trim( $codes[ $key ] ) ), 0, 100 ),
+				$processed_codes[ $key ],
 				'the code should be processed'
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The validation for meta tags entered in the Jetpack Settings page for site verification is overly strict. In fact, even the same meta tags we offer in our alternative UI (under "tools" in the wp-admin menu) don't work! (because they aren't self-closing tags, lack a space before the `>`, and use single instead of double quotes).

This PR updates the input validation we have for meta tags used for website verification services. We just want a meta tag that is valid enough so we can extract the value of the content property from it. HTML parser on browsers are quite flexible so we need to allow all kinds of valid meta tags.
For instance this change makes it so those are valid:
- `<meta name="google-site-verification" content="1234"/>` (no space before `/>`)
- `<meta name='google-site-verification' content='1234' />` (use of `'` instead of `"`)
- `<meta name='google-site-verification' content=1234 />` (does not use any quotes)
- `<meta content="1234" name="google-site-verification" />` (switches the order)
- `<meta name="google-site-verification" content="1234" some-prop />` (has extra properties)
- `<meta name="google-site-verification" content="1234">` (does not have a closing character)
...

#### Testing instructions:

Enter any of the formats above, both in the Jetpack Settings UI, and the same UI under "tools".

The content should be saved successfully without validation errors.

Enter a "bad" string in the JS UI, e.g. `<moota name="google-site-verification" content="1234"/>`

The content should fail to save with a validation error.

Note that the legacy UI under "tools" *will* actually accept `<moota name="google-site-verification" content="1234"/>` - that UI is going to be removed eventually so it's less of a concern.

#### Proposed changelog entry for your changes:
- Update input validation for meta tags given in site verification