### PR TITLE
REST API: Remove Content-Type Constraints

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5612,25 +5612,6 @@ p {
 			return null;
 		}
 
-		if ( ! empty( $_SERVER['CONTENT_TYPE'] ) ) {
-			$content_type = $_SERVER['CONTENT_TYPE'];
-		} elseif ( ! empty( $_SERVER['HTTP_CONTENT_TYPE'] ) ) {
-			$content_type = $_SERVER['HTTP_CONTENT_TYPE'];
-		}
-
-		if (
-			isset( $content_type ) &&
-			$content_type !== 'application/x-www-form-urlencoded' &&
-			$content_type !== 'application/json'
-		) {
-			$this->rest_authentication_status = new WP_Error(
-				'rest_invalid_request',
-				__( 'This Content-Type is not supported.', 'jetpack' ),
-				array( 'status' => 400 )
-			);
-			return null;
-		}
-
 		$verified = $this->verify_xml_rpc_signature();
 
 		if ( is_wp_error( $verified ) ) {

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -35,6 +35,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	public function tearDown() {
 		parent::tearDown();
 		unset(
+			$_SERVER['HTTP_CONTENT_TYPE'],
 			$_GET['_for'],
 			$_GET['token'],
 			$_GET['timestamp'],
@@ -242,11 +243,15 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_authentication_success() {
+		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+		$body = '{"modules":[]}';
+
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+
 		$_GET['token'] = 'pretend_this_is_valid:1:' . self::$admin_id;
 		$_GET['timestamp'] = (string) time();
 		$_GET['nonce'] = 'testing123';
-		$_GET['body-hash'] = jetpack_sha1_base64( '{"modules":[]}' );
+		$_GET['body-hash'] = jetpack_sha1_base64( $body );
 		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', implode( "\n", array(
 			$_GET['token'],
 			$_GET['timestamp'],
@@ -258,13 +263,115 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 			'/jetpack/v4/module/all/active',
 			'qstest=yep',
 		) ) . "\n", 'secret', true ) );
+
 		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/module/all/active' );
-		$this->request->set_header( 'Content-Type', 'application/json' );
-		$this->request->set_body( '{"modules":[]}' );
+		$this->request->set_header( 'Content-Type', $_SERVER['HTTP_CONTENT_TYPE'] );
+		$this->request->set_body( $body );
+
 		$response = $this->server->dispatch( $this->request );
-		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
+
+		// Success here is a 200. When we pass an empty array of modules,
+		// there's nothing to do.
+		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $data['code'] );
+		$this->assertEquals( self::$admin_id, get_current_user_id() );
+	}
+
+	/**
+	 * @covers Jetpack->wp_rest_authenticate
+	 * @requires PHP 5.2
+	 */
+	public function test_jetpack_rest_api_post_urlencoded_authentication_success() {
+		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+		$body = 'modules[]=nope';
+
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+
+		$_GET['token'] = 'pretend_this_is_valid:1:' . self::$admin_id;
+		$_GET['timestamp'] = (string) time();
+		$_GET['nonce'] = 'testing123';
+		$_GET['body-hash'] = jetpack_sha1_base64( $body );
+		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', implode( "\n", array(
+			$_GET['token'],
+			$_GET['timestamp'],
+			$_GET['nonce'],
+			$_GET['body-hash'],
+			'POST',
+			'example.org',
+			'80',
+			'/jetpack/v4/module/all/active',
+			'qstest=yep',
+		) ) . "\n", 'secret', true ) );
+
+		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/module/all/active' );
+		$this->request->set_header( 'Content-Type', $_SERVER['HTTP_CONTENT_TYPE'] );
+		$this->request->set_body( $body );
+		$this->request->set_body_params( wp_parse_args( $body ) );
+
+		$response = $this->server->dispatch( $this->request );
+		$data = $response->get_data();
+
+		// "Success" here is a 400, since we passed in an invalid module name.
+		// Check error code and params info to make sure we've made it through
+		// the auth code. "success" is an activate_modules() - not an auth error.
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $data['code'] );
+		$this->assertEquals( 'modules must be a list of valid modules', $data['data']['params']['modules'] );
+		$this->assertEquals( self::$admin_id, get_current_user_id() );
+	}
+
+	/**
+	 * @covers Jetpack->wp_rest_authenticate
+	 * @requires PHP 5.2
+	 */
+	public function test_jetpack_rest_api_post_multipart_authentication_success() {
+		$_SERVER['HTTP_CONTENT_TYPE'] = 'multipart/form-data; boundary=------------------------test';
+		// Making a valid multipart/form-data body isn't that important here.
+		// Since we pass it straight to both the body hash and the request's ->set_body(),
+		// the hashes should match no matter what we send in.
+		$body =   '--------------------------test' . chr( 13 ) . chr( 10 )
+			. 'Content-Disposition: form-data; name="modules[]"' . chr( 13 ) . chr( 10 )
+			. '' . chr( 13 ) . chr( 10 )
+			. 'nope' . chr( 13 ) . chr( 10 )
+			. '--------------------------test' . chr( 13 ) . chr( 10 )
+			. 'Content-Disposition: form-data; name="_jetpack_is_multipart"' . chr( 13 ) . chr( 10 )
+			. '' . chr( 13 ) . chr( 10 )
+			. '1' . chr( 13 ) . chr( 10 )
+			. '--------------------------test--';
+
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+
+		$_GET['token'] = 'pretend_this_is_valid:1:' . self::$admin_id;
+		$_GET['timestamp'] = (string) time();
+		$_GET['nonce'] = 'testing123';
+		$_GET['body-hash'] = jetpack_sha1_base64( $body );
+		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', implode( "\n", array(
+			$_GET['token'],
+			$_GET['timestamp'],
+			$_GET['nonce'],
+			$_GET['body-hash'],
+			'POST',
+			'example.org',
+			'80',
+			'/jetpack/v4/module/all/active',
+			'qstest=yep',
+		) ) . "\n", 'secret', true ) );
+
+		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/module/all/active' );
+		$this->request->set_header( 'Content-Type', $_SERVER['HTTP_CONTENT_TYPE'] );
+		$this->request->set_body( $body );
+		$this->request->set_body_params( array( 'modules' => array( 'nope' ), '_jetpack_is_multipart' => 1 ) );
+
+		$response = $this->server->dispatch( $this->request );
+		$data = $response->get_data();
+
+		// "Success" here is a 400, since we passed in an invalid module name.
+		// Check error code and params info to make sure we've made it through
+		// the auth code. "success" is an activate_modules() - not an auth error.
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $data['code'] );
+		$this->assertEquals( 'modules must be a list of valid modules', $data['data']['params']['modules'] );
 		$this->assertEquals( self::$admin_id, get_current_user_id() );
 	}
 


### PR DESCRIPTION
WordPress.com's D18560-code allows arbitrary `Content-Type`s and removes the need to base64-encode files before forwarding them to Jetpack.

Related to #9965

#### Changes proposed in this Pull Request:

* Remove Jetpack's Content-Type restrictions when handling a forwarded REST API request.

#### Testing instructions:

Testing from the WordPress.com side at D18560-code.

For Jetpack, `yarn docker:phpunit --filter=WP_Test_Jetpack_REST_API_Authentication`