### PR TITLE
Featured Content: Prevent tag hiding from REST API interactions

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -384,7 +384,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		public static function hide_featured_term( $terms, $taxonomies, $args ) {
 
 			// This filter is only appropriate on the front-end.
-			if ( is_admin() ) {
+			if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 				return $terms;
 			}
 


### PR DESCRIPTION
Fixes #7996

#### Changes proposed in this Pull Request:

* Returns early if it is a REST or XMLRPC request, in addition to admin.

#### Testing instructions:

* Setup a site with a featured-content using theme (I tried with Axon from WP.com's theme directory).
* Add a post with the tag "featured"
* Via Customizer, visit Featured Content, set tag as `featured`, and check the option to hide tag.
* Visit the front end and see the tag not present on the permalink page of the post.
* Visit the WP.com Editor for the post, see the tag is also missing.
* Apply patch.
* Revisit front end, confirm tag is still hidden.
* Revisit WP.com Editor, not see the tag is present.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Featured Content: No longer hides the "featured" tag from the WordPress.com Editor or the mobile apps.