### PR TITLE
Update youtube.php

### DIFF
--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -302,9 +302,9 @@ function youtube_id( $url ) {
 	}
 
 	if ( ( isset( $url['path'] ) && '/videoseries' == $url['path'] ) || isset( $qargs['list'] ) ) {
-		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' allowfullscreen='true' style='border:0;'></iframe>";
+		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "https://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' allowfullscreen='true' style='border:0;'></iframe>";
 	} else {
-		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' allowfullscreen='true' style='border:0;'></iframe>";
+		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "https://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' allowfullscreen='true' style='border:0;'></iframe>";
 	}
 
 	// Let's do some alignment wonder in a span, unless we're producing a feed


### PR DESCRIPTION
Fixed issue where HTTP video was being requested and would break on sites using HTTPS.

Fixes #

#### Changes proposed in this Pull Request:

* When embedding a YouTube playlist, the URL would be HTTP instead of HTTPS, causing sites using HTTPS to not display the videos.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Embed a YouTube playlist on a site using HTTPS. With this fix, it will load the playlist correctly.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixed issue where HTTP video was being requested and would break on sites using HTTPS.