### PR TITLE
Sync: Add previous theme info to when switching themes

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -6,8 +6,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
-		add_action( 'switch_theme', array( $this, 'sync_theme_support' ) );
-		add_action( 'jetpack_sync_current_theme_support', $callable );
+		add_action( 'switch_theme', array( $this, 'sync_theme_support' ), 10, 3 );
+		add_action( 'jetpack_sync_current_theme_support', $callable, 10, 2);
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_themes', $callable, 10, 2 );
@@ -357,16 +357,22 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_full_sync_theme_data', $callable );
 	}
 
-	public function sync_theme_support() {
+	public function sync_theme_support( $new_name, $new_theme, $old_theme = null ) {
+		// Previous theme support got added in WP 4.5
+		$previous_theme = false;
+		if ( $old_theme instanceof WP_Theme ) {
+			$previous_theme = $this->get_theme_support_info( $old_theme );
+		}
 		/**
 		 * Fires when the client needs to sync theme support info
 		 * Only sends theme support attributes whitelisted in Jetpack_Sync_Defaults::$default_theme_support_whitelist
 		 *
 		 * @since 4.2.0
 		 *
-		 * @param object the theme support hash
+		 * @param array the theme support array
+		 * @param array the previous theme since Jetpack 6.5.0
 		 */
-		do_action( 'jetpack_sync_current_theme_support' , $this->get_theme_support_info() );
+		do_action( 'jetpack_sync_current_theme_support' , $this->get_theme_support_info(), $previous_theme );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -562,19 +568,27 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 	}
 
-	private function get_theme_support_info() {
+	/**
+	 * @param null $theme the theme object!
+	 *
+	 * @return array
+	 */
+	private function get_theme_support_info( $theme = null ) {
 		global $_wp_theme_features;
 
 		$theme_support = array();
+		if ( $theme === null  ) { // we are dealing with the current theme!
+			$theme = wp_get_theme();
 
-		foreach ( Jetpack_Sync_Defaults::$default_theme_support_whitelist as $theme_feature ) {
-			$has_support = current_theme_supports( $theme_feature );
-			if ( $has_support ) {
-				$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
+			foreach ( Jetpack_Sync_Defaults::$default_theme_support_whitelist as $theme_feature ) {
+				$has_support = current_theme_supports( $theme_feature );
+				if ( $has_support ) {
+					$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
+				}
 			}
 		}
 
-		$theme = wp_get_theme();
+
 		$theme_support['name'] = $theme->get('Name');
 		$theme_support['version'] =  $theme->get('Version');
 		$theme_support['slug'] = $theme->get_stylesheet();

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -84,6 +84,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $current_theme->name, $switch_data->args[0]['name']);
 		$this->assertEquals( $current_theme->version, $switch_data->args[0]['version']);
 
+		$this->assertTrue( isset( $switch_data->args[1]['name'] ) );
+		$this->assertTrue( isset( $switch_data->args[1]['version'] ) );
+		$this->assertTrue( isset( $switch_data->args[1]['slug'] ) );
+		$this->assertTrue( isset( $switch_data->args[1]['uri'] ) );
+
 		foreach ( $theme_features as $theme_feature ) {
 			$synced_theme_support_value = $this->server_replica_storage->current_theme_supports( $theme_feature );
 			$this->assertEquals( current_theme_supports( $theme_feature ), $synced_theme_support_value, 'Feature(s) not synced' . $theme_feature );


### PR DESCRIPTION
When we switch themes we want to know more about the previous theme so that we can tell the user the the theme they switched to as well what theme they switched from.

Fixes https://github.com/Automattic/wp-calypso/issues/26821

#### Changes proposed in this Pull Request:
* include the theme array of the previous theme.

#### Testing instructions:
Do the test pass. 

We should be able to see the theme info show up on the .com side when we switch theme theme as well. 

We should be able to see the changes also appear on in the activity log when that part is done.