### PR TITLE
CLI: Publicize: Fix issue where publicize command would error for JN site

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1289,6 +1289,18 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
 		}
 
+		if ( Jetpack::is_development_mode() ) {
+			if (
+				! defined( 'JETPACK_DEV_DEBUG' ) &&
+				! has_filter( 'jetpack_development_mode' ) &&
+				false === strpos( site_url(), '.' )
+			) {
+				WP_CLI::error( __( "Jetpack is current in development mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in development mode, the publicize module will not load.", 'jetpack' ) );
+			}
+
+			WP_CLI::error( __( 'Jetpack is currently in development mode, so the publicize module will not load.', 'jetpack' ) );
+		}
+
 		$action        = $args[0];
 		$publicize     = new Publicize();
 		$identifier    = ! empty( $args[1] ) ? $args[1] : false;


### PR DESCRIPTION
JN sites set the `WP_HOME` and `WP_SITEURL` constants by doing the following:

```
define('SP_REQUEST_URL', ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST']);

define('WP_SITEURL', SP_REQUEST_URL);
define('WP_HOME', SP_REQUEST_URL);
```

In CLI, `$_SERVER['HTTP_HOST']` is either empty or isn't set, which causes the url to be `https://` or `http://`.

This causes the site to be in development mode due to this line:

https://github.com/Automattic/jetpack/blob/09794f658cca9ef3a5d3ae41bce02b04235c0b66/class.jetpack.php#L1599

#### Changes proposed in this Pull Request:

Add a a development mode check to the `wp jetpack publicize` command so that we bail when the `Publicize` class does not exist.

#### Testing instructions:

- On a JN site, SSH in
- Run `wp jetpack publicize list`
- Ensure there is an error like this:
    ```
    Fatal error: Uncaught Error: Class 'Publicize' not found in class.jetpack-cli.php:1278
    ```
- Checkout this patch
- Run `wp jetpack publicize list`
- Ensure there is no PHP error and that you get an error message like this:
    > Error: Jetpack is current in development mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in development mode, the publicize module will not load.
- In `wp-config.php`, add `define( 'JETPACK_DEV_DEBUG', true );`
- Run `wp jetpack publicize list`
- Ensure you get an error message like:
    > Error: Jetpack is currently in development mode.
- Open `wp-config.php` and comment out these lines:
    ```
    define('WP_SITEURL', SP_REQUEST_URL);
    define('WP_HOME', SP_REQUEST_URL);
    ```
- Ensure that you do not see any errors


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes a PHP error that could occur when running `wp jetpack publicize` while in development mode.