### PR TITLE
npm scripts: `clean-client` should clean out css/ too

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
-    "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
+    "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html css/",
     "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn install-if-deps-outdated && yarn build-client",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds `css/` to be cleaned as well as other built directories/files 
- This directory is built by our process, and is not hosted in this repo anyway. 

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

- run `yarn clean-client`: `css/` should be removed
- run `yarn build`: `css/` should be re-built

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
None needed
