### PR TITLE
Comment Likes: remove Gravatar and s* prefetches

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -11,15 +11,11 @@
  * Additional Search Queries: like widget, like button, like, likes
  */
 
-Jetpack::dns_prefetch( array(
-	'//widgets.wp.com',
-	'//s0.wp.com',
-	'//s1.wp.com',
-	'//s2.wp.com',
-	'//0.gravatar.com',
-	'//1.gravatar.com',
-	'//2.gravatar.com',
-) );
+Jetpack::dns_prefetch(
+	array(
+		'//widgets.wp.com',
+	)
+);
 
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-master-iframe.php';
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-settings.php';


### PR DESCRIPTION
@see #8090

#### Changes proposed in this Pull Request:

The Comment Likes feature was built based on WordPress.com' comment likes, where likers' Gravatars can be seen when hovering over the comment likes. 

We do not have that feature in Jetpack's Comment Likes though, so we do not need to prefetch all those extra domains. All Comment Likes use is the widgets.wp.com domain.

#### Testing instructions:

1. Enable Comment Likes on your site.
2. Load a post with comments.
3. Check the sources loaded on the page with your browser's dev console; you should notice that neither Gravatar `{0/1/2}.gravatar.com` subdomains are loaded by comment likes, nor `s{0/1/2}.wp.com`.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Comment Likes: only prefetch domains used by the feature.