### PR TITLE
WordAds: Cast a bool instead of using two not operators

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -499,7 +499,7 @@ HTML;
 	 * @since 4.5.0
 	 */
 	public function should_bail() {
-		return ! $this->option( 'wordads_approved' ) || ! ! $this->option( 'wordads_unsafe' );
+		return ! $this->option( 'wordads_approved' ) || (bool) $this->option( 'wordads_unsafe' );
 	}
 
 	/**


### PR DESCRIPTION
Discovered during the great PHPCBF hunt. Two `!`s are functionally the same as a `(bool)` and should be a tad bit faster.

#### Changes proposed in this Pull Request:

* Use type casting instead of a `!!`

#### Testing instructions:

* None

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
n/a
