### PR TITLE
Lazy Images: Fix issue introduced in #10054 where some images were double processed

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -170,13 +170,13 @@ class Jetpack_Lazy_Images {
 		}
 
 		$old_attributes = self::flatten_kses_hair_data( $old_attributes_kses_hair );
-		$new_attributes = self::process_image_attributes( $old_attributes );
 
 		// If we didn't add lazy attributes, just return the original image source.
-		if ( false === strpos( $new_attributes['class'], 'jetpack-lazy-image' ) ) {
+		if (! empty( $old_attributes['class'] ) && false !== strpos( $old_attributes['class'], 'jetpack-lazy-image' ) ) {
 			return $matches[0];
 		}
 
+		$new_attributes     = self::process_image_attributes( $old_attributes );
 		$new_attributes_str = self::build_attributes_string( $new_attributes );
 
 		return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -172,7 +172,7 @@ class Jetpack_Lazy_Images {
 		$old_attributes = self::flatten_kses_hair_data( $old_attributes_kses_hair );
 
 		// If we didn't add lazy attributes, just return the original image source.
-		if (! empty( $old_attributes['class'] ) && false !== strpos( $old_attributes['class'], 'jetpack-lazy-image' ) ) {
+		if ( ! empty( $old_attributes['class'] ) && false !== strpos( $old_attributes['class'], 'jetpack-lazy-image' ) ) {
 			return $matches[0];
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #10054, I introduced a bug that can occur when an image is processed multiple times. The condition that we had in `process_image()` to keep us from double processing an image was... messed up. 😞 

First, it was checking in the processed attributes, instead of the attributes for the image that we are about to process.

Second, the logic was backwards. We wanted to bail if we detected the presence of a class, but that condition was bailing if we did not detect the presence of the class.

#### Testing instructions:

This became apparent to me when testing against a site with the Storefront theme and WooCommerce. Specifically, blank space was showing where images should be on the shop page.

So, if possible, I would test the following against a WooCommerce site with Storefront:

- Create products with images and load the shop as well as individual products
- Create posts/pages with images
- Create posts/pages with galleries

Ensure that images load in all of the above. At this point, it's OK if the image collapses while loading. I am still working on adding/improving placeholder support separately.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes an issue where lazy loaded images could be double processed resulting in the image not being displayed properly.