### PR TITLE
Clean up duplicate post types in featured content

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -126,6 +126,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 			// Themes can allow Featured Content pages
 			if ( isset( $theme_support[0]['post_types'] ) ) {
 				self::$post_types = array_merge( self::$post_types, (array) $theme_support[0]['post_types'] );
+				self::$post_types = array_unique( self::$post_types );
 
 				// register post_tag support for each post type
 				foreach ( self::$post_types as $post_type ) {


### PR DESCRIPTION
Add array_unique for the post_types list.

array_merge appends arrays, and since post is set as the default, it means that for many post will be listed twice.

For example in Canard (an Automattic theme) where post_type is set to post and page the post_type will become array( 'post', 'post', 'page' )
https://github.com/Automattic/themes/blob/b8444897830573b47505a19623e1f3459a45aac4/canard/inc/jetpack.php#L22

By filtering the list we prevent the register_taxonomy_for_object_type from being called multiple times for the same post type, and we ensure the post_types are listed once when we later call get_posts.

To be honest I don't imagine it will make a huge amount of difference to anything but I was debugging a featured content issue in my theme and saw this and it confused me. This eliminates that confusion.

## Testing instructions

To test you should add theme support for Jetpack Featured Content as normal, but make sure to include the additional post types.

```
add_theme_support( 'featured-content', array(
		'filter'      => 'canard_get_featured_posts',
		'description' => __( 'The featured content section displays on the front page above the header.', 'canard' ),
		'max_posts'   => 5,
		'post_types'  => array( 'post', 'page' ),
	) );
```

Then, somewhere in your theme, add:

`	var_dump( Featured_Content::$post_types );`

And you should see that post is being listed twice.