### PR TITLE
Jetpack Live Branches: Add wordpress-5-beta feature 

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -29,6 +29,7 @@
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="wordpress-5-beta" class="task-list-item-checkbox">Launch with WordPress 5.0 Beta</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.6
+// @version      1.7
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*


### PR DESCRIPTION
Adds ability to launch a site with the latest beta for WordPress 5.0 instead of the latest stable verison.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates `tools/jetpack-live-branches/jetpack-live-branches.user.js` to include the checkbox for the feature `wordpress-5-beta`.
* Bumps version of script to 1.7

#### Testing instructions:

* Click here on [jetpack-live-branches.user.js](https://github.com/Automattic/jetpack/raw/add/wordpress-5-beta-to-jetpack-live-branches/tools/jetpack-live-branches/jetpack-live-branches.user.js) to install the version from this PR
* Confirm to upgrade script.
* Visit a PR.
* Confirm that you can launch a site with WordPress 5.0 running the PR.
* Then click here to reset your script to update to the latest version in master, for when this is merged. [jetpack-live-branches.user.js - version in master](https://github.com/Automattic/jetpack/raw/master/tools/jetpack-live-branches/jetpack-live-branches.user.js).
* Confirm to downgrade script.

#### Screenshot

> ![image](https://user-images.githubusercontent.com/746152/47509961-875e8480-d84d-11e8-8570-1dda8af32d61.png)


#### Proposed changelog entry for your changes:

None needed.
