### PR TITLE
Development: Add extension to .eslintrc

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -48,7 +48,7 @@ exclude_paths:
   - "**.travis.yml"
   - "**.npmrc"
   - "**.gitignore"
-  - "**.eslintrc"
+  - "**.eslintrc.js"
   - "**.editorconfig"
   - "**.pot"
   - "**.txt"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"parser": "babel-eslint",
 	"extends": "wpcalypso/react-a11y",
 	"env": {

--- a/.svnignore
+++ b/.svnignore
@@ -1,4 +1,4 @@
-.eslintrc
+.eslintrc.js
 .eslintignore
 .git
 .gitignore
@@ -9,7 +9,6 @@
 .npmrc
 .nvmrc
 .eslines.json
-.eslintrc
 .eslintcache
 readme.md
 .github

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -148,7 +148,7 @@ $ yarn test-client -R 'my_reporter'
 We strongly recommend that you install tools to review your code in your IDE. It will make it easier for you to notice any missing documentation or coding standards you should respect. Most IDEs display warnings and notices inside the editor, making it even easier.
 
 - You can find [Code Sniffer rules for WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation) here. Once you've installed these rulesets, you can [follow the instructions here](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use) to configure your IDE.
-- For JavaScript, we recommend installing ESLint. Most IDEs come with an ESLint plugin that you can use. Jetpack includes a `.eslintrc` file that defines our coding standards.
+- For JavaScript, we recommend installing ESLint. Most IDEs come with an ESLint plugin that you can use. Jetpack includes a `.eslintrc.js` file that defines our coding standards.
 
 ### Linting Jetpack's PHP
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
     "docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
     "docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
-    "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc",
+    "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc.js",
     "php:5.2-compatibility": "composer php:5.2-compatibility",
     "php:lint": "composer php:lint",
     "test-adminpage": "yarn test-client && yarn test-gui",

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -61,7 +61,7 @@ function create_release_gitignore {
 
 # Remove stuff from .svnignore for releases
 function modify_svnignore {
-    awk '!/.eslintrc/' .svnignore > temp && mv temp .svnignore
+    awk '!/.eslintrc.js/' .svnignore > temp && mv temp .svnignore
     awk '!/.eslintignore/' .svnignore > temp && mv temp .svnignore
     git commit .svnignore -m "Updated .svnignore"
 }


### PR DESCRIPTION
.eslintrc without extension is deprecated (https://eslint.org/docs/user-guide/configuring#configuration-file-formats).

The changes should not conflict with current development, only make it future-proof in case linters remove support for .eslintrc without extension.

#### Changes proposed in this Pull Request:

* Add .js extension to .eslintrc
* Change .eslintrc content to be a js module export, given that comments are not allowed in JSON
* Change references in other files to new file name

#### Testing instructions:

* No change in current testing structure
