### PR TITLE
Gutenpack: Add/contact form to the gutenberg editor

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -102,7 +102,8 @@ class Jetpack_Gutenberg {
 
 	/**
 	 * Filters the results of `apply_filter( 'jetpack_set_available_blocks', array() )`
-	 * using the contents of `_inc/blocks/blocks-manifest.json`
+	 * using the merged contents of `_inc/blocks/blocks-manifest.json` ( $preset_blocks )
+	 * and self::$jetpack_blocks ( $internal_blocks )
 	 *
 	 * @param $blocks The default list.
 	 *
@@ -111,12 +112,14 @@ class Jetpack_Gutenberg {
 	public static function jetpack_set_available_blocks( $blocks ) {
 		$preset_blocks_manifest =  self::preset_exists( 'block-manifest' ) ? self::get_preset( 'block-manifest' ) : (object) array( 'blocks' => $blocks );
 		$preset_blocks = isset( $preset_blocks_manifest->blocks ) ? (array) $preset_blocks_manifest->blocks : array() ;
+		$internal_blocks = array_keys( self::$jetpack_blocks );
+
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_blocks = isset( $preset_blocks_manifest->betaBlocks ) ? (array) $preset_blocks_manifest->betaBlocks : array();
-			return array_merge( $preset_blocks, $beta_blocks );
+			return array_unique( array_merge( $preset_blocks, $beta_blocks, $internal_blocks ) );
 		}
 
-		return $preset_blocks;
+		return array_unique( array_merge( $preset_blocks, $internal_blocks ) );
 	}
 
 	/**

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3152,16 +3152,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	}
 
-	function render_input_field( $type, $id, $value, $class, $placeholder, $required, $pattern = null, $title = null ) {
-		$pattern_render = $pattern ? " pattern='". ( $pattern ) ."'" : '';
-		$title_render = $title ? " title='".esc_attr( $title )."' " :  '';
+	function render_input_field( $type, $id, $value, $class, $placeholder, $required ) {
 		return "<input 
 					type='". esc_attr( $type ) ."' 
 					name='" . esc_attr( $id ) . "' 
 					id='" . esc_attr( $id ) . "' 
-					value='" . esc_attr( $value ) . "' "
-		            . $class . $placeholder . $pattern_render . $title_render
-					. ( $required ? " required aria-required='true' " : '' ) . " 
+					value='" . esc_attr( $value ) . "' 
+					" . $class . $placeholder . ' 
+					' . ( $required ? "required aria-required='true'" : '' ) . " 
 				/>\n";
 	}
 
@@ -3177,9 +3175,9 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		return $field;
 	}
 
-	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $pattern, $title ) {
+	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 		$field = $this->render_label( 'url', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required, $pattern, $title );
+		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required );
 		return $field;
 	}
 
@@ -3314,10 +3312,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$field .= $this->render_telephone_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			case 'url':
-				// @todo: this could be improved
-				$url_pattern = "(https?://)?(www\.)?([a-zA-Z0-9_%]*)\b\.[a-z]{2,22}(\.[a-z]{2})?((/[a-zA-Z0-9_%]*)+)?(\.[a-z]*)?";
-				$title = __( 'Enter a valid URL', 'jetpack' );
-				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $url_pattern, $title );
+				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			case 'textarea':
 				$field .= $this->render_textarea_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3152,14 +3152,16 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	}
 
-	function render_input_field( $type, $id, $value, $class, $placeholder, $required ) {
+	function render_input_field( $type, $id, $value, $class, $placeholder, $required, $pattern = null, $title = null ) {
+		$pattern_render = $pattern ? " pattern='". ( $pattern ) ."'" : '';
+		$title_render = $title ? " title='".esc_attr( $title )."' " :  '';
 		return "<input 
 					type='". esc_attr( $type ) ."' 
 					name='" . esc_attr( $id ) . "' 
 					id='" . esc_attr( $id ) . "' 
-					value='" . esc_attr( $value ) . "' 
-					" . $class . $placeholder . ' 
-					' . ( $required ? "required aria-required='true'" : '' ) . " 
+					value='" . esc_attr( $value ) . "' "
+		            . $class . $placeholder . $pattern_render . $title_render
+					. ( $required ? " required aria-required='true' " : '' ) . " 
 				/>\n";
 	}
 
@@ -3175,9 +3177,9 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		return $field;
 	}
 
-	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $pattern, $title ) {
 		$field = $this->render_label( 'url', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required );
+		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required, $pattern, $title );
 		return $field;
 	}
 
@@ -3312,7 +3314,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$field .= $this->render_telephone_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			case 'url':
-				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				// @todo: this could be improved
+				$url_pattern = "(https?://)?(www\.)?([a-zA-Z0-9_%]*)\b\.[a-z]{2,22}(\.[a-z]{2})?((/[a-zA-Z0-9_%]*)+)?(\.[a-z]*)?";
+				$title = __( 'Enter a valid URL', 'jetpack' );
+				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $url_pattern, $title );
 				break;
 			case 'textarea':
 				$field .= $this->render_textarea_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3179,7 +3179,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $pattern, $title ) {
 		$field = $this->render_label( 'url', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required, $pattern, $title );
+		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required, $pattern, $title );
 		return $field;
 	}
 
@@ -3314,8 +3314,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$field .= $this->render_telephone_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			case 'url':
-				// @todo: this could be improved
-				$url_pattern = "(https?://)?(www\.)?([a-zA-Z0-9_%]*)\b\.[a-z]{2,22}(\.[a-z]{2})?((/[a-zA-Z0-9_%]*)+)?(\.[a-z]*)?";
+				$url_pattern = "^(?:(?:https?|HTTPS?|ftp|FTP):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-zA-Z\u00a1-\uffff0-9]-*)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]-*)*[a-zA-Z\u00a1-\uffff0-9]+)*)(?::\d{2,})?(?:[\/?#]\S*)?$";
 				$title = __( 'Enter a valid URL', 'jetpack' );
 				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $url_pattern, $title );
 				break;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -283,57 +283,63 @@ class Grunion_Contact_Form_Plugin {
 		return Grunion_Contact_Form::parse( $atts, do_blocks( $content ) );
 	}
 
-	public static function guten_block_attrebutes_to_shotcode_attributes( $atts, $type ) {
+	public static function block_attributes_to_shortcode_attributes( $atts, $type ) {
 		$atts['type'] = $type;
 		if ( isset( $atts['className'] ) ) {
 			$atts['class'] = $atts['className'];
 			unset( $atts['className'] );
 		}
+
+		if ( isset( $atts['defaultValue'] ) ) {
+			$atts['default'] = $atts['defaultValue'];
+			unset( $atts['defaultValue'] );
+		}
+
 		return $atts;
 	}
 
 	public static function gutenblock_render_field_text( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'text' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'text' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_name( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'name' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'name' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_email( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'email' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'email' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_url( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'url' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'url' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_date( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'date' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'date' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_telephone( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'telephone' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'telephone' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_textarea( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'textarea' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'textarea' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_checkbox( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'checkbox' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'checkbox-multiple' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'checkbox-multiple' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_radio( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'radio' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'radio' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_select( $atts, $content ) {
-		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'select' );
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'select' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3139,10 +3139,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_label( $type = '', $id, $label, $required, $required_field_text ) {
+
+		$type_class = $type ? ' ' .$type : '';
 		return
 			"<label 
 				for='" . esc_attr( $id ) . "' 
-				class='grunion-field-label {$type}" . ( $this->is_error() ? ' form-error' : '' ) . "'
+				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'
 				>"
 				. esc_html( $label )
 				. ( $required ? '<span>' . $required_field_text . '</span>' : '' )
@@ -3174,13 +3176,13 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		$field = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
+		$field = $this->render_label( 'url', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required );
 		return $field;
 	}
 
 	function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
-		$field = $this->render_label( 'textarea', $id, $label, $required, $required_field_text );
+		$field = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
 		                name='" . esc_attr( $id ) . "' 
 		                id='contact-form-comment-" . esc_attr( $id ) . "' 
@@ -3194,7 +3196,6 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
-
 		$field = $this->render_label( '', $id, $label, $required, $required_field_text );
 		foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 			$option = Grunion_Contact_Form_Plugin::strip_tags( $option );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3179,7 +3179,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $pattern, $title ) {
 		$field = $this->render_label( 'url', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required, $pattern, $title );
+		$field .= $this->render_input_field( 'url', $id, $value, $class, $placeholder, $required, $pattern, $title );
 		return $field;
 	}
 
@@ -3314,7 +3314,8 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$field .= $this->render_telephone_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			case 'url':
-				$url_pattern = "^(?:(?:https?|HTTPS?|ftp|FTP):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-zA-Z\u00a1-\uffff0-9]-*)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]-*)*[a-zA-Z\u00a1-\uffff0-9]+)*)(?::\d{2,})?(?:[\/?#]\S*)?$";
+				// @todo: this could be improved
+				$url_pattern = "(https?://)?(www\.)?([a-zA-Z0-9_%]*)\b\.[a-z]{2,22}(\.[a-z]{2})?((/[a-zA-Z0-9_%]*)+)?(\.[a-z]*)?";
 				$title = __( 'Enter a valid URL', 'jetpack' );
 				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $url_pattern, $title );
 				break;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -232,6 +232,110 @@ class Grunion_Contact_Form_Plugin {
 		 */
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
+
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
+		if ( function_exists( 'register_block_type' ) ) {
+			register_block_type( 'jetpack/form', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+			) );
+
+			// Field render methods.
+			register_block_type( 'jetpack/field-text', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
+			) );
+			register_block_type( 'jetpack/field-name', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
+			) );
+			register_block_type( 'jetpack/field-email', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
+			) );
+			register_block_type( 'jetpack/field-url', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
+			) );
+			register_block_type( 'jetpack/field-date', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
+			) );
+			register_block_type( 'jetpack/field-telephone', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
+			) );
+			register_block_type( 'jetpack/field-textarea', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
+			) );
+			register_block_type( 'jetpack/field-checkbox', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
+			) );
+			register_block_type( 'jetpack/field-checkbox-multiple', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
+			) );
+			register_block_type( 'jetpack/field-radio', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
+			) );
+			register_block_type( 'jetpack/field-select', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
+			) );
+		}
+	}
+
+	public static function enqueue_block_editor_assets() {
+		wp_enqueue_script( 'jetpack-cf-gutenblock', plugins_url( 'block/build/editor.js', __FILE__ ), array(
+			'wp-blocks',
+			'wp-i18n',
+			'wp-element',
+		), filemtime( dirname( __FILE__ ) . '/block/build/editor.js' ) );
+
+		wp_enqueue_style( 'jetpack-cf-gutenblock', plugins_url( 'block/build/editor.css', __FILE__ ), array(
+			'wp-blocks',
+		), filemtime( dirname( __FILE__ ) . '/block/build/editor.css' ) );
+		wp_style_add_data( 'jetpack-cf-gutenblock', 'rtl', 'replace' );
+	}
+
+	public static function gutenblock_render_form( $atts, $content ) {
+		return Grunion_Contact_Form::parse( $atts, $content );
+	}
+
+	public static function gutenblock_render_field_text( $atts, $content ) {
+		$atts['type'] = 'text';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_name( $atts, $content ) {
+		$atts['type'] = 'name';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_email( $atts, $content ) {
+		$atts['type'] = 'email';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_url( $atts, $content ) {
+		$atts['type'] = 'url';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_date( $atts, $content ) {
+		$atts['type'] = 'date';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_telephone( $atts, $content ) {
+		$atts['type'] = 'telephone';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_textarea( $atts, $content ) {
+		$atts['type'] = 'textarea';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_checkbox( $atts, $content ) {
+		$atts['type'] = 'checkbox';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
+		$atts['type'] = 'checkbox-multiple';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_radio( $atts, $content ) {
+		$atts['type'] = 'radio';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
+	}
+	public static function gutenblock_render_field_select( $atts, $content ) {
+		$atts['type'] = 'select';
+		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 
 	/**
@@ -1687,7 +1791,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'show_subject'       => 'no', // only used in back-compat mode
 			'widget'             => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
 			'id'                 => null, // Not exposed to the user. Set above.
-			'submit_button_text' => __( 'Submit &#187;', 'jetpack' ),
+			'submit_button_text' => __( 'Submit', 'jetpack' ),
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -2032,7 +2136,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
 					$att_strs[] = esc_html( $val );
 				} elseif ( isset( $val ) ) { // A regular attr - value pair
-					$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ) . '\'';
+					if ( is_array( $val ) ) {
+						$att_strs[] = esc_html( $att ) . '=\'' . implode( ',', array_map( 'esc_html', $val ) ) . '\'';
+					} elseif ( is_bool( $val ) ) {
+						$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ? '1' : '' ) . '\'';
+					} else {
+						$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ) . '\'';
+					}
 				}
 			}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -214,9 +214,9 @@ class Grunion_Contact_Form_Plugin {
 		// POST handler
 		if (
 			isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' == strtoupper( $_SERVER['REQUEST_METHOD'] )
-		&&
+			&&
 			isset( $_POST['action'] ) && 'grunion-contact-form' == $_POST['action']
-		&&
+			&&
 			isset( $_POST['contact-form-id'] )
 		) {
 			add_action( 'template_redirect', array( $this, 'process_form_submission' ) );
@@ -233,7 +233,6 @@ class Grunion_Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		if ( function_exists( 'register_block_type' ) ) {
 			register_block_type( 'jetpack/form', array(
 				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
@@ -276,18 +275,6 @@ class Grunion_Contact_Form_Plugin {
 		}
 	}
 
-	public static function enqueue_block_editor_assets() {
-		wp_enqueue_script( 'jetpack-cf-gutenblock', plugins_url( 'block/build/editor.js', __FILE__ ), array(
-			'wp-blocks',
-			'wp-i18n',
-			'wp-element',
-		), filemtime( dirname( __FILE__ ) . '/block/build/editor.js' ) );
-
-		wp_enqueue_style( 'jetpack-cf-gutenblock', plugins_url( 'block/build/editor.css', __FILE__ ), array(
-			'wp-blocks',
-		), filemtime( dirname( __FILE__ ) . '/block/build/editor.css' ) );
-		wp_style_add_data( 'jetpack-cf-gutenblock', 'rtl', 'replace' );
-	}
 
 	public static function gutenblock_render_form( $atts, $content ) {
 		return Grunion_Contact_Form::parse( $atts, $content );
@@ -773,12 +760,12 @@ class Grunion_Contact_Form_Plugin {
 		// so this inline JS moves it from the top of the page to the bottom.
 		?>
 		<script type='text/javascript'>
-		var menu = document.getElementById( 'feedback-export' ),
-		wrapper = document.getElementsByClassName( 'wrap' )[0];
-		<?php if ( 'edit-feedback' === $current_screen->id ) : ?>
-		wrapper.appendChild(menu);
-		<?php endif; ?>
-		menu.style.display = 'block';
+            var menu = document.getElementById( 'feedback-export' ),
+                wrapper = document.getElementsByClassName( 'wrap' )[0];
+			<?php if ( 'edit-feedback' === $current_screen->id ) : ?>
+            wrapper.appendChild(menu);
+			<?php endif; ?>
+            menu.style.display = 'block';
 		</script>
 		<?php
 	}
@@ -1024,7 +1011,7 @@ class Grunion_Contact_Form_Plugin {
 					$messages[] = esc_html( $prevention_message );
 				} else {
 					$messages[] = sprintf(
-						// translators: %d: Post ID.
+					// translators: %d: Post ID.
 						__( 'Feedback ID %d could not be removed at this time.', 'jetpack' ),
 						$post_id
 					);
@@ -1040,7 +1027,7 @@ class Grunion_Contact_Form_Plugin {
 			} else {
 				$retained   = true;
 				$messages[] = sprintf(
-					// translators: %d: Post ID.
+				// translators: %d: Post ID.
 					__( 'Feedback ID %d could not be removed at this time.', 'jetpack' ),
 					$post_id
 				);
@@ -1927,9 +1914,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		if ( isset( $_GET['contact-form-id'] )
-			&& $_GET['contact-form-id'] == self::$last->get_attribute( 'id' )
-			&& isset( $_GET['contact-form-sent'], $_GET['contact-form-hash'] )
-			&& hash_equals( $form->hash, $_GET['contact-form-hash'] ) ) {
+		     && $_GET['contact-form-id'] == self::$last->get_attribute( 'id' )
+		     && isset( $_GET['contact-form-sent'], $_GET['contact-form-hash'] )
+		     && hash_equals( $form->hash, $_GET['contact-form-hash'] ) ) {
 			// The contact form was submitted.  Show the success message/results
 			$feedback_id = (int) $_GET['contact-form-sent'];
 
@@ -2170,9 +2157,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		if (
 			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
-		&&
+			&&
 			isset( $_POST['contact-form-id'] ) && $form->get_attribute( 'id' ) == $_POST['contact-form-id']
-		&&
+			&&
 			isset( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, $_POST['contact-form-hash'] )
 		) {
 			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
@@ -2339,7 +2326,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field          = $this->fields[ $field_ids['name'] ];
 			$comment_author = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
+				/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
 				)
 			);
@@ -2350,7 +2337,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field                = $this->fields[ $field_ids['email'] ];
 			$comment_author_email = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
+				/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
 				)
 			);
@@ -2361,7 +2348,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field              = $this->fields[ $field_ids['url'] ];
 			$comment_author_url = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
+				/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
 				)
 			);
@@ -2496,7 +2483,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		$headers = 'From: "' . $comment_author . '" <' . $from_email_addr . ">\r\n" .
-					'Reply-To: "' . $comment_author . '" <' . $reply_to_addr . ">\r\n";
+		           'Reply-To: "' . $comment_author . '" <' . $reply_to_addr . ">\r\n";
 
 		// Build feedback reference
 		$feedback_time  = current_time( 'mysql' );
@@ -2770,8 +2757,8 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		$html_message = sprintf(
-			// The tabs are just here so that the raw code is correctly formatted for developers
-			// They're removed so that they don't affect the final message sent to users
+		// The tabs are just here so that the raw code is correctly formatted for developers
+		// They're removed so that they don't affect the final message sent to users
 			str_replace(
 				"\t", '',
 				'<!doctype html>
@@ -3054,16 +3041,16 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		} elseif (
 			is_user_logged_in() &&
 			( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-			/**
-			 * Allow third-party tools to prefill the contact form with the user's details when they're logged in.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 3.2.0
-			 *
-			 * @param bool false Should the Contact Form be prefilled with your details when you're logged in. Default to false.
-			 */
-			true === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
+			  /**
+			   * Allow third-party tools to prefill the contact form with the user's details when they're logged in.
+			   *
+			   * @module contact-form
+			   *
+			   * @since 3.2.0
+			   *
+			   * @param bool false Should the Contact Form be prefilled with your details when you're logged in. Default to false.
+			   */
+			  true === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
 			)
 		) {
 			// Special defaults for logged-in users
@@ -3247,7 +3234,7 @@ function grunion_delete_old_spam() {
 		 *
 		 * @param bool $filter Should Jetpack optimize the table, defaults to false.
 		 */
-		apply_filters( 'grunion_optimize_table', false )
+	apply_filters( 'grunion_optimize_table', false )
 	) {
 		$wpdb->query( "OPTIMIZE TABLE $wpdb->posts" );
 	}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2379,7 +2379,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field          = $this->fields[ $field_ids['name'] ];
 			$comment_author = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-				/** This filter is already documented in core/wp-includes/comment-functions.php */
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
 				)
 			);
@@ -2390,7 +2390,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field                = $this->fields[ $field_ids['email'] ];
 			$comment_author_email = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-				/** This filter is already documented in core/wp-includes/comment-functions.php */
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
 				)
 			);
@@ -2401,7 +2401,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$field              = $this->fields[ $field_ids['url'] ];
 			$comment_author_url = Grunion_Contact_Form_Plugin::strip_tags(
 				stripslashes(
-				/** This filter is already documented in core/wp-includes/comment-functions.php */
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
 					apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
 				)
 			);
@@ -2810,8 +2810,8 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		$html_message = sprintf(
-		// The tabs are just here so that the raw code is correctly formatted for developers
-		// They're removed so that they don't affect the final message sent to users
+			// The tabs are just here so that the raw code is correctly formatted for developers
+			// They're removed so that they don't affect the final message sent to users
 			str_replace(
 				"\t", '',
 				'<!doctype html>
@@ -3060,13 +3060,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	function render() {
 		global $current_user, $user_identity;
 
-
-		$field_id       = $this->get_attribute( 'id' );
-		$field_type     = $this->get_attribute( 'type' );
-		$field_label    = $this->get_attribute( 'label' );
-		$field_required = $this->get_attribute( 'required' );
+		$field_id          = $this->get_attribute( 'id' );
+		$field_type        = $this->get_attribute( 'type' );
+		$field_label       = $this->get_attribute( 'label' );
+		$field_required    = $this->get_attribute( 'required' );
 		$field_placeholder = $this->get_attribute( 'placeholder' );
-		$class          = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
+		$class             = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
 
 		/**
 		 * Filters the "class" attribute of the contact form input
@@ -3123,8 +3122,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field_value = Grunion_Contact_Form_Plugin::strip_tags( $this->value );
 		$field_label = Grunion_Contact_Form_Plugin::strip_tags( $field_label );
 
-		$r = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required );
-
+		$rendered_field = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required );
 
 		/**
 		 * Filter the HTML of the Contact Form.
@@ -3133,11 +3131,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @since 2.6.0
 		 *
-		 * @param string $r Contact Form HTML output.
+		 * @param string $rendered_field Contact Form HTML output.
 		 * @param string $field_label Field label.
 		 * @param int|null $id Post ID.
 		 */
-		return apply_filters( 'grunion_contact_form_field_html', $r, $field_label, ( in_the_loop() ? get_the_ID() : null ) );
+		return apply_filters( 'grunion_contact_form_field_html', $rendered_field, $field_label, ( in_the_loop() ? get_the_ID() : null ) );
 	}
 
 	function render_label( $type = '', $id, $label, $required, $required_field_text ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -283,48 +283,57 @@ class Grunion_Contact_Form_Plugin {
 		return Grunion_Contact_Form::parse( $atts, do_blocks( $content ) );
 	}
 
+	public static function guten_block_attrebutes_to_shotcode_attributes( $atts, $type ) {
+		$atts['type'] = $type;
+		if ( isset( $atts['className'] ) ) {
+			$atts['class'] = $atts['className'];
+			unset( $atts['className'] );
+		}
+		return $atts;
+	}
+
 	public static function gutenblock_render_field_text( $atts, $content ) {
-		$atts['type'] = 'text';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'text' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_name( $atts, $content ) {
-		$atts['type'] = 'name';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'name' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_email( $atts, $content ) {
-		$atts['type'] = 'email';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'email' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_url( $atts, $content ) {
-		$atts['type'] = 'url';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'url' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_date( $atts, $content ) {
-		$atts['type'] = 'date';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'date' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_telephone( $atts, $content ) {
-		$atts['type'] = 'telephone';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'telephone' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_textarea( $atts, $content ) {
-		$atts['type'] = 'textarea';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'textarea' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_checkbox( $atts, $content ) {
-		$atts['type'] = 'checkbox';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'checkbox' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_checkbox_multiple( $atts, $content ) {
-		$atts['type'] = 'checkbox-multiple';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'checkbox-multiple' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_radio( $atts, $content ) {
-		$atts['type'] = 'radio';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'radio' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 	public static function gutenblock_render_field_select( $atts, $content ) {
-		$atts['type'] = 'select';
+		$atts = self::guten_block_attrebutes_to_shotcode_attributes( $atts, 'select' );
 		return Grunion_Contact_Form::parse_contact_field( $atts, $content );
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3060,13 +3060,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	function render() {
 		global $current_user, $user_identity;
 
-		$r = '';
 
 		$field_id       = $this->get_attribute( 'id' );
 		$field_type     = $this->get_attribute( 'type' );
 		$field_label    = $this->get_attribute( 'label' );
 		$field_required = $this->get_attribute( 'required' );
-		$placeholder    = $this->get_attribute( 'placeholder' );
+		$field_placeholder = $this->get_attribute( 'placeholder' );
 		$class          = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
 
 		/**
@@ -3078,10 +3077,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @param string $class Additional CSS classes for input class attribute.
 		 */
-		$class = apply_filters( 'jetpack_contact_form_input_class', $class );
-
-		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
-		$field_class       = "class='" . trim( esc_attr( $field_type ) . ' ' . esc_attr( $class ) ) . "' ";
+		$field_class = apply_filters( 'jetpack_contact_form_input_class', $class );
 
 		if ( isset( $_POST[ $field_id ] ) ) {
 			if ( is_array( $_POST[ $field_id ] ) ) {
@@ -3127,116 +3123,8 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field_value = Grunion_Contact_Form_Plugin::strip_tags( $this->value );
 		$field_label = Grunion_Contact_Form_Plugin::strip_tags( $field_label );
 
-		/**
-		 * Filter the Contact Form required field text
-		 *
-		 * @module contact-form
-		 *
-		 * @since 3.8.0
-		 *
-		 * @param string $var Required field text. Default is "(required)".
-		 */
-		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ) );
+		$r = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required );
 
-		switch ( $field_type ) {
-			case 'email':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label email" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<input type='email' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'telephone':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label telephone" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<input type='tel' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . "/>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'url':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label url" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<input type='url' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'textarea':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='contact-form-comment-" . esc_attr( $field_id ) . "' class='grunion-field-label textarea" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<textarea name='" . esc_attr( $field_id ) . "' id='contact-form-comment-" . esc_attr( $field_id ) . "' rows='20' " . $field_class . $field_placeholder . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . '>' . esc_textarea( $field_value ) . "</textarea>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'radio':
-				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
-					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					if ( $option ) {
-						$r     .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-						$r     .= "<input type='radio' name='" . esc_attr( $field_id ) . "' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( $option, $field_value, false ) . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . '/> ';
-						$r     .= esc_html( $option ) . "</label>\n";
-						$r     .= "\t\t<div class='clear-form'></div>\n";
-					}
-				}
-				$r .= "\t\t</div>\n";
-				break;
-			case 'checkbox':
-				$r .= "\t<div>\n";
-				$r .= "\t\t<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "'>\n";
-				$r .= "\t\t<input type='checkbox' name='" . esc_attr( $field_id ) . "' value='" . esc_attr__( 'Yes', 'jetpack' ) . "' " . $field_class . checked( (bool) $field_value, true, false ) . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . "/> \n";
-				$r .= "\t\t" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<div class='clear-form'></div>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'checkbox-multiple':
-				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
-					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					if ( $option  ) {
-						$r      .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-						$r      .= "<input type='checkbox' name='" . esc_attr( $field_id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( in_array( $option, (array) $field_value ), true, false ) . ' /> ';
-						$r      .= esc_html( $option ) . "</label>\n";
-						$r      .= "\t\t<div class='clear-form'></div>\n";
-					}
-				}
-				$r .= "\t\t</div>\n";
-				break;
-			case 'select':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label select" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t<select name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' " . $field_class . ( $field_required ? "required aria-required='true'" : '' ) . ">\n";
-				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
-					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					if ( $option ) {
-						$r     .= "\t\t<option" . selected( $option, $field_value, false ) . " value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "'>" . esc_html( $option ) . "</option>\n";
-					}
-				}
-				$r .= "\t</select>\n";
-				$r .= "\t</div>\n";
-				break;
-			case 'date':
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label " . esc_attr( $field_type ) . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<input type='text' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
-				$r .= "\t</div>\n";
-
-				wp_enqueue_script(
-					'grunion-frontend',
-					Jetpack::get_file_url_for_environment(
-						'_inc/build/contact-form/js/grunion-frontend.min.js',
-						'modules/contact-form/js/grunion-frontend.js'
-					),
-					array( 'jquery', 'jquery-ui-datepicker' )
-				);
-				wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( 'css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
-
-				// Using Core's built-in datepicker localization routine
-				wp_localize_jquery_ui_datepicker();
-				break;
-			default: // text field
-				// note that any unknown types will produce a text input, so we can use arbitrary type names to handle
-				// input fields like name, email, url that require special validation or handling at POST
-				$r .= "\n<div>\n";
-				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label " . esc_attr( $field_type ) . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				$r .= "\t\t<input type='text' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . "/>\n";
-				$r .= "\t</div>\n";
-		}
 
 		/**
 		 * Filter the HTML of the Contact Form.
@@ -3250,6 +3138,207 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		 * @param int|null $id Post ID.
 		 */
 		return apply_filters( 'grunion_contact_form_field_html', $r, $field_label, ( in_the_loop() ? get_the_ID() : null ) );
+	}
+
+	function render_label( $type = '', $id, $label, $required, $required_field_text ) {
+		return
+			"<label 
+				for='" . esc_attr( $id ) . "' 
+				class='grunion-field-label {$type}" . ( $this->is_error() ? ' form-error' : '' ) . "'
+				>"
+				. esc_html( $label )
+				. ( $required ? '<span>' . $required_field_text . '</span>' : '' )
+			. "</label>\n";
+
+	}
+
+	function render_input_field( $type, $id, $value, $class, $placeholder, $required ) {
+		return "<input 
+					type='". esc_attr( $type ) ."' 
+					name='" . esc_attr( $id ) . "' 
+					id='" . esc_attr( $id ) . "' 
+					value='" . esc_attr( $value ) . "' 
+					" . $class . $placeholder . ' 
+					' . ( $required ? "required aria-required='true'" : '' ) . " 
+				/>\n";
+	}
+
+	function render_email_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field = $this->render_label( 'email', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'email', $id, $value, $class, $placeholder, $required );
+		return $field;
+	}
+
+	function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
+		return $field;
+	}
+
+	function render_url_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
+		return $field;
+	}
+
+	function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field = $this->render_label( 'textarea', $id, $label, $required, $required_field_text );
+		$field .= "<textarea
+		                name='" . esc_attr( $id ) . "' 
+		                id='contact-form-comment-" . esc_attr( $id ) . "' 
+		                rows='20' "
+		                . $class
+		                . $placeholder
+		                . ' ' . ( $required ? "required aria-required='true'" : '' ) .
+		                '>' . esc_textarea( $value )
+		          . "</textarea>\n";
+		return $field;
+	}
+
+	function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
+
+		$field = $this->render_label( '', $id, $label, $required, $required_field_text );
+		foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+			$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
+			if ( $option ) {
+				$field .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+				$field .= "<input 
+									type='radio' 
+									name='" . esc_attr( $id ) . "' 
+									value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' "
+				                    . $class
+				                    . checked( $option, $value, false ) . ' '
+				                    . ( $required ? "required aria-required='true'" : '' )
+				              . '/> ';
+				$field .= esc_html( $option ) . "</label>\n";
+				$field .= "\t\t<div class='clear-form'></div>\n";
+			}
+		}
+		return $field;
+	}
+
+	function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		$field = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+			$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
+			$field .= "\t\t" . esc_html( $label ) . ( $required ? '<span>' . $required_field_text . '</span>' : '' );
+		$field .=  "</label>\n";
+		$field .= "<div class='clear-form'></div>\n";
+		return $field;
+	}
+
+	function render_checkbox_multiple_field( $id, $label, $value, $class, $required, $required_field_text  ) {
+		$field = $this->render_label( '', $id, $label, $required, $required_field_text );
+		foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+			$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
+			if ( $option  ) {
+				$field .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+				$field .= "<input type='checkbox' name='" . esc_attr( $id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $class . checked( in_array( $option, (array) $value ), true, false ) . ' /> ';
+				$field .= esc_html( $option ) . "</label>\n";
+				$field .= "\t\t<div class='clear-form'></div>\n";
+			}
+		}
+
+		return $field;
+	}
+
+	function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		$field = $this->render_label( 'select', $id, $label, $required, $required_field_text );
+		$field  .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
+		foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+			$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
+			if ( $option ) {
+				$field .= "\t\t<option"
+				               . selected( $option, $value, false )
+				               . " value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) )
+				               . "'>" . esc_html( $option )
+				          . "</option>\n";
+			}
+		}
+		$field  .= "\t</select>\n";
+		return $field;
+	}
+
+	function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field = $this->render_label( 'date', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
+
+		wp_enqueue_script(
+			'grunion-frontend',
+			Jetpack::get_file_url_for_environment(
+				'_inc/build/contact-form/js/grunion-frontend.min.js',
+				'modules/contact-form/js/grunion-frontend.js'
+			),
+			array( 'jquery', 'jquery-ui-datepicker' )
+		);
+		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( 'css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
+
+		// Using Core's built-in datepicker localization routine
+		wp_localize_jquery_ui_datepicker();
+		return $field;
+	}
+
+	function render_default_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder, $type ) {
+		$field = $this->render_label( $type, $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
+		return $field;
+	}
+
+	function render_field( $type, $id, $label, $value, $class, $placeholder, $required ) {
+
+		// $field = json_encode( array( $type, $id, $label, $value, $class, $placeholder, $required ) );
+
+		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
+		$field_class       = "class='" . trim( esc_attr( $type ) . ' ' . esc_attr( $class ) ) . "' ";
+		$wrap_classes = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds
+
+		$shell_field_class = "class='grunion-field-wrap grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
+		/**
+		/**
+		 * Filter the Contact Form required field text
+		 *
+		 * @module contact-form
+		 *
+		 * @since 3.8.0
+		 *
+		 * @param string $var Required field text. Default is "(required)".
+		 */
+		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ) );
+
+		$field = "\n<div {$shell_field_class} >\n"; // new in Jetpack 6.8.0
+		switch ( $type ) {
+			case 'email':
+				$field .= $this->render_email_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			case 'telephone':
+				$field .= $this->render_telephone_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			case 'url':
+				$field .= $this->render_url_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			case 'textarea':
+				$field .= $this->render_textarea_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			case 'radio':
+				$field .= $this->render_radio_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			case 'checkbox':
+				$field .= $this->render_checkbox_field( $id, $label, $value, $field_class, $required, $required_field_text );
+				break;
+			case 'checkbox-multiple':
+				$field .= $this->render_checkbox_multiple_field( $id, $label, $value, $field_class, $required, $required_field_text );
+				break;
+			case 'select':
+				$field .= $this->render_select_field( $id, $label, $value, $field_class, $required, $required_field_text );
+				break;
+			case 'date':
+				$field .= $this->render_date_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				break;
+			default: // text field
+				$field .= $this->render_default_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $type );
+				break;
+		}
+		$field .= "\t</div>\n";
+		return $field;
 	}
 }
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3140,6 +3140,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\n<div>\n";
 				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label telephone" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
 				$r .= "\t\t<input type='tel' name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' value='" . esc_attr( $field_value ) . "' " . $field_class . $field_placeholder . "/>\n";
+				$r .= "\t</div>\n";
 				break;
 			case 'url':
 				$r .= "\n<div>\n";

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -239,42 +239,42 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		register_block_type( 'jetpack/contact-form', array(
+		jetpack_register_block( 'contact-form', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 		) );
 
 		// Field render methods.
-		register_block_type( 'jetpack/field-text', array(
+		jetpack_register_block( 'field-text', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
 		) );
-		register_block_type( 'jetpack/field-name', array(
+		jetpack_register_block( 'field-name', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
 		) );
-		register_block_type( 'jetpack/field-email', array(
+		jetpack_register_block( 'field-email', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
 		) );
-		register_block_type( 'jetpack/field-url', array(
+		jetpack_register_block( 'field-url', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
 		) );
-		register_block_type( 'jetpack/field-date', array(
+		jetpack_register_block( 'field-date', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
 		) );
-		register_block_type( 'jetpack/field-telephone', array(
+		jetpack_register_block( 'field-telephone', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
 		) );
-		register_block_type( 'jetpack/field-textarea', array(
+		jetpack_register_block( 'field-textarea', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
 		) );
-		register_block_type( 'jetpack/field-checkbox', array(
+		jetpack_register_block( 'field-checkbox', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
 		) );
-		register_block_type( 'jetpack/field-checkbox-multiple', array(
+		jetpack_register_block( 'field-checkbox-multiple', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
 		) );
-		register_block_type( 'jetpack/field-radio', array(
+		jetpack_register_block( 'field-radio', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
 		) );
-		register_block_type( 'jetpack/field-select', array(
+		jetpack_register_block( 'field-select', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
 		) );
 	}
@@ -3229,7 +3229,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 }
 
-add_action( 'init', array( 'Grunion_Contact_Form_Plugin', 'init' ) );
+add_action( 'init', array( 'Grunion_Contact_Form_Plugin', 'init' ), 9 );
 
 add_action( 'grunion_scheduled_delete', 'grunion_delete_old_spam' );
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3149,10 +3149,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
 				foreach ( $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					$r     .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-					$r     .= "<input type='radio' name='" . esc_attr( $field_id ) . "' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( $option, $field_value, false ) . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . '/> ';
-					$r     .= esc_html( $option ) . "</label>\n";
-					$r     .= "\t\t<div class='clear-form'></div>\n";
+					if ( $option ) {
+						$r     .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+						$r     .= "<input type='radio' name='" . esc_attr( $field_id ) . "' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( $option, $field_value, false ) . ' ' . ( $field_required ? "required aria-required='true'" : '' ) . '/> ';
+						$r     .= esc_html( $option ) . "</label>\n";
+						$r     .= "\t\t<div class='clear-form'></div>\n";
+					}
 				}
 				$r .= "\t\t</div>\n";
 				break;
@@ -3168,10 +3170,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
 				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					$r     .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-					$r     .= "<input type='checkbox' name='" . esc_attr( $field_id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( in_array( $option, (array) $field_value ), true, false ) . ' /> ';
-					$r     .= esc_html( $option ) . "</label>\n";
-					$r     .= "\t\t<div class='clear-form'></div>\n";
+					if ( $option  ) {
+						$r      .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+						$r      .= "<input type='checkbox' name='" . esc_attr( $field_id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( in_array( $option, (array) $field_value ), true, false ) . ' /> ';
+						$r      .= esc_html( $option ) . "</label>\n";
+						$r      .= "\t\t<div class='clear-form'></div>\n";
+					}
 				}
 				$r .= "\t\t</div>\n";
 				break;
@@ -3181,7 +3185,9 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\t<select name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' " . $field_class . ( $field_required ? "required aria-required='true'" : '' ) . ">\n";
 				foreach ( $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
-					$r     .= "\t\t<option" . selected( $option, $field_value, false ) . " value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "'>" . esc_html( $option ) . "</option>\n";
+					if ( $option ) {
+						$r     .= "\t\t<option" . selected( $option, $field_value, false ) . " value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "'>" . esc_html( $option ) . "</option>\n";
+					}
 				}
 				$r .= "\t</select>\n";
 				$r .= "\t</div>\n";

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2110,6 +2110,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		return $compiled_form;
 	}
 
+	static function remove_empty( $single_value ) {
+		return ( $single_value !== '' );
+	}
+
 	/**
 	 * The contact-field shortcode processor
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
@@ -2130,7 +2134,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
 					$att_strs[] = esc_html( $val );
 				} elseif ( isset( $val ) ) { // A regular attr - value pair
-					if ( is_array( $val ) ) {
+					if ( ( $att === 'options' || $att === 'values' ) && is_string( $val ) ) { // remove any empty strings
+						$val = explode( ',', $val );
+					}
+ 					if ( is_array( $val ) ) {
+						$val =  array_filter( $val, array( __CLASS__, 'remove_empty' ) );
 						$att_strs[] = esc_html( $att ) . '=\'' . implode( ',', array_map( 'esc_html', $val ) ) . '\'';
 					} elseif ( is_bool( $val ) ) {
 						$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ? '1' : '' ) . '\'';
@@ -3147,7 +3155,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				break;
 			case 'radio':
 				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				foreach ( $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
 					if ( $option ) {
 						$r     .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
@@ -3183,7 +3191,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				$r .= "\n<div>\n";
 				$r .= "\t\t<label for='" . esc_attr( $field_id ) . "' class='grunion-field-label select" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
 				$r .= "\t<select name='" . esc_attr( $field_id ) . "' id='" . esc_attr( $field_id ) . "' " . $field_class . ( $field_required ? "required aria-required='true'" : '' ) . ">\n";
-				foreach ( $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
 					if ( $option ) {
 						$r     .= "\t\t<option" . selected( $option, $field_value, false ) . " value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "'>" . esc_html( $option ) . "</option>\n";

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2123,6 +2123,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		// Don't try to parse contact form fields if not inside a contact form
 		if ( ! Grunion_Contact_Form_Plugin::$using_contact_form_field ) {
 			$att_strs = array();
+			if ( ! isset( $attributes['label'] ) ) {
+				$attributes['label'] = self::get_default_label_from_type( $attributes['type'] );
+			}
 			foreach ( $attributes as $att => $val ) {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
 					$att_strs[] = esc_html( $val );
@@ -2172,6 +2175,35 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		// Output HTML
 		return $field->render();
+	}
+
+	static function get_default_label_from_type( $type ) {
+		switch ( $type ) {
+			case 'text':
+				return __( 'Text', 'jetpack' );
+			case 'name':
+				return __( 'Name', 'jetpack' );
+			case 'email':
+				return __( 'Email', 'jetpack' );
+			case 'url':
+				return __( 'Url', 'jetpack' );
+			case 'date':
+				return __( 'Date', 'jetpack' );
+			case 'telephone':
+				return __( 'Phone', 'jetpack' );
+			case 'textarea':
+				return __( 'Message', 'jetpack' );
+			case 'checkbox':
+				return __( 'Checkbox', 'jetpack' );
+			case 'checkbox-multiple':
+				return __( 'Choose several', 'jetpack' );
+			case 'radio':
+				return __( 'Choose one', 'jetpack' );
+			case 'select':
+				return __( 'Select one', 'jetpack' );
+			default:
+				return __( 'Unknown', 'jetpack' );
+		}
 	}
 
 	/**

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2160,12 +2160,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 						$val = explode( ',', $val );
 					}
  					if ( is_array( $val ) ) {
-						$val =  array_filter( $val, array( __CLASS__, 'remove_empty' ) );
-						$att_strs[] = esc_html( $att ) . '=\'' . implode( ',', array_map( 'esc_html', $val ) ) . '\'';
+						$val =  array_filter( $val, array( __CLASS__, 'remove_empty' ) ); // removes any empty strings
+						$att_strs[] = esc_html( $att ) . '="' . implode( ',', array_map( 'esc_html', $val ) ) . '"';
 					} elseif ( is_bool( $val ) ) {
-						$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ? '1' : '' ) . '\'';
+						$att_strs[] = esc_html( $att ) . '="' . esc_html( $val ? '1' : '' ) . '"';
 					} else {
-						$att_strs[] = esc_html( $att ) . '=\'' . esc_html( $val ) . '\'';
+						$att_strs[] = esc_html( $att ) . '="' . esc_html( $val ) . '"';
 					}
 				}
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3289,9 +3289,6 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_field( $type, $id, $label, $value, $class, $placeholder, $required ) {
-
-		// $field = json_encode( array( $type, $id, $label, $value, $class, $placeholder, $required ) );
-
 		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 		$field_class       = "class='" . trim( esc_attr( $type ) . ' ' . esc_attr( $class ) ) . "' ";
 		$wrap_classes = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -778,11 +778,11 @@ class Grunion_Contact_Form_Plugin {
 		// so this inline JS moves it from the top of the page to the bottom.
 		?>
 		<script type='text/javascript'>
-            var menu = document.getElementById( 'feedback-export' ),
+		    var menu = document.getElementById( 'feedback-export' ),
                 wrapper = document.getElementsByClassName( 'wrap' )[0];
-			<?php if ( 'edit-feedback' === $current_screen->id ) : ?>
+            <?php if ( 'edit-feedback' === $current_screen->id ) : ?>
             wrapper.appendChild(menu);
-			<?php endif; ?>
+            <?php endif; ?>
             menu.style.display = 'block';
 		</script>
 		<?php

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2123,8 +2123,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		// Don't try to parse contact form fields if not inside a contact form
 		if ( ! Grunion_Contact_Form_Plugin::$using_contact_form_field ) {
 			$att_strs = array();
-			if ( ! isset( $attributes['label'] ) ) {
-				$attributes['label'] = self::get_default_label_from_type( $attributes['type'] );
+			if ( ! isset( $attributes['label'] )  ) {
+				$type = isset( $attributes['type'] ) ? $attributes['type'] : null;
+				$attributes['label'] = self::get_default_label_from_type( $type );
 			}
 			foreach ( $attributes as $att => $val ) {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
@@ -2202,7 +2203,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			case 'select':
 				return __( 'Select one', 'jetpack' );
 			default:
-				return __( 'Unknown', 'jetpack' );
+				return null;
 		}
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -233,46 +233,50 @@ class Grunion_Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
-		if ( function_exists( 'register_block_type' ) ) {
-			register_block_type( 'jetpack/contact-form', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
-			) );
-
-			// Field render methods.
-			register_block_type( 'jetpack/field-text', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
-			) );
-			register_block_type( 'jetpack/field-name', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
-			) );
-			register_block_type( 'jetpack/field-email', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
-			) );
-			register_block_type( 'jetpack/field-url', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
-			) );
-			register_block_type( 'jetpack/field-date', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
-			) );
-			register_block_type( 'jetpack/field-telephone', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
-			) );
-			register_block_type( 'jetpack/field-textarea', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
-			) );
-			register_block_type( 'jetpack/field-checkbox', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
-			) );
-			register_block_type( 'jetpack/field-checkbox-multiple', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
-			) );
-			register_block_type( 'jetpack/field-radio', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
-			) );
-			register_block_type( 'jetpack/field-select', array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
-			) );
+		if ( Jetpack_Gutenberg::is_gutenberg_available() ) {
+			self::register_contact_form_blocks();
 		}
+	}
+
+	private static function register_contact_form_blocks() {
+		register_block_type( 'jetpack/contact-form', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+		) );
+
+		// Field render methods.
+		register_block_type( 'jetpack/field-text', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
+		) );
+		register_block_type( 'jetpack/field-name', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
+		) );
+		register_block_type( 'jetpack/field-email', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
+		) );
+		register_block_type( 'jetpack/field-url', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
+		) );
+		register_block_type( 'jetpack/field-date', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
+		) );
+		register_block_type( 'jetpack/field-telephone', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
+		) );
+		register_block_type( 'jetpack/field-textarea', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
+		) );
+		register_block_type( 'jetpack/field-checkbox', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
+		) );
+		register_block_type( 'jetpack/field-checkbox-multiple', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
+		) );
+		register_block_type( 'jetpack/field-radio', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
+		) );
+		register_block_type( 'jetpack/field-select', array(
+			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
+		) );
 	}
 
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2125,6 +2125,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		return $compiled_form;
 	}
 
+	/**
+	 * Only strip out empty string values and keep all the other values as they are.
+     *
+	 * @param $single_value
+	 *
+	 * @return bool
+	 */
 	static function remove_empty( $single_value ) {
 		return ( $single_value !== '' );
 	}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -279,7 +279,6 @@ class Grunion_Contact_Form_Plugin {
 		) );
 	}
 
-
 	public static function gutenblock_render_form( $atts, $content ) {
 		return Grunion_Contact_Form::parse( $atts, do_blocks( $content ) );
 	}
@@ -3271,7 +3270,7 @@ function grunion_delete_old_spam() {
 		 *
 		 * @param bool $filter Should Jetpack optimize the table, defaults to false.
 		 */
-	apply_filters( 'grunion_optimize_table', false )
+		apply_filters( 'grunion_optimize_table', false )
 	) {
 		$wpdb->query( "OPTIMIZE TABLE $wpdb->posts" );
 	}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -277,7 +277,7 @@ class Grunion_Contact_Form_Plugin {
 
 
 	public static function gutenblock_render_form( $atts, $content ) {
-		return Grunion_Contact_Form::parse( $atts, $content );
+		return Grunion_Contact_Form::parse( $atts, do_blocks( $content ) );
 	}
 
 	public static function gutenblock_render_field_text( $atts, $content ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -234,7 +234,7 @@ class Grunion_Contact_Form_Plugin {
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
 		if ( function_exists( 'register_block_type' ) ) {
-			register_block_type( 'jetpack/form', array(
+			register_block_type( 'jetpack/contact-form', array(
 				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 			) );
 
@@ -3130,7 +3130,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				break;
 			case 'checkbox-multiple':
 				$r .= "\t<div><label class='grunion-field-label" . ( $this->is_error() ? ' form-error' : '' ) . "'>" . esc_html( $field_label ) . ( $field_required ? '<span>' . $required_field_text . '</span>' : '' ) . "</label>\n";
-				foreach ( $this->get_attribute( 'options' ) as $optionIndex => $option ) {
+				foreach ( (array) $this->get_attribute( 'options' ) as $optionIndex => $option ) {
 					$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
 					$r     .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 					$r     .= "<input type='checkbox' name='" . esc_attr( $field_id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' " . $field_class . checked( in_array( $option, (array) $field_value ), true, false ) . ' /> ';

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -528,11 +528,323 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertEquals( "[contact-field type='name' required='1' label='Name'/]", $html );
 	}
 
-	public function test_make_sure_that_we_remove_empty_optsions_from_formfield() {
+	public function test_make_sure_that_we_remove_empty_options_from_form_field() {
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
 		$shortcode = "[contact-field type='select' required='1' options='fun,,run' label='fun times' values='go,,have some fun'/]";
 		$html = do_shortcode( $shortcode );
 		$this->assertEquals( "[contact-field type='select' required='1' options='fun,run' label='fun times' values='go,have some fun'/]", $html );
+	}
+
+	public function test_make_sure_text_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'text',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+	public function test_make_sure_email_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'email',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'email' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_url_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'url',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'url' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_telephone_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'telephone',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'tel' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_date_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'date',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_textarea_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'textarea',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'textarea' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_checkbox_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'checkbox',
+			'class' => 'lalala',
+			'default' => 'foo',
+			'placeholder' => 'PLACEHOLDTHIS!',
+			'id' => 'funID'
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
+		$this->assertValidCheckboxField( $this->render_field( $attributes ), $expected_attributes );
+	}
+	// Multiple fields
+	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'checkbox-multiple',
+			'class' => 'lalala',
+			'default' => 'option 1',
+			'id' => 'funID',
+			'options' => array( 'option 1', 'option 2' ),
+			'values' => array( 'option 1', 'option 2' ),
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_radio_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'radio',
+			'class' => 'lalala',
+			'default' => 'option 1',
+			'id' => 'funID',
+			'options' => array( 'option 1', 'option 2' ),
+			'values' => array( 'option 1', 'option 2' ),
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function test_make_sure_select_field_renders_as_expected() {
+		$attributes = array(
+			'label' => 'fun',
+			'type' => 'select',
+			'class' => 'lalala',
+			'default' => 'option 1',
+			'id' => 'funID',
+			'options' => array( 'option 1', 'option 2' ),
+			'values' => array( 'o1', 'o2' ),
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'select' ) );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	public function render_field( $attributes ) {
+		$form = new Grunion_Contact_Form( array() );
+		$field = new Grunion_Contact_Form_Field( $attributes, '', $form );
+		return $field->render();
+	}
+
+	public function getCommonDiv( $html ) {
+
+		$doc = new DOMDocument();
+		$doc->loadHTML( $html );
+
+		$div = $doc->getElementsByTagName('div' );
+		return $div[0];
+	}
+
+	public function assertCommonValidHtml( $wrapperDiv, $attributes ) {
+
+		if ( $attributes['type'] === 'date' ) {
+			$attributes['class'] = 'jp-contact-form-date';
+		}
+		$this->assertEquals(
+			$wrapperDiv->getAttribute( 'class' ),
+			"grunion-field-wrap grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap",
+			'div class attribute doesn\'t match'
+		);
+
+		// Get label
+		$labels = $wrapperDiv->getElementsByTagName( 'label' );
+		$label = $labels[0];
+
+		$this->assertEquals( trim( $label->nodeValue), $attributes['label'], 'Label is not what we expect it to be...' );
+	}
+
+	public function assertValidField( $html, $attributes ) {
+
+		$wrapperDiv = $this->getCommonDiv( $html );
+		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
+
+		// Get label
+		$labels = $wrapperDiv->getElementsByTagName( 'label' );
+		$label = $labels[0];
+
+		//Input
+		$inputs =  (
+			$attributes['type'] === 'textarea'
+			? $wrapperDiv->getElementsByTagName( 'textarea' )
+			: $wrapperDiv->getElementsByTagName( 'input' )
+		);
+		$input = $inputs[0];
+
+		// label matches for matches input ID
+		$this->assertEquals(
+			$label->getAttribute( 'for' ),
+			$input->getAttribute( 'id' ),
+			'label for does not equal input ID!'
+		);
+
+		$this->assertEquals( $input->getAttribute( 'placeholder' ), $attributes['placeholder'], 'Placeholder doesn\'t match' );
+		if ( $attributes['type'] === 'textarea' ) {
+			$this->assertEquals( $input->nodeValue, $attributes['default'], 'value and default doesn\'t match' );
+			$this->assertEquals(
+				$label->getAttribute( 'for' ),
+				'contact-form-comment-' . $input->getAttribute( 'name' )
+				, 'label for doesn\'t match the input name'
+			);
+		} else {
+			$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
+			$this->assertEquals( $input->getAttribute( 'value' ), $attributes['default'], 'value and default doesn\'t match' );
+			// label matches for matches input name
+			$this->assertEquals(
+				$label->getAttribute( 'for' ),
+				$input->getAttribute( 'name' )
+				, 'label for doesn\'t match the input name'
+			);
+		}
+
+		if ( $attributes['type'] === 'date' ) {
+			$this->assertEquals(
+				$input->getAttribute( 'class' ),
+				"{$attributes['type']} jp-contact-form-date",
+				'input class attribute doesn\'t match'
+			);
+		} else {
+			$this->assertEquals(
+				$input->getAttribute( 'class' ),
+				"{$attributes['type']} {$attributes['class']}",
+				'input class attribute doesn\'t match'
+			);
+		}
+
+
+	}
+
+	public function assertValidCheckboxField( $html, $attributes ) {
+
+		$wrapperDiv = $this->getCommonDiv( $html );
+		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
+
+		$labels = $wrapperDiv->getElementsByTagName( 'label' );
+		$label = $labels[0];
+
+		$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label '.$attributes['type'], 'label class doesn\'t match' );
+
+		$inputs = $label->getElementsByTagName( 'input' );
+		$input = $inputs[0];
+		$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
+		$this->assertEquals( $input->getAttribute( 'value' ), 'Yes', 'Input value doesn\'t match' );
+		$this->assertEquals( $input->getAttribute( 'type' ), $attributes['type'], 'Input type doesn\'t match' );
+		if ( $attributes['default'] ) {
+			$this->assertEquals( $input->getAttribute( 'checked' ), 'checked', 'Input checked doesn\'t match' );
+		}
+
+		$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' .$attributes['class'], 'Input class doesn\'t match' );
+	}
+
+	public function assertValidFieldMultiField( $html, $attributes ) {
+
+		$wrapperDiv = $this->getCommonDiv( $html );
+		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
+
+		// Get label
+		$labels = $wrapperDiv->getElementsByTagName( 'label' );
+		$label = $labels[0]; // Main Label
+
+		//Inputs
+		if ( $attributes['type'] === 'select' ) {
+			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label select', 'label class doesn\'t match' );
+			$inputs = $wrapperDiv->getElementsByTagName( 'select' );
+			$select = $inputs[0];
+			$this->assertEquals(
+				$label->getAttribute( 'for' ),
+				$select->getAttribute( 'id' ),
+				'label for does not equal input ID!'
+			);
+
+			$this->assertEquals(
+				$label->getAttribute( 'for' ),
+				$select->getAttribute( 'name' ),
+				'label for does not equal input name!'
+			);
+
+			$this->assertEquals( $select->getAttribute( 'class' ), 'select '. $attributes['class'], ' select class does not match expected' );
+
+			// First Option
+			$options = $select->getElementsByTagName( 'option' );
+			$option = $options[0];
+			$this->assertEquals( $option->getAttribute( 'value' ), $attributes['values'][0], 'Input value doesn\'t match' );
+			$this->assertEquals( $option->getAttribute( 'selected' ), 'selected', 'Input is not selected' );
+			$this->assertEquals( $option->nodeValue, $attributes['options'][0], 'Input does not match the option' );
+
+		} else {
+			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label', 'label class doesn\'t match' );
+			// Radio and Checkboxes
+			$second_label = $labels[1];
+			$inputs = $second_label->getElementsByTagName( 'input' );
+			$this->assertEquals( $second_label->nodeValue, ' ' . $attributes['options'][0] ); // extra space added for a padding
+
+			$input = $inputs[0];
+			$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
+			if (  $attributes['input_type'] === 'radio' ) {
+				$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
+			} else {
+				$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'] . '[]', 'Input name doesn\'t match' );
+			}
+			$this->assertEquals( $input->getAttribute( 'value' ), $attributes['values'][0], 'Input value doesn\'t match' );
+			$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' '. $attributes['class'], 'Input class doesn\'t match' );
+			$this->assertEquals( $input->getAttribute( 'checked' ), 'checked', 'Input checked doesn\'t match' );
+		}
 	}
 
 	/**
@@ -555,7 +867,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			$this->assertEquals( "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label='asdasd' type='text'/][contact-field id='1' required &#039;derp&#039; herp asd lkj]adsasd[/contact-field]", $html );
 		}
 	}
-
 
 	/**
 	 * Test get_export_data_for_posts with fully vaid data input.

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -687,9 +687,15 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		$doc = new DOMDocument();
 		$doc->loadHTML( $html );
+		return $this->getFirstElement( $doc, 'div' );
+	}
 
-		$div = $doc->getElementsByTagName('div' );
-		return $div[0];
+	public function getFirstElement( $dom, $tag, $index = 0) {
+		$elements = $dom->getElementsByTagName( $tag );
+		if ( !is_array( $elements ) ) {
+			$elements = iterator_to_array( $elements );
+		}
+		return $elements[ $index ];
 	}
 
 	public function assertCommonValidHtml( $wrapperDiv, $attributes ) {
@@ -704,8 +710,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		);
 
 		// Get label
-		$labels = $wrapperDiv->getElementsByTagName( 'label' );
-		$label = $labels[0];
+		$label = $this->getFirstElement( $wrapperDiv, 'label' );
 
 		$this->assertEquals( trim( $label->nodeValue), $attributes['label'], 'Label is not what we expect it to be...' );
 	}
@@ -716,16 +721,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
 
 		// Get label
-		$labels = $wrapperDiv->getElementsByTagName( 'label' );
-		$label = $labels[0];
+		$label = $this->getFirstElement( $wrapperDiv, 'label' );
 
 		//Input
-		$inputs =  (
+		$input =  (
 			$attributes['type'] === 'textarea'
-			? $wrapperDiv->getElementsByTagName( 'textarea' )
-			: $wrapperDiv->getElementsByTagName( 'input' )
+			? $this->getFirstElement( $wrapperDiv, 'textarea' )
+			: $this->getFirstElement( $wrapperDiv, 'input' )
 		);
-		$input = $inputs[0];
 
 		// label matches for matches input ID
 		$this->assertEquals(
@@ -775,13 +778,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$wrapperDiv = $this->getCommonDiv( $html );
 		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
 
-		$labels = $wrapperDiv->getElementsByTagName( 'label' );
-		$label = $labels[0];
+		$label = $this->getFirstElement( $wrapperDiv, 'label' );
+		$input = $this->getFirstElement( $label, 'input' );
 
 		$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label '.$attributes['type'], 'label class doesn\'t match' );
 
-		$inputs = $label->getElementsByTagName( 'input' );
-		$input = $inputs[0];
+
 		$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
 		$this->assertEquals( $input->getAttribute( 'value' ), 'Yes', 'Input value doesn\'t match' );
 		$this->assertEquals( $input->getAttribute( 'type' ), $attributes['type'], 'Input type doesn\'t match' );
@@ -798,14 +800,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
 
 		// Get label
-		$labels = $wrapperDiv->getElementsByTagName( 'label' );
-		$label = $labels[0]; // Main Label
+		$label = $this->getFirstElement( $wrapperDiv, 'label' );
 
 		//Inputs
 		if ( $attributes['type'] === 'select' ) {
 			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label select', 'label class doesn\'t match' );
-			$inputs = $wrapperDiv->getElementsByTagName( 'select' );
-			$select = $inputs[0];
+
+			$select = $this->getFirstElement( $wrapperDiv, 'select' );
 			$this->assertEquals(
 				$label->getAttribute( 'for' ),
 				$select->getAttribute( 'id' ),
@@ -821,8 +822,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			$this->assertEquals( $select->getAttribute( 'class' ), 'select '. $attributes['class'], ' select class does not match expected' );
 
 			// First Option
-			$options = $select->getElementsByTagName( 'option' );
-			$option = $options[0];
+			$option = $this->getFirstElement( $select, 'option' );
 			$this->assertEquals( $option->getAttribute( 'value' ), $attributes['values'][0], 'Input value doesn\'t match' );
 			$this->assertEquals( $option->getAttribute( 'selected' ), 'selected', 'Input is not selected' );
 			$this->assertEquals( $option->nodeValue, $attributes['options'][0], 'Input does not match the option' );
@@ -830,11 +830,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		} else {
 			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label', 'label class doesn\'t match' );
 			// Radio and Checkboxes
-			$second_label = $labels[1];
-			$inputs = $second_label->getElementsByTagName( 'input' );
+			$second_label = $this->getFirstElement( $wrapperDiv, 'label', 1 );
 			$this->assertEquals( $second_label->nodeValue, ' ' . $attributes['options'][0] ); // extra space added for a padding
 
-			$input = $inputs[0];
+			$input = $this->getFirstElement( $second_label, 'input' );
 			$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
 			if (  $attributes['input_type'] === 'radio' ) {
 				$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -521,6 +521,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertEquals( $shortcode, $html );
 	}
 
+	public function test_make_sure_that_we_add_defatul_lable_when_non_is_present() {
+		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		$shortcode = "[contact-field type='name' required='1' /]";
+		$html = do_shortcode( $shortcode );
+		$this->assertEquals( "[contact-field type='name' required='1' label='Name'/]", $html );
+	}
+
 	/**
 	 * @author tonykova
 	 * @covers Grunion_Contact_Form::parse_contact_field

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -528,6 +528,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertEquals( "[contact-field type='name' required='1' label='Name'/]", $html );
 	}
 
+	public function test_make_sure_that_we_remove_empty_optsions_from_formfield() {
+		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		$shortcode = "[contact-field type='select' required='1' options='fun,,run' label='fun times' values='go,,have some fun'/]";
+		$html = do_shortcode( $shortcode );
+		$this->assertEquals( "[contact-field type='select' required='1' options='fun,run' label='fun times' values='go,have some fun'/]", $html );
+	}
+
 	/**
 	 * @author tonykova
 	 * @covers Grunion_Contact_Form::parse_contact_field

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -515,7 +515,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	public function test_parse_contact_field_keeps_string_unchaned_when_no_escaping_necesssary() {
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
 
-		$shortcode = "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='asdasd' type='text'/][contact-field id='1' required derp herp asd lkj]adsasd[/contact-field]";
+		$shortcode = "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=\"email\" required=\"1\"/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]";
 		$html = do_shortcode( $shortcode );
 
 		$this->assertEquals( $shortcode, $html );
@@ -525,14 +525,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
 		$shortcode = "[contact-field type='name' required='1' /]";
 		$html = do_shortcode( $shortcode );
-		$this->assertEquals( "[contact-field type='name' required='1' label='Name'/]", $html );
+		$this->assertEquals( "[contact-field type=\"name\" required=\"1\" label=\"Name\"/]", $html );
 	}
 
 	public function test_make_sure_that_we_remove_empty_options_from_form_field() {
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
 		$shortcode = "[contact-field type='select' required='1' options='fun,,run' label='fun times' values='go,,have some fun'/]";
 		$html = do_shortcode( $shortcode );
-		$this->assertEquals( "[contact-field type='select' required='1' options='fun,run' label='fun times' values='go,have some fun'/]", $html );
+		$this->assertEquals( "[contact-field type=\"select\" required=\"1\" options=\"fun,run\" label=\"fun times\" values=\"go,have some fun\"/]", $html );
 	}
 
 	public function test_make_sure_text_field_renders_as_expected() {
@@ -861,9 +861,9 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// sure we don't output anything harmful
 
 		if ( version_compare( $wp_version, '4.9-alpha', '>') ){
-			$this->assertEquals( "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label='asdasd' type='text'/][contact-field id='1' required derp herp asd lkj]adsasd[/contact-field]", $html );
+			$this->assertEquals( "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]", $html );
 		} else {
-			$this->assertEquals( "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label='asdasd' type='text'/][contact-field id='1' required &#039;derp&#039; herp asd lkj]adsasd[/contact-field]", $html );
+			$this->assertEquals( "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]", $html );
 		}
 	}
 

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -692,8 +692,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	public function getFirstElement( $dom, $tag, $index = 0) {
 		$elements = $dom->getElementsByTagName( $tag );
-		if ( !is_array( $elements ) ) {
-			$elements = iterator_to_array( $elements );
+		if ( ! is_array( $elements ) ) {
+			return $elements->item( $index );
 		}
 		return $elements[ $index ];
 	}

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -863,7 +863,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		if ( version_compare( $wp_version, '4.9-alpha', '>') ){
 			$this->assertEquals( "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]", $html );
 		} else {
-			$this->assertEquals( "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required derp herp asd lkj]adsasd[/contact-field]", $html );
+			$this->assertEquals( "[contact-field label=\"Name\" type=\"name\" required=\"1\"/][contact-field label=\"Email\" type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label=\"asdasd\" type=\"text\"/][contact-field id=\"1\" required &#039;derp&#039; herp asd lkj]adsasd[/contact-field]", $html );
 		}
 	}
 


### PR DESCRIPTION
Fixes #9784

Simplifies the work done by @georgestephanis in https://github.com/Automattic/jetpack/pull/10256

By removing the js code since it should be automatically be included as part of the jetpack blocks. 
Now found here https://github.com/Automattic/wp-calypso/pull/27996 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

### Todo: 
[ ] Rendering on the front-end (waiting on externals) - 
https://github.com/WordPress/gutenberg/pull/11334/  

#### Testing instructions:
* Go to https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=add/gutenblocks/contact-form&branch=add/contact-form-gutenblock-sdk

1. Connect Jetpack 
2. Visit the editor. Add the new contact form. 
3. Does it work as expected? 


#### Proposed changelog entry for your changes:
Add the contact form to the Gutenberg editor. 
