### PR TITLE
Update jetpack-blocks to 1.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "1.0.0-alpha.0",
+    "@automattic/jetpack-blocks": "1.0.0-alpha.1",
     "ansi-colors": "^1.0.1",
     "babel-core": "6.8.0",
     "babel-eslint": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-1.0.0-alpha.0.tgz#29bab2d55824ec4a5ef2c30004954c20f7c8293b"
-  integrity sha512-EkaBON9+vJs5xmNPgufRoxY8gHE/AQjs3RselY0dr0WACdnnh3lFiI8+E8s2C9rJkb2WTweIhOYiKUURoJwINA==
+"@automattic/jetpack-blocks@1.0.0-alpha.1":
+  version "1.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-1.0.0-alpha.1.tgz#363794cbfcfcc6f6e3c5d748c3602e1a38f6c7cc"
+  integrity sha512-sfVl65Ow96YGANPvZAFvbMBi+rWWJXaY6FJ2rfbRQIdLs+AUSGYOgAn8cemjBY+n5fs9ppJ5lVbZ/7pGPOi2gg==
 
 "@octokit/rest@^15.5.0":
   version "15.9.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update jetpack-blocks dependency

#### Testing instructions:

gutenpack-jn

Do the included Gutenberg blocks work well?

Test:
- Markdown
- Related posts
- Tiled galleries

Make sure you connect in order to test blocks!