### PR TITLE
Include 'mobile_browser' param when requesting JITMs. This will allow mobile targeted messages

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -256,6 +256,7 @@ class Jetpack_JITM {
 		$path = add_query_arg( array(
 			'external_user_id' => urlencode_deep( $user->ID ),
 			'query_string'     => urlencode_deep( $query ),
+			'mobile_browser'   => jetpack_is_mobile( 'smart' ) ? 1 : 0,
 		), sprintf( '/sites/%d/jitm/%s', $site_id, $message_path ) );
 
 		// attempt to get from cache


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We would like to introduce Just in Time Messages (JITMs) that encourage users to download the WordPress mobile apps. These JITMs should only be delivered on mobile devices. Currently, the API has no awareness of the user agent or any other way of knowing what browser is used.

This PR adds a param `mobile_browser`  to the query string when requesting JITMs from the API. It indicates if the request is coming from a mobile browser.

@withinboredom do you think this is an appropriate way to pass this context to the API? We could pass the full UA, but that may be excessive.

#### Testing instructions:

Follow these steps on a desktop browser and a mobile device (such as the iOS Simulator):

* Go to wp-admin
* Observe API requests from Jetpack to `/jitm` in the the API.
* Mobile requests will have `?mobile_browser=1` and desktop requests will have `?mobile_browser=0`.

#### Proposed changelog entry for your changes:

I don't think a changelog entry is needed for this.
