### PR TITLE
Fix long site title display on Calypsoify pages

### DIFF
--- a/modules/calypsoify/style.css
+++ b/modules/calypsoify/style.css
@@ -161,6 +161,29 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 #calypso-sidebar-header ul li#calypso-sitename {
 	font-size: 12px;
 	color: #537994;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 225px;
+}
+
+#calypso-sidebar-header ul li#calypso-sitename:after {
+	content: '';
+	display: block;
+	position: absolute;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+	background: -webkit-gradient(linear, left top, right top, from(rgba(255,255,255,0)), color-stop(90%, #fff));
+	background: linear-gradient(to right, rgba(255,255,255,0), #fff 90%);
+	top: 0px;
+	bottom: 0px;
+	right: 0px;
+	left: auto;
+	width: 20%;
+	height: auto;
 }
 
 #calypso-sidebar-header ul li#calypso-plugins {


### PR DESCRIPTION
This PR fixes the display of long site titles on Calypsoify pages.

Before:

<img width="287" alt="screen shot 2018-11-01 at 3 29 16 pm" src="https://user-images.githubusercontent.com/689165/47874874-58b35180-ddeb-11e8-98cb-551d5b3dd060.png">

After:

<img width="288" alt="screen shot 2018-11-01 at 3 25 41 pm" src="https://user-images.githubusercontent.com/689165/47874881-5fda5f80-ddeb-11e8-9eec-0f4a03c3e834.png">

This matches the display on Calypso:

<img width="286" alt="screen shot 2018-11-01 at 3 29 24 pm" src="https://user-images.githubusercontent.com/689165/47874894-6963c780-ddeb-11e8-9de4-f6d90ab66f85.png">

#### Testing instructions:
* Set a long site title
* Activate Calypsoify 
* Verify that the long title is cut off and does not mess up the site title/plugin display text.
* Test a short name too.

#### Proposed changelog entry for your changes:
N/A