### PR TITLE
Admin page: add site Activity card

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -416,6 +416,14 @@ class PlanBody extends React.Component {
 						}
 
 						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Site Activity' ) }</h3>
+							<p>{ __( 'View a chronological list of all the changes and updates to your site in an organized, readable way.' ) }</p>
+							<Button onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) } href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl } className="is-primary">
+								{ __( 'View your site activity' ) }
+							</Button>
+						</div>
+
+						<div className="jp-landing__plan-features-card">
 							<h3 className="jp-landing__plan-features-title">{ __( 'Enjoy priority support' ) }</h3>
 							<p>{ __( 'We support all Jetpack users, regardless of plan. But customers on a paid subscription enjoy priority support so that security issues are identified and fixed for you as soon as possible.' ) }</p>
 						</div>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -194,6 +194,14 @@ class PlanBody extends React.Component {
 						'is-business-plan' === planClass && getRewindVaultPressCard()
 					}
 
+					<div className="jp-landing__plan-features-card">
+						<h3 className="jp-landing__plan-features-title">{ __( 'Site Activity' ) }</h3>
+						<p>{ __( 'View a chronological list of all the changes and updates to your site in an organized, readable way.' ) }</p>
+						<Button onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) } href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl } className="is-primary">
+							{ __( 'View your site activity' ) }
+						</Button>
+					</div>
+
 					{
 						( 'is-business-plan' === planClass || 'is-premium-plan' === planClass ) &&
 						( 'inactive' !== this.props.getModuleOverride( 'wordads' ) ) && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds an Activity card to the admin page.
* Related discussion: p9rlnk-yi-p2

#### Visuals:

![image](https://user-images.githubusercontent.com/390760/47353323-e2f50a80-d6b3-11e8-9ab0-7e1d32efd405.png)

#### Testing instructions:

* Fire up this PR.
* Go to your admin page: `[site_url]/wp-admin/admin.php?page=jetpack#/plans`.
* Make sure you see the card, and that the button and its tracking are working correctly.

#### Proposed changelog entry for your changes:

* Admin page: adds site Activity card.