### PR TITLE
Sync: Plugin action links set on current_screen instead of admin_init

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
-		add_action( 'admin_init', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
+		add_action( 'current_screen', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
 
 		// For some options, we should always send the change right away!
 		$always_send_updates_to_these_options = array(
@@ -122,7 +122,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_check_and_send_callables', '__return_true' );
 	}
 
-	public function set_plugin_action_links() {
+	public function set_plugin_action_links( $current_screen ) {
 		if (
 			! class_exists( 'DOMDocument' ) ||
 			! function_exists ( 'libxml_use_internal_errors' ) ||

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -131,10 +131,12 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
+		$current_screeen = get_current_screen();
+
 		$plugins_action_links = array();
 		// Is the transient lock in place?
 		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh', false );
-		if ( ! empty( $plugins_lock ) ) {
+		if ( ! empty( $plugins_lock ) && ( isset( $current_screeen->id ) && $current_screeen->id !== 'plugins' ) ) {
 			return;
 		}
 		$plugins = array_keys( Jetpack_Sync_Functions::get_plugins() );

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -122,7 +122,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_check_and_send_callables', '__return_true' );
 	}
 
-	public function set_plugin_action_links( $current_screen ) {
+	public function set_plugin_action_links() {
 		if (
 			! class_exists( 'DOMDocument' ) ||
 			! function_exists ( 'libxml_use_internal_errors' ) ||

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -749,7 +749,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			)
 		);
 
-		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
+		$this->assertEquals( $expected_array, $this->extract_plugins_we_are_testing( $plugins_action_links )  );
 
 		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
 		$this->resetCallableAndConstantTimeouts();
@@ -777,7 +777,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 	function extract_plugins_we_are_testing( $plugins_action_links ) {
 		$only_plugins_we_care_about = array();
-		if ( isset( $only_plugins_we_care_about['hello.php'] ) ) {
+		if ( isset( $plugins_action_links['hello.php'] ) ) {
 			$only_plugins_we_care_about['hello.php'] = isset( $plugins_action_links['hello.php'] ) ? $plugins_action_links['hello.php'] : '';
 		} else {
 			$only_plugins_we_care_about['hello.php'] = isset( $plugins_action_links['hello-dolly/hello.php'] ) ? $plugins_action_links['hello-dolly/hello.php'] : '';

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -752,6 +752,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $expected_array, $this->extract_plugins_we_are_testing( $plugins_action_links )  );
 
 		$helper_all->array_override = array( '<a href="not-fun.php">not fun</a>' );
+
 		$this->resetCallableAndConstantTimeouts();
 
 		set_current_screen( 'banana' );
@@ -762,10 +763,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// Nothing should have changed since we cache the results.
 		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
 
-		if ( file_exists( WP_CONTENT_DIR . 'plugins/hello.php' )  ) {
+		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello.php' )  ) {
 			activate_plugin('hello.php', '', false, true );
 		}
-		if ( file_exists( WP_CONTENT_DIR . 'plugins/hello-dolly/hello.php' ) ) {
+		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello-dolly/hello.php' ) ) {
 			activate_plugin('hello-dolly/hello.php', '', false, true );
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -731,7 +731,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'plugin_action_links_jetpack/jetpack.php', array( $helper_jetpack, 'filter_override_array' ), 10 );
 
 		$callables_module = new Jetpack_Sync_Module_Callables(); // Do the admin init here so that we calculate the plugin links
-		$callables_module->set_plugin_action_links();
+		set_current_screen( 'plugins' );
+		$callables_module->set_plugin_action_links( get_current_screen() );
 		// Let's see if the original values get synced
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
@@ -788,10 +789,11 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		delete_transient( 'jetpack_plugin_api_action_links_refresh' );
 		add_filter( 'plugin_action_links', array( $this, 'cause_fatal_error' ) );
 		$callables_module = new Jetpack_Sync_Module_Callables(); // Do the admin init here so that we calculate the plugin links
-		$callables_module->set_plugin_action_links();
+		set_current_screen( 'plugins' );
+		$callables_module->set_plugin_action_links( get_current_screen() );
 
 		$this->resetCallableAndConstantTimeouts();
-		$callables_module->set_plugin_action_links();
+		$callables_module->set_plugin_action_links( get_current_screen() );
 		$this->sender->do_sync();
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
 		$this->assertTrue( isset( $plugins_action_links['hello.php']['world'] ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -762,8 +762,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// Nothing should have changed since we cache the results.
 		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
 
-		activate_plugin('hello.php', '', false, true );
-		activate_plugin('hello-dolly/hello.php', '', false, true );
+		if ( file_exists( WP_CONTENT_DIR . 'plugins/hello.php' )  ) {
+			activate_plugin('hello.php', '', false, true );
+		}
+		if ( file_exists( WP_CONTENT_DIR . 'plugins/hello-dolly/hello.php' ) ) {
+			activate_plugin('hello-dolly/hello.php', '', false, true );
+		}
+
 		$this->resetCallableAndConstantTimeouts();
 		set_current_screen( 'banana' );
 		$this->sender->do_sync();


### PR DESCRIPTION
I took https://github.com/Automattic/jetpack/pull/9960 and made the test pass. 

Props to @TheCrowned for 9960. 

### Testing instructions
Same as #9960 

### Proposed changelog entry
Move the call set_plugin action links to a later filet so that more plugins can add their action links.
