### PR TITLE
Ensure old files aren't being built

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "scripts": {
     "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
-    "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html css/",
+    "clean-client": "rm -rf _inc/build/ css/",
     "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
-    "build": "yarn install-if-deps-outdated && yarn build-client",
+    "build": "yarn install-if-deps-outdated && yarn clean-client && yarn build-client",
     "build-client": "gulp",
     "build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
     "build-production": "yarn distclean && yarn && gulp languages:extract && yarn build-production-client",


### PR DESCRIPTION
Our build script moves everything it needs into the `_inc/build` folder, but doesn't first clean up anything existing. This results in whatever is on our computers being held over during a new build.

Fixes the vr-block JS from being included in the built branches.

#### Changes proposed in this Pull Request:
* Adds `clean-client` to the build script and update `clean-client` to just delete the whole build folder.

#### Testing instructions:
* Checkout branch-6.7-built.
* Notice the `_inc/build/shortcodes/js/blocks/` folder with the vr JS there. (It isn't in the actual repo anymore).
* Run yarn build without patch. It's still there. Run yarn build with the patch, it won't be.

#### Proposed changelog entry for your changes:

* Build script improvements.
