### PR TITLE
Masterbar: Add the activity link to the master bar

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -644,6 +644,18 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
+		if ( current_user_can( 'manage_options' ) ) {
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'blog',
+				'id'     => 'activity',
+				'title'  => esc_html__( 'Activity', 'jetpack' ),
+				'href'   => 'https://wordpress.com/activity/' . esc_attr( $this->primary_site_slug ),
+				'meta'   => array(
+					'class' => 'mb-icon',
+				),
+			) );
+		}
+
 		// Add Calypso plans link and plan type indicator
 		if ( is_user_member_of_blog( $current_user->ID ) ) {
 			$plans_url = 'https://wordpress.com/plans/' . esc_attr( $this->primary_site_slug );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -649,7 +649,7 @@ class A8C_WPCOM_Masterbar {
 				'parent' => 'blog',
 				'id'     => 'activity',
 				'title'  => esc_html__( 'Activity', 'jetpack' ),
-				'href'   => 'https://wordpress.com/activity/' . esc_attr( $this->primary_site_slug ),
+				'href'   => 'https://wordpress.com/activity-log/' . esc_attr( $this->primary_site_slug ),
 				'meta'   => array(
 					'class' => 'mb-icon',
 				),


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/26941 we are adding the activity log to the sidebar.

This PR adds the activity log to the master bar.

This is the complimentary .com pr D17682-code 

<img width="177" alt="screen_shot_2018-09-04_at_10_49_42_am" src="https://user-images.githubusercontent.com/115071/45048280-570a1f00-b030-11e8-8a01-7df1b1486d0f.png">


#### Changes proposed in this Pull Request:

* Add the activity link to the master bar

#### Testing instructions:
* Activate the Master bar to your site. 
* Manual testing: Does the activity log link work as expected? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add the activity link to the master bar