### PR TITLE
Fix - No GA code when `Enable Enhanced eCommerce` option is active but WooCommerce is not active

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -49,12 +49,6 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
-		// At this time, we only leverage universal analytics for enhanced ecommerce. If WooCommerce is not
-		// present, don't bother emitting the tracking ID or fetching analytics.js
-		if ( ! class_exists( 'WooCommerce' ) ) {
-			return;
-		}
-
 		/**
 		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
 		 *

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -50,7 +50,9 @@ class Jetpack_Google_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
-		if ( Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() ) {
+		// At this time, we only leverage universal analytics when enhanced ecommerce is selected and WooCommerce is active.
+		// Otherwise, don't bother emitting the tracking ID or fetching analytics.js
+		if ( Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() && class_exists( 'WooCommerce' ) ) {
 			$analytics = new Jetpack_Google_Analytics_Universal();
 		} else {
 			$analytics = new Jetpack_Google_Analytics_Legacy();

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -52,7 +52,7 @@ class Jetpack_Google_Analytics {
 	private function __construct() {
 		// At this time, we only leverage universal analytics when enhanced ecommerce is selected and WooCommerce is active.
 		// Otherwise, don't bother emitting the tracking ID or fetching analytics.js
-		if ( Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() && class_exists( 'WooCommerce' ) ) {
+		if ( class_exists( 'WooCommerce' ) && Jetpack_Google_Analytics_Options::enhanced_ecommerce_tracking_is_enabled() ) {
 			$analytics = new Jetpack_Google_Analytics_Universal();
 		} else {
 			$analytics = new Jetpack_Google_Analytics_Legacy();


### PR DESCRIPTION
👋from a HE. My first PR. Thanks for the feedback in advance :) 

Fixes #10091

#### Changes proposed in this Pull Request:

Currently, Jetpack does not output the GA tracking code in a specific case, which can be replicated as you see on #10091 : 

* `Enable Enhanced eCommerce` option is active
* But WooCommerce is not active

#### Testing instructions:

1. Activate WooCommerce on a Premium or Pro site.
2. In https://wordpress.com/settings/traffic/my-site.com, activate Enable Enhanced eCommerce.
3. Deactivate WooCommerce
4. Visit the site without login as an admin. 
5. Check the HTML output and find the GA code by searching `Jetpack Google Analytics`.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Fix Bug - Do not output the Google Analytics code when `Enable Enhanced eCommerce` option is active but WooCommerce is not active
