### PR TITLE
General: Update minimum required WordPress version to 4.8

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '4.7' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '4.8' );
 
 define( 'JETPACK__VERSION',            '6.6-alpha' );
 define( 'JETPACK_MASTER_USER',         true );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
-	<config name="minimum_supported_wp_version" value="4.7" />
+	<config name="minimum_supported_wp_version" value="4.8" />
 	<config name="testVersion" value="5.2-"/>
 
 	<rule ref="PHPCompatibility" />

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 6.4.2
-Requires at least: 4.7
+Requires at least: 4.8
 Tested up to: 4.9
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.


### PR DESCRIPTION
This is consistent with the current support that we announce.

We support current WordPress version and previous one.

#### Changes proposed in this Pull Request:

* Updates `JETPACK__MINIMUM_WP_VERSION` to `4.8`

#### Testing instructions:

* Start with a site with no Jetpack. 
* Install WP Downgrade to go back to WordPress 4.7
* Download ...

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
General: We updated the minimum WordPress version to 4.8