### PR TITLE
Improve Google Verification Service integration

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -57,11 +57,7 @@
 .jp-form-input-with-prefix {
 	display: inline-flex;
 	width: 100%;
-	margin-top: rem( 24px );
-
-	&:first-of-type {
-		margin-top: 0;
-	}
+	margin-bottom: rem( 24px );
 
 	span:first-child {
 		min-width: rem( 60px );

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -24,8 +24,8 @@ export const checkVerifyStatusGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_SUCCESS,
 				verified: data.verified,
 				token: data.token,
-				google_search_console_url: data.google_search_console_url,
-				google_verification_console_url: data.google_verification_console_url,
+				searchConsoleUrl: data.google_search_console_url,
+				verificationConsoleUrl: data.google_verification_console_url,
 			} );
 
 			return data;
@@ -46,8 +46,8 @@ export const verifySiteGoogle = () => {
 		return restApi.verifySiteGoogle().then( data => {
 			dispatch( {
 				verified: data.verified,
-				google_search_console_url: data.google_search_console_url,
-				google_verification_console_url: data.google_verification_console_url,
+				searchConsoleUrl: data.google_search_console_url,
+				verificationConsoleUrl: data.google_verification_console_url,
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_SUCCESS,
 			} );
 

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -25,6 +25,7 @@ export const checkVerifyStatusGoogle = () => {
 				verified: data.verified,
 				token: data.token,
 				google_search_console_url: data.google_search_console_url,
+				google_verification_console_url: data.google_verification_console_url,
 			} );
 
 			return data;
@@ -48,6 +49,7 @@ export const verifySiteGoogle = () => {
 			dispatch( {
 				verified: data.verified,
 				google_search_console_url: data.google_search_console_url,
+				google_verification_console_url: data.google_verification_console_url,
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_SUCCESS,
 			} );
 

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -34,8 +34,6 @@ export const checkVerifyStatusGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_FAIL,
 				error: error.response,
 			} );
-
-			return error.response;
 		} );
 	};
 };
@@ -63,8 +61,6 @@ export const verifySiteGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL,
 				error: error.response,
 			} );
-
-			return error.response;
 		} );
 	};
 };

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -32,8 +32,6 @@ export const checkVerifyStatusGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_FAIL,
 				error: error.response,
 			} );
-
-			return Promise.reject( error.response );
 		} );
 	};
 };
@@ -59,8 +57,6 @@ export const verifySiteGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL,
 				error: error.response,
 			} );
-
-			return Promise.reject( error.response );
 		} );
 	};
 };

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -32,6 +32,8 @@ export const checkVerifyStatusGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_FAIL,
 				error: error.response,
 			} );
+
+			return error.response;
 		} );
 	};
 };
@@ -57,6 +59,8 @@ export const verifySiteGoogle = () => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL,
 				error: error.response,
 			} );
+
+			return error.response;
 		} );
 	};
 };

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -23,7 +23,8 @@ export const checkVerifyStatusGoogle = () => {
 			dispatch( {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_SUCCESS,
 				verified: data.verified,
-				token: data.token
+				token: data.token,
+				google_search_console_url: data.google_search_console_url,
 			} );
 
 			return data;
@@ -46,6 +47,7 @@ export const verifySiteGoogle = () => {
 		return restApi.verifySiteGoogle().then( data => {
 			dispatch( {
 				verified: data.verified,
+				google_search_console_url: data.google_search_console_url,
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_SUCCESS,
 			} );
 

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -33,6 +33,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 				fetching: false,
 				verified: action.verified,
 				google_search_console_url: action.google_search_console_url,
+				google_verification_console_url: action.google_verification_console_url,
 				token: action.token,
 				error: null,
 			} );
@@ -45,6 +46,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 				verifying: false,
 				verified: action.verified,
 				google_search_console_url: action.google_search_console_url,
+				google_verification_console_url: action.google_verification_console_url,
 				error: null,
 			} );
 		case JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL:
@@ -99,4 +101,8 @@ export function getGoogleSiteVerificationError( state ) {
 
 export function getGoogleSearchConsoleUrl( state ) {
 	return get( state, 'jetpack.siteVerify.google.google_search_console_url', null );
+}
+
+export function getGoogleVerificationConsoleUrl( state ) {
+	return get( state, 'jetpack.siteVerify.google.google_verification_console_url', null );
 }

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -32,6 +32,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				fetching: false,
 				verified: action.verified,
+				google_search_console_url: action.google_search_console_url,
 				token: action.token,
 				error: null,
 			} );
@@ -43,6 +44,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				verifying: false,
 				verified: action.verified,
+				google_search_console_url: action.google_search_console_url,
 				error: null,
 			} );
 		case JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL:
@@ -93,4 +95,8 @@ export function isSiteVerifiedWithGoogle( state ) {
 
 export function getGoogleSiteVerificationError( state ) {
 	return get( state, 'jetpack.siteVerify.google.error', null );
+}
+
+export function getGoogleSearchConsoleUrl( state ) {
+	return get( state, 'jetpack.siteVerify.google.google_search_console_url', null );
 }

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -32,8 +32,8 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				fetching: false,
 				verified: action.verified,
-				google_search_console_url: action.google_search_console_url,
-				google_verification_console_url: action.google_verification_console_url,
+				searchConsoleUrl: action.searchConsoleUrl,
+				verificationConsoleUrl: action.verificationConsoleUrl,
 				token: action.token,
 				error: null,
 			} );
@@ -45,8 +45,8 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				verifying: false,
 				verified: action.verified,
-				google_search_console_url: action.google_search_console_url,
-				google_verification_console_url: action.google_verification_console_url,
+				searchConsoleUrl: action.searchConsoleUrl,
+				verificationConsoleUrl: action.verificationConsoleUrl,
 				error: null,
 			} );
 		case JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL:
@@ -100,9 +100,9 @@ export function getGoogleSiteVerificationError( state ) {
 }
 
 export function getGoogleSearchConsoleUrl( state ) {
-	return get( state, 'jetpack.siteVerify.google.google_search_console_url', null );
+	return get( state, 'jetpack.siteVerify.google.searchConsoleUrl', null );
 }
 
 export function getGoogleVerificationConsoleUrl( state ) {
-	return get( state, 'jetpack.siteVerify.google.google_verification_console_url', null );
+	return get( state, 'jetpack.siteVerify.google.verificationConsoleUrl', null );
 }

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -90,3 +90,7 @@ export function isConnectedToGoogleSiteVerificationAPI( state ) {
 export function isSiteVerifiedWithGoogle( state ) {
 	return get( state, 'jetpack.siteVerify.google.verified', false );
 }
+
+export function getGoogleSiteVerificationError( state ) {
+	return get( state, 'jetpack.siteVerify.google.error', null );
+}

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -29,6 +29,7 @@
 	font-size: 16px;
 	line-height: 1.5;
 	border: 1px solid #c8d7e1;
+	border-left: 0;
 	width: 100%;
 	display: flex;
 	flex-direction: row;

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -10,10 +10,17 @@
 	}
 }
 
+
+// we want to place.jp-form-input-with-prefix's margin after this element
+.jp-form-input-with-prefix-bottom-message {
+	top: rem( -24px );
+	position: relative;
+}
+
+
 .jp-form-site-verification-verified {
 	background-color: $white;
 	color: $green-primary;
-	display: inline-block;
 	box-sizing: border-box;
 	margin: 0;
 	padding: 7px 14px;
@@ -21,6 +28,10 @@
 	line-height: 1.5;
 	border: 1px solid #c8d7e1;
 	width: 100%;
+	display: flex;
+	flex-direction: row;
+	justify-content: left;
+	align-items: center;
 
 	.gridicon:first-child {
 		margin-right: 5px;

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -15,6 +15,7 @@
 .jp-form-input-with-prefix-bottom-message {
 	top: rem( -24px );
 	position: relative;
+	line-height: 2em;
 }
 
 

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -1,9 +1,37 @@
 @import "../scss/variables/_colors";
 
-.jp-form-suffix-site-verification-verified {
+.jp-form-google-label-unverified {
+	.dops-button {
+		margin: 0 15px;
+	}
+
+	.jp-form-google-separator {
+		padding: .5rem 0;
+	}
+}
+
+.jp-form-site-verification-verified {
+	background-color: $white;
 	color: $green-primary;
+	display: inline-block;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 7px 14px;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	width: 100%;
 
 	.gridicon:first-child {
 		margin-right: 5px;
 	}
+}
+
+.jp-form-site-verification-edit-button {
+	margin-left: 10px;
+	overflow: visible;
+}
+
+.jp-form-site-verification-verified-note {
+	font-size: 0.7em;
 }

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -16,6 +16,7 @@
 	top: rem( -24px );
 	position: relative;
 	line-height: 2em;
+	margin-top: 5px;
 }
 
 

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -84,10 +84,16 @@ class VerificationServicesComponent extends React.Component {
 	}
 
 	componentWillMount() {
-		this.checkVerifySite();
+		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
+			if ( token !== this.props.getSettingCurrentValue( 'google' ) ) {
+				return this.props.updateOptions( { google: token } );
+			}
+		} ).catch( () => {
+			// ignore error
+		} );
 	}
 
-	checkVerifySite() {
+	checkAndVerifySite() {
 		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
 			if ( token !== this.props.getSettingCurrentValue( 'google' ) ) {
 				return this.props.updateOptions( { google: token } );
@@ -108,12 +114,12 @@ class VerificationServicesComponent extends React.Component {
 
 		if ( ! this.props.isConnectedToGoogle ) {
 			requestExternalAccess( this.props.googleSiteVerificationConnectUrl, () => {
-				this.checkVerifySite();
+				this.checkAndVerifySite();
 			} );
 			return;
 		}
 
-		this.checkVerifySite();
+		this.checkAndVerifySite();
 	};
 
 	renderGoogleVerifyButton() {

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -263,10 +263,11 @@ class VerificationServicesComponent extends React.Component {
 								value={ this.getSiteVerificationValue( 'google' ) }
 								placeholder={ this.getMetaTag( 'google', '1234' ) }
 								className="code"
-								disabled={ this.props.isUpdating( 'google' ) || this.props.isSiteVerifiedWithGoogle }
+								disabled={ this.props.isUpdating( 'google' ) }
 								onChange={ this.props.onOptionChange } />
 							{ this.renderGoogleVerifyButton() }
 						</FormLabel>
+						<div>hello</div>
 						<FormLabel
 							className="jp-form-input-with-prefix"
 							key="verification_service_bing">

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -148,25 +148,35 @@ class GoogleVerificationServiceComponent extends React.Component {
 							</Button>
 						}
 					</FormLabel>
-					{ this.props.isSiteVerifiedWithGoogle && this.props.googleVerificationConsoleUrl &&
+					{ this.props.isSiteVerifiedWithGoogle &&
 						<div className="jp-form-input-with-prefix-bottom-message">
-							<SimpleNotice
-								status="is-warning"
-								isCompact
-								showDismiss={ false }
-								text={ __( 'Editing this HTML Tag code won’t unverify your site with your Google account.' ) }
-							>
-								<NoticeAction
-									external
-									href={ this.props.googleVerificationConsoleUrl }
+							{ this.props.googleVerificationConsoleUrl &&
+								<SimpleNotice
+									status="is-warning"
+									isCompact
+									showDismiss={ false }
+									text={ __( 'Editing this HTML Tag code won’t unverify your site with your Google account.' ) }
 								>
-									{ __( 'Unverify with Google' ) }
-								</NoticeAction>
-							</SimpleNotice>
+									<NoticeAction
+										external
+										href={ this.props.googleVerificationConsoleUrl }
+									>
+										{ __( 'Unverify with Google' ) }
+									</NoticeAction>
+								</SimpleNotice>
+							}
+							{ ! this.props.googleVerificationConsoleUrl &&
+								<SimpleNotice
+									status="is-warning"
+									isCompact
+									showDismiss={ false }
+									text={ __( 'Editing this HTML Tag code won’t unverify your site with the Google account it is connected to.' ) }
+								>
+								</SimpleNotice>
+							}
 						</div>
 					}
 				</div>
-
 			);
 		}
 

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -149,7 +149,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 						<div className="jp-form-input-with-prefix-bottom-message">
 							<SimpleNotice
 								status="is-warning"
-								isCompact={ true }
+								isCompact
 								showDismiss={ false }
 								text={ __( 'Editing this HTML Tag code won’t unverify your site with your Google account.' ) }
 							>
@@ -192,7 +192,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 								__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
 									components: {
 										a: <ExternalLink
-											icon={ true }
+											icon
 											iconSize={ 16 }
 											target="_blank" rel="noopener noreferrer"
 											href={ this.props.googleSearchConsoleUrl }

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -119,10 +119,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 		this.props.onSubmit( event );
 
-		// revert back to the choice selection if field is empty
-		if ( ! this.props.value ) {
-			this.toggleVerifyMethod();
-		}
+		this.toggleVerifyMethod();
 	};
 
 	render() {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -124,7 +124,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	render() {
 		const isForbidden = this.props.googleSiteVerificationError && this.props.googleSiteVerificationError.code === 'forbidden';
-		if ( this.state.inputVisible || isForbidden ) {
+		if ( this.state.inputVisible || isForbidden || ! this.props.isCurrentUserLinked ) {
 			return (
 				<div>
 					<FormLabel

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -133,11 +133,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 						className="jp-form-input-with-prefix"
 						key="verification_service_google">
 						<span>{ __( 'Google' ) }</span>
-						<span className="jp-form-site-verification-verified">
+						<div className="jp-form-site-verification-verified">
 							<Gridicon icon="checkmark-circle" size={ 20 } />
 							{ ' ' }
-							{ __( 'Your site is verified with Google' ) }
-						</span>
+							<span>{ __( 'Your site is verified with Google' ) }</span>
+						</div>
 						<Button
 							type="button"
 							className="jp-form-site-verification-edit-button"
@@ -145,7 +145,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
-					<div>
+					<div className="jp-form-input-with-prefix-bottom-message" >
 						{
 							__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
 								components: {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -30,10 +30,12 @@ import {
 	isVerifyingGoogleSite,
 	getGoogleSiteVerificationError,
 	getGoogleSearchConsoleUrl,
+	getGoogleVerificationConsoleUrl,
 } from 'state/site-verify';
 import { userCanManageOptions } from 'state/initial-state';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import { getSiteRawUrl } from 'state/initial-state';
+import SimpleNotice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action.jsx';
 
 class GoogleVerificationServiceComponent extends React.Component {
 	state = {
@@ -106,28 +108,57 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} );
 	};
 
+	quickSave = event => {
+		this.props.onSubmit( event );
+		// revert back to the choice selection if field is empty
+		if ( ! this.props.value ) {
+			this.toggleVerifyMethod();
+		}
+	};
+
 	render() {
 		if ( this.state.inputVisible ) {
 			return (
-				<FormLabel
-					className="jp-form-input-with-prefix"
-					key="verification_service_google">
-					<span>{ __( 'Google' ) }</span>
-					<TextInput
-						name="google"
-						value={ this.props.value }
-						placeholder={ this.props.placeholder }
-						className="code"
-						disabled={ this.props.isUpdating( 'google' ) }
-						onChange={ this.props.onOptionChange } />
-					<Button
-						primary
-						type="button"
-						className="jp-form-site-verification-edit-button"
-						onClick={ this.props.onSubmit }>
-						{ __( 'Save' ) }
-					</Button>
-				</FormLabel>
+				<div>
+					<FormLabel
+						className="jp-form-input-with-prefix"
+						key="verification_service_google">
+						<span>{ __( 'Google' ) }</span>
+						<TextInput
+							name="google"
+							value={ this.props.value }
+							placeholder={ this.props.placeholder }
+							className="code"
+							disabled={ this.props.isUpdating( 'google' ) }
+							onChange={ this.props.onOptionChange } />
+						<Button
+							primary
+							type="button"
+							className="jp-form-site-verification-edit-button"
+							onClick={ this.quickSave }>
+							{ __( 'Save' ) }
+						</Button>
+					</FormLabel>
+					{ this.props.isSiteVerifiedWithGoogle && this.props.googleVerificationConsoleUrl &&
+						<div className="jp-form-input-with-prefix-bottom-message">
+							<SimpleNotice
+								status="is-warning"
+								isCompact={ true }
+								showDismiss={ false }
+								text={ __( 'Editing this HTML Tag code won’t unverify your site with your Google account.' ) }
+							>
+								<NoticeAction
+									external
+									href={ this.props.googleVerificationConsoleUrl }
+								>
+									{ __( 'Unverify with Google' ) }
+									<Gridicon icon="external" size={ this.props.iconSize } />
+								</NoticeAction>
+							</SimpleNotice>
+						</div>
+					}
+				</div>
+
 			);
 		}
 
@@ -204,13 +235,13 @@ export default connect(
 			fetchingSiteData: isFetchingSiteData( state ),
 			googleSiteVerificationConnectUrl: getExternalServiceConnectUrl( state, 'google_site_verification' ),
 			googleSearchConsoleUrl: getGoogleSearchConsoleUrl( state ),
+			googleVerificationConsoleUrl: getGoogleVerificationConsoleUrl( state ),
 			fetchingGoogleSiteVerify: isFetchingGoogleSiteVerify( state ),
 			isConnectedToGoogle: isConnectedToGoogleSiteVerificationAPI( state ),
 			isSiteVerifiedWithGoogle: isSiteVerifiedWithGoogle( state ),
 			isVerifyingGoogleSite: isVerifyingGoogleSite( state ),
 			userCanManageOptions: userCanManageOptions( state ),
 			googleSiteVerificationError: getGoogleSiteVerificationError( state ),
-			rawUrl: getSiteRawUrl( state ),
 		};
 	},
 	{

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -29,6 +29,7 @@ import {
 	isSiteVerifiedWithGoogle,
 	isVerifyingGoogleSite,
 	getGoogleSiteVerificationError,
+	getGoogleSearchConsoleUrl,
 } from 'state/site-verify';
 import { userCanManageOptions } from 'state/initial-state';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
@@ -149,20 +150,22 @@ class GoogleVerificationServiceComponent extends React.Component {
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
-					<div className="jp-form-input-with-prefix-bottom-message" >
-						{
-							__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
-								components: {
-									a: <ExternalLink
-										icon={ true }
-										iconSize={ 16 }
-										target="_blank" rel="noopener noreferrer"
-										href={ 'https://search.google.com/search-console?resource_id=https://' + this.props.rawUrl }
-									/>
-								}
-							} )
-						}
-					</div>
+					{ this.props.googleSearchConsoleUrl &&
+						<div className="jp-form-input-with-prefix-bottom-message" >
+							{
+								__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
+									components: {
+										a: <ExternalLink
+											icon={ true }
+											iconSize={ 16 }
+											target="_blank" rel="noopener noreferrer"
+											href={ this.props.googleSearchConsoleUrl }
+										/>
+									}
+								} )
+							}
+						</div>
+					}
 				</div>
 			);
 		}
@@ -200,6 +203,7 @@ export default connect(
 		return {
 			fetchingSiteData: isFetchingSiteData( state ),
 			googleSiteVerificationConnectUrl: getExternalServiceConnectUrl( state, 'google_site_verification' ),
+			googleSearchConsoleUrl: getGoogleSearchConsoleUrl( state ),
 			fetchingGoogleSiteVerify: isFetchingGoogleSiteVerify( state ),
 			isConnectedToGoogle: isConnectedToGoogleSiteVerificationAPI( state ),
 			isSiteVerifiedWithGoogle: isSiteVerifiedWithGoogle( state ),

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -6,6 +6,7 @@ import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
 import ExternalLink from 'components/external-link';
 import { connect } from 'react-redux';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -75,10 +76,12 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} );
 	}
 
-	handleClickGoogleVerify = () => {
+	handleClickAutoVerify = () => {
 		if ( this.props.fetchingSiteData || this.props.fetchingGoogleSiteVerify ) {
 			return;
 		}
+
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_auto_verify_click' );
 
 		if ( ! this.props.isConnectedToGoogle ) {
 			requestExternalAccess( this.props.googleSiteVerificationConnectUrl, () => {
@@ -88,6 +91,12 @@ class GoogleVerificationServiceComponent extends React.Component {
 		}
 
 		this.checkAndVerifySite();
+	};
+
+	handleClickSetManually = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_click' );
+
+		this.toggleVerifyMethod( event );
 	};
 
 	toggleVerifyMethod = () => {
@@ -169,7 +178,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 					primary
 					type="button"
 					disabled={ disabled }
-					onClick={ this.handleClickGoogleVerify }>
+					onClick={ this.handleClickAutoVerify }>
 						{ __( 'Auto verify with Google' ) }
 				</Button>
 				<span className="jp-form-google-separator">
@@ -178,7 +187,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 				<Button
 					type="button"
 					disabled={ disabled }
-					onClick={ this.toggleVerifyMethod }>
+					onClick={ this.handleClickSetManually }>
 					{ __( 'Manually verify with Google' ) }
 				</Button>
 			</div>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -115,7 +115,10 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	quickSave = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save' );
+
 		this.props.onSubmit( event );
+
 		// revert back to the choice selection if field is empty
 		if ( ! this.props.value ) {
 			this.toggleVerifyMethod();

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -146,7 +146,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 								components: {
 									a: <ExternalLink
 										icon={ true }
-										iconSize={ 12 }
+										iconSize={ 16 }
 										target="_blank" rel="noopener noreferrer"
 										href={ 'https://search.google.com/search-console?resource_id=https://' + this.props.rawUrl }
 									/>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -40,7 +40,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	componentDidMount() {
 		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
-			if ( token !== this.props.value ) {
+			if ( ! this.props.getOptionValue( 'google' ) && token ) {
 				return this.props.updateOptions( { google: token } );
 			}
 		} );

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -123,7 +123,8 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	render() {
-		if ( this.state.inputVisible ) {
+		const isForbidden = this.props.googleSiteVerificationError && this.props.googleSiteVerificationError.code === 'forbidden';
+		if ( this.state.inputVisible || isForbidden ) {
 			return (
 				<div>
 					<FormLabel
@@ -137,13 +138,15 @@ class GoogleVerificationServiceComponent extends React.Component {
 							className="code"
 							disabled={ this.props.isUpdating( 'google' ) }
 							onChange={ this.props.onOptionChange } />
-						<Button
-							primary
-							type="button"
-							className="jp-form-site-verification-edit-button"
-							onClick={ this.quickSave }>
-							{ __( 'Save' ) }
-						</Button>
+						{ this.state.inputVisible &&
+							<Button
+								primary
+								type="button"
+								className="jp-form-site-verification-edit-button"
+								onClick={ this.quickSave }>
+								{ __( 'Save' ) }
+							</Button>
+						}
 					</FormLabel>
 					{ this.props.isSiteVerifiedWithGoogle && this.props.googleVerificationConsoleUrl &&
 						<div className="jp-form-input-with-prefix-bottom-message">

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -96,11 +96,6 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} );
 	};
 
-	quickSave = event => {
-		this.props.onSubmit( event );
-		this.toggleVerifyMethod();
-	};
-
 	render() {
 		if ( this.state.inputVisible ) {
 			return (
@@ -119,7 +114,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 						primary
 						type="button"
 						className="jp-form-site-verification-edit-button"
-						onClick={ this.quickSave }>
+						onClick={ this.props.onSubmit }>
 						{ __( 'Save' ) }
 					</Button>
 				</FormLabel>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -224,7 +224,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 					type="button"
 					disabled={ disabled }
 					onClick={ this.handleClickAutoVerify }>
-						{ __( 'Auto verify with Google' ) }
+						{ __( 'Auto-verify with Google' ) }
 				</Button>
 				<span className="jp-form-google-separator">
 					{ __( 'or' ) }

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -43,18 +43,24 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	componentDidMount() {
-		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
-			if ( ! this.props.getOptionValue( 'google' ) && token ) {
-				return this.props.updateOptions( { google: token } );
+		this.props.checkVerifyStatusGoogle().then( response => {
+			if ( ! response ) {
+				return;
+			}
+			if ( ! this.props.getOptionValue( 'google' ) && response.token ) {
+				return this.props.updateOptions( { google: response.token } );
 			}
 		} );
 	}
 
 	checkAndVerifySite() {
 		this.props.createNotice( 'is-info', __( 'Verifying...' ), { id: 'verifying-site-google' } );
-		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
-			if ( token !== this.props.value ) {
-				return this.props.updateOptions( { google: token } );
+		this.props.checkVerifyStatusGoogle().then( response => {
+			if ( ! response ) {
+				return;
+			}
+			if ( response.token !== this.props.value ) {
+				return this.props.updateOptions( { google: response.token } );
 			}
 		} ).then( () => {
 			this.props.removeNotice( 'verifying-site-google' );
@@ -152,7 +158,6 @@ class GoogleVerificationServiceComponent extends React.Component {
 									href={ this.props.googleVerificationConsoleUrl }
 								>
 									{ __( 'Unverify with Google' ) }
-									<Gridicon icon="external" size={ this.props.iconSize } />
 								</NoticeAction>
 							</SimpleNotice>
 						</div>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -1,0 +1,214 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+import ExternalLink from 'components/external-link';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isFetchingSiteData,
+} from 'state/site';
+import {
+	FormLabel
+} from 'components/forms';
+import Gridicon from 'components/gridicon';
+import Button from 'components/button';
+import requestExternalAccess from 'lib/sharing';
+import { getExternalServiceConnectUrl } from 'state/publicize/reducer';
+import {
+	checkVerifyStatusGoogle,
+	verifySiteGoogle,
+	isFetchingGoogleSiteVerify,
+	isConnectedToGoogleSiteVerificationAPI,
+	isSiteVerifiedWithGoogle,
+	isVerifyingGoogleSite,
+	getGoogleSiteVerificationError,
+} from 'state/site-verify';
+import { userCanManageOptions } from 'state/initial-state';
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
+import { getSiteRawUrl } from 'state/initial-state';
+
+class GoogleVerificationServiceComponent extends React.Component {
+	state = {
+		inputVisible: false
+	};
+
+	componentDidMount() {
+		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
+			if ( token !== this.props.value ) {
+				return this.props.updateOptions( { google: token } );
+			}
+		} );
+	}
+
+	checkAndVerifySite() {
+		this.props.createNotice( 'is-info', __( 'Verifying...' ), { id: 'verifying-site-google' } );
+		this.props.checkVerifyStatusGoogle().then( ( { token } ) => {
+			if ( token !== this.props.value ) {
+				return this.props.updateOptions( { google: token } );
+			}
+		} ).then( () => {
+			this.props.removeNotice( 'verifying-site-google' );
+			if ( ! this.props.isSiteVerifiedWithGoogle ) {
+				this.props.verifySiteGoogle().then( () => {
+					if ( this.props.googleSiteVerificationError ) {
+						this.props.createNotice(
+							'is-error',
+							__( 'Site failed to verify: %(error)s', {
+								args: {
+									error: this.props.googleSiteVerificationError.message
+								}
+							} ),
+							{
+								id: 'verify-site-google-error',
+								duration: 5000
+							}
+						);
+					}
+				} );
+			}
+		} );
+	}
+
+	handleClickGoogleVerify = () => {
+		if ( this.props.fetchingSiteData || this.props.fetchingGoogleSiteVerify ) {
+			return;
+		}
+
+		if ( ! this.props.isConnectedToGoogle ) {
+			requestExternalAccess( this.props.googleSiteVerificationConnectUrl, () => {
+				this.checkAndVerifySite();
+			} );
+			return;
+		}
+
+		this.checkAndVerifySite();
+	};
+
+	toggleVerifyMethod = () => {
+		this.setState( {
+			inputVisible: ! this.state.inputVisible,
+		} );
+	};
+
+	quickSave = event => {
+		this.props.onSubmit( event );
+		this.toggleVerifyMethod();
+	};
+
+	render() {
+		if ( this.state.inputVisible ) {
+			return (
+				<FormLabel
+					className="jp-form-input-with-prefix"
+					key="verification_service_google">
+					<span>{ __( 'Google' ) }</span>
+					<TextInput
+						name="google"
+						value={ this.props.value }
+						placeholder={ this.props.placeholder }
+						className="code"
+						disabled={ this.props.isUpdating( 'google' ) }
+						onChange={ this.props.onOptionChange } />
+					<Button
+						primary
+						type="button"
+						className="jp-form-site-verification-edit-button"
+						onClick={ this.quickSave }>
+						{ __( 'Save' ) }
+					</Button>
+				</FormLabel>
+			);
+		}
+
+		if ( this.props.isSiteVerifiedWithGoogle ) {
+			return (
+				<div>
+					<div
+						className="jp-form-input-with-prefix"
+						key="verification_service_google">
+						<span>{ __( 'Google' ) }</span>
+						<span className="jp-form-site-verification-verified">
+							<Gridicon icon="checkmark-circle" size={ 20 } />
+							{ ' ' }
+							{ __( 'Your site is verified with Google' ) }
+						</span>
+						<Button
+							type="button"
+							className="jp-form-site-verification-edit-button"
+							onClick={ this.toggleVerifyMethod }>
+							{ __( 'Edit' ) }
+						</Button>
+					</div>
+					<div>
+						{
+							__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
+								components: {
+									a: <ExternalLink
+										icon={ true }
+										iconSize={ 12 }
+										target="_blank" rel="noopener noreferrer"
+										href={ 'https://search.google.com/search-console?resource_id=https://' + this.props.rawUrl }
+									/>
+								}
+							} )
+						}
+					</div>
+				</div>
+			);
+		}
+
+		const disabled = this.props.fetchingSiteData || this.props.fetchingGoogleSiteVerify || this.props.isVerifyingGoogleSite;
+
+		return (
+			<div
+				className="jp-form-input-with-prefix jp-form-google-label-unverified"
+				key="verification_service_google">
+				<span>{ __( 'Google' ) }</span>
+				<Button
+					primary
+					type="button"
+					disabled={ disabled }
+					onClick={ this.handleClickGoogleVerify }>
+						{ __( 'Auto verify with Google' ) }
+				</Button>
+				<span className="jp-form-google-separator">
+					{ __( 'or' ) }
+				</span>
+				<Button
+					type="button"
+					disabled={ disabled }
+					onClick={ this.toggleVerifyMethod }>
+					{ __( 'Manually verify with Google' ) }
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		return {
+			fetchingSiteData: isFetchingSiteData( state ),
+			googleSiteVerificationConnectUrl: getExternalServiceConnectUrl( state, 'google_site_verification' ),
+			fetchingGoogleSiteVerify: isFetchingGoogleSiteVerify( state ),
+			isConnectedToGoogle: isConnectedToGoogleSiteVerificationAPI( state ),
+			isSiteVerifiedWithGoogle: isSiteVerifiedWithGoogle( state ),
+			isVerifyingGoogleSite: isVerifyingGoogleSite( state ),
+			userCanManageOptions: userCanManageOptions( state ),
+			googleSiteVerificationError: getGoogleSiteVerificationError( state ),
+			rawUrl: getSiteRawUrl( state ),
+		};
+	},
+	{
+		checkVerifyStatusGoogle,
+		createNotice,
+		removeNotice,
+		verifySiteGoogle,
+	}
+)( GoogleVerificationServiceComponent );


### PR DESCRIPTION
Fixes #10141
Requires server patch D18402-code

#### Changes proposed in this Pull Request:

* Do not verify the site on page load, even if the user already has a google site verification token, wait for the user to click on the "Auto verify with Google" button
* Display an error notice on request error
* Revamp of the google site verification UI, props to @jeffgolenski for his design proposal!

#### Testing instructions:
- Go to `/wp-admin/admin.php?page=jetpack#/traffic` (Jetpack > Settings > Traffic) and scroll down to Site Verification
- Try clicking on "Auto verify with Google", authenticate with Google and make sure your site is verified, go to https://www.google.com/webmasters/verification/home?hl=en&authuser=2 and make sure your site is in the list. Go to https://search.google.com/search-console and make sure your site is there as well
- You should see a link to the Google Search Console, click on it and verify that you can access your site there. Go to Sitemaps and check that your sitemap is added there (it will probably fail for `wpsandbox.me` sites as `/robots.txt` prevents googlebot from crawling the site)
- Unverify your site by clicking on the Manually verify with Google, emptying the field and saving, then go to https://www.google.com/webmasters/verification/home?hl=en&authuser=2 click on "Verification Details" and unverify for your email. You can also go to https://search.google.com/search-console select the property and remove it after the verification fails

#### Proposed changelog entry for your changes:
- Improve Google Verification Service integration