### PR TITLE
New Contact Form After Email Sent Hook

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2554,6 +2554,23 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		}
 
+		/**
+		 * Fires an action hook right after the email(s) have been sent.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 6.6.2
+		 *
+		 * @param int $post_id Post contact form lives on.
+		 * @param string|array $to Array of valid email addresses, or single email address.
+		 * @param string $subject Feedback email subject.
+		 * @param string $message Feedback email message.
+		 * @param string|array $headers Optional. Additional headers.
+		 * @param array $all_values Contact form fields.
+		 * @param array $extra_values Contact form fields not included in $all_values
+		 */
+		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
+
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return self::success_message( $post_id, $this );
 		}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2559,7 +2559,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 7.2.0
+		 * @since 7.3.0
 		 *
 		 * @param int $post_id Post contact form lives on.
 		 * @param string|array $to Array of valid email addresses, or single email address.

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2559,7 +2559,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @module contact-form
 		 *
-		 * @since 6.6.2
+		 * @since 7.2.0
 		 *
 		 * @param int $post_id Post contact form lives on.
 		 * @param string|array $to Array of valid email addresses, or single email address.


### PR DESCRIPTION
Fixes #8041

#### Changes proposed in this Pull Request:
* Adds new grunion_after_message_sent hook that can be fired after a contact form email has been sent.

#### Testing instructions:
* Add a call to `add_action( 'grunion_after_message_sent', 'my_custom_action' );` in a custom plugin file.
* Add a method `function my_custom_action( $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );`
* Test that all passed parameters contain the expected values.

#### Proposed changelog entry for your changes:
* Adds new Contact Form hook `grunion_after_message_sent` that will fire after a contact form email has been sent.
