### PR TITLE
JITM: add an option to display an "activate" button in JITM.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -94,7 +94,7 @@ jQuery( document ).ready( function( $ ) {
 		// Add to Jetpack notices within the Jetpack settings app.
 		$template.prependTo( $( '#jp-admin-notices' ) );
 
-		$( '#jitm-banner__activate a' ).click( function() {
+		$template.find( '#jitm-banner__activate a' ).click( function() {
 			var $activate_button = $( this );
 			$.ajax( {
 				url: window.jitm_config.api_root + 'jetpack/v4/module/' + $activate_button.data( 'module' ) + '/active',

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -101,6 +101,10 @@ jQuery( document ).ready( function( $ ) {
 				method: 'POST',
 				beforeSend: function( xhr ) {
 					xhr.setRequestHeader( 'X-WP-Nonce', $el.data( 'nonce' ) );
+
+					// Change the button status to disabled as the change is in progress.
+					$( '#jitm-banner__activate a' ).text( window.jitm_config.activating_module_text );
+					$( '#jitm-banner__activate a' ).attr( 'disabled', true );
 				}
 			} ).done( function() {
 				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -31,9 +31,22 @@ jQuery( document ).ready( function( $ ) {
 				html += '</div>';
 			}
 			html += '</div>';
+			if ( envelope.activate_module ) {
+				html += '<div class="jitm-banner__action" id="jitm-banner__activate">';
+				html += '<a href="#" data-module="' + envelope.activate_module + '" type="button" class="jitm-button is-compact is-primary jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '-activate_module">' + window.jitm_config.activate_module_text + '</a>';
+				html += '</div>';
+			}
 			if ( envelope.CTA.message ) {
+				var ctaClasses = 'jitm-button is-compact jptracks';
+				if (
+					envelope.CTA.primary &&
+					null === envelope.activate_module
+				) {
+					ctaClasses += ' is-primary';
+				}
+
 				html += '<div class="jitm-banner__action">';
-				html += '<a href="' + envelope.url + '" target="' + ( envelope.CTA.newWindow === false ? '_self' : '_blank') + '" rel="noopener noreferrer" title="' + envelope.CTA.message + '" data-module="' + envelope.feature_class + '" type="button" class="jitm-button is-compact ' + ( envelope.CTA.primary ? 'is-primary' : '' ) + ' jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '">' + envelope.CTA.message + '</a>';
+				html += '<a href="' + envelope.url + '" target="' + ( envelope.CTA.newWindow === false ? '_self' : '_blank' ) + '" rel="noopener noreferrer" title="' + envelope.CTA.message + '" data-module="' + envelope.feature_class + '" type="button" class="' + ctaClasses + '" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '">' + envelope.CTA.message + '</a>';
 				html += '</div>';
 			}
 			html += '<a href="#" data-module="' + envelope.feature_class + '" class="jitm-banner__dismiss"></a>';
@@ -80,6 +93,20 @@ jQuery( document ).ready( function( $ ) {
 
 		// Add to Jetpack notices within the Jetpack settings app.
 		$template.prependTo( $( '#jp-admin-notices' ) );
+
+		$( '#jitm-banner__activate a' ).click( function() {
+			var $activate_button = $( this );
+			$.ajax( {
+				url: window.jitm_config.api_root + 'jetpack/v4/module/' + $activate_button.data( 'module' ) + '/active',
+				method: 'POST',
+				beforeSend: function( xhr ) {
+					xhr.setRequestHeader( 'X-WP-Nonce', $el.data( 'nonce' ) );
+				}
+			} ).done( function() {
+				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );
+				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
+			} );
+		} );
 	};
 
 	$( '.jetpack-jitm-message' ).each( function() {

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -94,8 +94,16 @@ jQuery( document ).ready( function( $ ) {
 		// Add to Jetpack notices within the Jetpack settings app.
 		$template.prependTo( $( '#jp-admin-notices' ) );
 
+		// Handle Module activation button if it exists.
 		$template.find( '#jitm-banner__activate a' ).click( function() {
 			var $activate_button = $( this );
+
+			// Do not allow any requests if the button is disabled.
+			if ( $activate_button.attr( 'disabled' ) ) {
+				return false;
+			}
+
+			// Make request to activate module.
 			$.ajax( {
 				url: window.jitm_config.api_root + 'jetpack/v4/module/' + $activate_button.data( 'module' ) + '/active',
 				method: 'POST',

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -183,9 +183,10 @@ class Jetpack_JITM {
 			true
 		);
 		wp_localize_script( 'jetpack-jitm-new', 'jitm_config', array(
-			'api_root'              => esc_url_raw( rest_url() ),
-			'activate_module_text'  => esc_html__( 'Activate', 'jetpack' ),
-			'activated_module_text' => esc_html__( 'Activated', 'jetpack' ),
+			'api_root'               => esc_url_raw( rest_url() ),
+			'activate_module_text'   => esc_html__( 'Activate', 'jetpack' ),
+			'activated_module_text'  => esc_html__( 'Activated', 'jetpack' ),
+			'activating_module_text' => esc_html__( 'Activating', 'jetpack' ),
 		) );
 	}
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -183,7 +183,9 @@ class Jetpack_JITM {
 			true
 		);
 		wp_localize_script( 'jetpack-jitm-new', 'jitm_config', array(
-			'api_root' => esc_url_raw( rest_url() ),
+			'api_root'              => esc_url_raw( rest_url() ),
+			'activate_module_text'  => esc_html__( 'Activate', 'jetpack' ),
+			'activated_module_text' => esc_html__( 'Activated', 'jetpack' ),
 		) );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

It allows one to activate a Jetpack module right from inside a JITM.

Companion diff: D19898-code

----------

**Without an activate_module parameter**:
<img width="1334" alt="screenshot 2018-10-25 at 16 37 32" src="https://user-images.githubusercontent.com/426388/47509197-e1734000-d875-11e8-9fa0-acca24a4b040.png">

**with**:

<img width="1285" alt="screenshot 2018-10-25 at 16 58 55" src="https://user-images.githubusercontent.com/426388/47509884-4bd8b000-d877-11e8-9b28-4c7844dd703f.png">


----------

@joanrho I would like to have your opinion on this because I am not entirely familiar with the different styles that should be applied to buttons depending on their site. Here is what we have so far. 
I do not believe we have anything in there that I could use to indicate that the change is *in progress*:
https://github.com/Automattic/jetpack/blob/master/scss/jetpack-admin-jitm.scss

#### Testing instructions:

1. Apply D19898-code to your WordPress.com sandbox.
2. Point your Jetpack site to your WordPress.com sandbox by adding `define( 'JETPACK__SANDBOX_DOMAIN', 'sandboxme.wordpress.com' );` to your Jetpack site's `wp-config.php` file (replace `sandboxme` by your own WordPress.com sandbox address). Also add `define( 'SCRIPT_DEBUG', true );` to that same file.
3. Point `jetpack.com` to your WordPress.com sandbox in your hosts file.
4. Go to `{my-site}/wp-admin/admin.php?page=jetpack_modules` and make sure that the Photon CDN module is off on your site.
5. Add the following to your site to make sure the CDN will not intervene while testing this PR: `add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );`
6. You're all set to start testing! Go to the main dashboard of your Jetpack site.

Make sure you can turn on the module from the JITM.

When you refresh the page, the JITM should be gone.

#### Proposed changelog entry for your changes:
* JITM: add an option to display an "activate" button in JITM.
