### PR TITLE
Refine wording of search console integration

### DIFF
--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -187,9 +187,9 @@ class GoogleVerificationServiceComponent extends React.Component {
 									}
 									{ ' ' }
 									{
-										__( 'Note it will email you if any unusual events occur with your properties. ' +
-										'Unusual events include indications that your website has been {{a1}}hacked{{/a1}}, ' +
-										'or problems that Google had when {{a2}}crawling or indexing{{/a2}} your site.', {
+										__( 'Google will email about certain events that occur with your site, ' +
+										'including indications that your website has been {{a1}}hacked{{/a1}}, ' +
+										'or problems {{a2}}crawling or indexing{{/a2}} your site.', {
 											components: {
 												a1: <ExternalLink
 													icon


### PR DESCRIPTION
Slight change to the wording of the Search console option description

New wording

<img width="705" alt="wording after" src="https://user-images.githubusercontent.com/51896/46030274-8bf71800-c0aa-11e8-8724-68072dbaa929.png">

Old wording

<img width="674" alt="wording before" src="https://user-images.githubusercontent.com/51896/46030404-ebedbe80-c0aa-11e8-957b-1d46550a4a82.png">
