### PR TITLE
Narrower bottom border on site verify description

### DIFF
--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -24,7 +24,7 @@
 
 // we want to place.jp-form-input-with-prefix's margin after this element
 .jp-form-input-with-prefix-bottom-message {
-	top: rem( -24px );
+	top: rem( 20px );
 	position: relative;
 	line-height: 2em;
 	margin-top: 5px;

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -24,7 +24,7 @@
 
 // we want to place.jp-form-input-with-prefix's margin after this element
 .jp-form-input-with-prefix-bottom-message {
-	top: rem( 20px );
+	top: rem( -20px );
 	position: relative;
 	line-height: 2em;
 	margin-top: 5px;


### PR DESCRIPTION
Missing commit from https://github.com/Automattic/jetpack/pull/10263#pullrequestreview-162257922

@joanrho said:

> It could use the same consistent margin below the "Edit" button just above the jp-form-setting-explanation on mobile views. Setting .jp-form-input-with-prefix-bottom-message as -1.25rem instead of -1.5rem seemed to achieve the same visual result if you want to do it that way.

The difference is very subtle:

Before:

<img width="668" alt="border-before" src="https://user-images.githubusercontent.com/51896/46696646-7b28c500-cbc7-11e8-9826-c0b744513697.png">

After:

<img width="667" alt="border-after" src="https://user-images.githubusercontent.com/51896/46697751-318da980-cbca-11e8-8c5c-72c3a519b861.png">
