### PR TITLE
Sync: send gutenberg info when syncing posts

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -280,6 +280,23 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$this->previous_status[ $post->ID ] = $old_status;
 	}
 
+	/*
+	 * When publishing or updating a post, the Gutenberg editor sends two requests:
+	 * 1. sent to WP REST API endpoint `wp-json/wp/v2/posts/$id`
+	 * 2. sent to wp-admin/post.php `?post=$id&action=edit&classic-editor=1&meta_box=1`
+	 *
+	 * The 2nd request is to update post meta, which is not supported on WP REST API.
+	 * When syncing post data, we will include if this was a meta box update.
+	 */
+	public function is_gutenberg_meta_box_update() {
+		return (
+			isset( $_POST['action'], $_GET['classic-editor'], $_GET['meta_box'] ) &&
+			'editpost' === $_POST['action'] &&
+			'1' === $_GET['classic-editor'] &&
+			'1' === $_GET['meta_box']
+		);
+	}
+
 	public function wp_insert_post( $post_ID, $post = null, $update = null ) {
 		if ( ! is_numeric( $post_ID ) || is_null( $post ) ) {
 			return;
@@ -301,7 +318,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$state = array(
 			'is_auto_save' => (bool) Jetpack_Constants::get_constant( 'DOING_AUTOSAVE' ),
 			'previous_status' => $previous_status,
-			'just_published' => $just_published
+			'just_published' => $just_published,
+			'is_gutenberg_meta_box_update' => $this->is_gutenberg_meta_box_update(),
 		);
 		/**
 		 * Filter that is used to add to the post flags ( meta data ) when a post gets published

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -293,7 +293,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			isset( $_POST['action'], $_GET['classic-editor'], $_GET['meta_box'] ) &&
 			'editpost' === $_POST['action'] &&
 			'1' === $_GET['classic-editor'] &&
-			'1' === $_GET['meta_box']
+			'1' === $_GET['meta_box'] &&
+			is_plugin_active( 'gutenberg/gutenberg.php' )
 		);
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -294,7 +294,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			'editpost' === $_POST['action'] &&
 			'1' === $_GET['classic-editor'] &&
 			'1' === $_GET['meta_box'] &&
-			is_plugin_active( 'gutenberg/gutenberg.php' )
+			Jetpack::is_gutenberg_available()
 		);
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -122,40 +122,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 
 		$this->assertEquals( false, $event->args[3]['is_gutenberg_meta_box_update'] );
-
-		$this->post->post_content = "Updated using Gutenberg editor";
-		$plugins = is_multisite() ?
-			get_site_option( 'active_sitewide_plugins') :
-			get_option( 'active_plugins' );
-
-		$updated_plugins = array_merge( $plugins, array( 'gutenberg/gutenberg.php' ) );
-
-		if ( is_multisite() ) {
-			update_site_option( 'active_sitewide_plugins', $updated_plugins );
-		} else {
-			update_option( 'active_plugins', $updated_plugins  );
-		}
-
-		$_POST['action'] = 'editpost';
-		$_GET['classic-editor'] = '1';
-		$_GET['meta_box'] = '1';
-
-		wp_update_post( $this->post );
-
-		$this->sender->do_sync();
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
-
-		$this->assertEquals( true, $event->args[3]['is_gutenberg_meta_box_update'] );
-
-		unset( $_POST['action'] );
-		unset( $_GET['classic-editor'] );
-		unset( $_GET['meta_box'] );
-
-		if ( is_multisite() ) {
-			update_site_option( 'active_sitewide_plugins', $plugins );
-		} else {
-			update_option( 'active_plugins', $plugins  );
-		}
 	}
 
 	public function test_update_post_updates_data() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -113,6 +113,33 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->post->ID, $event->args[0] );
 	}
 
+	public function test_update_post_includes_gutenberg_info_in_state() {
+		$this->post->post_content = "Updated using classic editor";
+
+		wp_update_post( $this->post );
+
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event();
+
+		$this->assertEquals( false, $event->args[3]['is_gutenberg_meta_box_update'] );
+
+		$this->post->post_content = "Updated using Gutenberg editor";
+		$_POST['action'] = 'editpost';
+		$_GET['classic-editor'] = '1';
+		$_GET['meta_box'] = '1';
+
+		wp_update_post( $this->post );
+
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event();
+
+		$this->assertEquals( true, $event->args[3]['is_gutenberg_meta_box_update'] );
+
+		unset( $_POST['action'] );
+		unset( $_GET['classic-editor'] );
+		unset( $_GET['meta_box'] );
+	}
+
 	public function test_update_post_updates_data() {
 		$this->post->post_content = "foo bar";
 


### PR DESCRIPTION
This PR, specifically will detect if a post is being saved via Gutenberg's 2-request-post-saving mechanism, which sends 1 request to save the post, and one request to save stuff related to meta boxes.

The aim is to prevent from double-syncing stuff upstream, causing an issue where 2 events appear in the activity log.

To test:
- Apply this PR to a test site
- Publish and Update posts using the gutenberg editor, and with the classic editor
- Observe the sync data flowing up-stream
- Does `is_gutenberg_meta_box_update` appear as expected?

Before merging:
- Test and merge up-stream equivalent: D18168-code