### PR TITLE
Admin page: fix Activity card title

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -195,7 +195,7 @@ class PlanBody extends React.Component {
 					}
 
 					<div className="jp-landing__plan-features-card">
-						<h3 className="jp-landing__plan-features-title">{ __( 'Site Activity' ) }</h3>
+						<h3 className="jp-landing__plan-features-title">{ __( 'Activity' ) }</h3>
 						<p>{ __( 'View a chronological list of all the changes and updates to your site in an organized, readable way.' ) }</p>
 						<Button onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) } href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl } className="is-primary">
 							{ __( 'View your site activity' ) }
@@ -416,7 +416,7 @@ class PlanBody extends React.Component {
 						}
 
 						<div className="jp-landing__plan-features-card">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Site Activity' ) }</h3>
+							<h3 className="jp-landing__plan-features-title">{ __( 'Activity' ) }</h3>
 							<p>{ __( 'View a chronological list of all the changes and updates to your site in an organized, readable way.' ) }</p>
 							<Button onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) } href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl } className="is-primary">
 								{ __( 'View your site activity' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix the Activity card title on the admin page to be consistent with the latest version of its Calypso counterpart.
* `Site Activity` should now read `Activity`.
* See: https://github.com/Automattic/wp-calypso/pull/28009

#### References

* Previous PR where the card was added: https://github.com/Automattic/jetpack/pull/10374
* Related discussion: p9rlnk-yi-p2

#### Testing instructions:

* Fire up this PR.
* Go to your admin page: `[site_url]/wp-admin/admin.php?page=jetpack#/plans`.
* Look for the Activity card and make sure the title is `Activity`.

#### Proposed changelog entry for your changes:

* Admin page: fixes title in site Activity card.