### PR TITLE
Add method to disable Gutenberg on specific post types in Calypsoify

### DIFF
--- a/modules/class.jetpack-calypsoify.php
+++ b/modules/class.jetpack-calypsoify.php
@@ -182,6 +182,21 @@ class Jetpack_Calypsoify {
 		}
 	}
 
+	/**
+	 * Return whether a post type should display the Gutenberg/block editor.
+	 *
+	 * @since 6.7.0
+	 */
+	public function is_post_type_gutenberg( $post_type ) {
+		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+			return use_block_editor_for_post_type( $post_type );
+		} else {
+			// We use the filter introduced in WordPress 5.0 to be backwards compatible.
+			/** This filter is already documented in core/wp-admin/includes/post.php */
+			return apply_filters( 'use_block_editor_for_post_type', true, $post_type );
+		}
+	}
+
 	public function is_page_gutenberg() {
 		if ( ! Jetpack_Gutenberg::is_gutenberg_available() ) {
 			return false;
@@ -189,28 +204,17 @@ class Jetpack_Calypsoify {
 
 		$page = wp_basename( esc_url( $_SERVER['REQUEST_URI'] ) );
 
-		/**
-		 * Allow third-party plugins to register support for their post types in the full-screen Calypsoify gutenberg mode.
-		 *
-		 * @module calypsoify
-		 *
-		 * @since 6.7.0
-		 *
-		 * @param array $post_types Allowed post types.
-		 */
-		$allowed_gutenberg_post_types = apply_filters( 'jetpack_calypsoify_allowed_gutenberg_post_types', array( 'post', 'page' ) );
-
 		if ( false !== strpos( $page, 'post-new.php' ) && empty ( $_GET['post_type'] ) ) {
 			return true;
 		}
 
-		if ( false !== strpos( $page, 'post-new.php' ) && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $allowed_gutenberg_post_types ) ) {
+		if ( false !== strpos( $page, 'post-new.php' ) && isset( $_GET['post_type'] ) && $this->is_post_type_gutenberg( $_GET['post_type'] ) ) {
 			return true;
 		}
 
 		if ( false !== strpos( $page, 'post.php' ) ) {
 			$post = get_post( $_GET['post'] );
-			if ( isset( $post ) && isset( $post->post_type ) && in_array( $post->post_type, $allowed_gutenberg_post_types ) ) {
+			if ( isset( $post ) && isset( $post->post_type ) && $this->is_post_type_gutenberg( $post->post_type ) ) {
 				return true;
 			}
 		}
@@ -218,7 +222,7 @@ class Jetpack_Calypsoify {
 		if ( false !== strpos( $page, 'revision.php' ) ) {
 			$post   = get_post( $_GET['revision'] );
 			$parent = get_post( $post->post_parent );
-			if ( isset( $parent ) && isset( $parent->post_type ) && in_array( $parent->post_type, $allowed_gutenberg_post_types ) ) {
+			if ( isset( $parent ) && isset( $parent->post_type ) && $this->is_post_type_gutenberg( $parent->post_type ) ) {
 				return true;
 			}
 		}

--- a/modules/class.jetpack-calypsoify.php
+++ b/modules/class.jetpack-calypsoify.php
@@ -188,6 +188,7 @@ class Jetpack_Calypsoify {
 	 * @since 6.7.0
 	 */
 	public function is_post_type_gutenberg( $post_type ) {
+		// @TODO: Remove function check once 5.0 is the minimum supported WP version.
 		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
 			return use_block_editor_for_post_type( $post_type );
 		} else {


### PR DESCRIPTION
Right now, the Calypsoify module will put any `post-new.php` or `post.php` page into full-page/distraction free mode if Gutenberg is installed on a site. This can break navigation for custom post types like WooCommerce products, orders, coupons, etc.

In this PR, I propose whitelisting the mode for certain post types (post and page to start out with) and offer a filter.

We need this as a part of the work we are doing for p90Yrv-Pk-p2, so please let me know if we can't get this fix in for 6.7 and I can investigate an alternative fix from our side.

It also seems like there is a fatal in master right now, because `is_gutenberg_available` is a `Jetpack_Gutenberg` function, not a `Jetpack` function.

<img width="1282" alt="screen shot 2018-10-24 at 12 25 03 pm" src="https://user-images.githubusercontent.com/689165/47445862-ebb71080-d787-11e8-8416-60fc7c2895f2.png">

Testing instructions:

* Add the following bit of test code to disable Gutenberg for coupons, orders, and products:
```
<?php
function test_disable_gutenberg_for_post_type( $current_value, $post_type ) {
	$wc_post_types = array( 'shop_coupon', 'shop_order', 'product' );
	if ( in_array( $post_type, $wc_post_types ) ) {
		return false;
	}
	return $current_value;
}
add_filter( 'use_block_editor_for_post_type', 'test_disable_gutenberg_for_post_type', 10, 2 );
```
* Visit `/wp-admin/plugins.php?calypsoify=1` to see the new skin
* Test on a normal post (add and edit) and verify the full screen take over happens
* Test on a normal page (add and edit) and verify the full screen take over happens
* Test on a WooCommerce product (add and edit) and verify the sidebar shows