### PR TITLE
Make cancel link appear as a button for a11y

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -533,7 +533,7 @@ class Share_Email extends Sharing_Source {
 			/** This filter is documented in modules/stats.php */
 			echo apply_filters( 'jetpack_static_url', plugin_dir_url( __FILE__ ) . 'images/loading.gif' ); ?>" alt="loading" width="16" height="16" />
 			<input type="submit" value="<?php esc_attr_e( 'Send Email', 'jetpack' ); ?>" class="sharing_send" />
-			<a rel="nofollow" href="#cancel" class="sharing_cancel"><?php _e( 'Cancel', 'jetpack' ); ?></a>
+			<a rel="nofollow" href="#cancel" class="sharing_cancel" role="button"><?php _e( 'Cancel', 'jetpack' ); ?></a>
 
 			<div class="errors errors-1" style="display: none;">
 				<?php _e( 'Post was not sent - check your email addresses!', 'jetpack' ); ?>


### PR DESCRIPTION
Signed-off-by: Carol Ng <carol@carolkng.com>

Adds the `role="button"` attribute to the "Cancel" button for email sharing to make it appear as a button in screen readers.

Note: a better alternative would probably be to wrap the link in a button element, so if that's preferred, some guidance on what CSS attributes/files to pay attention to would be great.

Fixes #8842

#### Changes proposed in this Pull Request:

Should have no functional changes.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate to the "email sharing" page
* Using Voiceover (on Mac?), or another screen reader utility, hover over the "Cancel" link and make sure that the reader classifies it as a button

<screenshots forthcoming>

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improved accessibility of email sharing page -- links that don't link anywhere are now buttons
