### PR TITLE
REST API: Add a related posts endpoint 

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -177,6 +177,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => array( $site_endpoint , 'can_request' ),
 		) );
 
+		// Get related posts of a certain site post
+		register_rest_route( 'jetpack/v4', '/site/posts/related', array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => array( $site_endpoint, 'get_related_posts' ),
+			'permission_callback' => array( $site_endpoint , 'can_request' ),
+		) );
+
 		// Confirm that a site in identity crisis should be in staging mode
 		register_rest_route( 'jetpack/v4', '/identity-crisis/confirm-safe-mode', array(
 			'methods' => WP_REST_Server::EDITABLE,

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -49,6 +49,7 @@ class Jetpack_Core_API_Site_Endpoint {
 
 	/**
 	 * Returns the result of `/sites/%s/posts/%d/related` endpoint call.
+	 * Results are not cached and are retrieved in real time.
 	 *
 	 * @since 6.7.0
 	 *

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -48,6 +48,76 @@ class Jetpack_Core_API_Site_Endpoint {
 	}
 
 	/**
+	 * Returns the result of `/sites/%s/posts/%d/related` endpoint call.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param int ID of the post to get related posts of
+	 *
+	 * @return array
+	 */
+	public static function get_related_posts( $api_request ) {
+		$params = $api_request->get_params();
+		$post_id = ! empty( $params['post_id'] ) ? absint( $params['post_id'] ) : 0;
+
+		if ( ! $post_id ) {
+			return new WP_Error(
+				'incorrect_post_id',
+				esc_html__( 'You need to specify a correct ID of a post to return related posts for.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Make the API request
+		$request = sprintf( '/sites/%d/posts/%d/related', Jetpack_Options::get_option( 'id' ), $post_id );
+		$request_args = array(
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
+			'timeout'    => 10,
+			'method' => 'POST',
+		);
+		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1', $request_args );
+
+		// Bail if there was an error or malformed response
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return new WP_Error(
+				'failed_to_fetch_data',
+				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Decode the results
+		$results = json_decode( $response['body'], true );
+
+		// Bail if there were no results returned
+		if ( ! isset( $results['hits'] ) || ! is_array( $results['hits'] ) ) {
+			return new WP_Error(
+				'no_related_posts_found',
+				esc_html__( 'No related posts found for the specified post.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$related_posts_ids = array_map( array( $this, 'get_related_post_id' ), $response_body['hits'] );
+
+		$related_posts = array();
+		$related_posts_instance = Jetpack_RelatedPosts::init();
+		foreach ( $related_posts_ids as $related_post_id ) {
+			$related_posts[] = $related_posts_instance->get_related_post_data_for_post( $related_post_id, 0, 0 );
+		}
+
+		return rest_ensure_response( array(
+				'code' => 'success',
+				'message' => esc_html__( 'Related posts retrieved successfully.', 'jetpack' ),
+				'posts' => $related_posts,
+			)
+		);
+	}
+
+	/**
 	 * Check that the current user has permissions to request information about this site.
 	 *
 	 * @since 5.1.0
@@ -56,5 +126,17 @@ class Jetpack_Core_API_Site_Endpoint {
 	 */
 	public static function can_request() {
 		return current_user_can( 'jetpack_manage_modules' );
+	}
+
+	/**
+	 * Returns the post ID out of a related post entry from the
+	 * `/sites/%s/posts/%d/related` WP.com endpoint.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return int
+	 */
+	public function get_related_post_id( $item ) {
+		return $item['fields']['post_id'];
 	}
 }

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -101,7 +101,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
-		$related_posts_ids = array_map( array( $this, 'get_related_post_id' ), $response_body['hits'] );
+		$related_posts_ids = array_map( array( 'Jetpack_Core_API_Site_Endpoint', 'get_related_post_id' ), $response_body['hits'] );
 
 		$related_posts = array();
 		$related_posts_instance = Jetpack_RelatedPosts::init();
@@ -136,7 +136,7 @@ class Jetpack_Core_API_Site_Endpoint {
 	 *
 	 * @return int
 	 */
-	public function get_related_post_id( $item ) {
+	public static function get_related_post_id( $item ) {
 		return $item['fields']['post_id'];
 	}
 }

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -980,7 +980,7 @@ EOT;
 	 * @uses get_post, get_permalink, remove_query_arg, get_post_format, apply_filters
 	 * @return array
 	 */
-	protected function _get_related_post_data_for_post( $post_id, $position, $origin ) {
+	public function get_related_post_data_for_post( $post_id, $position, $origin ) {
 		$post = get_post( $post_id );
 
 		return array(
@@ -1198,7 +1198,7 @@ EOT;
 
 		$related_posts = array();
 		foreach ( $hits as $i => $hit ) {
-			$related_posts[] = $this->_get_related_post_data_for_post( $hit['id'], $i, $post_id );
+			$related_posts[] = $this->get_related_post_data_for_post( $hit['id'], $i, $post_id );
 		}
 		return $related_posts;
 	}

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1536,6 +1536,7 @@ EOT;
 
 	/**
 	 * Build an array of Related Posts.
+	 * By default returns cached results that are stored for up to 12 hours.
 	 *
 	 * @since 4.4.0
 	 *


### PR DESCRIPTION
This PR is part of an experiment to allow the Jetpack Related Posts block for Gutenberg to fetch and display the related posts in real time, after saving/autosaving the post.

#### Changes proposed in this Pull Request:

* Converts the `Jetpack_RelatedPosts::_get_related_post_data_for_post()` method to a public one.
* Introduces a `get_related_post_id` method to get the ID out of a related post endpoint entry item.
* Introduces a `/site/posts/related` WP REST API endpoint to query related posts for a particular post.

#### Testing instructions:

* Follow the instructions in https://github.com/Automattic/wp-calypso/pull/27659

#### Proposed changelog entry for your changes:

* Introduce endpoint for retrieving related posts of a particular post.