### PR TITLE
Gutenberg: Enqueue editor assets on Gutenberg action

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * General Gutenberg editor specific functionality
+ */
+class Jetpack_Gutenberg {
+	/**
+	 * Check if Gutenberg editor is available
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return bool
+	 */
+	public static function is_gutenberg_available() {
+		return function_exists( 'register_block_type' );
+	}
+
+	/**
+	 * Load Gutenberg assets
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return void
+	 */
+	public static function enqueue_block_assets() {
+		if ( ! self::should_load_blocks() ) {
+			return;
+		}
+
+		$rtl = is_rtl() ? '.rtl' : '';
+
+		/**
+		 * Filter to enable serving blocks via CDN
+		 *
+		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
+		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param bool false Whether to load Gutenberg blocks from CDN
+		 */
+		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
+			$cdn_base    = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
+			$view_script = "$cdn_base/view.js";
+			$view_style  = "$cdn_base/view$rtl.css";
+
+			/**
+			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param string
+			 */
+			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
+		} else {
+			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
+			$view_style  = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
+			$version     = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
+				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
+				: JETPACK__VERSION;
+		}
+
+		wp_enqueue_script( 'jetpack-blocks-view', $view_script, array(), $version );
+		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
+		wp_add_inline_script(
+			'wp-i18n',
+			'wp.i18n.setLocaleData( ' . Jetpack::get_i18n_data_json() . ', \'jetpack\' );'
+		);
+	}
+
+	/**
+	 * Load Gutenberg editor assets
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return void
+	 */
+	public static function enqueue_block_editor_assets() {
+		if ( ! self::should_load_blocks() ) {
+			return;
+		}
+
+		$rtl = is_rtl() ? '.rtl' : '';
+
+		/**
+		 * Filter to enable serving blocks via CDN
+		 *
+		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
+		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param bool false Whether to load Gutenberg blocks from CDN
+		 */
+		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
+			$cdn_base      = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
+			$editor_script = "$cdn_base/editor.js";
+			$editor_style  = "$cdn_base/editor$rtl.css";
+
+			/**
+			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
+			 *
+			 * @since 6.7.0
+			 *
+			 * @param string
+			 */
+			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
+		} else {
+			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
+			$editor_style  = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
+			$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+				: JETPACK__VERSION;
+		}
+
+		wp_enqueue_script(
+			'jetpack-blocks-editor',
+			$editor_script,
+			array(
+				'lodash',
+				'wp-api-fetch',
+				'wp-blocks',
+				'wp-components',
+				'wp-compose',
+				'wp-data',
+				'wp-date',
+				'wp-editor',
+				'wp-element',
+				'wp-hooks',
+				'wp-i18n',
+				'wp-keycodes',
+				'wp-plugins',
+				'wp-token-list',
+				'wp-url',
+			),
+			$version
+		);
+
+		wp_localize_script(
+			'jetpack-blocks-editor',
+			'Jetpack_Block_Assets_Base_Url',
+			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
+		);
+
+		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+	}
+
+	/**
+	 * Check whether conditions indicate Gutenberg blocks should be loaded
+	 *
+	 * Loading blocks is enabled by default and may be disabled via filter:
+	 *   add_filter( 'jetpack_gutenberg', '__return_false' );
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return bool
+	 */
+	public static function should_load_blocks() {
+		if ( ! Jetpack::is_active() ) {
+			return false;
+		}
+
+		/**
+		 * Filter to disable Gutenberg blocks
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param bool true Whether to load Gutenberg blocks
+		 */
+		return (bool) apply_filters( 'jetpack_gutenberg', true );
+	}
+}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -78,28 +78,13 @@ class Jetpack_Gutenberg {
 
 		$rtl = is_rtl() ? '.rtl' : '';
 
-		/**
-		 * Filter to enable serving blocks via CDN
-		 *
-		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool false Whether to load Gutenberg blocks from CDN
-		 */
+		/** This filter is already documented above */
 		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
 			$cdn_base      = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
 			$editor_script = "$cdn_base/editor.js";
 			$editor_style  = "$cdn_base/editor$rtl.css";
 
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.7.0
-			 *
-			 * @param string
-			 */
+			/** This filter is already documented above */
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
 			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -62,10 +62,6 @@ class Jetpack_Gutenberg {
 
 		wp_enqueue_script( 'jetpack-blocks-view', $view_script, array(), $version );
 		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
-		wp_add_inline_script(
-			'wp-i18n',
-			'wp.i18n.setLocaleData( ' . Jetpack::get_i18n_data_json() . ', \'jetpack\' );'
-		);
 	}
 
 	/**
@@ -140,6 +136,11 @@ class Jetpack_Gutenberg {
 			'jetpack-blocks-editor',
 			'Jetpack_Block_Assets_Base_Url',
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
+		);
+
+		wp_add_inline_script(
+			'wp-i18n',
+			'wp.i18n.setLocaleData( ' . Jetpack::get_i18n_data_json() . ', \'jetpack\' );'
 		);
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -533,7 +533,7 @@ class Jetpack {
 		}
 
 		// Load Gutenberg editor blocks
-		add_action( 'init', array( $this, 'load_jetpack_gutenberg' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'load_jetpack_gutenberg' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 
@@ -7304,7 +7304,7 @@ p {
 		 *
 		 * @param bool true Whether to load Gutenberg blocks
 		 */
-		if ( ! Jetpack::is_gutenberg_available() || ! apply_filters( 'jetpack_gutenberg', true ) ) {
+		if ( ! apply_filters( 'jetpack_gutenberg', true ) ) {
 			return;
 		}
 
@@ -7342,7 +7342,7 @@ p {
 				: JETPACK__VERSION;
 		}
 
-		wp_register_script(
+		wp_enqueue_script(
 			'jetpack-blocks-editor',
 			$editor_script,
 			array(
@@ -7371,16 +7371,9 @@ p {
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
-		wp_register_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-		wp_register_script( 'jetpack-blocks-view', $view_script, array(), $version );
-		wp_register_style( 'jetpack-blocks-view', $view_style, array(), $version );
-
-		register_block_type( 'jetpack/blocks', array(
-				'script'        => 'jetpack-blocks-view',
-				'style'         => 'jetpack-blocks-view',
-				'editor_script' => 'jetpack-blocks-editor',
-				'editor_style'  => 'jetpack-blocks-editor',
-		) );
+		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+		wp_enqueue_script( 'jetpack-blocks-view', $view_script, array(), $version );
+		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -532,9 +532,12 @@ class Jetpack {
 			Jetpack_Network::init();
 		}
 
-		// Load Gutenberg assets
-		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_assets' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+		/**
+		 * Prepare Gutenberg Editor functionality
+		 */
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
+		add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_assets' ) );
+		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 
@@ -7249,172 +7252,6 @@ p {
 		if ( $send_state_messages ) {
 			Jetpack::state( 'message', 'authorized' );
 		}
-	}
-
-	/**
-	 * Check if Gutenberg editor is available
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return bool
-	 */
-	public static function is_gutenberg_available() {
-		return function_exists( 'register_block_type' );
-	}
-
-	/**
-	 * Check whether conditions indicate Gutenberg blocks should be loaded
-	 *
-	 * Loading blocks is enabled by default and may be disabled via filter:
-	 *   add_filter( 'jetpack_gutenberg', '__return_false' );
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return bool
-	 */
-	public static function should_load_blocks() {
-		if ( ! Jetpack::is_active() ) {
-			return false;
-		}
-
-		/**
-		 * Filter to disable Gutenberg blocks
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool true Whether to load Gutenberg blocks
-		 */
-		return (bool) apply_filters( 'jetpack_gutenberg', true );
-	}
-
-	/**
-	 * Load Gutenberg assets
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return void
-	 */
-	public static function enqueue_block_assets() {
-		if ( ! self::should_load_blocks() ) {
-			return;
-		}
-
-		$rtl = is_rtl() ? '.rtl' : '';
-
-		/**
-		 * Filter to enable serving blocks via CDN
-		 *
-		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool false Whether to load Gutenberg blocks from CDN
-		 */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$view_script = "$cdn_base/view.js";
-			$view_style = "$cdn_base/view$rtl.css";
-
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string
-			 */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
-			$view_style = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
-				: JETPACK__VERSION;
-		}
-
-		wp_enqueue_script( 'jetpack-blocks-view', $view_script, array(), $version );
-		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
-		wp_add_inline_script(
-			'wp-i18n',
-			'wp.i18n.setLocaleData( ' . self::get_i18n_data_json() . ', \'jetpack\' );'
-		);
-	}
-
-	/**
-	 * Load Gutenberg editor assets
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return void
-	 */
-	public static function enqueue_block_editor_assets() {
-		if ( ! self::should_load_blocks() ) {
-			return;
-		}
-
-		$rtl = is_rtl() ? '.rtl' : '';
-
-		/**
-		 * Filter to enable serving blocks via CDN
-		 *
-		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool false Whether to load Gutenberg blocks from CDN
-		 */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$editor_script = "$cdn_base/editor.js";
-			$editor_style = "$cdn_base/editor$rtl.css";
-
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string
-			 */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
-			$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				: JETPACK__VERSION;
-		}
-
-		wp_enqueue_script(
-			'jetpack-blocks-editor',
-			$editor_script,
-			array(
-				'lodash',
-				'wp-api-fetch',
-				'wp-blocks',
-				'wp-components',
-				'wp-compose',
-				'wp-data',
-				'wp-date',
-				'wp-editor',
-				'wp-element',
-				'wp-hooks',
-				'wp-i18n',
-				'wp-keycodes',
-				'wp-plugins',
-				'wp-token-list',
-				'wp-url',
-			),
-			$version
-		);
-
-		wp_localize_script(
-			'jetpack-blocks-editor',
-			'Jetpack_Block_Assets_Base_Url',
-			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
-		);
-
-		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -294,7 +294,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			'editpost' === $_POST['action'] &&
 			'1' === $_GET['classic-editor'] &&
 			'1' === $_GET['meta_box'] &&
-			Jetpack::is_gutenberg_available()
+			Jetpack_Gutenberg::is_gutenberg_available()
 		);
 	}
 


### PR DESCRIPTION
Currently, we're enqueuing all Gutenberg assets on `init`, which is suboptimal (#10325).

Gutenberg offers [`enqueue_block_assets`](https://github.com/WordPress/gutenberg/blob/de2fab7b8d66eea6c1aeb4a51308d47225fc5df8/lib/client-assets.php#L1059-L1077) [`enqueue_block_editor_assets`](https://github.com/WordPress/gutenberg/blob/de2fab7b8d66eea6c1aeb4a51308d47225fc5df8/lib/client-assets.php#L1608-L1618
). This PR takes advantage of those actions rather than `init`.

Spotted in #10327 
Partial fix for #10325

#### Changes proposed in this Pull Request:

* Split view/editor script and style enqueue to appropriate Gutenberg-specific actions.
* Move growing Gutenberg-specific code out of `Jetpack` class and into its own new `Jetpack_Gutenberg` class.
* Move the `wp-i18n` Jetpack locale setup to editor assets where it's used.

#### Testing instructions:

* Does the Gutenberg editor still work correctly? gutenpack-jn
* Are Gutenberg editor scripts still correctly localized? Check for the `Jetpack_Block_Assets_Base_Url` global in the editor.
* make sure that the [sync handling](https://github.com/Automattic/jetpack/pull/10328/files#diff-b42b8628b3d5d856de376e02baace310R297) that used the moved `Jetpack::is_gutenberg_available()` -> `Jetpack_Gutenberg::is_gutenberg_available()` method continues to work correctly

#### Proposed changelog entry for your changes:

* Use `enqueue_block_assets` and `enqueue_block_editor_assets` for Gutenberg assets.
* Introduce `Jetpack_Gutenberg` class with related methods.

#### Follow up:
- Provide a mechanism to correctly set up `wp-i18n` with the Jetpack locale _exactly once_ when required (#10319).
-  D19535-code