### PR TITLE
Jetpack Gutenberg Blocks only load assets as required

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,9 +1,25 @@
 <?php
 
+
+function jetpack_register_block( $type, $args = array() ) {
+	Jetpack_Gutenberg::add_block( $type, $args );
+}
 /**
  * General Gutenberg editor specific functionality
  */
 class Jetpack_Gutenberg {
+
+	public static $all_blocks = array();
+
+	public static function add_block( $type, $args ) {
+		self::$all_blocks[ $type ] = $args;
+	}
+
+	public static function init() {
+		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
+		add_action( 'init', array( __CLASS__, 'load_all_blocks' ), 1000 );
+	}
+
 	/**
 	 * Check if Gutenberg editor is available
 	 *
@@ -15,64 +31,49 @@ class Jetpack_Gutenberg {
 		return function_exists( 'register_block_type' );
 	}
 
-	/**
-	 * Load Gutenberg assets
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return void
-	 */
-	public static function enqueue_block_assets() {
-		if ( ! self::should_load_blocks() ) {
+	public static function load_all_blocks() {
+		if ( ! self::is_gutenberg_available() ) {
 			return;
 		}
 
-		$rtl = is_rtl() ? '.rtl' : '';
+		foreach ( self::$all_blocks as $type => $args ) {
+			register_block_type(
+				'jetpack/' . $type,
+				$args
+			);
+		}
+	}
 
-		/**
-		 * Filter to enable serving blocks via CDN
-		 *
-		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool false Whether to load Gutenberg blocks from CDN
-		 */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base    = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$view_script = "$cdn_base/view.js";
-			$view_style  = "$cdn_base/view$rtl.css";
 
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string
-			 */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
-			$view_style  = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version     = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
+	public static function get_all_registed_blocks() {
+		return WP_Block_Type_Registry::get_instance()->get_all_registered();
+	}
+
+	public static function load_assets_as_required( $type ) {
+		// Enqueue styles
+		$style_relative_path = '_inc/blocks/'. $type .'/view.'. ( is_rtl() ? '.rtl' : '' ) .'css';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $style_relative_path ) ) {
+			$style_version       = Jetpack::is_development_version()
+				? filemtime( JETPACK__PLUGIN_DIR . $style_relative_path )
 				: JETPACK__VERSION;
+
+			$view_style  = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+
+			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
 		}
 
-		wp_enqueue_script(
-			'jetpack-blocks-view',
-			$view_script,
-			array(
-				'wp-element',
-				'wp-i18n',
-			),
-			$version
-		);
+		// Enqueue script
+		$script_relative_path = '_inc/blocks/'. $type .'/view.js';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+			$script_version       = Jetpack::is_development_version()
+				? filemtime( JETPACK__PLUGIN_DIR . $script_relative_path )
+				: JETPACK__VERSION;
 
-		Jetpack::setup_wp_i18n_locale_data();
+			$view_script  = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 
-		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version );
+		}
+
 	}
 
 	/**
@@ -89,21 +90,12 @@ class Jetpack_Gutenberg {
 
 		$rtl = is_rtl() ? '.rtl' : '';
 
-		/** This filter is already documented above */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base      = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$editor_script = "$cdn_base/editor.js";
-			$editor_style  = "$cdn_base/editor$rtl.css";
+		$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
+		$editor_style  = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
+		$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			: JETPACK__VERSION;
 
-			/** This filter is already documented above */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style  = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
-			$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				: JETPACK__VERSION;
-		}
 
 		wp_enqueue_script(
 			'jetpack-blocks-editor',
@@ -138,6 +130,10 @@ class Jetpack_Gutenberg {
 		Jetpack::setup_wp_i18n_locale_data();
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+		// enqueue all the assets for each block that is loaded.
+		foreach ( self::$all_blocks as $type => $args ) {
+			self::load_assets_as_required( $type );
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,8 +537,8 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_assets' ) );
-		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
+		Jetpack_Gutenberg::init();
+
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -27,3 +27,6 @@ function jetpack_markdown_posting_always_on() {
 	}
 }
 add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );
+
+// markdown block defention can be found in wp-calypso repo
+jetpack_register_block( 'markdown' );

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -76,3 +76,6 @@ class Jetpack_RelatedPosts_Module {
 
 // Do it.
 Jetpack_RelatedPosts_Module::instance();
+
+// Related Posts block definition can be found in wp-calypso repo
+jetpack_register_block( 'related-posts' );

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -30,3 +30,14 @@ function jetpack_tiled_gallery_configuration_load() {
 }
 
 jetpack_load_tiled_gallery();
+
+// Tile-gallery block definition can be found in wp-calypso repo
+jetpack_register_block( 'tiled-gallery', array(
+	'render_callback' => 'jetpack_tiled_gallery_load_assets'
+) );
+
+function jetpack_tiled_gallery_load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
+
+	return $content;
+}


### PR DESCRIPTION
This PR tries to load 

Only the required front end assets when the block is being rendered. 

It also removes the CDN part since we assume that part would be taken care of by the CDN project. 
cc: @zinigor (let me know if this is not the case) 

This PR implement a new jetpack_register_block function. Which helps Jetpack have a better understand what blocks are supported and active. Different modules could be disabled. This information could then also be used in the editor to show/hide the blocks there as well. 

## To test

Add the tile block and maker sure that the assests are only loaded on the front end (css and js) related to this. 

This is the required wp-calypso branch. https://github.com/Automattic/wp-calypso/pull/28066 that needs to be used to build the bundle. 



