### PR TITLE
Fix calypsoify masterbar to top of screen to fix gap

### DIFF
--- a/modules/calypsoify/style.css
+++ b/modules/calypsoify/style.css
@@ -375,6 +375,7 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	-webkit-box-shadow: none;
 	-mozilla-box-shadow: none;
 	height: 46px;
+	position: fixed;
 }
 
 #wpadminbar .ab-top-menu > li > .ab-item {


### PR DESCRIPTION
This PR fixes the gap between the masterbar and the top of the screen on mobile when calypsoify is turned on by fixing it to the screen similar to Calypso's masterbar.

Fixes #10521 

#### Changes proposed in this Pull Request:
Fix masterbar to top of the screen on mobile.

#### Testing instructions:

1.  Visit any page in your dashboard with Calypsoify enabled `&calypsoify=1`
2.  Narrow viewport to 480px or less.
3.  Note the masterbar fixed to the top of the screen on scroll and no gap.

##### Before
<img width="401" alt="screen shot 2018-11-02 at 9 26 23 am" src="https://user-images.githubusercontent.com/10561050/47926219-0ecf7780-de8e-11e8-9be2-ad5d9c9a896e.png">

##### After
<img width="380" alt="screen shot 2018-11-02 at 10 56 57 am" src="https://user-images.githubusercontent.com/10561050/47926216-0d05b400-de8e-11e8-9769-28fd7af9d081.png">