### PR TITLE
CSS Concat: add authors and Social Icons widgets to concat styles.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -60,6 +60,8 @@ class Jetpack {
 		'flickr-widget-style',
 		'jetpack-search-widget',
 		'jetpack-simple-payments-widget-style',
+		'jetpack-widget-social-icons-styles',
+		'jetpack-authors-widget',
 	);
 
 	/**


### PR DESCRIPTION
Fixes #10009

#### Changes proposed in this Pull Request:

Do not load the authors and Social Icons widgets' stylesheets separately, whether the widget is on the page or not; instead, load it as part of the `jetpack.css` file.

#### Testing instructions:

0. Make sure `SCRIPT_DEBUG` is not set to true on your site. 
1. Load your site and make sure the `modules/widgets/social-icons/social-icons.css` and `modules/widgets/authors/style.css` files are not loaded. 
2. Add the 2 widgets to your site, and make sure they are styled properly.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
CSS Concatenation: add Authors and Social Icons widgets to concatenated styles.