### PR TITLE
Shortcodes: Use Core's oEmbed for Vimeo

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -178,21 +178,6 @@ function wpcom_vimeo_embed_url( $matches, $attr, $url ) {
 	return vimeo_shortcode( array( $url ) );
 }
 
-/**
- * For bare URLs on their own line of the form
- * http://vimeo.com/12345
- *
- * @since 3.9
- *
- * @uses wpcom_vimeo_embed_url
- */
-function wpcom_vimeo_embed_url_init() {
-	wp_embed_register_handler( 'wpcom_vimeo_embed_url', '#https?://(.+\.)?vimeo\.com/#i', 'wpcom_vimeo_embed_url' );
-}
-
-// Register handler to modify Vimeo embeds using Jetpack's shortcode output.
-add_action( 'init', 'wpcom_vimeo_embed_url_init' );
-
 function vimeo_embed_to_shortcode( $content ) {
 	if ( ! is_string( $content ) || false === stripos( $content, 'player.vimeo.com/video/' ) ) {
 		return $content;

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -107,8 +107,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		the_content();
 		$actual = ob_get_clean();
 		wp_reset_postdata();
-		$this->assertContains( '<div class="embed-vimeo"', $actual );
-		$this->assertContains( '<iframe src="https://player.vimeo.com/video/'.$video_id.'"', $actual );
+		$this->assertContains( '<iframe src="https://player.vimeo.com/video/'  . $video_id, $actual );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #10529

Core's oEmbed handles more use cases than ours do, resulting in a poorer result with Jetpack. Let's just use Core's.

#### Changes proposed in this Pull Request:
* Remove Jetpack's oEmbed handler for Vimeo.

#### Testing instructions:
* Try every possible Vimeo URL's oEmbed. (see #10529)
* Try inserting the iframe when using an user within unfiltered_html caps (e.g. an Author on a regular site). 
* Verify they all load.

#### Proposed changelog entry for your changes:
* Rely on WordPress' native oEmbed support for VImeo links.

Marking this as DO NOT MERGE as this needs a lot of testing and open to discussion on if this makes sense.
