### PR TITLE
Simple Payments: Internationalization and CS fixes.

### DIFF
--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -18,13 +18,13 @@
 		value="<?php echo esc_attr( $instance['title'] ); ?>" />
 </p>
 <p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
-	<label for="<?php echo intval( $this->get_field_id( 'product_post_id' ) ); ?>">
+	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">
 		<?php esc_html_e( 'Select a Simple Payments Button:', 'jetpack' ); ?>
 	</label>
 	<select
 		class="widefat jetpack-simple-payments-products"
-		id="<?php echo intval( $this->get_field_id( 'product_post_id' ) ); ?>"
-		name="<?php echo intval( $this->get_field_name( 'product_post_id' ) ); ?>">
+		id="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'product_post_id' ) ); ?>">
 		<?php foreach ( $product_posts as $product_post ) { ?>
 			<option value="<?php echo esc_attr( $product_post->ID ); ?>" <?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
 				<?php echo esc_attr( get_the_title( $product_post ) ); ?>
@@ -57,8 +57,8 @@
 		class="jetpack-simple-payments-form-action" />
 	<input
 		type="hidden"
-		id="<?php echo absint( $this->get_field_id( 'form_product_id' ) ); ?>"
-		name="<?php echo absint( $this->get_field_name( 'form_product_id' ) ); ?>"
+		id="<?php echo esc_attr( $this->get_field_id( 'form_product_id' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'form_product_id' ) ); ?>"
 		value="<?php echo esc_attr( $instance['form_product_id'] ); ?>"
 		class="jetpack-simple-payments-form-product-id" />
 	<input

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -98,7 +98,7 @@
 			class="field-description widefat jetpack-simple-payments-form-product-description"
 			rows=5
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_description' ) ); ?>"
-			name="<?php echo esc_attr( $this->get_field_name( 'form_product_description' ) ); ?>"><?php  esc_html_e( $instance['form_product_description'] ); ?></textarea>
+			name="<?php echo esc_attr( $this->get_field_name( 'form_product_description' ) ); ?>"><?php echo esc_textarea( $instance['form_product_description'] ); ?></textarea>
 	</p>
 	<p class="cost">
 		<label for="<?php echo esc_attr( $this->get_field_id( 'form_product_price' ) ); ?>">

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Display the Simple Payments Form.
+ *
+ * @package Jetpack
+ */
+
+?>
 <p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
 		<?php esc_html_e( 'Widget Title', 'jetpack' ); ?>
@@ -10,23 +18,23 @@
 		value="<?php echo esc_attr( $instance['title'] ); ?>" />
 </p>
 <p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
-	<label for="<?php echo $this->get_field_id('product_post_id'); ?>">
+	<label for="<?php echo intval( $this->get_field_id( 'product_post_id' ) ); ?>">
 		<?php esc_html_e( 'Select a Simple Payments Button:', 'jetpack' ); ?>
 	</label>
 	<select
 		class="widefat jetpack-simple-payments-products"
-		id="<?php echo $this->get_field_id('product_post_id'); ?>"
-		name="<?php echo $this->get_field_name('product_post_id'); ?>">
+		id="<?php echo intval( $this->get_field_id( 'product_post_id' ) ); ?>"
+		name="<?php echo intval( $this->get_field_name( 'product_post_id' ) ); ?>">
 		<?php foreach ( $product_posts as $product_post ) { ?>
-			<option value="<?php echo esc_attr( $product_post->ID ) ?>" <?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
-				<?php echo esc_attr( get_the_title( $product_post ) ) ?>
+			<option value="<?php echo esc_attr( $product_post->ID ); ?>" <?php selected( (int) $instance['product_post_id'], $product_post->ID ); ?>>
+				<?php echo esc_attr( get_the_title( $product_post ) ); ?>
 			</option>
 		<?php } ?>
 	</select>
 </p>
 <?php if ( is_customize_preview() ) { ?>
 <p class="jetpack-simple-payments-products-warning" <?php if ( ! empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
-	<?php esc_html_e( "Looks like you don't have any products. You can create one using the Add New button below.", 'jetpack' ) ?>
+	<?php esc_html_e( "Looks like you don't have any products. You can create one using the Add New button below.", 'jetpack' ); ?>
 </p>
 <p>
 	<div class="alignleft">
@@ -43,14 +51,14 @@
 <div class="jetpack-simple-payments-form" style="display: none;">
 	<input
 		type="hidden"
-		id="<?php echo $this->get_field_id('form_action'); ?>"
-		name="<?php echo $this->get_field_name('form_action'); ?>"
+		id="<?php echo esc_attr( $this->get_field_id( 'form_action' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'form_action' ) ); ?>"
 		value="<?php echo esc_attr( $instance['form_action'] ); ?>"
 		class="jetpack-simple-payments-form-action" />
 	<input
 		type="hidden"
-		id="<?php echo $this->get_field_id('form_product_id'); ?>"
-		name="<?php echo $this->get_field_name('form_product_id'); ?>"
+		id="<?php echo absint( $this->get_field_id( 'form_product_id' ) ); ?>"
+		name="<?php echo absint( $this->get_field_name( 'form_product_id' ) ); ?>"
 		value="<?php echo esc_attr( $instance['form_product_id'] ); ?>"
 		class="jetpack-simple-payments-form-product-id" />
 	<input
@@ -108,8 +116,8 @@
 			class="field-currency widefat jetpack-simple-payments-form-product-currency"
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_currency' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_currency' ) ); ?>">
-			<?php foreach( Jetpack_Simple_Payments_Widget::$supported_currency_list as $code => $currency ) {?>
-				<option value="<?php echo esc_attr( $code ) ?>"<?php selected( $instance['form_product_currency'], $code ); ?>>
+			<?php foreach ( Jetpack_Simple_Payments_Widget::$supported_currency_list as $code => $currency ) { ?>
+				<option value="<?php echo esc_attr( $code ); ?>"<?php selected( $instance['form_product_currency'], $code ); ?>>
 					<?php echo esc_html( "$code $currency" ); ?>
 				</option>
 			<?php } ?>
@@ -143,7 +151,7 @@
 			id="<?php echo esc_attr( $this->get_field_id( 'form_product_email' ) ); ?>"
 			name="<?php echo esc_attr( $this->get_field_name( 'form_product_email' ) ); ?>"
 			type="email"
-			value="<?php  echo esc_attr( $instance['form_product_email'] ); ?>" />
+			value="<?php echo esc_attr( $instance['form_product_email'] ); ?>" />
 		<small>
 			<?php
 			printf(
@@ -170,7 +178,7 @@
 			</button>
 		</div>
 		<div class="alignright">
-			<button name="<?php echo $this->get_field_name('save'); ?>" class="button jetpack-simple-payments-save-product"><?php esc_html_e( 'Save', 'jetpack' ); ?></button>
+			<button name="<?php echo esc_attr( $this->get_field_name( 'save' ) ); ?>" class="button jetpack-simple-payments-save-product"><?php esc_html_e( 'Save', 'jetpack' ); ?></button>
 			<span> | <button type="button" class="button-link jetpack-simple-payments-cancel-form"><?php esc_html_e( 'Cancel', 'jetpack' ); ?></button></span>
 		</div>
 		<br class="clear">
@@ -182,8 +190,13 @@
 	<?php
 		printf(
 			wp_kses(
+				/* Translators: placeholder is a link to the customizer. */
 				__( 'This widget adds a payment button of your choice to your sidebar. To create or edit the payment buttons themselves, <a href="%s">use the Customizer</a>.', 'jetpack' ),
-				array( 'a' => array( 'href' => array() ) )
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
 			),
 			esc_url( add_query_arg( array( 'autofocus[panel]' => 'widgets' ), admin_url( 'customize.php' ) ) )
 		);

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -148,8 +148,14 @@
 			<?php
 			printf(
 				wp_kses(
-					__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a <a href="%s" %s>PayPal account</a> connected to a bank account.' ),
-					array( 'a' => array( 'href' => array(), 'target' => array() ) )
+					/* Translators: placeholders are a link to Paypal website and a target attribute. */
+					__( 'This is where PayPal will send your money. To claim a payment, you\'ll need a <a href="%1$s" %2$s>PayPal account</a> connected to a bank account.', 'jetpack' ),
+					array(
+						'a' => array(
+							'href'   => array(),
+							'target' => array(),
+						),
+					)
 				),
 				'https://paypal.com',
 				'target="_blank"'

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -6,9 +6,9 @@
 			</div>
 		</div>
 		<div class='jetpack-simple-payments-details'>
-			<div class='jetpack-simple-payments-title'><p><?php esc_attr_e( $instance['form_product_title'] ); ?></p></div>
-			<div class='jetpack-simple-payments-description'><p><?php  esc_html_e( $instance['form_product_description'] ); ?></p></div>
-			<div class='jetpack-simple-payments-price'><p><?php esc_attr_e( $instance['form_product_price'] ); ?> <?php esc_attr_e( $instance['form_product_currency'] ); ?></p></div>
+			<div class='jetpack-simple-payments-title'><p><?php echo esc_html( $instance['form_product_title'] ); ?></p></div>
+			<div class='jetpack-simple-payments-description'><p><?php echo esc_html( $instance['form_product_description'] ); ?></p></div>
+			<div class='jetpack-simple-payments-price'><p><?php echo esc_html( $instance['form_product_price'] ); ?> <?php echo esc_html( $instance['form_product_currency'] ); ?></p></div>
 			<div class='jetpack-simple-payments-purchase-box'>
 				<?php if ( $instance['form_product_multiple'] ) { ?>
 					<div class='jetpack-simple-payments-items'>

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,8 +1,16 @@
+<?php
+/**
+ * Display the Simple Payments Widget.
+ *
+ * @package Jetpack
+ */
+
+?>
 <div class='jetpack-simple-payments-wrapper'>
 	<div class='jetpack-simple-payments-product'>
 		<div class='jetpack-simple-payments-product-image' <?php if ( empty( $instance['form_product_image_id'] ) ) echo 'style="display:none;"'; ?>>
 			<div class='jetpack-simple-payments-image'>
-				<?php echo wp_get_attachment_image( $instance['form_product_image_id'], 'full' ) ?>
+				<?php echo wp_get_attachment_image( $instance['form_product_image_id'], 'full' ); ?>
 			</div>
 		</div>
 		<div class='jetpack-simple-payments-details'>


### PR DESCRIPTION
Fixes #10334

#### Changes proposed in this Pull Request:

- Do not use translation functions to return vars.
- add missing textdomain
- Various coding standards fixes.

#### Testing instructions:

1. Start wit a site using a Premium plan.
2. Go to Appearance > Customize > Widgets, and attempt to set up and make changes to a Simple Payments widget.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Simple Payments: Internationalization fixes.