### PR TITLE
Jetpack: Sync when an attachment is added to a post for the first time

### DIFF
--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -46,6 +46,14 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 	function process_update( $attachment_id, $attachment_after, $attachment_before ) {
 		// Check whether attachment was added to a post for the first time
 		if ( 0 === $attachment_before->post_parent && 0 !== $attachment_after->post_parent ) {
+			/**
+			 * Fires when an existing attachment is added to a post for the first time
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param int The attachment ID
+			 * @param object The attachment
+			 */
 			do_action( 'jetpack_sync_save_attach_attachment', $attachment_id, $attachment_after );
 		}
 	}

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -9,8 +9,10 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 		add_action( 'edit_attachment', array( $this, 'send_attachment_info' ) );
 		// Once we don't have to support 4.3 we can start using add_action( 'attachment_updated', $handler, 10, 3 ); instead
 		add_action( 'add_attachment', array( $this, 'send_attachment_info' ) );
+		add_action( 'attachment_updated', array( $this, 'process_update'), 10, 3 );
 		add_action( 'jetpack_sync_save_update_attachment', $callable, 10, 2 );
 		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 2 );
+		add_action( 'jetpack_sync_save_attach_attachment', $callable, 10, 2 );
 	}
 
 	function send_attachment_info( $attachment_id ) {
@@ -39,5 +41,12 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 			do_action( 'jetpack_sync_save_update_attachment', $attachment_id, $attachment );
 		}
 
+	}
+
+	function process_update( $attachment_id, $attachment_after, $attachment_before ) {
+		// Check whether attachment was added to a post for the first time
+		if ( 0 === $attachment_before->post_parent && 0 !== $attachment_after->post_parent ) {
+			do_action( 'jetpack_sync_save_attach_attachment', $attachment_id, $attachment_after );
+		}
 	}
 }

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -47,7 +47,7 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 			/**
 			 * Fires when an existing attachment is added to a post for the first time
 			 *
-			 * @since 6.5.0
+			 * @since 6.6.0
 			 *
 			 * @param int The attachment ID
 			 * @param object The attachment

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -39,6 +39,16 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 			 */
 			do_action( 'jetpack_sync_save_attach_attachment', $attachment_id, $attachment_after );
 		} else {
+			/**
+			 * Fires when the client needs to sync an updated attachment
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param int The attachment ID
+			 * @param object The attachment
+			 *
+			 * Previously this action was synced using jetpack_sync_save_add_attachment action.
+			 */
 			do_action( 'jetpack_sync_save_update_attachment', $attachment_id, $attachment_after );
 		}
 	}

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -6,8 +6,6 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
-		add_action( 'edit_attachment', array( $this, 'send_attachment_info' ) );
-		// Once we don't have to support 4.3 we can start using add_action( 'attachment_updated', $handler, 10, 3 ); instead
 		add_action( 'add_attachment', array( $this, 'send_attachment_info' ) );
 		add_action( 'attachment_updated', array( $this, 'process_update'), 10, 3 );
 		add_action( 'jetpack_sync_save_update_attachment', $callable, 10, 2 );
@@ -55,6 +53,8 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 			 * @param object The attachment
 			 */
 			do_action( 'jetpack_sync_save_attach_attachment', $attachment_id, $attachment_after );
+		} else {
+			do_action( 'jetpack_sync_save_update_attachment', $attachment_id, $attachment_after );
 		}
 	}
 }

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -6,39 +6,24 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
-		add_action( 'add_attachment', array( $this, 'send_attachment_info' ) );
+		add_action( 'add_attachment', array( $this, 'process_add' ) );
 		add_action( 'attachment_updated', array( $this, 'process_update'), 10, 3 );
 		add_action( 'jetpack_sync_save_update_attachment', $callable, 10, 2 );
 		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 2 );
 		add_action( 'jetpack_sync_save_attach_attachment', $callable, 10, 2 );
 	}
 
-	function send_attachment_info( $attachment_id ) {
+	function process_add( $attachment_id ) {
 		$attachment = get_post( $attachment_id );
-		if ( 'add_attachment' === current_filter() ) {
-			/**
-			 * Fires when the client needs to sync an new attachment
-			 *
-			 * @since 4.2.0
-			 *
-			 * @param int The attachment ID
-			 * @param object The attachment
-			 */
-			do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment );
-		} else {
-			/**
-			 * Fires when the client needs to sync an updated attachment
-			 *
-			 * @since 4.9.0
-			 *
-			 * @param int The attachment ID
-			 * @param object The attachment
-			 *
-			 * Previously this action was synced using jetpack_sync_save_add_attachment action.
-			 */
-			do_action( 'jetpack_sync_save_update_attachment', $attachment_id, $attachment );
-		}
-
+		/**
+		 * Fires when the client needs to sync an new attachment
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param int The attachment ID
+		 * @param object The attachment
+		 */
+		do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment );
 	}
 
 	function process_update( $attachment_id, $attachment_after, $attachment_before ) {

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -35,6 +35,7 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 			case 'jetpack_sync_save_update_attachment':
 			case 'jetpack_sync_save_add_attachment':
+			case 'jetpack_sync_save_attach_attachment':
 				list( $attachment_id, $attachment ) = $args;
 				$this->store->upsert_post( $attachment, $silent );
 				break;

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -261,6 +261,22 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( (bool) $add_attachment_event );
 	}
 
+	public function test_sync_attach_attachment_to_post() {
+		$modified_attachment           = clone $this->post;
+		$modified_attachment->post_parent = 1000;
+		do_action( 'attachment_updated', $this->post->ID, $modified_attachment, $this->post );
+
+		$this->sender->do_sync();
+
+		$attach_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_attach_attachment' );
+		$update_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_update_attachment' );
+		$add_attachment_event    = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
+
+		$this->assertTrue( (bool) $attach_attachment_event );
+		$this->assertFalse( (bool) $update_attachment_event );
+		$this->assertFalse( (bool) $add_attachment_event );
+	}
+
 	public function test_broken_do_wp_insert_post_does_not_break_sync() {
 		// Some plugins do unexpected things see pet-manager
 		$this->server_event_storage->reset();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -262,7 +262,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_attach_attachment_to_post() {
-		$modified_attachment           = clone $this->post;
+		$this->post->post_parent          = 0;
+		$modified_attachment              = clone $this->post;
 		$modified_attachment->post_parent = 1000;
 		do_action( 'attachment_updated', $this->post->ID, $modified_attachment, $this->post );
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -286,10 +286,15 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$this->server_event_storage->reset();
 
-		wp_insert_attachment( $attachment, dirname( __FILE__ ) . '/../files/jetpack.jpg', 1000 );
+		$post_id = wp_insert_attachment( $attachment, dirname( __FILE__ ) . '/../files/jetpack.jpg', 1000 );
 
 		$this->sender->do_sync();
-		
+
+		$remote_attachment = $this->server_replica_storage->get_post( $post_id );
+		$attachment        = get_post( $post_id );
+
+		$this->assertEquals( $attachment, $remote_attachment );
+
 		$attach_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_attach_attachment' );
 		$update_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_update_attachment' );
 		$add_attachment_event    = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );


### PR DESCRIPTION
This PR changes attachment update syncing to be triggered by `attachment_updated`, and syncs a specific action when the update changes the post_parent from 0 to non-zero, which is indicative of an attachment being attached to a post.

Testing Instructions:
Attach an existing post from your media library to a post by clicking `Add Media` in the post. You should see the `jetpack_sync_save_update_attachment` sync action come through on your wpcom sandbox.

phpunit tests were added to test this functionality as well