### PR TITLE
Gutenpack: Only load frontend assets as required

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,9 +1,15 @@
 <?php
 /**
+ * Handle the registration and use of all blocks available in Jetpack for the block editor, aka Gutenberg.
+ *
+ * @package Jetpack
+ */
+
+/**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @param $type string  The type will be prefixed with jetpack/
- * @param $args array   Arguments that are passed into the register_block_type
+ * @param string $type Slug of the block. Will be prefixed with jetpack/.
+ * @param array  $args Arguments that are passed into the register_block_type.
  *
  * @see register_block_type
  *
@@ -21,12 +27,28 @@ function jetpack_register_block( $type, $args = array() ) {
  */
 class Jetpack_Gutenberg {
 
+	/**
+	 * Array of blocks we will be registering.
+	 *
+	 * @var array $blocks Array of blocks we will be registering.
+	 */
 	public static $blocks = array();
 
+	/**
+	 * Add a block to the list of blocks to be registered.
+	 *
+	 * @param string $type Slug of the block.
+	 * @param array  $args Arguments that are passed into the register_block_type.
+	 */
 	public static function add_block( $type, $args ) {
 		self::$blocks[ $type ] = $args;
 	}
 
+	/**
+	 * Register all Jetpack blocks available.
+	 *
+	 * @return void|WP_Block_Type|false The registered block type on success, or false on failure.
+	 */
 	public static function load_blocks() {
 		if ( ! self::is_gutenberg_available() ) {
 			return;
@@ -80,8 +102,15 @@ class Jetpack_Gutenberg {
 		return (bool) apply_filters( 'jetpack_gutenberg', true );
 	}
 
+	/**
+	 * Only enqueue block assets when needed.
+	 *
+	 * @param string $type slug of the block.
+	 *
+	 * @return void
+	 */
 	public static function load_assets_as_required( $type ) {
-		// Enqueue styles
+		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( self::block_has_asset( $style_relative_path ) ) {
 			$style_version = self::get_asset_version( $style_relative_path );
@@ -89,19 +118,33 @@ class Jetpack_Gutenberg {
 			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
 		}
 
-		// Enqueue script
+		// Enqueue script.
 		$script_relative_path = '_inc/blocks/' . $type . '/view.js';
 		if ( self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version, false );
 		}
 	}
 
+	/**
+	 * Check if an asset exists for a block.
+	 *
+	 * @param string $file Path of the file we are looking for.
+	 *
+	 * @return bool $block_has_asset Does the file exist.
+	 */
 	public static function block_has_asset( $file ) {
 		return file_exists( JETPACK__PLUGIN_DIR . $file );
 	}
 
+	/**
+	 * Get the version number to use when loading the file. Allows us to bypass cache when developing.
+	 *
+	 * @param string $file Path of the file we are looking for.
+	 *
+	 * @return string $script_version Version number.
+	 */
 	public static function get_asset_version( $file ) {
 		return Jetpack::is_development_version() && self::block_has_asset( $file )
 			? filemtime( JETPACK__PLUGIN_DIR . $file )
@@ -159,7 +202,8 @@ class Jetpack_Gutenberg {
 				'wp-token-list',
 				'wp-url',
 			),
-			$version
+			$version,
+			false
 		);
 
 		wp_localize_script(

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -2,8 +2,10 @@
 /**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @params $type sting  The type will be prefixed with jetpack/
+ * @param $type string  The type will be prefixed with jetpack/
  * @param $args array   Arguments that are passed into the register_block_type
+ *
+ * @see register_block_type
  *
  * @since 6.7.0
  *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -80,7 +80,7 @@ class Jetpack_Gutenberg {
 
 	public static function load_assets_as_required( $type ) {
 		// Enqueue styles
-		$style_relative_path = '_inc/blocks/' . $type . '/view.' . ( is_rtl() ? '.rtl' : '' ) . 'css';
+		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( self::block_has_asset( $style_relative_path ) ) {
 			$style_version = self::get_asset_version( $style_relative_path );
 			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,9 +1,51 @@
 <?php
+function jetpack_register_block( $type, $args = array() ) {
+	Jetpack_Gutenberg::add_block( $type, $args );
+}
 
 /**
  * General Gutenberg editor specific functionality
  */
 class Jetpack_Gutenberg {
+
+	public static $all_blocks = array();
+	public static function add_block( $type, $args ) {
+		self::$all_blocks[ $type ] = $args;
+	}
+
+	public static function load_all_blocks() {
+		if ( ! self::is_gutenberg_available() ) {
+			return;
+		}
+		foreach ( self::$all_blocks as $type => $args ) {
+			register_block_type(
+				'jetpack/' . $type,
+				$args
+			);
+		}
+	}
+
+	public static function load_assets_as_required( $type ) {
+		// Enqueue styles
+		$style_relative_path = '_inc/blocks/'. $type .'/view.'. ( is_rtl() ? '.rtl' : '' ) .'css';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $style_relative_path ) ) {
+			$style_version       = Jetpack::is_development_version()
+				? filemtime( JETPACK__PLUGIN_DIR . $style_relative_path )
+				: JETPACK__VERSION;
+			$view_style  = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
+		}
+		// Enqueue script
+		$script_relative_path = '_inc/blocks/'. $type .'/view.js';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+			$script_version       = Jetpack::is_development_version()
+				? filemtime( JETPACK__PLUGIN_DIR . $script_relative_path )
+				: JETPACK__VERSION;
+			$view_script  = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version );
+		}
+	}
+
 	/**
 	 * Check if Gutenberg editor is available
 	 *
@@ -13,66 +55,6 @@ class Jetpack_Gutenberg {
 	 */
 	public static function is_gutenberg_available() {
 		return function_exists( 'register_block_type' );
-	}
-
-	/**
-	 * Load Gutenberg assets
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return void
-	 */
-	public static function enqueue_block_assets() {
-		if ( ! self::should_load_blocks() ) {
-			return;
-		}
-
-		$rtl = is_rtl() ? '.rtl' : '';
-
-		/**
-		 * Filter to enable serving blocks via CDN
-		 *
-		 * CDN cache is busted once a day or when Jetpack version changes. To customize it:
-		 *   add_filter( 'jetpack_gutenberg_cdn_cache_buster', function( $version ) { return time(); }, 10, 1 );
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool false Whether to load Gutenberg blocks from CDN
-		 */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base    = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$view_script = "$cdn_base/view.js";
-			$view_style  = "$cdn_base/view$rtl.css";
-
-			/**
-			 * Filter to modify cache busting for Gutenberg block assets loaded from CDN
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string
-			 */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$view_script = plugins_url( '_inc/blocks/view.js', JETPACK__PLUGIN_FILE );
-			$view_style  = plugins_url( "_inc/blocks/view$rtl.css", JETPACK__PLUGIN_FILE );
-			$version     = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/view.js' )
-				: JETPACK__VERSION;
-		}
-
-		wp_enqueue_script(
-			'jetpack-blocks-view',
-			$view_script,
-			array(
-				'wp-element',
-				'wp-i18n',
-			),
-			$version
-		);
-
-		Jetpack::setup_wp_i18n_locale_data();
-
-		wp_enqueue_style( 'jetpack-blocks-view', $view_style, array(), $version );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -18,7 +18,7 @@
  * @return void
  */
 function jetpack_register_block( $type, $args = array() ) {
-
+	$type = sanitize_title_with_dashes( $type );
 	Jetpack_Gutenberg::add_block( $type, $args );
 }
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,5 +1,16 @@
 <?php
+/**
+ * Helper function to register a Jetpack Gutenberg block
+ *
+ * @params $type sting  The type will be prefixed with jetpack/
+ * @param $args array   Arguments that are passed into the register_block_type
+ *
+ * @since 6.7.0
+ *
+ * @return void
+ */
 function jetpack_register_block( $type, $args = array() ) {
+
 	Jetpack_Gutenberg::add_block( $type, $args );
 }
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -19,7 +19,7 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
-		if ( self::should_load_blocks() ) {
+		if ( ! self::should_load_blocks() ) {
 			return;
 		}
 
@@ -85,7 +85,7 @@ class Jetpack_Gutenberg {
 		}
 	}
 
-	public function block_has_asset( $file ) {
+	public static function block_has_asset( $file ) {
 		return file_exists( JETPACK__PLUGIN_DIR . $file );
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -110,6 +110,7 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function load_assets_as_required( $type ) {
+		$type = sanitize_title_with_dashes( $type );
 		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( self::block_has_asset( $style_relative_path ) ) {

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -9,6 +9,7 @@ function jetpack_register_block( $type, $args = array() ) {
 class Jetpack_Gutenberg {
 
 	public static $blocks = array();
+
 	public static function add_block( $type, $args ) {
 		self::$blocks[ $type ] = $args;
 	}
@@ -21,6 +22,7 @@ class Jetpack_Gutenberg {
 		if ( self::should_load_blocks() ) {
 			return;
 		}
+
 		foreach ( self::$blocks as $type => $args ) {
 			register_block_type(
 				'jetpack/' . $type,
@@ -29,20 +31,56 @@ class Jetpack_Gutenberg {
 		}
 	}
 
+	/**
+	 * Check if Gutenberg editor is available
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return bool
+	 */
+	public static function is_gutenberg_available() {
+		return function_exists( 'register_block_type' );
+	}
+
+	/**
+	 * Check whether conditions indicate Gutenberg blocks should be loaded
+	 *
+	 * Loading blocks is enabled by default and may be disabled via filter:
+	 *   add_filter( 'jetpack_gutenberg', '__return_false' );
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return bool
+	 */
+	public static function should_load_blocks() {
+		if ( ! Jetpack::is_active() ) {
+			return false;
+		}
+
+		/**
+		 * Filter to disable Gutenberg blocks
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param bool true Whether to load Gutenberg blocks
+		 */
+		return (bool) apply_filters( 'jetpack_gutenberg', true );
+	}
+
 	public static function load_assets_as_required( $type ) {
 		// Enqueue styles
-		$style_relative_path = '_inc/blocks/'. $type .'/view.'. ( is_rtl() ? '.rtl' : '' ) .'css';
+		$style_relative_path = '_inc/blocks/' . $type . '/view.' . ( is_rtl() ? '.rtl' : '' ) . 'css';
 		if ( self::block_has_asset( $style_relative_path ) ) {
-			$style_version       = self::get_asset_version( $style_relative_path );
-			$view_style  = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+			$style_version = self::get_asset_version( $style_relative_path );
+			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
 		}
 
 		// Enqueue script
-		$script_relative_path = '_inc/blocks/'. $type .'/view.js';
+		$script_relative_path = '_inc/blocks/' . $type . '/view.js';
 		if ( self::block_has_asset( $script_relative_path ) ) {
-			$script_version       = self::get_asset_version( $script_relative_path );
-			$view_script  = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+			$script_version = self::get_asset_version( $script_relative_path );
+			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version );
 		}
 	}
@@ -55,17 +93,6 @@ class Jetpack_Gutenberg {
 		return Jetpack::is_development_version() && self::block_has_asset( $file )
 			? filemtime( JETPACK__PLUGIN_DIR . $file )
 			: JETPACK__VERSION;
-	}
-
-	/**
-	 * Check if Gutenberg editor is available
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return bool
-	 */
-	public static function is_gutenberg_available() {
-		return function_exists( 'register_block_type' );
 	}
 
 	/**
@@ -138,29 +165,5 @@ class Jetpack_Gutenberg {
 		Jetpack::setup_wp_i18n_locale_data();
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-	}
-
-	/**
-	 * Check whether conditions indicate Gutenberg blocks should be loaded
-	 *
-	 * Loading blocks is enabled by default and may be disabled via filter:
-	 *   add_filter( 'jetpack_gutenberg', '__return_false' );
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return bool
-	 */
-	public static function should_load_blocks() {
-		if ( ! Jetpack::is_active() ) {
-			return false;
-		}
-		/**
-		 * Filter to disable Gutenberg blocks
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param bool true Whether to load Gutenberg blocks
-		 */
-		return (bool) apply_filters( 'jetpack_gutenberg', true );
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 1000 );
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_assets' ) );
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_all_blocks' ), 1000 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_all_blocks' ), 1000 );
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 1000 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -255,7 +255,8 @@ gulp.task( 'languages:extract', function( done ) {
 	gulp.src( [
 		'_inc/client/**/*.js',
 		'_inc/client/**/*.jsx',
-		'_inc/blocks/*.js'
+		'_inc/blocks/*.js',
+		'_inc/blocks/**/*.js'
 	] )
 		.pipe( tap( function( file ) {
 			paths.push( file.path );

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -30,3 +30,12 @@ function jetpack_tiled_gallery_configuration_load() {
 }
 
 jetpack_load_tiled_gallery();
+
+// Tile-gallery block definition can be found in wp-calypso repo
+jetpack_register_block( 'tiled-gallery', array(
+	'render_callback' => 'jetpack_tiled_gallery_load_assets'
+) );
+function jetpack_tiled_gallery_load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
+	return $content;
+}

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -33,16 +33,17 @@ jetpack_load_tiled_gallery();
 
 // Tile-gallery block definition can be found in wp-calypso repo
 jetpack_register_block( 'tiled-gallery', array(
-	'render_callback' => 'jetpack_tiled_gallery_load_assets'
+	'render_callback' => 'jetpack_tiled_gallery_load_assets' // This is needed to enqueue front end assets as we request them instead of always
 ) );
 
 /**
  * Renders the tiled gallery dynamically to the user
+ * Currently we use the render_callback to include only load the front end assets when they are required.
  *
  * @param $attr array - array of attributes
  * @param $content string - content block
  *
- * @return mixed
+ * @return string
  */
 function jetpack_tiled_gallery_load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -35,6 +35,15 @@ jetpack_load_tiled_gallery();
 jetpack_register_block( 'tiled-gallery', array(
 	'render_callback' => 'jetpack_tiled_gallery_load_assets'
 ) );
+
+/**
+ * Renders the tiled gallery dynamically to the user
+ *
+ * @param $attr array - array of attributes
+ * @param $content string - content block
+ *
+ * @return mixed
+ */
 function jetpack_tiled_gallery_load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
 	return $content;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #10325 

Requires you to build the blocks via this branch:
https://github.com/Automattic/wp-calypso/pull/28066 

This PR implement a new `jetpack_register_block()` function. Which helps Jetpack have a better understand what blocks are supported and active. Different modules could be disabled. This information could then also be used in the editor to show/hide the blocks there as well.

I only added the tiled-gallery block because for now it is the only block that has frontend assets. 

#### Testing instructions:
URL: [JN test](https://jurassic.ninja/create/?jetpack-beta&branch=update/jetpack-gutenber-only-load-assets-as-required&shortlived&wp-debug-log&gutenberg&gutenpack)

Create a new tile gallery block. 
Notice that the tile gallery view.js is only loaded on the page where the block appears.


#### Proposed changelog entry for your changes:
Only load front end assets as required by the block. 
