### PR TITLE
Unset google meta tag on unverify error

### DIFF
--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -42,6 +42,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 
 	componentDidMount() {
 		this.props.checkVerifyStatusGoogle().then( response => {
+			// if the site is not in google search console anymore, reset the verification token
+			// and call checkVerifyStatusGoogle to unverify it
+			if ( this.props.googleSiteVerificationError && this.props.googleSiteVerificationError.code === 'unverify-site-error' ) {
+				this.props.updateOptions( { google: '' } ).then( () => this.props.checkVerifyStatusGoogle() );
+			}
 			if ( ! response ) {
 				return;
 			}


### PR DESCRIPTION
Fixes #10227

#### Changes proposed in this Pull Request:

* Automatically unset google verification token on page load when server failed to unverify site.
We want unverify the site when user has remove the property from their search console

#### Testing instructions:

- Verify your site with googl using the auto-verify feature
- Go to https://search.google.com/search-console/welcome select your site on the left panel, go to settings and remove property
- Refresh the page, you should see your settings updated (the token is being removed) and your site being unverified
- Check that your site is unverified by visiting those 2 links
    - https://search.google.com/search-console/welcome
    - https://www.google.com/webmasters/verification/home

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Automatically unverify site if user removed it from google search console