### PR TITLE
i18n extractor: extract strings from Gutenberg Blocks.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -252,7 +252,11 @@ gulp.task( 'languages:cleanup', function( done ) {
 gulp.task( 'languages:extract', function( done ) {
 	const paths = [];
 
-	gulp.src( [ '_inc/client/**/*.js', '_inc/client/**/*.jsx' ] )
+	gulp.src( [
+		'_inc/client/**/*.js',
+		'_inc/client/**/*.jsx',
+		'_inc/blocks/*.js'
+	] )
 		.pipe( tap( function( file ) {
 			paths.push( file.path );
 		} ) )

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -268,7 +268,7 @@ gulp.task( 'languages:extract', function( done ) {
 				phpArrayName: 'jetpack_strings',
 				format: 'PHP',
 				textdomain: 'jetpack',
-				keywords: [ 'translate', '__' ]
+				keywords: [ 'translate', '__', '_n', '_x', '_nx' ]
 			} );
 
 			done();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This changes the `gulp languages:extract` task so it can get the strings from any .js files in the `_inc/blocks` directory. This is currently where we place the Gutenberg Block files generated by the SDK.

In addition, the task now searches for `_n()`, `_x()` and `_nx()`, so we can account for any `@wordpress/i18n` localization function.

#### Testing instructions:

* Checkout the following Calypso branch: `remove/gutenberg-jetpack-textdomain` - ([Calypso PR](https://github.com/Automattic/wp-calypso/pull/28088))
* Run the following command while in the Calypso root dir:

```
NODE_ENV=production npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- \
--output-dir=/DIR_TO_JETPACK/_inc/blocks \
--watch
```

where `DIR_TO_JETPACK` is the directory to your local Jetpack repo.

* Switch to this branch in Jetpack.
* Make sure you have `gulp` globally installed.
* Run `gulp languages:extract`
* Verify `_inc/jetpack-strings.php` contains new strings, coming from any of the .js block files (towards the end of the file).
* Start a post.
* Insert some of our Jetpack blocks, verify they're properly translated.
  * To test this, change the Markdown block title to "Settings" and re-run the above Calypso command. "Settings" is a valid string that's already used by Jetpack and it's translated in many of the locales.

#### Proposed changelog entry for your changes:
* None.
