### PR TITLE
Sharing: do not record stats if the stats module is disabled.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -613,9 +613,10 @@ function sharing_add_footer() {
 
 		wp_enqueue_script( 'sharing-js' );
 		$sharing_js_options = array(
-			'lang'   => get_base_recaptcha_lang_code(),
+			'lang'            => get_base_recaptcha_lang_code(),
 			/** This filter is documented in modules/sharedaddy/sharing-service.php */
-			'counts' => apply_filters( 'jetpack_sharing_counts', true ),
+			'counts'          => apply_filters( 'jetpack_sharing_counts', true ),
+			'is_stats_active' => Jetpack::is_module_active( 'stats' ),
 		);
 		wp_localize_script( 'sharing-js', 'sharing_js_options', $sharing_js_options );
 	}

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -42,7 +42,9 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 						jQuery.getScript( service_request );
 					}
 
-					WPCOMSharing.bump_sharing_count_stat( service );
+					if ( sharing_js_options.is_stats_active ) {
+						WPCOMSharing.bump_sharing_count_stat( service );
+					}
 				}
 
 				WPCOMSharing.done_urls[ id ] = true;


### PR DESCRIPTION
Fixes #9678

#### Changes proposed in this Pull Request:

When the Stats module is disabled, do not use any tracking pixel on pages using sharing buttons.

#### Testing instructions:

1. Enable Sharing and Stats.
2. Add a Facebook button to your posts.
3. Load a post and check requests in the network tab; you will see 2 requests to `pixel.wp.com`; one for regular stats and one for sharing.
4. Disable the Stats module (under the old Module settings screen)
5. Reload the post's page; you should see no `pixel.wp.com` request.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

- Sharing: do not record stats if the stats module is disabled.