### PR TITLE
REST API: Activate Related Posts module if not active when requesting related posts

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -69,6 +69,17 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
+		// Activate the Related Posts module if it's not currently active
+		if ( ! Jetpack::is_module_active( 'related-posts' ) ) {
+			if ( ! Jetpack::activate_module( 'related-posts' ) ) {
+				return new WP_Error(
+					'module_activation_error',
+					esc_html__( 'We were unable to activate the Related Posts module.', 'jetpack' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
 		// Make the API request
 		$request = sprintf( '/sites/%d/posts/%d/related', Jetpack_Options::get_option( 'id' ), $post_id );
 		$request_args = array(

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -71,13 +71,16 @@ class Jetpack_Core_API_Site_Endpoint {
 
 		// Activate the Related Posts module if it's not currently active
 		if ( ! Jetpack::is_module_active( 'related-posts' ) ) {
-			if ( ! Jetpack::activate_module( 'related-posts' ) ) {
+			if ( ! Jetpack::activate_module( 'related-posts', false, false ) ) {
 				return new WP_Error(
 					'module_activation_error',
 					esc_html__( 'We were unable to activate the Related Posts module.', 'jetpack' ),
 					array( 'status' => 400 )
 				);
 			}
+
+			// We need to load the modules again if we've just activated the Related Posts module
+			Jetpack::load_modules();
 		}
 
 		// Make the API request


### PR DESCRIPTION
It appears that currently if we request related posts through the non-cached endpoint, it'll fail in a bad way if module isn't enabled (a PHP fatal error). So this PR updates the endpoint to autoenable the module.

#### Changes proposed in this Pull Request:

* Enable Related Posts module if it's deactivated when requesting related posts through the endpoint.

#### Testing instructions:

* Follow test instructions of https://github.com/Automattic/wp-calypso/pull/27659
* Deactivate the related posts module.
* Insert a Related Posts block.
* Verify the module gets activated when the initial related posts request is made.