### PR TITLE
Fix masterbar hover styles for Calypsoify

### DIFF
--- a/modules/calypsoify/style.css
+++ b/modules/calypsoify/style.css
@@ -380,11 +380,15 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	color: #fff;
 }
 
+#wpadminbar ul li#wp-admin-bar-ab-new-post {
+	border-radius: 3px;
+}
+
 #wpadminbar ul li#wp-admin-bar-ab-new-post:hover,
 #wpadminbar ul li#wp-admin-bar-ab-new-post:hover > .ab-item {
 	background: #fff !important;
 	opacity: 1;
-	border-radius: 5px;
+	border-radius: 3px !important;
 }
 
 
@@ -411,7 +415,7 @@ div#wpadminbar .quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon
 }
 
 #wpadminbar ul li#wp-admin-bar-ab-new-post a {
-	padding: 6px 20px;
+	padding: 6px 15px;
 	color: #0087be !important;
 }
 
@@ -420,8 +424,8 @@ div#wpadminbar .quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon
 	font-size: 14px !important;
 }
 
-#wpadminbar ul li#wp-admin-bar-ab-new-post a:before, #wpadminbar ul li#wp-admin-bar-ab-new-post a:after {
-	filter: brightness(4);
+#wpadminbar ul li#wp-admin-bar-ab-new-post a:before {
+	background-image: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+PGc+PHBhdGggZmlsbD0iIzAwODdiZSIgZD0iTTIxIDE0djVjMCAxLjEwNS0uODk1IDItMiAySDVjLTEuMTA1IDAtMi0uODk1LTItMlY1YzAtMS4xMDUuODk1LTIgMi0yaDV2Mkg1djE0aDE0di01aDJ6Ii8+PHBhdGggZmlsbD0iIzAwODdiZSIgZD0iTTIxIDdoLTRWM2gtMnY0aC00djJoNHY0aDJWOWg0Ii8+PC9nPjwvc3ZnPg==) !important;
 }
 
 #wpadminbar li#wp-admin-bar-blog.menupop > .ab-sub-wrapper,

--- a/modules/calypsoify/style.css
+++ b/modules/calypsoify/style.css
@@ -370,11 +370,29 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 
 #wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus, 
 #wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus, 
-#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item, 
-#wpadminbar .ab-top-menu > li.hover > .ab-item,
 #wpadminbar .ab-top-menu > li.ab-hover > .ab-item {
 	background: transparent !important;
 }
+
+#wpadminbar .ab-top-menu > li.hover > .ab-item,
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item {
+	background: #0099d8 !important;
+	color: #fff;
+}
+
+#wpadminbar ul li#wp-admin-bar-ab-new-post:hover,
+#wpadminbar ul li#wp-admin-bar-ab-new-post:hover > .ab-item {
+	background: #fff !important;
+	opacity: 1;
+	border-radius: 5px;
+}
+
+
+#wpadminbar ul li#wp-admin-bar-notes.active,
+#wpadminbar ul li#wp-admin-bar-notes.active > .ab-item {
+	background: #004967 !important;
+}
+
 
 #wpadminbar .ab-top-menu > li.my-sites > .ab-item,
 #wpadminbar .ab-top-menu > li.my-sites.hover > .ab-item,
@@ -394,7 +412,7 @@ div#wpadminbar .quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon
 
 #wpadminbar ul li#wp-admin-bar-ab-new-post a {
 	padding: 6px 20px;
-	color: #0087be !important
+	color: #0087be !important;
 }
 
 #wpadminbar ul li#wp-admin-bar-ab-new-post a span {


### PR DESCRIPTION
Fixes #10484.

This PR adds hover states to the masterbar items, which matches the behavior on WordPress.com

#### Testing instructions:
* Activate Calypsoify
* Hover over the Masterbar items and confirm you see the light blue hover.

<img width="731" alt="screen shot 2018-10-31 at 12 38 35 pm" src="https://user-images.githubusercontent.com/689165/47803905-e7e83880-dd09-11e8-8bee-b509f1f9d9d8.png">


#### Proposed changelog entry for your changes:
N/A
