### PR TITLE
General: Add badge if API is sandboxed

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -12,7 +12,7 @@ import analytics from 'lib/analytics';
 /**
  * Internal dependencies
  */
-import { getSiteConnectionStatus } from 'state/connection';
+import { getSiteConnectionStatus, getSandboxDomain } from 'state/connection';
 import { getCurrentVersion, userCanEditPosts } from 'state/initial-state';
 
 export class Masthead extends React.Component {
@@ -45,6 +45,9 @@ export class Masthead extends React.Component {
 		const devNotice = this.props.siteConnectionStatus === 'dev'
 			? <code>Dev Mode</code>
 			: '',
+			sandboxedBadge = this.props.sandboxDomain
+				? <code id="sandbox-domain-badge" title={ this.props.sandboxDomain }>API Sandboxed</code>
+				: '',
 			isDashboardView = includes( [ '/', '/dashboard', '/apps', '/plans' ], this.props.route.path ),
 			isStatic = '' === this.props.route.path;
 
@@ -65,6 +68,7 @@ export class Masthead extends React.Component {
 							</svg>
 						</a>
 						{ devNotice }
+						{ sandboxedBadge }
 					</div>
 					{
 						this.props.userCanEditPosts && (
@@ -102,6 +106,7 @@ export default connect(
 	state => {
 		return {
 			siteConnectionStatus: getSiteConnectionStatus( state ),
+			sandboxDomain: getSandboxDomain( state ),
 			currentVersion: getCurrentVersion( state ),
 			userCanEditPosts: userCanEditPosts( state )
 		};

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -68,3 +68,8 @@
 		text-align: left;
 	}
 }
+
+#sandbox-domain-badge {
+	background-color: red;
+	color: #ffffff;
+}

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -70,6 +70,12 @@
 }
 
 #sandbox-domain-badge {
-	background-color: red;
+	background: #d54e21;
+	text-transform: uppercase;
+	letter-spacing: 0.2em;
+	text-shadow: none;
+	font-size: 9px;
+	font-weight: bold;
+	cursor: pointer;
 	color: #ffffff;
 }

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -280,5 +280,5 @@ export function isUnavailableInDevMode( state, module ) {
  * @return {bool|string} False if not sandboxed, string of URL if so.
  */
 export function getSandboxDomain( state ) {
-	return get( state.jetpack.connection.status, [ 'siteConnected', 'sandboxedDomain' ], false );
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'sandboxDomain' ], false );
 }

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -272,3 +272,13 @@ export function requiresConnection( state, slug ) {
 export function isUnavailableInDevMode( state, module ) {
 	return isDevMode( state ) && requiresConnection( state, module );
 }
+
+/**
+ * Checks if the JETPACK__SANDBOX_DOMAIN is set
+ *
+ * @param  {Object}      state Global state tree
+ * @return {bool|string} False if not sandboxed, string of URL if so.
+ */
+export function getSandboxDomain( state ) {
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'sandboxedDomain' ], false );
+}

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -276,9 +276,9 @@ export function isUnavailableInDevMode( state, module ) {
 /**
  * Checks if the JETPACK__SANDBOX_DOMAIN is set
  *
- * @param  {Object}      state Global state tree
- * @return {bool|string} False if not sandboxed, string of URL if so.
+ * @param  {Object} state Global state tree
+ * @return {string} Value of the JETPACK__SANDBOX_DOMAIN constant. Empty string if not sandboxed - url if so.
  */
 export function getSandboxDomain( state ) {
-	return get( state.jetpack.connection.status, [ 'siteConnected', 'sandboxDomain' ], false );
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'sandboxDomain' ], '' );
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -244,7 +244,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
-				'sandboxedDomain' => JETPACK__SANDBOX_DOMAIN,
+				'sandboxDomain' => JETPACK__SANDBOX_DOMAIN,
 			),
 			'connectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -244,6 +244,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
+				'sandboxedDomain' => JETPACK__SANDBOX_DOMAIN,
 			),
 			'connectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This adds a very basic implementation that displays a badge if the `JETPACK__SANDBOX_DOMAIN` constant is in use, hence the API is sandboxed.  I don't think we need translation here. Only a12s will be using this constant anyway. 

It doesn't actually check the health of the sandboxed connection, only if a different URL is being used. 

![screen shot 2018-10-22 at 7 58 29 pm](https://user-images.githubusercontent.com/7129409/47326139-5c014d00-d635-11e8-88b7-acd9a83e9af2.png)

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

*Set `JETPACK__SANDBOX_DOMAIN` to point to your sandbox URL in wp-config.php 
*You should see the badge in all views of the main Jetpack admin 
*You should not expect to see it in any of the headers that are not rendered in React

*Clear the constant - the badge should be gone. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
I think none needed. 