### PR TITLE
Remove scheme from URL so sitemap stylesheets don't break across protocols

### DIFF
--- a/modules/sitemaps/sitemap-finder.php
+++ b/modules/sitemaps/sitemap-finder.php
@@ -29,7 +29,8 @@ class Jetpack_Sitemap_Finder {
 	 * @return string Complete URI of the given sitemap file.
 	 */
 	public function construct_sitemap_url( $filename ) {
-		return jetpack_sitemap_uri( $filename );
+		// strip scheme for sites where sitemap could be access via http or https
+		return preg_replace( '/^https?:/', '', jetpack_sitemap_uri( $filename ) );
 	}
 
 	/**

--- a/tests/php/modules/sitemaps/test_class.sitemap-finder.php
+++ b/tests/php/modules/sitemaps/test_class.sitemap-finder.php
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Sitemap_Finder extends WP_UnitTestCase {
 	public function test_sitemap_finder_recognize_default_master_sitemap() {
 		$finder = new Jetpack_Sitemap_Finder();
 
-		$array = parse_url( $finder->construct_sitemap_url( 'sitemap.xml' ) );
+		$array = wp_parse_url( $finder->construct_sitemap_url( 'sitemap.xml' ) );
 
 		$result = $finder->recognize_sitemap_uri(
 			// Get just the path+query part of the URL.


### PR DESCRIPTION
Many sites accept http or https protocols without redirecting.

If you view `/sitemap.xml` via HTTP and the XML stylesheet URL is a HTTPS url, then the content will not be displayed.

Example URL: 

https://www.goldsounds.com/sitemap.xml (works)
http://www.goldsounds.com/sitemap.xml (broken)

The Chrome devtools console displays the error:

> Unsafe attempt to load URL https://www.goldsounds.com/sitemap-index.xsl from frame with URL http://www.goldsounds.com/sitemap.xml. Domains, protocols and ports must match.

This patch just strips the `http[s]:` portion of the URL (if present) leaving `//rest-of-url.com/sitemap-index.xsl`, which allows the browser to download the resource using the same protocol as the current URL.

#### Changes proposed in this Pull Request:

* Remove protocol from sitemap stylesheet URL

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* Enable Jetpack sitemaps on a site which accepts HTTPS or HTTP URLs without redirecting, but the default protocol is HTTPS (i.e. in `home_url()`)
* Visit /sitemap.xml with HTTP and HTTPS protocols
* Content should be displayed for both URLs. Neither should show a white screen and console error.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
