### PR TITLE
Add Jetpack::setup_wp_i18n_locale_data method

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -131,10 +131,7 @@ class Jetpack_Gutenberg {
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
-		wp_add_inline_script(
-			'wp-i18n',
-			'wp.i18n.setLocaleData( ' . Jetpack::get_i18n_data_json() . ', \'jetpack\' );'
-		);
+		Jetpack::setup_wp_i18n_locale_data();
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 	}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -69,6 +69,9 @@ class Jetpack_Gutenberg {
 			),
 			$version
 		);
+
+		Jetpack::setup_wp_i18n_locale_data();
+
 		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2638,11 +2638,11 @@ class Jetpack {
 	}
 
 	/**
-	 * Sets up wp-i18n package with locale data
+	 * Add locale data setup to wp-i18n
 	 *
-	 * Any Jetpack script that depends on wp-i18n should use this method to setup the locale.
+	 * Any Jetpack script that depends on wp-i18n should use this method to set up the locale.
 	 *
-	 * The local setup depends on an adding inline script. This is error-prone and could easily
+	 * The locale setup depends on an adding inline script. This is error-prone and could easily
 	 * result in multiple additions of the same script when exactly 0 or 1 is desireable.
 	 *
 	 * This method provides a safe way to request the setup multiple times but add the script at

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2638,6 +2638,32 @@ class Jetpack {
 	}
 
 	/**
+	 * Sets up wp-i18n package with locale data
+	 *
+	 * Any Jetpack script that depends on wp-i18n should use this method to setup the locale.
+	 *
+	 * The local setup depends on an adding inline script. This is error-prone and could easily
+	 * result in multiple additions of the same script when exactly 0 or 1 is desireable.
+	 *
+	 * This method provides a safe way to request the setup multiple times but add the script at
+	 * most once.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return void
+	 */
+	public static function setup_wp_i18n_locale_data() {
+		static $script_added = false;
+		if ( ! $script_added ) {
+			$script_added = true;
+			wp_add_inline_script(
+				'wp-i18n',
+				'wp.i18n.setLocaleData( ' . Jetpack::get_i18n_data_json() . ', \'jetpack\' );'
+			);
+		}
+	}
+
+	/**
 	 * Return module name translation. Uses matching string created in modules/module-headings.php.
 	 *
 	 * @since 3.9.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Provide a mechanism to wetup `wp-i18n` locale exactly once and use it. This is an idempotent way of adding the script.

See https://github.com/Automattic/jetpack/pull/10328#discussion_r226586772 and https://github.com/Automattic/jetpack/pull/10361#pullrequestreview-166687301

#### Testing instructions:

gutenpack-jn

With Gutenberg enabled and Jetpack connected…

* In the Gutenberg editor, you should see the i18n script tag followed by the setup locale script _once_.
* On the frontend, you should see the i18n script tag followed by the setup locale script _once_.

#### Proposed changelog entry for your changes:

* Add `Jetpack::setup_wp_i18n_locale_data` method to help setup `wp-i18n` with locale data.

#### Screens

##### Backend (method invoked twice, added once)

![localedata](https://user-images.githubusercontent.com/841763/47243257-bc07b180-d3f1-11e8-8c60-f3fb1ee5a4e3.png)

##### Frontend (method invoked once, added once)

![localedata-front](https://user-images.githubusercontent.com/841763/47243256-bb6f1b00-d3f1-11e8-930c-a3df98b63d35.png)

##### Current master frontend (no script added, no locale data 😢 )

![master](https://user-images.githubusercontent.com/841763/47243415-30425500-d3f2-11e8-8631-aa487d4a15b9.png)

I haven't uploaded the screenshot, but I verified that if you naively add the script in both `enqueue_block_editor_assets` and `enqueue_block_assets` rather than using the approach in this PR, it is indeed added twice, which is undesirable.