### PR TITLE
6.7 Warm Welcome: enhanced Tracks

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -236,6 +236,7 @@ class JetpackStateNotices extends React.Component {
 				<UpgradeNoticeContent
 					dismiss={ this.dismissJetpackStateNotice }
 					isUnavailableInDevMode={ this.props.isUnavailableInDevMode }
+					version={ versionForUpgradeNotice }
 				/>
 			);
 		}

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -231,12 +231,13 @@ class JetpackStateNotices extends React.Component {
 		// Show custom message for upgraded Jetpack
 		const currentVersion = this.props.currentVersion;
 		const versionForUpgradeNotice = /(6\.7).*/;
-		if ( 'modules_activated' === message && currentVersion.match( versionForUpgradeNotice ) ) {
+		const match = currentVersion.match( versionForUpgradeNotice );
+		if ( 'modules_activated' === message && match ) {
 			return (
 				<UpgradeNoticeContent
 					dismiss={ this.dismissJetpackStateNotice }
 					isUnavailableInDevMode={ this.props.isUnavailableInDevMode }
-					version={ versionForUpgradeNotice }
+					version={ match[ '1' ] }
 				/>
 			);
 		}

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -24,6 +24,13 @@ import analytics from 'lib/analytics';
 
 const UpgradeNoticeContent = moduleSettingsForm(
 	class extends Component {
+		trackLearnMoreClick = () => {
+			analytics.tracks.recordJetpackClick( {
+				target: 'warm_welcome_learn_more',
+				version: this.props.version
+			} );
+		};
+
 		toggleModule = ( name, value ) => {
 			this.props.updateOptions( { [ name ]: ! value } );
 		};
@@ -82,12 +89,14 @@ const UpgradeNoticeContent = moduleSettingsForm(
 				// Track the main toggle switch.
 				analytics.tracks.recordJetpackClick( {
 					target: 'jetpack_site_accelerator_toggle',
-					toggled: 'on'
+					toggled: 'on',
+					from: 'warm_welcome'
 				} );
 			} else {
 				analytics.tracks.recordJetpackClick( {
 					target: 'jetpack_site_accelerator_toggle',
-					toggled: 'off'
+					toggled: 'off',
+					from: 'warm_welcome'
 				} );
 			}
 
@@ -95,7 +104,8 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			if ( this.props.getOptionValue( 'photon' ) !== newPhotonStatus ) {
 				analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
 					module: 'photon',
-					toggled: ( false === newPhotonStatus ) ? 'off' : 'on'
+					toggled: ( false === newPhotonStatus ) ? 'off' : 'on',
+					from: 'warm_welcome'
 				} );
 			}
 
@@ -103,7 +113,8 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			if ( this.props.getOptionValue( 'photon-cdn' ) !== newAssetCdnStatus ) {
 				analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
 					module: 'photon-cdn',
-					toggled: ( false === newAssetCdnStatus ) ? 'off' : 'on'
+					toggled: ( false === newAssetCdnStatus ) ? 'off' : 'on',
+					from: 'warm_welcome'
 				} );
 			}
 		};
@@ -230,6 +241,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 						<Button
 							primary={ true }
 							href="https://jetpack.com/support/site-accelerator/"
+							onClick={ this.trackLearnMoreClick }
 						>
 							{ __( 'Learn more' ) }
 						</Button>
@@ -254,6 +266,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 JetpackDialogue.propTypes = {
 	dismiss: PropTypes.func,
 	isUnavailableInDevMode: PropTypes.func,
+	version: PropTypes.string,
 };
 
 export default connect(

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -31,6 +31,22 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			} );
 		};
 
+		trackNoticeView = () => {
+			analytics.tracks.recordEvent(
+				'jetpack_warm_welcome_view',
+				{ version: this.props.version }
+			);
+		};
+
+		dismissNotice = () => {
+			analytics.tracks.recordJetpackClick( {
+				target: 'warm_welcome_learn_more',
+				version: this.props.version
+			} );
+
+			return this.props.dismiss;
+		};
+
 		toggleModule = ( name, value ) => {
 			this.props.updateOptions( { [ name ]: ! value } );
 		};
@@ -120,6 +136,8 @@ const UpgradeNoticeContent = moduleSettingsForm(
 		};
 
 		renderInnerContent() {
+			this.trackNoticeView();
+
 			const foundPhoton = this.props.isModuleFound( 'photon' );
 			const foundAssetCdn = this.props.isModuleFound( 'photon-cdn' );
 
@@ -256,7 +274,7 @@ const UpgradeNoticeContent = moduleSettingsForm(
 					svg={ <img src={ imagePath + 'jetpack-performance.svg' } width="250" alt={ __( "Jetpack's site accelerator" ) } /> }
 					title={ __( 'New in Jetpack!' ) }
 					content={ this.renderInnerContent() }
-					dismiss={ this.props.dismiss }
+					dismiss={ this.dismissNotice }
 				/>
 			);
 		}

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -24,6 +24,13 @@ import analytics from 'lib/analytics';
 
 const UpgradeNoticeContent = moduleSettingsForm(
 	class extends Component {
+		componentDidMount() {
+			analytics.tracks.recordEvent(
+				'jetpack_warm_welcome_view',
+				{ version: this.props.version }
+			);
+		}
+
 		trackLearnMoreClick = () => {
 			analytics.tracks.recordJetpackClick( {
 				target: 'warm_welcome_learn_more',
@@ -31,20 +38,13 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			} );
 		};
 
-		trackNoticeView = () => {
-			analytics.tracks.recordEvent(
-				'jetpack_warm_welcome_view',
-				{ version: this.props.version }
-			);
-		};
-
 		dismissNotice = () => {
 			analytics.tracks.recordJetpackClick( {
-				target: 'warm_welcome_learn_more',
+				target: 'warm_welcome_dismiss',
 				version: this.props.version
 			} );
 
-			return this.props.dismiss;
+			this.props.dismiss();
 		};
 
 		toggleModule = ( name, value ) => {
@@ -136,8 +136,6 @@ const UpgradeNoticeContent = moduleSettingsForm(
 		};
 
 		renderInnerContent() {
-			this.trackNoticeView();
-
 			const foundPhoton = this.props.isModuleFound( 'photon' );
 			const foundAssetCdn = this.props.isModuleFound( 'photon-cdn' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds more tracking to the warm welcome, such as: 
- Dismissing
- Viewing
- Adding a prop to the toggle event to signify that it happened here. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Kind of annoying to test, but: 
0. Enter this into your js console to be able to see tracks come through: `localStorage.setItem( 'debug', 'dops:analytics' );`
1. Hack jetpack.php's `JETPACK__VERSION` to be something lower than 6.7
2. Load the admin page
3. Un-hack the `JETPACK__VERSION` to be 6.7 again 
4. Open your browser console
5. Load the admin page - see the warm welcome. 
6. Test all of the things mentioned above - make sure the events are coming through. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

None
