### PR TITLE
Save Forms on pressing "Enter"

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -316,14 +316,14 @@ export const SettingsCard = props => {
 	}
 
 	return getModuleOverridenBanner() || (
-		<form className="jp-form-settings-card">
+		<form className="jp-form-settings-card" onSubmit={ isSaving ? () => {} : props.onSubmit } >
 			<SectionHeader label={ header }>
 				{
 					! props.hideButton && (
 						<Button
 							primary
 							compact
-							onClick={ isSaving ? () => {} : props.onSubmit }
+							type="submit"
 							disabled={ isSaving || ! props.isDirty() }>
 							{
 								isSaving


### PR DESCRIPTION
Fixes #10215

#### Changes proposed in this Pull Request:

* Modify SettingsForm Component to save changes on pressing "Enter"

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

1.  Navigate to Jetpack -> Settings -> Traffic -> Site Verification
1.  Enter Test into one or more of the Text input fields, including the "manual" Google verification form
1. Press Enter and confirm that the settings are updated ( via the notifications )
1. Further modify one of the fields
1. Press the "SAVE SETTINGS" button instead of pressing enter and confirm again that the settings are updated

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Update the SettingsForm Component to save on Enter being pressed in a child input