### PR TITLE
Site verify cancel button and tweak status

### DIFF
--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import get from 'lodash/get';
 import each from 'lodash/each';
 import analytics from 'lib/analytics';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -56,6 +57,11 @@ export function ModuleSettingsForm( InnerComponent ) {
 				...optionMaybeOptions
 			};
 			this.setState( { options: newOptions } );
+			return true;
+		};
+
+		resetFormStateOption = ( optionToReset ) => {
+			this.setState( { options: omit( this.state.options, [ optionToReset ] ) } );
 			return true;
 		};
 
@@ -208,6 +214,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
 					isSavingAnyOption={ this.isSavingAnyOption }
 					isDirty={ this.isDirty }
+					resetFormStateOption={ this.resetFormStateOption }
 					{ ...this.props } />
 			);
 		}

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -65,8 +65,13 @@
 
 	@include breakpoint( '<660px' ) {
 		margin-left: 0;
+		margin-right: 5px;
 		margin-top: 5px;
 	}
+}
+
+.jp-form-site-verification-buttons {
+	flex: 0 1 20em;
 }
 
 .jp-form-site-verification-verified-note {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -138,6 +138,8 @@ class GoogleVerificationServiceComponent extends React.Component {
 			is_owner: this.props.isOwner,
 		} );
 
+		this.props.updateFormStateOptionValue( 'google', this.props.getSettingCurrentValue( 'google' ) );
+		this.props.clearUnsavedSettingsFlag();
 		this.toggleVerifyMethod( event );
 	};
 
@@ -148,7 +150,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 		} );
 
 		this.props.onSubmit( event );
-	}
+	};
 
 	toggleVerifyMethod = () => {
 		this.setState( {

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -132,6 +132,15 @@ class GoogleVerificationServiceComponent extends React.Component {
 		this.toggleVerifyMethod( event );
 	};
 
+	quickSave = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
+			is_owner: this.props.isOwner,
+			is_empty: ! this.props.value
+		} );
+
+		this.props.onSubmit( event );
+	}
+
 	toggleVerifyMethod = () => {
 		this.setState( {
 			inputVisible: ! this.state.inputVisible,
@@ -162,13 +171,23 @@ class GoogleVerificationServiceComponent extends React.Component {
 							onChange={ this.props.onOptionChange }
 							onKeyPress={ this.handleOnTextInputKeyPress } />
 						{ this.state.inputVisible &&
-							<Button
-								primary
-								type="button"
-								className="jp-form-site-verification-edit-button"
-								onClick={ this.handleClickCancel }>
-								{ __( 'Cancel' ) }
-							</Button>
+							<div className="jp-form-site-verification-buttons">
+								<Button
+									primary
+									type="button"
+									className="jp-form-site-verification-edit-button"
+									disabled={ this.props.isUpdating( 'google' ) }
+									onClick={ this.quickSave }>
+									{ __( 'Save' ) }
+								</Button>
+								<Button
+									type="button"
+									className="jp-form-site-verification-edit-button"
+									disabled={ this.props.isUpdating( 'google' ) }
+									onClick={ this.handleClickCancel }>
+									{ __( 'Cancel' ) }
+								</Button>
+							</div>
 						}
 					</FormLabel>
 				</div>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -138,8 +138,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 			is_owner: this.props.isOwner,
 		} );
 
-		this.props.updateFormStateOptionValue( 'google', this.props.getSettingCurrentValue( 'google' ) );
-		this.props.clearUnsavedSettingsFlag();
+		this.props.resetFormStateOption( 'google' );
 		this.toggleVerifyMethod( event );
 	};
 

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -124,21 +124,18 @@ class GoogleVerificationServiceComponent extends React.Component {
 		this.toggleVerifyMethod( event );
 	};
 
+	handleClickCancel = event => {
+		analytics.tracks.recordEvent( 'jetpack_site_verification_google_cancel_click', {
+			is_owner: this.props.isOwner,
+		} );
+
+		this.toggleVerifyMethod( event );
+	};
+
 	toggleVerifyMethod = () => {
 		this.setState( {
 			inputVisible: ! this.state.inputVisible,
 		} );
-	};
-
-	quickSave = event => {
-		analytics.tracks.recordEvent( 'jetpack_site_verification_google_manual_verify_save', {
-			is_owner: this.props.isOwner,
-			is_empty: ! this.props.value
-		} );
-
-		this.props.onSubmit( event );
-
-		this.toggleVerifyMethod();
 	};
 
 	handleOnTextInputKeyPress = event => {
@@ -166,11 +163,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 							onKeyPress={ this.handleOnTextInputKeyPress } />
 						{ this.state.inputVisible &&
 							<Button
-								primary
+								scary
 								type="button"
 								className="jp-form-site-verification-edit-button"
-								onClick={ this.quickSave }>
-								{ __( 'Save' ) }
+								onClick={ this.handleClickCancel }>
+								{ __( 'Cancel' ) }
 							</Button>
 						}
 					</FormLabel>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -53,6 +53,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 			if ( ! this.props.getOptionValue( 'google' ) && response.token ) {
 				return this.props.updateOptions( { google: response.token } );
 			}
+
+			// show manual box if we have a non-verified site but we do have a local token
+			if ( this.props.getOptionValue( 'google' ) && ! response.token && ! response.verified ) {
+				this.setState( { inputVisible: true } );
+			}
 		} );
 	}
 

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -41,6 +41,10 @@ class GoogleVerificationServiceComponent extends React.Component {
 	};
 
 	componentDidMount() {
+		if ( ! this.props.isCurrentUserLinked ) {
+			return;
+		}
+
 		this.props.checkVerifyStatusGoogle().then( response => {
 			// if the site is not in google search console anymore, reset the verification token
 			// and call checkVerifyStatusGoogle to unverify it

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -163,7 +163,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 							onKeyPress={ this.handleOnTextInputKeyPress } />
 						{ this.state.inputVisible &&
 							<Button
-								scary
+								primary
 								type="button"
 								className="jp-form-site-verification-edit-button"
 								onClick={ this.handleClickCancel }>


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Builds on https://github.com/Automattic/jetpack/pull/10248
* If no token but local config on page load, enter "manual" UI
* Add cancel button to go from manual UI to chooser

Desktop

<img width="697" alt="cancel-btn" src="https://user-images.githubusercontent.com/51896/46556638-36deb180-c8b5-11e8-9813-cf93305ddb55.png">

Mobile

<img width="331" alt="cancel-btn-mobile" src="https://user-images.githubusercontent.com/51896/46556647-3cd49280-c8b5-11e8-9491-93b143c3a160.png">


#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* When site has config but no token in WPCOM, should show "manual" UI
* When editing manually then Cancel should go to chooser

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
