### PR TITLE
IS: Remove continue within a switch

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -150,8 +150,6 @@ class The_Neverending_Home_Page {
 								break;
 
 							default:
-								continue;
-
 								break;
 						}
 					}


### PR DESCRIPTION
For 7.3 compatibility, removed a duplicative `continue`. 