### PR TITLE
Handle google site verification errors in HTTP 200 responses

### DIFF
--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -20,6 +20,19 @@ export const checkVerifyStatusGoogle = ( keyringId = null ) => {
 			type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH
 		} );
 		return restApi.fetchVerifySiteGoogleStatus( keyringId ).then( data => {
+			if ( data.errors && data.errors.length > 0 ) {
+				const errorCode = Object.keys( data.errors )[ 0 ];
+				const errorMessage = data.errors[ errorCode ];
+				dispatch( {
+					type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_FAIL,
+					error: {
+						code: errorCode,
+						message: errorMessage,
+					}
+				} );
+				return data;
+			}
+
 			dispatch( {
 				type: JETPACK_SITE_VERIFY_GOOGLE_STATUS_FETCH_SUCCESS,
 				verified: data.verified,
@@ -45,6 +58,19 @@ export const verifySiteGoogle = ( keyringId ) => {
 			type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST
 		} );
 		return restApi.verifySiteGoogle( keyringId ).then( data => {
+			if ( data.errors && data.errors.length > 0 ) {
+				const errorCode = Object.keys( data.errors )[ 0 ];
+				const errorMessage = data.errors[ errorCode ];
+				dispatch( {
+					type: JETPACK_SITE_VERIFY_GOOGLE_REQUEST_FAIL,
+					error: {
+						code: errorCode,
+						message: errorMessage,
+					}
+				} );
+				return data;
+			}
+
 			dispatch( {
 				verified: data.verified,
 				isOwner: data.is_owner,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -524,15 +524,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( $xml->isError() ) {
 			return new WP_Error( 'error_checking_if_site_verified_google', sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() ) );
 		} else {
-			$response = $xml->getResponse();
-
-			if ( ! empty( $response['errors'] ) ) {
-				$error = new WP_Error;
-				$error->errors = $response['errors'];
-				return $error;
-			}
-
-			return $response;
+			return $xml->getResponse();
 		}
 	}
 


### PR DESCRIPTION
Fixes #10214

#### Changes proposed in this Pull Request:

This makes the jetpack IXR Client return valid 200 responses, even when the wpcom api returned an error. The error returned will be serialized and available in the response, we just need to check if response.errors is set.

#### Testing instructions:

- Unverify your site with google and reload the page.
- The error returned should in a HTTP 200 request

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Return HTTP code 200 for google site verification error responses