### PR TITLE
Gutenpack: opt-in for beta blocks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -167,22 +167,12 @@ class Jetpack_Gutenberg {
 		$rtl = is_rtl() ? '.rtl' : '';
 		$beta = defined( 'JETPACK_BETA_BLOCKS' ) && JETPACK_BETA_BLOCKS ? '-beta' : '';
 
-		/** This filter is already documented above */
-		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
-			$cdn_base      = 'https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks';
-			$editor_script = "$cdn_base/editor.js";
-			$editor_style  = "$cdn_base/editor$rtl.css";
+		$editor_script = plugins_url( "_inc/blocks/editor{$beta}.js", JETPACK__PLUGIN_FILE );
+		$editor_style  = plugins_url( "_inc/blocks/editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );
 
-			/** This filter is already documented above */
-			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
-		} else {
-			$editor_script = plugins_url( "_inc/blocks/editor{$beta}.js", JETPACK__PLUGIN_FILE );
-			$editor_style  = plugins_url( "_inc/blocks/editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );
-
-			$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
-				: JETPACK__VERSION;
-		}
+		$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
+			: JETPACK__VERSION;
 
 		wp_enqueue_script(
 			'jetpack-blocks-editor',

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -165,6 +165,7 @@ class Jetpack_Gutenberg {
 		}
 
 		$rtl = is_rtl() ? '.rtl' : '';
+		$beta = defined( 'JETPACK_BETA_BLOCKS' ) && JETPACK_BETA_BLOCKS ? '-beta' : '';
 
 		/** This filter is already documented above */
 		if ( apply_filters( 'jetpack_gutenberg_cdn', false ) ) {
@@ -175,8 +176,6 @@ class Jetpack_Gutenberg {
 			/** This filter is already documented above */
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
-			/** This filter is already documented above */
-			$beta = apply_filters( 'jetpack_beta_blocks', false ) ? '-beta' : '';
 			$editor_script = plugins_url( "_inc/blocks/editor{$beta}.js", JETPACK__PLUGIN_FILE );
 			$editor_style  = plugins_url( "_inc/blocks/editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -175,6 +175,7 @@ class Jetpack_Gutenberg {
 			/** This filter is already documented above */
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
+			/** This filter is already documented above */
 			$beta = apply_filters( 'jetpack_beta_blocks', false ) ? '-beta' : '';
 			$editor_script = plugins_url( "_inc/blocks/editor{$beta}.js", JETPACK__PLUGIN_FILE );
 			$editor_style  = plugins_url( "_inc/blocks/editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -175,8 +175,10 @@ class Jetpack_Gutenberg {
 			/** This filter is already documented above */
 			$version = apply_filters( 'jetpack_gutenberg_cdn_cache_buster', sprintf( '%s-%s', gmdate( 'd-m-Y' ), JETPACK__VERSION ) );
 		} else {
-			$editor_script = plugins_url( '_inc/blocks/editor.js', JETPACK__PLUGIN_FILE );
-			$editor_style  = plugins_url( "_inc/blocks/editor$rtl.css", JETPACK__PLUGIN_FILE );
+			$beta = apply_filters( 'jetpack_beta_blocks', false ) ? '-beta' : '';
+			$editor_script = plugins_url( "_inc/blocks/editor{$beta}.js", JETPACK__PLUGIN_FILE );
+			$editor_style  = plugins_url( "_inc/blocks/editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );
+
 			$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
 				? filemtime( JETPACK__PLUGIN_DIR . '_inc/blocks/editor.js' )
 				: JETPACK__VERSION;

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -30,22 +30,3 @@ function jetpack_tiled_gallery_configuration_load() {
 }
 
 jetpack_load_tiled_gallery();
-
-// Tile-gallery block definition can be found in wp-calypso repo
-jetpack_register_block( 'tiled-gallery', array(
-	'render_callback' => 'jetpack_tiled_gallery_load_assets' // This is needed to enqueue front end assets as we request them instead of always
-) );
-
-/**
- * Renders the tiled gallery dynamically to the user
- * Currently we use the render_callback to include only load the front end assets when they are required.
- *
- * @param $attr array - array of attributes
- * @param $content string - content block
- *
- * @return string
- */
-function jetpack_tiled_gallery_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
-	return $content;
-}


### PR DESCRIPTION
This PR will conditionally load Blocks in beta.

**How to test**

- First add `define( ‘JETPACK_BETA_BLOCKS’, true )` in a helper plugin to enable beta blocks.
- Build the blocks using the instructions on this PR on https://github.com/Automattic/wp-calypso/pull/28178
- Try one of the Beta blocks `vr` or `related-posts`


