### PR TITLE
JITM: update naming convention based on feedback.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -31,16 +31,16 @@ jQuery( document ).ready( function( $ ) {
 				html += '</div>';
 			}
 			html += '</div>';
-			if ( envelope.activate_module ) {
+			if ( envelope.has_activated_module ) {
 				html += '<div class="jitm-banner__action" id="jitm-banner__activate">';
-				html += '<a href="#" data-module="' + envelope.activate_module + '" type="button" class="jitm-button is-compact is-primary jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '-activate_module">' + window.jitm_config.activate_module_text + '</a>';
+				html += '<a href="#" data-module="' + envelope.has_activated_module + '" type="button" class="jitm-button is-compact is-primary jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' + envelope.id + '-activate_module">' + window.jitm_config.activate_module_text + '</a>';
 				html += '</div>';
 			}
 			if ( envelope.CTA.message ) {
 				var ctaClasses = 'jitm-button is-compact jptracks';
 				if (
 					envelope.CTA.primary &&
-					null === envelope.activate_module
+					null === envelope.has_activated_module
 				) {
 					ctaClasses += ' is-primary';
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This does not change the functionality behind that feature. Only the name changes.

Companion diff: D19898-code

`activate_module` is now `has_activated_module`.

#### Testing instructions:

1. Apply D19898-code to your WordPress.com sandbox.
2. Point your Jetpack site to your WordPress.com sandbox by adding `define( 'JETPACK__SANDBOX_DOMAIN', 'sandboxme.wordpress.com' );` to your Jetpack site's `wp-config.php` file (replace `sandboxme` by your own WordPress.com sandbox address). Also add `define( 'SCRIPT_DEBUG', true );` to that same file.
3. Point `jetpack.com` to your WordPress.com sandbox in your hosts file.
4. Go to `{my-site}/wp-admin/admin.php?page=jetpack_modules` and make sure that the Asset CDN module is off on your site.
5. Add the following to your site to make sure the CDN will not intervene while testing this PR: `add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );`
6. You're all set to start testing! Go to the main dashboard of your Jetpack site.

Make sure you can turn on the module from the JITM.

When you refresh the page, the JITM should be gone.

#### Proposed changelog entry for your changes:
* none
