### PR TITLE
Contact Form: Improve Email Address Handling Personal Data Eraser

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -798,7 +798,25 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array  $return Associative array with keys expected by core.
 	 */
 	public function personal_data_exporter( $email, $page = 1 ) {
-		$per_page    = 250;
+		return $this->_internal_personal_data_exporter( $email, $page );
+	}
+
+	/**
+	 * Internal method for exporting personal data.
+	 *
+	 * Allows us to have a different signature than core expects
+	 * while protecting against future core API changes.
+	 *
+	 * @internal
+	 * @since 6.5
+	 *
+	 * @param  string $email    Email address.
+	 * @param  int    $page     Page to export.
+	 * @param  int    $per_page Number of feedbacks to process per page. Internal use only (testing)
+	 *
+	 * @return array            Associative array with keys expected by core.
+	 */
+	public function _internal_personal_data_exporter( $email, $page = 1, $per_page = 250 ) {
 		$export_data = array();
 		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
 
@@ -855,7 +873,25 @@ class Grunion_Contact_Form_Plugin {
 	 * @return array         Associative array with keys expected by core.
 	 */
 	public function personal_data_eraser( $email, $page = 1 ) {
-		$per_page = 250;
+		return $this->_internal_personal_data_eraser( $email, $page );
+	}
+
+	/**
+	 * Internal method for erasing personal data.
+	 *
+	 * Allows us to have a different signature than core expects
+	 * while protecting against future core API changes.
+	 *
+	 * @internal
+	 * @since 6.5
+	 *
+	 * @param  string $email    Email address.
+	 * @param  int    $page     Page to erase.
+	 * @param  int    $per_page Number of feedbacks to process per page. Internal use only (testing)
+	 *
+	 * @return array            Associative array with keys expected by core.
+	 */
+	public function _internal_personal_data_eraser( $email, $page = 1, $per_page = 250 ) {
 		$removed  = false;
 		$retained = false;
 		$messages = array();

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -34,6 +34,18 @@ class Grunion_Contact_Form_Plugin {
 
 	static $using_contact_form_field = false;
 
+	/**
+	 * @var int The last Feedback Post ID Erased as part of the Personal Data Eraser.
+	 * Helps with pagination.
+	 */
+	private $pde_last_post_id_erased = 0;
+
+	/**
+	 * @var string The email address for which we are deleting/exporting all feedbacks
+	 * as part of a Personal Data Eraser or Personal Data Exporter request.
+	 */
+	private $pde_email_address = '';
+
 	static function init() {
 		static $instance = false;
 
@@ -922,10 +934,14 @@ class Grunion_Contact_Form_Plugin {
 	public function personal_data_post_ids_by_email( $email, $per_page = 250, $page = 1, $last_post_id = 0 ) {
 		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
+		$this->pde_last_post_id_erased = $last_post_id;
+		$this->pde_email_address = $email;
+
 		$post_ids = get_posts( array(
 			'post_type'        => 'feedback',
 			'post_status'      => 'publish',
-			's'                => 'AUTHOR EMAIL: ' . $email,
+			// This search parameter gets overwritten in ->personal_data_search_filter()
+			's'                => '..PDE..AUTHOR EMAIL:..PDE..',
 			'sentence'         => true,
 			'order'            => 'ASC',
 			'orderby'          => 'ID',
@@ -934,6 +950,9 @@ class Grunion_Contact_Form_Plugin {
 			'paged'            => $last_post_id ? 1 : $page,
 			'suppress_filters' => false,
 		) );
+
+		$this->pde_last_post_id_erased = 0;
+		$this->pde_email_address = '';
 
 		remove_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
@@ -955,20 +974,20 @@ class Grunion_Contact_Form_Plugin {
 		/*
 		 * Limits search to `post_content` only, and we only match the
 		 * author's email address whenever it's on a line by itself.
-		 * `CHAR(13)` = `\r`, `CHAR(10)` = `\n`
 		 */
-		if ( preg_match( '/AUTHOR EMAIL\: ([^{\s]+)/', $search, $m ) ) {
-			$option_name = sprintf( '_jetpack_pde_feedback_%s', md5( $m[1] ) );
-			$last_post_id = get_option( $option_name, 0 );
+		if ( $this->pde_email_address && false !== strpos( $search, '..PDE..AUTHOR EMAIL:..PDE..' ) ) {
+			$search = $wpdb->prepare(
+				" AND (
+					{$wpdb->posts}.post_content LIKE %s
+					OR {$wpdb->posts}.post_content LIKE %s
+				)",
+				// `chr( 10 )` = `\n`, `chr( 13 )` = `\r`
+				'%' . $wpdb->esc_like( chr( 10 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 10 ) ) . '%',
+				'%' . $wpdb->esc_like( chr( 13 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 13 ) ) . '%'
+			);
 
-			$esc_like_email = esc_sql( $wpdb->esc_like( 'AUTHOR EMAIL: ' . $m[1] ) );
-			$search         = " AND (
-				{$wpdb->posts}.post_content LIKE CONCAT('%', CHAR(13), '{$esc_like_email}', CHAR(13), '%')
-				OR {$wpdb->posts}.post_content LIKE CONCAT('%', CHAR(10), '{$esc_like_email}', CHAR(10), '%')
-			)";
-
-			if ( $last_post_id ) {
-				$search .= $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_post_id );
+			if ( $this->pde_last_post_id_erased ) {
+				$search .= $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $this->pde_last_post_id_erased );
 			}
 		}
 


### PR DESCRIPTION
Fixes #10076 

#### Changes proposed in this Pull Request:

Instead of doing a "normal" WP_Query search, we refine the search with a more complicated query. To do that, we extract the email address from the normal query, and use it to build the more complicated query.

We were not taking into account the fact that string representing the email address can change when used in the query: in particular, because we LIKE (and SQL) escapee the data, the strings representing email addresses with underscores in them change.

When we build the more complicated query, we do another round of LIKE (and SQL) escaping, which is one round too many :)

For an address like `under_score@example.com`, we end up actually searching for `under\\_score`.

Instead of relying on passing the email address around in the query itself, let's just hold on to it in an object property.

Also: some tests :)

#### Testing instructions:

1.`phpunit --filter=WP_Test_Grunion_Contact_Form`

Also:

2. Add a contact form to your site
3. Submit a feedback or two with a specific email address.
4. Go to wp-admin/ → Tools → Personal Data Eraser
5. Enter that email address
6. Hover over that email address's row in the table.
7. Click "Force Erase Personal Data"
8. See the success message
9. See the Feedbacks are gone in wp-admin/ → Feedback

#### Proposed changelog entry for your changes:

Fix bug affecting Contact Form Feedback Personal Data Erasure tool for email addresses containing underscores.