### PR TITLE
Gutenberg: Require wordpress/date as a dependency

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7366,6 +7366,7 @@ p {
 				'wp-components',
 				'wp-compose',
 				'wp-data',
+				'wp-date',
 				'wp-editor',
 				'wp-element',
 				'wp-i18n',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Include `@wordpress/date` as a dependency for custom gutenberg blocks.

#### Testing instructions:
* Follow instructions at https://github.com/Automattic/wp-calypso/pull/26530