### PR TITLE
Masterbar: Add activity tracking

### DIFF
--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -14,6 +14,7 @@
 		'wp-admin-bar-blog-info'                   : 'my_sites_blog_info',
 		'wp-admin-bar-site-view'                   : 'my_sites_view_site',
 		'wp-admin-bar-blog-stats'                  : 'my_sites_blog_stats',
+		'wp-admin-bar-activity': 'my_sites_activity',
 		'wp-admin-bar-plan'                        : 'my_sites_plan',
 		'wp-admin-bar-plan-badge'                  : 'my_sites_plan_badge',
 		//my sites - manage

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -1,4 +1,4 @@
-/*globals JSON */
+/*globals jQuery, JSON */
 ( function( $ ) {
 	var eventName = 'masterbar_click';
 
@@ -14,7 +14,7 @@
 		'wp-admin-bar-blog-info'                   : 'my_sites_blog_info',
 		'wp-admin-bar-site-view'                   : 'my_sites_view_site',
 		'wp-admin-bar-blog-stats'                  : 'my_sites_blog_stats',
-		'wp-admin-bar-activity': 'my_sites_activity',
+		'wp-admin-bar-activity'                    : 'my_sites_activity',
 		'wp-admin-bar-plan'                        : 'my_sites_plan',
 		'wp-admin-bar-plan-badge'                  : 'my_sites_plan_badge',
 		//my sites - manage


### PR DESCRIPTION
Adds click tracking to the new Activity link found in the masterbar.

#### Changes proposed in this Pull Request:
* 

#### Testing instructions:
1. Activate the masterbar. 
2. Click the new Activity Log link in the master bar. 

Do we send the new track click event?
@dereksmart  and suggestions how to see the events show up in tracks?


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
