### PR TITLE
Likes: ensure that the Likes column is accessible.

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -418,7 +418,7 @@ class Jetpack_Likes {
 		$date = $columns['date'];
 		unset( $columns['date'] );
 
-		$columns['likes'] = '<span class="vers"><img title="' . esc_attr__( 'Likes', 'jetpack' ) . '" alt="' . esc_attr__( 'Likes', 'jetpack' ) . '" src="//s0.wordpress.com/i/like-grey-icon.png" /></span>';
+		$columns['likes'] = '<span class="vers"><img title="' . esc_attr__( 'Likes', 'jetpack' ) . '" alt="' . esc_attr__( 'Likes', 'jetpack' ) . '" src="//s0.wordpress.com/i/like-grey-icon.png" /><span class="screen-reader-text">' . __( 'Likes', 'jetpack' ) . '</span></span>';
 		$columns['date'] = $date;
 
 		return $columns;


### PR DESCRIPTION
Fixes #10382

#### Changes proposed in this Pull Request:
 
- This will help folks know what the column is about when using a screen reader.
- This will also allow "Likes" to appear as the column name in the "Screen options" tab.

#### Testing instructions:

0. Start on a site where the Likes module is active.
1. Go to `Posts` -> `All Posts`
2. Click on `Screen Options`
3. Look at the `Columns` row
4. Label for the Likes column should appear.

**Before**

<img width="1567" alt="screen shot 2018-10-23 at 4 56 06 pm" src="https://user-images.githubusercontent.com/2846578/47390263-f1a7e580-d6e4-11e8-85ad-09c5c2991964.png">

**After**

<img width="912" alt="screenshot 2018-10-24 at 12 19 40" src="https://user-images.githubusercontent.com/426388/47424093-1d7ba780-d787-11e8-8e18-d6083d1dc896.png">

#### Proposed changelog entry for your changes:
* Likes: ensure that the Likes column is accessible.
