### PR TITLE
Simple payments: allow read+write access to meta fields via REST API

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -299,7 +299,7 @@ class Jetpack_Simple_Payments {
 		register_meta( 'post', 'spay_price', array(
 			'description'       => esc_html__( 'Simple payments; price.', 'jetpack' ),
 			'object_subtype'    => self::$post_type_product,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => array( $this, 'sanitize_price' ),
 			'show_in_rest'      => true,
 			'single'            => true,
 			'type'              => 'number',
@@ -308,7 +308,7 @@ class Jetpack_Simple_Payments {
 		register_meta( 'post', 'spay_currency', array(
 			'description'       => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
 			'object_subtype'    => self::$post_type_product,
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => array( $this, 'sanitize_currency' ),
 			'show_in_rest'      => true,
 			'single'            => true,
 			'type'              => 'string',
@@ -357,6 +357,62 @@ class Jetpack_Simple_Payments {
 			'single'            => true,
 			'type'              => 'string',
 		) );
+	}
+
+	/**
+	 * Sanitize three-character ISO-4217 Simple payments currency
+	 *
+	 * @link https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+	 *
+	 * List has to be in sync with list at the client side:
+	 * @link https://github.com/Automattic/wp-calypso/blob/6d02ffe73cc073dea7270a22dc30881bff17d8fb/client/lib/simple-payments/constants.js
+	 */
+	public function sanitize_currency( $currency ) {
+		$valid_currencies = array(
+			'USD',
+			'EUR',
+			'AUD',
+			'BRL',
+			'CAD',
+			'CZK',
+			'DKK',
+			'HKD',
+			'HUF',
+			'ILS',
+			'JPY',
+			'MYR',
+			'MXN',
+			'TWD',
+			'NZD',
+			'NOK',
+			'PHP',
+			'PLN',
+			'GBP',
+			'RUB',
+			'SGD',
+			'SEK',
+			'CHF',
+			'THB',
+		);
+
+		return in_array( $currency, $valid_currencies ) ? $currency : false;
+	}
+
+	/**
+	 * Sanitize price:
+	 *
+	 * Positive integers and floats
+	 * Supports two decimal places.
+	 * Maximum length: 10.
+	 *
+	 * See `price` from PayPal docs:
+	 * @link https://developer.paypal.com/docs/api/orders/v1/#definition-item
+	 *
+	 * @param      $value
+	 * @return null|string
+	 */
+	public static function sanitize_price( $price ) {
+		return preg_match( '/^[0-9]{0,10}(\.[0-9]{0,2})?$/', $price ) ? $price : false;
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -296,67 +296,67 @@ class Jetpack_Simple_Payments {
 	 * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
 	 */
 	public function register_meta_fields_in_rest_api() {
-			register_meta( 'post', 'spay_price', array(
-				'description'       => esc_html__( 'Simple payments; price.', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'absint',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'number',
-			) );
+		register_meta( 'post', 'spay_price', array(
+			'description'       => esc_html__( 'Simple payments; price.', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'number',
+		) );
 
-			register_meta( 'post', 'spay_currency', array(
-				'description'       => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			) );
+		register_meta( 'post', 'spay_currency', array(
+			'description'       => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+		) );
 
-			register_meta( 'post', 'spay_cta', array(
-				'description'       => esc_html__( 'Simple payments; text with "Buy" or other CTA', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			) );
+		register_meta( 'post', 'spay_cta', array(
+			'description'       => esc_html__( 'Simple payments; text with "Buy" or other CTA', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+		) );
 
-			register_meta( 'post', 'spay_multiple', array(
-				'description'       => esc_html__( 'Simple payments; allow multiple items', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'absint',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'integer',
-			) );
+		register_meta( 'post', 'spay_multiple', array(
+			'description'       => esc_html__( 'Simple payments; allow multiple items', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'integer',
+		) );
 
-			register_meta( 'post', 'spay_email', array(
-				'description'       => esc_html__( 'Simple payments button; paypal email.', 'jetpack' ),
-				'sanitize_callback' => 'sanitize_email',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			) );
+		register_meta( 'post', 'spay_email', array(
+			'description'       => esc_html__( 'Simple payments button; paypal email.', 'jetpack' ),
+			'sanitize_callback' => 'sanitize_email',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+		) );
 
-			register_meta( 'post', 'spay_formatted_price', array(
-				'description'       => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			) );
+		register_meta( 'post', 'spay_formatted_price', array(
+			'description'       => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+		) );
 
-			register_meta( 'post', 'spay_status', array(
-				'description'       => esc_html__( 'Simple payments; status.', 'jetpack' ),
-				'object_subtype'    => self::$post_type_product,
-				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			) );
+		register_meta( 'post', 'spay_status', array(
+			'description'       => esc_html__( 'Simple payments; status.', 'jetpack' ),
+			'object_subtype'    => self::$post_type_product,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+		) );
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -296,57 +296,68 @@ class Jetpack_Simple_Payments {
 	 * to that meta key.
 	 *
 	 * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
-	 * @link https://developer.wordpress.org/reference/functions/register_meta/
 	 */
 	public function register_meta_fields_in_rest_api() {
 			register_meta( 'post', 'spay_price', array(
-				// 'sanitize_callback' => array( $this, 'sanitize_status' ),
-				'type'         => 'number',
-				'description'  => esc_html__( 'Simple payments; price.', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; price.', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'number',
 			) );
 
 			register_meta( 'post', 'spay_currency', array(
-				'type'         => 'string',
-				'description'  => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
 			) );
 
 			register_meta( 'post', 'spay_cta', array(
-				'type'         => 'string',
-				'description'  => esc_html__( 'Simple payments; text with "Buy" or other CTA', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; text with "Buy" or other CTA', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
 			) );
 
 			register_meta( 'post', 'spay_multiple', array(
-				'type'         => 'number',
-				'description'  => esc_html__( 'Simple payments; allow for multiple items', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; allow multiple items', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'integer',
 			) );
 
 			register_meta( 'post', 'spay_email', array(
-				'type'         => 'string',
-				'description'  => esc_html__( 'Simple payments button; paypal email.', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments button; paypal email.', 'jetpack' ),
+				'sanitize_callback' => 'sanitize_email',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
 			) );
 
 			register_meta( 'post', 'spay_formatted_price', array(
-				'type'         => 'string',
-				'description'  => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
 			) );
 
 			register_meta( 'post', 'spay_status', array(
-				'type'         => 'string',
-				'description'  => esc_html__( 'Simple payments; status.', 'jetpack' ),
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => esc_html__( 'Simple payments; status.', 'jetpack' ),
+				'object_subtype'    => self::$post_type_product,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
 			) );
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -40,6 +40,9 @@ class Jetpack_Simple_Payments {
 
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
+		if ( function_exists( 'register_meta' ) ) {
+			add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
+		}
 	}
 
 	private function register_shortcode() {
@@ -284,6 +287,67 @@ class Jetpack_Simple_Payments {
 			'spay_multiple',
 			'spay_formatted_price',
 		) );
+	}
+
+	/**
+	 * Enable Simple payments custom meta values for access through the REST API.
+	 * Field’s value will be exposed on a .meta key in the endpoint response,
+	 * and WordPress will handle setting up the callbacks for reading and writing
+	 * to that meta key.
+	 *
+	 * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
+	 * @link https://developer.wordpress.org/reference/functions/register_meta/
+	 */
+	public function register_meta_fields_in_rest_api() {
+			register_meta( 'post', 'spay_price', array(
+				// 'sanitize_callback' => array( $this, 'sanitize_status' ),
+				'type'         => 'number',
+				'description'  => esc_html__( 'Simple payments; price.', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_currency', array(
+				'type'         => 'string',
+				'description'  => esc_html__( 'Simple payments; currency code.', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_cta', array(
+				'type'         => 'string',
+				'description'  => esc_html__( 'Simple payments; text with "Buy" or other CTA', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_multiple', array(
+				'type'         => 'number',
+				'description'  => esc_html__( 'Simple payments; allow for multiple items', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_email', array(
+				'type'         => 'string',
+				'description'  => esc_html__( 'Simple payments button; paypal email.', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_formatted_price', array(
+				'type'         => 'string',
+				'description'  => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
+
+			register_meta( 'post', 'spay_status', array(
+				'type'         => 'string',
+				'description'  => esc_html__( 'Simple payments; status.', 'jetpack' ),
+				'single'       => true,
+				'show_in_rest' => true,
+			) );
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -40,9 +40,7 @@ class Jetpack_Simple_Payments {
 
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
-		if ( function_exists( 'register_meta' ) ) {
-			add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
-		}
+		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
 	}
 
 	private function register_shortcode() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -358,7 +358,7 @@ class Jetpack_Simple_Payments {
 	 * List has to be in sync with list at the client side:
 	 * @link https://github.com/Automattic/wp-calypso/blob/6d02ffe73cc073dea7270a22dc30881bff17d8fb/client/lib/simple-payments/constants.js
 	 */
-	public function sanitize_currency( $currency ) {
+	public static function sanitize_currency( $currency ) {
 		$valid_currencies = array(
 			'USD',
 			'EUR',

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -353,10 +353,11 @@ class Jetpack_Simple_Payments {
 	/**
 	 * Sanitize three-character ISO-4217 Simple payments currency
 	 *
-	 * @link https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
-	 *
 	 * List has to be in sync with list at the client side:
 	 * @link https://github.com/Automattic/wp-calypso/blob/6d02ffe73cc073dea7270a22dc30881bff17d8fb/client/lib/simple-payments/constants.js
+	 *
+	 * Currencies should be supported by PayPal:
+	 * @link https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
 	 */
 	public static function sanitize_currency( $currency ) {
 		$valid_currencies = array(

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -340,15 +340,6 @@ class Jetpack_Simple_Payments {
 			'type'              => 'string',
 		) );
 
-		register_meta( 'post', 'spay_formatted_price', array(
-			'description'       => esc_html__( 'Simple payments; formatted price.', 'jetpack' ),
-			'object_subtype'    => self::$post_type_product,
-			'sanitize_callback' => 'sanitize_text_field',
-			'show_in_rest'      => true,
-			'single'            => true,
-			'type'              => 'string',
-		) );
-
 		register_meta( 'post', 'spay_status', array(
 			'description'       => esc_html__( 'Simple payments; status.', 'jetpack' ),
 			'object_subtype'    => self::$post_type_product,

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -22,7 +22,7 @@ class Jetpack_Simple_Payments {
 	static function getInstance() {
 		if ( ! self::$instance ) {
 			self::$instance = new self();
-			self::$instance->register_init_hook();
+			self::$instance->register_init_hooks();
 		}
 		return self::$instance;
 	}
@@ -38,7 +38,7 @@ class Jetpack_Simple_Payments {
 		wp_register_style( 'jetpack-simple-payments', plugins_url( '/simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 	}
 
-	private function register_init_hook() {
+	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
 	}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -326,10 +326,10 @@ class Jetpack_Simple_Payments {
 		register_meta( 'post', 'spay_multiple', array(
 			'description'       => esc_html__( 'Simple payments; allow multiple items', 'jetpack' ),
 			'object_subtype'    => self::$post_type_product,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => 'rest_sanitize_boolean',
 			'show_in_rest'      => true,
 			'single'            => true,
-			'type'              => 'integer',
+			'type'              => 'boolean',
 		) );
 
 		register_meta( 'post', 'spay_email', array(


### PR DESCRIPTION
Enable Simple payments custom meta values for access through the REST API. Field’s value will be exposed on a `.meta` key in the endpoint response, and WordPress will handle setting up the callbacks for reading and writing to that meta key.

This is needed for Simple Payments block to be able to read+create+update Simple payment buttons through the REST API.

https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
https://developer.wordpress.org/reference/functions/register_meta/

## Changes proposed in this Pull Request:

Enable Simple payments custom meta values for access through the REST API.

## Testing instructions:

- Have a site with simple payments enabled (premium or business plan)
- Create a post in Calypso editor and create a simple payments button (from "+ add" menu)
- Note down button's ID by looking at the posts HTML source (from shortcode e.g. `[simple-payment id="42"]`)
- Call API endpoint: 
    - Locally hosted Jetpack
        ```
        http://localhost/index.php?rest_route=/wp/v2/jp_pay_product/BUTTON_ID
        ```
    - WPCOM (apply D19907-code to test):
        ```
        https://public-api.wordpress.com/wp/v2/sites/YOUR_SITE_URL/jp_pay_product/BUTTON_ID
        ```
- Without this change, `meta` field is missing Simple payments meta fields, with the change you should see:
```
  "meta": {
    "spay_price": 3,
    "spay_currency": "HUF",
    "spay_cta": "",
    "spay_multiple": 1,
    "spay_email": "email@example.com",
    "spay_formatted_price": "Ft3",
    "spay_status": ""
  },
```

You should be able to write to this object as well. The easiest way to test reading+creating+writing would be following instructions from https://github.com/Automattic/wp-calypso/pull/28065

## Proposed changelog entry for your changes:

Enable Simple payments custom meta values for access through the REST API.