### PR TITLE
Slideshows: arrows must point in the right direction for all lang

### DIFF
--- a/modules/shortcodes/css/slideshow-shortcode.css
+++ b/modules/shortcodes/css/slideshow-shortcode.css
@@ -99,6 +99,7 @@ body div.slideshow-window * img {
 	-webkit-transition: 300ms opacity ease-out;
 	-moz-transition: 300ms opacity ease-out;
 	transition: 300ms opacity ease-out;
+	direction: ltr;
 }
 
 .slideshow-window:hover .slideshow-controls {


### PR DESCRIPTION
Fixes #7384

#### Changes proposed in this Pull Request:

Explicitly adding a direction to the default css ensures that direction gets flipped in the automatically generated RTL version of the file.

#### Testing instructions:

1. Add a slideshow to one of your posts (add a gallery, choose the slideshow gallery type).
2. In Settings > General, switch your site language to Hebrew for example.
3. View the post.
4. Ensure that the arrows in the slideshow point away from the center:

![](https://camo.githubusercontent.com/853c404a9c4c2c8bf217f1712caab1551e8c7515/68747470733a2f2f696d6167652e70726e747363722e636f6d2f696d6167652f4b50704a6d53674c5369616f6c4250317a324d3448772e706e67)

They should not look like this:

![](https://camo.githubusercontent.com/250cd30fdc37e1b03b1894b909190e3309354be5/68747470733a2f2f696d6167652e70726e747363722e636f6d2f696d6167652f77584b762d4b424152744f4b515f6e37794b4b3343412e706e67)

Note that the RTL file must be generated first, so you'll need to run `yarn build`, and only after #10162 has been merged.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Slideshows: ensure arrows point in the right direction for RTL Languages.
