### PR TITLE
Remove code no longer needed since WP minimum is 4.8+

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -299,7 +299,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 			),
 			'locale' => Jetpack::get_i18n_data_json(),
-			'localeSlug' => join( '-', explode( '_', jetpack_get_user_locale() ) ),
+			'localeSlug' => join( '-', explode( '_', get_user_locale() ) ),
 			'jetpackStateNotices' => array(
 				'messageCode' => Jetpack::state( 'message' ),
 				'errorCode' => Jetpack::state( 'error' ),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2612,7 +2612,7 @@ class Jetpack {
 	 * @return string The locale as JSON
 	 */
 	public static function get_i18n_data_json() {
-		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . jetpack_get_user_locale() . '.json';
+		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_user_locale() . '.json';
 
 		if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
 			$locale_data = @file_get_contents( $i18n_json );

--- a/functions.global.php
+++ b/functions.global.php
@@ -26,13 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function jetpack_get_user_locale() {
 	_deprecated_function( __FUNCTION__, 'jetpack-6.6.0', 'get_user_locale' );
-	$locale = get_locale();
-
-	if ( function_exists( 'get_user_locale' ) ) {
-		$locale = get_user_locale();
-	}
-
-	return $locale;
+	return get_user_locale();
 }
 
 /**

--- a/functions.global.php
+++ b/functions.global.php
@@ -20,13 +20,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Set the admin language, based on user language.
  *
  * @since 4.5.0
+ * @deprecated 6.6.0 Use Core function instead.
  *
  * @return string
- *
- * @todo Remove this function when WordPress 4.8 is released
- * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
  */
 function jetpack_get_user_locale() {
+	_deprecated_function( __FUNCTION__, 'jetpack-6.6.0', 'get_user_locale' );
 	$locale = get_locale();
 
 	if ( function_exists( 'get_user_locale' ) ) {

--- a/modules/after-the-deadline/proxy.php
+++ b/modules/after-the-deadline/proxy.php
@@ -84,12 +84,8 @@ function AtD_redirect_call() {
 
 	$user = wp_get_current_user();
 
-	$atd_lang = get_locale();
+	$atd_lang = get_user_locale( $user->ID );
 
-	// If we're on WPCOM, this function should be available.
-	if ( function_exists( 'get_user_locale' ) ) {
-		$atd_lang = get_user_locale( $user->ID );
-	}
 
 	if ( ! empty( $atd_lang ) ) {
 		if ( strpos($atd_lang, 'pt') !== false )

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1366,11 +1366,6 @@ class The_Neverending_Home_Page {
 			$results['type'] = 'empty';
 		}
 
-		// This should be removed when WordPress 4.8 is released.
-		if ( version_compare( $wp_version, '4.7', '<' ) && is_customize_preview() ) {
-			$wp_customize->remove_preview_signature();
-		}
-
 		wp_send_json(
 			/**
 			 * Filter the Infinite Scroll results.

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -105,12 +105,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		$user->allowed_mime_types = get_allowed_mime_types( $user );
 		$user->allcaps = $this->get_real_user_capabilities( $user );
 
-		if ( function_exists( 'get_user_locale' ) ) {
-
-			// Only set the user locale if it is different from the site local
-			if ( get_locale() !== get_user_locale( $user->ID ) ) {
-				$user->locale = get_user_locale( $user->ID );
-			}
+		// Only set the user locale if it is different from the site local
+		if ( get_locale() !== get_user_locale( $user->ID ) ) {
+			$user->locale = get_user_locale( $user->ID );
 		}
 
 		return $user;

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -614,7 +614,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function get_user_locale( $user_id ) {
-		return jetpack_get_user_locale( $user_id );
+		return get_user_locale( $user_id );
 	}
 
 	public function get_allowed_mime_types( $user_id ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -189,10 +189,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$user = $this->server_replica_storage->get_user( $user_id );
 		$this->assertEquals( get_allowed_mime_types( $user_id ), $this->server_replica_storage->get_allowed_mime_types( $user_id ) );
 
-		if ( function_exists( 'get_user_locale' ) ) {
-			$this->assertEquals( get_user_locale( $user_id ), $this->server_replica_storage->get_user_locale( $user_id ) );
-			$this->assertNull( $this->server_replica_storage->get_user_locale( $first_user_id ) );
-		}
+		$this->assertEquals( get_user_locale( $user_id ), $this->server_replica_storage->get_user_locale( $user_id ) );
+		$this->assertNull( $this->server_replica_storage->get_user_locale( $first_user_id ) );
+
 		// Lets make sure that we don't send users passwords around.
 		$this->assertFalse( isset( $user->data->user_pass ) );
 	}


### PR DESCRIPTION
Updates #10099 

#### Changes proposed in this Pull Request:

* Remove functionality needed prior to WordPress 4.8

#### Testing instructions:

* Verify that Infinite Scroll does not cause issues when previewing via the Customizer.
* Ensure Admin Pages are still properly translated when a user's language is not English.