### PR TITLE
Geolocation: only enqueue dashicons when necessary.

### DIFF
--- a/modules/geo-location/class.jetpack-geo-location.php
+++ b/modules/geo-location/class.jetpack-geo-location.php
@@ -33,6 +33,15 @@
 class Jetpack_Geo_Location {
 	private static $instance;
 
+	/**
+	 * Whether dashicons are enqueued.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @var bool
+	 */
+	private static $style_enqueued = false;
+
 	public static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_Geo_Location();
@@ -52,7 +61,6 @@ class Jetpack_Geo_Location {
 		add_action( 'init', array( $this, 'wordpress_init' ) );
 		add_action( 'wp_head', array( $this, 'wp_head' ) );
 		add_filter( 'the_content', array( $this, 'the_content_microformat' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		$this->register_rss_hooks();
 	}
@@ -150,6 +158,12 @@ class Jetpack_Geo_Location {
 
 		if ( ! $meta_values['is_public'] ) {
 			return;
+		}
+
+		if ( ! self::$style_enqueued ) {
+			// only enqueue scripts and styles when needed.
+			self::enqueue_scripts();
+			self::$style_enqueued = true;
 		}
 
 		echo "\n<!-- Jetpack Geo-location Tags -->\n";
@@ -262,7 +276,7 @@ class Jetpack_Geo_Location {
 	/**
 	 * Enqueue CSS for rendering post flair with geo-location.
 	 */
-	public function enqueue_scripts() {
+	private static function enqueue_scripts() {
 		wp_enqueue_style( 'dashicons' );
 	}
 


### PR DESCRIPTION
Fixes #10089

#### Changes proposed in this Pull Request:

Only enqueue the dashicons when we need them, when the icon must be displayed on the page, and only once.

#### Testing instructions:

1. Check out this branch.
2. Go to https://wordpress.com
3. Pick your site, and start writing a new post. Add a location to your post thanks to the option in the sidebar.
4. In your theme or in a functionality plugin, add the following:
```php
function jeherve_enable_geo(){
       	add_theme_support( 'jetpack-geo-location' );
}
add_action( 'after_setup_theme', 'jeherve_enable_geo' );
```
5. Make sure the little location icon appears alongside the post location when you view that post you just wrote.
6. Make sure the dashicons.css file is not loaded on your home page or on any other page, when logged out of your admin account.
7. Make sure there are no errors in your logs.

#### Proposed changelog entry for your changes:
* Geo Location: only enqueue Dashicons when necessary.