### PR TITLE
Sandboxing: only require sandbox file if the constant isn't empty

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -121,7 +121,7 @@ if ( Jetpack::is_module_active( 'photon' ) ) {
 	add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
 }
 
-if ( JETPACK__SANDBOX_DOMAIN ) {
+if ( defined( JETPACK__SANDBOX_DOMAIN ) && JETPACK__SANDBOX_DOMAIN ) {
 	require_once( JETPACK__PLUGIN_DIR . '_inc/jetpack-server-sandbox.php' );
 }
 


### PR DESCRIPTION
Fixes #10136

#### Changes proposed in this Pull Request:

The `JETPACK__SANDBOX_DOMAIN` constant is set to an empty string by default,
so the existing check wasn't useful enough; the sandbox file was required
even if you had not defined a custom sandbox domain on your end.

#### Testing instructions:

1. Add some debugging code to `_inc/jetpack-server-sandbox.php`
2. Do not set the `JETPACK__SANDBOX_DOMAIN` constant. 
3. Your debugging code should not run at all when this branch is active.

#### Proposed changelog entry for your changes:
Sandboxing: only require sandbox file if the constant isn't empty