### PR TITLE
WooCommerce Analytics: fix to refer to the static class property

### DIFF
--- a/modules/woocommerce-analytics/wp-woocommerce-analytics.php
+++ b/modules/woocommerce-analytics/wp-woocommerce-analytics.php
@@ -73,7 +73,7 @@ class Jetpack_WooCommerce_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
-		$analytics = new Jetpack_WooCommerce_Analytics_Universal();
+		self::$analytics = new Jetpack_WooCommerce_Analytics_Universal();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #10117 

#### Testing instructions:
* phpunit and JETPACK_TEST_WOOCOMMERCE=1 phpunit

#### Proposed changelog entry for your changes:

* WooCommerce Analytics: fix to refer to the static class property
