### PR TITLE
Add param to allow customizing boosting of fields searched

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -825,29 +825,37 @@ class Jetpack_Search {
 		if ( empty( $args['query_fields'] ) ) {
 			if ( defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX ) {
 				// VIP indices do not have per language fields
-				$match_fields        = array(
-					'title^0.1',
-					'content^0.1',
-					'excerpt^0.1',
-					'tag.name^0.1',
-					'category.name^0.1',
-					'author_login^0.1',
-					'author^0.1',
+				$match_fields = $this->_get_caret_boosted_fields(
+					array(
+						'title'         => 0.1,
+						'content'       => 0.1,
+						'excerpt'       => 0.1,
+						'tag.name'      => 0.1,
+						'category.name' => 0.1,
+						'author_login'  => 0.1,
+						'author'        => 0.1,
+					)
 				);
-				$boost_fields        = array(
-					'title^' . $this->_calc_boost_value( 'title', 2, $args['excess_boost'] ),
-					'tag.name^' . $this->_calc_boost_value( 'tag.name', 1, $args['excess_boost'] ),
-					'category.name^' . $this->_calc_boost_value( 'category.name', 1, $args['excess_boost'] ),
-					'author_login^' . $this->_calc_boost_value( 'author_login', 1, $args['excess_boost'] ),
-					'author^' . $this->_calc_boost_value( 'author', 1, $args['excess_boost'] ),
+
+				$boost_fields = $this->_get_caret_boosted_fields(
+					$this->_apply_boosts_multiplier( array(
+						'title'         => 2,
+						'tag.name'      => 1,
+						'category.name' => 1,
+						'author_login'  => 1,
+						'author'        => 1,
+					), $args['excess_boost'] )
 				);
-				$boost_phrase_fields = array(
-					'title',
-					'content',
-					'excerpt',
-					'tag.name',
-					'category.name',
-					'author',
+
+				$boost_phrase_fields = $this->_get_caret_boosted_fields(
+					array(
+						'title'         => 1,
+						'content'       => 1,
+						'excerpt'       => 1,
+						'tag.name'      => 1,
+						'category.name' => 1,
+						'author'        => 1,
+					)
 				);
 			} else {
 				$match_fields = $parser->merge_ml_fields(
@@ -858,22 +866,22 @@ class Jetpack_Search {
 						'tag.name'      => 0.1,
 						'category.name' => 0.1,
 					),
-					array(
-						'author_login^0.1',
-						'author^0.1',
-					)
+					$this->_get_caret_boosted_fields( array(
+						'author_login'  => 0.1,
+						'author'        => 0.1,
+					) )
 				);
 
 				$boost_fields = $parser->merge_ml_fields(
-					array(
-						'title'         => $this->_calc_boost_value( 'title', 2, $args['excess_boost'] ),
-						'tag.name'      => $this->_calc_boost_value( 'tag.name', 1, $args['excess_boost'] ),
-						'category.name' => $this->_calc_boost_value( 'category.name', 1, $args['excess_boost'] ),
-					),
-					array(
-						'author_login^' . $this->_calc_boost_value( 'author_login', 1, $args['excess_boost'] ),
-						'author^' . $this->_calc_boost_value( 'author', 1, $args['excess_boost'] ),
-					)
+					$this->_apply_boosts_multiplier( array(
+						'title'         => 2,
+						'tag.name'      => 1,
+						'category.name' => 1,
+					), $args['excess_boost'] ),
+					$this->_get_caret_boosted_fields( $this->_apply_boosts_multiplier( array(
+						'author_login'  => 1,
+						'author'        => 1,
+					), $args['excess_boost'] ) )
 				);
 
 				$boost_phrase_fields = $parser->merge_ml_fields(
@@ -884,9 +892,9 @@ class Jetpack_Search {
 						'tag.name'      => 1,
 						'category.name' => 1,
 					),
-					array(
-						'author',
-					)
+					$this->_get_caret_boosted_fields( array(
+						'author'        => 1,
+					) )
 				);
 			}
 		} else {
@@ -1793,11 +1801,43 @@ class Jetpack_Search {
 		}
 	}
 
-	private function _calc_boost_value( $field, $boost, array $add_boost ) {
-		if ( isset( $add_boost[ $field ] ) && $add_boost[ $field ] > 0 ) {
-			$boost *= $add_boost[ $field ];
+	/**
+	 * Transforms an array with fields name as keys and boosts as value into
+	 * shorthand "caret" format.
+	 *
+	 * @param array $fields_boost [ "title" => "2", "content" => "1" ]
+	 *
+	 * @return array [ "title^2", "content^1" ]
+	 */
+	private function _get_caret_boosted_fields( array $fields_boost ) {
+		$caret_boosted_fields = array();
+		foreach ( $fields_boost as $field => $boost ) {
+			$caret_boosted_fields[] = "$field^$boost";
+		}
+		return $caret_boosted_fields;
+	}
+
+	/**
+	 * Apply a multiplier to boost values.
+	 *
+	 * @param array $fields_boost [ "title" => 2, "content" => 1 ]
+	 * @param array $fields_boost_multiplier [ "title" => 0.1234 ]
+	 *
+	 * @return array [ "title" => "0.247", "content" => "1.000" ]
+	 */
+	private function _apply_boosts_multiplier( array $fields_boost, array $fields_boost_multiplier ) {
+		foreach( $fields_boost as $field_name => $field_boost ) {
+			if ( isset( $fields_boost_multiplier[ $field_name ] ) ) {
+				$fields_boost[ $field_name ] *= $fields_boost_multiplier[ $field_name ];
+			}
+
+			// Set a floor and format the number as string
+			$fields_boost[ $field_name ] = number_format(
+				max( 0.001, $fields_boost[ $field_name ] ),
+				3, '.', ''
+			);
 		}
 
-		return number_format( $boost, 3, '.', '' );
+		return $fields_boost;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This adds a param which can for now only be modified via filters which provide more control over how much importance we place on each field that is searched. Currently the following field boost values can be adjusted via this new `excess_boost` param:

* `title`
* `tag.name`
* `category.name`
* `author_login`
* `author`

The following fields are searched however they can not be boosted when terms are found in them:

* `content`
* `excerpt`

The boosting given is in excess of preconfigured boost and are multiplied to it thus a positive number must be given.

Caution: We may at some point adjust the default baseline boosting to provide better results which may amplify any manual fine tuning done with this filter.

#### Testing instructions:

This filter can be tested by adding something like the following then checking if results with the given query in tags is ranked higher than before the change.

```
/**
 * Give tags more weight in searches
 *
 * @param array    $es_wp_query_args
 * @param WP_Query $query
 *
 * @return array   The modified $es_wp_query_args
 */
function myexample_weigh_tags( array $es_wp_query_args, WP_Query $query ) {
  if ( !is_array( $es_wp_query_args['excess_boost'] ) ) {
    $es_wp_query_args['excess_boost'] = array();
  }

  // Add boost for tags
  $es_wp_query_args['excess_boost']['tag.name'] = 2.5;

  return $es_wp_query_args;
}
add_filter( 'jetpack_search_es_wp_query_args', 'myexample_weigh_tags', 10, 2 ); 
```

#### Proposed changelog entry for your changes:

* Jetpack Search: Adds an advanced `excess_boost` param which can be adjusted with filters to fine tune query scoring.