### PR TITLE
Remove translations for "Jetpack" and "WordPress.com"

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -160,7 +160,7 @@ export class Footer extends React.Component {
 							{
 								version
 									? __( 'Jetpack version %(version)s', { args: { version } } )
-									: __( 'Jetpack' )
+									: 'Jetpack'
 							}
 						</a>
 					</li>

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -9,10 +9,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	protected $is_redirecting = false;
 
 	function get_page_hook() {
-		$title = _x( 'Jetpack', 'The menu item label', 'jetpack' );
-
 		// Add the main admin Jetpack menu
-		return add_menu_page( 'Jetpack', $title, 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div' );
+		return add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div' );
 	}
 
 	function add_page_actions( $hook ) {

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -201,7 +201,7 @@ class Jetpack_Network {
 		$wp_admin_bar->add_node( array(
 			'parent' => 'network-admin',
 			'id'     => 'network-admin-jetpack',
-			'title'  => __( 'Jetpack', 'jetpack' ),
+			'title'  => 'Jetpack',
 			'href'   => $this->get_url( 'network_admin_page' ),
 		) );
 	}
@@ -267,7 +267,7 @@ class Jetpack_Network {
 	 * @since 2.9
 	 */
 	public function add_network_admin_menu() {
-		add_menu_page( __( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'jetpack_network_admin_page', 'jetpack', array( $this, 'wrap_network_admin_page' ), 'div', 3 );
+		add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_network_admin_page', 'jetpack', array( $this, 'wrap_network_admin_page' ), 'div', 3 );
 		$jetpack_sites_page_hook = add_submenu_page( 'jetpack', __( 'Jetpack Sites', 'jetpack' ), __( 'Sites', 'jetpack' ), 'jetpack_network_sites_page', 'jetpack', array( $this, 'wrap_network_admin_page' ) );
 		$jetpack_settings_page_hook = add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_network_settings_page', 'jetpack-settings', array( $this, 'wrap_render_network_admin_settings_page' ) );
 		add_action( "admin_print_styles-$jetpack_sites_page_hook",  array( 'Jetpack_Admin_Page', 'load_wrapper_styles' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3915,7 +3915,7 @@ p {
 
 	function plugin_action_links( $actions ) {
 
-		$jetpack_home = array( 'jetpack-home' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack' ), __( 'Jetpack', 'jetpack' ) ) );
+		$jetpack_home = array( 'jetpack-home' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack' ), 'Jetpack' ) );
 
 		if( current_user_can( 'jetpack_manage_modules' ) && ( Jetpack::is_active() || Jetpack::is_development_mode() ) ) {
 			return array_merge(

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -111,9 +111,9 @@ class Publicize_UI {
 			<p><?php
 
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				$platform =  __( 'WordPress.com', 'jetpack' );
+				$platform =  'WordPress.com';
 			} else {
-				$platform = __( 'Jetpack', 'jetpack' );
+				$platform = 'Jetpack';
 			}
 
 			printf(


### PR DESCRIPTION
Remove translations for `Jetpack` and `WordPress.com` as we never translate them anyway.

This came up at https://github.com/Automattic/wp-calypso/pull/27190#discussion_r218363254

See https://translate.wordpress.com/translation-style-guide/ for reference.

### Testing
- Check that Jetpack wp-admin menu works in single and multi installs
- Check that Publicize UI works