### PR TITLE
Jetpack Sync: Sync feedback keys and values

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2431,8 +2431,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'type'    => $field->attributes['type'],
 				'label'   => $field->attributes['label'],
 				'options' => isset( $field->attributes['options'] ) ? $field->attributes['options'] : '',
-				'post_id' => $post_id,
-
 			);
 		}
 		// capture all feedback keys, values, and types so we have it with delimiters in the future

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2423,6 +2423,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
+		// capture all feedback keys and values so we have it with delimiters in the future
+		update_post_meta( $post_id, '_feedback_all_fields', $this->addslashes_deep( $all_values ) );
+
 		if ( 'publish' == $feedback_status ) {
 			// Increase count of unread feedback.
 			$unread = get_option( 'feedback_unread_count', 0 ) + 1;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2430,7 +2430,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'value'   => $field->value,
 				'type'    => $field->attributes['type'],
 				'label'   => $field->attributes['label'],
-				'options' => $field->attributes['options'],
+				'options' => isset( $field->attributes['options'] ) ? $field->attributes['options'] : '',
 				'post_id' => $post_id,
 
 			);

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2431,6 +2431,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'type'    => $field->attributes['type'],
 				'label'   => $field->attributes['label'],
 				'options' => $field->attributes['options'],
+				'post_id' => $post_id,
 
 			);
 		}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2423,8 +2423,19 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
-		// capture all feedback keys and values so we have it with delimiters in the future
-		update_post_meta( $post_id, '_feedback_all_fields', $this->addslashes_deep( $all_values ) );
+		$form_data = array();
+		foreach ( $this->fields as $key => $field ) {
+			$form_data[ $key ] = array(
+				'key'     => $key,
+				'value'   => $field->value,
+				'type'    => $field->attributes['type'],
+				'label'   => $field->attributes['label'],
+				'options' => $field->attributes['options'],
+
+			);
+		}
+		// capture all feedback keys, values, and types so we have it with delimiters in the future
+		update_post_meta( $post_id, '_feedback_all_fields', $this->addslashes_deep( $form_data ) );
 
 		if ( 'publish' == $feedback_status ) {
 			// Increase count of unread feedback.

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -364,6 +364,7 @@ class Jetpack_Sync_Defaults {
 
 	static $post_meta_whitelist = array(
 		'_feedback_akismet_values',
+		'_feedback_all_fields',
 		'_feedback_email',
 		'_feedback_extra_fields',
 		'_g_feedback_shortcode',

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -168,8 +168,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'value'   => 'John Doe',
 				'type'    => 'name',
 				'label'   => 'Name',
-				'options' => array
-				(),
+				'options' => array(),
 				'post_id' => 5
 			),
 			'g4-dropdown' => array
@@ -206,8 +205,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'value'   => 'Texty text',
 				'type'    => 'text',
 				'label'   => 'Text',
-				'options' => array
-				(),
+				'options' => array(),
 				'post_id' => 5
 			)
 		);

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -169,7 +169,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'type'    => 'name',
 				'label'   => 'Name',
 				'options' => array(),
-				'post_id' => $submission->ID
 			),
 			'g' . $submission->ID . '-dropdown' => array
 			(
@@ -183,7 +182,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Second option',
 					'Third option',
 				),
-				'post_id' => $submission->ID
 			),
 			'g' . $submission->ID . '-radio' => array
 			(
@@ -197,7 +195,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Second option',
 					'Third option'
 				),
-				'post_id' => $submission->ID
 			),
 			'g' . $submission->ID . '-text' => array
 			(
@@ -206,7 +203,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'type'    => 'text',
 				'label'   => 'Text',
 				'options' => array(),
-				'post_id' => $submission->ID
 			)
 		);
 

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -169,7 +169,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'type'    => 'name',
 				'label'   => 'Name',
 				'options' => array(),
-				'post_id' => 5
+				'post_id' => $submission->ID
 			),
 			'g4-dropdown' => array
 			(
@@ -183,7 +183,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Second option',
 					'Third option',
 				),
-				'post_id' => 5
+				'post_id' => $submission->ID
 			),
 			'g4-radio' => array
 			(
@@ -197,7 +197,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Second option',
 					'Third option'
 				),
-				'post_id' => 5
+				'post_id' => $submission->ID
 			),
 			'g4-text' => array
 			(
@@ -206,7 +206,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'type'    => 'text',
 				'label'   => 'Text',
 				'options' => array(),
-				'post_id' => 5
+				'post_id' => $submission->ID
 			)
 		);
 

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -161,7 +161,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$submission = $feedback[0];
 		$all_fields = get_post_meta( $submission->ID, '_feedback_all_fields', true );
 
-		$id = $submission->ID - 1;
+		$id = $submission->post_parent;
 		$key_prefix = 'g' . $id;
 		$expected = array(
 			$key_prefix . '-name' => array(

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -162,16 +162,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$all_fields = get_post_meta( $submission->ID, '_feedback_all_fields', true );
 
 		$expected = array(
-			'g' . $submission->ID . '-name' => array
-			(
+			array(
 				'key'     => 'g4-name',
 				'value'   => 'John Doe',
 				'type'    => 'name',
 				'label'   => 'Name',
 				'options' => array(),
 			),
-			'g' . $submission->ID . '-dropdown' => array
-			(
+			array(
 				'key'     => 'g4-dropdown',
 				'value'   => 'First option',
 				'type'    => 'select',
@@ -183,8 +181,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Third option',
 				),
 			),
-			'g' . $submission->ID . '-radio' => array
-			(
+			array(
 				'key'     => 'g4-radio',
 				'value'   => 'Second option',
 				'type'    => 'radio',
@@ -196,8 +193,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Third option'
 				),
 			),
-			'g' . $submission->ID . '-text' => array
-			(
+			array(
 				'key'     => 'g4-text',
 				'value'   => 'Texty text',
 				'type'    => 'text',
@@ -206,7 +202,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $expected, $all_fields );
+		$this->assertEquals( $expected, array_values( $all_fields ) );
 	}
 
 	/**

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -161,16 +161,18 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$submission = $feedback[0];
 		$all_fields = get_post_meta( $submission->ID, '_feedback_all_fields', true );
 
+		$id = $submission->ID - 1;
+		$key_prefix = 'g' . $id;
 		$expected = array(
-			array(
-				'key'     => 'g4-name',
+			$key_prefix . '-name' => array(
+				'key'     => $key_prefix . '-name',
 				'value'   => 'John Doe',
 				'type'    => 'name',
 				'label'   => 'Name',
 				'options' => array(),
 			),
-			array(
-				'key'     => 'g4-dropdown',
+			$key_prefix . '-dropdown' => array(
+				'key'     => $key_prefix . '-dropdown',
 				'value'   => 'First option',
 				'type'    => 'select',
 				'label'   => 'Dropdown',
@@ -181,8 +183,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Third option',
 				),
 			),
-			array(
-				'key'     => 'g4-radio',
+			$key_prefix . '-radio' => array(
+				'key'     => $key_prefix . '-radio',
 				'value'   => 'Second option',
 				'type'    => 'radio',
 				'label'   => 'Radio',
@@ -193,8 +195,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 					'Third option'
 				),
 			),
-			array(
-				'key'     => 'g4-text',
+			$key_prefix . '-text' => array(
+				'key'     => $key_prefix . '-text',
 				'value'   => 'Texty text',
 				'type'    => 'text',
 				'label'   => 'Text',
@@ -202,7 +204,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $expected, array_values( $all_fields ) );
+		$this->assertEquals( $expected, $all_fields );
 	}
 
 	/**

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -133,6 +133,89 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers Grunion_Contact_Form::process_submission
+	 *
+	 * Tests that the submission will store all of the fields as metadata
+	 */
+	public function test_process_submission_will_store_all_field_metadata() {
+		// Fill field values
+		$this->add_field_values( array(
+			'name'     => 'John Doe',
+			'dropdown' => 'First option',
+			'radio'    =>'Second option',
+			'text'     =>'Texty text'
+		) );
+
+		// Initialize a form with name, dropdown and radiobutton (first, second
+		// and third option), text field
+		$form = new Grunion_Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$result = $form->process_submission();
+
+		// Processing should be successful and produce the success message
+		$this->assertTrue( is_string( $result ) );
+
+		$feedback = get_posts( array( 'post_type' => 'feedback' ) );
+		$this->assertEquals( 1, count( $feedback ), 'There should be one feedback after process_submission' );
+
+		// All field should be saved
+		$submission = $feedback[0];
+		$all_fields = get_post_meta( $submission->ID, '_feedback_all_fields', true );
+
+		$expected = array(
+			'g4-name' => array
+			(
+				'key'     => 'g4-name',
+				'value'   => 'John Doe',
+				'type'    => 'name',
+				'label'   => 'Name',
+				'options' => array
+				(),
+				'post_id' => 5
+			),
+			'g4-dropdown' => array
+			(
+				'key'     => 'g4-dropdown',
+				'value'   => 'First option',
+				'type'    => 'select',
+				'label'   => 'Dropdown',
+				'options' => array
+				(
+					'First option',
+					'Second option',
+					'Third option',
+				),
+				'post_id' => 5
+			),
+			'g4-radio' => array
+			(
+				'key'     => 'g4-radio',
+				'value'   => 'Second option',
+				'type'    => 'radio',
+				'label'   => 'Radio',
+				'options' => array
+				(
+					'First option',
+					'Second option',
+					'Third option'
+				),
+				'post_id' => 5
+			),
+			'g4-text' => array
+			(
+				'key'     => 'g4-text',
+				'value'   => 'Texty text',
+				'type'    => 'text',
+				'label'   => 'Text',
+				'options' => array
+				(),
+				'post_id' => 5
+			)
+		);
+
+		$this->assertEquals( $expected, $all_fields );
+	}
+
+	/**
 	 * @author tonykova
 	 * @covers Grunion_Contact_Form::process_submission
 	 *

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -162,7 +162,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$all_fields = get_post_meta( $submission->ID, '_feedback_all_fields', true );
 
 		$expected = array(
-			'g4-name' => array
+			'g' . $submission->ID . '-name' => array
 			(
 				'key'     => 'g4-name',
 				'value'   => 'John Doe',
@@ -171,7 +171,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				'options' => array(),
 				'post_id' => $submission->ID
 			),
-			'g4-dropdown' => array
+			'g' . $submission->ID . '-dropdown' => array
 			(
 				'key'     => 'g4-dropdown',
 				'value'   => 'First option',
@@ -185,7 +185,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				'post_id' => $submission->ID
 			),
-			'g4-radio' => array
+			'g' . $submission->ID . '-radio' => array
 			(
 				'key'     => 'g4-radio',
 				'value'   => 'Second option',
@@ -199,7 +199,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				'post_id' => $submission->ID
 			),
-			'g4-text' => array
+			'g' . $submission->ID . '-text' => array
 			(
 				'key'     => 'g4-text',
 				'value'   => 'Texty text',

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1208,10 +1208,10 @@ That was a cool video.';
 		add_post_meta( $post_id, '_feedback_all_fields', $feedback_fields );
 
 		$this->sender->do_sync();
-		$events = $this->server_event_storage->get_all_events( 'added_post_meta' );
+		$event = $this->server_event_storage->get_most_recent_event( 'added_post_meta' );
 
-		$this->assertEquals( $events[0]->args[2], '_feedback_all_fields' );
-		$this->assertEquals( $events[0]->args[3], $feedback_fields );
+		$this->assertEquals( $event->args[2], '_feedback_all_fields' );
+		$this->assertEquals( $event->args[3], $feedback_fields );
 	}
 
 	function add_a_hello_post_type() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1164,7 +1164,6 @@ That was a cool video.';
 				'type'    => 'name',
 				'label'   => 'Name',
 				'options' => array(),
-				'post_id' => $post_id
 			),
 			'g4-dropdown' => array
 			(
@@ -1178,7 +1177,6 @@ That was a cool video.';
 					'Second option',
 					'Third option',
 				),
-				'post_id' => $post_id
 			),
 			'g4-radio' => array
 			(
@@ -1192,7 +1190,6 @@ That was a cool video.';
 					'Second option',
 					'Third option'
 				),
-				'post_id' => $post_id
 			),
 			'g4-text' => array
 			(
@@ -1201,7 +1198,6 @@ That was a cool video.';
 				'type'    => 'text',
 				'label'   => 'Text',
 				'options' => array(),
-				'post_id' => $post_id
 			)
 		);
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1141,6 +1141,79 @@ That was a cool video.';
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 
+	public function test_sync_feedback_fields_when_feedback_submitted() {
+		/*
+		 * Note that a test for ensuring the proper meta is set when the feedback
+		 * form is submitted was added here,
+		 *
+		 * tests/php/modules/contact-form/test_class.grunion-contact-form.php
+		 * test_process_submission_will_store_all_field_metadata()
+		 *
+		 * In the test below, we will just set the meta and ensure it is
+		 * synced, rather than duplicate the feedback form test
+		 */
+
+		$user_id = $this->factory->user->create();
+		$post_id = $this->factory->post->create( array( 'post_author' => $user_id, 'post_type' => 'feedback' ) );
+
+		$feedback_fields = array(
+			'g4-name' => array
+			(
+				'key'     => 'g4-name',
+				'value'   => 'John Doe',
+				'type'    => 'name',
+				'label'   => 'Name',
+				'options' => array(),
+				'post_id' => $post_id
+			),
+			'g4-dropdown' => array
+			(
+				'key'     => 'g4-dropdown',
+				'value'   => 'First option',
+				'type'    => 'select',
+				'label'   => 'Dropdown',
+				'options' => array
+				(
+					'First option',
+					'Second option',
+					'Third option',
+				),
+				'post_id' => $post_id
+			),
+			'g4-radio' => array
+			(
+				'key'     => 'g4-radio',
+				'value'   => 'Second option',
+				'type'    => 'radio',
+				'label'   => 'Radio',
+				'options' => array
+				(
+					'First option',
+					'Second option',
+					'Third option'
+				),
+				'post_id' => $post_id
+			),
+			'g4-text' => array
+			(
+				'key'     => 'g4-text',
+				'value'   => 'Texty text',
+				'type'    => 'text',
+				'label'   => 'Text',
+				'options' => array(),
+				'post_id' => $post_id
+			)
+		);
+
+		add_post_meta( $post_id, '_feedback_all_fields', $feedback_fields );
+
+		$this->sender->do_sync();
+		$events = $this->server_event_storage->get_all_events( 'added_post_meta' );
+
+		$this->assertEquals( $events[0]->args[2], '_feedback_all_fields' );
+		$this->assertEquals( $events[0]->args[3], $feedback_fields );
+	}
+
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;


### PR DESCRIPTION
This PR syncs structured data submitted to feedback forms so that it can be used downstream by the Activity Log.

#### Testing instructions:

Please follow the instructions here so that you can view live sync data: PCYsg-hnH-p2
and ensure that the data for all of the fields you add to a feedback/contact form are synced via the `added_post_meta` action with the `_feedback_add_fields` key.

New phpunit tests ensure that this meta is added when a feedback form is submitted and that the data is synced when it is added.