### PR TITLE
require_lib: remove extra line to bring files in sync

### DIFF
--- a/require-lib.php
+++ b/require-lib.php
@@ -1,5 +1,4 @@
 <?php
-
 function jetpack_require_lib( $slug ) {
 	if ( !preg_match( '|^[a-z0-9/_.-]+$|i', $slug ) ) {
 		trigger_error( "Cannot load a library with invalid slug $slug.", E_USER_ERROR );


### PR DESCRIPTION
Removes an extra line of whitespace to help the wp.com sync tools parse things accurately.