### PR TITLE
Connection Banners: update wording for Site Accelerator.

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -454,7 +454,7 @@ class Jetpack_Connection_Banner {
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
 							<img src="<?php echo esc_url( plugins_url( 'images/cloud-based.svg', JETPACK__PLUGIN_FILE ) ); ?>" alt="<?php
 								esc_attr_e(
-									'Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers.',
+									'Activate Jetpack’s site accelerator to load pages faster, optimize your images, and serve your images and static files (like CSS and JavaScript) from our global network of servers. You’ll also reduce bandwidth usage, which may lead to lower hosting costs.',
 									'jetpack'
 								);
 							?>" height="auto" width="225" />
@@ -463,7 +463,7 @@ class Jetpack_Connection_Banner {
 						<p>
 							<?php
 							esc_html_e(
-								'Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers. Let us do the heavy lifting for you by reducing bandwidth usage which could potentially lower your hosting costs.',
+								'Activate Jetpack’s site accelerator to load pages faster, optimize your images, and serve your images and static files (like CSS and JavaScript) from our global network of servers. You’ll also reduce bandwidth usage, which may lead to lower hosting costs.',
 								'jetpack'
 							);
 							?>
@@ -914,7 +914,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							'Optimize: Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers.',
+							'Optimize: activate Jetpack’s site accelerator to load pages faster, optimize your images, and serve your images and static files (like CSS and JavaScript) from our global network of servers. You’ll also reduce bandwidth usage, which may lead to lower hosting costs.',
 							'jetpack'
 						);
 					?></p>


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Update the wording on the new messages introduced in #10377, as per feedback on p6TEKc-2mI-p2.

#### Testing instructions:

* Fire up this PR.
* Check the full screen connection banner appearing when you first activate Jetpack; it now includes a new paragraph in the "Marketing & Performance" section.
* Check the pre-connection banner and the Site Security and Performance tabs in particular.

#### Proposed changelog entry for your changes:

* None
