### PR TITLE
Height should be checking for a minimum of 200 and not a maximum

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -208,7 +208,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		$height = (int) $new_instance['height'];
 		if ( $height ) {
 			// From publish.twitter.com: height >= 200
-			$instance['height'] = max( $height, 200 );
+			$instance['height'] = min( $height, 200 );
 		} else {
 			$instance['height'] = '';
 		}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* The Twitter timeline height says it should be a minimum of 200 px, but the code is checking for a maximum of 200. This fixes it

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Add the Twitter Timeline widget, enter a number higher than 200 and it will properly save now.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Fixed issue where you couldn't enter a height of higher than 200 in the Twitter Timeline Widget.
