### PR TITLE
VideoPress: avoid duplicate rel attributes.

### DIFF
--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -292,7 +292,7 @@ class VideoPress_Player {
 		$html .= '<input type="submit" value="' . __( 'Submit', 'jetpack' ) . '" style="cursor:pointer;border-radius: 1em;border:1px solid #333;background-color:#333;background:-webkit-gradient( linear, left top, left bottom, color-stop(0.0, #444), color-stop(1, #111) );background:-moz-linear-gradient(center top, #444 0%, #111 100%);font-size:13px;padding:4px 10px 5px;line-height:1em;vertical-align:top;color:white;text-decoration:none;margin:0" />';
 
 		$html .= '</fieldset>';
-		$html .= '<p style="padding-top:20px;padding-bottom:60px;text-align:' . $text_align . ';"><a rel="nofollow" href="http://videopress.com/" rel="noopener noreferrer" target="_blank" style="color:rgb(128,128,128);text-decoration:underline;font-size:15px">' . __( 'More information', 'jetpack' ) . '</a></p>';
+		$html .= '<p style="padding-top:20px;padding-bottom:60px;text-align:' . $text_align . ';"><a rel="nofollow noopener noreferrer" href="http://videopress.com/" target="_blank" style="color:rgb(128,128,128);text-decoration:underline;font-size:15px">' . __( 'More information', 'jetpack' ) . '</a></p>';
 
 		$html .= '</div>';
 		return $html;
@@ -341,7 +341,7 @@ class VideoPress_Player {
 			$html .= esc_attr( $this->video->title );
 		$html .= '" src="' . $thumbnail . '" width="' . $this->video->calculated_width . '" height="' . $this->video->calculated_height . '" /></div>';
 		if ( isset( $this->options['freedom'] ) && $this->options['freedom'] === true )
-			$html .= '<p class="robots-nocontent">' . sprintf( __( 'You do not have sufficient <a rel="nofollow" href="%s" rel="noopener noreferrer" target="_blank">freedom levels</a> to view this video. Support free software and upgrade.', 'jetpack' ), 'http://www.gnu.org/philosophy/free-sw.html' ) . '</p>';
+			$html .= '<p class="robots-nocontent">' . sprintf( __( 'You do not have sufficient <a rel="nofollow noopener noreferrer" href="%s" target="_blank">freedom levels</a> to view this video. Support free software and upgrade.', 'jetpack' ), 'http://www.gnu.org/philosophy/free-sw.html' ) . '</p>';
 		elseif ( isset( $this->video->title ) )
 			$html .= '<p>' . esc_html( $this->video->title ) . '</p>';
 		$html .= '</video>';
@@ -795,7 +795,7 @@ class VideoPress_Player {
 		foreach ( $this->get_flash_parameters() as $attribute => $value ) {
 			$flash_params .= '<param name="' . esc_attr( $attribute ) . '" value="' . esc_attr( $value ) . '" />';
 		}
-		$flash_help = sprintf( __( 'This video requires <a rel="nofollow" href="%s" rel="noopener noreferrer" target="_blank">Adobe Flash</a> for playback.', 'jetpack' ), 'http://www.adobe.com/go/getflashplayer');
+		$flash_help = sprintf( __( 'This video requires <a rel="nofollow noopener noreferrer" href="%s" target="_blank">Adobe Flash</a> for playback.', 'jetpack' ), 'http://www.adobe.com/go/getflashplayer');
 		$flash_player_url = esc_url( $this->video->players->swf->url, array( 'http', 'https' ) );
 		$description = '';
 		if ( isset( $this->video->title ) ) {


### PR DESCRIPTION
Fixes #9999

#### Changes proposed in this Pull Request:

Remove duplicate `rel` attributes added in #9644

#### Testing instructions:

Check #9644 for any links including a duplicate set of `rel` attributes.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
VideoPress: avoid duplicate rel attributes in links.