### PR TITLE
Sitemaps: Ensures sitemap creation immediately upon activation

### DIFF
--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -29,28 +29,11 @@ add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_on_activate' );
  * @since 4.8.0
  */
 function jetpack_sitemap_on_activate() {
+	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-constants.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-buffer.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-stylist.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-librarian.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-finder.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-builder.php';
-
-	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
-	wp_clear_scheduled_hook( 'jetpack_sitemap_generate_on_activate' );
-
-	add_action( 'jetpack_sitemap_generate_on_activate', 'jetpack_sitemap_creation_job' );
-
-	wp_schedule_single_event( time() + 60, 'jetpack_sitemap_generate_on_activate' );
-}
-
-/**
- * Initial sitemap creation
- *
- * @since 6.7.0
- */
-
-function jetpack_sitemap_creation_job() {
-	$sitemap_builder = new Jetpack_Sitemap_Builder();
-	$sitemap_builder->update_sitemap();
 }

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -39,8 +39,18 @@ function jetpack_sitemap_on_activate() {
 	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
 	wp_clear_scheduled_hook( 'jetpack_sitemap_generate_on_activate' );
 
-	$sitemap_builder = new Jetpack_Sitemap_Builder();
-	add_action( 'jetpack_sitemap_generate_on_activate', array( $sitemap_builder, 'update_sitemap' ) );
+	add_action( 'jetpack_sitemap_generate_on_activate', 'jetpack_sitemap_creation_job' );
 
 	wp_schedule_single_event( time() + 60, 'jetpack_sitemap_generate_on_activate' );
+}
+
+/**
+ * Initial sitemap creation
+ *
+ * @since 6.7.0
+ */
+
+function jetpack_sitemap_creation_job() {
+	$sitemap_builder = new Jetpack_Sitemap_Builder();
+	$sitemap_builder->update_sitemap();
 }

--- a/modules/sitemaps/sitemap-state.php
+++ b/modules/sitemaps/sitemap-state.php
@@ -43,7 +43,7 @@ class Jetpack_Sitemap_State {
 	 *     @type array  max           The latest index of each sitemap type seen.
 	 * }
 	 */
-	private static function initial( $type = '' ) {
+	private static function initial( $type = JP_PAGE_SITEMAP_TYPE ) {
 		return array(
 			'sitemap-type'  => $type,
 			'last-added'    => 0,

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -387,9 +387,21 @@ class Jetpack_Sitemap_Manager {
 		);
 
 		if ( ! wp_next_scheduled( 'jp_sitemap_cron_hook' ) ) {
-			wp_schedule_single_event( time() + 60, 'jp_sitemap_cron_hook' );
+			/**
+			 * Filter maximum number of minutes to randomly wait until generating sitemaps. Default 15.
+			 *
+			 * This filter allows a site operator or hosting provider to potentialy spread out sitemap generation for a
+			 * lot of sites over time. By default, it will be randomly done over 15 minutes.
+			 *
+			 * @module sitemaps
+			 * @since 6.6.1
+			 *
+			 * @param int $maximum Maximum number of minutes.
+			 */
+			$randomness = MINUTE_IN_SECONDS * mt_rand( 1, apply_filters( 'jetpack_sitemap_generation_randomness', 15 ) ); // Randomly space it out to start within next fifteen minutes.
+			wp_schedule_single_event( time() + $randomness, 'jp_sitemap_cron_hook' );
 			wp_schedule_event(
-				time(),
+				time() + $randomness,
 				'sitemap-interval',
 				'jp_sitemap_cron_hook'
 			);

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -388,7 +388,7 @@ class Jetpack_Sitemap_Manager {
 
 		if ( ! wp_next_scheduled( 'jp_sitemap_cron_hook' ) ) {
 			/**
-			 * Filter maximum number of minutes to randomly wait until generating sitemaps. Default 15.
+			 * Filter the delay in seconds until sitemap generation cron job is started.
 			 *
 			 * This filter allows a site operator or hosting provider to potentialy spread out sitemap generation for a
 			 * lot of sites over time. By default, it will be randomly done over 15 minutes.
@@ -396,11 +396,11 @@ class Jetpack_Sitemap_Manager {
 			 * @module sitemaps
 			 * @since 6.6.1
 			 *
-			 * @param int $maximum Maximum number of minutes.
+			 * @param int $delay Time to delay in seconds.
 			 */
-			$randomness = MINUTE_IN_SECONDS * mt_rand( 1, apply_filters( 'jetpack_sitemap_generation_randomness', 15 ) ); // Randomly space it out to start within next fifteen minutes.
+			$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * mt_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
 			wp_schedule_event(
-				time() + $randomness,
+				time() + $delay,
 				'sitemap-interval',
 				'jp_sitemap_cron_hook'
 			);

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -387,6 +387,7 @@ class Jetpack_Sitemap_Manager {
 		);
 
 		if ( ! wp_next_scheduled( 'jp_sitemap_cron_hook' ) ) {
+			wp_schedule_single_event( time() + 60, 'jp_sitemap_cron_hook' );
 			wp_schedule_event(
 				time(),
 				'sitemap-interval',

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -399,7 +399,6 @@ class Jetpack_Sitemap_Manager {
 			 * @param int $maximum Maximum number of minutes.
 			 */
 			$randomness = MINUTE_IN_SECONDS * mt_rand( 1, apply_filters( 'jetpack_sitemap_generation_randomness', 15 ) ); // Randomly space it out to start within next fifteen minutes.
-			wp_schedule_single_event( time() + $randomness, 'jp_sitemap_cron_hook' );
 			wp_schedule_event(
 				time() + $randomness,
 				'sitemap-interval',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Don't try to call up sitemaps with a passed object through a cron job.

#### Testing instructions:

* New JN site.
* Activate sitemaps and immediately check it.
* Within a couple of minutes, is the sitemap present?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Improve initial sitemap creation process.
