### PR TITLE
SVN Deploy Script: Use correct path

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -75,7 +75,7 @@ done
 echo "Done!"
 
 echo "Generating Jetpack CDN Manifest"
-php ./bin/build-asset-cdn-json.php
+php ./trunk/bin/build-asset-cdn-json.php
 echo "Done!"
 
 # Tag the release.


### PR DESCRIPTION
Fixes #10208

#### Changes proposed in this Pull Request:

* Update to the SVN script to reflect proper location within the svn dir.

#### Testing instructions:

* from `branch-6.6` in the JP root, run `./tools/deploy-to-svn.sh HEAD` (it won't actually deploy, so safe to test as such).

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* none