### PR TITLE
Fix Stat Type of Google Site Verification 

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -309,8 +309,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function get_external_services_connect_urls() {
 		$connect_urls = array();
 		jetpack_require_lib( 'class.jetpack-keyring-service-helper' );
-		foreach ( Jetpack_Keyring_Service_Helper::$SERVICES as $service_name ) {
-			$connect_urls[ $service_name ] = Jetpack_Keyring_Service_Helper::connect_url( $service_name );
+		foreach ( Jetpack_Keyring_Service_Helper::$SERVICES as $service_name => $service_info ) {
+			$connect_urls[ $service_name ] = Jetpack_Keyring_Service_Helper::connect_url( $service_name, $service_info[ 'for' ] );
 		}
 		return $connect_urls;
 	}

--- a/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -15,13 +15,27 @@ class Jetpack_Keyring_Service_Helper {
 	}
 
 	public static $SERVICES = array(
-		'facebook',
-		'twitter',
-		'linkedin',
-		'tumblr',
-		'path',
-		'google_plus',
-		'google_site_verification',
+		'facebook' => array(
+			'for' => 'publicize'
+		),
+		'twitter' => array(
+			'for' => 'publicize'
+		),
+		'linkedin' => array(
+			'for' => 'publicize'
+		),
+		'tumblr' => array(
+			'for' => 'publicize'
+		),
+		'path' => array(
+			'for' => 'publicize'
+		),
+		'google_plus' => array(
+			'for' => 'publicize'
+		),
+		'google_site_verification' => array(
+			'for' => 'other'
+		)
 	);
 
 	private function __construct() {
@@ -76,22 +90,23 @@ class Jetpack_Keyring_Service_Helper {
 		return $url;
 	}
 
-	static function connect_url( $service_name ) {
+	static function connect_url( $service_name, $for ) {
 		return add_query_arg( array(
 			'action'   => 'request',
 			'service'  => $service_name,
 			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
 			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
+			'for'      => $for,
 		), menu_page_url( 'sharing', false ) );
 	}
 
-	static function refresh_url( $service_name ) {
+	static function refresh_url( $service_name, $for ) {
 		return add_query_arg( array(
 			'action'   => 'request',
 			'service'  => $service_name,
 			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
 			'refresh'  => 1,
-			'for'      => 'publicize',
+			'for'      => $for,
 			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
 		), admin_url( 'options-general.php?page=sharing' ) );
 	}

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -248,12 +248,12 @@ class Publicize extends Publicize_Base {
 		}
 	}
 
-	function connect_url( $service_name ) {
-		return Jetpack_Keyring_Service_Helper::connect_url( $service_name );
+	function connect_url( $service_name, $for = 'publicize' ) {
+		return Jetpack_Keyring_Service_Helper::connect_url( $service_name, $for );
 	}
 
-	function refresh_url( $service_name ) {
-		return Jetpack_Keyring_Service_Helper::refresh_url( $service_name );
+	function refresh_url( $service_name, $for = 'publicize' ) {
+		return Jetpack_Keyring_Service_Helper::refresh_url( $service_name, $for );
 	}
 
 	function disconnect_url( $service_name, $id ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Change the stat type ( `for` on our end ) of the Google Site Verification keyring service

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

1. Install Redux Dev Tools
2. Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard` on Jetpack test site
3. Inspect the Redux state with the dev tools
4. Verify that under `jetpack.publicize.connectUrls` every services url ends with the query arg `&for=publicize` except for `google_site_verification` which ends with `&for=other`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Change the stat type of the Google Site Verification keyring service