### PR TITLE
Gutenberg: add view files to Gutenberg tester

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7379,17 +7379,17 @@ p {
 		);
 
 		 wp_register_script(
-		   'jetpack-blocks-view',
-		   $block_script,
-		   array(),
-		   $version
+			'jetpack-blocks-view',
+			$view_script,
+			array(),
+			$version
 		 );
 
 		 wp_register_style(
-		   'jetpack-blocks-view',
-		   $block_style,
-		   array(),
-		   $version
+			'jetpack-blocks-view',
+			$view_style,
+			array(),
+			$version
 		 );
 
 		register_block_type( 'jetpack/blocks', array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7295,10 +7295,10 @@ p {
 	 *
 	 *
 	 * Loading blocks is disabled by default and enabled via filter:
-	 *   add_filter( 'jetpack_gutenberg', '__return_true', 10 );
+	 *   add_filter( 'jetpack_gutenberg', '__return_true' );
 	 *
 	 * When enabled, blocks are loaded from CDN by default. To load locally instead:
-	 *   add_filter( 'jetpack_gutenberg_cdn', '__return_false', 10 );
+	 *   add_filter( 'jetpack_gutenberg_cdn', '__return_false' );
 	 *
 	 * Note that when loaded locally, you need to build the files yourself:
 	 * - _inc/blocks/jetpack-editor.js
@@ -7334,10 +7334,10 @@ p {
 		 */
 		if ( apply_filters( 'jetpack_gutenberg_cdn', true ) ) {
 			$cdn_base = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$editor_script = "$cdn_base/jetpack-editor.js";
-			$editor_style = "$cdn_base/jetpack-editor$rtl.css";
-			$view_script = "$cdn_base/jetpack-view.js";
-			$view_style = "$cdn_base/jetpack-view$rtl.css";
+			$editor_script = "$cdn_base/editor.js";
+			$editor_style = "$cdn_base/editor$rtl.css";
+			$view_script = "$cdn_base/view.js";
+			$view_style = "$cdn_base/view$rtl.css";
 
 			/**
 			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
@@ -7348,11 +7348,13 @@ p {
 			 */
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
-			$editor_script = plugins_url( '_inc/blocks/jetpack-editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style = plugins_url( "_inc/blocks/jetpack-editor$rtl.css", JETPACK__PLUGIN_FILE );
-			$view_script = plugins_url( '_inc/blocks/jetpack-view.js', JETPACK__PLUGIN_FILE );
-			$view_style = plugins_url( "_inc/blocks/jetpack-view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) ? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) : JETPACK__VERSION;
+			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
+			$editor_style = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
+			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
+			$view_style = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
+			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+				: JETPACK__VERSION;
 		}
 
 		wp_register_script(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7352,7 +7352,7 @@ p {
 			$editor_style = plugins_url( "_inc/blocks/jetpack-editor$rtl.css", JETPACK__PLUGIN_FILE );
 			$view_script = plugins_url( '_inc/blocks/jetpack-view.js', JETPACK__PLUGIN_FILE );
 			$view_style = plugins_url( "_inc/blocks/jetpack-view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) : JETPACK__VERSION;
+			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) ? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) : JETPACK__VERSION;
 		}
 
 		wp_register_script(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7371,26 +7371,9 @@ p {
 			$version
 		);
 
-		wp_register_style(
-			'jetpack-blocks-editor',
-			$editor_style,
-			array(),
-			$version
-		);
-
-		 wp_register_script(
-			'jetpack-blocks-view',
-			$view_script,
-			array(),
-			$version
-		 );
-
-		 wp_register_style(
-			'jetpack-blocks-view',
-			$view_style,
-			array(),
-			$version
-		 );
+		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );
+		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
 
 		register_block_type( 'jetpack/blocks', array(
 				'script'        => 'jetpack-blocks-view',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7323,6 +7323,8 @@ p {
 			return;
 		}
 
+		$rtl = is_rtl() ? '.rtl' : '';
+
 		/**
 		 * Filter to turn off serving blocks via CDN
 		 *
@@ -7331,8 +7333,11 @@ p {
 		 * @param bool true Whether to load Gutenberg blocks from CDN
 		 */
 		if ( apply_filters( 'jetpack_gutenberg_cdn', true ) ) {
-			$editor_script = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks/jetpack-editor.js';
-			$editor_style = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks/jetpack-editor.css';
+			$cdn_base = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
+			$editor_script = "$cdn_base/jetpack-editor.js";
+			$editor_style = "$cdn_base/jetpack-editor$rtl.css";
+			$view_script = "$cdn_base/jetpack-view.js";
+			$view_style = "$cdn_base/jetpack-view$rtl.css";
 
 			/**
 			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
@@ -7344,7 +7349,9 @@ p {
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
 			$editor_script = plugins_url( '_inc/blocks/jetpack-editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style = plugins_url( '_inc/blocks/jetpack-editor.css', JETPACK__PLUGIN_FILE );
+			$editor_style = plugins_url( "_inc/blocks/jetpack-editor$rtl.css", JETPACK__PLUGIN_FILE );
+			$view_script = plugins_url( '_inc/blocks/jetpack-view.js', JETPACK__PLUGIN_FILE );
+			$view_style = plugins_url( "_inc/blocks/jetpack-view$rtl.css", JETPACK__PLUGIN_FILE );
 			$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/jetpack-editor.js' ) : JETPACK__VERSION;
 		}
 
@@ -7371,7 +7378,23 @@ p {
 			$version
 		);
 
+		 wp_register_script(
+		   'jetpack-blocks-view',
+		   $block_script,
+		   array(),
+		   $version
+		 );
+
+		 wp_register_style(
+		   'jetpack-blocks-view',
+		   $block_style,
+		   array(),
+		   $version
+		 );
+
 		register_block_type( 'jetpack/blocks', array(
+				'script'        => 'jetpack-blocks-view',
+				'style'         => 'jetpack-blocks-view',
 				'editor_script' => 'jetpack-blocks-editor',
 				'editor_style'  => 'jetpack-blocks-editor',
 		) );


### PR DESCRIPTION
- Adds `view` files to Gutenberg tester
- Renames editor files from `jetpack-editor.*` to `editor.*`
- Add support for RTL CSS files

#### Testing instructions:

- Switch to `try/stylish-hello-dolly` branch in Calypso (https://github.com/Automattic/wp-calypso/pull/27241)
- From calypso folder, generate files — note to change `output-dir` to correct place:
    ```bash
    npm run sdk -- gutenberg \
      --editor-script=client/gutenberg/extensions/presets/jetpack/editor.js \
      --view-script=client/gutenberg/extensions/presets/jetpack/view.js \
      --output-editor-file=editor \
      --output-view-file=view \
      --output-dir=/absolute_path_to_your_jetpack/_inc/blocks
    ```
- Add these filters to your Jetpack setup, e.g. to a file in `mu-plugins` folder:
    ```php
    add_filter( 'jetpack_gutenberg', '__return_true' );
    ```
    These will: enable loading these Gutenberg assets from the CDN. You should see all the files throw 404. We'll still need tofollow up and add these files.
- To disable loading via CDN and load files from your local disk instead, add:
    ```php
    add_filter( 'jetpack_gutenberg_cdn', '__return_false' );
    ```
    You should now see all the files load and _"Hello Dolly"_ Gutenberg block be available:
    ![image](https://user-images.githubusercontent.com/87168/45624262-88ec9e00-ba92-11e8-90c2-47c20010c81e.png)

- If you switch your site to RTL mode (~e.g. with [rtl-tester](https://wordpress.org/plugins/rtl-tester/)~ e.g. by changing your language from settings to Hebrew. RTL tester doesn't seem to trigger `is_rtl()`), you should see at both theme, and the editor side RTL CSS files loaded instead.