### PR TITLE
Akismet: Always cache key result

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7135,7 +7135,7 @@ p {
 	 * @return bool True = Akismet available. False = Aksimet not available.
 	 */
 	public static function is_akismet_active() {
-		if ( method_exists( 'Akismet' , 'http_post' ) ) {
+		if ( method_exists( 'Akismet', 'http_post' ) ) {
 			$akismet_key = Akismet::get_api_key();
 			if ( ! $akismet_key ) {
 				return false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7143,13 +7143,10 @@ p {
 			$cached_key_verification = get_transient( 'jetpack_akismet_key_is_valid' );
 
 			// We cache the result of the Akismet key verification for ten minutes.
-			if ( in_array( $cached_key_verification, array( 'valid', 'invalid' ) ) ) {
+			if ( $cached_key_verification ) {
 				$akismet_key_state = $cached_key_verification;
 			} else {
 				$akismet_key_state = Akismet::verify_key( $akismet_key );
-				if ( 'failed' === $akismet_key_state ) {
-					return false;
-				}
 				set_transient( 'jetpack_akismet_key_is_valid', $akismet_key_state, 10 * MINUTE_IN_SECONDS );
 			}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7142,8 +7142,10 @@ p {
 			}
 			$cached_key_verification = get_transient( 'jetpack_akismet_key_is_valid' );
 
+			// Do not used the cache result in wp-admin or REST API requests if the key isn't valid, in case someone is actively renewing, etc.
+			$recheck = ( ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && 'valid' !== $cached_key_verification ) ? true : false;
 			// We cache the result of the Akismet key verification for ten minutes.
-			if ( $cached_key_verification ) {
+			if ( $cached_key_verification && ! $recheck ) {
 				$akismet_key_state = $cached_key_verification;
 			} else {
 				$akismet_key_state = Akismet::verify_key( $akismet_key );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7158,14 +7158,14 @@ p {
 		$akismet_key_state = get_transient( 'jetpack_akismet_key_is_valid' );
 
 		// Do not used the cache result in wp-admin or REST API requests if the key isn't valid, in case someone is actively renewing, etc.
-		$recheck = ( ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && 'valid' !== $akismet_key_state ) ? true : false;
+		$recheck = ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && 'valid' !== $akismet_key_state;
 		// We cache the result of the Akismet key verification for ten minutes.
 		if ( ! $akismet_key_state || $recheck ) {
 			$akismet_key_state = Akismet::verify_key( $akismet_key );
 			set_transient( 'jetpack_akismet_key_is_valid', $akismet_key_state, 10 * MINUTE_IN_SECONDS );
 		}
 
-		$status = ( 'valid' === $akismet_key_state );
+		$status = 'valid' === $akismet_key_state;
 
 		return $status;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Always cache the result of the Akismet key check.

#### Testing instructions:
* Do something that requires the Akismet check. For example, add a Email sharing button via the Sharing module to your site.
* Monitor your server's outbound HTTP and see that Akismet is checked no more than once on the front-end when looking at a post with an e-mail sharing button added.

#### Proposed changelog entry for your changes:

* Improves caching of Akismet status.
