### PR TITLE
Sync: Sync all posts once after first connection

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1135,15 +1135,13 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$current_user = wp_get_current_user();
 
 		$expected_sync_config = array( 
-			'options' => true,
-			'functions' => true, 
-			'constants' => true, 
-			'users' => array( $current_user->ID )
+			'options'         => true,
+			'network_options' => is_multisite(),
+			'functions'       => true,
+			'constants'       => true,
+			'posts'           => true,
+			'users'           => 'initial',
 		);
-
-		if ( is_multisite() ) {
-			$expected_sync_config['network_options'] = true;
-		}
 
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

History
* Historically we were syncing posts on any module activation
* 3 weeks ago we stopped doing so

What's new
* This PR propose we full sync all posts(only once) after the first connection.

#### Testing instructions:

Using this branch instead of Master, follow the instructions here: p7rcWF-UK-p2 
and check that `jetpack_full_sync_posts` happens.