### PR TITLE
General: Update .editorconfig for txt files from CRLF to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,8 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[{*.txt,wp-config-sample.php}]
+[*.txt]
+end_of_line = lf
+
+[wp-config-sample.php]
 end_of_line = crlf


### PR DESCRIPTION
Original work by @abidhahmed .

The commit here was cherry-picked from #9980 and removed from that PR.

#### Changes proposed in this Pull Request:

* Update line-endings config in `.editorconfig` for `.txt` files from CRLF to LF.

#### Testing instructions:

1. Check this branch
1. Open readme.txt in an editor that support `.editorconfig` files and confirm all is good.

#### Proposed changelog entry for your changes:

