### PR TITLE
Comments: Fix missing status param error

### DIFF
--- a/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
@@ -90,8 +90,9 @@ class WPCOM_JSON_API_Bulk_Update_Comments_Endpoint extends WPCOM_JSON_API_Endpoi
 			} else {
 				$result['results'] = $this->bulk_delete_comments( $comment_ids );
 			}
-		} else if ( isset( $input['status'] ) ) {
-			$result['results'] = $this->bulk_update_comments_status( $comment_ids, $input['status'] );
+		} else {
+			$status = isset( $input['status'] ) ? $input['status'] : '';
+			$result['results'] = $this->bulk_update_comments_status( $comment_ids, $status );
 		}
 
 		wp_defer_comment_counting( false );


### PR DESCRIPTION
A late commit to #9990 changed the behaviour of the Bulk Update Comment Status endpoint when the request is missing the `status` parameter.

https://github.com/Automattic/jetpack/pull/9990/commits/e046d50d222239e921fcc153833cec2e37ff5f69#diff-e0f9cad9828665a0ca86b565495efe3fR93

The expected response would be a `WP_Error` complaining about the empty status.
But, by adding that `isset`, we effectively skipped the callback (where the `WP_Error` would have been thrown), and returned a generic empty response, which, even if not strictly incorrect, it doesn't give the consumer of the API any useful information.

#### Changes proposed in this Pull Request:

* Replaces an `else if` with an `else` so that the Bulk Update Comment Status endpoint callback is always executed.
* Make sure that the `$input['status']` param is only used if `isset`, otherwise defaults to an empty string `''`.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Checkout this branch on a Jetpack site.
* Head over to https://developer.wordpress.com/docs/api/console/ and select WP.COM API v1.
* Search for the `POST /sites/$site/comments/status​` endpoints and try it on the Jetpack site, providing some `comment_ids` (even if made up), but omitting the `status`.
* Make sure the response is a `WP_Error` with invalid status `400` and the following message:
> Invalid comment status value provided: ''.