### PR TITLE
Docs: JPS: Remove mention of wpcom_user_email

### DIFF
--- a/docs/partners/plan-provisioning-direct-api.md
+++ b/docs/partners/plan-provisioning-direct-api.md
@@ -107,7 +107,6 @@ Plans can be provisioned by making a request using your partner token from the s
 - __force_connect__:  (optional) A true/false value indicating whether to re-connect a user even if we already have tokens for them. Useful for sites that have gotten into a bad state.
 - __onboarding__:     (optional) If true, put the user through our onboarding wizard for new sites.
 - __wpcom_user_id__:  (optional) For certain keys, enables auto-connecting a WordPress.com user to the site non-interactively.
-- __wpcom_user_email__: (optional) For certain keys, enables auto-connecting a WordPress.com user to the site non-interactively, and if necessary creating a WordPress.com account.
 
 ### Response Parameters (/provision)
 


### PR DESCRIPTION
This functionality was only intended to be used by VIP Go and internal "partners". After being initially added, we have now removed the functionality. I removed final traces of `wpcom_user_email` in D19364 so now no mention of `wpcom_user_email` is found in the API.

This functionality is planned to become more widely available to hosting partners in the near future with automated account creation and connection, which won't use this `wpcom_user_email` parameter either. 

#### Changes proposed in this Pull Request:

* Remove mention of `wpcom_user_email` in Jetpack partners documentation.

#### Testing instructions:

* Check that all mention of `wpcom_user_email` removed from `docs/partners` directory.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Removes mention of `wpcom_user_email` from partner documentation.