### PR TITLE
Fix: PHP Notice

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -296,7 +296,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		}
 
 		$user = get_user_by( 'id', $user_id );
-		if ( $meta_key === $user->cap_key  ) {
+		if ( isset( $user->cap_key ) && $meta_key === $user->cap_key ) {
 			$this->add_flags( $user_id, array( 'capabilities_changed' => true ) );
 		}
 


### PR DESCRIPTION
This PR fixes a PHP notice found in my error log>

In cases where get_user_by doesn't return a valid user object this PR supressed the followind php Notice.

```
[04-Sep-2018 20:23:06 UTC] PHP Notice:  Trying to get property of non-object in /var/www/html/wp-content/plugins/jetpack/sync/class.jetpack-sync-module-users.php on line 299
[04-Sep-2018 20:23:06 UTC] PHP Stack trace:
[04-Sep-2018 20:23:06 UTC] PHP   1. {main}() /var/www/html/wp-admin/themes.php:0
[04-Sep-2018 20:23:06 UTC] PHP   2. switch_theme($stylesheet = *uninitialized*) /var/www/html/wp-admin/themes.php:33
[04-Sep-2018 20:23:06 UTC] PHP   3. do_action($tag = *uninitialized*, $arg = *uninitialized*, *uninitialized*, *uninitialized*) /var/www/html/wp-includes/theme.php:753
[04-Sep-2018 20:23:06 UTC] PHP   4. WP_Hook->do_action($args = *uninitialized*) /var/www/html/wp-includes/plugin.php:453
[04-Sep-2018 20:23:06 UTC] PHP   5. WP_Hook->apply_filters($value = *uninitialized*, $args = *uninitialized*) /var/www/html/wp-includes/class-wp-hook.php:310
[04-Sep-2018 20:23:06 UTC] PHP   6. TGM_Plugin_Activation->update_dismiss(*uninitialized*) /var/www/html/wp-includes/class-wp-hook.php:288
[04-Sep-2018 20:23:06 UTC] PHP   7. delete_metadata($meta_type = *uninitialized*, $object_id = *uninitialized*, $meta_key = *uninitialized*, $meta_value = *uninitialized*, $delete_all = *uninitialized*) /var/www/html/wp-content/themes/influencer/inc/tgmpa/class-tgm-plugin-activation.php:1910
[04-Sep-2018 20:23:06 UTC] PHP   8. do_action($tag = *uninitialized*, $arg = *uninitialized*, *uninitialized*, *uninitialized*, *uninitialized*) /var/www/html/wp-includes/meta.php:433
[04-Sep-2018 20:23:06 UTC] PHP   9. WP_Hook->do_action($args = *uninitialized*) /var/www/html/wp-includes/plugin.php:453
[04-Sep-2018 20:23:06 UTC] PHP  10. WP_Hook->apply_filters($value = *uninitialized*, $args = *uninitialized*) /var/www/html/wp-includes/class-wp-hook.php:310
[04-Sep-2018 20:23:06 UTC] PHP  11. Jetpack_Sync_Module_Users->maybe_save_user_meta($meta_id = *uninitialized*, $user_id = *uninitialized*, $meta_key = *uninitialized*, $value = *uninitialized*) /var/www/html/wp-includes/class-wp-hook.php:286
```
#### Testing instructions:
I am not sure how to reproduce the error :( 

#### Changes proposed in this Pull Request:
* Fixes a PHP Notice found.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Removes a PHP Notice 
