### PR TITLE
CLI: Publicize: Fixes an issue where an error could occur when publicize not active

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1289,6 +1289,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
 		}
 
+		if ( ! Jetpack::is_module_active( 'publicize' ) ) {
+			WP_CLI::error( __( 'The publicize module is not active.', 'jetpack' ) );
+		}
+
 		if ( Jetpack::is_development_mode() ) {
 			if (
 				! defined( 'JETPACK_DEV_DEBUG' ) &&
@@ -1299,6 +1303,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			}
 
 			WP_CLI::error( __( 'Jetpack is currently in development mode, so the publicize module will not load.', 'jetpack' ) );
+		}
+
+		if ( ! class_exists( 'Publicize' ) ) {
+			WP_CLI::error( __( 'The publicize module is not loaded.', 'jetpack' ) );
 		}
 
 		$action        = $args[0];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #10075, we fixed an issue where the `wp jetpack publicize` command would error due to the publicize module not being loaded because the site was in development mode. What I didn't consider at the time was that the same error would occur if the module had been deactivated and the `wp jetpack publicize` command was called.

This PR fixes that by adding a check to see if the Publicize module has been loaded.

#### Testing instructions:

On a connected site:

- In `wp-config.php`, add `define( 'JETPACK_DEV_DEBUG', true );`
- Run `wp jetpack publicize list`
- Ensure you get an error message like:
    > Error: Jetpack is currently in development mode.
- Ensure that you do not see any errors
- Remove `JETPACK_DEV_DEBUG` define
- Run `wp jetpack module deactivate publicize`
- Run `wp jetpack publicize list`
- Ensure that you get an error message like this:
    > The publicize module is not active.
- Optionally, change line `1308` to `if ( class_exists( 'Publicize' ) ) {` and run `wp jetpack publicize`
- Ensure that you get an error message like:
    > The publicize module is not loaded.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes issue where `wp jetpack publicize` command could error if publicize module was not active.