### PR TITLE
Proposal: Update npm/yarn and composer commands php:5.2-compatibility to just php:compatibility

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -19,7 +19,7 @@ const jsLintResult = spawnSync( 'eslint-eslines', [ ...jsFiles, '--', '--diff=in
 
 let phpLintResult;
 if ( phpFiles.length > 0 ) {
-	phpLintResult = spawnSync( 'composer', [ 'php:5.2-compatibility', ...phpFiles, ], {
+	phpLintResult = spawnSync( 'composer', [ 'php:compatibility', ...phpFiles, ], {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpcompatibility/phpcompatibility-wp": "^1.0"
     },
     "scripts": {
-      "php:5.2-compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
+      "php:compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
       "php:lint": "composer install && vendor/bin/phpcs -p"
     }
 }

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -172,18 +172,18 @@ _There's also a handy `yarn php:lint` that will run `composer php:lint` if you p
 $ yarn php:lint
 ```
 
-### Checking Jetpack's PHP for PHP 5.2 Compatibility
+### Checking Jetpack's PHP for compatibility with different versions of PHP since 5.2
 
 We have a handy `composer` script that will just run the PHP CodeSniffer `PHPCompatibilityWP` ruleset checking for code not compatible with PHP 5.2
 
 ```sh
-$ composer php:5.2-compatibility .
+$ composer php:compatibility .
 ```
 
-_There's also a handy `yarn php:5.2-compatibility` that will run `composer php:5.2-compatibility` if you prefer_.
+_There's also a handy `yarn php:compatibility` that will run `composer php:compatibility` if you prefer_.
 
 ```sh
-$ yarn php:5.2-compatibility .
+$ yarn php:compatibility .
 ```
 
 ### Linting Jetpack's JavaScript

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
     "docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
     "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc.js",
-    "php:5.2-compatibility": "composer php:5.2-compatibility",
+    "php:compatibility": "composer php:compatibility",
     "php:lint": "composer php:lint",
     "test-adminpage": "yarn test-client && yarn test-gui",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",


### PR DESCRIPTION
These scripts, defined in `package.json` and `composer.json` actually check for compatibility among a few versions of PHP and not just 5.2. 

#### Changes proposed in this Pull Request:

* Updates every reference reading `php:5.2-compatibility` to `php:compatibility`.

#### Testing instructions:

* Standing on the Jetpack source directory.
* Run `yarn php:compatibility .`  Confirm everytning runs ok although a few warnings are shown.
  * Run `composer php:compatibility` and expect the same results.
* Check the [rendered version of development-environment.md](https://github.com/Automattic/jetpack/blob/update/rename-php-5.2-compatibility/docs/development-environment.md#checking-jetpacks-php-for-compatibility-with-different-versions-of-php-since-52).

cc @jeherve @brbrr makes sense? 


#### Proposed changelog entry

Shouldn't make it into the changelog probably