### PR TITLE
Docker: Configurable Host Ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 ## FILES
 .DS_Store
+# Custom environment for docker-compose (used by docker-compose.yml)
+/.env
 languages/messages.pot
 .idea
 *.iml
@@ -23,6 +25,7 @@ yarn-error.log
 !/docker/data/mysql/.gitkeep
 /docker/logs/*
 !/docker/logs/.gitkeep
+# Custom environment for docker containers
 /docker/.env
 /docker/wordpress-develop/*
 !/docker/wordpress-develop/.gitkeep

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,6 +51,27 @@ You should follow [Jetpack’s development documentation](../docs/development-en
 
 WordPress’ `WP_SITEURL` and `WP_HOME` constants are configured to be dynamic in `./docker/wordpress/wp-config.php` so you shouldn’t need to change these even if you access the site via different domains.
 
+## Environment Variables, `.env` Files, and Ports
+
+You can control some of the behavior of Jetpack's Docker configuration with environment variables. Note, though, that there are two types of environments:
+1. The host environment in which the `yarn docker:*` (`docker-compose`) commands run when creating/managing the containers.
+2. The containers' environments.
+
+### Host Environment
+
+You can set the following variables on a per-command basis (`PORT_WORDPRESS=8000 yarn docker:up`) or, preferably, in a `./.env` file in Jetpack's root directory.
+
+* `PORT_WORDPRESS`: (default=`80`) The port on your host machine connected to the WordPress container's HTTP server.
+* `PORT_MYSQL`: (default=`3306`) The port on your host machine connected to the MySQL container's MySQL server.
+* `PORT_MAILDEV`: (default=`1080`) The port on your host machine connected to the MailDev container's MailDev HTTP server.
+* `PORT_SMTP`: (default=`25`) The port on your host machine connected to the MailDev container's SMTP server.
+* `PORT_SFTP`: (default=`1022`) The port on your host machine connected to the SFTP container's SFTP server.
+
+### Container Environments
+
+Configurable settings are documented in the [`./docker/default.env` file](https://github.com/Automattic/jetpack/blob/master/docker/default.env).
+Customizations should go into a `./docker/.env` file you create, though, not in the `./docker/default.env` file.
+
 ## Working with containers
 
 ### Quick install WordPress

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -80,8 +80,14 @@ if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
 	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 fi
 
+WP_HOST_PORT=":$HOST_PORT"
+
+if [ 80 -eq "$HOST_PORT" ]; then
+	WP_HOST_PORT=""
+fi
+
 echo
-echo "Open http://${WP_DOMAIN} to see your site!"
+echo "Open http://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
 echo
 
 # Run apache in the foreground so the container keeps running

--- a/docker/default.env
+++ b/docker/default.env
@@ -13,21 +13,22 @@
 # Note that these variables are not available in docker-compose.yml
 # Variables show up defined inside containers only.
 
-# WordPress
+# WordPress - Only WP_ADMIN_PASSWORD needs to be changed
 WP_DOMAIN=localhost
 WP_ADMIN_USER=wordpress
 WP_ADMIN_EMAIL=wordpress@example.com
+# If this site is or will be publicly accessible, change WP_ADMIN_PASSWORD to something unique and secure
 WP_ADMIN_PASSWORD=wordpress
 WP_TITLE=HelloWord
 
-# Database
+# Database - No changes necessary
 MYSQL_HOST=db:3306
 MYSQL_DATABASE=wordpress
 MYSQL_USER=wordpress
 MYSQL_PASSWORD=wordpress
 MYSQL_ROOT_PASSWORD=wordpress
 
-# SFTP container users (user:pass:UID)
+# SFTP container users (user:pass:UID) - Password needs to be changed
 #
 # IMPORTANT: One of the users you define must be `wordpress` because paths in
 # `docker/docker-compose.yml` are fixed. You can modify their password, though.
@@ -38,6 +39,8 @@ MYSQL_ROOT_PASSWORD=wordpress
 # Define multiple users separated by space
 #
 # Read more: https://github.com/atmoz/sftp
+#
+# If this site is or will be publicly accessible, change the password below (the middle part) to something unique and secure
 SFTP_USERS=wordpress:wordpress:1001
 
 # Xdebug

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,3 +82,5 @@ services:
     env_file:
       - default.env
       - .env
+    environment:
+      - HOST_PORT=${PORT_WORDPRESS}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./data/mysql:/var/lib/mysql
     restart: always
     ports:
-      - "3306:3306"
+      - "${PORT_MYSQL:-3306}:3306"
     env_file:
       - default.env
       - .env
@@ -28,8 +28,8 @@ services:
     container_name: maildev
     restart: always
     ports:
-      - "1080:80"
-      - "25:25"
+      - "${PORT_MAILDEV:-1080}:80"
+      - "${PORT_SMTP:-25}:25"
 
   ## SFTP server running at localhost:1022
   sftp:
@@ -41,7 +41,7 @@ services:
       - ./mu-plugins:/home/wordpress/var/www/html/wp-content/mu-plugins
       - ./wordpress:/home/wordpress/var/www/html
     ports:
-      - "1022:22"
+      - "${PORT_SFTP:-1022}:22"
     env_file:
       - ./default.env
       - ./.env
@@ -77,7 +77,7 @@ services:
       - ./logs/php:/var/log/php
       - ./bin:/var/scripts
     ports:
-      - "80:80"
+      - "${PORT_WORDPRESS:-80}:80"
     restart: always
     env_file:
       - default.env


### PR DESCRIPTION
Use environment variables (`PORT_WORDPRESS`, `PORT_MYSQL`, ...) to configure the host ports of the docker containers.

A second attempt at #10048, now with a much simpler implemenation.

#### Changes proposed in this Pull Request:

Updates `docker/docker-compose.yml` to look for `PORT_WORDPRESS`, etc. environment variables when assigning host ports to the various docker containers.

Uses Docker Compose's [Variable Substitution](https://docs.docker.com/compose/compose-file/#variable-substitution). You can also add these environment variables to `.env` (different than `docker/.env`), and they will get picked up by `yarn docker:compose`.

#### Use Case:

The WordPress container runs on host port 80, which I'm already using on my machine. This results in the following error:

```
nukta:jetpack mdawaffe$ yarn docker:up
yarn run v1.9.4
$ yarn docker:compose up
$ yarn docker:env && yarn docker:config && docker-compose -f docker/docker-compose.yml up
$ node -e "require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );"
Removing jetpack_wordpress
jetpack_mysql is up-to-date
jetpack_sftp is up-to-date
maildev is up-to-date
Recreating 7d866c9eebcc_jetpack_wordpress ... error

ERROR: for 7d866c9eebcc_jetpack_wordpress  Cannot start service wordpress: driver failed programming external connectivity on endpoint jetpack_wordpress (ee43c694d27923528b4659fdf6a19fe0fc83d6e57a586cde5b826930390dedd9): Error starting userland proxy: Bind for 0.0.0.0:80: unexpected error (Failure EADDRINUSE)

ERROR: for wordpress  Cannot start service wordpress: driver failed programming external connectivity on endpoint jetpack_wordpress (ee43c694d27923528b4659fdf6a19fe0fc83d6e57a586cde5b826930390dedd9): Error starting userland proxy: Bind for 0.0.0.0:80: unexpected error (Failure EADDRINUSE)
ERROR: Encountered errors while bringing up the project.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### Testing instructions:

1. `PORT_WORDPRESS=1234 yarn docker:up`
2. Verify that the site is accessible at `http://localhost:1234`.
3. `yarn docker:down` (do not specify environment variable)
4. Verify that everything stops despite not specifying `PORT_WORDPRESS`

#### Proposed changelog entry for your changes:

Use environment variables (`PORT_WORDPRESS`, `PORT_MYSQL`, ...) to configure the host ports of the docker containers.