### PR TITLE
Convert Jetpack::dns_prefetch to wp_resource_hints

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -11,13 +11,14 @@
  * Additional Search Queries: like widget, like button, like, likes
  */
 
-add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
-function jetpack_dns_prefetch( $urls, $relation_type ) {
+function jetpack_dns_comment_likes_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//widgets.wp.com';
 	}
 	return $urls;
 }
+add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
+
 
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-master-iframe.php';
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-settings.php';

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -11,11 +11,13 @@
  * Additional Search Queries: like widget, like button, like, likes
  */
 
-Jetpack::dns_prefetch(
-	array(
-		'//widgets.wp.com',
-	)
-);
+add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
+function jetpack_dns_prefetch( $urls, $relation_type ) {
+	if( 'dns-prefetch' == $relation_type ) {
+		$urls[] = '//widgets.wp.com';
+	}
+	return $urls;
+}
 
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-master-iframe.php';
 require_once dirname( __FILE__ ) . '/likes/jetpack-likes-settings.php';

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -30,7 +30,7 @@ function jetpack_comments_configuration_load() {
 
 add_action( 'jetpack_modules_loaded', 'jetpack_comments_load' );
 
-function jetpack_dns_prefetch( $urls, $relation_type ) {
+function jetpack_comments_dns_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//jetpack.wordpress.com'; 
 		$urls[] = '//s0.wp.com';

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -30,13 +30,18 @@ function jetpack_comments_configuration_load() {
 
 add_action( 'jetpack_modules_loaded', 'jetpack_comments_load' );
 
-Jetpack::dns_prefetch( array(
-	'//jetpack.wordpress.com',
-	'//s0.wp.com',
-	'//s1.wp.com',
-	'//s2.wp.com',
-	'//public-api.wordpress.com',
-	'//0.gravatar.com',
-	'//1.gravatar.com',
-	'//2.gravatar.com',
-) );
+function jetpack_dns_prefetch( $urls, $relation_type ) {
+	if( 'dns-prefetch' == $relation_type ) {
+		$urls[] = '//jetpack.wordpress.com'; 
+		$urls[] = '//s0.wp.com';
+		$urls[] = '//s1.wp.com';
+		$urls[] = '//s2.wp.com';
+		$urls[] = '//public-api.wordpress.com';
+		$urls[] = '//0.gravatar.com';
+		$urls[] = '//1.gravatar.com';
+		$urls[] = '//2.gravatar.com';
+	}
+	return $urls;
+}
+
+add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -11,7 +11,7 @@
  * Additional Search Queries: like, likes, wordpress.com
  */
 
-function jetpack_dns_prefetch( $urls, $relation_type ) {
+function jetpack_comment_likes_dns_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//widgets.wp.com'; 
 		$urls[] = '//s0.wp.com';

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -11,7 +11,7 @@
  * Additional Search Queries: like, likes, wordpress.com
  */
 
-function jetpack_comment_likes_dns_prefetch( $urls, $relation_type ) {
+function jetpack_likes_dns_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//widgets.wp.com'; 
 		$urls[] = '//s0.wp.com';

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -11,13 +11,18 @@
  * Additional Search Queries: like, likes, wordpress.com
  */
 
-Jetpack::dns_prefetch( array(
-	'//widgets.wp.com',
-	'//s0.wp.com',
-	'//0.gravatar.com',
-	'//1.gravatar.com',
-	'//2.gravatar.com',
-) );
+function jetpack_dns_prefetch( $urls, $relation_type ) {
+	if( 'dns-prefetch' == $relation_type ) {
+		$urls[] = '//widgets.wp.com'; 
+		$urls[] = '//s0.wp.com';
+		$urls[] = '//0.gravatar.com';
+		$urls[] = '//1.gravatar.com';
+		$urls[] = '//2.gravatar.com';
+	}
+	return $urls;
+}
+ add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
+
 
 include_once dirname( __FILE__ ) . '/likes/jetpack-likes-master-iframe.php';
 include_once dirname( __FILE__ ) . '/likes/jetpack-likes-settings.php';

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -31,15 +31,19 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
-		Jetpack::dns_prefetch( array(
-			'//s0.wp.com',
-			'//s1.wp.com',
-			'//s2.wp.com',
-			'//0.gravatar.com',
-			'//1.gravatar.com',
-			'//2.gravatar.com',
-		) );
-
+		function jetpack_dns_prefetch( $urls, $relation_type ) {
+			if( 'dns-prefetch' == $relation_type ) {
+				$urls[] = '//s0.wp.com';
+				$urls[] = '//s1.wp.com';
+				$urls[] = '//s2.wp.com';
+				$urls[] = '//0.gravatar.com';
+				$urls[] = '//1.gravatar.com';
+				$urls[] = '//2.gravatar.com';
+			}
+			return $urls;
+		}
+		 add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
+		
 		// Atomic only
 		if ( jetpack_is_atomic_site() ) {
 			// override user setting that hides masterbar from site's front.

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -31,7 +31,7 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
-		function jetpack_dns_prefetch( $urls, $relation_type ) {
+		function jetpack_masterbar_dns_prefetch( $urls, $relation_type ) {
 			if( 'dns-prefetch' == $relation_type ) {
 				$urls[] = '//s0.wp.com';
 				$urls[] = '//s1.wp.com';

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -14,9 +14,13 @@
 
 $GLOBALS['concatenate_scripts'] = false;
 
-Jetpack::dns_prefetch( array(
-	'//c0.wp.com',
-) );
+function jetpack_dns_prefetch( $urls, $relation_type ) {
+	if( 'dns-prefetch' == $relation_type ) {
+		$urls[] = '//c0.wp.com'; 
+	}
+	return $urls;
+}
+add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
 
 class Jetpack_Photon_Static_Assets_CDN {
 	const CDN = 'https://c0.wp.com/';

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -14,7 +14,7 @@
 
 $GLOBALS['concatenate_scripts'] = false;
 
-function jetpack_dns_prefetch( $urls, $relation_type ) {
+function jetpack_photon_cdn_dns_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//c0.wp.com'; 
 	}

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -13,7 +13,7 @@
  * Additional Search Queries: photon, image, cdn, performance, speed
  */
 
-function jetpack_dns_prefetch( $urls, $relation_type ) {
+function jetpack_photon_dns_prefetch( $urls, $relation_type ) {
 	if( 'dns-prefetch' == $relation_type ) {
 		$urls[] = '//i0.wp.com';
 		$urls[] = '//i1.wp.com';

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -13,10 +13,14 @@
  * Additional Search Queries: photon, image, cdn, performance, speed
  */
 
-Jetpack::dns_prefetch( array(
-	'//i0.wp.com',
-	'//i1.wp.com',
-	'//i2.wp.com',
-) );
+function jetpack_dns_prefetch( $urls, $relation_type ) {
+	if( 'dns-prefetch' == $relation_type ) {
+		$urls[] = '//i0.wp.com';
+		$urls[] = '//i1.wp.com';
+		$urls[] = '//i2.wp.com';
+	}
+	return $urls;
+}
+ add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
 
 Jetpack_Photon::instance();

--- a/modules/shortcodes/videopress.php
+++ b/modules/shortcodes/videopress.php
@@ -8,12 +8,14 @@
 
 if ( ! Jetpack::is_module_active( 'videopress' ) ) {
 
-	Jetpack::dns_prefetch(
-		array(
-			'//v0.wordpress.com',
-		)
-	);
-
+	function jetpack_dns_prefetch( $urls, $relation_type ) {
+		if( 'dns-prefetch' == $relation_type ) {
+			$urls[] = '//v0.wordpress.com'; 
+		}
+		return $urls;
+	}
+	 add_filter( 'wp_resource_hints', 'jetpack_resource_hints', 10, 2 );
+	
 	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/utility-functions.php';
 	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/shortcode.php';
 

--- a/modules/shortcodes/videopress.php
+++ b/modules/shortcodes/videopress.php
@@ -8,7 +8,7 @@
 
 if ( ! Jetpack::is_module_active( 'videopress' ) ) {
 
-	function jetpack_dns_prefetch( $urls, $relation_type ) {
+	function jetpack_videopress_dns_prefetch( $urls, $relation_type ) {
 		if( 'dns-prefetch' == $relation_type ) {
 			$urls[] = '//v0.wordpress.com'; 
 		}


### PR DESCRIPTION
@see #8090 and #10330
NOTE: This PR started out looking solely at Comment Likes, however I am now looking at all `Jetpack::dns_prefetch` functions to potentially convert to `wp_resource_hints` and therefore deprecate the Jetpack specific function, per https://github.com/Automattic/jetpack/issues/8090#issuecomment-430952444

#### Changes proposed in this Pull Request:

The Comment Likes feature current registers dns-prefetch resources via Jetpack's own function. Since the creation of this feature/function, [wp_resource_hints()](https://developer.wordpress.org/reference/functions/wp_resource_hints/) has been created, that allows a user/plugin/theme to register resource hints for use in browsers.

#### Testing instructions:

1. Enable Comment Likes on your site.
2. Load a post with comments.
3. Check page source code with your browser's dev console. You should see `<link rel="dns-prefetch" href="//widgets.wp.com">` is now in your `head` section

#### Proposed changelog entry for your changes:
- Comment Likes: Utilize wp_resource_hints() function to register dns-prefetch URLs
