### PR TITLE
Update Google Site Verification UI

### DIFF
--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -168,39 +168,45 @@ class GoogleVerificationServiceComponent extends React.Component {
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
+
 					{ this.props.googleSearchConsoleUrl &&
 						<div className="jp-form-input-with-prefix-bottom-message" >
-							<p>{
-								__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
-									components: {
-										a: <ExternalLink
-											icon
-											iconSize={ 16 }
-											target="_blank" rel="noopener noreferrer"
-											href={ this.props.googleSearchConsoleUrl }
-										/>
+							<div className="jp-form-setting-explanation" >
+								<p>
+									{
+										__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}.", {
+											components: {
+												a: <ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank" rel="noopener noreferrer"
+													href={ this.props.googleSearchConsoleUrl }
+												/>
+											}
+										} )
 									}
-								} )
-							}</p>
-							<p>{
-								__( 'Search Console will email you if any unusual events occur with your properties. \
-								Unusual events include indications that your website has been {{a1}}hacked{{/a1}} or problems that Google had when {{a2}}crawling or indexing{{/a2}} your site', {
-									components: {
-										a1: <ExternalLink
-											icon
-											iconSize={ 16 }
-											target="_blank" rel="noopener noreferrer"
-											href={ 'https://developers.google.com/web/fundamentals/security/hacked/' }
-										/>,
-										a2: <ExternalLink
-											icon
-											iconSize={ 16 }
-											target="_blank" rel="noopener noreferrer"
-											href={ 'https://www.google.com/insidesearch/howsearchworks/crawling-indexing.html' }
-										/>
+									{ ' ' }
+									{
+										__( 'Note it will email you if any unusual events occur with your properties. \
+										Unusual events include indications that your website has been {{a1}}hacked{{/a1}}, or problems that Google had when {{a2}}crawling or indexing{{/a2}} your site.', {
+											components: {
+												a1: <ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank" rel="noopener noreferrer"
+													href={ 'https://developers.google.com/web/fundamentals/security/hacked/' }
+												/>,
+												a2: <ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank" rel="noopener noreferrer"
+													href={ 'https://www.google.com/insidesearch/howsearchworks/crawling-indexing.html' }
+												/>
+											}
+										} )
 									}
-								} )
-							}</p>
+								</p>
+							</div>
 						</div>
 					}
 				</div>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -170,7 +170,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 					</div>
 					{ this.props.googleSearchConsoleUrl &&
 						<div className="jp-form-input-with-prefix-bottom-message" >
-							{
+							<p>{
 								__( "Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}", {
 									components: {
 										a: <ExternalLink
@@ -181,7 +181,26 @@ class GoogleVerificationServiceComponent extends React.Component {
 										/>
 									}
 								} )
-							}
+							}</p>
+							<p>{
+								__( 'Search Console will email you if any unusual events occur with your properties. \
+								Unusual events include indications that your website has been {{a1}}hacked{{/a1}} or problems that Google had when {{a2}}crawling or indexing{{/a2}} your site', {
+									components: {
+										a1: <ExternalLink
+											icon
+											iconSize={ 16 }
+											target="_blank" rel="noopener noreferrer"
+											href={ 'https://developers.google.com/web/fundamentals/security/hacked/' }
+										/>,
+										a2: <ExternalLink
+											icon
+											iconSize={ 16 }
+											target="_blank" rel="noopener noreferrer"
+											href={ 'https://www.google.com/insidesearch/howsearchworks/crawling-indexing.html' }
+										/>
+									}
+								} )
+							}</p>
 						</div>
 					}
 				</div>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -30,12 +30,9 @@ import {
 	isVerifyingGoogleSite,
 	getGoogleSiteVerificationError,
 	getGoogleSearchConsoleUrl,
-	getGoogleVerificationConsoleUrl,
 } from 'state/site-verify';
 import { userCanManageOptions } from 'state/initial-state';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action.jsx';
 
 class GoogleVerificationServiceComponent extends React.Component {
 	state = {
@@ -148,34 +145,6 @@ class GoogleVerificationServiceComponent extends React.Component {
 							</Button>
 						}
 					</FormLabel>
-					{ this.props.isSiteVerifiedWithGoogle &&
-						<div className="jp-form-input-with-prefix-bottom-message">
-							{ this.props.googleVerificationConsoleUrl &&
-								<SimpleNotice
-									status="is-warning"
-									isCompact
-									showDismiss={ false }
-									text={ __( 'Editing this HTML Tag code won’t unverify your site with your Google account.' ) }
-								>
-									<NoticeAction
-										external
-										href={ this.props.googleVerificationConsoleUrl }
-									>
-										{ __( 'Unverify with Google' ) }
-									</NoticeAction>
-								</SimpleNotice>
-							}
-							{ ! this.props.googleVerificationConsoleUrl &&
-								<SimpleNotice
-									status="is-warning"
-									isCompact
-									showDismiss={ false }
-									text={ __( 'Editing this HTML Tag code won’t unverify your site with the Google account it is connected to.' ) }
-								>
-								</SimpleNotice>
-							}
-						</div>
-					}
 				</div>
 			);
 		}
@@ -253,7 +222,6 @@ export default connect(
 			fetchingSiteData: isFetchingSiteData( state ),
 			googleSiteVerificationConnectUrl: getExternalServiceConnectUrl( state, 'google_site_verification' ),
 			googleSearchConsoleUrl: getGoogleSearchConsoleUrl( state ),
-			googleVerificationConsoleUrl: getGoogleVerificationConsoleUrl( state ),
 			fetchingGoogleSiteVerify: isFetchingGoogleSiteVerify( state ),
 			isConnectedToGoogle: isConnectedToGoogleSiteVerificationAPI( state ),
 			isSiteVerifiedWithGoogle: isSiteVerifiedWithGoogle( state ),


### PR DESCRIPTION
**DO NOT MERGE**
 Includes changes from #10143 and should be rebased and merged after

Adds a disclaimer to the Google Site Verification that warns users that connecting to Google Search Console will cause emails to be sent to them.

#### Changes proposed in this Pull Request:

**Before**
<img width="730" alt="screen shot 2018-09-24 at 7 05 23 pm" src="https://user-images.githubusercontent.com/2810519/45988682-fbc6bd80-c02c-11e8-9fa0-3789a2215f29.png">

**After**
<img width="723" alt="screen shot 2018-09-24 at 7 03 13 pm" src="https://user-images.githubusercontent.com/2810519/45988688-05502580-c02d-11e8-929c-d93ac66d7997.png">


#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Load up a Jurassic.Ninja Live Branch [here](https://jurassic.ninja/create?jetpack-beta&branch=update/google-site-verification-ui&shortlived&wp-debug-log)
* Connect to WordPress.com
* Navigate to https://[my-site].jurassic.ninja/wp-admin/admin.php?page=jetpack#/traffic
* Scroll to the "Site verification" pane
* Connect your site to Google via the "Auto-verify with Google" button
* Verify that the screen now is nearly identical with the "After" image above