### PR TITLE
Improve style of site verification section for mobile devices

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -67,11 +67,26 @@
 		color: #4f748e;
 		padding: rem( 8px ) rem( 14px );
 		white-space: nowrap;
+
+		@include breakpoint( '<660px' ) {
+			display: block;
+			text-align: left;
+		}
 	}
 
 	input[type="text"] {
 		width: 100%;
-		border-left: 0;
+		@include breakpoint( '>660px' ) {
+			border-left: 0;
+		}
+		@include breakpoint( '<660px' ) {
+			border-top: 0;
+		}
+	}
+
+	@include breakpoint( '<660px' ) {
+		display: block;
+		box-sizing: border-box;
 	}
 }
 

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -72,3 +72,14 @@
 .jp-form-site-verification-verified-note {
 	font-size: 0.7em;
 }
+
+.jp-form-google-label-unverified-actions {
+	display: flex;
+	align-content: center;
+
+	.dops-button {
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+}
+

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -1,12 +1,23 @@
 @import "../scss/variables/_colors";
+@import "../scss/mixin_breakpoint";
 
 .jp-form-google-label-unverified {
 	.dops-button {
 		margin: 0 15px;
+
+		@include breakpoint( '<660px' ) {
+			margin-top: 10px;
+			width: 40%;
+		}
 	}
 
 	.jp-form-google-separator {
 		padding: .5rem 0;
+
+		@include breakpoint( '<660px' ) {
+			margin: 25px 0 0;
+			display: inline-block;
+		}
 	}
 }
 
@@ -29,7 +40,6 @@
 	font-size: 16px;
 	line-height: 1.5;
 	border: 1px solid #c8d7e1;
-	border-left: 0;
 	width: 100%;
 	display: flex;
 	flex-direction: row;
@@ -39,11 +49,24 @@
 	.gridicon:first-child {
 		margin-right: 5px;
 	}
+
+	@include breakpoint( '>660px' ) {
+		border-left: 0;
+	}
+
+	@include breakpoint( '<660px' ) {
+		border-top: 0;
+	}
 }
 
 .jp-form-site-verification-edit-button {
 	margin-left: 10px;
 	overflow: visible;
+
+	@include breakpoint( '<660px' ) {
+		margin-left: 0;
+		margin-top: 5px;
+	}
 }
 
 .jp-form-site-verification-verified-note {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -245,22 +245,24 @@ class GoogleVerificationServiceComponent extends React.Component {
 				className="jp-form-input-with-prefix jp-form-google-label-unverified"
 				key="verification_service_google">
 				<span>{ __( 'Google' ) }</span>
-				<Button
-					primary
-					type="button"
-					disabled={ disabled }
-					onClick={ this.handleClickAutoVerify }>
-						{ __( 'Auto-verify with Google' ) }
-				</Button>
-				<span className="jp-form-google-separator">
-					{ __( 'or' ) }
-				</span>
-				<Button
-					type="button"
-					disabled={ disabled }
-					onClick={ this.handleClickSetManually }>
-					{ __( 'Manually verify with Google' ) }
-				</Button>
+				<div className="jp-form-google-label-unverified-actions" >
+					<Button
+						primary
+						type="button"
+						disabled={ disabled }
+						onClick={ this.handleClickAutoVerify }>
+							{ __( 'Auto-verify with Google' ) }
+					</Button>
+					<span className="jp-form-google-separator">
+						{ __( 'or' ) }
+					</span>
+					<Button
+						type="button"
+						disabled={ disabled }
+						onClick={ this.handleClickSetManually }>
+						{ __( 'Manually verify with Google' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #10219

#### Changes proposed in this Pull Request:

* Improve styles for Site Verification on small devices
Thanks to @jeffgolenski for helping on this!

#### Testing instructions:

- Visit `Jetpack > Settings > Site Verification` on a device with a screen less than 660px wide (or emulate it with chrome).
- Check that the design looks good

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Improve style of the site verification section for mobile devices