### PR TITLE
Connection Banner: update with site Activity and site accelerator copy

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -351,7 +351,7 @@ class Jetpack_Connection_Banner {
 						<p>
 							<?php
 							esc_html_e(
-								'Jetpack protects your site against brute force attacks and unauthorized logins. We also monitor your site for downtime and keep your plugins updated. You can view a chronological list of when these changes and updates occurred.',
+								'Jetpack protects your site against brute force attacks and unauthorized logins. We also monitor your site for downtime and keep your plugins updated. You can view a chronological list of these activities.',
 								'jetpack'
 							);
 							?>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -914,7 +914,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							'Earn: Generate revenue with the WordPress.com ad program and accept payment for goods and services via PayPal.',
+							'Optimize: Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers.',
 							'jetpack'
 						);
 					?></p>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -351,7 +351,7 @@ class Jetpack_Connection_Banner {
 						<p>
 							<?php
 							esc_html_e(
-								'Jetpack protects your site against brute force attacks and unauthorized logins. We also monitor your site for downtime and keep your plugins updated.',
+								'Jetpack protects your site against brute force attacks and unauthorized logins. We also monitor your site for downtime and keep your plugins updated. You can view a chronological list of when these changes and updates occurred.',
 								'jetpack'
 							);
 							?>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -449,29 +449,21 @@ class Jetpack_Connection_Banner {
 
 					<!-- slide 4: Performance -->
 					<div class="jp-wpcom-connect__slide jp-wpcom-connect__slide-four">
-						<h2><?php esc_html_e( 'Faster site speeds through the WordPress.com CDN', 'jetpack' ) ?></h2>
+						<h2><?php esc_html_e( 'Faster performance and site speeds', 'jetpack' ); ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'images/cloud-based.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
-									esc_attr_e(
-										'Jetpack automatically optimizes and speeds up images using the global WordPress.com Content Delivery Network (CDN)',
+							<img src="<?php echo esc_url( plugins_url( 'images/cloud-based.svg', JETPACK__PLUGIN_FILE ) ); ?>" alt="<?php
+								esc_attr_e(
+									'Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers.',
 									'jetpack'
-								); ?>" height="auto" width="225" />
+								);
+							?>" height="auto" width="225" />
 						</div>
 
 						<p>
 							<?php
 							esc_html_e(
-								'Jetpack automatically optimizes and speeds up images using the global WordPress.com Content Delivery Network (CDN). Let us do the heavy lifting for you by reducing bandwidth usage which could potentially lower your hosting costs.',
-								'jetpack'
-							);
-							?>
-						</p>
-
-						<p>
-							<?php
-							esc_html_e(
-								'Use of our CDN is unlimited and scales with your site for free. You can also use it for your theme images to further speed up your site.',
+								'Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers. Let us do the heavy lifting for you by reducing bandwidth usage which could potentially lower your hosting costs.',
 								'jetpack'
 							);
 							?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates the full connection banner.

<img width="943" alt="screenshot 2018-10-24 at 9 17 12" src="https://user-images.githubusercontent.com/426388/47413158-d9c87400-d76d-11e8-8faa-96b69ca6f5aa.png">

* Updates the connection banner copy.
* The Site Security tab and the Performance tab now have modified text.

> Jetpack protects your site against brute force attacks and unauthorized logins. We also monitor your site for downtime and keep your plugins updated. **You can view a chronological list of these activities.**

![image](https://user-images.githubusercontent.com/390760/47358157-dd51f180-d6c0-11e8-9dcb-3d91e42895e9.png)

<img width="1294" alt="screenshot 2018-10-24 at 9 13 08" src="https://user-images.githubusercontent.com/426388/47412848-0cbe3800-d76d-11e8-9ab0-b3c629de4a4e.png">


#### Testing instructions:

* Fire up this PR.
* Check the full screen connection banner appearing when you first activate Jetpack; it now includes a new paragraph in the "Marketing & Performance" section.
* Check the pre-connection banner and the Site Security and Performance tabs in particular.

#### Proposed changelog entry for your changes:

* Connection banner: update copy to introduce the site accelerator and the Activity Log features.