### PR TITLE
REST API: Ensure URL is a string before passing to esc_url_raw

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -396,6 +396,13 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$return[$key] = false;
 			break;
 		case 'url' :
+			if ( is_object( $value ) && isset( $value->url ) && false !== strpos( $value->url, 'https://videos.files.wordpress.com/' ) ) {
+				$value = $value->url;
+			}
+			// Check for string since esc_url_raw() expects one.
+			if ( ! is_string( $value ) ) {
+				break;
+			}
 			$return[$key] = (string) esc_url_raw( $value );
 			break;
 		case 'string' :


### PR DESCRIPTION
Ensure an URL is a string before passing it to `esc_url_raw` with a special consideration for a VideoPress issue.

The VideoPress issue would be resolved by #10492, but this file is synced with WordPress.com and so trying to account for older version of Jetpack.

#### Changes proposed in this Pull Request:
* Verify a URL is a string, except for a VideoPress case, which we now take account for.

#### Testing instructions:
* Same as #10492, except do not apply that patch. Apply WordPress.com patch in the diff mentioned below.
* Attempt to query the attachment via the API. Before the patches, it returns empty. After it should work.

#### Proposed changelog entry for your changes:
* n/a
