### PR TITLE
Jetpack Debuger: Remoeves fatal error when jetpack full sync is disabled

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -115,17 +115,20 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n" . esc_html( "PLAN: " . self::what_jetpack_plan() );
 
 		$debug_info .= "\r\n";
+
+		$debug_info .= "\r\n" .  "-- SYNC Status -- ";
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-		$sync_statuses = $sync_module->get_status();
-		$human_readable_sync_status = array();
-		foreach( $sync_statuses  as $sync_status => $sync_status_value ) {
-			$human_readable_sync_status[ $sync_status ] =
-				in_array( $sync_status, array( 'started', 'queue_finished', 'send_started', 'finished' ) )
-				? date( 'r', $sync_status_value ) : $sync_status_value ;
+		if ( $sync_module ) {
+			$sync_statuses = $sync_module->get_status();
+			$human_readable_sync_status = array();
+			foreach( $sync_statuses  as $sync_status => $sync_status_value ) {
+				$human_readable_sync_status[ $sync_status ] =
+					in_array( $sync_status, array( 'started', 'queue_finished', 'send_started', 'finished' ) )
+						? date( 'r', $sync_status_value ) : $sync_status_value ;
+			}
+			$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $human_readable_sync_status, 1 ) );
 		}
-
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $human_readable_sync_status, 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR. 'sync/class.jetpack-sync-sender.php';
 


### PR DESCRIPTION
Removed Fatal error when a plugin removed the full sync module on the jetpack debug page.
```
Fatal error: Uncaught Error: Call to a member function get_status() on boolean in /var/www/html/wp-content/plugins/jetpack/class.jetpack-debugger.php on line 120
```

The plugin that removes the module looks like 
```
/*
 * Plugin Name: Remove Jetpack's Full Sync Module
 * Author: Automattic
 * Version: 1.0
 * License: GPL2+
 */
add_filter('jetpack_sync_modules', 'jetpack_stop_remove_full_sync_module' );
function jetpack_stop_remove_full_sync_module( $modules ) {
	return array_diff( (array) $modules, array( 'Jetpack_Sync_Module_Full_Sync' ) );
}
```

#### Changes proposed in this Pull Request:

* Make the debugger less prone to fatal errors. By checking that the full sync module is available. 

#### Testing instructions:
1. Add the plugin and activate it by coping and pasting the code into a file int the plugins folder.
2. Visit the debug page (wp-admin/admin.php?page=jetpack-debugger) and notice that the fatal error is not there any more. 

#### Proposed changelog entry for your changes:
* Jetpack Debugger: remove fatal when Jetpack full sync is disabled.

