### PR TITLE
Gutenberg: do not load our blocks by default.

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -162,6 +162,6 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param bool true Whether to load Gutenberg blocks
 		 */
-		return (bool) apply_filters( 'jetpack_gutenberg', true );
+		return (bool) apply_filters( 'jetpack_gutenberg', false );
 	}
 }

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -160,7 +160,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param bool true Whether to load Gutenberg blocks
+		 * @param bool $jetpack_gutenberg Whether to load Gutenberg blocks
 		 */
 		return (bool) apply_filters( 'jetpack_gutenberg', false );
 	}

--- a/docs/guides/gutenberg-blocks.md
+++ b/docs/guides/gutenberg-blocks.md
@@ -10,6 +10,14 @@ _Note: Since the Gutenberg SDK is still being actively developed, the developmen
     yarn docker:wp plugin install gutenberg --activate
     ```
 
+1. In Jetpack, enable loading block assets by adding following filters to your local mu-plugins folder:
+
+```php
+add_filter( 'jetpack_gutenberg', '__return_true', 10 );
+```
+
+If you use Jetpack-Docker, you could add these to `docker/mu-plugins/0-custom.php`
+
 1. Jetpack will now load these files when editing posts in Gutenberg:
 
     ```


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's keep this feature off by default for this release. This will allow us to ship the blocks, but not display them in the UI until you manually enable them with the filter.

This will allow us to:
- test the blocks with the stable version if we need to.
- test our release process and make sure all the blocks are correctly shipped.
- index the strings currently available in the blocks, so they can be translated by the next release.

Related discussion: 
p1540891056186200-slack-jetpack-gutenberg

**See pafL3P-6y-p2 to see if this will be needed or not.**

#### Testing instructions:

1. Check out this PR.
2. Go to Posts > Add New.
3. Make sure no block is available when you search for `/markdown` or `/tiled` for example.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* none
