### PR TITLE
Activity Log: update remote url

### DIFF
--- a/_inc/client/at-a-glance/activity.jsx
+++ b/_inc/client/at-a-glance/activity.jsx
@@ -33,7 +33,7 @@ class DashActivity extends Component {
 	render() {
 		const { siteRawUrl, inDevMode } = this.props;
 		// const sitePlan = get( this.props.sitePlan, 'product_slug', 'jetpack_free' );
-		const activityLogLink = <a href={ `https://wordpress.com/stats/activity/${ siteRawUrl }` } />;
+		const activityLogLink = <a href={ `https://wordpress.com/activity/${ siteRawUrl }` } />;
 		// const hasBackups = includes( [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_VIP ], sitePlan );
 		// const maybeUpgrade = hasBackups
 		// 	? __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and rewind them if you need to.", {

--- a/_inc/client/at-a-glance/activity.jsx
+++ b/_inc/client/at-a-glance/activity.jsx
@@ -33,7 +33,7 @@ class DashActivity extends Component {
 	render() {
 		const { siteRawUrl, inDevMode } = this.props;
 		// const sitePlan = get( this.props.sitePlan, 'product_slug', 'jetpack_free' );
-		const activityLogLink = <a href={ `https://wordpress.com/activity/${ siteRawUrl }` } />;
+		const activityLogLink = <a href={ `https://wordpress.com/activity-log/${ siteRawUrl }` } />;
 		// const hasBackups = includes( [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_VIP ], sitePlan );
 		// const maybeUpgrade = hasBackups
 		// 	? __( "{{a}}View your site's activity{{/a}} in a single feed where you can see when events occur and rewind them if you need to.", {

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -118,7 +118,7 @@ class PlanBody extends React.Component {
 					<div className="jp-landing__plan-features-card">
 						<h3 className="jp-landing__plan-features-title">{ __( 'Backups' ) }</h3>
 						<p>{ __( 'Real-time backup of all your site data with unlimited space, one-click restores, and automated security scanning.' ) }</p>
-						<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl } className="is-primary">
+						<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/activity/' + this.props.siteRawUrl } className="is-primary">
 							{ __( 'View your security activity' ) }
 						</Button>
 					</div>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -118,7 +118,7 @@ class PlanBody extends React.Component {
 					<div className="jp-landing__plan-features-card">
 						<h3 className="jp-landing__plan-features-title">{ __( 'Backups' ) }</h3>
 						<p>{ __( 'Real-time backup of all your site data with unlimited space, one-click restores, and automated security scanning.' ) }</p>
-						<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/activity/' + this.props.siteRawUrl } className="is-primary">
+						<Button onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) } href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl } className="is-primary">
 							{ __( 'View your security activity' ) }
 						</Button>
 					</div>

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -65,7 +65,7 @@ class BackupsScanRewind extends Component {
 			feature={ 'rewind' }
 			description={ __( 'Your site is being backed up in real time and regularly scanned for security threats.' ) }
 			className="is-upgrade-premium jp-banner__no-border"
-			href={ 'https://wordpress.com/stats/activity/' + this.props.siteRawUrl }
+			href={ 'https://wordpress.com/activity/' + this.props.siteRawUrl }
 		/>;
 	};
 

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -65,7 +65,7 @@ class BackupsScanRewind extends Component {
 			feature={ 'rewind' }
 			description={ __( 'Your site is being backed up in real time and regularly scanned for security threats.' ) }
 			className="is-upgrade-premium jp-banner__no-border"
-			href={ 'https://wordpress.com/activity/' + this.props.siteRawUrl }
+			href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl }
 		/>;
 	};
 


### PR DESCRIPTION
We are changing the URL from 'wordpress.com/stats/activity/' to 'wordpress.com/activity-log/'

See: https://github.com/Automattic/wp-calypso/pull/26941

This PR will update links in the dashboard to point to the activity log's new URL:

**In the at-a-glance section:**

<img width="377" alt="screen shot 2018-09-04 at 7 34 44 am" src="https://user-images.githubusercontent.com/2694219/45029032-531cd380-b015-11e8-96b4-3ca9e257115e.png">

**In the plans section:**

<img width="685" alt="screen shot 2018-09-04 at 7 35 15 am" src="https://user-images.githubusercontent.com/2694219/45029044-5fa12c00-b015-11e8-8b99-e7e91936c78c.png">

**In the settings -> security section:**

<img width="746" alt="screen shot 2018-09-04 at 7 36 00 am" src="https://user-images.githubusercontent.com/2694219/45029067-7182cf00-b015-11e8-8d2c-89419b381c5c.png">
