### PR TITLE
More constants added to error log for the Jetpack test suite

### DIFF
--- a/docker/config/wp-tests-config.php
+++ b/docker/config/wp-tests-config.php
@@ -25,6 +25,16 @@ define( 'WP_DEBUG', true );
 // Enable error logging for tests
 define( 'WP_DEBUG_LOG', true );
 
+// Additional constants for better error log
+@error_reporting( E_ALL );
+@ini_set( 'log_errors', true );
+@ini_set( 'log_errors_max_len', '0' );
+
+define( 'WP_DEBUG_DISPLAY', false );
+define( 'CONCATENATE_SCRIPTS', false );
+define( 'SCRIPT_DEBUG', true );
+define( 'SAVEQUERIES', true );
+
 // ** MySQL settings ** //
 
 // This configuration file will be used by the copy of WordPress being tested.


### PR DESCRIPTION
Fixes #9773

#### Changes proposed in this Pull Request:

* Constants mentioned in the following issue have been added in this PR - https://github.com/Automattic/jetpack/issues/9773

#### Testing instructions:
- You need to output to log from test files e.g. with `error_log('boom')`
- [Instructions for running tests in Docker setup](https://github.com/Automattic/jetpack/tree/4f6c69e8c8d7406a68dcbb4d16f6bc17e18fc0d7/docker#running-unit-tests)
- Tail logs from Docker setup with `yarn docker:tail` while running those tests — you should see "boom" with this change. Without the change you don't see it.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* N/A
