### PR TITLE
Add a way to cancel editing of google site verification tag

### DIFF
--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -124,21 +124,18 @@ class GoogleVerificationServiceComponent extends React.Component {
 		this.toggleVerifyMethod( event );
 	};
 
+	handleClickCancel = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_cancel_click', {
+			is_owner: this.props.isOwner,
+		} );
+
+		this.toggleVerifyMethod( event );
+	};
+
 	toggleVerifyMethod = () => {
 		this.setState( {
 			inputVisible: ! this.state.inputVisible,
 		} );
-	};
-
-	quickSave = event => {
-		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
-			is_owner: this.props.isOwner,
-			is_empty: ! this.props.value
-		} );
-
-		this.props.onSubmit( event );
-
-		this.toggleVerifyMethod();
 	};
 
 	handleOnTextInputKeyPress = event => {
@@ -166,11 +163,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 							onKeyPress={ this.handleOnTextInputKeyPress } />
 						{ this.state.inputVisible &&
 							<Button
-								primary
+								scary
 								type="button"
 								className="jp-form-site-verification-edit-button"
-								onClick={ this.quickSave }>
-								{ __( 'Save' ) }
+								onClick={ this.handleClickCancel }>
+								{ __( 'Cancel' ) }
 							</Button>
 						}
 					</FormLabel>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -163,7 +163,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 							onKeyPress={ this.handleOnTextInputKeyPress } />
 						{ this.state.inputVisible &&
 							<Button
-								scary
+								primary
 								type="button"
 								className="jp-form-site-verification-edit-button"
 								onClick={ this.handleClickCancel }>


### PR DESCRIPTION
Fixes #10209

#### Changes proposed in this Pull Request:

* This replaces the Save button with a cancel button. The top section "SAVE SETTINGS" can still be used to save changes.

#### Testing instructions:

* Try modifying the google tag and interacting with the Edit and Cancel button

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Add a way to cancel editing of google site verification tag