### PR TITLE
Standalone Block Registration/Block Dependencies

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -110,7 +110,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @return void
 	 */
-	public static function load_assets_as_required( $type, $script_dependencies = null ) {
+	public static function load_assets_as_required( $type, $script_dependencies = array() ) {
 		$type = sanitize_title_with_dashes( $type );
 		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -106,10 +106,11 @@ class Jetpack_Gutenberg {
 	 * Only enqueue block assets when needed.
 	 *
 	 * @param string $type slug of the block.
+	 * @param array $script_dependencies An array of view-side Javascript dependencies to be enqueued.
 	 *
 	 * @return void
 	 */
-	public static function load_assets_as_required( $type, $dependencies = null ) {
+	public static function load_assets_as_required( $type, $script_dependencies = null ) {
 		$type = sanitize_title_with_dashes( $type );
 		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
@@ -124,7 +125,7 @@ class Jetpack_Gutenberg {
 		if ( self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $dependencies, $script_version, false );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
 		}
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -109,7 +109,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @return void
 	 */
-	public static function load_assets_as_required( $type ) {
+	public static function load_assets_as_required( $type, $dependencies = null ) {
 		$type = sanitize_title_with_dashes( $type );
 		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
@@ -124,7 +124,7 @@ class Jetpack_Gutenberg {
 		if ( self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, array(), $script_version, false );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $dependencies, $script_version, false );
 		}
 	}
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Load code specific to Gutenberg blocks which are not tied to a module.
+ * This file is unusual, and is not an actual `module` as such.
+ * It is included in ./module-extras.php
+ *
+ */
+
+jetpack_register_block(
+	'map',
+	array(
+		'render_callback' => 'jetpack_map_load_assets',
+	)
+);
+
+function jetpack_map_load_assets( $attr, $content ) {
+	$dependencies = array(
+		'wp-element',
+		'wp-i18n',
+		'wp-api-fetch',
+	);
+	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
+	return $content;
+}

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -13,6 +13,14 @@ jetpack_register_block(
 	)
 );
 
+/**
+ * Map block registration/dependency declaration.
+ *
+ * @param array  $attr - Array containing the map block attributes.
+ * @param string $content - String containing the map block content.
+ *
+ * @return string
+ */
 function jetpack_map_block_load_assets( $attr, $content ) {
 	$dependencies = array(
 		'wp-element',

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -9,11 +9,11 @@
 jetpack_register_block(
 	'map',
 	array(
-		'render_callback' => 'jetpack_map_load_assets',
+		'render_callback' => 'jetpack_map_block_load_assets',
 	)
 );
 
-function jetpack_map_load_assets( $attr, $content ) {
+function jetpack_map_block_load_assets( $attr, $content ) {
 	$dependencies = array(
 		'wp-element',
 		'wp-i18n',

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -27,7 +27,6 @@ $tools = array(
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
 	'geo-location.php',
 	'class.jetpack-calypsoify.php',
-	'blocks.php',
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode
@@ -37,6 +36,11 @@ if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 		'seo-tools/jetpack-seo-titles.php',
 		'seo-tools/jetpack-seo-posts.php',
 	);
+}
+
+/* If Gutenberg blocks are enabled, register blocks that aren't associated with modules */
+if ( Jetpack_Gutenberg::should_load_blocks() ) {
+	$tools[] = 'blocks.php';
 }
 
 /**

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -27,6 +27,7 @@ $tools = array(
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
 	'geo-location.php',
 	'class.jetpack-calypsoify.php',
+	'blocks.php',
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode


### PR DESCRIPTION
This adds a few pieces needed for the Map block (and similar future ones) to work following recent changes to block building and view script loading in https://github.com/Automattic/jetpack/pull/10405 and https://github.com/Automattic/wp-calypso/pull/28066. 

### Fixes

1) The Map block doesn't correspond to a pre-Gutenberg Jetpack module, so it needs a new structure for PHP registration. For normal modules this is done in their dedicated directory in `modules/`. Here, this is done in `modules/blocks.php`.
2)  The Map  block has a few view-side dependencies, and this PR creates a way to declare these. 

### Testing instructions:

To test the Map block, it will need to be built from the https://github.com/Automattic/wp-calypso/tree/try/map-key branch. The Calypso branch resolves a naming consistency problem (`map` vs. `maps-block`) and temporarily adds a hardcoded Google Maps API key so it can be used without the changes in https://github.com/Automattic/wp-calypso/tree/try/map-key. This Calypso branch is meant only for testing with this PR, and will be deleted after this PR merges.

### To test with Jetpack docker:

1) Checkout `wp-calypso` branch [try/map-key](https://github.com/Automattic/wp-calypso/tree/try/map-key). 
2) Checkout `jetpack` branch [`try/block-dependencies`](https://github.com/Automattic/jetpack/tree/try/block-dependencies).
3) Build Map block by running this SDK command from the root of `wp-calypso` repo: `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=PATH_TO_JETPACK_REPO/_inc/blocks`. (Replace PATH_TO_JETPACK_REPO with relevant path).
4) In Jetpack repo, verify that `_inc/blocks/map/` exists and contains `view.css|view.js|view.rtl.css`.
5) Create a post, add Map block, publish. 

### To test with Jurassic Ninja use this link:
https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=try/map-key&branch=try/block-dependencies

### Flows to verify

1: Verify that Map block loads and renders in editor and view. If the view.js or any of the dependencies are missing the block will be completely blank.

2: In view, watch Network tab to verify that all dependent Javascript files are loading. Among others you should see:
- `/wp-content/plugins/jetpack/_inc/blocks/map/view.js`
- `/wp-content/plugins/gutenberg/vendor/react-dom.min`
- `/wp-content/plugins/gutenberg/vendor/react.min.ab6b06d4.js` (or similar)
- `/wp-content/plugins/gutenberg/build/element/index.js`
- `/wp-content/plugins/gutenberg/build/i18n/index.js`
- `/wp-content/plugins/gutenberg/build/api-fetch/index.js`

3: Remove the map block (or create a second post without it), publish and view. In the Network tab none of the above files should be loading.

### Proposed changelog entry for your changes:

- Add module/blocks.php file for registration of blocks without corresponding modules.
- Allow individual blocks to declare their view dependencies.