### PR TITLE
Publicize: Sync WordPress.com and Jetpack UI

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -23,8 +23,6 @@ class Publicize extends Publicize_Base {
 
 		add_action( 'load-settings_page_sharing', array( $this, 'force_user_connection' ) );
 
-		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_checkbox_default' ), 10, 4 );
-
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
 
 		add_action( 'wp_insert_post', array( $this, 'save_publicized' ), 11, 3 );
@@ -123,12 +121,17 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_connections( $service_name, $_blog_id = false, $_user_id = false ) {
+		if ( false === $_user_id ) {
+			$_user_id = $this->user_id();
+		}
+
 		$connections           = $this->get_all_connections();
 		$connections_to_return = array();
+
 		if ( ! empty( $connections ) && is_array( $connections ) ) {
 			if ( ! empty( $connections[ $service_name ] ) ) {
 				foreach ( $connections[ $service_name ] as $id => $connection ) {
-					if ( 0 == $connection['connection_data']['user_id'] || $this->user_id() == $connection['connection_data']['user_id'] ) {
+					if ( 0 == $connection['connection_data']['user_id'] || $_user_id == $connection['connection_data']['user_id'] ) {
 						$connections_to_return[ $id ] = $connection;
 					}
 				}
@@ -163,6 +166,10 @@ class Publicize extends Publicize_Base {
 
 	function get_connection_id( $connection ) {
 		return $connection['connection_data']['id'];
+	}
+
+	function get_connection_unique_id( $connection ) {
+		return $connection['connection_data']['token_id'];
 	}
 
 	function get_connection_meta( $connection ) {
@@ -231,20 +238,35 @@ class Publicize extends Publicize_Base {
 
 	function globalization() {
 		if ( 'on' == $_REQUEST['global'] ) {
-			$id = $_REQUEST['connection'];
+			$globalize_connection = $_REQUEST['connection'];
 
 			if ( ! current_user_can( $this->GLOBAL_CAP ) ) {
 				return;
 			}
 
-			Jetpack::load_xml_rpc_client();
-			$xml = new Jetpack_IXR_Client();
-			$xml->query( 'jetpack.globalizePublicizeConnection', $id, 'globalize' );
+			$this->globalize_connection( $connection_id );
+		}
+	}
 
-			if ( ! $xml->isError() ) {
-				$response = $xml->getResponse();
-				Jetpack_Options::update_option( 'publicize_connections', $response );
-			}
+	function globalize_connection( $connection_id ) {
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client();
+		$xml->query( 'jetpack.globalizePublicizeConnection', $connection_id, 'globalize' );
+
+		if ( ! $xml->isError() ) {
+			$response = $xml->getResponse();
+			$this->receive_updated_publicize_connections( $response );
+		}
+	}
+
+	function unglobalize_connection( $connection_id ) {
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client();
+		$xml->query( 'jetpack.globalizePublicizeConnection', $connection_id, 'unglobalize' );
+
+		if ( ! $xml->isError() ) {
+			$response = $xml->getResponse();
+			$this->receive_updated_publicize_connections( $response );
 		}
 	}
 
@@ -270,7 +292,7 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @return array List of social networks.
 	 */
-	function get_services( $filter = 'all' ) {
+	function get_services( $filter = 'all', $_blog_id = false, $_user_id = false ) {
 		$services = array(
 			'facebook'    => array(),
 			'twitter'     => array(),
@@ -284,7 +306,7 @@ class Publicize extends Publicize_Base {
 		} else {
 			$connected_services = array();
 			foreach ( $services as $service => $empty ) {
-				$connections = $this->get_connections( $service );
+				$connections = $this->get_connections( $service, $_blog_id, $_user_id );
 				if ( $connections ) {
 					$connected_services[ $service ] = $connections;
 				}
@@ -649,18 +671,6 @@ class Publicize extends Publicize_Base {
 		// Nonce check
 		check_admin_referer( 'save_' . $service_name . '_token_' . $_REQUEST['connection'] );
 		$this->globalization();
-	}
-
-	/**
-	 * Already-published posts should not be Publicized by default. This filter sets checked to
-	 * false if a post has already been published.
-	 */
-	function publicize_checkbox_default( $checked, $post_id, $name, $connection ) {
-		if ( 'publish' == get_post_status( $post_id ) ) {
-			return false;
-		}
-
-		return $checked;
 	}
 
 	/**

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -305,17 +305,17 @@ class Publicize extends Publicize_Base {
 			return $services;
 		} else {
 			$connected_services = array();
-			foreach ( $services as $service => $empty ) {
-				$connections = $this->get_connections( $service, $_blog_id, $_user_id );
+			foreach ( $services as $service_name => $empty ) {
+				$connections = $this->get_connections( $service_name, $_blog_id, $_user_id );
 				if ( $connections ) {
-					$connected_services[ $service ] = $connections;
+					$connected_services[ $service_name ] = $connections;
 				}
 			}
 			return $connected_services;
 		}
 	}
 
-	function get_connection( $service, $id, $_blog_id = false, $_user_id = false ) {
+	function get_connection( $service_name, $id, $_blog_id = false, $_user_id = false ) {
 		// Stub
 	}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -292,7 +292,7 @@ abstract class Publicize_Base {
 	 * Globalizes a Connection
 	 *
 	 * @param string $connection_id Connection ID
-	 * @return bool Falsey on faulure. Truthy on success.
+	 * @return bool Falsey on failure. Truthy on success.
 	 */
 	abstract function globalize_connection( $connection_id );
 
@@ -300,7 +300,7 @@ abstract class Publicize_Base {
 	 * Unglobalizes a Connection
 	 *
 	 * @param string $connection_id Connection ID
-	 * @return bool Falsey on faulure. Truthy on success.
+	 * @return bool Falsey on failure. Truthy on success.
 	 */
 	abstract function unglobalize_connection( $connection_id );
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -420,7 +420,8 @@ abstract class Publicize_Base {
 		if ( $this->is_connecting_connection( $connection ) ) {
 			return true;
 		}
-		$connection_data = $connection->get_meta( 'connection_data' );
+		$connection_meta = $this->get_connection_meta( $connection );
+		$connection_data = $connection_meta['connection_data'];
 		return isset( $connection_data[ 'meta' ][ 'facebook_page' ] );
 	}
 
@@ -431,7 +432,8 @@ abstract class Publicize_Base {
 	 * @return bool
 	 */
 	function is_connecting_connection( $connection ) {
-		$connection_data = $connection->get_meta( 'connection_data' );
+		$connection_meta = $this->get_connection_meta( $connection );
+		$connection_data = $connection_meta['connection_data'];
 		return isset( $connection_data[ 'meta' ]['options_responses'] );
 	}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -151,7 +151,7 @@ abstract class Publicize_Base {
 		if ( !$_user_id )
 			$_user_id = $this->user_id();
 
-		$connections = $this->get_connections( $service, $_blog_id, $_user_id );
+		$connections = $this->get_connections( $service_name, $_blog_id, $_user_id );
 		return ( is_array( $connections ) && count( $connections ) > 0 ? true : false );
 	}
 
@@ -240,7 +240,7 @@ abstract class Publicize_Base {
 	 * @param false|int $_user_id The user ID. Use false (default) for the current user
 	 * @return false|object[]|array[] false if no connections exist
 	 */
-	abstract function get_connection( $service, $connection_id, $_blog_id = false, $_user_id = false );
+	abstract function get_connection( $service_name, $connection_id, $_blog_id = false, $_user_id = false );
 
 	/**
 	 * Get the Connection ID.
@@ -738,11 +738,11 @@ abstract class Publicize_Base {
 		}
 
 		$labels = array();
-		foreach ( $services as $service => $display_names ) {
+		foreach ( $services as $service_name => $display_names ) {
 			$labels[] = sprintf(
 				/* translators: Service name is %1$s, and account name is %2$s. */
 				esc_html__( '%1$s (%2$s)', 'jetpack' ),
-				esc_html( $service ),
+				esc_html( $service_name ),
 				esc_html( implode( ', ', $display_names ) )
 			);
 		}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -125,7 +125,7 @@ abstract class Publicize_Base {
 	/**
 	 * Get services for the given blog and user.
 	 *
-	 * Can return all avaialable services or just the ones with an active connection.
+	 * Can return all available services or just the ones with an active connection.
 	 *
 	 * @param string $filter
 	 *        'all' (default) - Get all services available for connecting
@@ -377,7 +377,7 @@ abstract class Publicize_Base {
 	}
 
 	/**
-	 * Weather the user needs to select additional options after connecting
+	 * Whether the user needs to select additional options after connecting
 	 *
 	 * @param string $service_name 'facebook', 'twitter', etc.
 	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -107,33 +107,210 @@ abstract class Publicize_Base {
 		// then check meta and publicize based on that. stage 3 implemented on wpcom
 		add_action( 'transition_post_status', array( $this, 'flag_post_for_publicize' ), 10, 3 );
 		add_action( 'save_post', array( &$this, 'save_meta' ), 20, 2 );
+
+		// Default checkbox state for each Connection
+		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_checkbox_default' ), 10, 4 );
+
+		// Alter the "Post Publish" admin notice to mention the Connections we Publicized to.
 		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 20, 1 );
 
 		// Connection test callback
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
 	}
 
+/*
+ * Services: Facebook, Twitter, etc.
+ */
+
 	/**
-	* Functions to be implemented by the extended class (publicize-wpcom or publicize-jetpack)
-	*/
-	abstract function get_connection_id( $connection );
+	 * Get services for the given blog and user.
+	 *
+	 * Can return all avaialable services or just the ones with an active connection.
+	 *
+	 * @param string $filter
+	 *        'all' (default) - Get all services available for connecting
+	 *        'connected'     - Get all services currently connected
+	 * @param false|int $_blog_id The blog ID. Use false (default) for the current blog
+	 * @param false|int $_user_id The user ID. Use false (default) for the current user
+	 * @return array
+	 */
+	abstract function get_services( $filter = 'all', $_blog_id = false, $_user_id = false );
+
+	/**
+	 * Does the given user have a connection to the service on the given blog?
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param false|int $_blog_id The blog ID. Use false (default) for the current blog
+	 * @param false|int $_user_id The user ID. Use false (default) for the current user
+	 * @return bool
+	 */
+	function is_enabled( $service_name, $_blog_id = false, $_user_id = false ) {
+		if ( !$_blog_id )
+			$_blog_id = $this->blog_id();
+
+		if ( !$_user_id )
+			$_user_id = $this->user_id();
+
+		$connections = $this->get_connections( $service, $_blog_id, $_user_id );
+		return ( is_array( $connections ) && count( $connections ) > 0 ? true : false );
+	}
+
+	/**
+	 * Generates a connection URL.
+	 *
+	 * This is the URL, which, when visited by the user, starts the authentication
+	 * process required to forge a connection.
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @return string
+	 */
 	abstract function connect_url( $service_name );
-	abstract function disconnect_url( $service_name, $id );
+
+	/**
+	 * Generates a Connection refresh URL.
+	 *
+	 * This is the URL, which, when visited by the user, re-authenticates their
+	 * connection to the service.
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @return string
+	 */
+	abstract function refresh_url( $service_name );
+
+	/**
+	 * Generates a disconnection URL.
+	 *
+	 * This is the URL, which, when visited by the user, breaks their connection
+	 * with the service.
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param string $connection_id Connection ID
+	 * @return string
+	 */
+	abstract function disconnect_url( $service_name, $connection_id );
+
+	/**
+	 * Returns a display name for the Service
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @return string
+	 */
+	public static function get_service_label( $service_name ) {
+		switch ( $service_name ) {
+			case 'linkedin':
+				return 'LinkedIn';
+				break;
+			case 'google_plus':
+				return  'Google+';
+				break;
+			case 'twitter':
+			case 'facebook':
+			case 'tumblr':
+			default:
+				return ucfirst( $service_name );
+				break;
+		}
+	}
+
+/*
+ * Connections: For each Service, there can be multiple connections
+ * for a given user. For example, one user could be connected to Twitter
+ * as both @jetpack and as @wordpressdotcom
+ *
+ * For historical reasons, Connections are represented as an object
+ * on WordPress.com and as an array in Jetpack.
+ */
+
+	/**
+	 * Get the active Connections of a Service
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param false|int $_blog_id The blog ID. Use false (default) for the current blog
+	 * @param false|int $_user_id The user ID. Use false (default) for the current user
+	 * @return false|object[]|array[] false if no connections exist
+	 */
+	abstract function get_connections( $service_name, $_blog_id = false, $_user_id = false );
+
+	/**
+	 * Get a single Connection of a Service
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param string $connection_id Connection ID
+	 * @param false|int $_blog_id The blog ID. Use false (default) for the current blog
+	 * @param false|int $_user_id The user ID. Use false (default) for the current user
+	 * @return false|object[]|array[] false if no connections exist
+	 */
+	abstract function get_connection( $service, $connection_id, $_blog_id = false, $_user_id = false );
+
+	/**
+	 * Get the Connection ID.
+	 *
+	 * Note that this is different than the Connection's uniqueid.
+	 *
+	 * Via a quirk of history, ID is globally unique and unique_id
+	 * is only unique per site.
+	 *
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return string
+	 */
+	abstract function get_connection_id( $connection );
+
+	/**
+	 * Get the Connection unique_id
+	 *
+	 * Note that this is different than the Connections ID.
+	 *
+	 * Via a quirk of history, ID is globally unique and unique_id
+	 * is only unique per site.
+	 *
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return string
+	 */
+	abstract function get_connection_unique_id( $connection );
+
+	/**
+	 * Get the Connection's Meta data
+	 *
+	 * @param object|array Connection
+	 * @return array Connection Meta
+	 */
 	abstract function get_connection_meta( $connection );
-	abstract function get_services( $filter = 'all' );
-	abstract function get_connections( $service, $_blog_id = false, $_user_id = false );
-	abstract function get_connection( $service, $id, $_blog_id = false, $_user_id = false );
-	abstract function flag_post_for_publicize( $new_status, $old_status, $post );
-	abstract function test_connection( $service_name, $connection );
-	abstract function disconnect( $service, $connection_id, $_blog_id = false, $_user_id = false, $force_delete = false );
 
 	/**
-	* Shared Functions
-	*/
+	 * Disconnect a Connection
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param string $connection_id Connection ID
+	 * @param false|int $_blog_id The blog ID. Use false (default) for the current blog
+	 * @param false|int $_user_id The user ID. Use false (default) for the current user
+	 * @param bool $force_delete Whether to skip permissions checks
+	 * @return false|void False on failure. Void on success.
+	 */
+	abstract function disconnect( $service_name, $connection_id, $_blog_id = false, $_user_id = false, $force_delete = false );
 
 	/**
-	* Returns an external URL to the connection's profile
-	*/
+	 * Globalizes a Connection
+	 *
+	 * @param string $connection_id Connection ID
+	 * @return bool Falsey on faulure. Truthy on success.
+	 */
+	abstract function globalize_connection( $connection_id );
+
+	/**
+	 * Unglobalizes a Connection
+	 *
+	 * @param string $connection_id Connection ID
+	 * @return bool Falsey on faulure. Truthy on success.
+	 */
+	abstract function unglobalize_connection( $connection_id );
+
+	/**
+	 * Returns an external URL to the Connection's profile
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return false|string False on failure. URL on success.
+	 */
 	function get_profile_link( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
@@ -176,19 +353,14 @@ abstract class Publicize_Base {
 	}
 
 	/**
-	* Returns a display name for the connection
-	*/
+	 * Returns a display name for the Connection
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return string
+	 */
 	function get_display_name( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
-
-		if ( 'facebook' === $service_name ) {
-			if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
-				return $cmeta['connection_data']['meta']['display_name'];
-			}
-
-			return __( 'Connecting...', 'jetpack' );
-
-		}
 
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
 			return $cmeta['connection_data']['meta']['display_name'];
@@ -204,23 +376,13 @@ abstract class Publicize_Base {
 		}
 	}
 
-	public static function get_service_label( $service_name ) {
-		switch ( $service_name ) {
-			case 'linkedin':
-				return 'LinkedIn';
-				break;
-			case 'google_plus':
-				return  'Google+';
-				break;
-			case 'twitter':
-			case 'facebook':
-			case 'tumblr':
-			default:
-				return ucfirst( $service_name );
-				break;
-		}
-	}
-
+	/**
+	 * Weather the user needs to select additional options after connecting
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return bool
+	 */
 	function show_options_popup( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
@@ -245,33 +407,146 @@ abstract class Publicize_Base {
 		return false;
 	}
 
+	/**
+	 * Whether the Connection is "valid" wrt Facebook's requirements.
+	 *
+	 * Must be connected to a Page (not a Profile).
+	 * (Also returns true if we're in the middle of the connection process)
+	 *
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return bool
+	 */
+	function is_valid_facebook_connection( $connection ) {
+		if ( $this->is_connecting_connection( $connection ) ) {
+			return true;
+		}
+		$connection_data = $connection->get_meta( 'connection_data' );
+		return isset( $connection_data[ 'meta' ][ 'facebook_page' ] );
+	}
+
+	/**
+	 * Whether the Connection currently being connected
+	 *
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return bool
+	 */
+	function is_connecting_connection( $connection ) {
+		$connection_data = $connection->get_meta( 'connection_data' );
+		return isset( $connection_data[ 'meta' ]['options_responses'] );
+	}
+
+	/**
+	 * AJAX Handler to run connection tests on all Connections
+	 * @return void
+	 */
+	function test_publicize_conns() {
+		$test_results = array();
+
+		foreach ( (array) $this->get_services( 'connected' ) as $service_name => $connections ) {
+			foreach ( $connections as $connection ) {
+
+				$id = $this->get_connection_id( $connection );
+
+				$connection_test_passed = true;
+				$connection_test_message = __( 'This connection is working correctly.' , 'jetpack' );
+				$user_can_refresh = false;
+				$refresh_text = '';
+				$refresh_url = '';
+
+				$connection_test_result = true;
+				if ( method_exists( $this, 'test_connection' ) ) {
+					$connection_test_result = $this->test_connection( $service_name, $connection );
+				}
+
+				if ( is_wp_error( $connection_test_result ) ) {
+					$connection_test_passed = false;
+					$connection_test_message = $connection_test_result->get_error_message();
+					$error_data = $connection_test_result->get_error_data();
+
+					$user_can_refresh = $error_data['user_can_refresh'];
+					$refresh_text = $error_data['refresh_text'];
+					$refresh_url = $error_data['refresh_url'];
+				}
+				// Mark facebook profiles as deprecated
+				if ( 'facebook' === $service_name ) {
+					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
+						$connection_test_passed = false;
+						$user_can_refresh = false;
+						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.' );
+					}
+				}
+
+				$unique_id = null;
+				if ( ! empty( $connection->unique_id ) ) {
+					$unique_id = $connection->unique_id;
+				} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
+					$unique_id = $connection['connection_data']['token_id'];
+				}
+
+				$test_results[] = array(
+					'connectionID'          => $id,
+					'serviceName'           => $service_name,
+					'connectionTestPassed'  => $connection_test_passed,
+					'connectionTestMessage' => esc_attr( $connection_test_message ),
+					'userCanRefresh'        => $user_can_refresh,
+					'refreshText'           => esc_attr( $refresh_text ),
+					'refreshURL'            => $refresh_url,
+					'unique_id'             => $unique_id,
+				);
+			}
+		}
+
+		wp_send_json_success( $test_results );
+	}
+
+	/**
+	 * Run the connection test for the Connection
+	 *
+	 * @param string $service_name 'facebook', 'twitter', etc.
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return WP_Error|true WP_Error on failure. True on success
+	 */
+	abstract function test_connection( $service_name, $connection );
+
+/*
+ * Site Data
+ */
+
 	function user_id() {
-		global $current_user;
-		return $current_user->ID;
+		return get_current_user_id();
 	}
 
 	function blog_id() {
 		return get_current_blog_id();
 	}
 
-	/**
-	* Returns true if a user has a connection to a particular service, false otherwise
-	*/
-	function is_enabled( $service, $_blog_id = false, $_user_id = false ) {
-		if ( !$_blog_id )
-			$_blog_id = $this->blog_id();
-
-		if ( !$_user_id )
-			$_user_id = $this->user_id();
-
-		$connections = $this->get_connections( $service, $_blog_id, $_user_id );
-		return ( is_array( $connections ) && count( $connections ) > 0 ? true : false );
-	}
+/*
+ * Posts
+ */
 
 	/**
-	* Fires when a post is saved, checks conditions and saves state in postmeta so that it
-	* can be picked up later by @see ::publicize_post() on WordPress.com codebase.
-	*/
+	 * Checks old and new status to see if the post should be flagged as
+	 * ready to Publicize.
+	 *
+	 * Attached to the `transition_post_status` filter.
+	 *
+	 * @param string $new_status
+	 * @param string $old_status
+	 * @param WP_Post $post
+	 * @return void
+	 */
+	abstract function flag_post_for_publicize( $new_status, $old_status, $post );
+
+	/**
+	 * Fires when a post is saved, checks conditions and saves state in postmeta so that it
+	 * can be picked up later by @see ::publicize_post() on WordPress.com codebase.
+	 *
+	 * Attached to the `save_post` action.
+	 *
+	 * @param int $post_id
+	 * @param WP_Post $post
+	 * @return void
+	 */
 	function save_meta( $post_id, $post ) {
 		$cron_user = null;
 		$submit_post = true;
@@ -428,6 +703,15 @@ abstract class Publicize_Base {
 		// Next up will be ::publicize_post()
 	}
 
+	/**
+	 * Alters the "Post Published" message to include information about where the post
+	 * was Publicized to.
+	 *
+	 * Attached to the `post_updated_messages` filter
+	 *
+	 * @param string[] $messages
+	 * @return string[]
+	 */
 	public function update_published_message( $messages ) {
 		global $post_type, $post_type_object, $post;
 		if ( ! $this->post_type_is_publicizeable( $post_type ) ) {
@@ -489,6 +773,14 @@ abstract class Publicize_Base {
 		return $messages;
 	}
 
+	/**
+	 * Get the Connections the Post was just Publicized to.
+	 *
+	 * Only reliable just after the Post was published.
+	 *
+	 * @param int $post_id
+	 * @return string[] Array of Service display name => Connection display name
+	 */
 	function get_publicizing_services( $post_id ) {
 		$services = array();
 
@@ -513,14 +805,38 @@ abstract class Publicize_Base {
 	}
 
 	/**
-	* Is a given post type Publicize-able?
-	*
-	* Not every CPT lends itself to Publicize-ation.  Allow CPTs to register by adding their CPT via
-	* the publicize_post_types array filter.
-	*
-	* @param string $post_type The post type to check.
-	* @return bool True if the post type can be Publicized.
-	*/
+	 * Is the post Publicize-able?
+	 *
+	 * Only valid prior to Publicizing a Post.
+	 *
+	 * @param WP_Post $post
+	 * @return bool
+	 */
+	function post_is_publicizeable( $post ) {
+		if ( ! $this->post_type_is_publicizeable( $post->post_type ) )
+			return false;
+
+		// This is more a precaution. To only publicize posts that are published. (Mostly relevant for Jetpack sites)
+		if ( 'publish' !== $post->post_status ) {
+			return false;
+		}
+
+		// If it's not flagged as ready, then abort. @see ::flag_post_for_publicize()
+		if ( ! get_post_meta( $post->ID, $this->PENDING, true ) )
+			return false;
+
+		return true;
+	}
+
+	/**
+	 * Is a given post type Publicize-able?
+	 *
+	 * Not every CPT lends itself to Publicize-ation.  Allow CPTs to register by adding their CPT via
+	 * the publicize_post_types array filter.
+	 *
+	 * @param string $post_type The post type to check.
+	 * @return bool True if the post type can be Publicized.
+	 */
 	function post_type_is_publicizeable( $post_type ) {
 		if ( 'post' == $post_type )
 			return true;
@@ -528,79 +844,38 @@ abstract class Publicize_Base {
 		return post_type_supports( $post_type, 'publicize' );
 	}
 
-	function is_valid_facebook_connection( $connection ) {
-		if ( $this->is_connecting_connection( $connection ) ) {
-			return true;
+	/**
+	 * Already-published posts should not be Publicized by default. This filter sets checked to
+	 * false if a post has already been published.
+	 *
+	 * Attached to the `publicize_checkbox_default` filter
+	 *
+	 * @param bool $checked
+	 * @param int $post_id
+	 * @param string $service_name 'facebook', 'twitter', etc
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return bool
+	 */
+	function publicize_checkbox_default( $checked, $post_id, $service_name, $connection ) {
+		if ( 'publish' == get_post_status( $post_id ) ) {
+			return false;
 		}
-		return isset( $connection['connection_data']['meta']['facebook_page'] );
+
+		return $checked;
 	}
 
-	function is_connecting_connection( $connection ) {
-		return isset( $connection['connection_data']['meta']['options_responses'] );
-	}
+/*
+ * Util
+ */
 
 	/**
-	 * Runs tests on all the connections and returns the results to the caller
+	 * Converts a Publicize message template string into a sprintf format string
+	 *
+	 * @param string[] $args
+	 *               0 - The Publicize message template: 'Check out my post: %title% @ %url'
+	 *             ... - The template tags 'title', 'url', etc.
+	 * @return string
 	 */
-	function test_publicize_conns() {
-		$test_results = array();
-
-		foreach ( (array) $this->get_services( 'connected' ) as $service_name => $connections ) {
-			foreach ( $connections as $connection ) {
-
-				$id = $this->get_connection_id( $connection );
-
-				$connection_test_passed = true;
-				$connection_test_message = __( 'This connection is working correctly.' , 'jetpack' );
-				$user_can_refresh = false;
-				$refresh_text = '';
-				$refresh_url = '';
-
-				$connection_test_result = true;
-				if ( method_exists( $this, 'test_connection' ) ) {
-					$connection_test_result = $this->test_connection( $service_name, $connection );
-				}
-
-				if ( is_wp_error( $connection_test_result ) ) {
-					$connection_test_passed = false;
-					$connection_test_message = $connection_test_result->get_error_message();
-					$error_data = $connection_test_result->get_error_data();
-
-					$user_can_refresh = $error_data['user_can_refresh'];
-					$refresh_text = $error_data['refresh_text'];
-					$refresh_url = $error_data['refresh_url'];
-				}
-
-				// Mark facebook profiles as deprecated
-				if ( 'facebook' === $service_name && ! $this->is_valid_facebook_connection( $connection ) ) {
-					$connection_test_passed = false;
-					$user_can_refresh = false;
-					$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.', 'jetpack');
-				}
-
-				$unique_id = null;
-				if ( ! empty( $connection->unique_id ) ) {
-					$unique_id = $connection->unique_id;
-				} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
-					$unique_id = $connection['connection_data']['token_id'];
-				}
-
-				$test_results[] = array(
-					'connectionID'          => $id,
-					'serviceName'           => $service_name,
-					'connectionTestPassed'  => $connection_test_passed,
-					'connectionTestMessage' => esc_attr( $connection_test_message ),
-					'userCanRefresh'        => $user_can_refresh,
-					'refreshText'           => esc_attr( $refresh_text ),
-					'refreshURL'            => $refresh_url,
-					'unique_id'             => $unique_id,
-				);
-			}
-		}
-
-		wp_send_json_success( $test_results );
-	}
-
 	protected static function build_sprintf( $args ) {
 		$search = array();
 		$replace = array();

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -10,6 +10,8 @@ class Publicize_UI {
 	*/
 	public $publicize;
 
+	protected $publicize_settings_url = '';
+
 	/**
 	* Hooks into WordPress to display the various pieces of UI and load our assets
 	*/
@@ -22,6 +24,14 @@ class Publicize_UI {
 	}
 
 	function init() {
+		$this->publicize_settings_url = apply_filters_deprecated(
+			'jetpack_override_publicize_settings_url',
+			array( admin_url( 'options-general.php?page=sharing' ) ),
+			'6.5',
+			false,
+			__( 'This filter will be removed in a future version of Jetpack', 'jetpack' )
+		);
+
 		// Show only to users with the capability required to manage their Publicize connections.
 		/**
 		 * Filter what user capability is required to use the publicize form on the edit post page. Useful if publish post capability has been removed from role.
@@ -521,13 +531,12 @@ jQuery( function($) {
 			}
 
 			if( ! testResult.connectionTestPassed && ! testResult.userCanRefresh ) {
-
 				$( '#wpas-submit-' + testResult.unique_id ).prop( "checked", false ).prop( "disabled", true );
 				if ( ! facebookNotice ) {
 					var message = '<p>'
 						+ testResult.connectionTestMessage
 						+ '</p><p>'
-						+ ' <a class="button" href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" rel="noopener noreferrer" target="_blank">'
+						+ ' <a class="button" href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank">'
 						+ '<?php echo esc_html( __( 'Update Your Sharing Settings' ,'jetpack' ) ); ?>'
 						+ '</a>'
 						+ '<p>';
@@ -627,7 +636,7 @@ jQuery( function($) {
 							<strong><?php echo esc_html( $item ); ?></strong>
 						<?php endforeach; ?>
 					</span>
-					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( admin_url( 'options-general.php?page=sharing' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php else : ?>
 					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
 					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -119,7 +119,8 @@ class Publicize_UI {
 			}
 
 			printf(
-				__( 'You have successfully connected your %1$s account with %2$s.', '1: Service Name (Facebook, Twitter, ...), 2. WordPress.com or Jetpack', 'jetpack' ),
+				/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Site type (WordPress.com or Jetpack) */
+				__( 'You have successfully connected your %1$s account with %2$s.', 'jetpack' ),
 				Publicize::get_service_label( $service_name ),
 				$platform
 			); ?></p>
@@ -291,7 +292,11 @@ class Publicize_UI {
 	function broken_connection( $service_name, $id ) { ?>
 		<div id="thickbox-content">
 			<div class='error'>
-				<p><?php printf( __( 'There was a problem connecting to %s. Please disconnect and try again.', 'jetpack' ), Publicize::get_service_label( $service_name ) ); ?></p>
+				<p><?php printf(
+					/* translators: %s: Service Name (Facebook, Twitter, ...) */
+					__( 'There was a problem connecting to %s. Please disconnect and try again.', 'jetpack' ),
+					Publicize::get_service_label( $service_name )
+				); ?></p>
 			</div>
 		</div><?php
 	}
@@ -771,7 +776,8 @@ jQuery( function($) {
 					}
 
 					$label = sprintf(
-						_x( '%1$s: %2$s', 'Service: Account connected as', 'jetpack' ),
+						/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Username on Service (@jetpack, ...) */
+						__( '%1$s: %2$s', 'jetpack' ),
 						esc_html( $this->publicize->get_service_label( $name ) ),
 						esc_html( $this->publicize->get_display_name( $name, $connection ) )
 					);

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -157,6 +157,7 @@ class Publicize_UI {
 		);
 
 		if ( $override_publicize_settings_page ) {
+			echo $override_publicize_settings_page;
 			return;
 		}
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -74,7 +74,7 @@ class Publicize_UI {
 	}
 
 	function wrapper_admin_page() {
-		Jetpack_Admin_Page::wrap_ui( array( &$this, 'management_page' ), array( 'is-wide' => true ) );
+		Jetpack_Admin_Page::wrap_ui( array( $this, 'management_page' ), array( 'is-wide' => true ) );
 	}
 	/**
 	* Management page to load if Sharedaddy is not active so the 'pre_admin_screen_sharing' action exists.

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -703,7 +703,7 @@ jQuery( function($) {
 
 					$unique_id = $this->publicize->get_connection_unique_id( $connection );
 
-					// Was this connections (OR, old-format service) already Publicized to?
+					// Was this connection (OR, old-format service) already Publicized to?
 					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags
 					$all_services_done = $all_services_done && $done;
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -405,6 +405,13 @@ jQuery( function($) {
 	// set the initial placeholder
 	postTitle.trigger( 'keyup' );
 
+	// If a custom message has been provided, open the UI so the author remembers
+	if ( wpasTitle.val() && ! wpasTitle.prop( 'disabled' ) && wpasTitle.attr( 'placeholder' ) !== wpasTitle.val() ) {
+		$( '#publicize-form' ).show();
+		$( '#publicize-defaults' ).hide();
+		$( '#publicize-form-edit' ).hide();
+	}
+
 	$('#publicize-disconnected-form-show').click( function() {
 		$('#publicize-form').slideDown( 'fast' );
 		$(this).hide();

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -196,38 +196,38 @@ class Publicize_UI {
 				<div class='left'>
 
 				<?php
-				foreach ( $services as $name => $service ) :
-					$connect_url = $this->publicize->connect_url( $name );
+				foreach ( $services as $service_name => $service ) :
+					$connect_url = $this->publicize->connect_url( $service_name );
 					if ( $service_num == ( round ( ( $total_num_of_services / 2 ), 0 ) ) )
 						echo "</div><div class='right'>";
 					$service_num++;
 					?>
 					<div class="publicize-service-entry" <?php if ( $service_num > 0 ): ?>class="connected"<?php endif; ?> >
-						<div id="<?php echo esc_attr( $name ); ?>" class="publicize-service-left">
-							<a href="<?php echo esc_url( $connect_url ); ?>" id="service-link-<?php echo esc_attr( $name ); ?>" target="_top"><?php echo $this->publicize->get_service_label( $name ); ?></a>
+						<div id="<?php echo esc_attr( $service_name ); ?>" class="publicize-service-left">
+							<a href="<?php echo esc_url( $connect_url ); ?>" id="service-link-<?php echo esc_attr( $service_name ); ?>" target="_top"><?php echo $this->publicize->get_service_label( $service_name ); ?></a>
 						</div>
 
 
 						<div class="publicize-service-right">
-							<?php if ( $this->publicize->is_enabled( $name ) && $connections = $this->publicize->get_connections( $name ) ) : ?>
+							<?php if ( $this->publicize->is_enabled( $service_name ) && $connections = $this->publicize->get_connections( $service_name ) ) : ?>
 								<ul>
 									<?php
 									foreach( $connections as $c ) :
 										$id = $this->publicize->get_connection_id( $c );
-										$disconnect_url = $this->publicize->disconnect_url( $name, $id );
+										$disconnect_url = $this->publicize->disconnect_url( $service_name, $id );
 
 										$cmeta = $this->publicize->get_connection_meta( $c );
-										$profile_link = $this->publicize->get_profile_link( $name, $c );
-										$connection_display = $this->publicize->get_display_name( $name, $c );
+										$profile_link = $this->publicize->get_profile_link( $service_name, $c );
+										$connection_display = $this->publicize->get_display_name( $service_name, $c );
 
-										$options_nonce = wp_create_nonce( 'options_page_' . $name . '_' . $id ); ?>
+										$options_nonce = wp_create_nonce( 'options_page_' . $service_name . '_' . $id ); ?>
 
-										<?php if ( $this->publicize->show_options_popup( $name, $c ) ): ?>
+										<?php if ( $this->publicize->show_options_popup( $service_name, $c ) ): ?>
 										<script type="text/javascript">
 										jQuery(document).ready( function($) {
 											showOptionsPage.call(
 											this,
-											'<?php echo esc_js( $name ); ?>',
+											'<?php echo esc_js( $service_name ); ?>',
 											'<?php echo esc_js( $options_nonce ); ?>',
 											'<?php echo esc_js( $id ); ?>'
 											);
@@ -272,11 +272,11 @@ class Publicize_UI {
 
 
 							<?php
-								$connections = $this->publicize->get_connections( $name );
+								$connections = $this->publicize->get_connections( $service_name );
 								if ( empty ( $connections ) ) { ?>
-									<a id="<?php echo esc_attr( $name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
+									<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
 								<?php } else { ?>
-									<a id="<?php echo esc_attr( $name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
+									<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
 			  					<?php } ?>
 			  			</div>
 			  		</div>
@@ -696,7 +696,7 @@ jQuery( function($) {
 			// In addition to looking at $all_done, we also look through the currently active services
 			// To see if they are all done.
 			$all_services_done = true;
-			foreach ( $services as $name => $connections ) {
+			foreach ( $services as $service_name => $connections ) {
 				foreach ( $connections as $connection ) {
 					$connection_meta = $this->publicize->get_connection_meta( $connection );
 					$connection_data = $connection_meta['connection_data'];
@@ -704,7 +704,7 @@ jQuery( function($) {
 					$unique_id = $this->publicize->get_connection_unique_id( $connection );
 
 					// Was this connection (OR, old-format service) already Publicized to?
-					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags
+					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $service_name, true ) ); // New and old style flags
 					$all_services_done = $all_services_done && $done;
 
 					/**
@@ -716,10 +716,10 @@ jQuery( function($) {
 					 *
 					 * @param bool true Should the post be publicized to a given service? Default to true.
 					 * @param int $post->ID Post ID.
-					 * @param string $name Service name.
+					 * @param string $service_name Service name.
 					 * @param array $connection_data Array of information about all Publicize details for the site.
 					 */
-					if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $name, $connection_data ) ) {
+					if ( ! $continue = apply_filters( 'wpas_submit_post?', true, $post->ID, $service_name, $connection_data ) ) {
 						continue;
 					}
 
@@ -739,10 +739,10 @@ jQuery( function($) {
 							is_array( $connection )
 							&&
 							(
-								( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['meta']['external_id'] ] ) )
+								( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection['meta']['external_id'] ] ) )
 								||
 								// Jetpack's connection data looks a little different.
-								( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $name ][ $connection['external_id'] ] ) )
+								( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection['external_id'] ] ) )
 							)
 						)
 					);
@@ -768,10 +768,10 @@ jQuery( function($) {
 						 *
 						 * @param bool   $checked Indicates if this connection should be enabled. Default true.
 						 * @param int    $post->ID ID of the current post
-						 * @param string $name Name of the connection (Facebook, Twitter, etc)
+						 * @param string $service_name Name of the connection (Facebook, Twitter, etc)
 						 * @param array  $connection Array of data about the connection.
 						 */
-						$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
+						$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $service_name, $connection );
 					}
 
 					// Determine the state of the checkbox (on/off) and allow filtering
@@ -785,10 +785,10 @@ jQuery( function($) {
 					 *
 					 * @param bool $checked Should the Publicize checkbox be enabled for a given service.
 					 * @param int $post->ID Post ID.
-					 * @param string $name Service name.
+					 * @param string $service_name Service name.
 					 * @param array $connection Array of connection details.
 					 */
-					$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $name, $connection );
+					$checked = apply_filters( 'publicize_checkbox_default', $checked, $post->ID, $service_name, $connection );
 
 					// Force the checkbox to be checked if the post was DONE, regardless of what the filter does
 					if ( $done ) {
@@ -803,12 +803,12 @@ jQuery( function($) {
 					$label = sprintf(
 						/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Username on Service (@jetpack, ...) */
 						__( '%1$s: %2$s', 'jetpack' ),
-						esc_html( $this->publicize->get_service_label( $name ) ),
-						esc_html( $this->publicize->get_display_name( $name, $connection ) )
+						esc_html( $this->publicize->get_service_label( $service_name ) ),
+						esc_html( $this->publicize->get_display_name( $service_name, $connection ) )
 					);
 
 					if (
-						$name === 'facebook'
+						$service_name === 'facebook'
 					&&
 						! $this->publicize->is_valid_facebook_connection( $connection )
 					&&
@@ -827,7 +827,7 @@ jQuery( function($) {
 					?>
 					<li>
 						<label for="wpas-submit-<?php echo esc_attr( $unique_id ); ?>">
-							<input type="checkbox" name="wpas[submit][<?php echo $unique_id; ?>]" id="wpas-submit-<?php echo $unique_id; ?>" class="wpas-submit-<?php echo $name; ?>" value="1" <?php
+							<input type="checkbox" name="wpas[submit][<?php echo $unique_id; ?>]" id="wpas-submit-<?php echo $unique_id; ?>" class="wpas-submit-<?php echo $service_name; ?>" value="1" <?php
 								checked( true, $checked );
 								echo $disabled;
 							?> />

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -730,21 +730,18 @@ jQuery( function($) {
 							in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
 							&&
 							(
+								// New flags
 								get_post_meta( $post->ID, $this->publicize->POST_SKIP . $unique_id, true )
 								||
-								get_post_meta( $post->ID, $this->publicize->POST_SKIP . $connection->name )
+								// Old flags
+								get_post_meta( $post->ID, $this->publicize->POST_SKIP . $service_name )
 							)
 						)
 						||
 						(
 							is_array( $connection )
 							&&
-							(
-								( isset( $connection['meta']['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection['meta']['external_id'] ] ) )
-								||
-								// Jetpack's connection data looks a little different.
-								( isset( $connection['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection['external_id'] ] ) )
-							)
+							isset( $connection_meta['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection_meta['external_id'] ] )
 						)
 					);
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -698,17 +698,10 @@ jQuery( function($) {
 			$all_services_done = true;
 			foreach ( $services as $name => $connections ) {
 				foreach ( $connections as $connection ) {
-					$connection_data = '';
-					if ( method_exists( $connection, 'get_meta' ) )
-						$connection_data = $connection->get_meta( 'connection_data' );
-					elseif ( ! empty( $connection['connection_data'] ) )
-						$connection_data = $connection['connection_data'];
+					$connection_meta = $this->publicize->get_connection_meta( $connection );
+					$connection_data = $connection_meta['connection_data'];
 
-					if ( ! empty( $connection->unique_id ) ) {
-						$unique_id = $connection->unique_id;
-					} else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
-						$unique_id = $connection['connection_data']['token_id'];
-					}
+					$unique_id = $this->publicize->get_connection_unique_id( $connection );
 
 					// Was this connections (OR, old-format service) already Publicized to?
 					$done = ( 1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $unique_id, true ) ||  1 == get_post_meta( $post->ID, $this->publicize->POST_DONE . $name, true ) ); // New and old style flags

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -148,6 +148,18 @@ class Publicize_UI {
 	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
 	 */
 	function admin_page() {
+		$override_publicize_settings_page = apply_filters_deprecated(
+			'jetpack_override_publicize_settings_page',
+			array( false ),
+			'6.5',
+			false,
+			__( 'This filter will be removed in a future version of Jetpack', 'jetpack' )
+		);
+
+		if ( $override_publicize_settings_page ) {
+			return;
+		}
+
 		$_blog_id = get_current_blog_id();
 		?>
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -27,7 +27,7 @@ class Publicize_UI {
 		$this->publicize_settings_url = apply_filters_deprecated(
 			'jetpack_override_publicize_settings_url',
 			array( admin_url( 'options-general.php?page=sharing' ) ),
-			'6.5',
+			'6.7',
 			false,
 			__( 'This filter will be removed in a future version of Jetpack', 'jetpack' )
 		);
@@ -151,7 +151,7 @@ class Publicize_UI {
 		$override_publicize_settings_page = apply_filters_deprecated(
 			'jetpack_override_publicize_settings_page',
 			array( false ),
-			'6.5',
+			'6.7',
 			false,
 			__( 'This filter will be removed in a future version of Jetpack', 'jetpack' )
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* New (and already deprecated) filter for customizing Publicize Settings URL. Do not use :) It will go away.
* New (and already deprecated) filter for customizing Publicize Settings Page. Also do not use :) Same.
* Code formatting tweaks
* Translation fixes (mostly `/* translators: */` comments).
* Improve default message handling: Show as placeholder if textarea is empty
* Improve custom message handling: On page load, if there is a "non-trivial" custom message (one that is not empty and does not match the default message), open the UI so that the author remembers. (Use case: when a custom message is explicitly set to the default message, then the post title changes.)

#### Testing instructions:

##### Does it Work?
1. Add at least two Publicize connections on a test site.
2. Create a post in the Classic (non-Gutenberg) editor.
3. Set it to publicize to one connection, but not the others.
4. Save as Draft.
5. See that the Publicize settings are correct after saving the draft (set to publicize to one connection, but not the others).
6. Publish the post.
7. See the publicize results on the one connection (e.g., the tweet).
8. In the post editor, see all Publicize checkboxes disabled (this is the same as the old behavior).

##### Publicize Message UI
1. In the Classic (non-Gutenberg) editor, create a new post.
2. Set the title to "Hello World".
3. Set the contents to "Yay".
4. Save as Draft.
5. See the Publicize settings are still **closed** on the new page load after saving the draft.
6. Edit the Publicize message. Erase all contents in the message.
7. See the message box's placeholder matches the post's title.
8. Save as draft.
9. See the Publicize message UI is still **closed** on the new page load after saving the draft.
10. Edit the Publicize message. Set the Publicize message to "Something else".
11. Save as draft.
12. See the Publicize message UI is now **open** on the new page load after saving the draft.
13. Edit the Publicize settings. Set the Publicize message to "Hello World".
14. Save as draft.
15. See the Publicize message UI is again **closed** on the new page load after saving the 
draft.
16. Set the title to "New Title"
17. Save as Draft.
18. See the Publicize message UI is again **open** on the new page load after saving the 
draft.

#### Proposed changelog entry for your changes:

Updated Jetpack's and WordPress.com's Publicize user interface to match.