### PR TITLE
Experiment: Register wpcom color scheme block

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -74,6 +74,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		) );
 
+		register_rest_route( 'jetpack/v4', 'me/settings', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_me_settings',
+				'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::update_me_settings',
+				'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+			)
+		) );
+
 		register_rest_route( 'jetpack/v4', '/jitm', array(
 			'methods'  => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::get_jitm_message',
@@ -395,6 +408,56 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$body = wp_remote_retrieve_body( $request );
 		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
 			$data = $body;
+		} else {
+			// something went wrong so we'll just return the response without caching
+			return $body;
+		}
+
+		return $data;
+	}
+
+	public static function get_me_settings( $request ) {
+		$request = Jetpack_Client::wpcom_json_api_request_as_user(
+			'/me/settings',
+			'1.1',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			),
+			null,
+			'rest'
+		);
+
+		$body = wp_remote_retrieve_body( $request );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			$data = json_decode( $body );
+		} else {
+			// something went wrong so we'll just return the response without caching
+			return $body;
+		}
+
+		return $data;
+	}
+
+	public static function update_me_settings( $request ) {
+		$request = Jetpack_Client::wpcom_json_api_request_as_user(
+			'/me/settings',
+			'1.1',
+			array(
+				'method'  => 'POST',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			),
+			$request->get_body(),
+			'rest'
+		);
+
+		$body = wp_remote_retrieve_body( $request );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			$data = json_decode( $body );
 		} else {
 			// something went wrong so we'll just return the response without caching
 			return $body;

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -449,6 +449,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'method'  => 'POST',
 				'headers' => array(
 					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+					'Content-Type'    => 'application/json',
 				),
 			),
 			$request->get_body(),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -690,6 +690,30 @@ class Jetpack {
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
 		}
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_wpcom_color_scheme_block_assets' ) );
+	}
+
+	function enqueue_wpcom_color_scheme_block_assets() {
+		wp_enqueue_script(
+			'wpcom_color_scheme_block',
+			plugins_url( '_inc/build/wpcom-color-scheme/block.js', __FILE__ ),
+			array(
+				'wp-api-fetch',
+				'wp-blocks',
+				'wp-element',
+				'wp-i18n',
+			),
+			JETPACK__VERSION,
+			true
+		);
+
+		// TODO: fix Calypso's config when building from the SDK
+		wp_add_inline_script(
+			'wpcom_color_scheme_block',
+			'window.configData={};',
+			'before'
+		);
 	}
 
 	function point_edit_post_links_to_calypso( $default_url, $post_id ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -714,6 +714,13 @@ class Jetpack {
 			'window.configData={};',
 			'before'
 		);
+
+		// TODO: move to a separate file instead of inlining it
+		wp_add_inline_script(
+			'wpcom_color_scheme_block',
+			'window.wp.apiFetch.use( function( options, next ) { return next( { ...options, path: options.path.replace( /^\/me/, "jetpack/v4/me" ) } ) } );',
+			'before'
+		);
 	}
 
 	function point_edit_post_links_to_calypso( $default_url, $post_id ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -721,6 +721,14 @@ class Jetpack {
 			'window.wp.apiFetch.use( function( options, next ) { return next( { ...options, path: options.path.replace( /^\/me/, "jetpack/v4/me" ) } ) } );',
 			'before'
 		);
+
+		wp_enqueue_style(
+			'wpcom_color_scheme_block',
+			plugins_url( '_inc/build/wpcom-color-scheme/block.css', __FILE__ ),
+			array(),
+			JETPACK__VERSION,
+			true
+		);
 	}
 
 	function point_edit_post_links_to_calypso( $default_url, $post_id ) {


### PR DESCRIPTION
This PR is a WIP, and is a counterpart of https://github.com/Automattic/wp-calypso/pull/26937.  

The PR introduces some `apiFetch` middleware and a couple of endpoints that can be used to access `/me/settings` from the Jetpack side. Finally, it registers the block that we build from Calypso.

See https://github.com/Automattic/wp-calypso/pull/26937 for detailed instructions on how to test this.