### PR TITLE
Sitemaps: Remove double encoding of site name

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1349,7 +1349,7 @@ class Jetpack_Sitemap_Builder {
 				'lastmod' => jp_sitemap_datetime( $post->post_modified_gmt ),
 				'news:news' => array(
 					'news:publication' => array(
-						'news:name'     => get_bloginfo( 'name' ),
+						'news:name'     => html_entity_decode( get_bloginfo( 'name' ) ),
 						'news:language' => $language,
 					),
 					/** This filter is already documented in core/wp-includes/feed.php */


### PR DESCRIPTION
Fixes #10033

#### Changes proposed in this Pull Request:

* Decode HTML entities on site name before adding it to the news sitemap to prevent double encoding issues.  These are encoded by WordPress core and stored encoded in the database, so it's not as easy as just removing a filter.

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Set up or change a site to have the site name (`blog_name`) contain an ampersand (`&`).
* Enable Jetpack Sitemaps
* Post a new post to generate a new news sitemap.
* Visit `/news-sitemap.xml` and view double encoded ampersands in the `<news:name>` tag.
* Apply Patch
* Post a new post to generate a new news sitemap.
* Visit `/news-sitemap.xml` and view single encoded ampersands in the `<news:name>` tag.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Sitemaps: Remove double encoding of site name in news sitemap.
