### PR TITLE
Simple Payments: PayPal script execution error on Gutenberg

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -49,7 +49,9 @@ class Jetpack_Simple_Payments {
 	public function init_hook_action() {
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_rest_api_types' ) );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'allow_sync_post_meta' ) );
-		$this->register_scripts_and_styles();
+		if ( ! is_admin() ) {
+			$this->register_scripts_and_styles();
+		}
 		$this->register_shortcode();
 		$this->setup_cpts();
 


### PR DESCRIPTION
PayPal scripts are registered only for the site's Frontend to prevent execution errors when loading Gutenberg on WP-Admin.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #10481

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Prevent registering PayPal Express Checkout scripts on the Admin Page.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jurassic Ninja: https://jurassic.ninja/create?jetpack-beta&branch=fix/simple-payments-frontend-only-register-scripts&gutenpack&gutenberg&calypsobranch=add/gutenpack-simplepayments-ui
* Connect Jetpack, purchase "premium" or "business" plan.
* Create new post in Gutenberg and add "Payment button" block.
* Open your browser's developer tools on the _Console_ tab.
* Save the product, publish the post and then refresh the editor.
* These errors should no longer appear:

![screen shot 2018-11-02 at 18 04 40](https://user-images.githubusercontent.com/233601/47940635-0bf27800-deca-11e8-84ed-594ac34275ee.png)

* Navigate to the published post and verify that there are no regressions on the site's frontend.