### PR TITLE
Open Graph: Remove unused arg

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -272,7 +272,10 @@ function jetpack_og_tags() {
  *
  * @return array The source ('src'), 'width', and 'height' of the image.
  */
-function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) {
+function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null ) {
+	if ( ! empty( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '6.6.0' );
+	}
 	$image = array();
 
 	if ( is_singular() && ! is_home() ) {

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -280,7 +280,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 
 	if ( is_singular() && ! is_home() ) {
 		// Grab obvious image if post is an attachment page for an image
-		if ( is_attachment( get_the_ID() ) && 'image' == substr( get_post_mime_type(), 0, 5 ) ) {
+		if ( is_attachment( get_the_ID() ) && 'image' === substr( get_post_mime_type(), 0, 5 ) ) {
 			$image['src'] = wp_get_attachment_url( get_the_ID() );
 		}
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -261,7 +261,18 @@ function jetpack_og_tags() {
 	echo $og_output;
 }
 
-function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { // Facebook requires thumbnails to be a minimum of 200x200
+/**
+ * Returns an image used in social shares.
+ *
+ * @since 2.0.0
+ *
+ * @param int $width Minimum width for the image. Default is 200 based on Facebook's requirement.
+ * @param int $height Minimum height for the image. Default is 200 based on Facebook's requirement.
+ * @param null $deprecated Deprecated.
+ *
+ * @return array The source ('src'), 'width', and 'height' of the image.
+ */
+function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) {
 	$image = array();
 
 	if ( is_singular() && ! is_home() ) {

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -266,8 +266,8 @@ function jetpack_og_tags() {
  *
  * @since 2.0.0
  *
- * @param int $width Minimum width for the image. Default is 200 based on Facebook's requirement.
- * @param int $height Minimum height for the image. Default is 200 based on Facebook's requirement.
+ * @param int  $width Minimum width for the image. Default is 200 based on Facebook's requirement.
+ * @param int  $height Minimum height for the image. Default is 200 based on Facebook's requirement.
  * @param null $deprecated Deprecated.
  *
  * @return array The source ('src'), 'width', and 'height' of the image.
@@ -298,7 +298,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 			}
 		}
 	} elseif ( is_author() ) {
-		$author = get_queried_object();
+		$author       = get_queried_object();
 		$image['src'] = get_avatar_url( $author->user_email, array(
 			'size' => $width,
 		) );
@@ -317,28 +317,28 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 	// Second fall back, Site Logo.
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_logo' ) && jetpack_has_site_logo() ) ) {
 		$image_id = jetpack_get_site_logo( 'id' );
-		$logo = wp_get_attachment_image_src( $image_id, 'full' );
+		$logo     = wp_get_attachment_image_src( $image_id, 'full' );
 		if (
 			isset( $logo[0], $logo[1], $logo[2] )
 			&& ( _jetpack_og_get_image_validate_size( $logo[1], $logo[2], $width, $height ) )
 		) {
-			$image['src']     = $logo[0];
-			$image['width']   = $logo[1];
-			$image['height']  = $logo[2];
+			$image['src']    = $logo[0];
+			$image['width']  = $logo[1];
+			$image['height'] = $logo[2];
 		}
 	}
 
 	// Third fall back, Core Site Icon, if valid in size. Added in WP 4.3.
 	if ( empty( $image ) && ( function_exists( 'has_site_icon' ) && has_site_icon() ) ) {
 		$image_id = get_option( 'site_icon' );
-		$icon = wp_get_attachment_image_src( $image_id, 'full' );
+		$icon     = wp_get_attachment_image_src( $image_id, 'full' );
 		if (
 			isset( $icon[0], $icon[1], $icon[2] )
 			&& ( _jetpack_og_get_image_validate_size( $icon[1], $icon[2], $width, $height ) )
 		) {
-			$image['src']     = $icon[0];
-			$image['width']   = $icon[1];
-			$image['height']  = $icon[2];
+			$image['src']    = $icon[0];
+			$image['width']  = $icon[1];
+			$image['height'] = $icon[2];
 		}
 	}
 


### PR DESCRIPTION
While researching a tangential issue, I realized there's an arg that's never used in `jetpack_og_get_image`. In looking at the history, it was never used in Jetpack ever. The parent command from the WP.com side once used it, but was removed prior to Jetpack gaining OG.

#### Changes proposed in this Pull Request:

* Deprecates argument for `jetpack_og_get_image`

#### Testing instructions:

* Ensure a deprecated arg warning is thrown when WP_DEBUG is true.

#### Proposed changelog entry:

None.