### PR TITLE
Map Block Dependencies, Second Try

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -64,10 +64,11 @@ class Jetpack_Gutenberg {
 			'jetpack-blocks-view',
 			$view_script,
 			array(
+				'wp-element',
 				'wp-i18n',
-				'wp-element'
 			),
-			$version );
+			$version
+		);
 		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -60,7 +60,12 @@ class Jetpack_Gutenberg {
 				: JETPACK__VERSION;
 		}
 
-		wp_enqueue_script( 'jetpack-blocks-view', $view_script, array(), $version );
+		$view_script_dependencies = array(
+			'wp-i18n',
+			'wp-element'
+		);
+
+		wp_enqueue_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version );
 		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -60,12 +60,14 @@ class Jetpack_Gutenberg {
 				: JETPACK__VERSION;
 		}
 
-		$view_script_dependencies = array(
-			'wp-i18n',
-			'wp-element'
-		);
-
-		wp_enqueue_script( 'jetpack-blocks-view', $view_script, $view_script_dependencies, $version );
+		wp_enqueue_script(
+			'jetpack-blocks-view',
+			$view_script,
+			array(
+				'wp-i18n',
+				'wp-element'
+			),
+			$version );
 		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 


### PR DESCRIPTION
This PR replaces https://github.com/Automattic/jetpack/pull/10319. It simply enqueues Localization and `wp-element` scripts on the view side, which enables Map block's React component to render.


#### Testing instructions:

gutenpack-jn

See https://github.com/Automattic/wp-calypso/pull/27836