### PR TITLE
Warm Update: first pass at a message welcoming users post-update

### DIFF
--- a/_inc/client/components/jetpack-dialogue/style.scss
+++ b/_inc/client/components/jetpack-dialogue/style.scss
@@ -89,6 +89,18 @@
 	padding: rem( 8px ) 0 0;
 }
 
+.jp-upgrade-notice__content {
+	.jp-upgrade-notice__enable-module {
+		.jp-form-has-child {
+			padding-left: 30px;
+
+			.jp-form-fieldset {
+				margin-bottom: 0.4rem;
+			}
+		}
+	}
+}
+
 .jp-upgrade-notice__enable-module {
 	margin-bottom: calc(1em + 8px);
 

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -16,6 +16,7 @@ import {
 	getJetpackStateNoticesMessageCode,
 	getJetpackStateNoticesErrorDescription
 } from 'state/jetpack-notices';
+import { isUnavailableInDevMode } from 'state/connection';
 import NoticeAction from 'components/notice/notice-action.jsx';
 import UpgradeNoticeContent from 'components/upgrade-notice-content';
 import { getSiteAdminUrl } from 'state/initial-state';
@@ -232,7 +233,10 @@ class JetpackStateNotices extends React.Component {
 		const versionForUpgradeNotice = /(6\.7).*/;
 		if ( 'modules_activated' === message && currentVersion.match( versionForUpgradeNotice ) ) {
 			return (
-				<UpgradeNoticeContent dismiss={ this.dismissJetpackStateNotice } adminUrl={ this.props.adminUrl } />
+				<UpgradeNoticeContent
+					dismiss={ this.dismissJetpackStateNotice }
+					isUnavailableInDevMode={ this.props.isUnavailableInDevMode }
+				/>
 			);
 		}
 
@@ -271,6 +275,7 @@ export default connect(
 			jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
 			jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state ),
 			adminUrl: getSiteAdminUrl( state ),
+			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 		};
 	}
 )( JetpackStateNotices );

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -229,7 +229,7 @@ class JetpackStateNotices extends React.Component {
 
 		// Show custom message for upgraded Jetpack
 		const currentVersion = this.props.currentVersion;
-		const versionForUpgradeNotice = /(5\.8).*/;
+		const versionForUpgradeNotice = /(6\.7).*/;
 		if ( 'modules_activated' === message && currentVersion.match( versionForUpgradeNotice ) ) {
 			return (
 				<UpgradeNoticeContent dismiss={ this.dismissJetpackStateNotice } adminUrl={ this.props.adminUrl } />

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -12,22 +12,155 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import JetpackDialogue from 'components/jetpack-dialogue';
-import decodeEntities from 'lib/decode-entities';
 import { imagePath } from 'constants/urls';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { getModule } from 'state/modules';
+import { getModule, getModuleOverride } from 'state/modules';
+import { isModuleFound as _isModuleFound } from 'state/search';
+import { FormFieldset } from 'components/forms';
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsGroup from 'components/settings-group';
+import analytics from 'lib/analytics';
+
 const UpgradeNoticeContent = moduleSettingsForm(
 	class extends Component {
 		toggleModule = ( name, value ) => {
 			this.props.updateOptions( { [ name ]: ! value } );
 		};
 
+		handleSiteAcceleratorChange = () => {
+			// Initial status for both modules.
+			let newPhotonStatus = this.props.getOptionValue( 'photon' );
+			let newAssetCdnStatus = this.props.getOptionValue( 'photon-cdn' );
+
+			// Check if any of the CDN options are on.
+			const siteAcceleratorStatus = newPhotonStatus || newAssetCdnStatus;
+
+			// Are the modules available?
+			const photonStatus = this.props.getModuleOverride( 'photon' );
+			const assetCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
+
+			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
+			if ( true === siteAcceleratorStatus ) {
+				if ( false === ! newPhotonStatus && 'active' !== photonStatus ) {
+					newPhotonStatus = false;
+
+					this.props.updateOptions( {
+						photon: false,
+						'tiled-gallery': false,
+						tiled_galleries: false
+					} );
+				}
+				if ( false === ! newAssetCdnStatus && 'active' !== assetCdnStatus ) {
+					newAssetCdnStatus = false;
+
+					this.props.updateOptions( {
+						'photon-cdn': false
+					} );
+				}
+			} else {
+				if ( false === newPhotonStatus && 'inactive' !== photonStatus ) {
+					newPhotonStatus = true;
+
+					this.props.updateOptions( {
+						photon: true,
+						'tiled-gallery': true,
+						tiled_galleries: true
+					} );
+				}
+				if ( false === newAssetCdnStatus && 'inactive' !== assetCdnStatus ) {
+					newAssetCdnStatus = true;
+
+					this.props.updateOptions( {
+						'photon-cdn': true
+					} );
+				}
+			}
+
+			// If at least one of the modules is now on, let's reflect that with the status of our main toggle.
+			if ( true === newPhotonStatus || true === newAssetCdnStatus ) {
+				// Track the main toggle switch.
+				analytics.tracks.recordJetpackClick( {
+					target: 'jetpack_site_accelerator_toggle',
+					toggled: 'on'
+				} );
+			} else {
+				analytics.tracks.recordJetpackClick( {
+					target: 'jetpack_site_accelerator_toggle',
+					toggled: 'off'
+				} );
+			}
+
+			// Track any potential Photon toggle switch.
+			if ( this.props.getOptionValue( 'photon' ) !== newPhotonStatus ) {
+				analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
+					module: 'photon',
+					toggled: ( false === newPhotonStatus ) ? 'off' : 'on'
+				} );
+			}
+
+			// Track any potential Photon CDN toggle switch.
+			if ( this.props.getOptionValue( 'photon-cdn' ) !== newAssetCdnStatus ) {
+				analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
+					module: 'photon-cdn',
+					toggled: ( false === newAssetCdnStatus ) ? 'off' : 'on'
+				} );
+			}
+		};
+
 		renderInnerContent() {
-			const assetCdn = this.props.module( 'photon-cdn' );
+			const foundPhoton = this.props.isModuleFound( 'photon' );
+			const foundAssetCdn = this.props.isModuleFound( 'photon-cdn' );
+
+			// Check if any of the CDN options are on.
+			const siteAcceleratorStatus = this.props.getOptionValue( 'photon' ) || this.props.getOptionValue( 'photon-cdn' );
+
+			// Is at least one of the 2 modules available (not hidden via a module override)?
+			const photonStatus = this.props.getModuleOverride( 'photon' );
+			const assetCdnStatus = this.props.getModuleOverride( 'photon-cdn' );
+			const canDisplaySiteAcceleratorSettings = ( foundPhoton && foundAssetCdn ) && ( 'inactive' !== photonStatus || 'inactive' !== assetCdnStatus );
+
+			// Monitor any changes that should cause our main toggle to appear toggling.
+			let togglingSiteAccelerator;
+			// First Photon activating.
+			if ( ! this.props.getOptionValue( 'photon' ) && this.props.isSavingAnyOption( 'photon' ) ) {
+				if ( this.props.getOptionValue( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			// Then Asset CDN activating.
+			} else if ( ! this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+				if ( this.props.getOptionValue( 'photon' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			// Then Photon deactivating.
+			} else if ( this.props.getOptionValue( 'photon' ) && this.props.isSavingAnyOption( 'photon' ) ) {
+				if ( this.props.getOptionValue( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+
+				// Is the Asset CDN being disabled as well?
+				if ( this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+					togglingSiteAccelerator = true;
+				}
+			// Then Asset CDN deactivating.
+			} else if ( this.props.getOptionValue( 'photon-cdn' ) && this.props.isSavingAnyOption( 'photon-cdn' ) ) {
+				if ( this.props.getOptionValue( 'photon' ) ) {
+					togglingSiteAccelerator = false;
+				} else {
+					togglingSiteAccelerator = true;
+				}
+			} else {
+				togglingSiteAccelerator = false;
+			}
+
 			return (
-				<div>
+				<div className="jp-upgrade-notice__content">
 					<p>
 						{ __( 'This release of Jetpack brings major new features and big improvements to your WordPress site.' ) }
 					</p>
@@ -55,21 +188,41 @@ const UpgradeNoticeContent = moduleSettingsForm(
 
 					<div className="jp-upgrade-notice__enable-module">
 
-						<SettingsGroup
-							hasChild
-							module={ assetCdn }>
-
-							<ModuleToggle
-								slug="photon-cdn"
-								disabled={ false }
-								activated={ this.props.getOptionValue( 'photon-cdn' ) }
-								toggling={ this.props.isSavingAnyOption( 'photon-cdn' ) }
-								toggleModule={ this.toggleModule }
+						<SettingsGroup hasChild>
+							<CompactFormToggle
+								checked={ siteAcceleratorStatus }
+								toggling={ togglingSiteAccelerator }
+								onChange={ this.handleSiteAcceleratorChange }
+								disabled={ ! canDisplaySiteAcceleratorSettings }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ decodeEntities( assetCdn.description ) }
+									{ __( 'Enable site accelerator' ) }
 								</span>
-							</ModuleToggle>
+							</CompactFormToggle>
+							<FormFieldset>
+								<ModuleToggle
+									slug="photon"
+									disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+									activated={ this.props.getOptionValue( 'photon' ) }
+									toggling={ this.props.isSavingAnyOption( 'photon' ) }
+									toggleModule={ this.toggleModule }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Speed up image load times' ) }
+									</span>
+								</ModuleToggle>
+								<ModuleToggle
+									slug="photon-cdn"
+									disabled={ false }
+									activated={ this.props.getOptionValue( 'photon-cdn' ) }
+									toggling={ this.props.isSavingAnyOption( 'photon-cdn' ) }
+									toggleModule={ this.toggleModule }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Speed up static file load times' ) }
+									</span>
+								</ModuleToggle>
+							</FormFieldset>
 						</SettingsGroup>
 					</div>
 
@@ -103,13 +256,16 @@ const UpgradeNoticeContent = moduleSettingsForm(
 );
 
 JetpackDialogue.propTypes = {
-	dismiss: PropTypes.func
+	dismiss: PropTypes.func,
+	isUnavailableInDevMode: PropTypes.func,
 };
 
 export default connect(
 	( state ) => {
 		return {
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			module: ( module_name ) => getModule( state, module_name ),
+			getModuleOverride: ( module_name ) => getModuleOverride( state, module_name ),
 		};
 	}
 )( UpgradeNoticeContent );

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -229,14 +229,10 @@ const UpgradeNoticeContent = moduleSettingsForm(
 					<div className="jp-dialogue__cta-container">
 						<Button
 							primary={ true }
-							href="https://wp.me/p1moTy-aEq"
+							href="https://jetpack.com/support/site-accelerator/"
 						>
-							{ __( 'Read the announcement' ) }
+							{ __( 'Learn more' ) }
 						</Button>
-
-						<p className="jp-dialogue__note">
-							<a href="https://jetpack.com/pricing">{ __( 'Compare paid plans' ) }</a>
-						</p>
 					</div>
 				</div>
 			);

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -25,7 +25,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 		};
 
 		renderInnerContent() {
-			const lazyImages = this.props.module( 'lazy-images' );
+			const assetCdn = this.props.module( 'photon-cdn' );
 			return (
 				<div>
 					<p>
@@ -37,62 +37,48 @@ const UpgradeNoticeContent = moduleSettingsForm(
 					</h2>
 
 					<p>
-						{ __( 'Sites with large numbers of images can now activate the Lazy Loading Images feature, which significantly ' +
-							'speeds up loading times for visitors. Instead of waiting for the entire page to load, ' +
-							'Jetpack will instead show pages instantly, and only download additional images when they are about to come into view.' ) }
+						{ __( 'Jetpack 6.7 introduces a new feature to help make your site faster. Our site accelerator already ' +
+							'offered speedier and optimized images served from our global Content Delivery Network. ' +
+							'Now we can also speed up your site by serving your static files (think CSS and JavaScript) from the same network.'
+						) }
 					</p>
 
 					<p>
-						{ __( 'If this sounds like a great improvement (and it is) you can enable it now by clicking the toggle below.' ) }
+						{ __( 'Turn on one or both and see decreased page load speeds, ' +
+						'as well as reduced bandwidth usage—which may lead to lower hosting costs.'
+						) }
+					</p>
+
+					<p>
+						{ __( 'Enable site acceleration now by clicking the toggle below.' ) }
 					</p>
 
 					<div className="jp-upgrade-notice__enable-module">
 
 						<SettingsGroup
 							hasChild
-							disableInDevMode
-							module={ lazyImages }>
+							module={ assetCdn }>
 
 							<ModuleToggle
-								slug="lazy-images"
+								slug="photon-cdn"
 								disabled={ false }
-								activated={ this.props.getOptionValue( 'lazy-images' ) }
-								toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
+								activated={ this.props.getOptionValue( 'photon-cdn' ) }
+								toggling={ this.props.isSavingAnyOption( 'photon-cdn' ) }
 								toggleModule={ this.toggleModule }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ decodeEntities( lazyImages.description ) }
+									{ decodeEntities( assetCdn.description ) }
 								</span>
 							</ModuleToggle>
 						</SettingsGroup>
 					</div>
 
-					<p>
-						{ __( 'We have also upgraded all our Premium plan customers to unlimited high-speed video storage ' +
-							'(up from 13GB), and significantly reduced the CSS and JavaScript assets that Jetpack downloads ' +
-							'when using features like infinite scroll and embedding rich content.' ) }
-					</p>
-
-					<h2>
-						{ __( 'Faster, more relevant search results' ) }
-					</h2>
-
-					<a href="https://wp.me/p1moTy-731" rel="noopener noreferrer" target="_blank">
-						<img src="https://jetpackme.files.wordpress.com/2018/02/jetpack-elasticsearch-powered-search.png" width="700" alt={ __( 'Elasticsearch' ) } />
-					</a>
-
-					<p>
-						{ __( 'Our faster site search is now available to all Professional' +
-							' plan customers. This replaces the default WordPress search with an Elasticsearch-powered infrastructure that returns faster, more ' +
-							'relevant results to users.' ) }
-					</p>
-
 					<div className="jp-dialogue__cta-container">
 						<Button
 							primary={ true }
-							href="https://jetpack.com/?p=27095"
+							href="https://wp.me/p1moTy-aEq"
 						>
-							{ __( 'Read the full announcement!' ) }
+							{ __( 'Read the announcement' ) }
 						</Button>
 
 						<p className="jp-dialogue__note">
@@ -106,7 +92,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 		render() {
 			return (
 				<JetpackDialogue
-					svg={ <img src={ imagePath + 'jetpack-search.svg' } width="250" alt={ __( 'Jetpack Search' ) } /> }
+					svg={ <img src={ imagePath + 'jetpack-performance.svg' } width="250" alt={ __( "Jetpack's site accelerator" ) } /> }
 					title={ __( 'Major new features from Jetpack' ) }
 					content={ this.renderInnerContent() }
 					dismiss={ this.props.dismiss }


### PR DESCRIPTION
**Work In Progress**

- Related discussion: p1HpG7-5J1-p2
- Awaiting copy and visuals
- Should land after #10311

#### Changes proposed in this Pull Request:

- Add messaging around the Asset CDN feature.
- Add toggle to turn on that feature.
- Add performance image as top image.

<img width="757" alt="screenshot 2018-10-25 at 22 48 57" src="https://user-images.githubusercontent.com/426388/47529569-7c850d80-d8a8-11e8-9911-853336dcc72c.png">

#### Testing instructions:

1. Manually change the `JETPACK__VERSION` constant in `jetpack.php` from `6.7-alpha` to `6.7`
2. Go to Jetpack > Dashboard.
3. See the update message.
    - It should only appear the first time you load the page.
    - All links and action buttons should work.
    - There should be no mistakes in the copy.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Dashboard: new notice highlighting changes in this release.