### PR TITLE
Fix Error on Verification Settings No Change

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -747,6 +747,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'pinterest':
 				case 'yandex':
 					$grouped_options          = $grouped_options_current = (array) get_option( 'verification_services_codes' );
+					$matches = array();
+					if ( preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $value, $matches ) ) {
+						$value = $matches[ 2 ];
+					}
 					$grouped_options[$option] = $value;
 
 					// If option value was the same, consider it done.

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -746,12 +746,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'bing':
 				case 'pinterest':
 				case 'yandex':
-					$grouped_options          = $grouped_options_current = (array) get_option( 'verification_services_codes' );
-					$matches = array();
-					if ( preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $value, $matches ) ) {
-						$value = $matches[ 2 ];
+					$grouped_options = $grouped_options_current = (array) get_option( 'verification_services_codes' );
+
+					// Extracts the content attribute from the HTML meta tag if needed
+					if ( preg_match( '#.*<meta name="(?:[^"]+)" content="([^"]+)" />.*#i', $value, $matches ) ) {
+						$grouped_options[ $option ] = $matches[1];
+					} else {
+						$grouped_options[ $option ] = $value;
 					}
-					$grouped_options[$option] = $value;
 
 					// If option value was the same, consider it done.
 					$updated = $grouped_options_current != $grouped_options ? update_option( 'verification_services_codes', $grouped_options ) : true;


### PR DESCRIPTION
Fixes #10254

#### Changes proposed in this Pull Request:

* Strip Meta Tags from Verification Values when checking changes

##### Before
![before](https://user-images.githubusercontent.com/2810519/46703241-2727db80-cbdb-11e8-80bc-4300300d92fa.gif)

##### After
![after](https://user-images.githubusercontent.com/2810519/46703183-e334d680-cbda-11e8-99ee-50f668f3c7fa.gif)
#### Testing instructions:

1. Navigate to Jetpack -> Settings -> Traffic -> Site verification
2. Set a value in the Bing, Pinterest, or Yandex Fields
3. Save the value by pressing enter or clicking "SAVE SETTINGS"
4. Temporarily modify the value, then revert your changes so that the "SAVE SETTINGS" Button is a clickable blue
5. Save the value by pressing enter or clicking "SAVE SETTINGS"
6. Confirm that the a "green check" notification with the test "Updated Settings" appears

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Strip Meta Tags from Verification Values when checking changes

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: