### PR TITLE
Asset CDN / Photon: group the 2 features under a single module card in the admin.

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -51,7 +51,8 @@ export class Writing extends React.Component {
 			'infinite-scroll',
 			'minileven',
 			'videopress',
-			'lazy-images'
+			'lazy-images',
+			'photon-cdn'
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -82,8 +82,19 @@ const SpeedUpSite = moduleSettingsForm(
 				}
 			}
 
-			// Track the main toggle switch.
-			analytics.tracks.recordJetpackClick( 'jetpack_site_accelerator_toggle' );
+			// If at least one of the modules is now on, let's reflect that with the status of our main toggle.
+			if ( true === newPhotonStatus || true === newPhotonCdnStatus ) {
+				// Track the main toggle switch.
+				analytics.tracks.recordJetpackClick( {
+					target: 'jetpack_site_accelerator_toggle',
+					toggled: 'on'
+				} );
+			} else {
+				analytics.tracks.recordJetpackClick( {
+					target: 'jetpack_site_accelerator_toggle',
+					toggled: 'off'
+				} );
+			}
 
 			// Track any potential Photon toggle switch.
 			if ( this.props.getOptionValue( 'photon' ) !== newPhotonStatus ) {

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -41,7 +41,7 @@ const SpeedUpSite = moduleSettingsForm(
 			const photonCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
 
 			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
-			if ( false === ! CdnStatus ) {
+			if ( true === CdnStatus ) {
 				if ( false === ! this.props.getOptionValue( 'photon' ) && 'active' !== photonStatus ) {
 					this.props.updateOptions( {
 						photon: false,

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -184,7 +184,7 @@ const SpeedUpSite = moduleSettingsForm(
 						<SettingsGroup
 							hasChild
 							support={ {
-								link: 'https://jetpack.com/support/image-cdn/',
+								link: 'http://jetpack.com/support/site-accelerator/',
 							} }
 							>
 							<p>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -33,16 +33,37 @@ const SpeedUpSite = moduleSettingsForm(
 		};
 
 		handleCdnChange = () => {
-			const currentPhoton = this.props.getOptionValue( 'photon' );
-			const currentCdn = this.props.getOptionValue( 'photon-cdn' );
+			// Check if any of the CDN options are on.
+			const CdnStatus = this.props.getOptionValue( 'photon' ) || this.props.getOptionValue( 'photon-cdn' );
 
-			// Tiled Galleries depends on Photon. Deactivate it when Photon is deactivated.
-			this.props.updateOptions( {
-				photon: ! currentPhoton,
-				'tiled-gallery': ! currentPhoton,
-				tiled_galleries: ! currentPhoton,
-				'photon-cdn': ! currentCdn
-			} );
+			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
+			if ( false === ! CdnStatus ) {
+				if ( false === ! this.props.getOptionValue( 'photon' ) ) {
+					this.props.updateOptions( {
+						photon: false,
+						'tiled-gallery': false,
+						tiled_galleries: false
+					} );
+				}
+				if ( false === ! this.props.getOptionValue( 'photon-cdn' ) ) {
+					this.props.updateOptions( {
+						'photon-cdn': false
+					} );
+				}
+			} else {
+				if ( false === this.props.getOptionValue( 'photon' ) ) {
+					this.props.updateOptions( {
+						photon: true,
+						'tiled-gallery': true,
+						tiled_galleries: true
+					} );
+				}
+				if ( false === this.props.getOptionValue( 'photon-cdn' ) ) {
+					this.props.updateOptions( {
+						'photon-cdn': true
+					} );
+				}
+			}
 		};
 
 		render() {

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -53,16 +53,14 @@ const SpeedUpSite = moduleSettingsForm(
 							disableInDevMode
 							module={ photon }
 							support={ {
-								link: 'https://jetpack.com/support/photon/',
+								link: 'https://jetpack.com/support/image-cdn/',
 							} }
 							>
 							<p>
 								{ __(
 									"Jetpack's global Content Delivery Network (CDN) optimizes " +
 										'images so your visitors enjoy the fastest experience ' +
-										'regardless of device or location. It also helps you ' +
-										'save space on your hosting plan, since images are ' +
-										'stored on our servers.'
+										'regardless of device or location.'
 								) }
 							</p>
 							<ModuleToggle

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -135,6 +135,45 @@ const SpeedUpSite = moduleSettingsForm(
 			// Display the main toggle in main search results as long as one of the modules is not hidden.
 			const canAppearInSearch = ( foundPhoton || foundPhotonCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== photonCdnStatus );
 
+			// Monitor any changes that should cause our main toggle to appear toggling.
+			let togglingSiteAccelerator;
+			// First Photon activating.
+			if ( ! this.props.getOptionValue( 'photon' ) && this.props.isSavingAnyOption( 'photon' ) ) {
+				if ( this.props.getOptionValue( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			// Then Asset CDN activating.
+			} else if ( ! this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+				if ( this.props.getOptionValue( 'photon' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			// Then Photon deactivating.
+			} else if ( this.props.getOptionValue( 'photon' ) && this.props.isSavingAnyOption( 'photon' ) ) {
+				if ( this.props.getOptionValue( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+
+				// Is the Asset CDN being disabled as well?
+				if ( this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = true;
+				}
+			// Then Asset CDN deactivating.
+			} else if ( this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+				if ( this.props.getOptionValue( 'photon' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			} else {
+				togglingSiteAccelerator = false;
+			}
+
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -158,7 +197,7 @@ const SpeedUpSite = moduleSettingsForm(
 							{ canAppearInSearch &&
 								<CompactFormToggle
 									checked={ CdnStatus }
-									toggling={ this.props.isSavingAnyOption( [ 'photon', 'photon-cdn' ] ) && ! CdnStatus }
+									toggling={ togglingSiteAccelerator }
 									onChange={ this.handleCdnChange }
 									disabled={ ! canDisplayCdnSettings }
 								>

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -245,7 +245,7 @@ const SpeedUpSite = moduleSettingsForm(
 							>
 							<p>
 								{ __(
-									"Lazy-loading images improve your site's speed and create a " +
+									'Lazy-loading images will improve your site’s speed and create a ' +
 										'smoother viewing experience. Images will load as visitors ' +
 										'scroll down the screen, instead of all at once.'
 								) }

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -19,7 +19,7 @@ const SpeedUpSite = moduleSettingsForm(
 	class extends Component {
 		toggleModule = ( name, value ) => {
 			if ( 'photon' === name ) {
-				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
+				// Tiled Galleries depends on Photon. Deactivate it if Photon is deactivated.
 				if ( false === ! value ) {
 					this.props.updateOptions( { photon: false, 'tiled-gallery': false, tiled_galleries: false } );
 				} else {

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -33,20 +33,20 @@ const SpeedUpSite = moduleSettingsForm(
 			}
 		};
 
-		handleCdnChange = () => {
+		handleSiteAcceleratorChange = () => {
 			// Initial status for both modules.
 			let newPhotonStatus = this.props.getOptionValue( 'photon' );
-			let newPhotonCdnStatus = this.props.getOptionValue( 'photon-cdn' );
+			let newAssetCdnStatus = this.props.getOptionValue( 'photon-cdn' );
 
 			// Check if any of the CDN options are on.
-			const CdnStatus = newPhotonStatus || newPhotonCdnStatus;
+			const siteAcceleratorStatus = newPhotonStatus || newAssetCdnStatus;
 
 			// Are the modules available?
 			const photonStatus = this.props.getModuleOverride( 'photon' );
-			const photonCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
+			const assetCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
 
 			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
-			if ( true === CdnStatus ) {
+			if ( true === siteAcceleratorStatus ) {
 				if ( false === ! newPhotonStatus && 'active' !== photonStatus ) {
 					newPhotonStatus = false;
 
@@ -56,8 +56,8 @@ const SpeedUpSite = moduleSettingsForm(
 						tiled_galleries: false
 					} );
 				}
-				if ( false === ! newPhotonCdnStatus && 'active' !== photonCdnStatus ) {
-					newPhotonCdnStatus = false;
+				if ( false === ! newAssetCdnStatus && 'active' !== assetCdnStatus ) {
+					newAssetCdnStatus = false;
 
 					this.props.updateOptions( {
 						'photon-cdn': false
@@ -73,8 +73,8 @@ const SpeedUpSite = moduleSettingsForm(
 						tiled_galleries: true
 					} );
 				}
-				if ( false === newPhotonCdnStatus && 'inactive' !== photonCdnStatus ) {
-					newPhotonCdnStatus = true;
+				if ( false === newAssetCdnStatus && 'inactive' !== assetCdnStatus ) {
+					newAssetCdnStatus = true;
 
 					this.props.updateOptions( {
 						'photon-cdn': true
@@ -83,7 +83,7 @@ const SpeedUpSite = moduleSettingsForm(
 			}
 
 			// If at least one of the modules is now on, let's reflect that with the status of our main toggle.
-			if ( true === newPhotonStatus || true === newPhotonCdnStatus ) {
+			if ( true === newPhotonStatus || true === newAssetCdnStatus ) {
 				// Track the main toggle switch.
 				analytics.tracks.recordJetpackClick( {
 					target: 'jetpack_site_accelerator_toggle',
@@ -105,35 +105,35 @@ const SpeedUpSite = moduleSettingsForm(
 			}
 
 			// Track any potential Photon CDN toggle switch.
-			if ( this.props.getOptionValue( 'photon-cdn' ) !== newPhotonCdnStatus ) {
+			if ( this.props.getOptionValue( 'photon-cdn' ) !== newAssetCdnStatus ) {
 				analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
 					module: 'photon-cdn',
-					toggled: ( false === newPhotonCdnStatus ) ? 'off' : 'on'
+					toggled: ( false === newAssetCdnStatus ) ? 'off' : 'on'
 				} );
 			}
 		};
 
 		render() {
 			const foundPhoton = this.props.isModuleFound( 'photon' );
-			const foundPhotonCdn = this.props.isModuleFound( 'photon-cdn' );
+			const foundAssetCdn = this.props.isModuleFound( 'photon-cdn' );
 			const foundLazyImages = this.props.isModuleFound( 'lazy-images' );
 
-			if ( ! foundPhoton && ! foundLazyImages && ! foundPhotonCdn ) {
+			if ( ! foundPhoton && ! foundLazyImages && ! foundAssetCdn ) {
 				return null;
 			}
 
 			const lazyImages = this.props.module( 'lazy-images' );
 
 			// Check if any of the CDN options are on.
-			const CdnStatus = this.props.getOptionValue( 'photon' ) || this.props.getOptionValue( 'photon-cdn' );
+			const siteAcceleratorStatus = this.props.getOptionValue( 'photon' ) || this.props.getOptionValue( 'photon-cdn' );
 
 			// Is at least one of the 2 modules available (not hidden via a module override)?
 			const photonStatus = this.props.getModuleOverride( 'photon' );
-			const photonCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
-			const canDisplayCdnSettings = ( foundPhoton && foundPhotonCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== photonCdnStatus );
+			const assetCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
+			const canDisplaySiteAcceleratorSettings = ( foundPhoton && foundAssetCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== assetCdnStatus );
 
 			// Display the main toggle in main search results as long as one of the modules is not hidden.
-			const canAppearInSearch = ( foundPhoton || foundPhotonCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== photonCdnStatus );
+			const canAppearInSearch = ( foundPhoton || foundAssetCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== assetCdnStatus );
 
 			// Monitor any changes that should cause our main toggle to appear toggling.
 			let togglingSiteAccelerator;
@@ -180,7 +180,7 @@ const SpeedUpSite = moduleSettingsForm(
 					header={ __( 'Performance & speed' ) }
 					hideButton>
 
-					{ ( foundPhoton || foundPhotonCdn ) &&
+					{ ( foundPhoton || foundAssetCdn ) &&
 						<SettingsGroup
 							hasChild
 							support={ {
@@ -196,10 +196,10 @@ const SpeedUpSite = moduleSettingsForm(
 							</p>
 							{ canAppearInSearch &&
 								<CompactFormToggle
-									checked={ CdnStatus }
+									checked={ siteAcceleratorStatus }
 									toggling={ togglingSiteAccelerator }
-									onChange={ this.handleCdnChange }
-									disabled={ ! canDisplayCdnSettings }
+									onChange={ this.handleSiteAcceleratorChange }
+									disabled={ ! canDisplaySiteAcceleratorSettings }
 								>
 									<span className="jp-form-toggle-explanation">
 										{ __( 'Enable site accelerator' ) }
@@ -220,7 +220,7 @@ const SpeedUpSite = moduleSettingsForm(
 										</span>
 									</ModuleToggle>
 								}
-								{ foundPhotonCdn &&
+								{ foundAssetCdn &&
 									<ModuleToggle
 										slug="photon-cdn"
 										activated={ this.props.getOptionValue( 'photon-cdn' ) }

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -8,6 +8,8 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { FormFieldset } from 'components/forms';
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -30,16 +32,33 @@ const SpeedUpSite = moduleSettingsForm(
 			}
 		};
 
+		handleCdnChange = () => {
+			const currentPhoton = this.props.getOptionValue( 'photon' );
+			const currentCdn = this.props.getOptionValue( 'photon-cdn' );
+
+			// Tiled Galleries depends on Photon. Deactivate it when Photon is deactivated.
+			this.props.updateOptions( {
+				photon: ! currentPhoton,
+				'tiled-gallery': ! currentPhoton,
+				tiled_galleries: ! currentPhoton,
+				'photon-cdn': ! currentCdn
+			} );
+		};
+
 		render() {
 			const foundPhoton = this.props.isModuleFound( 'photon' );
+			const foundPhotonCdn = this.props.isModuleFound( 'photon-cdn' );
 			const foundLazyImages = this.props.isModuleFound( 'lazy-images' );
 
-			if ( ! foundPhoton && ! foundLazyImages ) {
+			if ( ! foundPhoton && ! foundLazyImages && ! foundPhotonCdn ) {
 				return null;
 			}
 
 			const photon = this.props.module( 'photon' );
 			const lazyImages = this.props.module( 'lazy-images' );
+
+			// Check if any of the CDN options are on.
+			const CdnStatus = this.props.getOptionValue( 'photon' ) || this.props.getOptionValue( 'photon-cdn' );
 
 			return (
 				<SettingsCard
@@ -47,10 +66,9 @@ const SpeedUpSite = moduleSettingsForm(
 					header={ __( 'Performance & speed' ) }
 					hideButton>
 
-					{ foundPhoton &&
+					{ foundPhoton && foundPhotonCdn &&
 						<SettingsGroup
 							hasChild
-							disableInDevMode
 							module={ photon }
 							support={ {
 								link: 'https://jetpack.com/support/image-cdn/',
@@ -59,21 +77,42 @@ const SpeedUpSite = moduleSettingsForm(
 							<p>
 								{ __(
 									"Jetpack's global Content Delivery Network (CDN) optimizes " +
-										'images so your visitors enjoy the fastest experience ' +
-										'regardless of device or location.'
+										'files and images so your visitors enjoy ' +
+										'the fastest experience regardless of device or location.'
 								) }
 							</p>
-							<ModuleToggle
-								slug="photon"
-								disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
-								activated={ this.props.getOptionValue( 'photon' ) }
-								toggling={ this.props.isSavingAnyOption( 'photon' ) }
-								toggleModule={ this.toggleModule }
+							<CompactFormToggle
+								checked={ CdnStatus }
+								toggling={ this.props.isSavingAnyOption( [ 'photon', 'photon-cdn' ] ) && ! CdnStatus }
+								onChange={ this.handleCdnChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Serve images from our global CDN' ) }
+									{ __( 'Enable Site Accelerator' ) }
 								</span>
-							</ModuleToggle>
+							</CompactFormToggle>
+							<FormFieldset>
+								<ModuleToggle
+									slug="photon"
+									disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+									activated={ this.props.getOptionValue( 'photon' ) }
+									toggling={ this.props.isSavingAnyOption( 'photon' ) }
+									toggleModule={ this.toggleModule }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Speed up images' ) }
+									</span>
+								</ModuleToggle>
+								<ModuleToggle
+									slug="photon-cdn"
+									activated={ this.props.getOptionValue( 'photon-cdn' ) }
+									toggling={ this.props.isSavingAnyOption( 'photon-cdn' ) }
+									toggleModule={ this.toggleModule }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Speed up all static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack' ) }
+									</span>
+								</ModuleToggle>
+							</FormFieldset>
 						</SettingsGroup>
 					}
 

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -89,6 +89,9 @@ const SpeedUpSite = moduleSettingsForm(
 			const photonCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
 			const canDisplayCdnSettings = ( foundPhoton && foundPhotonCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== photonCdnStatus );
 
+			// Display the main toggle in main search results as long as one of the modules is not hidden.
+			const canAppearInSearch = ( foundPhoton || foundPhotonCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== photonCdnStatus );
+
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -109,7 +112,7 @@ const SpeedUpSite = moduleSettingsForm(
 										'the fastest experience regardless of device or location.'
 								) }
 							</p>
-							{ foundPhoton && foundPhotonCdn &&
+							{ canAppearInSearch &&
 								<CompactFormToggle
 									checked={ CdnStatus }
 									toggling={ this.props.isSavingAnyOption( [ 'photon', 'photon-cdn' ] ) && ! CdnStatus }

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -189,9 +189,8 @@ const SpeedUpSite = moduleSettingsForm(
 							>
 							<p>
 								{ __(
-									"Jetpack's global Content Delivery Network (CDN) optimizes " +
-										'files and images so your visitors enjoy ' +
-										'the fastest experience regardless of device or location.'
+									'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
+										'and static files (like CSS and JavaScript) from our global network of servers.'
 								) }
 							</p>
 							{ canAppearInSearch &&
@@ -216,7 +215,7 @@ const SpeedUpSite = moduleSettingsForm(
 										toggleModule={ this.toggleModule }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Speed up images' ) }
+											{ __( 'Speed up image load times' ) }
 										</span>
 									</ModuleToggle>
 								}
@@ -228,7 +227,7 @@ const SpeedUpSite = moduleSettingsForm(
 										toggleModule={ this.toggleModule }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Speed up all static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack' ) }
+											{ __( 'Speed up static file load times' ) }
 										</span>
 									</ModuleToggle>
 								}

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -117,7 +117,7 @@ const SpeedUpSite = moduleSettingsForm(
 									disabled={ ! canDisplayCdnSettings }
 								>
 									<span className="jp-form-toggle-explanation">
-										{ __( 'Enable Site Accelerator' ) }
+										{ __( 'Enable site accelerator' ) }
 									</span>
 								</CompactFormToggle>
 							}

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -238,4 +238,14 @@ class Jetpack_Photon_Static_Assets_CDN {
 		return false;
 	}
 }
-Jetpack_Photon_Static_Assets_CDN::go();
+/**
+ * Allow plugins to short-circuit the Asset CDN, even when the module is on.
+ *
+ * @since 6.7.0
+ *
+ * @param false bool Should the Asset CDN be blocked? False by default.
+ * @var [type]
+ */
+if ( true !== apply_filters( 'jetpack_force_disable_site_accelerator', false ) ) {
+	Jetpack_Photon_Static_Assets_CDN::go();
+}

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -42,6 +42,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 * Filters Jetpack CDN's Core version number and locale. Can be used to override the values
 		 * that Jetpack uses to retrieve assets. Expects the values to be returned in an array.
 		 *
+		 * @module photon-cdn
+		 *
 		 * @since 6.6
 		 *
 		 * @param array $values array( $version  = core assets version, i.e. 4.9.8, $locale = desired locale )
@@ -96,6 +98,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 * that Jetpack uses to retrieve assets. For example, when testing a development version of Jetpack
 		 * the assets are not yet published, so you may need to override the version value to either
 		 * trunk, or the latest available version. Expects the values to be returned in an array.
+		 *
+		 * @module photon-cdn
 		 *
 		 * @since 6.6
 		 *
@@ -158,6 +162,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 * Used for other plugins to provide their bundled assets via filter to
 		 * prevent the need of storing them in an option or an external api request
 		 * to w.org.
+		 *
+		 * @module photon-cdn
 		 *
 		 * @since 6.6
 		 *
@@ -241,10 +247,11 @@ class Jetpack_Photon_Static_Assets_CDN {
 /**
  * Allow plugins to short-circuit the Asset CDN, even when the module is on.
  *
+ * @module photon-cdn
+ *
  * @since 6.7.0
  *
  * @param false bool Should the Asset CDN be blocked? False by default.
- * @var [type]
  */
 if ( true !== apply_filters( 'jetpack_force_disable_site_accelerator', false ) ) {
 	Jetpack_Photon_Static_Assets_CDN::go();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Update the support link to use the new name we've given to the Photon feature.
- Remove mention of "saving space" since Photon does not do that. => Fixes #10300
- Fix a comment: Tiled Galleries depend on Photon, not Carousel.
- **Create a new admin UI card with both the Photon and Asset CDN options, grouped under a single toggle.**

@see p9jf6J-11u-p2 for more information about this. The copy is not final, as per the discussion there.

**Before**

<img width="791" alt="screenshot 2018-10-12 at 15 46 16" src="https://user-images.githubusercontent.com/426388/46873029-f98a9e80-ce35-11e8-900f-2df8aa04e963.png">

**After**

<img width="776" alt="screenshot 2018-10-22 at 11 42 52" src="https://user-images.githubusercontent.com/426388/47286596-a4961780-d5ef-11e8-82fa-8e8ec5a78595.png">


#### Testing instructions:

0. Add `add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );` to a functionality plugin on your site to avoid getting old JS files when viewing the admin panel with the Asset CDN module on.
1. Go to Jetpack > Settings > Writing.
2. You should see the new section, reflecting the current status of your site.
3. Toggling the main option should allow you to turn everything on at once.
4. You can still toggle the 2 options separately.
5. If your site is in development mode, you cannot toggle the Photon option.

One annoyance you'll face during testing is that when turning on the Asset CDN option, and then refreshing the page, the admin interface will be broken. That is because the Asset CDN feature cannot serve files from a development version at the moment. To turn the option back off, you will need to go to this page:

`{yoursite.com}/wp-admin/admin.php?page=jetpack_modules&s=asset`

#### Proposed changelog entry for your changes:
* Asset CDN: add option to toggle the new feature from the Jetpack Dashboard.