### PR TITLE
Fix gap for sidebar in calypsoify on mobile

### DIFF
--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -346,11 +346,11 @@ body,
 
 @media screen and (max-width: 600px) {
   #calypso-sidebar-header {
-    top: 46px;
+    top: 32px;
   }
 
   .auto-fold #adminmenu {
-    top: 46px;
+    top: 32px;
   }
 }
 


### PR DESCRIPTION
This PR fixes positioning for open sidebar on viewports <600px when Calypsoify is enabled.

Fixes #10551 

#### Changes proposed in this Pull Request:
Move the sidebar positioning to be flush with the masterbar on the top.

#### Testing instructions:
1.  Visit any page in dashboard with Calypsoify enabled (calypsoify=1)
2.  Open the sidebar menu with the hamburger menu on a viewport <600px
3.  Note the gap no longer exists between the top navigation and the sidebar menu

#### Proposed changelog entry for your changes:
Update mobile menu positioning on mobile.

#### Screenshots
<img width="241" alt="screen shot 2018-11-06 at 2 50 50 pm" src="https://user-images.githubusercontent.com/10561050/48093023-3307bd00-e1dc-11e8-8737-2c9ed59b0f87.png">
