### PR TITLE
Add support for SSO without a connection/confirmation.

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -628,7 +628,7 @@ class Jetpack_SSO {
 		if ( ! $nonce ) {
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client( array(
-				'user_id' => Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
+				'user_id' => $user_id && Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
 			) );
 			$xml->query( 'jetpack.sso.requestNonce' );
 
@@ -661,7 +661,7 @@ class Jetpack_SSO {
 
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
+			'user_id' => $user_id && Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
 		) );
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
@@ -673,7 +673,8 @@ class Jetpack_SSO {
 		}
 
 		$user_data = (object) $user_data;
-		$user = null;
+		$user      = null;
+		$user_id   = 0;
 
 		/**
 		 * Fires before Jetpack's SSO modifies the log in form.

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -620,14 +620,15 @@ class Jetpack_SSO {
 	}
 
 	static function request_initial_nonce() {
-		$nonce = ! empty( $_COOKIE[ 'jetpack_sso_nonce' ] )
+		$user_id = get_current_user_id();
+		$nonce   = ! empty( $_COOKIE[ 'jetpack_sso_nonce' ] )
 			? $_COOKIE[ 'jetpack_sso_nonce' ]
 			: false;
 
 		if ( ! $nonce ) {
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client( array(
-				'user_id' => get_current_user_id(),
+				'user_id' => Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
 			) );
 			$xml->query( 'jetpack.sso.requestNonce' );
 
@@ -654,12 +655,13 @@ class Jetpack_SSO {
 	 * The function that actually handles the login!
 	 */
 	function handle_login() {
+		$user_id       = get_current_user_id();
 		$wpcom_nonce   = sanitize_key( $_GET['sso_nonce'] );
 		$wpcom_user_id = (int) $_GET['user_id'];
 
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id(),
+			'user_id' => Jetpack::is_user_connected( $user_id ) ? $user_id : 0,
 		) );
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -804,7 +804,7 @@ class Jetpack_SSO {
 				Jetpack::init()->verify_json_api_authorization_request( $json_api_auth_environment );
 				Jetpack::init()->store_json_api_authorization_token( $user->user_login, $user );
 
-			} else if ( ! $is_user_connected ) {
+			} else if ( ! $is_user_connected && Jetpack_SSO_Helpers::should_connect() ) {
 				$calypso_env = ! empty( $_GET['calypso_env'] )
 					? sanitize_key( $_GET['calypso_env'] )
 					: '';

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -290,7 +290,7 @@ class Jetpack_SSO_Helpers {
 	 * Default behavior is to connect every SSO request, but if `?connect=0`
 	 * (or another falsy value) then we allow a user to log in without connecting.
 	 *
-	 * @since 6.8
+	 * @since 6.8.0
 	 *
 	 * @return bool
 	 */

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -296,14 +296,14 @@ class Jetpack_SSO_Helpers {
 	 */
 	static function should_connect() {
 		if ( empty( $_COOKIE['jetpack_sso_original_request'] ) ) {
-			return false;
+			return true;
 		}
 
 		$original_request = esc_url_raw( $_COOKIE['jetpack_sso_original_request'] );
 
 		$parsed_url = wp_parse_url( $original_request );
 		if ( empty( $parsed_url ) || empty( $parsed_url['query'] ) ) {
-			return false;
+			return true;
 		}
 
 		$args = array();

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -285,6 +285,38 @@ class Jetpack_SSO_Helpers {
 	}
 
 	/**
+	 * Checks the initial `$_REQUEST` to see if `?connect` was set explicitly.
+	 *
+	 * Default behavior is to connect every SSO request, but if `?connect=0`
+	 * (or another falsy value) then we allow a user to log in without connecting.
+	 *
+	 * @since 6.8
+	 *
+	 * @return bool
+	 */
+	static function should_connect() {
+		if ( empty( $_COOKIE['jetpack_sso_original_request'] ) ) {
+			return false;
+		}
+
+		$original_request = esc_url_raw( $_COOKIE['jetpack_sso_original_request'] );
+
+		$parsed_url = wp_parse_url( $original_request );
+		if ( empty( $parsed_url ) || empty( $parsed_url['query'] ) ) {
+			return false;
+		}
+
+		$args = array();
+		wp_parse_str( $parsed_url['query'], $args );
+
+		if ( empty( $args ) || ! isset( $args['connect'] ) ) {
+			return true;
+		}
+
+		return filter_var( $args['connect'], FILTER_VALIDATE_BOOLEAN );
+	}
+
+	/**
 	 * This method returns an environment array that is meant to simulate `$_REQUEST` when the initial
 	 * JSON API auth request was made.
 	 *

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -239,13 +239,13 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), '?hello=world' );
 
 		// With `connect=[truthy]`, returns true
-		foreach ( [ '1', 'yes', 'on', 'true', 'yeS', 'oN', 'TruE' ] as $_truthy ) {
+		foreach ( array( '1', 'yes', 'on', 'true', 'yeS', 'oN', 'TruE' ) as $_truthy ) {
 			$_COOKIE['jetpack_sso_original_request'] = 'http://website.com?connect=' . rawurlencode( $_truthy );
 			$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), '?connect=' . $_truthy );
 		}
 
 		// With `connect=[anything else]`, returns false
-		foreach ( [ '0', 'no', 'off', 'false', 'nO', 'oFf', 'FalsE', 'abc', '123' ] as $_falsy ) {
+		foreach ( array( '0', 'no', 'off', 'false', 'nO', 'oFf', 'FalsE', 'abc', '123' ) as $_falsy ) {
 			$_COOKIE['jetpack_sso_original_request'] = 'http://website.com?connect=' . rawurlencode( $_falsy );
 			$this->assertFalse( Jetpack_SSO_Helpers::should_connect(), '?connect=' . $_falsy );
 		}

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -221,6 +221,36 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		remove_filter( 'jetpack_sso_allowed_actions', array( $this, 'allow_hello_world_login_action_for_sso' ) );
 	}
 
+	function test_should_connect_helper() {
+		// With no cookie returns true
+		unset( $_COOKIE['jetpack_sso_original_request'] );
+		$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), 'no cookie' );
+
+		// With empty cookie returns true
+		$_COOKIE['jetpack_sso_original_request'] = '';
+		$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), 'empty cookie' );
+
+		// With empty query, returns true
+		$_COOKIE['jetpack_sso_original_request'] = 'http://website.com';
+		$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), 'no query' );
+
+		// With no `connect` query argument, returns true
+		$_COOKIE['jetpack_sso_original_request'] = 'http://website.com?hello=world';
+		$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), '?hello=world' );
+
+		// With `connect=[truthy]`, returns true
+		foreach ( [ '1', 'yes', 'on', 'true', 'yeS', 'oN', 'TruE' ] as $_truthy ) {
+			$_COOKIE['jetpack_sso_original_request'] = 'http://website.com?connect=' . rawurlencode( $_truthy );
+			$this->assertTrue( Jetpack_SSO_Helpers::should_connect(), '?connect=' . $_truthy );
+		}
+
+		// With `connect=[anything else]`, returns false
+		foreach ( [ '0', 'no', 'off', 'false', 'nO', 'oFf', 'FalsE', 'abc', '123' ] as $_falsy ) {
+			$_COOKIE['jetpack_sso_original_request'] = 'http://website.com?connect=' . rawurlencode( $_falsy );
+			$this->assertFalse( Jetpack_SSO_Helpers::should_connect(), '?connect=' . $_falsy );
+		}
+	}
+
 	function test_get_json_api_auth_environment() {
 		// With no cookie returns false
 		$_COOKIE['jetpack_sso_original_request'] = '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Allow site "connections" to be bypassed in favor of just the SSO login action itself whenever the original login URL contains `?connect=false`.
  e.g., `https://example.com/wp-login.php?connect=false`

#### Testing instructions

* See D19940-code for example a8c use case.
* Patch D19940-code and follow test instructions there.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog entry necessary.