### PR TITLE
Sitemaps: Only strip protocol for sitemap stylesheets

### DIFF
--- a/modules/sitemaps/sitemap-finder.php
+++ b/modules/sitemaps/sitemap-finder.php
@@ -29,8 +29,14 @@ class Jetpack_Sitemap_Finder {
 	 * @return string Complete URI of the given sitemap file.
 	 */
 	public function construct_sitemap_url( $filename ) {
-		// strip scheme for sites where sitemap could be access via http or https
-		return preg_replace( '/^https?:/', '', jetpack_sitemap_uri( $filename ) );
+		$url = jetpack_sitemap_uri( $filename );
+
+		if ( pathinfo( $filename, PATHINFO_EXTENSION ) === 'xsl' ) {
+			// strip scheme for sites where sitemap could be access via http or https
+			$url = preg_replace( '/^https?:/', '', $url );
+		}
+
+		return $url;
 	}
 
 	/**


### PR DESCRIPTION
After https://github.com/Automattic/jetpack/pull/10363 , we stripped the protocol from sitemap URLs. The original intention was to not break the sitemap stylesheet; however, per https://www.sitemaps.org/protocol.html#index, it needs to have a matching protocol.

Running our sitemaps through various validators, about half balk at the URLs as we pass them. This could still result in an issue if someone submits a sitemap to a consumer with a different scheme than what they are generated.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Only strip protocol from sitemaps.

#### Testing instructions:
* Activate sitemaps on a site that is accessible via http and https, with http as default.
* View sitemap in https.
* Stylesheet should work, full URLs should be displayed.

#### Proposed changelog entry for your changes:
* None, fixes a regression added during the 6.7 cycle.
