### PR TITLE
Sitemaps: Various improvements

### DIFF
--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -8,6 +8,8 @@
  * Auto Activate: Public
  * Module Tags: Recommended, Traffic
  * Additional Search Queries: sitemap, traffic, search, site map, seo
+ *
+ * @package Jetpack
  */
 
 /**
@@ -17,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( '1' == get_option( 'blog_public' ) ) {
+if ( '1' == get_option( 'blog_public' ) ) { // loose comparison okay.
 	include_once 'sitemaps/sitemaps.php';
 }
 

--- a/modules/sitemaps/sitemap-buffer-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-fallback.php
@@ -23,9 +23,9 @@ abstract class Jetpack_Sitemap_Buffer_Fallback extends Jetpack_Sitemap_Buffer {
 	protected $buffer;
 
 	public function __construct( $item_limit, $byte_limit, $time = '1970-01-01 00:00:00' ) {
-		$this->is_full_flag = false;
+		$this->is_full_flag  = false;
 		$this->is_empty_flag = true;
-		$this->timestamp = $time;
+		$this->timestamp     = $time;
 
 		$this->finder = new Jetpack_Sitemap_Finder();
 
@@ -59,9 +59,9 @@ abstract class Jetpack_Sitemap_Buffer_Fallback extends Jetpack_Sitemap_Buffer {
 			return false;
 		} else {
 			$this->item_capacity -= 1;
-			$added_string = $this->array_to_xml_string( $array );
-			$this->buffer .= $added_string;
-			$this->is_empty_flag = false;
+			$added_string         = $this->array_to_xml_string( $array );
+			$this->buffer        .= $added_string;
+			$this->is_empty_flag  = false;
 
 			mbstring_binary_safe_encoding(); // So we can safely use strlen().
 			$this->byte_capacity -= strlen( $added_string );
@@ -136,7 +136,7 @@ abstract class Jetpack_Sitemap_Buffer_Fallback extends Jetpack_Sitemap_Buffer {
 		$string = '';
 
 		foreach ( $array as $key => $value ) {
-			$key = preg_replace( '/[^a-zA-Z:_-]/', '_', $key );
+			$key     = preg_replace( '/[^a-zA-Z:_-]/', '_', $key );
 			$string .= ' ' . $key . '="' . esc_attr( $value ) . '"';
 		}
 

--- a/modules/sitemaps/sitemap-buffer-image-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-image-fallback.php
@@ -45,7 +45,7 @@ class Jetpack_Sitemap_Buffer_Image extends Jetpack_Sitemap_Buffer_Fallback {
 				"<!-- generator='jetpack-{$jetpack_version}' -->" . PHP_EOL
 				. "<?xml-stylesheet type='text/xsl' href='{$sitemap_xsl_url}'?>" . PHP_EOL
 				. '<urlset ' . $this->array_to_xml_attr_string( $namespaces ) . '>' . PHP_EOL,
-				'</urlset>'
+				'</urlset>',
 			);
 
 			$this->byte_capacity -= strlen( join( '', $this->root ) );

--- a/modules/sitemaps/sitemap-buffer-master-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-master-fallback.php
@@ -21,13 +21,13 @@ class Jetpack_Sitemap_Buffer_Master extends Jetpack_Sitemap_Buffer_Fallback {
 		if ( ! isset( $this->root ) ) {
 
 			$sitemap_index_xsl_url = $this->finder->construct_sitemap_url( 'sitemap-index.xsl' );
-			$jetpack_version = JETPACK__VERSION;
+			$jetpack_version       = JETPACK__VERSION;
 
 			$this->root = array(
 				"<!-- generator='jetpack-{$jetpack_version}' -->" . PHP_EOL
 				. "<?xml-stylesheet type='text/xsl' href='{$sitemap_index_xsl_url}'?>" . PHP_EOL
 				. "<sitemapindex xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>" . PHP_EOL,
-				'</sitemapindex>'
+				'</sitemapindex>',
 			);
 
 			$this->byte_capacity -= strlen( join( '', $this->root ) );

--- a/modules/sitemaps/sitemap-buffer-news-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-news-fallback.php
@@ -38,14 +38,14 @@ class Jetpack_Sitemap_Buffer_News extends Jetpack_Sitemap_Buffer_Fallback {
 				)
 			);
 
-			$jetpack_version = JETPACK__VERSION;
+			$jetpack_version      = JETPACK__VERSION;
 			$news_sitemap_xsl_url = $this->finder->construct_sitemap_url( 'news-sitemap.xsl' );
 
 			$this->root = array(
 				"<!-- generator='jetpack-{$jetpack_version}' -->" . PHP_EOL
 				. "<?xml-stylesheet type='text/xsl' href='{$news_sitemap_xsl_url}'?>" . PHP_EOL
 				. '<urlset ' . $this->array_to_xml_attr_string( $namespaces ) . '>',
-				'</urlset>'
+				'</urlset>',
 			);
 
 			$this->byte_capacity -= strlen( join( '', $this->root ) );

--- a/modules/sitemaps/sitemap-buffer-page-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-page-fallback.php
@@ -44,7 +44,7 @@ class Jetpack_Sitemap_Buffer_Page extends Jetpack_Sitemap_Buffer_Fallback {
 				"<!-- generator='jetpack-{$jetpack_version}' -->" . PHP_EOL
 				. "<?xml-stylesheet type='text/xsl' href='{$sitemap_xsl_url}'?>" . PHP_EOL
 				. '<urlset ' . $this->array_to_xml_attr_string( $namespaces ) . '>',
-				'</urlset>'
+				'</urlset>',
 			);
 
 			$this->byte_capacity -= strlen( join( '', $this->root ) );

--- a/modules/sitemaps/sitemap-buffer-video-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-video-fallback.php
@@ -39,13 +39,13 @@ class Jetpack_Sitemap_Buffer_Video extends Jetpack_Sitemap_Buffer_Fallback {
 			);
 
 			$video_sitemap_xsl_url = $this->finder->construct_sitemap_url( 'video-sitemap.xsl' );
-			$jetpack_version = JETPACK__VERSION;
+			$jetpack_version       = JETPACK__VERSION;
 
 			$this->root = array(
 				"<!-- generator='jetpack-{$jetpack_version}' -->" . PHP_EOL
 				. "<?xml-stylesheet type='text/xsl' href='{$video_sitemap_xsl_url}'?>" . PHP_EOL
 				. '<urlset ' . $this->array_to_xml_attr_string( $namespaces ) . '>',
-				'</urlset>'
+				'</urlset>',
 			);
 
 			$this->byte_capacity -= strlen( join( '', $this->root ) );

--- a/modules/sitemaps/sitemap-buffer.php
+++ b/modules/sitemaps/sitemap-buffer.php
@@ -108,10 +108,10 @@ abstract class Jetpack_Sitemap_Buffer {
 	 */
 	public function __construct( $item_limit, $byte_limit, $time ) {
 		$this->is_full_flag = false;
-		$this->timestamp = $time;
+		$this->timestamp    = $time;
 
 		$this->finder = new Jetpack_Sitemap_Finder();
-		$this->doc = new DOMDocument( '1.0', 'UTF-8' );
+		$this->doc    = new DOMDocument( '1.0', 'UTF-8' );
 
 		$this->item_capacity = max( 1, intval( $item_limit ) );
 		$this->byte_capacity = max( 1, intval( $byte_limit ) ) - strlen( $this->doc->saveXML() );
@@ -133,10 +133,9 @@ abstract class Jetpack_Sitemap_Buffer {
 	 * don't do anything and report success.
 	 *
 	 * @since 4.8.0
+	 * @deprecated 5.3.0 Use Jetpack_Sitemap_Buffer::append.
 	 *
 	 * @param string $item The item to be added.
-	 *
-	 * @return bool True if the append succeeded, False if not.
 	 */
 	public function try_to_add_item( $item ) {
 		_deprecated_function(
@@ -173,7 +172,7 @@ abstract class Jetpack_Sitemap_Buffer {
 			return false;
 		} else {
 			$this->item_capacity -= 1;
-			$added_element = $this->array_to_xml_string( $array, $this->get_root_element(), $this->doc );
+			$added_element        = $this->array_to_xml_string( $array, $this->get_root_element(), $this->doc );
 
 			$this->byte_capacity -= strlen( $this->doc->saveXML( $added_element ) );
 
@@ -189,8 +188,8 @@ abstract class Jetpack_Sitemap_Buffer {
 	 * @return string The contents of the buffer (with the footer included).
 	 */
 	public function contents() {
-		if( $this->is_empty() ) {
-			// The sitemap should have at least the root element added to the DOM
+		if ( $this->is_empty() ) {
+			// The sitemap should have at least the root element added to the DOM.
 			$this->get_root_element();
 		}
 		return $this->doc->saveXML();
@@ -280,8 +279,8 @@ abstract class Jetpack_Sitemap_Buffer {
 	 * @since 4.8.0 Rename, add $depth parameter, and change return type.
 	 * @since 5.3.0 Refactor, remove $depth parameter, add $parent and $root, make access protected.
 	 *
-	 * @param array  $array A recursive associative array of tag/child relationships.
-	 * @param DOMElement $parent (optional) an element to which new children should be added.
+	 * @param array       $array A recursive associative array of tag/child relationships.
+	 * @param DOMElement  $parent (optional) an element to which new children should be added.
 	 * @param DOMDocument $root (optional) the parent document.
 	 *
 	 * @return string|DOMDocument The rendered XML string or an object if root element is specified.
@@ -291,7 +290,7 @@ abstract class Jetpack_Sitemap_Buffer {
 
 		if ( null === $parent ) {
 			$return_string = true;
-			$parent = $root = new DOMDocument();
+			$parent        = $root = new DOMDocument();
 		}
 
 		if ( is_array( $array ) ) {

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -117,11 +117,7 @@ class Jetpack_Sitemap_Builder {
 			$this->logger->report( '-- Updating...' );
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
-					__(
-						'-- WARNING: Jetpack can not load necessary XML manipulation libraries. '
-						. 'This can happen if XML support in PHP is not enabled on your server. '
-						. 'XML support is highly recommended for WordPress and Jetpack, please enable '
-						. 'it or contact your hosting provider about it.',
+					__( '-- WARNING: Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is highly recommended for WordPress and Jetpack, please enable it or contact your hosting provider.',
 						'jetpack'
 					),
 					true

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -529,8 +529,8 @@ class Jetpack_Sitemap_Builder {
 			JP_SITEMAP_MAX_BYTES
 		);
 
-		// Add entry for the main page (only if we're at the first one).
-		if ( 1 === $number ) {
+		// Add entry for the main page (only if we're at the first one) and it isn't already going to be included as a page.
+		if ( 1 === $number && 'page' !== get_option( 'show_on_front' ) ) {
 			$item_array = array(
 				'url' => array(
 					'loc' => home_url(),

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -7,6 +7,7 @@
  * @author Automattic
  */
 
+/* Include sitemap subclasses, if not already, and include proper buffer based on phpxml's availability. */
 require_once dirname( __FILE__ ) . '/sitemap-constants.php';
 require_once dirname( __FILE__ ) . '/sitemap-buffer.php';
 
@@ -78,7 +79,7 @@ class Jetpack_Sitemap_Builder {
 	 */
 	public function __construct() {
 		$this->librarian = new Jetpack_Sitemap_Librarian();
-		$this->finder = new Jetpack_Sitemap_Finder();
+		$this->finder    = new Jetpack_Sitemap_Finder();
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$this->logger = new Jetpack_Sitemap_Logger();
@@ -117,7 +118,8 @@ class Jetpack_Sitemap_Builder {
 			$this->logger->report( '-- Updating...' );
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
-					__( '-- WARNING: Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is highly recommended for WordPress and Jetpack, please enable it or contact your hosting provider.',
+					__(
+						'-- WARNING: Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is highly recommended for WordPress and Jetpack, please enable it or contact your hosting provider.',
 						'jetpack'
 					),
 					true
@@ -231,7 +233,7 @@ class Jetpack_Sitemap_Builder {
 				$finished = true;
 
 				break;
-		} // End switch().
+		} // End switch.
 
 		// Unlock the state.
 		Jetpack_Sitemap_State::unlock();
@@ -262,12 +264,14 @@ class Jetpack_Sitemap_Builder {
 
 		if ( false === $result ) {
 			// If no sitemap was generated, advance to the next type.
-			Jetpack_Sitemap_State::check_in( array(
-				'sitemap-type'  => $index_type,
-				'last-added'    => 0,
-				'number'        => 0,
-				'last-modified' => '1970-01-01 00:00:00',
-			) );
+			Jetpack_Sitemap_State::check_in(
+				array(
+					'sitemap-type'  => $index_type,
+					'last-added'    => 0,
+					'number'        => 0,
+					'last-modified' => '1970-01-01 00:00:00',
+				)
+			);
 
 			if ( $this->logger ) {
 				$this->logger->report( "-- Cleaning Up $sitemap_type" );
@@ -275,19 +279,22 @@ class Jetpack_Sitemap_Builder {
 
 			// Clean up old files.
 			$this->librarian->delete_numbered_sitemap_rows_after(
-				$state['number'], $sitemap_type
+				$state['number'],
+				$sitemap_type
 			);
 
 			return;
 		}
 
 		// Otherwise, update the state.
-		Jetpack_Sitemap_State::check_in( array(
-			'sitemap-type'  => $state['sitemap-type'],
-			'last-added'    => $result['last_id'],
-			'number'        => $state['number'] + 1,
-			'last-modified' => $result['last_modified'],
-		) );
+		Jetpack_Sitemap_State::check_in(
+			array(
+				'sitemap-type'  => $state['sitemap-type'],
+				'last-added'    => $result['last_id'],
+				'number'        => $state['number'] + 1,
+				'last-modified' => $result['last_modified'],
+			)
+		);
 
 		if ( true === $result['any_left'] ) {
 			// If there's more work to be done with this type, return.
@@ -295,12 +302,14 @@ class Jetpack_Sitemap_Builder {
 		}
 
 		// Otherwise, advance state to the next sitemap type.
-		Jetpack_Sitemap_State::check_in( array(
-			'sitemap-type'  => $index_type,
-			'last-added'    => 0,
-			'number'        => 0,
-			'last-modified' => '1970-01-01 00:00:00',
-		) );
+		Jetpack_Sitemap_State::check_in(
+			array(
+				'sitemap-type'  => $index_type,
+				'last-added'    => 0,
+				'number'        => 0,
+				'last-modified' => '1970-01-01 00:00:00',
+			)
+		);
 
 		if ( $this->logger ) {
 			$this->logger->report( "-- Cleaning Up $sitemap_type" );
@@ -308,7 +317,8 @@ class Jetpack_Sitemap_Builder {
 
 		// Clean up old files.
 		$this->librarian->delete_numbered_sitemap_rows_after(
-			$state['number'] + 1, $sitemap_type
+			$state['number'] + 1,
+			$sitemap_type
 		);
 	}
 
@@ -326,12 +336,14 @@ class Jetpack_Sitemap_Builder {
 
 		// If only 0 or 1 sitemaps were built, advance to the next type and return.
 		if ( 1 >= $state['max'][ $sitemap_type ]['number'] ) {
-			Jetpack_Sitemap_State::check_in( array(
-				'sitemap-type'  => $next_type,
-				'last-added'    => 0,
-				'number'        => 0,
-				'last-modified' => '1970-01-01 00:00:00',
-			) );
+			Jetpack_Sitemap_State::check_in(
+				array(
+					'sitemap-type'  => $next_type,
+					'last-added'    => 0,
+					'number'        => 0,
+					'last-modified' => '1970-01-01 00:00:00',
+				)
+			);
 
 			if ( $this->logger ) {
 				$this->logger->report( "-- Cleaning Up $index_type" );
@@ -339,7 +351,8 @@ class Jetpack_Sitemap_Builder {
 
 			// There are no indices of this type.
 			$this->librarian->delete_numbered_sitemap_rows_after(
-				0, $index_type
+				0,
+				$index_type
 			);
 
 			return;
@@ -355,12 +368,14 @@ class Jetpack_Sitemap_Builder {
 
 		// If no index was built, advance to the next type and return.
 		if ( false === $result ) {
-			Jetpack_Sitemap_State::check_in( array(
-				'sitemap-type'  => $next_type,
-				'last-added'    => 0,
-				'number'        => 0,
-				'last-modified' => '1970-01-01 00:00:00',
-			) );
+			Jetpack_Sitemap_State::check_in(
+				array(
+					'sitemap-type'  => $next_type,
+					'last-added'    => 0,
+					'number'        => 0,
+					'last-modified' => '1970-01-01 00:00:00',
+				)
+			);
 
 			if ( $this->logger ) {
 				$this->logger->report( "-- Cleaning Up $index_type" );
@@ -368,19 +383,22 @@ class Jetpack_Sitemap_Builder {
 
 			// Clean up old files.
 			$this->librarian->delete_numbered_sitemap_rows_after(
-				$state['number'], $index_type
+				$state['number'],
+				$index_type
 			);
 
 			return;
 		}
 
 		// Otherwise, check in the state.
-		Jetpack_Sitemap_State::check_in( array(
-			'sitemap-type'  => $index_type,
-			'last-added'    => $result['last_id'],
-			'number'        => $state['number'] + 1,
-			'last-modified' => $result['last_modified'],
-		) );
+		Jetpack_Sitemap_State::check_in(
+			array(
+				'sitemap-type'  => $index_type,
+				'last-added'    => $result['last_id'],
+				'number'        => $state['number'] + 1,
+				'last-modified' => $result['last_modified'],
+			)
+		);
 
 		// If there are still sitemaps left to index, return.
 		if ( true === $result['any_left'] ) {
@@ -388,12 +406,14 @@ class Jetpack_Sitemap_Builder {
 		}
 
 		// Otherwise, advance to the next type.
-		Jetpack_Sitemap_State::check_in( array(
-			'sitemap-type'  => $next_type,
-			'last-added'    => 0,
-			'number'        => 0,
-			'last-modified' => '1970-01-01 00:00:00',
-		) );
+		Jetpack_Sitemap_State::check_in(
+			array(
+				'sitemap-type'  => $next_type,
+				'last-added'    => 0,
+				'number'        => 0,
+				'last-modified' => '1970-01-01 00:00:00',
+			)
+		);
 
 		if ( $this->logger ) {
 			$this->logger->report( "-- Cleaning Up $index_type" );
@@ -401,10 +421,9 @@ class Jetpack_Sitemap_Builder {
 
 		// We're done generating indices of this type.
 		$this->librarian->delete_numbered_sitemap_rows_after(
-			$state['number'] + 1, $index_type
+			$state['number'] + 1,
+			$index_type
 		);
-
-		return;
 	}
 
 	/**
@@ -415,6 +434,9 @@ class Jetpack_Sitemap_Builder {
 	 * @since 4.8.0
 	 */
 	private function build_master_sitemap( $max ) {
+		$page  = array();
+		$image = array();
+		$video = array();
 		if ( $this->logger ) {
 			$this->logger->report( '-- Building Master Sitemap.' );
 		}
@@ -426,10 +448,10 @@ class Jetpack_Sitemap_Builder {
 
 		if ( 0 < $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
-				$page['filename'] = jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, 1 );
+				$page['filename']      = jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, 1 );
 				$page['last_modified'] = jp_sitemap_datetime( $max[ JP_PAGE_SITEMAP_TYPE ]['lastmod'] );
 			} else {
-				$page['filename'] = jp_sitemap_filename(
+				$page['filename']      = jp_sitemap_filename(
 					JP_PAGE_SITEMAP_INDEX_TYPE,
 					$max[ JP_PAGE_SITEMAP_INDEX_TYPE ]['number']
 				);
@@ -448,10 +470,10 @@ class Jetpack_Sitemap_Builder {
 
 		if ( 0 < $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
-				$image['filename'] = jp_sitemap_filename( JP_IMAGE_SITEMAP_TYPE, 1 );
+				$image['filename']      = jp_sitemap_filename( JP_IMAGE_SITEMAP_TYPE, 1 );
 				$image['last_modified'] = jp_sitemap_datetime( $max[ JP_IMAGE_SITEMAP_TYPE ]['lastmod'] );
 			} else {
-				$image['filename'] = jp_sitemap_filename(
+				$image['filename']      = jp_sitemap_filename(
 					JP_IMAGE_SITEMAP_INDEX_TYPE,
 					$max[ JP_IMAGE_SITEMAP_INDEX_TYPE ]['number']
 				);
@@ -470,10 +492,10 @@ class Jetpack_Sitemap_Builder {
 
 		if ( 0 < $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
-				$video['filename'] = jp_sitemap_filename( JP_VIDEO_SITEMAP_TYPE, 1 );
+				$video['filename']      = jp_sitemap_filename( JP_VIDEO_SITEMAP_TYPE, 1 );
 				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_TYPE ]['lastmod'] );
 			} else {
-				$video['filename'] = jp_sitemap_filename(
+				$video['filename']      = jp_sitemap_filename(
 					JP_VIDEO_SITEMAP_INDEX_TYPE,
 					$max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['number']
 				);
@@ -555,7 +577,8 @@ class Jetpack_Sitemap_Builder {
 		// Add as many items to the buffer as possible.
 		while ( $last_post_id >= 0 && false === $buffer->is_full() ) {
 			$posts = $this->librarian->query_posts_after_id(
-				$last_post_id, JP_SITEMAP_BATCH_SIZE
+				$last_post_id,
+				JP_SITEMAP_BATCH_SIZE
 			);
 
 			if ( null == $posts ) { // WPCS: loose comparison ok.
@@ -688,7 +711,7 @@ class Jetpack_Sitemap_Builder {
 	 * }
 	 */
 	public function build_one_image_sitemap( $number, $from_id ) {
-		$last_post_id = $from_id;
+		$last_post_id   = $from_id;
 		$any_posts_left = true;
 
 		if ( $this->logger ) {
@@ -704,7 +727,8 @@ class Jetpack_Sitemap_Builder {
 		// Add as many items to the buffer as possible.
 		while ( false === $buffer->is_full() ) {
 			$posts = $this->librarian->query_images_after_id(
-				$last_post_id, JP_SITEMAP_BATCH_SIZE
+				$last_post_id,
+				JP_SITEMAP_BATCH_SIZE
 			);
 
 			if ( null == $posts ) { // WPCS: loose comparison ok.
@@ -766,7 +790,7 @@ class Jetpack_Sitemap_Builder {
 	 * }
 	 */
 	public function build_one_video_sitemap( $number, $from_id ) {
-		$last_post_id = $from_id;
+		$last_post_id   = $from_id;
 		$any_posts_left = true;
 
 		if ( $this->logger ) {
@@ -782,7 +806,8 @@ class Jetpack_Sitemap_Builder {
 		// Add as many items to the buffer as possible.
 		while ( false === $buffer->is_full() ) {
 			$posts = $this->librarian->query_videos_after_id(
-				$last_post_id, JP_SITEMAP_BATCH_SIZE
+				$last_post_id,
+				JP_SITEMAP_BATCH_SIZE
 			);
 
 			if ( null == $posts ) { // WPCS: loose comparison ok.
@@ -868,7 +893,7 @@ class Jetpack_Sitemap_Builder {
 
 		// Add pointer to the previous sitemap index (unless we're at the first one).
 		if ( 1 !== $number ) {
-			$i = $number - 1;
+			$i              = $number - 1;
 			$prev_index_url = $this->finder->construct_sitemap_url(
 				jp_sitemap_filename( $index_type, $i )
 			);
@@ -887,7 +912,9 @@ class Jetpack_Sitemap_Builder {
 		while ( false === $buffer->is_full() ) {
 			// Retrieve a batch of posts (in order).
 			$posts = $this->librarian->query_sitemaps_after_id(
-				$sitemap_type, $last_sitemap_id, JP_SITEMAP_BATCH_SIZE
+				$sitemap_type,
+				$last_sitemap_id,
+				JP_SITEMAP_BATCH_SIZE
 			);
 
 			// If there were no posts to get, make a note.
@@ -1022,7 +1049,7 @@ class Jetpack_Sitemap_Builder {
 				$the_stored_news_sitemap,
 				JP_NEWS_SITEMAP_INTERVAL
 			);
-		} // End if().
+		} // End if.
 
 		return $the_stored_news_sitemap;
 	}
@@ -1164,7 +1191,7 @@ class Jetpack_Sitemap_Builder {
 			),
 		);
 
-		$item_array['url']['image:image']['image:title'] = $post->post_title;
+		$item_array['url']['image:image']['image:title']   = $post->post_title;
 		$item_array['url']['image:image']['image:caption'] = $post->post_excerpt;
 
 		/**
@@ -1341,10 +1368,10 @@ class Jetpack_Sitemap_Builder {
 
 		$item_array = array(
 			'url' => array(
-				'loc' => $url,
-				'lastmod' => jp_sitemap_datetime( $post->post_modified_gmt ),
+				'loc'       => $url,
+				'lastmod'   => jp_sitemap_datetime( $post->post_modified_gmt ),
 				'news:news' => array(
-					'news:publication' => array(
+					'news:publication'      => array(
 						'news:name'     => html_entity_decode( get_bloginfo( 'name' ) ),
 						'news:language' => $language,
 					),

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -10,6 +10,7 @@
  * @package Jetpack
  */
 
+/* Ensure sitemap constants are available. */
 require_once dirname( __FILE__ ) . '/sitemap-constants.php';
 
 /**
@@ -39,12 +40,14 @@ class Jetpack_Sitemap_Librarian {
 	 * }
 	 */
 	public function read_sitemap_data( $name, $type ) {
-		$post_array = get_posts( array(
-			'numberposts' => 1,
-			'title' => $name,
-			'post_type' => $type,
-			'post_status' => 'draft'
-		) );
+		$post_array = get_posts(
+			array(
+				'numberposts' => 1,
+				'title'       => $name,
+				'post_type'   => $type,
+				'post_status' => 'draft',
+			)
+		);
 
 		$the_post = array_shift( $post_array );
 
@@ -83,21 +86,25 @@ class Jetpack_Sitemap_Librarian {
 
 		if ( null === $the_post ) {
 			// Post does not exist.
-			wp_insert_post(array(
-				'post_title'   => $name,
-				'post_content' => base64_encode( $contents ),
-				'post_type'    => $type,
-				'post_date'    => date( 'Y-m-d H:i:s', strtotime( $timestamp ) ),
-			));
+			wp_insert_post(
+				array(
+					'post_title'   => $name,
+					'post_content' => base64_encode( $contents ),
+					'post_type'    => $type,
+					'post_date'    => date( 'Y-m-d H:i:s', strtotime( $timestamp ) ),
+				)
+			);
 		} else {
 			// Post does exist.
-			wp_insert_post(array(
-				'ID'           => $the_post['id'],
-				'post_title'   => $name,
-				'post_content' => base64_encode( $contents ),
-				'post_type'    => $type,
-				'post_date'    => date( 'Y-m-d H:i:s', strtotime( $timestamp ) ),
-			));
+			wp_insert_post(
+				array(
+					'ID'           => $the_post['id'],
+					'post_title'   => $name,
+					'post_content' => base64_encode( $contents ),
+					'post_type'    => $type,
+					'post_date'    => date( 'Y-m-d H:i:s', strtotime( $timestamp ) ),
+				)
+			);
 		}
 	}
 
@@ -160,8 +167,8 @@ class Jetpack_Sitemap_Librarian {
 		$any_left = true;
 
 		while ( true === $any_left ) {
-			$position += 1;
-			$name = jp_sitemap_filename( $type, $position );
+			$position++;
+			$name     = jp_sitemap_filename( $type, $position );
 			$any_left = $this->delete_sitemap_data( $name, $type );
 		}
 	}
@@ -188,16 +195,18 @@ class Jetpack_Sitemap_Librarian {
 	 * @access protected
 	 * @since 5.3.0
 	 *
-	 * @param String $type
+	 * @param String $type Type of sitemap.
 	 */
 	protected function delete_sitemap_type_data( $type ) {
-		$ids = get_posts( array(
-			'post_type' => $type,
-			'post_status' => 'draft',
-			'fields' => 'ids'
-		) );
+		$ids = get_posts(
+			array(
+				'post_type'   => $type,
+				'post_status' => 'draft',
+				'fields'      => 'ids',
+			)
+		);
 
-		foreach( $ids as $id ) {
+		foreach ( $ids as $id ) {
 			wp_trash_post( $id );
 		}
 	}

--- a/modules/sitemaps/sitemap-logger.php
+++ b/modules/sitemaps/sitemap-logger.php
@@ -44,12 +44,11 @@ class Jetpack_Sitemap_Logger {
 	 * @param string $message An optional message string to be written to the debug log on initialization.
 	 */
 	public function __construct( $message = null ) {
-		$this->key = wp_generate_password( 5, false );
+		$this->key       = wp_generate_password( 5, false );
 		$this->starttime = microtime( true );
 		if ( ! is_null( $message ) ) {
 			$this->report( $message );
 		}
-		return;
 	}
 
 	/**
@@ -59,7 +58,7 @@ class Jetpack_Sitemap_Logger {
 	 * @since 4.8.0
 	 *
 	 * @param string  $message  The string to be written to the log.
-	 * @param boolean $is_error If true, $message will be logged even if JETPACK_DEV_DEBUG is not enabled
+	 * @param boolean $is_error If true, $message will be logged even if JETPACK_DEV_DEBUG is not enabled.
 	 */
 	public function report( $message, $is_error = false ) {
 		$message = 'jp-sitemap-' . $this->key . ': ' . $message;
@@ -69,8 +68,7 @@ class Jetpack_Sitemap_Logger {
 		if ( ! $is_error && ! ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) ) {
 			return;
 		}
-		error_log( $message );
-		return;
+		error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 
 	/**
@@ -84,6 +82,5 @@ class Jetpack_Sitemap_Logger {
 	public function time( $message = '' ) {
 		$time = round( microtime( true ) - $this->starttime, 3 );
 		$this->report( $message . ' ' . $time . ' seconds elapsed.' );
-		return;
 	}
 }

--- a/modules/sitemaps/sitemap-state.php
+++ b/modules/sitemaps/sitemap-state.php
@@ -7,6 +7,7 @@
  * @author Automattic
  */
 
+/* Include standard constants and librarian. */
 require_once dirname( __FILE__ ) . '/sitemap-constants.php';
 require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
 
@@ -75,16 +76,15 @@ class Jetpack_Sitemap_State {
 	 * @access public
 	 * @since 4.8.0
 	 *
-	 * @param array $state {
+	 * @param array $state Array of the Sitemap state details.
 	 *     @type string sitemap-type  The type of sitemap to be generated.
 	 *     @type int    last-added    The largest index to be added to a generated sitemap page.
 	 *     @type int    number        The index of the last sitemap to be generated.
 	 *     @type string last-modified The latest timestamp seen.
-	 * }
 	 */
 	public static function check_in( $state ) {
 		// Get the old max value.
-		$sitemap_old = get_option( 'jetpack-sitemap-state', self::initial() );
+		$sitemap_old  = get_option( 'jetpack-sitemap-state', self::initial() );
 		$state['max'] = $sitemap_old['max'];
 
 		// Update the max value of the current type.

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -151,9 +151,9 @@ class Jetpack_Sitemap_Manager {
 		if ( '' === $the_content ) {
 			$error = __( 'No sitemap found. Please try again later.', 'jetpack' );
 			if ( current_user_can( 'manage_options' ) ) {
-				$next = date_i18n( 'F j, Y g:i a', wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
-				/* translators: %s is a date/time for next sitemap generation. */
-				$error = sprintf( __( 'No sitemap found. The system will try to build it again at %s', 'jetpack' ), $next );
+				$next = human_time_diff( wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+				/* translators: %s is a human_time_diff until next sitemap generation. */
+				$error = sprintf( __( 'No sitemap found. The system will try to build it again in %s.', 'jetpack' ), $next );
 			}
 
 			wp_die(

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -31,6 +31,7 @@
  * @author Automattic
  */
 
+/* Include all of the sitemap subclasses. */
 require_once dirname( __FILE__ ) . '/sitemap-constants.php';
 require_once dirname( __FILE__ ) . '/sitemap-buffer.php';
 require_once dirname( __FILE__ ) . '/sitemap-stylist.php';
@@ -50,6 +51,8 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 class Jetpack_Sitemap_Manager {
 
 	/**
+	 * Librarian object for storing and retrieving sitemap data.
+	 *
 	 * @see Jetpack_Sitemap_Librarian
 	 * @since 4.8.0
 	 * @var Jetpack_Sitemap_Librarian $librarian Librarian object for storing and retrieving sitemap data.
@@ -57,6 +60,8 @@ class Jetpack_Sitemap_Manager {
 	private $librarian;
 
 	/**
+	 * Logger object for reporting debug messages.
+	 *
 	 * @see Jetpack_Sitemap_Logger
 	 * @since 4.8.0
 	 * @var Jetpack_Sitemap_Logger $logger Logger object for reporting debug messages.
@@ -64,9 +69,11 @@ class Jetpack_Sitemap_Manager {
 	private $logger;
 
 	/**
+	 * Finder object for handling sitemap URIs.
+	 *
 	 * @see Jetpack_Sitemap_Finder
 	 * @since 4.8.0
-	 * @var Jetpack_Sitemap_Finder $finder Finder object for dealing with sitemap URIs.
+	 * @var Jetpack_Sitemap_Finder $finder Finder object for handling with sitemap URIs.
 	 */
 	private $finder;
 
@@ -78,7 +85,7 @@ class Jetpack_Sitemap_Manager {
 	 */
 	public function __construct() {
 		$this->librarian = new Jetpack_Sitemap_Librarian();
-		$this->finder = new Jetpack_Sitemap_Finder();
+		$this->finder    = new Jetpack_Sitemap_Finder();
 
 		if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
 			$this->logger = new Jetpack_Sitemap_Logger();
@@ -128,8 +135,6 @@ class Jetpack_Sitemap_Manager {
 			array( $this, 'callback_action_filter_sitemap_location' ),
 			999
 		);
-
-		return;
 	}
 
 	/**
@@ -344,9 +349,6 @@ class Jetpack_Sitemap_Manager {
 				);
 			}
 		}
-
-		// URL did not match any sitemap patterns.
-		return;
 	}
 
 	/**
@@ -386,7 +388,7 @@ class Jetpack_Sitemap_Manager {
 	 */
 	private function schedule_sitemap_generation() {
 		// Add cron schedule.
-		add_filter( 'cron_schedules', array( $this, 'callback_add_sitemap_schedule' ) );
+		add_filter( 'cron_schedules', array( $this, 'callback_add_sitemap_schedule' ) ); // phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
 
 		add_action(
 			'jp_sitemap_cron_hook',
@@ -405,7 +407,7 @@ class Jetpack_Sitemap_Manager {
 			 *
 			 * @param int $delay Time to delay in seconds.
 			 */
-			$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * mt_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
+			$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * wp_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
 			wp_schedule_event(
 				time() + $delay,
 				'sitemap-interval',
@@ -433,7 +435,7 @@ class Jetpack_Sitemap_Manager {
 		$discover_sitemap = apply_filters( 'jetpack_sitemap_generate', true );
 
 		if ( true === $discover_sitemap ) {
-			$sitemap_url      = $this->finder->construct_sitemap_url( 'sitemap.xml' );
+			$sitemap_url = $this->finder->construct_sitemap_url( 'sitemap.xml' );
 			echo 'Sitemap: ' . esc_url( $sitemap_url ) . "\n";
 		}
 
@@ -451,8 +453,6 @@ class Jetpack_Sitemap_Manager {
 			$news_sitemap_url = $this->finder->construct_sitemap_url( 'news-sitemap.xml' );
 			echo 'Sitemap: ' . esc_url( $news_sitemap_url ) . "\n";
 		}
-
-		return;
 	}
 
 	/**
@@ -470,13 +470,13 @@ class Jetpack_Sitemap_Manager {
 	 *
 	 * @access public
 	 * @since 5.3.0
-	 * @since 6.7.0 Schedules a regeneration after 60 seconds.
+	 * @since 6.7.0 Schedules a regeneration.
 	 */
 	public function callback_action_purge_data() {
 		$this->callback_action_flush_news_sitemap_cache();
 		$this->librarian->delete_all_stored_sitemap_data();
 		/** This filter is documented in modules/sitemaps/sitemaps.php */
-		$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * mt_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
+		$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * wp_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
 		wp_schedule_single_event( time() + $delay, 'jp_sitemap_cron_hook' );
 	}
 
@@ -525,8 +525,6 @@ class Jetpack_Sitemap_Manager {
 				''
 			)
 		);
-
-		return;
 	}
 
 } // End Jetpack_Sitemap_Manager class.

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -149,8 +149,15 @@ class Jetpack_Sitemap_Manager {
 		set_query_var( 'feed', 'sitemap' );
 
 		if ( '' === $the_content ) {
+			$error = __( 'No sitemap found. Please try again later.', 'jetpack' );
+			if ( current_user_can( 'manage_options' ) ) {
+				$next = date_i18n( 'F j, Y g:i a', wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+				/* translators: %s is a date/time for next sitemap generation. */
+				$error = sprintf( __( 'No sitemap found. The system will try to build it again at %s', 'jetpack' ), $next );
+			}
+
 			wp_die(
-				esc_html__( "No sitemap found. Maybe it's being generated. Please try again later.", 'jetpack' ),
+				esc_html( $error ),
 				esc_html__( 'Sitemaps', 'jetpack' ),
 				array(
 					'response' => 404,

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -476,8 +476,8 @@ class Jetpack_Sitemap_Manager {
 		$this->callback_action_flush_news_sitemap_cache();
 		$this->librarian->delete_all_stored_sitemap_data();
 		/** This filter is documented in modules/sitemaps/sitemaps.php */
-		$randomness = MINUTE_IN_SECONDS * mt_rand( 1, apply_filters( 'jetpack_sitemap_generation_randomness', 15 ) ); // Randomly space it out to start within next fifteen minutes.
-		wp_schedule_single_event( time() + $randomness, 'jp_sitemap_cron_hook' );
+		$delay = apply_filters( 'jetpack_sitemap_generation_delay', MINUTE_IN_SECONDS * mt_rand( 1, 15 ) ); // Randomly space it out to start within next fifteen minutes.
+		wp_schedule_single_event( time() + $delay, 'jp_sitemap_cron_hook' );
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -475,7 +475,9 @@ class Jetpack_Sitemap_Manager {
 	public function callback_action_purge_data() {
 		$this->callback_action_flush_news_sitemap_cache();
 		$this->librarian->delete_all_stored_sitemap_data();
-		wp_schedule_single_event( time() + 60, 'jp_sitemap_cron_hook' );
+		/** This filter is documented in modules/sitemaps/sitemaps.php */
+		$randomness = MINUTE_IN_SECONDS * mt_rand( 1, apply_filters( 'jetpack_sitemap_generation_randomness', 15 ) ); // Randomly space it out to start within next fifteen minutes.
+		wp_schedule_single_event( time() + $randomness, 'jp_sitemap_cron_hook' );
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -470,10 +470,12 @@ class Jetpack_Sitemap_Manager {
 	 *
 	 * @access public
 	 * @since 5.3.0
+	 * @since 6.7.0 Schedules a regeneration after 60 seconds.
 	 */
 	public function callback_action_purge_data() {
 		$this->callback_action_flush_news_sitemap_cache();
 		$this->librarian->delete_all_stored_sitemap_data();
+		wp_schedule_single_event( time() + 60, 'jp_sitemap_cron_hook' );
 	}
 
 	/**


### PR DESCRIPTION
After digging in to figure out the initial creation issue ( #10274 ), I made a pass at the other pending issues.
Fixes #7992 #8549 #9159 #9363

#### Changes proposed in this Pull Request:

* Updates a concatenated string to a single string.
* Checks if the home_url is a static page and if so, do not include it in the sitemap (as it would already be included when pages are added to the sitemap)
* Modifies the "no sitemap" error when visiting sitemap.xml for logged-in admins to display the next cron run time.
* When the sitemap data is reset following a Jetpack upgrade, schedule a new generation task one minute in the future. Before, it would wait until the next scheduled attempt, which could be up to 12 hours under default settings.

#### Testing instructions:

* Site with Sitemaps already active.
* Set the home page as a static page.
* Bump the version within JP (or set the Jetpack_Options value for `version` down so `plugin_upgrade` fires.
* Immediately check sitemap.xml. If it was within the first minute, see the new error message displayed for admins. Notice the time should be within a minute.
* After 1 minute, confirm the new sitemap is generated.
* Using a plugin like WPCrontrol, confirm the sitemap cron job is still on a regular `sitemap interval` schedule.
* Confirm the home page URL (set in step 2 above) only displays one.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Sitemaps: Ensure homepage is only included once.
* Sitemaps: Provide richer "not found" message to site admins.
* Sitemaps: Ensure sitemap is refreshed faster after upgrading Jetpack.
