### PR TITLE
Sitemaps: Do not include images not published

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1228,6 +1228,15 @@ class Jetpack_Sitemap_Builder {
 			);
 		}
 
+		// Do not include the video if the attached parent is not published.
+		// Unattached will be published. Otherwise, will inherit parent status.
+		if ( 'publish' !== get_post_status( $post ) ) {
+			return array(
+				'xml'           => null,
+				'last_modified' => null,
+			);
+		}
+
 		$parent_url = esc_url( get_permalink( get_post( $post->post_parent ) ) );
 		if ( '' == $parent_url ) { // WPCS: loose comparison ok.
 			$parent_url = esc_url( get_permalink( $post ) );

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1040,7 +1040,9 @@ class Jetpack_Sitemap_Builder {
 	 *
 	 * @param WP_Post $post The post to be processed.
 	 *
-	 * @return array An array representing the post URL.
+	 * @return array
+	 *              @type array  $xml An XML fragment representing the post URL.
+	 *              @type string $last_modified Date post was last modified.
 	 */
 	private function post_to_sitemap_item( $post ) {
 
@@ -1118,7 +1120,7 @@ class Jetpack_Sitemap_Builder {
 	 * @param WP_Post $post The image post to be processed.
 	 *
 	 * @return array
-	 *              @type string $xml An XML fragment representing the post URL.
+	 *              @type array  $xml An XML fragment representing the post URL.
 	 *              @type string $last_modified Date post was last modified.
 	 */
 	private function image_post_to_sitemap_item( $post ) {
@@ -1203,7 +1205,9 @@ class Jetpack_Sitemap_Builder {
 	 *
 	 * @param WP_Post $post The video post to be processed.
 	 *
-	 * @return string An XML fragment representing the post URL.
+	 * @return array
+	 *              @type array  $xml An XML fragment representing the post URL.
+	 *              @type string $last_modified Date post was last modified.
 	 */
 	private function video_post_to_sitemap_item( $post ) {
 

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1117,7 +1117,9 @@ class Jetpack_Sitemap_Builder {
 	 *
 	 * @param WP_Post $post The image post to be processed.
 	 *
-	 * @return string An XML fragment representing the post URL.
+	 * @return array
+	 *              @type string $xml An XML fragment representing the post URL.
+	 *              @type string $last_modified Date post was last modified.
 	 */
 	private function image_post_to_sitemap_item( $post ) {
 

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1142,6 +1142,15 @@ class Jetpack_Sitemap_Builder {
 
 		$url = wp_get_attachment_url( $post->ID );
 
+		// Do not include the image if the attached parent is not published.
+		// Unattached will be published. Otherwise, will inherit parent status.
+		if ( 'publish' !== get_post_status( $post ) ) {
+			return array(
+				'xml'           => null,
+				'last_modified' => null,
+			);
+		}
+
 		$parent_url = get_permalink( get_post( $post->post_parent ) );
 		if ( '' == $parent_url ) { // WPCS: loose comparison ok.
 			$parent_url = get_permalink( $post );


### PR DESCRIPTION
Fixes #8138

#### Changes proposed in this Pull Request:

* Before adding an image to the image sitemap, check the post status. When an attachment is checked for status, the following is returned:

1. If the image is private, it will be returned as private. Not included in the sitemap.
2. If the image is unattached, it is assumed published. Included in the sitemap.
3. Otherwise, it will assume the parent status. Any status other than "publish" is not included in the sitemap.

#### Testing instructions:

* Create a new draft post
* Upload a new image to that post. Do not reuse an existing image.
* Save as draft.
* Let the sitemap regenerate. Check the image sitemap.
* Notice the image is included and the link is the parent's permalink (?p=123).
* This page will 404 if not logged in, as a draft.
* Apply patch.
* Try again. Image not included.
#### Proposed changelog entry for your changes:
* No longer add images attached to non-published posts to the image sitemap.