### PR TITLE
Search Widget: Set default value to avoid undefined index warnings

### DIFF
--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -246,6 +246,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 				'user_sort_enabled'  => true,
 				'sort'               => self::DEFAULT_SORT,
 				'filters'            => array( array() ),
+				'post_types'         => array(),
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Sets a default for the `post_type` index to avoid a undefined index warning. As seen on a customer's site.

This occurred because the widget originally did not set a post_types value, but was added later, some widget instances exist in the wild without it. When parsing the widget args, a default isn't defined and a theme helper function uses it without checking for existence. 

By adding it as a default, it provides this value in all cases, including older widget instances.

#### Testing instructions:
* Jetpack site running 5.7 (before #8471), with a plan that supports search.
* Activate Search and add a widget.
* Update to latest Jetpack
* Open the page with the widget, see the warning in the log.
