### PR TITLE
Recipes: recipe block.

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -16,6 +16,9 @@ class Jetpack_Recipes {
 	function __construct() {
 		add_action( 'init', array( $this, 'action_init' ) );
 
+		// Create our Gutenberg block.
+		add_action( 'init', array( $this, 'init_block' ) );
+
 		add_filter( 'wp_kses_allowed_html', array( $this, 'add_recipes_kses_rules' ), 10, 2 );
 	}
 
@@ -146,6 +149,56 @@ class Jetpack_Recipes {
 	}
 
 	/**
+	 * Register Gutenberg Block element.
+	 */
+	public static function init_block() {
+		// Bail early if Gutenberg is not installed.
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
+		wp_register_script(
+			'jetpack-recipes-block-editor',
+			Jetpack::get_file_url_for_environment( '_inc/blocks/editor.js', '_inc/blocks/editor.js' ),
+			array( 'wp-element', 'wp-blocks', 'wp-editor', 'wp-components', 'wp-i18n' ),
+			JETPACK__VERSION,
+			false
+		);
+
+		wp_register_script(
+			'jetpack-recipes-block-view',
+			Jetpack::get_file_url_for_environment( '_inc/blocks/view.js', '_inc/blocks/view.js' ),
+			array( 'wp-element', 'wp-blocks', 'wp-editor', 'wp-components', 'wp-i18n' ),
+			JETPACK__VERSION,
+			false
+		);
+
+		wp_register_style(
+			'jetpack-recipes-block-view-styles',
+			Jetpack::get_file_url_for_environment( '_inc/blocks/view.css', '_inc/blocks/view.css' ),
+			array(),
+			JETPACK__VERSION
+		);
+
+		wp_register_style(
+			'jetpack-recipes-block-editor-styles',
+			Jetpack::get_file_url_for_environment( '_inc/blocks/editor.css', '_inc/blocks/editor.css' ),
+			array(),
+			JETPACK__VERSION
+		);
+
+		register_block_type(
+			'a8c/recipes',
+			array(
+				'script'        => 'jetpack-recipes-block-view',
+				'editor_script' => 'jetpack-recipes-block-editor',
+				'style'         => 'jetpack-recipes-block-view-styles',
+				'editor_style'  => 'jetpack-recipes-block-editor-styles',
+			)
+		);
+	}
+
+	/**
 	 * Our [recipe] shortcode.
 	 * Prints recipe data styled to look good on *any* theme.
 	 *
@@ -197,7 +250,7 @@ class Jetpack_Recipes {
 
 			if ( '' !== $atts['servings'] ) {
 				$html .= sprintf(
-					'<li class="jetpack-recipe-servings" itemprop="recipeYield"><strong>%1$s: </strong>%2$s</li>',
+					'<li class="jetpack-recipe-servings" itemprop=""><strong>%1$s: </strong>%2$s</li>',
 					esc_html_x( 'Servings', 'recipe', 'jetpack' ),
 					esc_html( $atts['servings'] )
 				);


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/426388/46439090-9d38c800-c72d-11e8-9b88-9f9d43616c2f.png)

#### Changes proposed in this Pull Request:
 
**Do not merge this PR**

This is a companion of this Calypso PR:
https://github.com/Automattic/wp-calypso/pull/27665

#### Testing instructions:

* If you run Jetpack locally: 
  * Setup and run the Jetpack docker environment.
  * Expose the Jetpack docker environment to public using ngrok.
  * Make sure to connect Jetpack to WP.com.
  * Apply this branch on your local Jetpack repo.
  * Checkout this branch.
  * Build the blocks in Calypso running the following command: 
`npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is the directory that leads to your local Jetpack.
* If you run Jetpack on Jurassic Ninja:
  * Spin up a site in Jurassic Ninja: https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=add/recipes-block&jetpack-beta&branch=add/recipes-block
* Open your Jetpack site in wp-admin.
* Start a new post.
* Insert the Recipes block.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Nothing so far.