### PR TITLE
Simple Payments: Stop contributors from creating inaccessible buttons with a "pending" post status.

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -351,7 +351,7 @@ class Jetpack_Simple_Payments {
 			'edit_post'             => 'edit_posts',
 			'read_post'             => 'read_private_posts',
 			'delete_post'           => 'delete_posts',
-			'edit_posts'            => 'edit_posts',
+			'edit_posts'            => 'publish_posts',
 			'edit_others_posts'     => 'edit_others_posts',
 			'publish_posts'         => 'publish_posts',
 			'read_private_posts'    => 'read_private_posts',


### PR DESCRIPTION
When Contributors attempt to add a Simple Payments button, the API call (to `/sites/:site/posts/new`) will succeed, creating a new button post entry in the site's database. However, this post (of type `jp_pay_product`) will have a `pending` status, due to [custom post type handling in the API](https://github.com/Automattic/jetpack/blob/master/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php#L216). The button insert will fail in the Calypso UI, and site admins won't be able to interact with these zombie buttons since we explicitly list only published buttons in the UI.

Rather than have buttons of multiple possible statuses in the database, and rather than interfering with the current handling of all CPTs  in the API, this PR bumps the `edit_posts` capability for `jp_pay_product` to `publish_posts`, making only Authors and above capable of creating Simple Payment buttons; Contributors will now get a failed permissions response, and no button post will be added to the site database.

**Testing**

* Add a contributor to a Jetpack site with a business plan (so that Simple Payments are available).
* Using the contributor, add a Simple Payments button in Calypso; notice the UI shows an error, but devtools reveals the successful creation of the post.
* Sandbox the API and apply this patch (the dotcom patch).
* Attempt to add a button again, and note the API response is `error: "unauthorized"`
* With a user that is an author or higher, verify you can still successfully add a Simple Payment button with the patch applied.