### PR TITLE
Google Apps shortcode: allow presentations to appear fullscreen.

### DIFF
--- a/modules/shortcodes/googleapps.php
+++ b/modules/shortcodes/googleapps.php
@@ -175,7 +175,7 @@ function googleapps_shortcode( $atts ) {
 	do_action( 'jetpack_bump_stats_extras', 'embeds', googleapps_service_name( $attr['domain'], $attr['dir'] ) );
 
 	return sprintf(
-		'<iframe src="%s" frameborder="0" width="%s" height="%s" marginheight="0" marginwidth="0"></iframe>',
+		'<iframe src="%s" frameborder="0" width="%s" height="%s" marginheight="0" marginwidth="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>',
 		esc_url( 'https://' . $attr['domain'] . '.google.com/' . $attr['query'] ),
 		esc_attr( $attr['width'] ),
 		esc_attr( $attr['height'] )

--- a/tests/php/modules/shortcodes/test_class.googleapps.php
+++ b/tests/php/modules/shortcodes/test_class.googleapps.php
@@ -145,7 +145,7 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 	function test_spreadsheet_widget_variation_4() {
 		$embed     = '<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQOnHvMNvmHbXUCDAyzUedmA8UWctJqSkUwS8cC7KHF1XASTzRdVYu09tYvDl5xAPwCsaNRNODADmzm/pubhtml?widget=true&amp;headers=false"></iframe>';
 		$shortcode = googleapps_embed_to_shortcode( $embed );
-		
+
 		$expected_shortcode = '[googleapps domain="docs" dir="spreadsheets/d/e/2PACX-1vQOnHvMNvmHbXUCDAyzUedmA8UWctJqSkUwS8cC7KHF1XASTzRdVYu09tYvDl5xAPwCsaNRNODADmzm/pubhtml" query="widget=true&amp;headers=false" /]';
 
 		$this->assertEquals( $expected_shortcode, $shortcode );
@@ -203,6 +203,17 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 		$expected_shortcode = '[googleapps domain="drive" dir="file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" query="" width="640" height="480" /]';
 
 		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_embed_can_fullscreen() {
+		$embed           = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true"></iframe>';
+		$expected_output = 'allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"';
+
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+		add_shortcode( 'googleapps', 'googleapps_shortcode' );
+		$to_embed = do_shortcode( $shortcode );
+
+		$this->assertContains( $expected_output, $to_embed );
 	}
 
 }


### PR DESCRIPTION
Fixes #10321

#### Changes proposed in this Pull Request:

Some Google Embeds include a "full screen" button that can only work if the iFrame is allowed full screen.
This PR adds the necessary attributes the iFrame that is output when using the Google Apps shortcode.

#### Testing instructions:

1. Add the following shortcode to one of your posts:
`[googleapps domain="docs" dir="presentation/d/e/2PACX-1vRMI59SXqqVAuFl0onFKUeMyYymBm1fNdWAgO52fHV3omO8M6UAwCHC8iDHitjSLe3ppnYurePjGhSv/embed" query="start=false&loop=false&delayms=3000" width="960" height="569" /]`
2. The slideshow will be embedded, and the option to open the slideshow in fullscreen should work.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Google Apps shortcode: allow presentations to appear full screen.