### PR TITLE
WooCommerce Analytics: a fix to check if the WC session is a valid object

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -79,29 +79,31 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$blogid = Jetpack::get_option( 'id' );
 
 		// check for previous add-to-cart cart events
-		$data = WC()->session->get( 'wca_session_data' );
-		if ( ! empty( $data ) ) {
-			foreach ( $data as $data_instance ) {
-				$product = wc_get_product( $data_instance['product_id'] );
-				if ( ! $product ) {
-					continue;
+		if ( is_object( WC()->session ) ) {
+			$data = WC()->session->get( 'wca_session_data' );
+			if ( ! empty( $data ) ) {
+				foreach ( $data as $data_instance ) {
+					$product = wc_get_product( $data_instance['product_id'] );
+					if ( ! $product ) {
+						continue;
+					}
+					$product_details = $this->get_product_details( $product );
+					wc_enqueue_js(
+						"_wca.push( {
+								'_en': '" . esc_js( $data_instance['event'] ) . "',
+								'blog_id': '" . esc_js( $blogid ) . "',
+								'pi': '" . esc_js( $data_instance['product_id'] ) . "',
+								'pn': '" . esc_js( $product_details['name'] ) . "',
+								'pc': '" . esc_js( $product_details['category'] ) . "',
+								'pp': '" . esc_js( $product_details['price'] ) . "',
+								'pq': '" . esc_js( $data_instance['quantity'] ) . "',
+								'ui': '" . esc_js( $this->get_user_id() ) . "',
+							} );"
+					);
 				}
-				$product_details = $this->get_product_details( $product );
-				wc_enqueue_js(
-					"_wca.push( {
-							'_en': '" . esc_js( $data_instance['event'] ) . "',
-							'blog_id': '" . esc_js( $blogid ) . "',
-							'pi': '" . esc_js( $data_instance['product_id'] ) . "',
-							'pn': '" . esc_js( $product_details['name'] ) . "',
-							'pc': '" . esc_js( $product_details['category'] ) . "',
-							'pp': '" . esc_js( $product_details['price'] ) . "',
-							'pq': '" . esc_js( $data_instance['quantity'] ) . "',
-							'ui': '" . esc_js( $this->get_user_id() ) . "',
-						} );"
-				);
+				// clear data
+				WC()->session->set( 'wca_session_data', '' );
 			}
-			// clear data
-			WC()->session->set( 'wca_session_data', '' );
 		}
 	}
 
@@ -339,8 +341,12 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$quantity = ( $quantity == 0 ) ? 1 : $quantity;
 
 		// check for existing data
-		$data = WC()->session->get( 'wca_session_data' );
-		if ( empty( $data ) || ! is_array( $data ) ) {
+		if ( is_object( WC()->session ) ) {
+			$data = WC()->session->get( 'wca_session_data' );
+			if ( empty( $data ) || ! is_array( $data ) ) {
+				$data = array();
+			}
+		} else {
 			$data = array();
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #10533 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Two checks to ensure `WC()->session` exists before calling `get`

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm not clear on how to replicate the issue as reported in #10533 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* WooCommerce Analytics: ensure `WC()->session` exists before calling `get` method
