### PR TITLE
Remove Jetpack blocks CDN

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7291,9 +7291,6 @@ p {
 	 * - _inc/blocks/view.css
 	 * - _inc/blocks/view.rtl.css
 	 *
-	 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-	 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-	 *
 	 * @since 6.5.0
 	 *
 	 * @return void

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7283,9 +7283,6 @@ p {
 	 * Loading blocks is disabled by default and enabled via filter:
 	 *   add_filter( 'jetpack_gutenberg', '__return_true' );
 	 *
-	 * When enabled, blocks are loaded from CDN by default. To load locally instead:
-	 *   add_filter( 'jetpack_gutenberg_cdn', '__return_false' );
-	 *
 	 * Note that when loaded locally, you need to build the files yourself:
 	 * - _inc/blocks/editor.js
 	 * - _inc/blocks/editor.css
@@ -7318,37 +7315,13 @@ p {
 
 		$rtl = is_rtl() ? '.rtl' : '';
 
-		/**
-		 * Filter to turn off serving blocks via CDN
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool true Whether to load Gutenberg blocks from CDN
-		 */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', true ) ) {
-			$cdn_base = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$editor_script = "$cdn_base/editor.js";
-			$editor_style = "$cdn_base/editor$rtl.css";
-			$view_script = "$cdn_base/view.js";
-			$view_style = "$cdn_base/view$rtl.css";
-
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string
-			 */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
-			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
-			$view_style = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				: JETPACK__VERSION;
-		}
+		$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
+		$editor_style = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
+		$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
+		$view_style = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
+		$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			: JETPACK__VERSION;
 
 		wp_register_script(
 			'jetpack-blocks-editor',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7312,17 +7312,13 @@ p {
 
 		$rtl = is_rtl() ? '.rtl' : '';
 
-		$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
-		$editor_style = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
-		$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
-		$view_style = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
 		$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
 			? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
 			: JETPACK__VERSION;
 
 		wp_register_script(
 			'jetpack-blocks-editor',
-			$editor_script,
+			plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE ),
 			array(
 				'lodash',
 				'wp-api-fetch',
@@ -7339,16 +7335,15 @@ p {
 			),
 			$version
 		);
-
 		wp_localize_script(
 			'jetpack-blocks-editor',
 			'Jetpack_Block_Assets_Base_Url',
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
-		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );
-		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
+		wp_register_style( 'jetpack-blocks-editor', plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE ), array(), $version );
+		wp_register_script( 'jetpack-blocks-view', plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE ), array(), $version );
+		wp_register_style( 'jetpack-blocks-view', plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE ), array(), $version );
 
 		register_block_type( 'jetpack/blocks', array(
 				'script'        => 'jetpack-blocks-view',

--- a/docs/guides/gutenberg-blocks.md
+++ b/docs/guides/gutenberg-blocks.md
@@ -5,7 +5,7 @@ _Note: Since the Gutenberg SDK is still being actively developed, the developmen
 1.  Install & activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
 
     If you use Jetpack-Docker, you can use WP-CLI:
-	
+
     ```bash
     yarn docker:wp plugin install gutenberg --activate
     ```
@@ -14,7 +14,6 @@ _Note: Since the Gutenberg SDK is still being actively developed, the developmen
 
     ```php
     add_filter( 'jetpack_gutenberg', '__return_true', 10 );
-    add_filter( 'jetpack_gutenberg_cdn', '__return_false', 10 );
     ```
 
     If you use Jetpack-Docker, you could add these to `docker/mu-plugins/0-custom.php`
@@ -41,15 +40,7 @@ _Note: Since the Gutenberg SDK is still being actively developed, the developmen
     _inc/blocks/view.js
     ```
 
-    Without setting `jetpack_gutenberg_cdn` to false, Jetpack would load these assets from CDN with 24h cache buster:
-
-    https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks/
-
-    This is great for letting team-outsiders test our current set of Jetpack blocks; let's deploy these when ever we have something to show.
-
-    Use the helper script introduced in D18479-code to produce these assets locally for your sandbox so that you can then commit and deploy.
-
-    Note that we currently have a fixed list of dependencies which is just everything current trial blocks depend on: https://github.com/Automattic/jetpack/blob/b4a057fad975f3db8097fd62e702e276fd3d4389/class.jetpack.php#L7355-L7366
+    Note that we currently have a fixed list of dependencies which is just everything existing blocks depend on: https://github.com/Automattic/jetpack/blob/b4a057fad975f3db8097fd62e702e276fd3d4389/class.jetpack.php#L7355-L7366
 
     We don't have a mechanism in SDK to export these during compile time.
 


### PR DESCRIPTION
The Jetpack blocks specific CDN is not widely used for development and has been superseded by local block code. Remove it.

Supersedes #10293

Related changes: D19308-code

#### Changes proposed in this Pull Request:

* Remove the Gutenberg block CDN

#### Testing instructions:

* Blocks are no longer loaded from the Jetpack-Gutenberg-blocks-specific CDN
* Blocks are loaded locally

#### Proposed changelog entry for your changes:

Remove the Jetpack blocks specific CDN