### PR TITLE
Gutenberg: Add a Related Posts block

### DIFF
--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -66,6 +66,9 @@ class RelatedPostsComponent extends React.Component {
 						link: 'https://jetpack.com/support/related-posts/',
 					} }
 				>
+					<p className="jp-form-setting-explanation">
+						{ __( 'The following settings will impact all related posts on your site, except for those you created via the block editor:' ) }
+					</p>
 					<ModuleToggle
 						slug="related-posts"
 						disabled={ unavailableInDevMode }

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -95,7 +95,7 @@ class Jetpack_Related_Posts_Customize {
 		// If selective refresh is available, implement it.
 		if ( isset( $wp_customize->selective_refresh ) ) {
 			$wp_customize->selective_refresh->add_partial( "$this->prefix", array(
-				'selector'            => '.jp-relatedposts',
+				'selector'            => '.jp-relatedposts:not(.jp-relatedposts-block)',
 				'settings'            => $selective_options,
 				'render_callback'     => __CLASS__ . '::render_callback',
 				'container_inclusive' => false,

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -144,7 +144,7 @@ class Jetpack_Related_Posts_Customize {
 	 * @return bool
 	 */
 	public static function is_single() {
-		if ( self::contains_related_posts_block() ) ) {
+		if ( self::contains_related_posts_block() ) {
 			return false;
 		}
 		return is_single();

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -115,23 +115,33 @@ class Jetpack_Related_Posts_Customize {
 
 	/**
 	 * Check that we're in a single post view.
+	 * Will return `false` if the current post contains a Related Posts block,
+	 * because in that case we want to hide the Customizer controls.
 	 *
 	 * @since 4.4.0
 	 *
 	 * @return bool
 	 */
 	public static function is_single() {
+		if ( has_block( 'jetpack/related-posts' ) ) {
+			return false;
+		}
 		return is_single();
 	}
 
 	/**
 	 * Check that we're not in a single post view.
+	 * Will return `false` if the current post contains a Related Posts block,
+	 * because in that case we want to hide the Customizer controls.
 	 *
 	 * @since 4.4.0
 	 *
 	 * @return bool
 	 */
 	public static function is_not_single() {
+		if ( has_block( 'jetpack/related-posts' ) ) {
+			return false;
+		}
 		return ! is_single();
 	}
 

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -114,6 +114,27 @@ class Jetpack_Related_Posts_Customize {
 	}
 
 	/**
+	 * Check whether the current post contains a Related Posts block.
+	 * If we're on WP < 5.0, this automatically means it doesn't,
+	 * because block support is intrododuced in WP 5.0.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return bool
+	 */
+	public static function contains_related_posts_block() {
+		if ( ! function_exists( 'has_block' ) ) {
+			return false;
+		}
+
+		if ( has_block( 'jetpack/related-posts' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check that we're in a single post view.
 	 * Will return `false` if the current post contains a Related Posts block,
 	 * because in that case we want to hide the Customizer controls.
@@ -123,7 +144,7 @@ class Jetpack_Related_Posts_Customize {
 	 * @return bool
 	 */
 	public static function is_single() {
-		if ( has_block( 'jetpack/related-posts' ) ) {
+		if ( self::contains_related_posts_block() ) ) {
 			return false;
 		}
 		return is_single();
@@ -139,7 +160,7 @@ class Jetpack_Related_Posts_Customize {
 	 * @return bool
 	 */
 	public static function is_not_single() {
-		if ( has_block( 'jetpack/related-posts' ) ) {
+		if ( self::contains_related_posts_block() ) {
 			return false;
 		}
 		return ! is_single();

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -290,6 +290,8 @@ EOT;
 			return '';
 		}
 
+		remove_filter( 'the_content', array( $this, 'filter_add_target_to_dom' ), 40 );
+
 		ob_start();
 		?>
 		<div id="jp-relatedposts" class="jp-relatedposts jp-relatedposts-block" style="display: block;">

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -279,7 +279,7 @@ EOT;
 		$block_attributes = array(
 			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
 			'show_date' => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
-			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : true,
+			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : false,
 			'layout' => isset( $attributes['postLayout'] ) && $attributes['postLayout'] === 'list' ? $attributes['postLayout'] : 'grid',
 			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -276,13 +276,11 @@ EOT;
 	 * @return string
 	 */
 	public function render_block( $attributes ) {
-		$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : __( 'Related', 'jetpack' );
 		$block_attributes = array(
 			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
 			'show_date' => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
 			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : true,
 			'layout' => isset( $attributes['postLayout'] ) && $attributes['postLayout'] === 'list' ? $attributes['postLayout'] : 'grid',
-			'headline' => $headline,
 			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
@@ -297,12 +295,6 @@ EOT;
 		ob_start();
 		?>
 		<div id="jp-relatedposts" class="jp-relatedposts" style="display: block;">
-			<?php if ( strlen( $headline ) > 0 ): ?>
-				<h3 class="jp-relatedposts-headline">
-					<em><?php echo esc_html( $headline ); ?></em>
-				</h3>
-			<?php endif; ?>
-
 			<div class="jp-relatedposts-items jp-relatedposts-items-visual jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
 				<?php foreach ( $related_posts as $index => $related_post ): 
 					$classes = array_filter( array(

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -80,7 +80,9 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init',  array( $this, 'rest_register_related_posts' ) );
 		}
 
-		jetpack_register_block( 'related-posts' );
+		jetpack_register_block( 'related-posts', array(
+			'render_callback' => array( $this, 'render_block' ),
+		) );
 	}
 
 	/**
@@ -253,22 +255,6 @@ EOT;
 	 * GUTENBERG BLOCK
 	 * ===============
 	 */
-
-	/**
-	 * Register the Related Posts Gutenberg block on server.
-	 *
-	 * @action init
-	 * @uses register_block_type
-	 * @return null
-	 */
-	public function register_block() {
-		register_block_type(
-			'a8c/related-posts',
-			array(
-				'render_callback' => array( $this, 'render_block' ),
-			)
-		);
-	}
 
 	/**
 	 * Render the related posts markup.

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -177,13 +177,18 @@ class Jetpack_RelatedPosts {
 
 	/**
 	 * Adds a target to the post content to load related posts into if a shortcode for it did not already exist.
+	 * Will skip adding the target if the post content contains a Related Posts block.
 	 *
 	 * @filter the_content
 	 * @param string $content
 	 * @returns string
 	 */
 	public function filter_add_target_to_dom( $content ) {
-		if ( !$this->_found_shortcode ) {
+		if ( function_exists( 'has_block' ) && has_block( 'jetpack/related-posts', $content ) ) {
+			return $content;
+		}
+
+		if ( ! $this->_found_shortcode ) {
 			$content .= "\n" . $this->get_target_html();
 		}
 
@@ -296,8 +301,6 @@ EOT;
 		if ( ! $related_posts ) {
 			return '';
 		}
-
-		remove_filter( 'the_content', array( $this, 'filter_add_target_to_dom' ), 40 );
 
 		ob_start();
 		?>

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -53,7 +53,6 @@ class Jetpack_RelatedPosts {
 	protected $_convert_charset;
 	protected $_previous_post_id;
 	protected $_found_shortcode = false;
-	protected $block_attributes = array();
 
 	/**
 	 * Constructor for Jetpack_RelatedPosts.
@@ -272,47 +271,101 @@ EOT;
 	}
 
 	/**
-	 * Overwrite the current related posts options and render the related posts shortcode.
+	 * Render the related posts markup.
 	 *
 	 * @return string
 	 */
 	public function render_block( $attributes ) {
-		$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : esc_html__( 'Related', 'jetpack' );
+		$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : __( 'Related', 'jetpack' );
 		$block_attributes = array(
-			'enabled' => true,
-			'show_headline' => strlen( $headline ) > 0,
 			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
 			'show_date' => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
 			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : true,
-			'layout' => ! empty( $attributes['postLayout'] ) ? $attributes['postLayout'] : 'grid',
+			'layout' => isset( $attributes['postLayout'] ) && $attributes['postLayout'] === 'list' ? $attributes['postLayout'] : 'grid',
 			'headline' => $headline,
 			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
-		$this->set_block_attributes( $block_attributes );
+		$related_posts = $this->get_for_post_id( get_the_ID(), array(
+			'size' => $block_attributes['size'],
+		) );
 
-		add_filter( 'jetpack_relatedposts_filter_options', array( $this, 'get_block_attributes' ) );
+		if ( ! $related_posts ) {
+			return '';
+		}
 
-		return '[' . self::SHORTCODE . ']';
-	}
+		ob_start();
+		?>
+		<div id="jp-relatedposts" class="jp-relatedposts" style="display: block;">
+			<?php if ( strlen( $headline ) > 0 ): ?>
+				<h3 class="jp-relatedposts-headline">
+					<em><?php echo esc_html( $headline ); ?></em>
+				</h3>
+			<?php endif; ?>
 
-	/**
-	 * Returns the current Gutenberg block attributes
-	 *
-	 * @return array
-	 */
-	public function get_block_attributes() {
-		return $this->block_attributes;
-	}
+			<div class="jp-relatedposts-items jp-relatedposts-items-visual jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
+				<?php foreach ( $related_posts as $index => $related_post ): 
+					$classes = array_filter( array(
+						'jp-relatedposts-post',
+						'jp-relatedposts-post' . $index,
+						! empty( $block_attributes['show_thumbnails'] ) ? 'jp-relatedposts-post-thumbs' : '',
+					) );
+					?>
+					<div
+						class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
+						data-post-id="<?php echo esc_attr( $related_post['id'] ); ?>"
+						data-post-format="<?php echo esc_attr( ! empty( $related_post['format'] ) ? $related_post['format'] : 'false' ); ?>"
+					>
+						<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ): ?>
+							<a class="jp-relatedposts-post-a"
+								href="<?php echo esc_url( $related_post['url'] ) ?>"
+								title="<?php echo esc_attr( $related_post['title'] ) ?>"
+								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
+								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
+								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
+							>
+								<img class="jp-relatedposts-post-img"
+									src="<?php echo esc_url( $related_post['img']['src'] ) ?>"
+									width="<?php echo esc_attr( $related_post['img']['width'] ) ?>"
+									alt="<?php echo esc_attr( $related_post['title'] ) ?>"
+								/>
+							</a>
+						<?php endif; ?>
 
-	/**
-	 * Updates the current Gutenberg block attributes
-	 *
-	 * @param $attributes string
-	 * @return void
-	 */
-	public function set_block_attributes( $attributes = array() ) {
-		$this->block_attributes = $attributes;
+						<h4 class="jp-relatedposts-post-title">
+							<a
+								class="jp-relatedposts-post-a"
+								href="<?php echo esc_url( $related_post['url'] ) ?>"
+								title="<?php echo esc_attr( $related_post['title'] ) ?>"
+								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
+								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
+								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
+							>
+								<?php echo esc_html( $related_post['title'] ); ?>
+							</a>
+						</h4>
+
+						<p class="jp-relatedposts-post-excerpt"><?php echo esc_html( $related_post['excerpt'] ); ?></p>
+
+						<?php if ( $block_attributes['show_date'] ): ?>
+							<p class="jp-relatedposts-post-date" style="display: block;">
+								<?php echo esc_html( $related_post['date'] ); ?>
+							</p>
+						<?php endif; ?>
+
+						<?php if ( $block_attributes['show_context'] ): ?>
+							<p class="jp-relatedposts-post-context">
+								<?php echo esc_html( $related_post['context'] ); ?>
+							</p>
+						<?php endif; ?>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
+		<?php
+		$html = ob_get_clean();
+
+		return $html;
 	}
 
 	/**

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -267,9 +267,9 @@ EOT;
 	 */
 	public function render_block( $attributes ) {
 		$block_attributes = array(
-			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
+			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) && $attributes['displayThumbnails'],
 			'show_date'       => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
-			'show_context'    => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : false,
+			'show_context'    => isset( $attributes['displayContext'] ) && $attributes['displayContext'],
 			'layout'          => isset( $attributes['postLayout'] ) && 'list' === $attributes['postLayout'] ? $attributes['postLayout'] : 'grid',
 			'size'            => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -292,7 +292,7 @@ EOT;
 
 		ob_start();
 		?>
-		<div id="jp-relatedposts" class="jp-relatedposts" style="display: block;">
+		<div id="jp-relatedposts" class="jp-relatedposts jp-relatedposts-block" style="display: block;">
 			<div class="jp-relatedposts-items jp-relatedposts-items-visual jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
 				<?php foreach ( $related_posts as $index => $related_post ): 
 					$classes = array_filter( array(

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -295,7 +295,7 @@ EOT;
 		ob_start();
 		?>
 		<div id="jp-relatedposts" class="jp-relatedposts jp-relatedposts-block" style="display: block;">
-			<div class="jp-relatedposts-items jp-relatedposts-items-visual jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
+			<div class="jp-relatedposts-items <?php echo $block_attributes['show_thumbnails'] ? 'jp-relatedposts-items-visual ' : ''; ?>jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
 				<?php foreach ( $related_posts as $index => $related_post ): 
 					$classes = array_filter( array(
 						'jp-relatedposts-post',

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20150408';
+	const VERSION = '20181213';
 	const SHORTCODE = 'jetpack-related-posts';
 	private static $instance = null;
 	private static $instance_raw = null;

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -300,6 +300,10 @@ EOT;
 						'jp-relatedposts-post' . $index,
 						! empty( $block_attributes['show_thumbnails'] ) ? 'jp-relatedposts-post-thumbs' : '',
 					) );
+					$title_attr = $related_post['title'];
+					if ( $related_post['excerpt'] !== '' ) {
+						$title_attr .= "\n\n" . $related_post['excerpt'];
+					}
 					?>
 					<div
 						class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
@@ -309,7 +313,7 @@ EOT;
 						<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ): ?>
 							<a class="jp-relatedposts-post-a"
 								href="<?php echo esc_url( $related_post['url'] ); ?>"
-								title="<?php echo esc_attr( $related_post['title'] ); ?>"
+								title="<?php echo esc_attr( $title_attr ); ?>"
 								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
 								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
 								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
@@ -317,7 +321,7 @@ EOT;
 								<img class="jp-relatedposts-post-img"
 									src="<?php echo esc_url( $related_post['img']['src'] ); ?>"
 									width="<?php echo esc_attr( $related_post['img']['width'] ); ?>"
-									alt="<?php echo esc_attr( $related_post['title'] ); ?>"
+									alt="<?php echo esc_attr( $title_attr ); ?>"
 								/>
 							</a>
 						<?php endif; ?>
@@ -326,7 +330,7 @@ EOT;
 							<a
 								class="jp-relatedposts-post-a"
 								href="<?php echo esc_url( $related_post['url'] ); ?>"
-								title="<?php echo esc_attr( $related_post['title'] ); ?>"
+								title="<?php echo esc_attr( $title_attr ); ?>"
 								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
 								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
 								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -77,12 +77,15 @@ class Jetpack_RelatedPosts {
 
 		// Add Related Posts to the REST API Post response.
 		if ( function_exists( 'register_rest_field' ) ) {
-			add_action( 'rest_api_init',  array( $this, 'rest_register_related_posts' ) );
+			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		jetpack_register_block( 'related-posts', array(
-			'render_callback' => array( $this, 'render_block' ),
-		) );
+		jetpack_register_block(
+			'related-posts',
+			array(
+				'render_callback' => array( $this, 'render_block' ),
+			)
+		);
 	}
 
 	/**
@@ -259,15 +262,16 @@ EOT;
 	/**
 	 * Render the related posts markup.
 	 *
+	 * @param array $attributes Block attributes.
 	 * @return string
 	 */
 	public function render_block( $attributes ) {
 		$block_attributes = array(
 			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
-			'show_date' => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
-			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : false,
-			'layout' => isset( $attributes['postLayout'] ) && $attributes['postLayout'] === 'list' ? $attributes['postLayout'] : 'grid',
-			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
+			'show_date'       => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
+			'show_context'    => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : false,
+			'layout'          => isset( $attributes['postLayout'] ) && 'list' === $attributes['postLayout'] ? $attributes['postLayout'] : 'grid',
+			'size'            => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
 		$excludes = array();
@@ -281,10 +285,13 @@ EOT;
 			$excludes = array_unique( array_filter( array_map( 'absint', $excludes ) ) );
 		}
 
-		$related_posts = $this->get_for_post_id( get_the_ID(), array(
-			'size' => $block_attributes['size'],
-			'exclude_post_ids' => $excludes,
-		) );
+		$related_posts = $this->get_for_post_id(
+			get_the_ID(),
+			array(
+				'size'             => $block_attributes['size'],
+				'exclude_post_ids' => $excludes,
+			)
+		);
 
 		if ( ! $related_posts ) {
 			return '';
@@ -296,14 +303,17 @@ EOT;
 		?>
 		<div id="jp-relatedposts" class="jp-relatedposts jp-relatedposts-block" style="display: block;">
 			<div class="jp-relatedposts-items <?php echo $block_attributes['show_thumbnails'] ? 'jp-relatedposts-items-visual ' : ''; ?>jp-relatedposts-<?php echo esc_attr( $block_attributes['layout'] ); ?>">
-				<?php foreach ( $related_posts as $index => $related_post ): 
-					$classes = array_filter( array(
-						'jp-relatedposts-post',
-						'jp-relatedposts-post' . $index,
-						! empty( $block_attributes['show_thumbnails'] ) ? 'jp-relatedposts-post-thumbs' : '',
-					) );
+				<?php
+				foreach ( $related_posts as $index => $related_post ) :
+					$classes = array_filter(
+						array(
+							'jp-relatedposts-post',
+							'jp-relatedposts-post' . $index,
+							! empty( $block_attributes['show_thumbnails'] ) ? 'jp-relatedposts-post-thumbs' : '',
+						)
+					);
 					$title_attr = $related_post['title'];
-					if ( $related_post['excerpt'] !== '' ) {
+					if ( '' !== $related_post['excerpt'] ) {
 						$title_attr .= "\n\n" . $related_post['excerpt'];
 					}
 					?>
@@ -312,7 +322,7 @@ EOT;
 						data-post-id="<?php echo esc_attr( $related_post['id'] ); ?>"
 						data-post-format="<?php echo esc_attr( ! empty( $related_post['format'] ) ? $related_post['format'] : 'false' ); ?>"
 					>
-						<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ): ?>
+						<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ) : ?>
 							<a class="jp-relatedposts-post-a"
 								href="<?php echo esc_url( $related_post['url'] ); ?>"
 								title="<?php echo esc_attr( $title_attr ); ?>"
@@ -343,13 +353,13 @@ EOT;
 
 						<p class="jp-relatedposts-post-excerpt"><?php echo esc_html( $related_post['excerpt'] ); ?></p>
 
-						<?php if ( $block_attributes['show_date'] ): ?>
+						<?php if ( $block_attributes['show_date'] ) : ?>
 							<p class="jp-relatedposts-post-date" style="display: block;">
 								<?php echo esc_html( $related_post['date'] ); ?>
 							</p>
 						<?php endif; ?>
 
-						<?php if ( $block_attributes['show_context'] ): ?>
+						<?php if ( $block_attributes['show_context'] ) : ?>
 							<p class="jp-relatedposts-post-context">
 								<?php echo esc_html( $related_post['context'] ); ?>
 							</p>

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -490,6 +490,7 @@ EOT;
 		$options = $this->get_options();
 
 		$ui_settings_template = <<<EOT
+<p class="description">%s</p>
 <ul id="settings-reading-relatedposts-customize">
 	<li>
 		<label><input name="jetpack_relatedposts[show_headline]" type="checkbox" value="1" %s /> %s</label>
@@ -511,6 +512,7 @@ EOT;
 EOT;
 		$ui_settings = sprintf(
 			$ui_settings_template,
+			esc_html__( 'The following settings will impact all related posts on your site, except for those you created via the block editor:', 'jetpack' ),
 			checked( $options['show_headline'], true, false ),
 			esc_html__( 'Highlight related content with a heading', 'jetpack' ),
 			checked( $options['show_thumbnails'], true, false ),

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -53,6 +53,7 @@ class Jetpack_RelatedPosts {
 	protected $_convert_charset;
 	protected $_previous_post_id;
 	protected $_found_shortcode = false;
+	protected $block_attributes = array();
 
 	/**
 	 * Constructor for Jetpack_RelatedPosts.
@@ -88,44 +89,6 @@ class Jetpack_RelatedPosts {
 	 * ACTIONS & FILTERS
 	 * =================
 	 */
-
-	/**
-	 * Register the Related Posts Gutenberg block on server.
-	 *
-	 * @action init
-	 * @uses add_settings_field, __, register_setting, add_action
-	 * @return null
-	 */
-	public function register_block() {
-		register_block_type(
-			'jetpack/related-posts',
-			array(
-				'render_callback' => array( $this, 'render_block' ),
-			)
-		);
-	}
-
-	public function render_block( $attributes ) {
-		$shortcode_atts = array(
-			'enabled' => true,
-			'show_headline' => isset( $attributes['headline'] ) && strlen( $attributes['headline'] ) > 0,
-			'show_thumbnails' => ! empty( $attributes['displayThumbnails'] ),
-			'show_date' => ! empty( $attributes['displayDate'] ),
-			'show_context' => ! empty( $attributes['displayContext'] ),
-			'layout' => ! empty( $attributes['postLayout'] ) ? $attributes['postLayout'] : 'grid',
-			'headline' => isset( $attributes['headline'] ) ? $attributes['headline'] : '',
-			'size' => ! empty( $attributes['postsToShow'] ) ? $attributes['postsToShow'] : 3,
-		);
-
-		$parsed_atts = array();
-		foreach ( $shortcode_atts as $attribute => $value ) {
-			$parsed_atts[] = $attribute . '="' . esc_attr( $value ) . '"';
-		}
-
-		$string_atts = implode( ' ', $parsed_atts );
-
-		return '[' . self::SHORTCODE . ' ' . $string_atts . ']';
-	}
 
 	/**
 	 * Add a checkbox field to Settings > Reading for enabling related posts.
@@ -284,6 +247,72 @@ EOT;
 			return '';
 		}
 		return "\n\n<!-- Jetpack Related Posts is not supported in this context. -->\n\n";
+	}
+
+	/**
+	 * ===============
+	 * GUTENBERG BLOCK
+	 * ===============
+	 */
+
+	/**
+	 * Register the Related Posts Gutenberg block on server.
+	 *
+	 * @action init
+	 * @uses register_block_type
+	 * @return null
+	 */
+	public function register_block() {
+		register_block_type(
+			'a8c/related-posts',
+			array(
+				'render_callback' => array( $this, 'render_block' ),
+			)
+		);
+	}
+
+	/**
+	 * Overwrite the current related posts options and render the related posts shortcode.
+	 *
+	 * @return string
+	 */
+	public function render_block( $attributes ) {
+		$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : esc_html__( 'Related', 'jetpack' );
+		$block_attributes = array(
+			'enabled' => true,
+			'show_headline' => strlen( $headline ) > 0,
+			'show_thumbnails' => isset( $attributes['displayThumbnails'] ) ? (bool) $attributes['displayThumbnails'] : false,
+			'show_date' => isset( $attributes['displayDate'] ) ? (bool) $attributes['displayDate'] : true,
+			'show_context' => isset( $attributes['displayContext'] ) ? (bool) $attributes['displayContext'] : true,
+			'layout' => ! empty( $attributes['postLayout'] ) ? $attributes['postLayout'] : 'grid',
+			'headline' => $headline,
+			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
+		);
+
+		$this->set_block_attributes( $block_attributes );
+
+		add_filter( 'jetpack_relatedposts_filter_options', array( $this, 'get_block_attributes' ) );
+
+		return '[' . self::SHORTCODE . ']';
+	}
+
+	/**
+	 * Returns the current Gutenberg block attributes
+	 *
+	 * @return array
+	 */
+	public function get_block_attributes() {
+		return $this->block_attributes;
+	}
+
+	/**
+	 * Updates the current Gutenberg block attributes
+	 *
+	 * @param $attributes string
+	 * @return void
+	 */
+	public function set_block_attributes( $attributes = array() ) {
+		$this->block_attributes = $attributes;
 	}
 
 	/**

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -318,16 +318,16 @@ EOT;
 					>
 						<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ): ?>
 							<a class="jp-relatedposts-post-a"
-								href="<?php echo esc_url( $related_post['url'] ) ?>"
-								title="<?php echo esc_attr( $related_post['title'] ) ?>"
+								href="<?php echo esc_url( $related_post['url'] ); ?>"
+								title="<?php echo esc_attr( $related_post['title'] ); ?>"
 								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
 								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
 								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
 							>
 								<img class="jp-relatedposts-post-img"
-									src="<?php echo esc_url( $related_post['img']['src'] ) ?>"
-									width="<?php echo esc_attr( $related_post['img']['width'] ) ?>"
-									alt="<?php echo esc_attr( $related_post['title'] ) ?>"
+									src="<?php echo esc_url( $related_post['img']['src'] ); ?>"
+									width="<?php echo esc_attr( $related_post['img']['width'] ); ?>"
+									alt="<?php echo esc_attr( $related_post['title'] ); ?>"
 								/>
 							</a>
 						<?php endif; ?>
@@ -335,8 +335,8 @@ EOT;
 						<h4 class="jp-relatedposts-post-title">
 							<a
 								class="jp-relatedposts-post-a"
-								href="<?php echo esc_url( $related_post['url'] ) ?>"
-								title="<?php echo esc_attr( $related_post['title'] ) ?>"
+								href="<?php echo esc_url( $related_post['url'] ); ?>"
+								title="<?php echo esc_attr( $related_post['title'] ); ?>"
 								rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
 								data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
 								data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -90,6 +90,44 @@ class Jetpack_RelatedPosts {
 	 */
 
 	/**
+	 * Register the Related Posts Gutenberg block on server.
+	 *
+	 * @action init
+	 * @uses add_settings_field, __, register_setting, add_action
+	 * @return null
+	 */
+	public function register_block() {
+		register_block_type(
+			'jetpack/related-posts',
+			array(
+				'render_callback' => array( $this, 'render_block' ),
+			)
+		);
+	}
+
+	public function render_block( $attributes ) {
+		$shortcode_atts = array(
+			'enabled' => true,
+			'show_headline' => isset( $attributes['headline'] ) && strlen( $attributes['headline'] ) > 0,
+			'show_thumbnails' => ! empty( $attributes['displayThumbnails'] ),
+			'show_date' => ! empty( $attributes['displayDate'] ),
+			'show_context' => ! empty( $attributes['displayContext'] ),
+			'layout' => ! empty( $attributes['postLayout'] ) ? $attributes['postLayout'] : 'grid',
+			'headline' => isset( $attributes['headline'] ) ? $attributes['headline'] : '',
+			'size' => ! empty( $attributes['postsToShow'] ) ? $attributes['postsToShow'] : 3,
+		);
+
+		$parsed_atts = array();
+		foreach ( $shortcode_atts as $attribute => $value ) {
+			$parsed_atts[] = $attribute . '="' . esc_attr( $value ) . '"';
+		}
+
+		$string_atts = implode( ' ', $parsed_atts );
+
+		return '[' . self::SHORTCODE . ' ' . $string_atts . ']';
+	}
+
+	/**
 	 * Add a checkbox field to Settings > Reading for enabling related posts.
 	 *
 	 * @action admin_init

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -130,17 +130,7 @@ class Jetpack_RelatedPosts {
 			return;
 
 		if ( isset( $_GET['relatedposts'] ) ) {
-			$excludes = array();
-			if ( isset( $_GET['relatedposts_exclude'] ) ) {
-				if ( is_string( $_GET['relatedposts_exclude'] ) ) {
-					$excludes = explode( ',', $_GET['relatedposts_exclude'] );
-				} elseif ( is_array( $_GET['relatedposts_exclude'] ) ) {
-					$excludes = array_values( $_GET['relatedposts_exclude'] );
-				}
-
-				$excludes = array_unique( array_filter( array_map( 'absint', $excludes ) ) );
-			}
-
+			$excludes = $this->parse_numeric_get_arg( 'relatedposts_exclude' );
 			$this->_action_frontend_init_ajax( $excludes );
 		} else {
 			if ( isset( $_GET['relatedposts_hit'], $_GET['relatedposts_origin'], $_GET['relatedposts_position'] ) ) {
@@ -279,17 +269,7 @@ EOT;
 			'size'            => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
-		$excludes = array();
-		if ( isset( $_GET['relatedposts_origin'] ) ) {
-			if ( is_string( $_GET['relatedposts_origin'] ) ) {
-				$excludes = explode( ',', $_GET['relatedposts_origin'] );
-			} elseif ( is_array( $_GET['relatedposts_origin'] ) ) {
-				$excludes = array_values( $_GET['relatedposts_origin'] );
-			}
-
-			$excludes = array_unique( array_filter( array_map( 'absint', $excludes ) ) );
-		}
-
+		$excludes = $this->parse_numeric_get_arg( 'relatedposts_origin' );
 		$related_posts = $this->get_for_post_id(
 			get_the_ID(),
 			array(
@@ -382,6 +362,32 @@ EOT;
 	 * PUBLIC UTILITY FUNCTIONS
 	 * ========================
 	 */
+
+	/**
+	 * Parse a numeric GET variable to an array of values.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @uses absint
+	 *
+	 * @param string $arg Name of the GET variable
+	 * @return array $result Parsed value(s)
+	 */
+	public function parse_numeric_get_arg( $arg ) {
+		$result = array();
+
+		if ( isset( $_GET[ $arg ] ) ) {
+			if ( is_string( $_GET[ $arg ] ) ) {
+				$result = explode( ',', $_GET[ $arg ] );
+			} elseif ( is_array( $_GET[ $arg ] ) ) {
+				$result = array_values( $_GET[ $arg ] );
+			}
+
+			$result = array_unique( array_filter( array_map( 'absint', $result ) ) );
+		}
+
+		return $result;
+	}
 
 	/**
 	 * Gets options set for Jetpack_RelatedPosts and merge with defaults.

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -270,8 +270,20 @@ EOT;
 			'size' => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
+		$excludes = array();
+		if ( isset( $_GET['relatedposts_origin'] ) ) {
+			if ( is_string( $_GET['relatedposts_origin'] ) ) {
+				$excludes = explode( ',', $_GET['relatedposts_origin'] );
+			} elseif ( is_array( $_GET['relatedposts_origin'] ) ) {
+				$excludes = array_values( $_GET['relatedposts_origin'] );
+			}
+
+			$excludes = array_unique( array_filter( array_map( 'absint', $excludes ) ) );
+		}
+
 		$related_posts = $this->get_for_post_id( get_the_ID(), array(
 			'size' => $block_attributes['size'],
+			'exclude_post_ids' => $excludes,
 		) );
 
 		if ( ! $related_posts ) {

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -194,6 +194,13 @@
 		}
 	};
 
+	function afterPostsHaveLoaded() {
+		jprp.setVisualExcerptHeights();
+		$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click(function() {
+			this.href = jprp.getTrackedUrl( this );
+		});
+	}
+
 	/**
 	 * Initialize Related Posts.
 	 */
@@ -202,6 +209,11 @@
 
 		var endpointURL = jprp.getEndpointURL(),
 			$relatedPosts = $( '#jp-relatedposts' );
+
+		if ( $( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
+			afterPostsHaveLoaded();
+			return;
+		}
 
 		$.getJSON( endpointURL, function( response ) {
 			if ( 0 === response.items.length || 0 === $relatedPosts.length ) {
@@ -229,15 +241,11 @@
 			html = ! showThumbnails ? jprp.generateMinimalHtml( response.items, options ) : jprp.generateVisualHtml( response.items, options );
 
 			$relatedPosts.append( html );
-			jprp.setVisualExcerptHeights();
 			if ( options.showDate ) {
 				$relatedPosts.find( '.jp-relatedposts-post-date' ).show();
 			}
 			$relatedPosts.show();
-
-			$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click(function() {
-				this.href = jprp.getTrackedUrl( this );
-			});
+			afterPostsHaveLoaded();
 		} );
 	}
 

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -196,9 +196,9 @@
 
 	function afterPostsHaveLoaded() {
 		jprp.setVisualExcerptHeights();
-		$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click(function() {
+		$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click( function() {
 			this.href = jprp.getTrackedUrl( this );
-		});
+		} );
 	}
 
 	/**


### PR DESCRIPTION
Currently, the Related Posts functionality works as a singleton - multiple instances aren't expected, and overriding settings inline isn't easy because of the way we currently fetch settings and build the markup. We are keeping the singleton behavior, but we are now adding a new way to render related posts - the Gutenberg block.

This PR registers a Related Posts Gutenberg block uses the same markup for the Gutenberg block, without reusing the existing functionality to build the markup. This allows us to reuse most of the existing functionality provided by the module.

If you wish to learn more about the block UI, you can have a look at https://github.com/Automattic/wp-calypso/pull/26530.

#### Changes proposed in this Pull Request:

* Register a new Gutenberg block for Related Posts.
* Use the existing shortcode/widget markup to create block server rendering from scratch.
* Prevent the customizer from modifying the block markup in the frontend.
* Reuse the excluded posts functionality, to prevent from going in circle, back and forth between the same 2 related posts.
* Prevent from displaying legacy related posts when there is a Related Posts block in the current post content
* Reorder some of the module JS to prevent it from inserting related posts in the dedicated wrapper when it shouldn't

#### Testing instructions:

* Use one of your Jetpack sites.
  * Ideally, test this on a site that has some posts already, in order to be able to use the already indexed posts without the need to create related posts and wait for indexing.
  * If you don't have a local site you can test on, spin up a new Jurassic Ninja site with Jetpack, Gutenberg and the Calypso built block. You might want to try with a non-shortlived site to be able to test the front end. You can use the following link to spin up a site with all this: https://jurassic.ninja/create/?gutenpack&jetpack-beta&branch=add/jetpack-related-posts-block-server-reg 
* Connect the site to WP.com, and activate all recommended features.
* If you don't wish to create a bunch of posts yourself, [import the example theme unit test content](https://raw.githubusercontent.com/WPTRT/theme-unit-test/master/themeunittestdata.wordpress.xml).
* Write a post, insert a Related Posts block. 
* Play the block settings, verify it looks and works well both in wp-admin and in the frontend of your site.
* Note that it will take some time for related posts to be indexed, recognized and displayed in the front end. Also, some minimum of posts need to be created - creating 10 posts should be enough.
* Verify that customizer on a post with related posts block doesn't touch the markup of the block.
* Verify that when navigating from post A to its related post B, post B's related posts output doesn't contain a link to A.

#### Proposed changelog entry for your changes:

* Introduced a new Related Posts block for Gutenberg.