### PR TITLE
Build Tools: Invalidate `require.cache` of the correct path.

### DIFF
--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -158,8 +158,6 @@ function onBuild( done, err, stats ) {
 export const build = gulp.series( 'react:master' );
 
 function buildStatic( done ) {
-	let path;
-
 	const jsdom = require( 'jsdom' );
 
 	log( 'Building static HTML from built JS…' );
@@ -184,9 +182,13 @@ function buildStatic( done ) {
 		};
 
 		try {
-			path = __dirname + '/../../_inc/build/static.js';
+			// normalize path
+			const path = require.resolve( __dirname + '/../../_inc/build/static.js' );
 
-			delete require.cache[ path ]; // Making sure NodeJS requires this file every time this is called
+			// Making sure NodeJS requires this file every time this is called
+			delete require.cache[ path ];
+
+			// Will throw when `path` does not exist, skipping file generation below that depends on `path`.
 			require( path );
 
 			gulp.src( [ '_inc/build/static*' ] )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

`static.html` and friends depend on `static.js` as built by webpack.

After `static.html` and friends are generated, all `static*` files are deleted, which means `static.html` and friends cannot be generated again until `static.js` has been regenerated first.

When `watch`ing, `static.js` is only regenerated when files in that webpack entry point are modified. We attempt to regenerate `static.html` and friends, though, whenever *any* watched file changes, skipping that regeneration only when `require( static.js )` fails.

To ensure `require( static.js )` fails when `static.js` does not exist, we invalidate the `require.cache` for that path. Previously, though, we were not invalidating the correct path, which meant that we regenerated `static.html` and friends even when `static.js` did not exist. Refreshing the Jetpack admin page after that botched regeneration led to a page displaying only: "undefined".

In this PR: Invalidate the correct path.

A better/additional solution might be to ensure we don't even go through that codepath when `watch` rebuilds the `admin` webpack entry but not the `static` one.

#### Testing instructions:
1. run `yarn react:watch`, wait for the initial build to complete.
2. Make and save a change to `_inc/client/main.jsx`.
3. See `react:watch` rebuild.
4. Go to wp-admin/ -> Jetpack -> Dashboard (reload the page if you're already there)

Prior to this PR: See only "undefined".

After this PR: See the dashboard as expected.

#### Proposed changelog entry for your changes:
* Ensure `yarn react:watch` does not try to generate `static.html` when its dependencies are absent.