### PR TITLE
Jetpack: Add url request was made on/from to actor

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -269,6 +269,7 @@ class Jetpack_Sync_Listener {
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_wp_admin'      => is_admin(),
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
+			'from_url'         => $this->get_request_url(),
 		);
 
 		if ( $this->should_send_user_data_with_actor( $current_filter ) ) {
@@ -300,5 +301,9 @@ class Jetpack_Sync_Listener {
 		$this->full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
 		$this->set_queue_size_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
 		$this->set_queue_lag_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_lag' ) );
+	}
+
+	function get_request_url() {
+		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -304,7 +304,6 @@ class Jetpack_Sync_Listener {
 	}
 
 	function get_request_url() {
-		global $wp;
-		return add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -304,6 +304,7 @@ class Jetpack_Sync_Listener {
 	}
 
 	function get_request_url() {
-		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+		global $wp;
+		return add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -87,9 +87,6 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$current_user  = wp_get_current_user();
 
-		global $wp;
-		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
-
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -104,7 +101,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
-			'from_url'         => $current_url,
+			'from_url'         => $this->get_page_url(),
 		);
 
 		$all = $queue->get_all();
@@ -123,9 +120,6 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$current_user = wp_get_current_user();
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 
-		global $wp;
-		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
-
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -142,7 +136,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'ip'               => jetpack_protect_get_ip(),
 			'user_agent'       => 'Jetpack Unit Tests',
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
-			'from_url'         => $current_url,
+			'from_url'         => $this->get_page_url(),
 		);
 
 		$all = $queue->get_all();
@@ -163,9 +157,6 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 		remove_filter( 'jetpack_sync_actor_user_data', '__return_false' );
 
-		global $wp;
-		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
-
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -180,7 +171,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
-			'from_url'         => $current_url,
+			'from_url'         => $this->get_page_url(),
 		);
 
 		$all = $queue->get_all();
@@ -199,5 +190,9 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' ) );
 		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' )->silent );
+	}
+
+	function get_page_url() {
+		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -86,6 +86,10 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->factory->post->create();
 		$current_user  = wp_get_current_user();
+
+		global $wp;
+		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -100,7 +104,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
-			'from_url'         => 'http://127.0.0.1',
+			'from_url'         => $current_url,
 		);
 
 		$all = $queue->get_all();

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -100,6 +100,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
+			'from_url'         => 'http://127.0.0.1',
 		);
 
 		$all = $queue->get_all();

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -123,6 +123,9 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$current_user = wp_get_current_user();
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 
+		global $wp;
+		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -139,6 +142,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'ip'               => jetpack_protect_get_ip(),
 			'user_agent'       => 'Jetpack Unit Tests',
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
+			'from_url'         => $current_url,
 		);
 
 		$all = $queue->get_all();
@@ -158,6 +162,10 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'jetpack_sync_actor_user_data', '__return_false' );
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 		remove_filter( 'jetpack_sync_actor_user_data', '__return_false' );
+
+		global $wp;
+		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
@@ -172,6 +180,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_wp_rest'       => defined( 'REST_REQUEST' ) ? REST_REQUEST : false,
 			'is_ajax'          => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 			'is_cli'           => defined( 'WP_CLI' ) ? WP_CLI : false,
+			'from_url'         => $current_url,
 		);
 
 		$all = $queue->get_all();


### PR DESCRIPTION
This PR adds the url the request was made on/from to the sync actor to assist in troubleshooting issues where the actor and or payload data does not seem correct.

#### Testing instructions:

Please see the detailed instructions I've added for how to observe Jetpack Sync data that is sent from Jetpack to a WPCOM sandbox: PCYsg-hnH-p2

Please follow the above instructions, make a post on your Jetpack site, and confirm that the sync payload (array) that appears in your terminal has a `from_url` field.