### PR TITLE
Disable Google verification using API if site is under construction

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -518,12 +518,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 		// - https://wordpress.org/plugins/under-construction-page
 		// - https://wordpress.org/plugins/ultimate-under-construction
 		// - https://wordpress.org/plugins/coming-soon
+		$mm_coming_soon = get_option( 'mm_coming_soon', null );
+		$underConstructionActivationStatus = get_option( 'underConstructionActivationStatus', null );
+		$ucp_options = get_option( 'ucp_options', array() );
+		$uuc_settings = get_option( 'uuc_settings', array() );
+		$csp4 = get_option( 'seed_csp4_settings_content', array() );
 		if (
-			'true' === get_option( 'mm_coming_soon', 'false' ) ||
-			1 == get_option( 'underConstructionActivationStatus', null ) ||
-			1 == get_option( 'ucp_options', array() )[ 'status' ] ||
-			1 == get_option( 'uuc_settings', array() )[ 'enable' ] ||
-			! get_transient( '_seed_csp4_welcome_screen_activation_redirect' )
+			'true' === $mm_coming_soon ||
+			1 == $underConstructionActivationStatus ||
+			( is_array( $ucp_options ) && 1 == $ucp_options[ 'status' ] ) ||
+			( is_array( $uuc_settings ) && 1 == $uuc_settings[ 'enable' ] ) ||
+			( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) )
 		) {
 			return new WP_Error( 'under_construction', __( 'Site is under construction and cannot be verified' ) );
 		}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -512,7 +512,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array|wp-error
 	 */
 	public static function is_site_verified_and_token( $request ) {
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		/**
 		 * Return an error if the site uses a Maintenance / Coming Soon plugin
 		 * and if the plugin is configured to make the site private.
@@ -533,11 +532,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$uuc_settings                         = get_option( 'uuc_settings', array() );
 		$csp4                                 = get_option( 'seed_csp4_settings_content', array() );
 		if (
-			( is_plugin_active( 'mojo-marketplace-wp-plugin' ) && 'true' === $mm_coming_soon )
-			|| is_plugin_active( 'mojo-under-construction' ) && 1 == $under_construction_activation_status // WPCS: loose comparison ok.
-			|| ( is_plugin_active( 'under-construction-page' ) && isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
-			|| ( is_plugin_active( 'ultimate-under-construction' ) && isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
-			|| ( is_plugin_active( 'coming-soon' ) &&  isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
+			( Jetpack::is_plugin_active( 'mojo-marketplace-wp-plugin/mojo-marketplace.php' ) && 'true' === $mm_coming_soon )
+			|| Jetpack::is_plugin_active( 'mojo-under-construction/mojo-contruction.php' ) && 1 == $under_construction_activation_status // WPCS: loose comparison ok.
+			|| ( Jetpack::is_plugin_active( 'under-construction-page/under-construction.php' ) && isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
+			|| ( Jetpack::is_plugin_active( 'ultimate-under-construction/ultimate-under-construction.php' ) && isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
+			|| ( Jetpack::is_plugin_active( 'coming-soon/coming-soon.php' ) &&  isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
 			/**
 			 * Allow plugins to mark a site as "under construction".
 			 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -512,6 +512,22 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array|wp-error
 	 */
 	public static function is_site_verified_and_token( $request ) {
+		// Site is likely displaying the Under Construction page using one of those plugins
+		// - https://github.com/mojoness/mojo-marketplace-wp-plugin (used by bluehost)
+		// - https://wordpress.org/plugins/mojo-under-construction
+		// - https://wordpress.org/plugins/under-construction-page
+		// - https://wordpress.org/plugins/ultimate-under-construction
+		// - https://wordpress.org/plugins/coming-soon
+		if (
+			'true' === get_option( 'mm_coming_soon', 'false' ) ||
+			1 == get_option( 'underConstructionActivationStatus', null ) ||
+			1 == get_option( 'ucp_options', array() )[ 'status' ] ||
+			1 == get_option( 'uuc_settings', array() )[ 'enable' ] ||
+			! get_transient( '_seed_csp4_welcome_screen_activation_redirect' )
+		) {
+			return new WP_Error( 'under_construction', __( 'Site is under construction and cannot be verified' ) );
+		}
+
 		Jetpack::load_xml_rpc_client();
  		$xml = new Jetpack_IXR_Client( array(
  			'user_id' => get_current_user_id(),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -512,6 +512,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array|wp-error
 	 */
 	public static function is_site_verified_and_token( $request ) {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		/**
 		 * Return an error if the site uses a Maintenance / Coming Soon plugin
 		 * and if the plugin is configured to make the site private.
@@ -532,11 +533,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$uuc_settings                         = get_option( 'uuc_settings', array() );
 		$csp4                                 = get_option( 'seed_csp4_settings_content', array() );
 		if (
-			'true' === $mm_coming_soon
-			|| 1 == $under_construction_activation_status // WPCS: loose comparison ok.
-			|| ( isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
-			|| ( isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
-			|| ( isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
+			( is_plugin_active( 'mojo-marketplace-wp-plugin' ) && 'true' === $mm_coming_soon )
+			|| is_plugin_active( 'mojo-under-construction' ) && 1 == $under_construction_activation_status // WPCS: loose comparison ok.
+			|| ( is_plugin_active( 'under-construction-page' ) && isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
+			|| ( is_plugin_active( 'ultimate-under-construction' ) && isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
+			|| ( is_plugin_active( 'coming-soon' ) &&  isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
 			/**
 			 * Allow plugins to mark a site as "under construction".
 			 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -534,9 +534,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if (
 			'true' === $mm_coming_soon
 			|| 1 == $under_construction_activation_status // WPCS: loose comparison ok.
-			|| ( is_array( $ucp_options ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
-			|| ( is_array( $uuc_settings ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
-			|| ( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
+			|| ( isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
+			|| ( isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
+			|| ( isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
 			/**
 			 * Allow plugins to mark a site as "under construction".
 			 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -530,7 +530,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			( is_array( $uuc_settings ) && 1 == $uuc_settings[ 'enable' ] ) ||
 			( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) )
 		) {
-			return new WP_Error( 'forbidden', __( 'Site is under construction and cannot be verified' ) );
+			return new WP_Error( 'forbidden', __( 'Site is under construction and cannot be verified', 'jetpack' ) );
 		}
 
 		Jetpack::load_xml_rpc_client();

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -530,7 +530,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			( is_array( $uuc_settings ) && 1 == $uuc_settings[ 'enable' ] ) ||
 			( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) )
 		) {
-			return new WP_Error( 'under_construction', __( 'Site is under construction and cannot be verified' ) );
+			return new WP_Error( 'forbidden', __( 'Site is under construction and cannot be verified' ) );
 		}
 
 		Jetpack::load_xml_rpc_client();

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -523,12 +523,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$ucp_options = get_option( 'ucp_options', array() );
 		$uuc_settings = get_option( 'uuc_settings', array() );
 		$csp4 = get_option( 'seed_csp4_settings_content', array() );
+		$mm_coming_soon                       = get_option( 'mm_coming_soon', null );
+		$under_construction_activation_status = get_option( 'underConstructionActivationStatus', null );
+		$ucp_options                          = get_option( 'ucp_options', array() );
+		$uuc_settings                         = get_option( 'uuc_settings', array() );
+		$csp4                                 = get_option( 'seed_csp4_settings_content', array() );
 		if (
-			'true' === $mm_coming_soon ||
-			1 == $underConstructionActivationStatus ||
-			( is_array( $ucp_options ) && 1 == $ucp_options[ 'status' ] ) ||
-			( is_array( $uuc_settings ) && 1 == $uuc_settings[ 'enable' ] ) ||
-			( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) )
+			'true' === $mm_coming_soon
+			|| 1 == $under_construction_activation_status // WPCS: loose comparison ok.
+			|| ( is_array( $ucp_options ) && 1 == $ucp_options['status'] ) // WPCS: loose comparison ok.
+			|| ( is_array( $uuc_settings ) && 1 == $uuc_settings['enable'] ) // WPCS: loose comparison ok.
+			|| ( is_array( $csp4 ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // WPCS: loose comparison ok.
 		) {
 			return new WP_Error( 'forbidden', __( 'Site is under construction and cannot be verified', 'jetpack' ) );
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This PR fixes an edge case, that may happen on Bluehost, where a site is not public yet and thus setting the verification token does not work. This detects this state for a few of the most popular coming-soon/under-construction plugins and disables the feature.

#### Testing instructions:

- Install one of the following plugin:
		 - https://github.com/mojoness/mojo-marketplace-wp-plugin (used by bluehost)
		 - https://wordpress.org/plugins/mojo-under-construction (skip this one as it seems to be erroring)
		 - https://wordpress.org/plugins/under-construction-page
		 - https://wordpress.org/plugins/ultimate-under-construction
		 - https://wordpress.org/plugins/coming-soon
- Activate it and switch the site into maintenance mode
- Go to the `Jetpack > Settings > Traffic` and notice the Google auto verify feature is disabled
- Switch the site back to available and notice the auto verify feature is back

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Disable Google auto-verify for sites under construction