### PR TITLE
Improve Sandboxing for Automattic Developers

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -170,9 +170,7 @@ class Jetpack_Provision { //phpcs:ignore
 		$request = array(
 			'headers' => array(
 				'Authorization' => "Bearer $access_token",
-				'Host'          => defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' )
-					? JETPACK__WPCOM_JSON_API_HOST_HEADER
-					: 'public-api.wordpress.com',
+				'Host'          => 'public-api.wordpress.com',
 			),
 			'timeout' => 60,
 			'method'  => 'POST',
@@ -253,7 +251,7 @@ class Jetpack_Provision { //phpcs:ignore
 		$request = array(
 			'headers' => array(
 				'Authorization' => "Bearer " . $access_token,
-				'Host'          => defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' ) ? JETPACK__WPCOM_JSON_API_HOST_HEADER : 'public-api.wordpress.com',
+				'Host'          => 'public-api.wordpress.com',
 			),
 			'timeout' => 10,
 			'method'  => 'POST',

--- a/_inc/jetpack-server-sandbox.php
+++ b/_inc/jetpack-server-sandbox.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This feature is only useful for Automattic developers.
+ * It configures Jetpack to talk to staging/sandbox servers
+ * on WordPress.com instead of production servers.
+ */
+
+/**
+ * @param string $sandbox Sandbox domain
+ * @param string $url URL of request about to be made
+ * @param array  $headers Headers of request about to be made
+ * @return array [ 'url' => new URL, 'host' => new Host ]
+ */
+function jetpack_server_sandbox_request_parameters( $sandbox, $url, $headers ) {
+	$host = '';
+
+	$url_host = parse_url( $url, PHP_URL_HOST );
+
+	switch ( $url_host ) {
+	case 'public-api.wordpress.com' :
+	case 'jetpack.wordpress.com' :
+	case 'dashboard.wordpress.com' :
+		$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
+		$url = preg_replace(
+			'@^(https?://)' . preg_quote( $url_host, '@' ) . '(?=[/?#].*|$)@',
+			'\\1' . $sandbox,
+			$url,
+			1
+		);
+	}
+
+	return compact( 'url', 'host' );
+}
+
+/**
+ * Modifies parameters of request in order to send the request to the
+ * server specified by `JETPACK__SANDBOX_DOMAIN`.
+ *
+ * Attached to the `requests-requests.before_request` filter.
+ * @param string &$url URL of request about to be made
+ * @param array  &$headers Headers of request about to be made
+ * @return void
+ */
+function jetpack_server_sandbox( &$url, &$headers ) {
+	if ( ! JETPACK__SANDBOX_DOMAIN ) {
+		return;
+	}
+
+	$original_url = $url;
+
+	$request_parameters = jetpack_server_sandbox_request_parameters( JETPACK__SANDBOX_DOMAIN, $url, $headers );
+	$url = $request_parameters['url'];
+	if ( $request_parameters['host'] ) {
+		$headers['Host'] = $request_parameters['host'];
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( sprintf( "SANDBOXING via '%s': '%s'", JETPACK__SANDBOX_DOMAIN, $original_url ) );
+		}
+	}
+}
+
+add_action( 'requests-requests.before_request', 'jetpack_server_sandbox', 10, 2 );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -889,7 +889,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$request = array(
 			'headers' => array(
 				'Authorization' => "Bearer " . $token->access_token,
-				'Host'          => defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' ) ? JETPACK__WPCOM_JSON_API_HOST_HEADER : 'public-api.wordpress.com',
+				'Host'          => 'public-api.wordpress.com',
 			),
 			'timeout' => 60,
 			'method'  => 'POST',

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -132,17 +132,6 @@ class Jetpack_Client {
 			'Authorization' => "X_JETPACK " . join( ' ', $header_pieces ),
 		) );
 
-		$host = parse_url( $url, PHP_URL_HOST );
-
-		// If we have a JETPACK__WPCOM_JSON_API_HOST_HEADER set, then let's use
-		// that, otherwise, let's fallback to the standard.
-		if ( defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' ) && JETPACK__WPCOM_JSON_API_HOST_HEADER ) {
-			$request['headers']['Host'] = JETPACK__WPCOM_JSON_API_HOST_HEADER;
-
-		} elseif ( $host === JETPACK__WPCOM_JSON_API_HOST ) {
-			$request['headers']['Host'] = 'public-api.wordpress.com';
-		}
-
 		if ( 'header' != $args['auth_location'] ) {
 			$url = add_query_arg( 'signature', urlencode( $signature ), $url );
 		}

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -5,7 +5,6 @@
 // the proxy to send the X-Forwarded-Port header.
 defined( 'JETPACK_SIGNATURE__HTTP_PORT'  ) or define( 'JETPACK_SIGNATURE__HTTP_PORT' , 80  );
 defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) or define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
-defined( 'JETPACK__WPCOM_JSON_API_HOST' )  or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 
 class Jetpack_Signature {
 	public $token;
@@ -160,10 +159,6 @@ class Jetpack_Signature {
 		$parsed = parse_url( $url );
 		if ( !isset( $parsed['host'] ) ) {
 			return new Jetpack_Error( 'invalid_signature', sprintf( 'The required "%s" parameter is malformed.', 'url' ) );
-		}
-
-		if ( $parsed['host'] === JETPACK__WPCOM_JSON_API_HOST ) {
-			$parsed['host'] = 'public-api.wordpress.com';
 		}
 
 		if ( !empty( $parsed['port'] ) ) {

--- a/jetpack.php
+++ b/jetpack.php
@@ -27,6 +27,8 @@ defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'ht
 defined( 'JETPACK_PROTECT__API_HOST' )       or define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
 defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 
+defined( 'JETPACK__SANDBOX_DOMAIN' ) or define( 'JETPACK__SANDBOX_DOMAIN', '' );
+
 /**
  * Returns the location of Jetpack's lib directory. This filter is applied
  * in require_lib().
@@ -117,6 +119,10 @@ add_filter( 'is_jetpack_site', '__return_true' );
  */
 if ( Jetpack::is_module_active( 'photon' ) ) {
 	add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
+}
+
+if ( JETPACK__SANDBOX_DOMAIN ) {
+	require_once( JETPACK__PLUGIN_DIR . '_inc/jetpack-server-sandbox.php' );
 }
 
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php' );


### PR DESCRIPTION
Currently, Jetpack provides a number of configurable constants that define various domains and endpoints (public-api.wordpress.com, dashboard.wordpress.com, etc.). These constants serve two purposes in Jetpack:
1. So we don't have to keep typing the same domains over and over again (typo prone), and
2. So we can change them to point various requests at Automattic sandboxes.

These two purposes get muddled. When we want to point public-api.wordpress.com requests to a sandbox, for example, we set the `JETPACK__WPCOM_JSON_API_HOST` constant. This:
* [changes the URL](https://github.com/Automattic/jetpack/blob/d7a1fadb4163d62d388c1b636c05f261fbab31fd/class.jetpack-client.php#L338) to use the sandbox domain,
* tells `Jetpack_Client` to set a [`Host` header](https://github.com/Automattic/jetpack/blob/d7a1fadb4163d62d388c1b636c05f261fbab31fd/class.jetpack-client.php#L137-L144) so that the sandbox correctly interprets the request as one to public-api.wordpress.com, *and*
* requires that `Jetpack_Signature` [handle these altered requests](https://github.com/Automattic/jetpack/blob/d7a1fadb4163d62d388c1b636c05f261fbab31fd/class.jetpack-signature.php#L165-L167) as if they were *unaltered* (to make sure the correct signature is generated).

To make everything work, we alter the URL, pull a switcheroo on the Host header to get the sandbox to interpret the request correctly, and unalter the URL in `Jetpack_Signature`. It's confusing.

More problematically, it doesn't work. `Jetpack_Client` and `Jetpack_Signature` only know about public-api.wordpress.com. They don't know what to do if we want to sandbox a request to jetpack.wordpress.com, for example, which makes doing anything with Jetpack's XML-RPC code even more annoying 😃

I'm proposing we change everything 😰 

#### Changes proposed in this Pull Request:

* All the existing constants should only fulfill purpose 1 above (DRY typing). I didn't go so far as to remove the `defined()` calls (leaving only the `define()` calls) yet, but I think we should.
* Add a new constant, `JETPACK__SANDBOX_DOMAIN`, that has only one purpose: setting up request sandboxing.
* Strip out all the sandbox/host/edge case handling code from `Jetpack_Client`, `Jetpack_Signature` and elsewhere.
* Include a new "plugin" that, when the new constant is non-empty, intercepts all `wp_remote_request()` (and friends) calls and does the URL/Host switcheroo at that level. This is at a lower level than `Jetpack_Client`/`Jetpack_Signature`, so:
  1. We don't need to build sandbox handling into those classes, and
  2. We capture *all* requests to the sandboxable domains, not just the ones that go through `Jetpack_Client`.

`JETPACK__SANDBOX_DOMAIN` must be a `{something}.wordpress.com` domain, and must have it's DNS permanently pointed to your sandbox (by the Systems team).

Documentation updates to follow if this looks good to folks.

NB: For those of us who have been using the "beta" plugin I wrote that does the same thing, the name of the sandboxing constant has changed from `JETPACK_SANDBOX__DOMAIN` to `JETPACK__SANDBOX_DOMAIN` 😱 

#### Testing instructions:

1. Ensure whatever server your site is running on does *not* have custom DNS resolution for public-api.wordpress.com or jetpack.wordpress.com (/etc/hosts, DNS server, whatever). Most commonly: remove those domains from your /etc/hosts file(s).
2. `define( 'WP_DEBUG', true );`
3. Put https://gist.github.com/mdawaffe/599f03ee3d6c869c141d34db5b1fcf94 in your WordPress root.
4. Watch for requests on your sandbox.
5. Tail your site's error log.
6. Run `test.php`.
7. You will not see any requests go to your sandbox :)
8. `define( 'JETPACK__SANDBOX_DOMAIN', '{your sandbox}.wordpress.com' );`
9. Run `test.php`.
10. In your site's error log, you will see claims that the requests have been sandboxed.
11. On your sandbox, you will see the requests.

#### Proposed changelog entry for your changes:

Simplify the logic of Jetpack's signed HTTP requests code.