### PR TITLE
Add target to Publicize and ShareButtons components

### DIFF
--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -43,6 +43,7 @@ export const Publicize = moduleSettingsForm(
 							className="jp-settings-card__configure-link"
 							onClick={ this.trackClickConfigure }
 							target="_blank"
+							rel="noopener noreferrer"
 							href={ 'https://wordpress.com/sharing/' + siteRawUrl }>
 							{ __( 'Connect your social media accounts' ) }
 						</Card>

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -42,6 +42,7 @@ export const Publicize = moduleSettingsForm(
 							compact
 							className="jp-settings-card__configure-link"
 							onClick={ this.trackClickConfigure }
+							target="_blank"
 							href={ 'https://wordpress.com/sharing/' + siteRawUrl }>
 							{ __( 'Connect your social media accounts' ) }
 						</Card>

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -52,6 +52,8 @@ export const Publicize = moduleSettingsForm(
 						<Card
 							compact
 							className="jp-settings-card__configure-link"
+							target="_blank"
+							rel="noopener noreferrer"
 							href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>
 							{ __( 'Connect your user account to WordPress.com to use this feature' ) }
 						</Card>

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -33,14 +33,43 @@ export const ShareButtons = moduleSettingsForm(
 
 			const configCard = () => {
 				if ( isDevMode ) {
-					return <Card compact className="jp-settings-card__configure-link" href={ siteAdminUrl + 'options-general.php?page=sharing' }>{ __( 'Configure your sharing buttons' ) }</Card>;
+					return (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							href={ siteAdminUrl + 'options-general.php?page=sharing' }
+						>
+							{__( 'Configure your sharing buttons' )}
+						</Card>
+					);
 				}
 
 				if ( isLinked ) {
-					return <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } target="_blank" href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
+					return (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackClickConfigure }
+							target="_blank"
+							rel="noopener noreferrer"
+							href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }
+						>
+							{__( 'Configure your sharing buttons' )}
+						</Card>
+					);
 				}
 
-				return <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;
+				return (
+					<Card
+						compact
+						className="jp-settings-card__configure-link"
+						href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }
+					>
+						{__(
+							'Connect your user account to WordPress.com to use this feature'
+						)}
+					</Card>
+				);
 			};
 
 			return (
@@ -48,26 +77,28 @@ export const ShareButtons = moduleSettingsForm(
 					{ ...this.props }
 					header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
 					module="sharing"
-					hideButton>
+					hideButton
+				>
 					<SettingsGroup
 						disableInDevMode
 						module={ { module: 'sharing' } }
 						support={ {
-							text: __( 'Adds sharing buttons to your content so that visitors can share it on social media sites.' ),
-							link: 'https://jetpack.com/support/sharing/',
+							text: __(
+								'Adds sharing buttons to your content so that visitors can share it on social media sites.'
+							),
+							link: 'https://jetpack.com/support/sharing/'
 						} }
-						>
+					>
 						<ModuleToggle
 							slug="sharedaddy"
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
-							toggleModule={ this.props.toggleModuleNow }>
-								{ __( 'Add sharing buttons to your posts' ) }
-							</ModuleToggle>
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							{__( 'Add sharing buttons to your posts' )}
+						</ModuleToggle>
 					</SettingsGroup>
-					{
-						isActive && configCard()
-					}
+					{isActive && configCard()}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -37,7 +37,7 @@ export const ShareButtons = moduleSettingsForm(
 				}
 
 				if ( isLinked ) {
-					return <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
+					return <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } target="_blank" href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
 				}
 
 				return <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -63,6 +63,8 @@ export const ShareButtons = moduleSettingsForm(
 					<Card
 						compact
 						className="jp-settings-card__configure-link"
+						target="_blank"
+						rel="noopener noreferrer"
 						href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }
 					>
 						{__(


### PR DESCRIPTION
Fixes #10244

Card component set the icon to 'external' when target is defined so I've set this prop in Publicize and ShareButtons components. 

#### Changes proposed in this Pull Request:

* Set target of Publicize and ShareButtons components
* Use external link icon instead of arrow

#### Testing instructions:

* Manually on Chrome
* yarn test-client and yarn test-gui
