### PR TITLE
Update Gutenberg block availability checks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -61,7 +61,7 @@ class Jetpack_Gutenberg {
 		}
 
 		/**
-		 * Filter the list of blocks that are available though jetpack.
+		 * Filter the list of blocks that are available through jetpack.
 		 *
 		 * This filter is populated by Jetpack_Gutenberg::jetpack_set_available_blocks
 		 *
@@ -296,7 +296,7 @@ class Jetpack_Gutenberg {
 			'Jetpack_Block_Assets_Base_Url',
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
-		
+
 		wp_localize_script(
 			'jetpack-blocks-editor',
 			'Jetpack_Initial_State',

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -299,25 +299,6 @@ class Jetpack_Gutenberg {
 
 		wp_localize_script(
 			'jetpack-blocks-editor',
-			'Jetpack_Initial_State',
-			array(
-				'getModules' => array(
-					'markdown'      => array(
-						'name'      => 'markdown',
-						'activated' => Jetpack::is_module_active( 'markdown' ),
-						'override'  => Jetpack_Modules_Overrides::instance()->get_module_override( 'markdown' )
-					),
-					'related-posts' => array(
-						'name'      => 'related-posts',
-						'activated' => Jetpack::is_module_active( 'related-posts' ),
-						'override'  => Jetpack_Modules_Overrides::instance()->get_module_override( 'related-posts' )
-					)
-				)
-			)
-		);
-
-		wp_localize_script(
-			'jetpack-blocks-editor',
 			'Jetpack_Editor_Initial_State',
 			array(
 				'available_blocks' => self::get_block_availability(),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -539,6 +539,7 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
+		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -27,3 +27,5 @@ function jetpack_markdown_posting_always_on() {
 	}
 }
 add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );
+
+jetpack_register_block( 'markdown' );

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -76,3 +76,4 @@ class Jetpack_RelatedPosts_Module {
 
 // Do it.
 Jetpack_RelatedPosts_Module::instance();
+jetpack_register_block( 'related-posts' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 			<file>tests/php/test_class.jetpack-client-server.php</file>
 			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
+			<file>tests/php/test_class.jetpack-gutenberg.php</file>
 			<file>tests/php/test_class.jetpack-constants.php</file>
 			<file>tests/php/test_class.jetpack-connection-banner.php</file>
 			<file>tests/php/test_class.jetpack-options.php</file>

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -1,0 +1,34 @@
+<?php
+
+class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
+
+	public function add_test_block( $blocks ) {
+		return array_merge( $blocks, array( 'test' ) );
+	}
+
+	public function test_jetpack_register_block_registers_a_gutenberg_block() {
+
+		if ( ! function_exists( 'register_block_type' ) ) {
+			$this->markTestSkipped( 'register_block_type not available' );
+			return;
+		}
+
+		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+			$this->markTestSkipped( 'WP_Block_Type_Registry not available' );
+			return;
+		}
+
+		// Create a user and set it up as current.
+		$current_master_id = $this->factory->user->create( array( 'user_login' => 'current_master' ) );
+
+		// Mock a connection
+		Jetpack_Options::update_option( 'master_user', $current_master_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $current_master_id => "honey.badger.$current_master_id" ) );
+		add_filter( 'jetpack_set_available_blocks',  array( $this, 'add_test_block' ) );
+		jetpack_register_block( 'test' );
+		Jetpack_Gutenberg::load_blocks();
+		$test_block = WP_Block_Type_Registry::get_instance()->get_registered( 'jetpack/test' );
+		$this->assertEquals( 'jetpack/test', $test_block->name );
+	}
+
+}


### PR DESCRIPTION
This PR exposes a new global javascript variable to the gutenberg edtior: `Jetpack_Editor_Initial_State`

`Jetpack_Editor_Initial_State` includes a list of available blocks and Jetpack's connection status

`Jetpack_Editor_Initial_State` replaces`Jetpack_Initial_State` as a lighter way for Gutenberg components to make use of Jetpack data.


Fixes #

Part of master issue: #10198

#### Testing instructions:

If you are testing locally on Docker, ensure you are [running blocks from here](https://github.com/Automattic/wp-calypso/pull/28467).
If you want to try this on jurassic.ninja, use this link: https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/jetpack-data-path&branch=update/gutenberg-blocks-availability

1. Get this branch running on a test site!
2. In the post editor, ensure Markdown block still works as expected. ( Block is unavailable when markdown is not active, block is available when markdown is active )
3. In the post editor, ensure Related Post block still works as expected ( Block is unavailable when related-posts is not active, block is available when related-posts is active )