### PR TITLE
Make sure fields for other services don't change when we edit and save a verification token

### DIFF
--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -58,7 +58,7 @@ class VerificationServicesComponent extends React.Component {
 	getSiteVerificationValue( service ) {
 		const optionValue = this.props.getOptionValue( service );
 		// if current value is equal to the initial value, update format for display
-		if ( ! this.props.isDirty() ) {
+		if ( optionValue === this.props.getSettingCurrentValue( service ) ) {
 			return this.getMetaTag( service, optionValue );
 		}
 


### PR DESCRIPTION
Fixes #10245

#### Changes proposed in this Pull Request:

* This PR fixes a bug related to the token fields showing undesired value changes on save.

#### Testing instructions:

- Go to `Jetpack > Settings > Traffic > Site Verification`
- Enter verification token values for several services
- Save settings
- Edit one value and make sur the other values remain unchanged

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Fix inconsistent save button behaviour for Site Verify