### PR TITLE
JITMs: Fix styling to work better with a popular plugin

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -119,6 +119,7 @@
 
 .jitm-card {
 	display: block;
+	clear: both;
 	position: relative;
 	margin: rem( 16px ) 0 0 auto;
 	padding: rem( 16px );
@@ -398,4 +399,8 @@
 
 .jitm-banner__action + .jitm-banner__dismiss {
 	margin-left: rem( 10px );
+}
+
+#dolly + .jitm-card {
+  margin: 3rem 1rem 0 auto;
 }


### PR DESCRIPTION
@jeffgolenski and I worked together to fix some styling issues.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #9221

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Fix some spacing when a popular plugin is present:

<img width="847" alt="screen shot 2018-11-05 at 5 50 24 pm" src="https://user-images.githubusercontent.com/1883296/48013289-41929d80-e124-11e8-8dea-f6b7de9af1b1.png">

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Turn on Hello Dolly on a site with no plan and akismet inactive
2. View the comments page
3. See a jitm that doesn't collide with the hello dolly text

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

No changelog entry is needed except maybe: Improved plugin compatibility