### PR TITLE
Decouple Publicize Connection Lists from UI Take 2

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -391,7 +391,7 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	public function is_post_done_sharing( $post_id = null ) {
+	public function post_is_done_sharing( $post_id = null ) {
 		// Defaults to current post if $post_id is null.
 		$post = get_post( $post_id );
 		if ( is_null( $post ) ) {

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -391,7 +391,7 @@ class Publicize extends Publicize_Base {
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	public function done_sharing_post( $post_id = null ) {
+	public function is_post_done_sharing( $post_id = null ) {
 		// Defaults to current post if $post_id is null.
 		$post = get_post( $post_id );
 		if ( is_null( $post ) ) {

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -379,6 +379,29 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
+	 * Checks if post has already been shared by Publicize in the past.
+	 *
+	 * Jetpack uses two methods:
+	 * 1. A POST_DONE . 'all' postmeta flag, or
+	 * 2. if the post has already been published.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
+	 *
+	 * @return bool True if post has already been shared by Publicize, false otherwise.
+	 */
+	public function done_sharing_post( $post_id = null ) {
+		// Defaults to current post if $post_id is null.
+		$post = get_post( $post_id );
+		if ( is_null( $post ) ) {
+			return false;
+		}
+
+		return 'publish' == $post->post_status || get_post_meta( $post->ID, $this->POST_DONE . 'all', true );
+	}
+
+	/**
 	 * Save a flag locally to indicate that this post has already been Publicized via the selected
 	 * connections.
 	 */

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -548,7 +548,7 @@ abstract class Publicize_Base {
 		}
 
 		$services = $this->get_services( 'connected' );
-		$all_done = $this->done_sharing_post( $post_id );
+		$all_done = $this->is_post_done_sharing( $post_id );
 
 		// We don't allow Publicizing to the same external id twice, to prevent spam.
 		$service_id_done = (array) get_post_meta( $post_id, $this->POST_SERVICE_DONE, true );
@@ -681,7 +681,7 @@ abstract class Publicize_Base {
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	abstract public function done_sharing_post( $post_id = null );
+	abstract public function is_post_done_sharing( $post_id = null );
 
 	/**
 	 * Retrieves full list of available Publicize connection services.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -684,26 +684,13 @@ abstract class Publicize_Base {
 	/**
 	 * Checks if post has already been shared by Publicize in the past.
 	 *
-	 * We can set an _all flag to indicate that this post is completely done as
-	 * far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
-	 * have Publicize disabled.
-	 *
 	 * @since 6.7.0
-	 *
-	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
 	 *
 	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	public function done_sharing_post( $post_id = null ) {
-		global $publicize_ui;
-		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
-		if ( is_null( $post ) ) {
-			return false;
-		}
-		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $publicize_ui->in_jetpack && 'publish' == $post->post_status );
-	}
+	abstract public function done_sharing_post( $post_id = null );
 
 	/**
 	 * Retrieves full list of available Publicize connection services.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -526,13 +526,14 @@ abstract class Publicize_Base {
 	 * @return array {
 	 *     Array of UI setup data for connection list form.
 	 *
-	 *     @type string 'unique_id'    ID string representing connection
-	 *     @type string 'service_name' Slug of the connection's service (facebook, twitter, ...)
-	 *     @type string 'label'        Service Label and Connection's Username: "Twitter: @jetpack"
-	 *     @type bool   'enabled'      Default value for the connection (e.g., for a checkbox).
-	 *     @type bool   'done'         Has this connection already been publicized to?
-	 *     @type bool   'toggleable'   Is the user allowed to change the value for the connection?
-	 *     @type bool   'global'       Is this connection a global one?
+	 *     @type string 'unique_id'     ID string representing connection
+	 *     @type string 'service_name'  Slug of the connection's service (facebook, twitter, ...)
+	 *     @type string 'service_label' Service Label (Facebook, Twitter, ...)
+	 *     @type string 'display_name'  Connection's human-readable Username: "@jetpack"
+	 *     @type bool   'enabled'       Default value for the connection (e.g., for a checkbox).
+	 *     @type bool   'done'          Has this connection already been publicized to?
+	 *     @type bool   'toggleable'    Is the user allowed to change the value for the connection?
+	 *     @type bool   'global'        Is this connection a global one?
 	 * }
 	 */
 	public function get_filtered_connection_data( $selected_post_id = null ) {
@@ -654,17 +655,11 @@ abstract class Publicize_Base {
 					$enabled = true;
 				}
 
-				$label  = sprintf(
-					/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Username on Service (@jetpack, ...) */
-					__( '%1$s: %2$s', 'jetpack' ),
-					$this->get_service_label( $service_name ),
-					$this->get_display_name( $service_name, $connection )
-				);
-
 				$connection_list[] = array(
-					'unique_id'    => $unique_id,
-					'service_name' => $service_name,
-					'label'        => $label,
+					'unique_id'     => $unique_id,
+					'service_name'  => $service_name,
+					'service_label' => $this->get_service_label( $service_name ),
+					'display_name'  => $this->get_display_name( $service_name, $connection ),
 
 					'enabled'      => $enabled,
 					'done'         => $done,

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -533,7 +533,6 @@ abstract class Publicize_Base {
 	 *     @type bool   'done'         Has this connection already been publicized to?
 	 *     @type bool   'toggleable'   Is the user allowed to change the value for the connection?
 	 *     @type bool   'global'       Is this connection a global one?
-	 *     @type bool   'visible'      Should the connection be shown to the user?
 	 * }
 	 */
 	public function get_filtered_connection_data( $selected_post_id = null ) {
@@ -632,10 +631,8 @@ abstract class Publicize_Base {
 				 * If this is a global connection and this user doesn't have enough permissions to modify
 				 * those connections, don't let them change it.
 				 */
-				$visible = true;
 				if ( ! $done && ( 0 == $connection_data['user_id'] && ! current_user_can( $this->GLOBAL_CAP ) ) ) {
 					$toggleable = false;
-					$visible = false;
 
 					/**
 					 * Filters the checkboxes for global connections with non-prilvedged users.
@@ -649,7 +646,7 @@ abstract class Publicize_Base {
 					 * @param string $service_name Name of the connection (Facebook, Twitter, etc)
 					 * @param array  $connection Array of data about the connection.
 					 */
-					$enabled = apply_filters( 'publicize_checkbox_global_default', true, $post_id, $service_name, $connection );
+					$enabled = apply_filters( 'publicize_checkbox_global_default', $enabled, $post_id, $service_name, $connection );
 				}
 
 				// Force the checkbox to be checked if the post was DONE, regardless of what the filter does.
@@ -673,7 +670,6 @@ abstract class Publicize_Base {
 					'done'         => $done,
 					'toggleable'   => $toggleable,
 					'global'       => 0 == $connection_data['user_id'],
-					'visible'      => $visible,
 				);
 			}
 		}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -510,6 +510,232 @@ abstract class Publicize_Base {
 	 */
 	abstract function test_connection( $service_name, $connection );
 
+	/**
+	 * Retrieves current list of connections and applies filters.
+	 *
+	 * Retrieves current available connections and checks if the connections
+	 * have already been used to share current post. Finally, the checkbox
+	 * form UI fields are calculated. This function exposes connection form
+	 * data directly as array so it can be retrieved for static HTML generation
+	 * or JSON consumption.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param integer $selected_post_id Optional. Post ID to query connection status for.
+	 *
+	 * @return array {
+	 *     Array of UI setup data for connection list form.
+	 *
+	 *     @type string 'unique_id'    ID string representing connection
+	 *     @type string 'service_name' Slug of the connection's service (facebook, twitter, ...)
+	 *     @type string 'label'        Service Label and Connection's Username: "Twitter: @jetpack"
+	 *     @type bool   'enabled'      Default value for the connection (e.g., for a checkbox).
+	 *     @type bool   'done'         Has this connection already been publicized to?
+	 *     @type bool   'toggleable'   Is the user allowed to change the value for the connection?
+	 *     @type bool   'global'       Is this connection a global one?
+	 *     @type bool   'visible'      Should the connection be shown to the user?
+	 * }
+	 */
+	public function get_filtered_connection_data( $selected_post_id = null ) {
+		$connection_list = array();
+
+		$post = get_post( $selected_post_id ); // Defaults to current post if $post_id is null.
+		// Handle case where there is no current post.
+		if ( ! empty( $post ) ) {
+			$post_id = $post->ID;
+		} else {
+			$post_id = null;
+		}
+
+		$services = $this->get_services( 'connected' );
+		$all_done = $this->done_sharing_post( $post_id );
+
+		// We don't allow Publicizing to the same external id twice, to prevent spam.
+		$service_id_done = (array) get_post_meta( $post_id, $this->POST_SERVICE_DONE, true );
+
+		foreach ( $services as $service_name => $connections ) {
+			foreach ( $connections as $connection ) {
+				$connection_meta = $this->get_connection_meta( $connection );
+				$connection_data = $connection_meta['connection_data'];
+
+				$unique_id = $this->get_connection_unique_id( $connection );
+
+
+				// Was this connection (OR, old-format service) already Publicized to?
+				$done = ! empty( $post ) && (
+					// New flags
+					1 == get_post_meta( $post->ID, $this->POST_DONE . $unique_id, true )
+					||
+					// old flags
+					1 == get_post_meta( $post->ID, $this->POST_DONE . $service_name, true )
+				);
+
+				/**
+				 * Filter whether a post should be publicized to a given service.
+				 *
+				 * @module publicize
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param bool true Should the post be publicized to a given service? Default to true.
+				 * @param int $post_id Post ID.
+				 * @param string $service_name Service name.
+				 * @param array $connection_data Array of information about all Publicize details for the site.
+				 */
+				if ( ! apply_filters( 'wpas_submit_post?', true, $post_id, $service_name, $connection_data ) ) {
+					continue;
+				}
+
+				// Should we be skipping this one?
+				$skip = (
+					(
+						! empty( $post )
+						&&
+						in_array( $post->post_status, array( 'publish', 'draft', 'future' ) )
+						&&
+						(
+							// New flags
+							get_post_meta( $post_id, $this->POST_SKIP . $unique_id, true )
+							||
+							// Old flags
+							get_post_meta( $post->ID, $this->POST_SKIP . $service_name )
+						)
+					)
+					||
+					(
+						is_array( $connection )
+						&&
+						isset( $connection_meta['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection_meta['external_id'] ] )
+					)
+				);
+
+				// If this one has already been publicized to, don't let it happen again.
+				$toggleable = ! $done && ! $all_done;
+
+				// Determine the state of the checkbox (on/off) and allow filtering.
+				$enabled = $done || ! $skip;
+				/**
+				 * Filter the checkbox state of each Publicize connection appearing in the post editor.
+				 *
+				 * @module publicize
+				 *
+				 * @since 2.0.1
+				 *
+				 * @param bool $enabled Should the Publicize checkbox be enabled for a given service.
+				 * @param int $post_id Post ID.
+				 * @param string $service_name Service name.
+				 * @param array $connection Array of connection details.
+				 */
+				$enabled = apply_filters( 'publicize_checkbox_default', $enabled, $post_id, $service_name, $connection );
+
+				/**
+				 * If this is a global connection and this user doesn't have enough permissions to modify
+				 * those connections, don't let them change it.
+				 */
+				$visible = true;
+				if ( ! $done && ( 0 == $connection_data['user_id'] && ! current_user_can( $this->GLOBAL_CAP ) ) ) {
+					$toggleable = false;
+					$visible = false;
+
+					/**
+					 * Filters the checkboxes for global connections with non-prilvedged users.
+					 *
+					 * @module publicize
+					 *
+					 * @since 3.7.0
+					 *
+					 * @param bool   $enabled Indicates if this connection should be enabled. Default true.
+					 * @param int    $post_id ID of the current post
+					 * @param string $service_name Name of the connection (Facebook, Twitter, etc)
+					 * @param array  $connection Array of data about the connection.
+					 */
+					$enabled = apply_filters( 'publicize_checkbox_global_default', true, $post_id, $service_name, $connection );
+				}
+
+				// Force the checkbox to be checked if the post was DONE, regardless of what the filter does.
+				if ( $done ) {
+					$enabled = true;
+				}
+
+				$label  = sprintf(
+					/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Username on Service (@jetpack, ...) */
+					__( '%1$s: %2$s', 'jetpack' ),
+					$this->get_service_label( $service_name ),
+					$this->get_display_name( $service_name, $connection )
+				);
+
+				$connection_list[] = array(
+					'unique_id'    => $unique_id,
+					'service_name' => $service_name,
+					'label'        => $label,
+
+					'enabled'      => $enabled,
+					'done'         => $done,
+					'toggleable'   => $toggleable,
+					'global'       => 0 == $connection_data['user_id'],
+					'visible'      => $visible,
+				);
+			}
+		}
+
+		return $connection_list;
+	}
+
+	/**
+	 * Checks if post has already been shared by Publicize in the past.
+	 *
+	 * We can set an _all flag to indicate that this post is completely done as
+	 * far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
+	 * have Publicize disabled.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
+	 *
+	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
+	 *
+	 * @return bool True if post has already been shared by Publicize, false otherwise.
+	 */
+	public function done_sharing_post( $post_id = null ) {
+		global $publicize_ui;
+		$post = get_post( $post_id ); // Defaults to current post if $post_id is null.
+		if ( is_null( $post ) ) {
+			return false;
+		}
+		return get_post_meta( $post->ID, $this->POST_DONE . 'all', true ) || ( $publicize_ui->in_jetpack && 'publish' == $post->post_status );
+	}
+
+	/**
+	 * Retrieves full list of available Publicize connection services.
+	 *
+	 * Retrieves current available publicize service connections
+	 * with associated labels and URLs.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return array {
+	 *     Array of UI service connection data for all services
+	 *
+	 *     @type string 'name'  Name of service.
+	 *     @type string 'label' Display label for service.
+	 *     @type string 'url'   URL for adding connection to service.
+	 * }
+	 */
+	function get_available_service_data() {
+		$available_services     = $this->get_services( 'all' );
+		$available_service_data = array();
+
+		foreach ( $available_services as $service_name => $service ) {
+			$available_service_data[] = array(
+				'name'  => $service_name,
+				'label' => $this->get_service_label( $service_name ),
+				'url'   => $this->connect_url( $service_name ),
+			);
+		}
+
+		return $available_service_data;
+	}
+
 /*
  * Site Data
  */

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -548,7 +548,7 @@ abstract class Publicize_Base {
 		}
 
 		$services = $this->get_services( 'connected' );
-		$all_done = $this->is_post_done_sharing( $post_id );
+		$all_done = $this->post_is_done_sharing( $post_id );
 
 		// We don't allow Publicizing to the same external id twice, to prevent spam.
 		$service_id_done = (array) get_post_meta( $post_id, $this->POST_SERVICE_DONE, true );
@@ -681,7 +681,7 @@ abstract class Publicize_Base {
 	 *
 	 * @return bool True if post has already been shared by Publicize, false otherwise.
 	 */
-	abstract public function is_post_done_sharing( $post_id = null );
+	abstract public function post_is_done_sharing( $post_id = null );
 
 	/**
 	 * Retrieves full list of available Publicize connection services.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -595,7 +595,7 @@ abstract class Publicize_Base {
 						&&
 						(
 							// New flags
-							get_post_meta( $post_id, $this->POST_SKIP . $unique_id, true )
+							get_post_meta( $post->ID, $this->POST_SKIP . $unique_id, true )
 							||
 							// Old flags
 							get_post_meta( $post->ID, $this->POST_SKIP . $service_name )

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -519,7 +519,7 @@ abstract class Publicize_Base {
 	 * data directly as array so it can be retrieved for static HTML generation
 	 * or JSON consumption.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 *
 	 * @param integer $selected_post_id Optional. Post ID to query connection status for.
 	 *
@@ -688,7 +688,7 @@ abstract class Publicize_Base {
 	 * far as Publicize is concerned. Jetpack uses this approach. All published posts in Jetpack
 	 * have Publicize disabled.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 *
 	 * @global Publicize_UI $publicize_ui UI instance that contains the 'in_jetpack' property
 	 *
@@ -711,7 +711,7 @@ abstract class Publicize_Base {
 	 * Retrieves current available publicize service connections
 	 * with associated labels and URLs.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 *
 	 * @return array {
 	 *     Array of UI service connection data for all services

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -626,6 +626,20 @@ jQuery( function($) {
 	}
 
 	/**
+	 * @param string $service_label Service's human-readable Label ("Facebook", "Twitter", ...)
+	 * @param string $display_name Connection's human-readable Username ("@jetpack", ...)
+	 * @return string
+	 */
+	private function connection_label( $service_label, $display_name ) {
+		return sprintf(
+			/* translators: %1$s: Service Name (Facebook, Twitter, ...), %2$s: Username on Service (@jetpack, ...) */
+			__( '%1$s: %2$s', 'jetpack' ),
+			$service_label,
+			$display_name
+		);
+	}
+
+	/**
 	* Controls the metabox that is displayed on the post page
 	* Allows the user to customize the message that will be sent out to the social network, as well as pick which
 	* networks to publish to. Also displays the character counter and some other information.
@@ -661,7 +675,10 @@ jQuery( function($) {
 							continue;
 						}
 
-						$labels[] = sprintf( '<strong>%s</strong>', esc_html( $connection_data['label'] ) );
+						$labels[] = sprintf(
+							'<strong>%s</strong>',
+							esc_html( $this->connection_label( $connection_data['service_label'], $connection_data['display_name'] ) )
+						);
 					}
 
 				?>
@@ -753,7 +770,7 @@ jQuery( function($) {
 						/>
 					<?php endif; ?>
 
-						<?php echo esc_html( $connection_data['label'] ); ?>
+						<?php echo esc_html( $this->connection_label( $connection_data['service_label'], $connection_data['display_name'] ) ); ?>
 
 					</label>
 				</li>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -649,20 +649,36 @@ jQuery( function($) {
 		?>
 		<div id="publicize" class="misc-pub-section misc-pub-section-last">
 			<span id="publicize-title">
-				<?php esc_html_e( 'Publicize:', 'jetpack' ); ?>
-				<?php if ( 0 < count( $connections_data ) ) : ?>
-					<?php $publicize_form = $this->get_metabox_form_connected( $connections_data ); ?>
-					<span id="publicize-defaults">
-					<?php foreach ( $connections_data as $connection_data ) : if ( $connection_data['enabled'] ) : ?>
-						<strong><?php echo esc_html( $connection_data['label'] ); ?></strong>
-					<?php endif; endforeach; ?>
-					</span>
+			<?php
+				esc_html_e( 'Publicize:', 'jetpack' );
+
+				if ( 0 < count( $connections_data ) ) :
+					$publicize_form = $this->get_metabox_form_connected( $connections_data );
+
+					$labels = array();
+					foreach ( $connections_data as $connection_data ) {
+						if ( ! $connection_data['enabled'] ) {
+							continue;
+						}
+
+						$labels[] = sprintf( '<strong>%s</strong>', esc_html( $connection_data['label'] ) );
+					}
+
+				?>
+					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
 					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
-				<?php else : ?>
-					<?php $publicize_form = $this->get_metabox_form_disconnected( $available_services ); ?>
+				<?php
+
+				else :
+					$publicize_form = $this->get_metabox_form_disconnected( $available_services );
+
+				?>
 					<strong><?php echo __( 'Not Connected', 'jetpack' ); ?></strong>
 					<a href="#" id="publicize-disconnected-form-show"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a><br />
-				<?php endif; ?>
+				<?php
+
+				endif;
+			?>
 			</span>
 			<?php
 			/**

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -734,7 +734,6 @@ jQuery( function($) {
 
 				<li>
 					<label for="wpas-submit-<?php echo esc_attr( $connection_data['unique_id'] ); ?>">
-					<?php if ( $connection_data['visible'] ) : ?>
 						<input
 							type="checkbox"
 							name="wpas[submit][<?php echo esc_attr( $connection_data['unique_id'] ); ?>]"
@@ -746,7 +745,7 @@ jQuery( function($) {
 							disabled( false, $connection_data['toggleable'] );
 						?>
 						/>
-					<?php else : // Need to submit a value to force a global connection to post ?>
+					<?php if ( $connection_data['enabled'] && ! $connection_data['toggleable'] ) : // Need to submit a value to force a global connection to POST ?>
 						<input
 							type="hidden"
 							name="wpas[submit][<?php echo esc_attr( $connection_data['unique_id'] ); ?>]"

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -644,8 +644,8 @@ jQuery( function($) {
 		if ( ! is_array( $available_services ) )
 			$available_services = array();
 
-		if ( ! is_array( $services ) )
-			$services = array();
+		if ( ! is_array( $connections_data ) )
+			$connections_data = array();
 		?>
 		<div id="publicize" class="misc-pub-section misc-pub-section-last">
 			<span id="publicize-title">

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -735,7 +735,7 @@ jQuery( function($) {
 	private function get_metabox_form_connected( $connections_data ) {
 		global $post;
 
-		$all_done = $this->publicize->is_post_done_sharing();
+		$all_done = $this->publicize->post_is_done_sharing();
 		$all_connections_done = true;
 
 		ob_start();

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -735,7 +735,7 @@ jQuery( function($) {
 	private function get_metabox_form_connected( $connections_data ) {
 		global $post;
 
-		$all_done = $this->publicize->done_sharing_post();
+		$all_done = $this->publicize->is_post_done_sharing();
 		$all_connections_done = true;
 
 		ob_start();

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -244,17 +244,17 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * the helper method that checks post flags to prevent re-sharing
 	 * of already shared post.
 	 *
-	 * @covers Publicize::done_sharing_post()
+	 * @covers Publicize::is_post_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_done_sharing_post_for_done_all() {
+	public function test_is_post_done_sharing_for_done_all() {
 		$this->assertFalse(
-			$this->publicize->done_sharing_post( $this->post->ID ),
+			$this->publicize->is_post_done_sharing( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 		update_post_meta( $this->post->ID, $this->publicize->POST_DONE . 'all', true );
 		$this->assertTrue(
-			$this->publicize->done_sharing_post( $this->post->ID ),
+			$this->publicize->is_post_done_sharing( $this->post->ID ),
 			'Posts flagged as \'done\' should return true done sharing'
 		);
 	}
@@ -263,12 +263,12 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that "done sharing post" logic is correct. Checks
 	 * that already published post is correctly reported as 'done'.
 	 *
-	 * @covers Publicize::done_sharing_post()
+	 * @covers Publicize::is_post_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_done_sharing_post_for_published() {
+	public function test_is_post_done_sharing_for_published() {
 		$this->assertFalse(
-			$this->publicize->done_sharing_post( $this->post->ID ),
+			$this->publicize->is_post_done_sharing( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 
@@ -277,7 +277,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		wp_insert_post( $this->post->to_array() );
 
 		$this->assertTrue(
-			$this->publicize->done_sharing_post( $this->post->ID ),
+			$this->publicize->is_post_done_sharing( $this->post->ID ),
 			'Published post should be flagged as \'done\''
 		);
 	}
@@ -346,15 +346,15 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * no current post. 'Done' return value should be false
 	 * so a new post will not have connections disabled.
 	 *
-	 * @covers Publicize::done_sharing_post()
+	 * @covers Publicize::is_post_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_done_sharing_post_null_post() {
+	public function test_is_post_done_sharing_null_post() {
 		/**
 		 * Simulate null post by not providing post_id argument and
 		 * when current $post value is unset.
 		 */
-		$done_sharing = $this->publicize->done_sharing_post();
+		$done_sharing = $this->publicize->is_post_done_sharing();
 		$this->assertFalse(
 			$done_sharing,
 			'Done sharing value should be false for null post id'

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -244,17 +244,17 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * the helper method that checks post flags to prevent re-sharing
 	 * of already shared post.
 	 *
-	 * @covers Publicize::is_post_done_sharing()
+	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_is_post_done_sharing_for_done_all() {
+	public function test_post_is_done_sharing_for_done_all() {
 		$this->assertFalse(
-			$this->publicize->is_post_done_sharing( $this->post->ID ),
+			$this->publicize->post_is_done_sharing( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 		update_post_meta( $this->post->ID, $this->publicize->POST_DONE . 'all', true );
 		$this->assertTrue(
-			$this->publicize->is_post_done_sharing( $this->post->ID ),
+			$this->publicize->post_is_done_sharing( $this->post->ID ),
 			'Posts flagged as \'done\' should return true done sharing'
 		);
 	}
@@ -263,12 +263,12 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that "done sharing post" logic is correct. Checks
 	 * that already published post is correctly reported as 'done'.
 	 *
-	 * @covers Publicize::is_post_done_sharing()
+	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_is_post_done_sharing_for_published() {
+	public function test_post_is_done_sharing_for_published() {
 		$this->assertFalse(
-			$this->publicize->is_post_done_sharing( $this->post->ID ),
+			$this->publicize->post_is_done_sharing( $this->post->ID ),
 			'Unshared/published post should not be \'done\''
 		);
 
@@ -277,7 +277,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		wp_insert_post( $this->post->to_array() );
 
 		$this->assertTrue(
-			$this->publicize->is_post_done_sharing( $this->post->ID ),
+			$this->publicize->post_is_done_sharing( $this->post->ID ),
 			'Published post should be flagged as \'done\''
 		);
 	}
@@ -346,15 +346,15 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * no current post. 'Done' return value should be false
 	 * so a new post will not have connections disabled.
 	 *
-	 * @covers Publicize::is_post_done_sharing()
+	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
-	public function test_is_post_done_sharing_null_post() {
+	public function test_post_is_done_sharing_null_post() {
 		/**
 		 * Simulate null post by not providing post_id argument and
 		 * when current $post value is unset.
 		 */
-		$done_sharing = $this->publicize->is_post_done_sharing();
+		$done_sharing = $this->publicize->post_is_done_sharing();
 		$this->assertFalse(
 			$done_sharing,
 			'Done sharing value should be false for null post id'

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -12,7 +12,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Current test user id produced by factory method.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 * @var integer $user_id ID of current user.
 	 */
 	private $user_id;
@@ -20,7 +20,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Facebook connection.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 * @var integer FACEBOOK_CONNECTION_INDEX index number of facebook connection.
 	 */
 	const FACEBOOK_CONNECTION_INDEX = 0;
@@ -28,7 +28,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	/**
 	 * Index in 'publicize_connections' test data of Tumblr connection.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 * @var integer TUMBLR_CONNECTION_INDEX index number of Tumblr connection.
 	 */
 	const TUMBLR_CONNECTION_INDEX = 1;
@@ -243,7 +243,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * of already shared post.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_done_sharing_post_for_done_all() {
 		$this->assertFalse(
@@ -262,7 +262,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * that already published post is correctly reported as 'done'.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_done_sharing_post_for_published() {
 		$this->assertFalse(
@@ -285,7 +285,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * connections that are valid for the current user.
 	 *
 	 * @covers Publicize::get_services_connected()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_get_services_connected() {
 		$connected_services = $this->publicize->get_services( 'connected' );
@@ -299,7 +299,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * has not been shared yet.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_no_filters() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -346,7 +346,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * so a new post will not have connections disabled.
 	 *
 	 * @covers Publicize::done_sharing_post()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_done_sharing_post_null_post() {
 		/**
@@ -366,7 +366,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * through without disabling connections.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_null_post() {
 		/**
@@ -391,7 +391,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * been applied.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_filter_wpas_submit_post() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -429,7 +429,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can be used to cause such a connection to be shown.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_global_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -462,7 +462,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * can correctly set default value to unchecked.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_default() {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -489,7 +489,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * its checkbox should be disabled.
 	 *
 	 * @covers Publicize::get_filtered_connection_data()
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_disabled_done_all() {
 		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
@@ -530,7 +530,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * get_filtered_connection_data so this callback can be reused
 	 * for all filter test cases.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 *
 	 * @param bool   $enabled         Should the connection be enabled.
 	 * @param int    $post_id         Post ID.

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -9,6 +9,30 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	private $post;
 	private $original_user = 0;
 
+	/**
+	 * Current test user id produced by factory method.
+	 *
+	 * @since 6.5.0
+	 * @var integer $user_id ID of current user.
+	 */
+	private $user_id;
+
+	/**
+	 * Index in 'publicize_connections' test data of Facebook connection.
+	 *
+	 * @since 6.5.0
+	 * @var integer FACEBOOK_CONNECTION_INDEX index number of facebook connection.
+	 */
+	const FACEBOOK_CONNECTION_INDEX = 0;
+
+	/**
+	 * Index in 'publicize_connections' test data of Tumblr connection.
+	 *
+	 * @since 6.5.0
+	 * @var integer TUMBLR_CONNECTION_INDEX index number of Tumblr connection.
+	 */
+	const TUMBLR_CONNECTION_INDEX = 1;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -18,7 +42,35 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
 		$this->post = get_post( $post_id );
 
-		Jetpack_Options::update_options( array( 'publicize_connections' => array( 'facebook' => array( 'id_number' => array( 'connection_data' => array( 'user_id' => 0 ) ) ) ) ) );
+		$this->user_id = $this->factory->user->create();
+		wp_set_current_user( $this->user_id );
+
+		Jetpack_Options::update_options( array(
+			'publicize_connections' => array(
+				'facebook' => array(
+					'id_number' => array(
+						'connection_data' => array(
+							'user_id'  => 0,
+							'token_id' => 'test-unique-id123',
+							'meta'     => array(
+								'display_name' => 'test-display-name123',
+							),
+						),
+					),
+				),
+				'tumblr'   => array(
+					'id_number' => array(
+						'connection_data' => array(
+							'user_id'  => $this->user_id,
+							'token_id' => 'test-unique-id456',
+							'meta'     => array(
+								'display_name' => 'test-display-name456',
+							),
+						),
+					),
+				),
+			),
+		) );
 
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags_check' ), 20, 2 );
 
@@ -183,5 +235,301 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		// There are no connections for user 2, so we should only get blog-level connections.
 		wp_set_current_user( 2 );
 		$this->assertSame( array( 'facebook' => $facebook_connection ), $publicize->get_all_connections_for_user() );
+	}
+
+	/**
+	 * Verifies that "done sharing post" logic is correct. Checks
+	 * the helper method that checks post flags to prevent re-sharing
+	 * of already shared post.
+	 *
+	 * @covers Publicize::done_sharing_post()
+	 * @since 6.5.0
+	 */
+	public function test_done_sharing_post_for_done_all() {
+		$this->assertFalse(
+			$this->publicize->done_sharing_post( $this->post->ID ),
+			'Unshared/published post should not be \'done\''
+		);
+		update_post_meta( $this->post->ID, $this->publicize->POST_DONE . 'all', true );
+		$this->assertTrue(
+			$this->publicize->done_sharing_post( $this->post->ID ),
+			'Posts flagged as \'done\' should return true done sharing'
+		);
+	}
+
+	/**
+	 * Verifies that "done sharing post" logic is correct. Checks
+	 * that already published post is correctly reported as 'done'.
+	 *
+	 * @covers Publicize::done_sharing_post()
+	 * @since 6.5.0
+	 */
+	public function test_done_sharing_post_for_published() {
+		$this->assertFalse(
+			$this->publicize->done_sharing_post( $this->post->ID ),
+			'Unshared/published post should not be \'done\''
+		);
+
+		// 'Publish' the post.
+		$this->post->post_status = 'publish';
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertTrue(
+			$this->publicize->done_sharing_post( $this->post->ID ),
+			'Published post should be flagged as \'done\''
+		);
+	}
+
+	/**
+	 * Verifies that get_services_connected returns all test
+	 * connections that are valid for the current user.
+	 *
+	 * @covers Publicize::get_services_connected()
+	 * @since 6.5.0
+	 */
+	public function test_get_services_connected() {
+		$connected_services = $this->publicize->get_services( 'connected' );
+		$this->assertTrue( isset( $connected_services['facebook'] ) );
+		$this->assertTrue( isset( $connected_services['tumblr'] ) );
+	}
+
+	/**
+	 * Verifies that connection data is returned correctly
+	 * when there are no connection filters and the post
+	 * has not been shared yet.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_get_filtered_connection_data_no_filters() {
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		$test_c          = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertEquals(
+			'test-unique-id456',
+			$test_c['unique_id']
+		);
+		$this->assertEquals(
+			'tumblr',
+			$test_c['name'],
+			'Second test connection name should be \'tumbler\''
+		);
+		$this->assertTrue(
+			$test_c['checked'],
+			'The connection has not been shared to and there are no filters so connection should be \'checked\' by default.'
+		);
+		$this->assertEquals(
+			'',
+			$test_c['disabled'],
+			'Connection should not be disabled, so disabled string should be empty.'
+		);
+		$this->assertTrue(
+			$test_c['active'],
+			'Connection should be active because there are no filters and the connection has not been shared to.'
+		);
+		$this->assertFalse(
+			$test_c['hidden_checkbox'],
+			'hidden_checkbox should be false since current user can use this connection.'
+		);
+		$this->assertEquals(
+			'Tumblr: test-display-name456',
+			$test_c['label'],
+			'Label should follow pattern: [Service name]: [user-display-name].'
+		);
+		$this->assertEquals(
+			'test-display-name456',
+			$test_c['display_name']
+		);
+	}
+
+	/**
+	 * Verify case where no post id is provided and there is
+	 * no current post. 'Done' return value should be false
+	 * so a new post will not have connections disabled.
+	 *
+	 * @covers Publicize::done_sharing_post()
+	 * @since 6.5.0
+	 */
+	public function test_done_sharing_post_null_post() {
+		/**
+		 * Simulate null post by not providing post_id argument and
+		 * when current $post value is unset.
+		 */
+		$done_sharing = $this->publicize->done_sharing_post();
+		$this->assertFalse(
+			$done_sharing,
+			'Done sharing value should be false for null post id'
+		);
+	}
+
+	/**
+	 * Verify case where no post id is provided and there is
+	 * no current post. Connections data should be passed
+	 * through without disabling connections.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_get_filtered_connection_data_null_post() {
+		/**
+		 * Simulate null post by not providing post_id argument and
+		 * when current $post value is unset.
+		 */
+		$connection_list   = $this->publicize->get_filtered_connection_data();
+		$tumblr_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$tumblr_connection['disabled'],
+			'All connections should be enabled for null post id'
+		);
+	}
+
+	/**
+	 * Verify 'wpas_submit_post?' filter functionality by checking
+	 * connection list before and after a 'no facebook' filter has
+	 * been applied.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_filter_wpas_submit_post() {
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		// Second connection should be 'tumblr' for unfiltered list.
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertEquals(
+			'facebook',
+			$facebook_connection['name'],
+			'Facebook connection should be available prior to filtering'
+		);
+
+		add_filter( 'wpas_submit_post?', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+		// Get connection list again now that filter has been added.
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
+
+		$this->assertEquals(
+			1,
+			count( $connection_list ),
+			'Connection list should be 1 long after \'facebook\' connection removed.'
+		);
+		// First and only connection should be 'tumblr' for unfiltered list.
+		$tumblr_connection = $connection_list[0];
+		$this->assertEquals(
+			'tumblr',
+			$tumblr_connection['name'],
+			'Tumblr connection should still be available after filtering out facebook connection.'
+		);
+	}
+
+	/**
+	 * By default, global connections (where user_id == 0)
+	 * are hidden for users that do not have the appropriate
+	 * capability. This test verifies that the
+	 * 'publicize_checkbox_global_default' filter
+	 * can be used to cause such a connection to be shown.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_filter_publicize_checkbox_global_default() {
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertTrue(
+			$facebook_connection['hidden_checkbox'],
+			'Facebook connection checkbox should be hidden by default since test user does not have capability.'
+		);
+
+		add_filter( 'publicize_checkbox_global_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+
+		// Get connection list again now that filter has been added.
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$facebook_connection['hidden_checkbox'],
+			'Facebook connection checkbox should not be set to hidden since filter set hidden to false.'
+		);
+
+	}
+
+	/**
+	 *
+	 * By default, all connection checkboxes are 'checked'.
+	 * This test confirms that the 'publicize_checkbox_default'
+	 * can correctly set default value to unchecked.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_filter_publicize_checkbox_default() {
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertTrue(
+			$facebook_connection['checked'],
+			'Facebook connection should be checked by default with no filtering applied.'
+		);
+
+		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
+
+		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$facebook_connection['checked'],
+			'Facebook connection should be un-checked by default after filtering applied.'
+		);
+	}
+
+	/**
+	 * Confirms that a connection will be disabled after post is 'done.'
+	 *
+	 * If a post has already been published (and is this 'done' sharing),
+	 * its checkbox should be disabled.
+	 *
+	 * @covers Publicize::get_filtered_connection_data()
+	 * @since 6.5.0
+	 */
+	public function test_get_filtered_connection_data_disabled_done_all() {
+		$connection_list = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		// First connection should be 'facebook' for unfiltered list.
+		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertFalse(
+			$facebook_connection['disabled'],
+			'Facebook connection should not be disabled if the post is not \'done\'.'
+		);
+
+		/**
+		 * Publish post so the post will be considered 'done' publicizing
+		 * all connections should be disabled.
+		 */
+		$this->post->post_status = 'publish';
+		wp_insert_post( $this->post->to_array() );
+
+		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
+		$facebook_connection = $connection_list[ self::TUMBLR_CONNECTION_INDEX ];
+		$this->assertTrue(
+			$facebook_connection['disabled'],
+			'Facebook connection should be disabled if the post is \'done\'.'
+		);
+	}
+
+	/**
+	 * Filter callback to uncheck checkbox for 'faceboook' connection.
+	 *
+	 * Filter callback interface is the same for all filters within
+	 * get_filtered_connection_data so this callback can be reused
+	 * for all filter test cases.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param bool   $enabled         Should the connection be enabled.
+	 * @param int    $post_id         Post ID.
+	 * @param string $service_name    Name of social service to share to.
+	 * @param array  $connection_data Array of information about all Publicize details for the site.
+	 *
+	 * @return bool Whether or not the connection is enabled for the filter.
+	 */
+	public function publicize_connection_filter_no_facebook( $enabled, $post_id, $service_name, $connection_data ) {
+		// Block 'facebook' connection and let all others pass through.
+		if ( 'facebook' === $service_name ) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 }

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -334,10 +334,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			$test_c['global'],
 			'Connection should not be global.'
 		);
-		$this->assertTrue(
-			$test_c['visible'],
-			'Connection should be visible.'
-		);
 	}
 
 	/**
@@ -439,8 +435,8 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			'Facebook connection checkbox should be global.'
 		);
 		$this->assertFalse(
-			$facebook_connection['visible'],
-			'Facebook connection checkbox should be hidden by default since test user does not have capability.'
+			$facebook_connection['toggleable'],
+			'Facebook connection checkbox should be disabled by default since test user does not permission to uncheck.'
 		);
 
 		add_filter( 'publicize_checkbox_global_default', array( $this, 'publicize_connection_filter_no_facebook' ), 10, 4 );
@@ -449,8 +445,12 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$connection_list     = $this->publicize->get_filtered_connection_data( $this->post->ID );
 		$facebook_connection = $connection_list[ self::FACEBOOK_CONNECTION_INDEX ];
 		$this->assertTrue(
-			$facebook_connection['visible'],
-			'Facebook connection checkbox should not be set to hidden since filter set hidden to false.'
+			$facebook_connection['global'],
+			'Facebook connection checkbox should be global even after filtering to uncheck.'
+		);
+		$this->assertFalse(
+			$global_connection['enabled'],
+			'Global connection checkbox should be unchecked after filter to uncheck.'
 		);
 
 	}

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -316,9 +316,12 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			$connection_data['unique_id']
 		);
 		$this->assertEquals(
-			'Facebook: test-display-name456',
-			$connection_data['label'],
-			'Label should follow pattern: [Service name]: [user-display-name].'
+			'Facebook',
+			$connection_data['service_label']
+		);
+		$this->assertEquals(
+			'test-display-name456',
+			$connection_data['display_name']
 		);
 		$this->assertTrue(
 			$connection_data['enabled'],


### PR DESCRIPTION
Take 2 of the excellent #9955 by @c-shultz. See #9039.

Updated to work on top of #10043.

#### Changes proposed in this Pull Request:
* Adds a method to `Publicize_Base` to get the list of Publicize Connections suitable for use in UI.
* Cleans up logic v. presentation boundary in `Publicize_UI`.

#### Testing instructions:
##### Automated Tests
1. `yarn docker:phpunit --filter=WP_Test_Publicize`

##### Manual Tests
1. Under an *admin* account, set up a test site with two publicize accounts: one "global" (available to all users of the site), one not global.
2. As that *admin*, go to the Classic (non-Gutenberg) editor, and look at the Publicize UI for a new post.
3. You should see two checked checkboxes: one for each connection. You should be able to uncheck each (the inputs should not be disabled).
4. Publish the post.
5. You should see the publicized content (tweet, FB update, etc.) on both connections.
6. Under an *author* account, go to the Classic (non-Gutenberg) editor, and look at the Publicize UI or a new post.
7. You should see one checked-but disabled checkbox for the global connection. You should not see any evidence at all of the admin's non-global connection.
8. Publish a post as that *author*.
9. See the publicized content (tweet, FB update, etc.) on the global connection.

#### Proposed changelog entry for your changes:
None? Part of a larger initiative to provide Publicize data via REST API.