### PR TITLE
Register `wp-url` script

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7360,6 +7360,7 @@ p {
 				'wp-keycodes',
 				'wp-plugins',
 				'wp-token-list',
+				'wp-url',
 			),
 			$version
 		);


### PR DESCRIPTION
As [suggested](https://github.com/Automattic/wp-calypso/pull/27929#pullrequestreview-166094475) by @tyxla.

### Testing instructions

Verify that Jetpack still builds and runs correctly.