### PR TITLE
Sharing: save post meta on the media edit screen as well.

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -275,6 +275,7 @@ function sharing_email_check( $true, $post, $data ) {
 add_action( 'init', 'sharing_init' );
 add_action( 'add_meta_boxes', 'sharing_add_meta_box' );
 add_action( 'save_post', 'sharing_meta_box_save' );
+add_action( 'edit_attachment', 'sharing_meta_box_save' );
 add_action( 'sharing_email_send_post', 'sharing_email_send_post' );
 add_filter( 'sharing_email_can_send', 'sharing_email_check_for_spam_via_akismet' );
 add_action( 'sharing_global_options', 'sharing_global_resources', 30 );


### PR DESCRIPTION
Fixes #10150

#### Changes proposed in this Pull Request:

Until now, we only saved post meta when saving a post, not when saving an attachment.
This problem does not exist with Likes as we already hook into `edit_attachment` there.

#### Testing instructions:

1) Go to WP-Admin > Media > Open an image
2) Hit `edit more details` option
3) Disable sharing buttons from the right sidebar
4) Save settings
5) Make sure your settings are saved properly.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Sharing: allow saving sharing button options on media edit page as well.