### PR TITLE
Site Settings API: add jetpack search controls

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -42,6 +42,8 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'jetpack_relatedposts_enabled'         => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'   => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails' => '(bool) Show thumbnails in related posts?',
+		'jetpack_search_enabled'               => '(bool) Enable Jetpack Search',
+		'jetpack_search_supported'             => '(bool) Jetpack Search supported',
 		'jetpack_protect_whitelist'            => '(array) List of IP addresses to whitelist',
 		'infinite_scroll'                      => '(bool) Support infinite scroll of posts?',
 		'default_category'                     => '(int) Default post category',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -42,6 +42,8 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'jetpack_relatedposts_enabled'         => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'   => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails' => '(bool) Show thumbnails in related posts?',
+		'jetpack_search_enabled'               => '(bool) Enable Jetpack Search',
+		'jetpack_search_supported'             => '(bool) Jetpack Search supported',
 		'jetpack_protect_whitelist'            => '(array) List of IP addresses to whitelist',
 		'infinite_scroll'                      => '(bool) Support infinite scroll of posts?',
 		'default_category'                     => '(int) Default post category',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -42,6 +42,8 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'jetpack_relatedposts_enabled'         => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'   => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails' => '(bool) Show thumbnails in related posts?',
+		'jetpack_search_enabled'               => '(bool) Enable Jetpack Search',
+		'jetpack_search_supported'             => '(bool) Jetpack Search supported',
 		'jetpack_protect_whitelist'            => '(array) List of IP addresses to whitelist',
 		'infinite_scroll'                      => '(bool) Support infinite scroll of posts?',
 		'default_category'                     => '(int) Default post category',


### PR DESCRIPTION
Differential Revision: D17676-code

This commit syncs r180015-wpcom and brings these three files in sync. It has already been merged to wpcom. 

#### Changes proposed in this Pull Request:

Summary:
- indicator of if jp search supported
- enable/disable flag

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

Test Plan:
- TeamCity Tests (done)
- Apply the patch and ensure that `/sites/%site/settings` is returning the correct value for the given site. And no errors. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Either none or... "API: add flags to determine if Jetpack Search is enabled and supported."
