### PR TITLE
Debugger:Add PHP XML check

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -232,7 +232,7 @@ class Jetpack_Debugger {
 
 		$tests['XML']['result'] = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
 		/* translators: Link to Jetpack Hosting support page. */
-		$tests['XML']['fail_message'] = esc_html__( sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ), 'jetpack' );
+		$tests['XML']['fail_message'] = __( sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ), 'jetpack' );
 
 		$tests['HTTP']['result']       = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
 		$tests['HTTP']['fail_message'] = esc_html__( 'Your site isn’t reaching the Jetpack servers.', 'jetpack' );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -230,9 +230,8 @@ class Jetpack_Debugger {
 
 		$tests = array();
 
-		$tests['XML']['result'] = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
-		/* translators: This is the same error as seen in Core's class-IXR-message.php's parse function. */
-		$tests['XML']['fail_message'] = esc_html__( "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension.", 'jetpack' );
+		$tests['XML']['result']       = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
+		$tests['XML']['fail_message'] = esc_html__( 'Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is required for WordPress and Jetpack, please enable it or contact your hosting provider.', 'jetpack' );
 
 		$tests['HTTP']['result']       = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
 		$tests['HTTP']['fail_message'] = esc_html__( 'Your site isn’t reaching the Jetpack servers.', 'jetpack' );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -232,7 +232,7 @@ class Jetpack_Debugger {
 
 		$tests['XML']['result'] = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
 		/* translators: Link to Jetpack Hosting support page. */
-		$tests['XML']['fail_message'] = __( sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ), 'jetpack' );
+		$tests['XML']['fail_message'] = esc_html__( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ .', 'jetpack' );
 
 		$tests['HTTP']['result']       = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
 		$tests['HTTP']['fail_message'] = esc_html__( 'Your site isn’t reaching the Jetpack servers.', 'jetpack' );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -230,8 +230,9 @@ class Jetpack_Debugger {
 
 		$tests = array();
 
-		$tests['XML']['result']       = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
-		$tests['XML']['fail_message'] = esc_html__( 'Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is required for WordPress and Jetpack, please enable it or contact your hosting provider.', 'jetpack' );
+		$tests['XML']['result'] = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
+		/* translators: Link to Jetpack Hosting support page. */
+		$tests['XML']['fail_message'] = esc_html__( sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ), 'jetpack' );
 
 		$tests['HTTP']['result']       = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
 		$tests['HTTP']['fail_message'] = esc_html__( 'Your site isn’t reaching the Jetpack servers.', 'jetpack' );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -230,6 +230,10 @@ class Jetpack_Debugger {
 
 		$tests = array();
 
+		$tests['XML']['result'] = ( function_exists( 'xml_parser_create' ) ) ? 'PASS' : false;
+		/* translators: This is the same error as seen in Core's class-IXR-message.php's parse function. */
+		$tests['XML']['fail_message'] = esc_html__( "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension.", 'jetpack' );
+
 		$tests['HTTP']['result']       = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
 		$tests['HTTP']['fail_message'] = esc_html__( 'Your site isn’t reaching the Jetpack servers.', 'jetpack' );
 

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -151,7 +151,7 @@ class Jetpack_Sitemap_Builder {
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
 					__(
-						sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ),
+						'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our >server requirements at https://jetpack.com/support/server-requirements/ .',
 						'jetpack'
 					),
 					true

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -151,7 +151,7 @@ class Jetpack_Sitemap_Builder {
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
 					__(
-						'Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is required for WordPress and Jetpack, please enable it or contact your hosting provider.',
+						sprintf( 'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our <a href="%s">server requirements</a>.', 'https://jetpack.com/support/server-requirements/' ),
 						'jetpack'
 					),
 					true

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -151,7 +151,7 @@ class Jetpack_Sitemap_Builder {
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
 					__(
-						'-- WARNING: Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is highly recommended for WordPress and Jetpack, please enable it or contact your hosting provider.',
+						'Jetpack can not load necessary XML manipulation libraries. This can happen if XML support in PHP is not enabled on your server. XML support is required for WordPress and Jetpack, please enable it or contact your hosting provider.',
 						'jetpack'
 					),
 					true


### PR DESCRIPTION
Generally, PHP's XML extension is built as part of PHP. Since PHP 7.0, however, especially on Ubuntu-based systems, it is often not included unless `php-xml` has been installed (using `apt-get install php-xml` or `apt-get install php7.0-xml`, `yum -y install php-xml`, etc).

When we are working with a customer, this can be hard to realize with the current debugging suite. This would add an explicit check for one of the php-xml functions.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add an explicit check for a php-xml function.

#### Testing instructions:

* On a JN or other known working site, visit the Jetpack debugger via the footer of the jetpack dashboard page and ensure the XML test passes (via the advanced debug results).
* Install PHP 7.x on a clean Ubuntu server and intentionally do not install php-xml. Typically, this will put us in the error state. Repeat the above. Ensure it fails.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Improve debugging suite to determine when php-xml is not installed.

h/t @danjjohnson for the suggestion.