### PR TITLE
Always Chose Google Account When Verifying

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -249,13 +249,21 @@ function JetpackRestApiClient( root, nonce ) {
 			.then( checkStatus )
 			.then( parseJsonResponse ),
 
-		fetchVerifySiteGoogleStatus: () => getRequest( `${ apiRoot }jetpack/v4/verify-site/google`, getParams )
-			.then( checkStatus )
-			.then( parseJsonResponse ),
+		fetchVerifySiteGoogleStatus: ( keyringId ) => {
+			const request = ( keyringId !== null )
+				? getRequest( `${ apiRoot }jetpack/v4/verify-site/google/${ keyringId }`, getParams )
+				: getRequest( `${ apiRoot }jetpack/v4/verify-site/google`, getParams );
 
-		verifySiteGoogle: () => postRequest( `${ apiRoot }jetpack/v4/verify-site/google`, postParams )
-			.then( checkStatus )
-			.then( parseJsonResponse )
+			return request
+				.then( checkStatus )
+				.then( parseJsonResponse );
+		},
+
+		verifySiteGoogle: ( keyringId ) => postRequest( `${ apiRoot }jetpack/v4/verify-site/google`, postParams, {
+			body: JSON.stringify( { keyring_id: keyringId } ),
+		} )
+		.then( checkStatus )
+		.then( parseJsonResponse )
 	};
 
 	function addCacheBuster( route ) {

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -24,6 +24,7 @@ export const checkVerifyStatusGoogle = ( keyringId = null ) => {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_SUCCESS,
 				verified: data.verified,
 				token: data.token,
+				isOwner: data.is_owner,
 				searchConsoleUrl: data.google_search_console_url,
 				verificationConsoleUrl: data.google_verification_console_url,
 			} );

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -47,6 +47,7 @@ export const verifySiteGoogle = ( keyringId ) => {
 		return restApi.verifySiteGoogle( keyringId ).then( data => {
 			dispatch( {
 				verified: data.verified,
+				isOwner: data.is_owner,
 				searchConsoleUrl: data.google_search_console_url,
 				verificationConsoleUrl: data.google_verification_console_url,
 				type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_SUCCESS,

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -14,12 +14,12 @@ import restApi from 'rest-api';
 import { translate as __ } from 'i18n-calypso';
 import { createNotice } from 'components/global-notices/state/notices/actions';
 
-export const checkVerifyStatusGoogle = () => {
+export const checkVerifyStatusGoogle = ( keyringId = null ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH
 		} );
-		return restApi.fetchVerifySiteGoogleStatus().then( data => {
+		return restApi.fetchVerifySiteGoogleStatus( keyringId ).then( data => {
 			dispatch( {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_SUCCESS,
 				verified: data.verified,
@@ -38,12 +38,12 @@ export const checkVerifyStatusGoogle = () => {
 	};
 };
 
-export const verifySiteGoogle = () => {
+export const verifySiteGoogle = ( keyringId ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST
 		} );
-		return restApi.verifySiteGoogle().then( data => {
+		return restApi.verifySiteGoogle( keyringId ).then( data => {
 			dispatch( {
 				verified: data.verified,
 				searchConsoleUrl: data.google_search_console_url,

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -32,6 +32,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				fetching: false,
 				verified: action.verified,
+				isOwner: action.isOwner,
 				searchConsoleUrl: action.searchConsoleUrl,
 				verificationConsoleUrl: action.verificationConsoleUrl,
 				token: action.token,
@@ -105,4 +106,8 @@ export function getGoogleSearchConsoleUrl( state ) {
 
 export function getGoogleVerificationConsoleUrl( state ) {
 	return get( state, 'jetpack.siteVerify.google.verificationConsoleUrl', null );
+}
+
+export function isGoogleSiteVerificationOwner( state ) {
+	return get( state, 'jetpack.siteVerify.google.isOwner', false );
 }

--- a/_inc/client/state/site-verify/reducer.js
+++ b/_inc/client/state/site-verify/reducer.js
@@ -46,6 +46,7 @@ export const google = ( state = { fetching: false, verifying: false, verified: f
 			return assign( {}, state, {
 				verifying: false,
 				verified: action.verified,
+				isOwner: action.isOwner,
 				searchConsoleUrl: action.searchConsoleUrl,
 				verificationConsoleUrl: action.verificationConsoleUrl,
 				error: null,

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -95,13 +95,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_auto_verify_click' );
 
-		if ( ! this.props.isConnectedToGoogle ) {
-			analytics.tracks.recordEvent( 'jetpack_site_verification_google_authenticate' );
-			requestExternalAccess( this.props.googleSiteVerificationConnectUrl, () => {
-				this.checkAndVerifySite();
-			} );
-			return;
-		}
+		requestExternalAccess( this.props.googleSiteVerificationConnectUrl, ( keyringId ) => {
+			if ( keyringId ) {
+				this.checkAndVerifySite( keyringId );
+			}
+		} );
 	};
 
 	handleClickSetManually = event => {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -28,6 +28,7 @@ import {
 	isConnectedToGoogleSiteVerificationAPI,
 	isSiteVerifiedWithGoogle,
 	isVerifyingGoogleSite,
+	isGoogleSiteVerificationOwner,
 	getGoogleSiteVerificationError,
 	getGoogleSearchConsoleUrl,
 } from 'state/site-verify';
@@ -104,7 +105,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	handleClickSetManually = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_click', {
-			is_owner: this.isOwner(),
+			is_owner: this.props.isOwner,
 		} );
 
 		this.toggleVerifyMethod( event );
@@ -112,7 +113,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	handleClickEdit = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_edit_click', {
-			is_owner: this.isOwner(),
+			is_owner: this.props.isOwner,
 		} );
 
 		this.toggleVerifyMethod( event );
@@ -126,7 +127,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	quickSave = event => {
 		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
-			is_owner: this.isOwner(),
+			is_owner: this.props.isOwner,
 			is_empty: ! this.props.value
 		} );
 
@@ -134,10 +135,6 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 		this.toggleVerifyMethod();
 	};
-
-	isOwner() {
-		return !! this.props.googleSearchConsoleUrl;
-	}
 
 	render() {
 		const isForbidden = this.props.googleSiteVerificationError && this.props.googleSiteVerificationError.code === 'forbidden';
@@ -189,7 +186,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 						</Button>
 					</div>
 
-					{ this.isOwner() &&
+					{ this.props.isOwner &&
 						<div className="jp-form-input-with-prefix-bottom-message" >
 							<div className="jp-form-setting-explanation" >
 								<p>
@@ -274,6 +271,7 @@ export default connect(
 			isVerifyingGoogleSite: isVerifyingGoogleSite( state ),
 			userCanManageOptions: userCanManageOptions( state ),
 			googleSiteVerificationError: getGoogleSiteVerificationError( state ),
+			isOwner: isGoogleSiteVerificationOwner( state ),
 		};
 	},
 	{

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -50,9 +50,9 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} );
 	}
 
-	checkAndVerifySite() {
+	checkAndVerifySite( keyringId ) {
 		this.props.createNotice( 'is-info', __( 'Verifying...' ), { id: 'verifying-site-google' } );
-		this.props.checkVerifyStatusGoogle().then( response => {
+		this.props.checkVerifyStatusGoogle( keyringId ).then( response => {
 			if ( ! response ) {
 				return;
 			}
@@ -62,7 +62,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} ).then( () => {
 			this.props.removeNotice( 'verifying-site-google' );
 			if ( ! this.props.isSiteVerifiedWithGoogle ) {
-				this.props.verifySiteGoogle().then( () => {
+				this.props.verifySiteGoogle( keyringId ).then( () => {
 					if ( this.props.googleSiteVerificationError ) {
 						const errorMessage = this.props.googleSiteVerificationError.message;
 						analytics.tracks.recordEvent( 'jetpack_site_verification_google_verify_error', {
@@ -102,8 +102,6 @@ class GoogleVerificationServiceComponent extends React.Component {
 			} );
 			return;
 		}
-
-		this.checkAndVerifySite();
 	};
 
 	handleClickSetManually = event => {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -389,11 +389,24 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
 		) );
 
+		register_rest_route( 'jetpack/v4', '/verify-site/(?P<service>[a-z\-_]+)/(?<keyring_id>[0-9]+)', array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => __CLASS__ . '::is_site_verified_and_token',
+			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+		) );
+
 		// Site Verify: tell a service to verify the site
 		register_rest_route( 'jetpack/v4', '/verify-site/(?P<service>[a-z\-_]+)', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::verify_site',
 			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+			'args' => array(
+				'keyring_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'validate_callback' => __CLASS__  . '::validate_posint',
+				),
+			)
 		) );
 	}
 
@@ -478,8 +491,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return $result;
 	}
 
+
 	/**
-	 * Checks if this site has been verified using a service - only 'google' supported at present
+	 * Checks if this site has been verified using a service - only 'google' supported at present - and a specfic
+	 *  keyring to use to get the token if it is not
 	 *
 	 * Returns 'verified' = true/false, and a token if 'verified' is false and site is ready for verification
 	 *
@@ -495,11 +510,16 @@ class Jetpack_Core_Json_Api_Endpoints {
  			'user_id' => get_current_user_id(),
 		) );
 
-		$xml->query( 'jetpack.isSiteVerified', array(
+		$args = array(
 			'user_id' => get_current_user_id(),
 			'service' => $request[ 'service' ],
-			)
 		);
+
+		if ( isset( $request[ 'keyring_id' ] ) ) {
+			$args[ 'keyring_id' ] = $request[ 'keyring_id' ];
+		}
+
+		$xml->query( 'jetpack.isSiteVerified', $args );
 
 		if ( $xml->isError() ) {
 			return new WP_Error( 'error_checking_if_site_verified_google', sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() ) );
@@ -516,15 +536,20 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 	}
 
+
+
 	public static function verify_site( $request ) {
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id(),
 		) );
 
+		$params = $request->get_json_params();
+
 		$xml->query( 'jetpack.verifySite', array(
 				'user_id' => get_current_user_id(),
 				'service' => $request[ 'service' ],
+				'keyring_id' => $params[ 'keyring_id' ],
 			)
 		);
 


### PR DESCRIPTION
Fixes #10217 
Fixes #10218

Requires D18820-code

#### Changes proposed in this Pull Request:

* Never use existing Google Site Verification tokens when verifying a site, always request external access

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

**Setup**
* Apply D18820-code
* Point Jetpack to Sandbox
* Set `public-api.wordpress.com` to your sandbox IP


**Testing**
1. Go to Jetpack -> Settings -> Traffic
2. Click "Verify with Google"
3. You will be prompted to authorize the connection in a popup
4. The UI should change to tell you that your site was verified
5. Click the "Edit" button, clear the field, and click "Save"
6. Click the link to the Google Search Console and Un-verify the site  
7. Return to Jetpack -> Settings -> Traffic
8. Click "Verify with Google" again
9. Confirm that the same popup from top 3 appears, and that you can chose a different Google Account


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: