### PR TITLE
Docs: Update docblocks to use correct version syntax

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -395,7 +395,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			/**
 			 * Pre-upgrade action
 			 *
-			 * @since 4.4
+			 * @since 4.4.0
 			 *
 			 * @param array $plugin           Plugin data
 			 * @param array $plugin           Array of plugin objects

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -105,7 +105,7 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 			/**
 			 * Pre-upgrade action
 			 *
-			 * @since 4.4
+			 * @since 4.4.0
 			 *
 			 * @param object $theme WP_Theme object
 			 * @param array $themes Array of theme objects

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1030,7 +1030,7 @@ class A8C_WPCOM_Masterbar {
 			/**
 			 * Fires when menu items are added to the masterbar "My Sites" menu.
 			 *
-			 * @since 5.4
+			 * @since 5.4.0
 			 */
 			do_action( 'jetpack_masterbar' );
 		}

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -44,7 +44,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 *
 		 * @module photon-cdn
 		 *
-		 * @since 6.6
+		 * @since 6.6.0
 		 *
 		 * @param array $values array( $version  = core assets version, i.e. 4.9.8, $locale = desired locale )
 		 */
@@ -101,7 +101,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 *
 		 * @module photon-cdn
 		 *
-		 * @since 6.6
+		 * @since 6.6.0
 		 *
 		 * @param array $values array( $slug = the plugin repository slug, i.e. jetpack, $version = the plugin version, i.e. 6.6 )
 		 */
@@ -165,7 +165,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		 *
 		 * @module photon-cdn
 		 *
-		 * @since 6.6
+		 * @since 6.6.0
 		 *
 		 * @param array $assets The assets array for the plugin.
 		 * @param string $version The version of the plugin being requested.

--- a/modules/protect/blocked-login-page.php
+++ b/modules/protect/blocked-login-page.php
@@ -44,7 +44,7 @@ class Jetpack_Protect_Blocked_Login_Page {
 		 *
 		 * @module protect
 		 *
-		 * @since 5.6
+		 * @since 5.6.0
 		 *
 		 * @param bool $can_send_recovery_emails Defaults to true.
 		 */

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -339,7 +339,7 @@ class Jetpack_Sync_Actions {
 		 * Allows overriding the offset that the sync cron jobs will first run. This can be useful when scheduling
 		 * cron jobs across multiple sites in a network.
 		 *
-		 * @since 4.5
+		 * @since 4.5.0
 		 *
 		 * @param int    $start_time_offset
 		 * @param string $hook

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -148,7 +148,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param array The default list of options.
 		 */
@@ -167,7 +167,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 6.1
+		 * @since 6.1.0
 		 *
 		 * @param array The list of options synced without content.
 		 */
@@ -202,7 +202,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param array The default list of constants options.
 		 */
@@ -281,7 +281,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param array The default list of callables.
 		 */
@@ -355,7 +355,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param array The default list of multisite callables.
 		 */
@@ -408,7 +408,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @module sync
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param array The default list of meta data keys.
 		 */

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -210,7 +210,7 @@ class Jetpack_Sync_Functions {
 		/**
 		 * Allows overriding of the home_url value that is synced back to WordPress.com.
 		 *
-		 * @since 5.2
+		 * @since 5.2.0
 		 *
 		 * @param string $home_url
 		 */
@@ -223,7 +223,7 @@ class Jetpack_Sync_Functions {
 		/**
 		 * Allows overriding of the site_url value that is synced back to WordPress.com.
 		 *
-		 * @since 5.2
+		 * @since 5.2.0
 		 *
 		 * @param string $site_url
 		 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The parser that builds developer.jetpack.com displays new hooks by version introduced. The accepted format is X.Y.Z. Some hooks were added with only a X.Y indicator, which ends up having two groupings for the same version.

#### Testing instructions:

None.

#### Proposed changelog entry for your changes:

* None.
