### PR TITLE
Infinite Scroll: Prevent DOM Caching when Switching to/from Fullscreen

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -486,6 +486,14 @@ Scroller.prototype.checkViewportOnLoad = function( ev ) {
 	ev.data.self.ensureFilledViewport();
 }
 
+function fullscreenState() {
+	return document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement
+		? 1
+		: 0;
+}
+
+var previousFullScrenState = fullscreenState();
+
 /**
  * Identify archive page that corresponds to majority of posts shown in the current browser window.
  */
@@ -496,7 +504,20 @@ Scroller.prototype.determineURL = function () {
 		windowSize   = windowBottom - windowTop,
 		setsInView   = [],
 		setsHidden   = [],
-		pageNum      = false;
+		pageNum      = false,
+		currentFullScreenState = fullscreenState();
+
+	// xor - check if the state has changed
+	if ( previousFullScrenState ^ currentFullScreenState ) {
+		// If we just switched to/from fullscreen,
+		// don't do the div clearing/caching or the
+		// URL setting. Doing so can break video playback
+		// if the video goes to fullscreen.
+
+		previousFullScrenState = currentFullScreenState;
+		return;
+	}
+	previousFullScrenState = currentFullScreenState;
 
 	// Find out which sets are in view
 	$( '.' + self.wrapperClass ).each( function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When scrolling, Infinite Scroll periodically looks to see what DOM
elements are no longer in the viewport, caches them, and removes them from
the DOM.

On Android (and others?), switching to/from fullscreen triggers the
`scroll` event, which, in turn, triggers this DOM manipulation. The switch
to fullscreen mode also confuses Infinite Scroll's understanding of what
is visible in the viewport.

Playing a VideoPress video (or fullscreening a Vimeo or other video) on
Android can therefore remove the video from the DOM, which obviously
breaks everything :)

This patch uses the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API)
to determine if the browser has switched to or from fullscreen in between
throttled scroll events. If it has, Infinite Scroll will not do any of its
DOM manipulation. (Any manipulation required will get picked up if the
viewer continues to scroll.)

Reported: p1535429757000200-slack-CBG1CP4EN

Differential Revision: D17671-code

This commit syncs r180311-wpcom.

#### Testing instructions:

Test Plan:
1. On a test site, have enough posts for Infinite Scroll.
2. On a post sufficiently early (at least one Infinite Scroll "page"
   down), add a VideoPress video, e.g. `[wpvideo MnTIDupg]`
3. On Android, open the site, and scroll down until the VideoPress post is
   visible.
4. Click the video to begin play.

Prior to this patch: see the video start to play, then immediately
disappear.

After this patch: see the video play.

Also:
* Make sure things look normal elsewhere, both mobile and desktop.

#### Proposed changelog entry for your changes:

Fix video playback of VideoPress videos loaded via Infinite Scroll.