### PR TITLE
Gutenberg: update editor script deps

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7362,6 +7362,8 @@ p {
 			'jetpack-blocks-editor',
 			$editor_script,
 			array(
+				'lodash',
+				'wp-api-fetch',
 				'wp-blocks',
 				'wp-components',
 				'wp-compose',
@@ -7369,6 +7371,7 @@ p {
 				'wp-date',
 				'wp-editor',
 				'wp-element',
+				'wp-hooks',
 				'wp-i18n',
 				'wp-plugins',
 			),


### PR DESCRIPTION
Add additional dependencies for Jetpack Gutenberg blocks.

Adding these early on to avoid needs for switching away from a stable version of Jetpack when testing blocks in future. None of the currently shipped versions of blocks (Markdown or Tiled Gallery) use these dependencies yet but we have other blocks in the works.

- `lodash`: many of [our blocks](https://github.com/Automattic/wp-calypso/tree/e29640763f230188febbacbbde61c7c13c2b35b8/client/gutenberg/extensions) are already depending on Lodash. So far this has worked because other dependencies depend on it as well, but it's good to be explicit about these.

- `wp-hooks`: gives access to block filters and actions. Likely going to be needed with Tiled Gallery block https://github.com/Automattic/wp-calypso/pull/27369

- `wp-api-fetch`: used to communicate with WP REST API. Currently used at colour scheme block -experiment, which gives some confidence that we might need this elsewhere, too: https://github.com/Automattic/wp-calypso/pull/26937

gutenpack-jn

#### Changes proposed in this Pull Request:

* Adds `lodash`, `wp-hooks` and `wp-api-fetch` as dependencies for Jetpack Gutenberg blocks.

#### Testing instructions:
- Create a new JN site with this branch + Gutenberg blocks: https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&branch=update/gutenberg-deps
- Open a post in Gutenberg editor, add e.g. Markdown block
- Everything should work smoothly. Check no new issues in console. 👌 
- Not sure what else since these blocks don't use those deps yet — check at least that `window.wp.hooks` and `window.wp.apiFetch` are available?

#### Testing locally instead of Jurassic Ninja
If you would like to test with local Jetpack instead, apply these filters to enable Gutenberg blocks locally:

```php
add_filter( 'jetpack_gutenberg', '__return_true' );
add_filter( 'jetpack_gutenberg_cdn', '__return_true' );
add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
```

JS bundle in CDN currently has an issue, which you can fix by applying D18720-code first.
