### PR TITLE
Responsive Videos: avoid notice when param is not given.

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -61,11 +61,11 @@ function jetpack_responsive_videos_embed_html( $html ) {
 }
 
 /**
- * Check if oEmbed is YouTube or Vimeo before wrapping.
+ * Check if oEmbed is a `$video_patterns` provider video before wrapping.
  *
  * @return string
  */
-function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
+function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url = null ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 		return $html;
 	}


### PR DESCRIPTION
Fixes #3048

#### Changes proposed in this Pull Request:

Avoid PHP notice when param is not given.

This was already fixed in #3243, but got reverted by mistake in ab7f2e0d3619bfc483723727bb427656e1581898

#### Testing instructions:

1. Add the following to your theme's functions.php file or to a functionality plugin:
```php
function jeherve_enable_resp() {
       	add_theme_support( 'jetpack-responsive-videos' );
}
add_action( 'after_setup_theme', 'jeherve_enable_resp' );
```
2. Add a few videos from YouTube or Vimeo to your posts. 
3. View your site on a mobile device.
4. Make sure you do not see any PHP notices. 

#### Proposed changelog entry for your changes:
Responsive Videos: avoid PHP notice.