### PR TITLE
Add tracks events for google site verification result

### DIFF
--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -108,7 +108,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	handleClickSetManually = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_click', {
-			isOwner: this.isOwner(),
+			is_owner: this.isOwner(),
 		} );
 
 		this.toggleVerifyMethod( event );
@@ -116,7 +116,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	handleClickEdit = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_edit_click', {
-			isOwner: this.isOwner(),
+			is_owner: this.isOwner(),
 		} );
 
 		this.toggleVerifyMethod( event );
@@ -130,8 +130,8 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	quickSave = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
-			isOwner: this.isOwner(),
-			isEmpty: ! this.props.value
+			is_owner: this.isOwner(),
+			is_empty: ! this.props.value
 		} );
 
 		this.props.onSubmit( event );

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -107,7 +107,17 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	handleClickSetManually = event => {
-		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_click' );
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_click', {
+			isOwner: this.isOwner(),
+		} );
+
+		this.toggleVerifyMethod( event );
+	};
+
+	handleClickEdit = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_edit_click', {
+			isOwner: this.isOwner(),
+		} );
 
 		this.toggleVerifyMethod( event );
 	};
@@ -119,12 +129,18 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	quickSave = event => {
-		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save' );
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
+			isOwner: this.isOwner(),
+		} );
 
 		this.props.onSubmit( event );
 
 		this.toggleVerifyMethod();
 	};
+
+	isOwner() {
+		return !! this.props.googleSearchConsoleUrl;
+	}
 
 	render() {
 		const isForbidden = this.props.googleSiteVerificationError && this.props.googleSiteVerificationError.code === 'forbidden';
@@ -171,12 +187,12 @@ class GoogleVerificationServiceComponent extends React.Component {
 						<Button
 							type="button"
 							className="jp-form-site-verification-edit-button"
-							onClick={ this.toggleVerifyMethod }>
+							onClick={ this.handleClickEdit }>
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
 
-					{ this.props.googleSearchConsoleUrl &&
+					{ this.isOwner() &&
 						<div className="jp-form-input-with-prefix-bottom-message" >
 							<div className="jp-form-setting-explanation" >
 								<p>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -131,6 +131,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 	quickSave = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
 			isOwner: this.isOwner(),
+			isEmpty: ! this.props.value
 		} );
 
 		this.props.onSubmit( event );

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -62,14 +62,17 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} ).then( () => {
 			this.props.removeNotice( 'verifying-site-google' );
 			if ( ! this.props.isSiteVerifiedWithGoogle ) {
-				this.props.verifySiteGoogle().then( response => {
+				this.props.verifySiteGoogle().then( () => {
 					if ( this.props.googleSiteVerificationError ) {
-						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_error' );
+						const errorMessage = this.props.googleSiteVerificationError.message;
+						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_error', {
+							message: errorMessage
+						} );
 						this.props.createNotice(
 							'is-error',
 							__( 'Site failed to verify: %(error)s', {
 								args: {
-									error: this.props.googleSiteVerificationError.message
+									error: errorMessage
 								}
 							} ),
 							{
@@ -77,7 +80,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 								duration: 5000
 							}
 						);
-					} else if ( response.verified ) {
+					} else if ( this.props.isSiteVerifiedWithGoogle ) {
 						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_success' );
 					}
 				} );

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -96,6 +96,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_auto_verify_click' );
 
 		if ( ! this.props.isConnectedToGoogle ) {
+			analytics.tracks.recordEvent( 'jetpack_site_verification_google_authenticate' );
 			requestExternalAccess( this.props.googleSiteVerificationConnectUrl, () => {
 				this.checkAndVerifySite();
 			} );

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -62,8 +62,9 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} ).then( () => {
 			this.props.removeNotice( 'verifying-site-google' );
 			if ( ! this.props.isSiteVerifiedWithGoogle ) {
-				this.props.verifySiteGoogle().then( () => {
+				this.props.verifySiteGoogle().then( response => {
 					if ( this.props.googleSiteVerificationError ) {
+						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_error' );
 						this.props.createNotice(
 							'is-error',
 							__( 'Site failed to verify: %(error)s', {
@@ -76,6 +77,8 @@ class GoogleVerificationServiceComponent extends React.Component {
 								duration: 5000
 							}
 						);
+					} else if ( response.verified ) {
+						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_success' );
 					}
 				} );
 			}


### PR DESCRIPTION
Follow up for https://github.com/Automattic/jetpack/pull/10143

#### Changes proposed in this Pull Request:

We already have the following events triggered on the `Jetpack > Settings > Traffic` page:
- `jetpack_site_verification_google_auto_verify_click` upon clicking on the "Auto-verify with Google" button
- `jetpack_site_verification_google_manual_verify_click` upon clicking on the "Manually verify with Google" button
- `jetpack_site_verification_google_manual_verify_save` upon clicking on the "Save" button

This PR adds the following ones:
- `jetpack_site_verification_google_verify_success` upon receiving a successful verification response from the server
- `jetpack_site_verification_google_verify_error` upon receiving a failed verification response from the server
- `jetpack_site_verification_google_authenticate` upon opening the popup oauth2 flow for the user
- `jetpack_site_verification_google_edit_click` upon clicking on the "Edit" button

It also adds custom properties to some of those events (whenever it makes sense to have them):
- `isOwner` boolean, true if the user owns the google verification token
- `isEmpty` if the meta tag is emptied.

#### Testing instructions:

- Go to `Jetpack > Settings > Traffic`
- Try different actions and monitor in Chrome devtools for `https://pixel.wp.com/t.gif....` calls
- Go to Tracks backend to check that the events were received

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

- Update Google Site verification to improve analytics