### PR TITLE
Live Branches: add gutenpack param if a PR uses the Gutenberg label

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -21,19 +21,20 @@
 		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log&gutenberg${ isGutenbergPr ? '&gutenpack' : '' }`;
 		let link = base + query;
 		const canLiveTestText =
-			'<div id="jetpack-live-branches">' +
-			'<h2>Jetpack Live Branches</h2>' +
-			'<p style="height:3em;" ><a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="' + link + '">' + link + '</a></p>' +
-			'<ul>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>' +
-			'<li class="task-list-item enabled"><input type="checkbox" name="wp-downgrade" class="task-list-item-checkbox">Launch with WP Downgrade installed</li>' +
-			'</ul>' +
-			'</div>';
+			`<div id="jetpack-live-branches">
+			<h2>Jetpack Live Branches</h2>
+			<p style="height:3em;" ><a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="${ link }">${ link }</a></p>
+			<ul>
+			<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="wp-downgrade" class="task-list-item-checkbox">Launch with WP Downgrade installed</li>
+			</ul>
+			</div>`;
 		const branchIsForkedText =
 			'<div id="jetpack-live-branches">' +
 			'<h2>Jetpack Live Branches</h2>' +

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.5
+// @version      1.6
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -16,8 +16,9 @@
 		const branch = jQuery( '.head-ref' ).text();
 		const branchIsForked = branch.includes( ':' );
 		const branchIsMerged = $( '.gh-header-meta .State' ).text().trim() === 'Merged';
-		const query = 'jetpack-beta&branch=' + branch + '&shortlived&wp-debug-log&gutenberg';
+		const isGutenbergPr = $( '.discussion-sidebar .sidebar-labels .labels' ).children( 'a' ).attr( 'title' ) === 'Gutenberg';
 		const base = 'https://jurassic.ninja/create?';
+		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log&gutenberg${ isGutenbergPr ? '&gutenpack' : '' }`;
 		let link = base + query;
 		const canLiveTestText =
 			'<div id="jetpack-live-branches">' +

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -16,7 +16,7 @@
 		const branch = jQuery( '.head-ref' ).text();
 		const branchIsForked = branch.includes( ':' );
 		const branchIsMerged = $( '.gh-header-meta .State' ).text().trim() === 'Merged';
-		const isGutenbergPr = $( '.discussion-sidebar .sidebar-labels .labels' ).children( 'a' ).attr( 'title' ) === 'Gutenberg';
+		const isGutenbergPr = $( ".discussion-sidebar .sidebar-labels .labels a[title='Gutenberg']" ).length;
 		const base = 'https://jurassic.ninja/create?';
 		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log&gutenberg${ isGutenbergPr ? '&gutenpack' : '' }`;
 		let link = base + query;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The extra parameter allows us to generate Jetpack sites with the blocks already built when the PR is about Gutenberg.

This could be useful in PRs like this one for example: #10357

#### Testing instructions:

1. Add the updated .js file to Tampermonkey.
2. Verify that the Live branch link that is created includes `&gutenpack` at the end on PRs like this one.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
None