### PR TITLE
Verbiage enhancements for WordPress.com login settings

### DIFF
--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -72,6 +72,13 @@ export const SSO = moduleSettingsForm(
 							link: 'https://jetpack.com/support/sso/',
 						} }
 						>
+						<p>
+							{ __(
+							'Add an extra layer of security to your website by enabling WordPress.com log in and secure ' +
+							'authentication. If you have multiple sites with this option enabled, you will be able to log into every ' +
+							'one of them with the same credentials.'
+							) }
+						</p>
 						<ModuleToggle
 							slug="sso"
 							disabled={ unavailableInDevMode }


### PR DESCRIPTION
Fixes #9760 . First Jetpack PR, let me know if needs some tweaking.

#### Changes proposed in this Pull Request:

* Added clarification text about what WordPress.com login authentication does:

<img width="1280" alt="screen shot 2018-10-14 at 17 32 54" src="https://user-images.githubusercontent.com/3812076/46915629-16f76e00-cfd8-11e8-9f61-139236239cbc.png">

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Enhancement: Improved WordPress.com login authentication settings verbiage
