### PR TITLE
Heartbeat: Improve xmlrpc request argument handling 

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -140,8 +140,13 @@ class Jetpack_Heartbeat {
 	}
 
 	public static function jetpack_xmlrpc_methods( $methods ) {
-		$methods['jetpack.getHeartbeatData'] = array( __CLASS__, 'generate_stats_array' );
+		$methods['jetpack.getHeartbeatData'] = array( __CLASS__, 'xmlrpc_data_response' );
 		return $methods;
+	}
+
+	public static function xmlrpc_data_response( $params = array() ) {
+		$params = empty( $params ) ? '' : $params;
+		return self::generate_stats_array( $params );
 	}
 
 	public function deactivate() {

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -145,6 +145,9 @@ class Jetpack_Heartbeat {
 	}
 
 	public static function xmlrpc_data_response( $params = array() ) {
+		// The WordPress XML-RPC server sets a default param of array()
+		// if no argument is passed on the request and the method handlers get this array in $params.
+		// generate_stats_array() needs a string as first argument.
 		$params = empty( $params ) ? '' : $params;
 		return self::generate_stats_array( $params );
 	}


### PR DESCRIPTION
Fixes #10070

Props to @kraftbj for finding the source of the issue.

> The XML-RPC server sets a default param of `array()` via https://github.com/WordPress/WordPress/blob/4.9.8/wp-includes/IXR/class-IXR-message.php#L17
and it passes that to the method via https://github.com/WordPress/WordPress/blob/4.9.8/wp-includes/IXR/class-IXR-server.php#L65

_The proposal here is based on a personal opinion that using `generate_stats_array` was being overloaded in usage as both a direct xmlrpc method handler and a statically callable method for other purposes._

#### Changes proposed in this Pull Request:

* Adds a new static method `Jetpack_Heartbeat:: xmlrpc_data_response` method as handler for the XML RPC request `jetpack.getHeartbeatData`.

#### Testing instructions:

* Start with a connected Jetpack site, and `WP_DEBUG` `WP_DEBUG_LOG` constants set to true.
* Pass your site through the Jetpack Debugger.
* Expect not to see PHP notices logged. Before this changeset, you should have expected to see PHP notices logged as described in #10070 . 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
