### PR TITLE
Shortcodes: ensure that we generate RTL & min files for slideshows

### DIFF
--- a/tools/builder/admin-css.js
+++ b/tools/builder/admin-css.js
@@ -16,7 +16,7 @@ const admincss = [
 	'modules/custom-post-types/comics/comics.css',
 	'modules/shortcodes/css/recipes.css',
 	'modules/shortcodes/css/recipes-print.css',
-
+	'modules/shortcodes/css/slideshow-shortcode.css',
 	'modules/after-the-deadline/atd.css',
 	'modules/after-the-deadline/tinymce/css/content.css',
 	'modules/contact-form/css/editor-inline-editing-style.css',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Up until now, no rtl files or min files were generated when running `yarn build`.
This caused issues on RTL sites, but also in other places where we look for the file,
like in the work we are doing in #10102

#### Testing instructions:

Apply this branch, run `yarn build`, and check for 2 new minified files and an RTL file under `modules/shortcodes/css/`.

You can also check that the slideshows look good on a site using an RTL language.

#### Proposed changelog entry for your changes:
Shortcodes: ensure we build minified and RTL stylesheets for slideshows.