### PR TITLE
Connection banner: update based on feedback.

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -873,7 +873,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							'Optimize: Upload images and videos directly to our powerful servers that present your media with lightning speed.',
+							"Optimize: Jetpack's site accelerator uploads images, videos, and static files like CSS to our powerful servers and delivers them at lightning-fast speeds to your visitors. You'll also save precious bandwidth.",
 							'jetpack'
 						);
 					?></p>
@@ -914,7 +914,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							'Optimize: activate Jetpack’s site accelerator to load pages faster, optimize your images, and serve your images and static files (like CSS and JavaScript) from our global network of servers. You’ll also reduce bandwidth usage, which may lead to lower hosting costs.',
+							'Earn: Generate revenue with the WordPress.com ad program and accept payment for goods and services with our simple payments button.',
 							'jetpack'
 						);
 					?></p>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -873,7 +873,7 @@ class Jetpack_Connection_Banner {
 					?></p>
 					<p><?php
 						esc_html_e(
-							"Optimize: Jetpack's site accelerator uploads images, videos, and static files like CSS to our powerful servers and delivers them at lightning-fast speeds to your visitors. You'll also save precious bandwidth.",
+							'Optimize: Jetpack’s site accelerator uploads images, videos, and static files like CSS to our powerful servers and delivers them at lightning-fast speeds to your visitors. You’ll also save precious bandwidth.',
 							'jetpack'
 						);
 					?></p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

update wording of the main connection banner based on feedback on p1HpG7-5J1-p2 

Here is the new look:

<img width="961" alt="screenshot 2018-10-30 at 16 57 45" src="https://user-images.githubusercontent.com/426388/47731815-3099e600-dc65-11e8-9a3c-ca300d414106.png">

#### Testing instructions:

* Fire up this PR.
* Check the full screen connection banner appearing when you first activate Jetpack; you will want to check the 2 first sections.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
