### PR TITLE
CLI: Fix issue where help for publicize command did not show long description

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1229,7 +1229,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 	}
 
-	/*
+	/**
 	 * Allows management of publicize connections.
 	 *
 	 * ## OPTIONS
@@ -1238,8 +1238,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : The action to perform.
 	 * ---
 	 * options:
-	 *  - list
-	 *  - disconnect
+	 *   - list
+	 *   - disconnect
 	 * ---
 	 *
 	 * [<identifier>]
@@ -1250,24 +1250,39 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * ---
 	 * default: table
 	 * options:
-	 *  - table
-	 *  - json
-	 *  - csv
-	 *  - yaml
-	 *  - ids
-	 *  - count
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - ids
+	 *   - count
 	 * ---
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp jetpack publicize list
-	 * wp jetpack publicize list twitter
-	 * wp --user=1 jetpack publicize list
-	 * wp --user=1 jetpack publicize list twitter
-	 * wp jetpack publicize list 123456
-	 * wp jetpack publicize disconnect 123456
-	 * wp jetpack publicize disconnect all
-	 * wp jetpack publicize disconnect twitter
+	 *     # List all publicize connections.
+	 *     $ wp jetpack publicize list
+	 *
+	 *     # List publicize connections for a given service.
+	 *     $ wp jetpack publicize list twitter
+	 *
+	 *     # List all publicize connections for a given user.
+	 *     $ wp --user=1 jetpack publicize list
+	 *
+	 *     # List all publicize connections for a given user and service.
+	 *     $ wp --user=1 jetpack publicize list twitter
+	 *
+	 *     # Display details for a given connection.
+	 *     $ wp jetpack publicize list 123456
+	 *
+	 *     # Diconnection a given connection.
+	 *     $ wp jetpack publicize disconnect 123456
+	 *
+	 *     # Disconnect all connections.
+	 *     $ wp jetpack publicize disconnect all
+	 *
+	 *     # Disconnect all connections for a given service.
+	 *     $ wp jetpack publicize disconnect twitter
 	 */
 	public function publicize( $args, $named_args ) {
 		if ( ! Jetpack::is_active() ) {


### PR DESCRIPTION
While testing for #10072, I noticed that `wp jetpack publicize --help` wasn't returning the correct output. Specifically, it wasn't returning examples or options for the command.

#### Changes proposed in this Pull Request:

* Fix documentation for `wp jetpack publicize` command so that the `wp jetpack publicize --help` works properly.
* Bring documentation closer in line to WP-CLI documentation standards

#### Testing instructions:

- Against `master`, run `wp jetpack publicize --help` and observe output like this:
    ```
    NAME
    
      wp jetpack publicize
    
    SYNOPSIS
    
      wp jetpack publicize
    
    
    
    GLOBAL PARAMETERS
    
      --path=<path>
          Path to the WordPress files.
    
      --url=<url>
          Pretend request came from given URL. In multisite, this argument is how the target site is specified.
    
      --ssh=[<scheme>:][<user>@]<host|container>[:<port>][<path>]
          Perform operation against a remote server over SSH (or a container using scheme of "docker", "docker-compose", "vagrant").
    
      --http=<http>
          Perform operation against a remote WordPress install over HTTP.
    ...
    ```
- Checkout `update/update-cli-publicize-help`, run `wp jetpack publicize --help` and observe output like this:
    ```
    NAME
    
      wp jetpack publicize
    
    DESCRIPTION
    
      Allows management of publicize connections.
    
    SYNOPSIS
    
      wp jetpack publicize <list|disconnect> [<identifier>] [--format=<format>]
    
    OPTIONS
    
      <list|disconnect>
        The action to perform.
        ---
        options:
          - list
          - disconnect
        ---
    
      [<identifier>]
        The connection ID or service to perform an action on.
    
      [--format=<format>]
        Allows overriding the output of the command when listing connections.
        ---
        default: table
        options:
          - table
          - json
          - csv
          - yaml
          - ids
          - count
        ---
    
    EXAMPLES
    
        # List all publicize connections.
        $ wp jetpack publicize list
    
        # List publicize connections for a given service.
        $ wp jetpack publicize list twitter
    ...
    ```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes issue where the long description didn't show for the wp jetpack publicize command when running wp jetpack publicize --help.