### PR TITLE
Gutenberg: Add @wordpress/edit-post dependency

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -113,6 +113,7 @@ class Jetpack_Gutenberg {
 				'wp-compose',
 				'wp-data',
 				'wp-date',
+				'wp-edit-post',
 				'wp-editor',
 				'wp-element',
 				'wp-hooks',


### PR DESCRIPTION
The `@wordpress/edit-post` dependency is needed for the Publicize Gutenberg extension to work.

#### Changes proposed in this Pull Request:

* Add `@wordpress/edit-post` dependency to our Gutenberg block assets.

#### Testing instructions:

* Checkout this branch
* Do a fresh `yarn distclean && yarn build`.
* Verify build still works well.
* Verify `edit-post` assets are included while in the Gutenberg editor.
