### PR TITLE
Search: improve upgrade/feature messaging

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -28,7 +28,7 @@ const renderCard = ( props ) => (
 		label={ __( 'Search' ) }
 		module="search"
 		support={ {
-			text: __( 'Jetpack’s Search module is a powerful replacement for the search capability built into WordPress.' ),
+			text: __( 'Jetpack Search is a powerful replacement for the search capability built into WordPress.' ),
 			link: 'https://jetpack.com/support/search/',
 		} }
 		className={ props.className }
@@ -73,7 +73,7 @@ class DashSearch extends Component {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
 				pro_inactive: true,
-				content: __( 'Give your visitors {{a}}a great search experience{{/a}}.', {
+				content: __( 'Replace the built-in search with a fast, scalable, customizable, and highly-relevant search {{a}}hosted in the WordPress.com cloud{{/a}}.', {
 					components: {
 						a: <a
 							href={ 'https://jetpack.com/features/design/elasticsearch-powered-search/' }
@@ -91,7 +91,7 @@ class DashSearch extends Component {
 					label={ __( 'Search' ) }
 					module="search"
 					support={ {
-						text: __( 'Jetpack’s Search module is a powerful replacement for the search capability built into WordPress.' ),
+						text: __( 'Jetpack Search is a powerful replacement for the search capability built into WordPress.' ),
 						link: 'https://jetpack.com/support/search/',
 					} }
 					className="jp-dash-item__is-active"
@@ -109,7 +109,7 @@ class DashSearch extends Component {
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
 			pro_inactive: false,
-			content: __( '{{a}}Activate{{/a}} to replace the WordPress built-in search with an improved search experience.', {
+			content: __( '{{a}}Activate{{/a}} to replace the WordPress built-in search with an advanced search experience.', {
 				components: {
 					a: <a href="javascript:void(0)" onClick={ activateSearch } />
 				}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -193,7 +193,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Faster, more relevant and more powerful sitewide search.' ) }
+						title={ __( 'Add faster, more advanced searching to your site with Jetpack Professional.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
@@ -257,13 +257,6 @@ export const SettingsCard = props => {
 
 			case FEATURE_SEO_TOOLS_JETPACK:
 				if ( 'is-business-plan' !== planClass && 'is-premium-plan' !== planClass ) {
-					return false;
-				}
-
-				break;
-
-			case FEATURE_SEARCH_JETPACK:
-				if ( 'is-business-plan' !== planClass ) {
 					return false;
 				}
 

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -65,13 +65,6 @@ export class Traffic extends React.Component {
 			<div>
 				<QuerySite />
 				{
-					foundStats && (
-						<SiteStats
-							{ ...commonProps }
-						/>
-					)
-				}
-				{
 					foundSearch && (
 						<Search
 							{ ...commonProps }
@@ -110,6 +103,13 @@ export class Traffic extends React.Component {
 						<GoogleAnalytics
 							{ ...commonProps }
 							configureUrl={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl + '#analytics' }
+						/>
+					)
+				}
+				{
+					foundStats && (
+						<SiteStats
+							{ ...commonProps }
 						/>
 					)
 				}

--- a/_inc/client/traffic/search.jsx
+++ b/_inc/client/traffic/search.jsx
@@ -18,9 +18,12 @@ import { getSiteAdminUrl } from 'state/initial-state';
 import { getSitePlan } from 'state/site';
 import { isFetchingSiteData } from 'state/site';
 import { FormFieldset } from 'components/forms';
+import { getPlanClass } from 'lib/plans/constants';
 
 class Search extends React.Component {
 	render() {
+		const plan_is_business = ( 'is-business-plan' === getPlanClass( this.props.sitePlan.product_slug ) );
+		const module_enabled = this.props.getOptionValue( 'search' );
 		return (
 			<SettingsCard
 				{ ...this.props }
@@ -32,30 +35,32 @@ class Search extends React.Component {
 					hasChild
 					module={ { module: 'search' } }
 					support={ {
-						text: __( 'Replaces the default WordPress search with a faster, filterable search experience.' ),
+						text: __( 'Jetpack Search supports many customizations.' ),
 						link: 'https://jetpack.com/support/search',
 					} }>
-					<ModuleToggle
-						slug="search"
-						compact
-						activated={ this.props.getOptionValue( 'search' ) }
-						toggling={ this.props.isSavingAnyOption( 'search' ) }
-						toggleModule={ this.props.toggleModuleNow }>
-						{ __( 'Replace WordPress built-in search with an improved search experience' ) }
-					</ModuleToggle>
-					{ this.props.getOptionValue( 'search' ) && (
+					<p>{ __( 'The built-in WordPress search is great for sites without much content. But as your site grows, searches slow down and return less relevant results.' ) } </p>
+					<p>{ __( 'Jetpack Search replaces the built-in search with a fast, scalable, customizable, and highly-relevant search hosted in the WordPress.com cloud. The result: Your users find the content they want, faster.' ) } </p>
+					{ plan_is_business && (
+						<ModuleToggle
+							slug="search"
+							compact
+							activated={ module_enabled }
+							toggling={ this.props.isSavingAnyOption( 'search' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{ __( 'Replace WordPress built-in search with an advanced search experience' ) }
+						</ModuleToggle>
+					) }
+					{ plan_is_business && module_enabled && (
 						<FormFieldset>
 							<p className="jp-form-setting-explanation">
-								{ __( 'Add the Jetpack Search widget to your sidebar to configure advanced search filters.' ) }
+								{ __( 'Add the Jetpack Search widget to your sidebar to configure sorting and filters.' ) }
 							</p>
 						</FormFieldset>
 					) }
 				</SettingsGroup>
-				{
-					this.props.getOptionValue( 'search' ) && (
-						<Card compact className="jp-settings-card__configure-link" href="customize.php?autofocus[panel]=widgets">{ __( 'Add Jetpack Search Widget' ) }</Card>
-					)
-				}
+				{ plan_is_business && module_enabled && (
+					<Card compact className="jp-settings-card__configure-link" href="customize.php?autofocus[panel]=widgets">{ __( 'Add Jetpack Search Widget' ) }</Card>
+				) }
 			</SettingsCard>
 		);
 	}


### PR DESCRIPTION
Fixes #9747

Makes changes to the upgrade messages. The exact language was iterated on a bit in https://github.com/Automattic/wp-calypso/pull/27059 and this PR has them matching. Similar to that PR I also moved the site search settings further down on the page.

The changes affect the UI in the Jetpack dashboard:
- Main at a glance page wording changed a little bit when not upgraded
- On the Settings->Traffic page the wording changed a lot both when activated and not

Screenshots of the new upgrade wording:

<img width="788" alt="screen shot 2018-09-13 at 6 16 20 pm" src="https://user-images.githubusercontent.com/820871/45522830-ca273a00-b782-11e8-9705-f2608914391a.png">

<img width="759" alt="screen shot 2018-09-13 at 6 15 40 pm" src="https://user-images.githubusercontent.com/820871/45522824-bf6ca500-b782-11e8-9829-93111899b50b.png">

<img width="776" alt="screen shot 2018-09-13 at 6 15 56 pm" src="https://user-images.githubusercontent.com/820871/45522826-c4c9ef80-b782-11e8-814f-e3f987dc1bd7.png">

