### PR TITLE
CSS concatenation: fix differences between what the 2 lists.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -46,6 +46,7 @@ class Jetpack {
 		'sharedaddy',
 		'jetpack-slideshow',
 		'presentations',
+		'quiz',
 		'jetpack-subscriptions',
 		'jetpack-responsive-videos-style',
 		'jetpack-social-menu',
@@ -57,13 +58,13 @@ class Jetpack {
 		'jetpack-top-posts-widget',
 		'jetpack_image_widget',
 		'jetpack-my-community-widget',
+		'jetpack-authors-widget',
 		'wordads',
 		'eu-cookie-law-style',
 		'flickr-widget-style',
 		'jetpack-search-widget',
 		'jetpack-simple-payments-widget-style',
 		'jetpack-widget-social-icons-styles',
-		'jetpack-authors-widget',
 	);
 
 	/**

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -44,7 +44,6 @@ const concat_list = [
 	'modules/widgets/image-widget/style.css',
 	'modules/widgets/my-community/style.css',
 	'modules/widgets/authors/style.css',
-	'css/jetpack-idc-admin-bar.css',
 	'modules/wordads/css/style.css',
 	'modules/widgets/eu-cookie-law/style.css',
 	'modules/widgets/flickr/style.css',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #10280

One list is for the files being dequeued.
The other list is for the content of those files to be concatenated into jetpack.css.

The 2 lists should match, but that was not the case. I updated them.

Noting that I also removed The IDC file since it is meant to be used in wp-admin only.

#### Testing instructions:

Ensure that the CSS file used to style Quizzes (shortcode) is not inserted when adding a quiz to your site like so:
https://en.support.wordpress.com/quiz-shortcode/

The quiz should still be styled properly thanks to CSS added to `jetpack.css`.

Noting that `WP_DEBUG` should be set to `false` on your site while testing.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
CSS Concatenation: make sure all concatenated CSS is up to date.