### PR TITLE
Added line breaks to namespace attribute.

### DIFF
--- a/modules/geo-location/class.jetpack-geo-location.php
+++ b/modules/geo-location/class.jetpack-geo-location.php
@@ -235,7 +235,7 @@ class Jetpack_Geo_Location {
 	 * Add the georss namespace during RSS generation.
 	 */
 	public function rss_namespace() {
-		echo 'xmlns:georss="http://www.georss.org/georss" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" ';
+		echo PHP_EOL . 'xmlns:georss="http://www.georss.org/georss" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"' . PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
Before the geolocation tool would add the namespace attribute that was not separated by anything in the beginning of the string. This caused issues like #9885, where a plugin would add their own namespacing and cause a validation error because Jetpack would add a namespace right next to it without any spacing.

This PR, however, does not fix the problem of duplicate namespace attributes, which would also cause validation errors. In case of duplicate namespaces we need to disable Jetpack's functionality one plugin at a time by adding them to conflicts.

Fixes #9885 

#### Changes proposed in this Pull Request:

* Adds `PHP_EOL` to both ends of the namespace string.

#### Testing instructions:

* Add a plugin that uses the `rss2_ns` hook, or better yet, create one yourself: https://gist.github.com/zinigor/8c2fb946536be33b2cb141d5808d57b4
* Feed your feed into [the validator](https://validator.w3.org/feed/). You can get your feed by adding `/rss` to the end of the site URL.
* See that it doesn't validate.
* Roll this PR on.
* See that it validates.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed compatibility issues with plugins that added meta attributes to site feeds.