### PR TITLE
Twenty Nineteen: Fix Content Options post details alignment.

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -293,3 +293,10 @@
 	}
 }
 
+/**
+ * Content Options
+ */
+.twentynineteen-customizer .entry .entry-meta > span,
+.twentynineteen-customizer .entry .entry-footer > span {
+	display: inline;
+}

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -108,3 +108,19 @@ function twentynineteen_override_post_thumbnail( $width ) {
 	}
 }
 add_filter( 'twentynineteen_can_show_post_thumbnail', 'twentynineteen_override_post_thumbnail', 10, 2 );
+
+/**
+ * Adds custom classes to the array of body classes.
+ *
+ * @param array $classes Classes for the body element.
+ * @return array
+ */
+function twentynineteen_jetpack_body_classes( $classes ) {
+	// Adds a class if we're in the Customizer
+	if ( is_customize_preview() ) :
+		$classes[] = 'twentynineteen-customizer';
+	endif;
+
+	return $classes;
+}
+add_filter( 'body_class', 'twentynineteen_jetpack_body_classes' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #10511

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Add a class to the body when visiting the customizer and change the display property of the span elements to `inline`.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install the Twenty Nineteen theme on your site
2. Go to Appearance > Customize > Content Options.
3. In the customizer, navigate to a single post.
4. Toggle the post meta options such as "Display Date"
5. The post meta will appear aligned, as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix Content Options post details alignment
