### PR TITLE
Gutenberg: Disable Jetpack blocks when disconnected

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7320,6 +7320,9 @@ p {
 		 *
 		 * @param bool false Whether to load Gutenberg blocks
 		 */
+		if ( ! Jetpack::is_active() ) {
+			return;
+		}
 		if ( ! Jetpack::is_gutenberg_available() || ! apply_filters( 'jetpack_gutenberg', false ) ) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

From pafL3P-1X-p2

> [When] Jetpack is disconnected […], blocks will not show up or work […] previously added blocks will behave as if Jetpack was deactivated.

Do not register Gutenberg blocks when Jetpack is disconnected. This is the same behavior as it Jetpack were deactivated.

Should we enable the blocks in Dev Mode?


#### Testing instructions:

- Connect a new Jetpack site with this branch, Gutenberg, and the Gutenberg Jetpack blocks
- Open the Gutenberg editor and confirm you can add an existing block `/markdown`. Create the block and save the draft.
- Disconnect Jetpack
- Return the the draft. You should now see a Classic Editor block instead of the Jetpack block.