### PR TITLE
Add additional checks to CDN to avoid rewriting too many paths.

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -216,7 +216,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return Boolean whether the file is a JS or CSS.
 	 */
 	public static function is_js_or_css_file( $path ) {
-		return in_array( substr( $path, -3 ), array( 'css', '.js' ), true );
+		return ( false === strpos( $path, '?' ) ) && in_array( substr( $path, -3 ), array( 'css', '.js' ), true );
 	}
 
 	/**


### PR DESCRIPTION
This handles cases where the url looks like `/wp-admin/admin-ajax.php?action=get_my_whatever_css` -- which ends in `css`

I'm having a hard time thinking of things we'd want to rewrite that wouldn't end in `css` or `.js` and would include a `?` in the path.  Open to ideas though.

# Testing instructions
- Add a filter to your site that would enqueue an URL that looks like CSS but is actually not:
```
add_action( 'init', function() {
	wp_enqueue_style( 'blablablab', '/wp-admin/admin-ajax.php?action=get_my_whatever_css' );
});
```
- See that CDN will rewrite that request to serve it from the CDN.
- Use this PR, see that the request does not get rewritten to be served from CDN, but instead goes to your site directly.
- You will see request errors in both cases, the only difference is the URL.

# Proposed changelog entry
Fixed Jetpack CDN handling of URLs that load dynamic assets.