### PR TITLE
Exploration: Use latest phpcompatibility from master to run against PHP 7.3 sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,21 @@
     "require"    : {
         "composer/installers": "~1.6"
     },
+    "repositories": [{
+	    "type":"package",
+	    "package": {
+		"name": "phpcompatibility/phpcompatibility",
+		"version": "8.3.0",
+		"source": {
+		    "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+		    "type": "git",
+		    "reference": "master"
+		}
+	    }
+    }],
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
+        "phpcompatibility/phpcompatibility": "8.3.0",
         "wp-coding-standards/wpcs": "1.2.1",
         "sirbrillig/phpcs-variable-analysis": "2.3.0",
         "phpcompatibility/phpcompatibility-wp": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ba6c22a2ae314440dfd1b6a2dd8cee3",
+    "content-hash": "4e2ddfee6da89e062e2a7485a29f925b",
     "packages": [
         {
             "name": "composer/installers",
@@ -196,16 +196,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.0.0",
+            "version": "9.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25"
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
-                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
                 "shasum": ""
             },
             "require": {
@@ -250,20 +250,30 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-10-07T17:38:02+00:00"
+            "time": "2018-12-30T23:16:27+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility",
+            "version": "8.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "master"
+            },
+            "type": "library"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "67d89dcef47f351144d24b247aa968f2269162f7"
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/67d89dcef47f351144d24b247aa968f2269162f7",
-                "reference": "67d89dcef47f351144d24b247aa968f2269162f7",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
                 "shasum": ""
             },
             "require": {
@@ -300,7 +310,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2018-10-07T17:59:30+00:00"
+            "time": "2018-12-16T19:10:44+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -401,16 +411,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
                 "shasum": ""
             },
             "require": {
@@ -448,7 +458,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2018-12-19T23:57:18+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
PR to test how phpcompatibility rules for PHP 7.3 new stuff runs on Jetpack's codebase

#### Changes proposed in this Pull Request:

* Just makes `phpcompatibility/phpcompatibility` be installed from GitHub `master` by `composer`.

#### Testing instructions:

1. Check out this branch
2. Remove your current `vendor` dir `rm -rf vendor`.
3. Run `composer install`.
4. Run `composer php:5.2-compatibility .`
5. Verify that you get results about PHP 7.3 deprecations like the usage of `continue` in switch statements.

```
FILE: ...ack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------
 762 | WARNING | Targeting a 'switch' control structure with a
     |         | 'continue' statement is strongly discouraged and
     |         | will throw a warning as of PHP 7.3.
 771 | WARNING | Targeting a 'switch' control structure with a
     |         | 'continue' statement is strongly discouraged and
     |         | will throw a warning as of PHP 7.3.
----------------------------------------------------------------------
```
