### PR TITLE
Search: fix path to CSS file to be minified

### DIFF
--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -44,7 +44,7 @@ const concat_list = [
 	'modules/wordads/css/style.css',
 	'modules/widgets/eu-cookie-law/style.css',
 	'modules/widgets/flickr/style.css',
-	'modules/search/css/search-widget-frontend.css',
+	'modules/widgets/search/css/search-widget-frontend.css',
 	'modules/widgets/simple-payments/style.css',
 ];
 


### PR DESCRIPTION
This PR fixes the path to the file to be minified. Since it was incorrect, it wasn't being minified but it was in the styles enqueued, and thus removed from being included on its own. This resulted in missing styles and wrong layout in the front end.

#### Testing instructions:

Verify that the new path leads to the right file, it's this

https://github.com/Automattic/jetpack/blob/master/modules/widgets/search/css/search-widget-frontend.css

You can also build this branch and verify that styles are correct now.