### PR TITLE
Gutenberg: Add global JETPACK_BLOCK_ASSETS_BASE_URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7364,6 +7364,12 @@ p {
 			$version
 		);
 
+		$script = sprintf(
+			'var JETPACK_BLOCK_ASSETS_BASE_URL = %s;',
+			wp_json_encode( plugins_url( "_inc/blocks/", JETPACK__PLUGIN_FILE ) )
+		);
+		wp_add_inline_script( 'jetpack-blocks-editor', $script, 'before' );
+
 		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );
 		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7366,7 +7366,7 @@ p {
 
 		$script = sprintf(
 			'var JETPACK_BLOCK_ASSETS_BASE_URL = %s;',
-			wp_json_encode( plugins_url( "_inc/blocks/", JETPACK__PLUGIN_FILE ) )
+			wp_json_encode( plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE ) )
 		);
 		wp_add_inline_script( 'jetpack-blocks-editor', $script, 'before' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7366,7 +7366,7 @@ p {
 
 		wp_localize_script(
 			'jetpack-blocks-editor',
-			'JETPACK_BLOCK_ASSETS_BASE_URL',
+			'Jetpack_Block_Assets_Base_Url',
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7364,11 +7364,11 @@ p {
 			$version
 		);
 
-		$script = sprintf(
-			'var JETPACK_BLOCK_ASSETS_BASE_URL = %s;',
-			wp_json_encode( plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE ) )
+		wp_localize_script(
+			'jetpack-blocks-editor',
+			'JETPACK_BLOCK_ASSETS_BASE_URL',
+			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
-		wp_add_inline_script( 'jetpack-blocks-editor', $script, 'before' );
 
 		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );


### PR DESCRIPTION
Expose a global variable identifying the dynamic URL base for Gutenberg SDK-built assets. This allows for splitting.

See companion PR: https://github.com/Automattic/wp-calypso/pull/27274

`gutenpack-jn` (Add `&calypsobranch=update/conditional-module-load`)