### PR TITLE
Protect: update math_form() method input tag

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -130,13 +130,13 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				<span style="vertical-align:super;">
 					<?php echo "$num1 &nbsp; + &nbsp; $num2 &nbsp; = &nbsp;"; ?>
 				</span>
-				<input
-					type="text"
-					id="jetpack_protect_answer"
-					name="jetpack_protect_num"
-					value=""
-					size="2"
-					style="width:30px;height:25px;vertical-align:middle;font-size:13px;"
+				<input 
+					type="text" 
+					id="jetpack_protect_answer" 
+					name="jetpack_protect_num" 
+					value="" 
+					size="2" 
+					style="width:30px;height:25px;vertical-align:middle;font-size:13px;" 
 					class="input" />
 				<input type="hidden" name="jetpack_protect_answer" value="<?php echo $ans; ?>" />
 			</div>

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -130,14 +130,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				<span style="vertical-align:super;">
 					<?php echo "$num1 &nbsp; + &nbsp; $num2 &nbsp; = &nbsp;"; ?>
 				</span>
-				<input 
-					type="text" 
-					id="jetpack_protect_answer" 
-					name="jetpack_protect_num" 
-					value="" 
-					size="2" 
-					style="width:30px;height:25px;vertical-align:middle;font-size:13px;" 
-					class="input" />
+				<input type="text" id="jetpack_protect_answer" name="jetpack_protect_num" value="" size="2" style="width:30px;height:25px;vertical-align:middle;font-size:13px;" class="input" />
 				<input type="hidden" name="jetpack_protect_answer" value="<?php echo $ans; ?>" />
 			</div>
 		<?php


### PR DESCRIPTION
Adds a single space before each line break in the jetpack_protect_num input tag in order to allow a space to be maintained between the tag name and the attributes when output is buffered. This would maintain compatibility with front end login plugins that need to buffer the output and collect it in ob_get_contents() so it can be displayed in a widget or main content.

Fixes #

#### Changes proposed in this Pull Request:

* Add a single space before each line break in the jetpack_protect_num input tag, most importantly between "<input" and "type="

#### Testing instructions:

* The problem does not present itself when Protect is used somewhere like wp-login.php.  However, when used with a front end login plugin that needs to buffer output (such as WP-Members), line breaks are lost.  So testing with WP-Members would show the issue.

#### Proposed changelog entry:

* Added white space before line breaks in jetpack_protect_num input tag for buffered output.
