### PR TITLE
Tonesque: fix typo in function's comment.

### DIFF
--- a/_inc/lib/tonesque.php
+++ b/_inc/lib/tonesque.php
@@ -86,7 +86,7 @@ class Tonesque {
 	 *
 	 * Construct object from image.
 	 *
-	 * @param optional $type (hex, rgb, hsl)
+	 * @param optional $type (hex, rgb, hsv)
 	 * @return color as a string formatted as $type
 	 *
  	 */


### PR DESCRIPTION
Fixes #10124

#### Changes proposed in this Pull Request:

The color function accepts a type parameter that can be one of the following strings: hex, rgb, or hsv.


#### Testing instructions:

Not much to test here. You can check the `get_color` function downer in the same file, to see what types can be used.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Tonesque: fix typo in function's comment.