### PR TITLE
Sharing: handle WordPress.com's situation (stats always active)

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -611,12 +611,19 @@ function sharing_add_footer() {
 			endif;
 		endif;
 
+		// Is the Stats module active? It is always active on WordPress.com.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$is_stats_active = true;
+		} else {
+			$is_stats_active = Jetpack::is_module_active( 'stats' );
+		}
+
 		wp_enqueue_script( 'sharing-js' );
 		$sharing_js_options = array(
 			'lang'            => get_base_recaptcha_lang_code(),
 			/** This filter is documented in modules/sharedaddy/sharing-service.php */
 			'counts'          => apply_filters( 'jetpack_sharing_counts', true ),
-			'is_stats_active' => Jetpack::is_module_active( 'stats' ),
+			'is_stats_active' => $is_stats_active,
 		);
 		wp_localize_script( 'sharing-js', 'sharing_js_options', $sharing_js_options );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We cannot rely on `Jetpack::is_module_active()` on WordPress.com,
so we must do an additional check before to use the function.

@see https://github.com/Automattic/jetpack/pull/10120#discussion_r218159456

Note that I had also taken a different approach earlier in 178ca1d48be41faa5de9dd3a28e9b806b3dd9bac , but opted for this PR instead, after receiving feedback. Happy to reconsider though, if needed.

#### Testing instructions:

1. Enable Sharing and Stats.
2. Add a Facebook button to your posts.
3. Load a post and check requests in the network tab; you will see 2 requests to `pixel.wp.com`; one for regular stats and one for sharing.
4. Disable the Stats module (under the old Module settings screen)
5. Reload the post's page; you should see no `pixel.wp.com` request.