### PR TITLE
Asset CDN: rename module and add links to support doc.

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -682,3 +682,20 @@ function jetpack_woocommerce_analytics_more_info() {
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_woocommerce-analytics', 'jetpack_woocommerce_analytics_more_info' );
+
+/**
+ * Assets CDN
+ */
+function jetpack_assetcdn_more_link() {
+	echo 'http://jetpack.com/support/asset-cdn/';
+}
+add_action( 'jetpack_learn_more_button_photon-cdn', 'jetpack_assetcdn_more_link' );
+
+function jetpack_assetcdn_more_info() {
+	esc_html_e(
+		'Our asset CDN is a site acceleration service.
+		That means that we host static assets like JavaScript and CSS shipped with WordPress Core and Jetpack from our servers, alleviating the load on your server.',
+		'jetpack'
+	);
+}
+add_action( 'jetpack_module_more_info_photon-cdn', 'jetpack_assetcdn_more_info' );

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Photon CDN
+ * Module Name: Asset CDN
  * Module Description: Serve static assets from our servers
  * Sort Order: 26
  * Recommendation Order: 1


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Rename the module, and add a link to the support doc from the `wp-admin/admin.php?page=jetpack_modules`

#### Testing instructions:

1. Go to `{your-site}/wp-admin/admin.php?page=jetpack_modules`
2. Search for the Asset CDN module. 
3. Try activating and deactivating it.
4. Try clicking on it and make sure the link is correct.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
None
