### PR TITLE
Gutenberg: Map Block Dependencies

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7376,8 +7376,10 @@ p {
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
+		$view_script_dependencies = array( 'wp-blocks', 'jquery' );
+
 		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );
+		wp_register_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version );
 		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
 
 		register_block_type( 'jetpack/blocks', array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7382,7 +7382,7 @@ p {
 		);
 
 		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-		wp_register_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version );
+		wp_register_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version, true );
 		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
 		register_block_type( 'jetpack/blocks', array(
 				'script'        => 'jetpack-blocks-view',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7376,12 +7376,14 @@ p {
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
-		$view_script_dependencies = array( 'wp-blocks', 'jquery' );
+		$view_script_dependencies = array(
+			'wp-i18n',
+			'wp-element'
+		);
 
 		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 		wp_register_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version );
 		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
-
 		register_block_type( 'jetpack/blocks', array(
 				'script'        => 'jetpack-blocks-view',
 				'style'         => 'jetpack-blocks-view',


### PR DESCRIPTION
This PR simply adds the two dependencies required by the Map Block, `wp-i18n` and `wp-element`. I'm creating the PR at this stage only to enable Jurassic Ninja testing.

#### Testing instructions:

See https://github.com/Automattic/wp-calypso/pull/27836.