### PR TITLE
Upgrading: Defensive coding when we care about a 'new' method

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -421,7 +421,7 @@ class Jetpack {
 
 		Jetpack::maybe_set_version_option();
 
-		if ( class_exists( 'Jetpack_Widget_Conditions' ) ) {
+		if ( method_exists( 'Jetpack_Widget_Conditions', 'migrate_post_type_rules' ) ) {
 			Jetpack_Widget_Conditions::migrate_post_type_rules();
 		}
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -504,6 +504,9 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 */
 		function form( $instance ) {
 			$jetpack_simple_payments = Jetpack_Simple_Payments::getInstance();
+			if ( ! method_exists( $jetpack_simple_payments, 'is_enabled_jetpack_simple_payments' ) ) {
+				return;
+			}
 			if ( ! $jetpack_simple_payments->is_enabled_jetpack_simple_payments() ) {
 				require dirname( __FILE__ ) . '/simple-payments/admin-warning.php';
 				return;


### PR DESCRIPTION
Fixes #9910

#### Changes proposed in this Pull Request:

* When wanting a specific function that is new to a class, we should check specifically for that method.

#### Testing instructions:

* Not really sure. On a site with opcode enabled without file system monitoring, install Jetpack 4.5 or so, then upgrade to something like 6.6.1 for the first one?

@jeherve I don't know if this is a good idea or not. Ideally, servers wouldn't run opcache without clearing on file system changes or core would solve https://core.trac.wordpress.org/ticket/36455 .