### PR TITLE
Gutenberg: update block dependencies for Tiled gallery

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -66,6 +66,7 @@ class Jetpack_Gutenberg {
 			array(
 				'wp-element',
 				'wp-i18n',
+				'wp-token-list',
 			),
 			$version
 		);
@@ -123,6 +124,7 @@ class Jetpack_Gutenberg {
 				'wp-i18n',
 				'wp-keycodes',
 				'wp-plugins',
+				'wp-rich-text',
 				'wp-token-list',
 				'wp-url',
 			),


### PR DESCRIPTION
Tiled gallery relies on `wp-token-list` to be available at the frontend and `wp-rich-text` to be available at the editor.

Tiled Gallery PR on Calypso side (https://github.com/Automattic/wp-calypso/pull/27458) depends on this PR.

#### Testing instructions:

See testing instructions from https://github.com/Automattic/wp-calypso/pull/27458

#### Proposed changelog entry

_No user facing changes._