### PR TITLE
Jetpack Sync: Prevent full sync when Jetpack is updated

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -458,7 +458,6 @@ add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
-add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 0 );
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ), 10, 2 );
 add_action( 'jetpack_user_authorized', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 0 );
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -17,29 +17,6 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $post_id, $event->args[0] );
 	}
 
-	function test_upgrading_sends_options_constants_and_callables() {
-		/** This action is documented in class.jetpack.php */
-		do_action( 'updating_jetpack_version', '4.2', '4.1' );
-
-		global $wpdb;
-
-		$current_user = wp_get_current_user();
-
-		$expected_sync_config = array( 
-			'options' => true,
-			'functions' => true, 
-			'constants' => true, 
-			'users' => array( $current_user->ID )
-		);
-
-		if ( is_multisite() ) {
-			$expected_sync_config['network_options'] = true;
-		}
-		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
-		
-		$this->assertEquals( $sync_status['config'], $expected_sync_config );
-	}
-
 	function test_schedules_incremental_sync_cron() {
 		// we need to run this again because cron is cleared between tests
 		Jetpack_Sync_Actions::init_sync_cron_jobs();


### PR DESCRIPTION
This PR removes the invocation of Jetpack_Sync_Actions::do_initial_sync() when Jetpack is updated. This will prevent resources from being overwhelmed when a new version of Jetpack is deployed to many sites concurrently.

#### Testing instructions:

Follow the instructions at PCYsg-hnH-p2 to observe what is synced in real time. Ensure there is no full sync when you update Jetpack. 