### PR TITLE
Experiment: Add core-api base wpcom/v2 ping endpoint  that would allow to measure roundtrip time from .com to a Jetpack site

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/ping.php
+++ b/_inc/lib/core-api/wpcom-endpoints/ping.php
@@ -16,8 +16,7 @@ class WPCOM_REST_API_V2_Endpoint_Ping {
 	}
 
 	public function get_data( $request ) {
-		sleep(3);
-		return array( 'end' => time() );
+		return array( 'current_time' => time() );
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/ping.php
+++ b/_inc/lib/core-api/wpcom-endpoints/ping.php
@@ -1,0 +1,24 @@
+<?php
+
+class WPCOM_REST_API_V2_Endpoint_Ping {
+
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route( 'wpcom/v2', '/ping', array(
+			array(
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => array( $this, 'get_data' ),
+			),
+		) );
+	}
+
+	public function get_data( $request ) {
+		sleep(3);
+		return array( 'end' => time() );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Ping' );


### PR DESCRIPTION
Fixes nothing.

#### Changes proposed in this Pull Request:

* adds an endpoint `/wp-json/wpcom/v2/ping`.

#### Testing instructions:

Testing instructions incoming. Should go side by side with a diff.

#### Proposed changelog entry for your changes:

none needed