### PR TITLE
Docs: Update repo URL from https to git based

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -24,7 +24,7 @@ _**All commands mentioned in this document should be run from the base Jetpack d
 Install prerequisites and clone the repository:
 
 ```sh
-git clone https://github.com/Automattic/jetpack.git && cd jetpack
+git clone git@github.com:Automattic/jetpack.git && cd jetpack
 ```
 
 Optionally, copy settings file to modify it:

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -26,7 +26,7 @@ $ yarn distclean
 2. Clone this repository inside your Plugins directory.
 
 	```
-	$ git clone https://github.com/Automattic/jetpack.git
+	$ git clone git@github.com:Automattic/jetpack.git
 	$ cd jetpack
 	```
 


### PR DESCRIPTION
Having the `https` based URL may be confusing for folks onboarding.

#### Changes proposed in this Pull Request:

* Updates `docker/README.md` to have the `git` based version of the URL for the Jetpack repo.
* Updates `docs/development-environment.md` to have the `git` based version of the URL for the Jetpack repo.
 
#### Testing instructions:

* Check the rendered version of the docs, confirm the URL looks fine.
  * [docker/README.md](https://github.com/Automattic/jetpack/blob/fix/docker-docks-git-path/docker/README.md#to-get-started).
  * [docs/development-environment.md](https://github.com/Automattic/jetpack/blob/fix/docker-docks-git-path/docs/development-environment.md#a-note-on-node-versions-used-for-the-build-tasks).

#### Proposed changelog entry for your changes:
