### PR TITLE
Search: Sync with the WP.com codebase

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -201,15 +201,6 @@ class Jetpack_Search {
 	}
 
 	/**
-	 * Does this site have a VIP index
-	 *
-	 * @since 6.0
-	 */
-	public function has_vip_index() {
-		return defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX;
-	}
-
-	/**
 	 * When an Elasticsearch query fails, this stores it and enqueues some debug information in the footer.
 	 *
 	 * @since 5.6.0
@@ -841,7 +832,7 @@ class Jetpack_Search {
 		$parser = new Jetpack_WPES_Search_Query_Parser( $args['query'], array( get_locale() ) );
 
 		if ( empty( $args['query_fields'] ) ) {
-			if ( $this->has_vip_index() ) {
+			if ( Jetpack_Search_Helpers::site_has_vip_index() ) {
 				// VIP indices do not have per language fields
 				$match_fields = $this->_get_caret_boosted_fields(
 					array(

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -150,7 +150,7 @@ class Jetpack_Search {
 	 * @since 5.0.0
 	 */
 	public function setup() {
-		if ( ! Jetpack::is_active() || ! Jetpack::active_plan_supports( 'search' ) ) {
+		if ( ! Jetpack::is_active() || ! $this->is_search_supported() ) {
 			return;
 		}
 
@@ -160,9 +160,9 @@ class Jetpack_Search {
 			return;
 		}
 
-		require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
-		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
-		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
+		require_once( dirname( __FILE__ ) . '/class.jetpack-search-helpers.php' );
+		require_once( dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php' );
+		require_once( JETPACK__PLUGIN_DIR . 'modules/widgets/search.php' );
 
 		$this->init_hooks();
 	}
@@ -189,6 +189,24 @@ class Jetpack_Search {
 		}
 
 		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
+	}
+
+	/**
+	 * Is search supported on the current plan
+	 *
+	 * @since 6.0
+	 */
+	public function is_search_supported() {
+		return Jetpack::active_plan_supports( 'search' );
+	}
+
+	/**
+	 * Does this site have a VIP index
+	 *
+	 * @since 6.0
+	 */
+	public function has_vip_index() {
+		return defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX;
 	}
 
 	/**
@@ -823,7 +841,7 @@ class Jetpack_Search {
 		$parser = new Jetpack_WPES_Search_Query_Parser( $args['query'], array( get_locale() ) );
 
 		if ( empty( $args['query_fields'] ) ) {
-			if ( defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX ) {
+			if ( $this->has_vip_index() ) {
 				// VIP indices do not have per language fields
 				$match_fields = $this->_get_caret_boosted_fields(
 					array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This syncs `class.jetpack-search.php` with the WP.com codebase.

The only element left unsync-ed is Tracks, I'm not completely sure how the `record_tracks_event` / `jetpack_record_tracks_event` transformation usually works?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

no functional changes

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

WIP

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

no changelog entry needed
