### PR TITLE
Fix long site title display on Calypsoify pages (mobile)

### DIFF
--- a/modules/calypsoify/style.css
+++ b/modules/calypsoify/style.css
@@ -186,6 +186,12 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	height: auto;
 }
 
+@media screen and (max-width:782px) {
+	#calypso-sidebar-header ul li#calypso-sitename {
+		width: 150px;
+	}
+}
+
 #calypso-sidebar-header ul li#calypso-plugins {
 	font-weight: bold;
 	color: #2e4453;


### PR DESCRIPTION
As a follow up to #10507, @joshuatf noted that we need a different width for mobile displays, otherwise the title is still broken on screens `<783px`. (Not that there are other mobile issues you can see here that are not addressed. See #10473).

Sorry for not catching that sooner @jeherve, @kraftbj!
 
#### Testing instructions: 
* Set a long site title
* Activate Calypsoify
* Shrink your screen size down `<783px`.
* Verify that the long title is cut off and does not mess up the site title/plugin display text.

<img width="302" alt="screen shot 2018-11-02 at 9 43 48 am" src="https://user-images.githubusercontent.com/689165/47919118-f444d080-de84-11e8-9ef6-9275d467eb79.png">


#### Proposed changelog entry for your changes:
N/A
