### PR TITLE
Gravatar Widget: do not autocapitalize this instance of WordPress.

### DIFF
--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -413,7 +413,8 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 				return 'Yahoo!';
 			case 'youtube':
 				return 'YouTube';
-			case 'WordPress':
+			// phpcs:ignore WordPress.WP.CapitalPDangit
+			case 'wordpress':
 				return 'WordPress';
 			case 'tripit':
 				return 'TripIt';


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

#10170 introduced this issue when we automatically fixed that instance of the "WordPress" string.

#### Testing instructions:

Coding style fixes.