### PR TITLE
Prevent Save and Cancel buttons from wraping

### DIFF
--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -72,6 +72,7 @@
 
 .jp-form-site-verification-buttons {
 	flex: 0 1 20em;
+	display: inline-flex;
 }
 
 .jp-form-site-verification-verified-note {


### PR DESCRIPTION
This patch fixes a styling issue in the site verification module which appears when the Save an Cancel buttons are translated in a language that uses longer words:

**Before:**
![image](https://user-images.githubusercontent.com/230230/47074334-7f259a00-d1fa-11e8-81af-3312a1f5b09d.png)

**After:**
![image](https://user-images.githubusercontent.com/230230/47074620-0a9f2b00-d1fb-11e8-972c-db0e48873128.png)


In this case the buttons wraps and are not properly aligned. Forcing the container div to use an inline display should fix the issue

#### Testing instructions:

- Switch your language to french and go to the Traffic settings.
- Ensure the display issue is fixed

#### Proposed changelog entry for your changes:
- Fix a button display issue in the google site verification tools