### PR TITLE
Widgets: concatenate author and Social Icons widget CSS

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -33,7 +33,9 @@ class Jetpack {
 	public $HTTP_RAW_POST_DATA = null; // copy of $GLOBALS['HTTP_RAW_POST_DATA']
 
 	/**
-	 * @var array The handles of styles that are concatenated into jetpack.css
+	 * @var array The handles of styles that are concatenated into jetpack.css.
+	 *
+	 * When making changes to that list, you must also update concat_list in tools/builder/frontend-css.js.
 	 */
 	public $concatenated_style_handles = array(
 		'jetpack-carousel',

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -47,7 +47,6 @@ const concat_list = [
 	'modules/widgets/search/css/search-widget-frontend.css',
 	'modules/widgets/simple-payments/style.css',
 	'modules/widgets/social-icons/social-icons.css',
-	'modules/widgets/authors/style.css',
 ];
 
 /**

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -17,7 +17,11 @@ import util from 'gulp-util';
  */
 import { transformRelativePath } from './transform-relative-paths';
 
-/* Front-end CSS to be concatenated */
+/**
+ * Front-end CSS to be concatenated.
+ *
+ * When making changes to that list, you must also update $concatenated_style_handles in class.jetpack.php.
+ */
 const concat_list = [
 	'modules/carousel/jetpack-carousel.css',
 	'modules/contact-form/css/grunion.css',

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -46,6 +46,8 @@ const concat_list = [
 	'modules/widgets/flickr/style.css',
 	'modules/widgets/search/css/search-widget-frontend.css',
 	'modules/widgets/simple-payments/style.css',
+	'modules/widgets/social-icons/social-icons.css',
+	'modules/widgets/authors/style.css',
 ];
 
 /**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Follow up for #10153

The files were not enqueued anymore as of the PR above, but the CSS
did not get added to the jetpack.css file that is enqueued instead of the singular files.

#### Testing instructions:

1. Checkout this branch.
2. run `gulp frontendcss`
3. Check that `css/jetpack.css` was updated and includes the necessary CSS.
4. Add the 2 widgets to a site where `WP_DEBUG` is set to `false`.
5. Make sure the widgets look good.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Widgets: fix missing CSS for the Authors and the Social Icons Widgets.