### PR TITLE
Add Tracks Event on Google Site Verification

### DIFF
--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -51,7 +51,16 @@ function jetpack_verification_print_meta() {
 				} else {
 					$verification_code = $verification_services_codes[ "$name" ];
 				}
-				$ver_tag = sprintf( '<meta name="%s" content="%s" />', esc_attr( $service['key'] ), esc_attr( $verification_code ) );
+				$ver_tag = sprintf( '<meta name="%s" content="%s" />', esc_attr( $service["key"] ), esc_attr( $verification_code ) );
+
+				if (
+					isset( $_SERVER['HTTP_USER_AGENT'] ) &&
+					preg_match( '/.*Google-Site-Verification.*/', $_SERVER['HTTP_USER_AGENT'] ) &&
+					'google-site-verification' === $service[ 'key' ]
+				) {
+					jetpack_require_lib( 'tracks/client' );
+					jetpack_tracks_record_event( wp_get_current_user(), 'jetpack_google_verification_attempt' );
+				}
 				/**
 				 * Filter the meta tag template used for all verification tools.
 				 *


### PR DESCRIPTION
Fixes #

* Add an Event when a Meta Verification Tag is returned to a Google Site Verification request

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

TBD

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

TBD