### PR TITLE
Debugger: Introduce testing suite

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -916,6 +916,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array|WP_Error WP_Error returned if connection test does not succeed.
 	 */
 	public static function jetpack_connection_test() {
+		jetpack_require_lib( 'debugger' );
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
 			sprintf( '/jetpack-blogs/%d/test-connection', Jetpack_Options::get_option( 'id' ) ),
 			Jetpack_Client::WPCOM_JSON_API_VERSION

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -917,33 +917,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function jetpack_connection_test() {
 		jetpack_require_lib( 'debugger' );
-		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
-			sprintf( '/jetpack-blogs/%d/test-connection', Jetpack_Options::get_option( 'id' ) ),
-			Jetpack_Client::WPCOM_JSON_API_VERSION
-		);
+		$cxntests = new Jetpack_Cxn_Tests();
 
-		if ( is_wp_error( $response ) ) {
-			/* translators: %1$s is the error code, %2$s is the error message */
-			return new WP_Error( 'connection_test_failed', sprintf( __( 'Connection test failed (#%1$s: %2$s)', 'jetpack' ), $response->get_error_code(), $response->get_error_message() ), array( 'status' => $response->get_error_code() ) );
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		if ( ! $body ) {
-			return new WP_Error( 'connection_test_failed', __( 'Connection test failed (empty response body)', 'jetpack' ), array( 'status' => $response->get_error_code() ) );
-		}
-
-		$result = json_decode( $body );
-		$is_connected = (bool) $result->connected;
-		$message = $result->message;
-
-		if ( $is_connected ) {
-			return rest_ensure_response( array(
-				'code' => 'success',
-				'message' => $message,
-			) );
+		if ( $cxntests->pass() ) {
+			return rest_ensure_response(
+				array(
+					'code'    => 'success',
+					'message' => __( 'All connection tests passed.', 'jetpack' ),
+				)
+			);
 		} else {
-			return new WP_Error( 'connection_test_failed', $message, array( 'status' => $response->get_error_code() ) );
+			return $cxntests->output_fails_as_wp_error();
 		}
+
 	}
 
 	public static function rewind_data() {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -955,7 +955,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			array(
 				'rest_route' => $_GET['rest_route'],
 				'timestamp' => intval( $_GET['timestamp'] ),
-				'url' => $_GET['url'],
+				'url' => wp_unslash( $_GET['url'] ),
 			)
 		);
 

--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Loading the various functions used for Jetpack Debugging.
+ *
+ * @package Jetpack.
+ */
+
+/* Jetpack Connection Testing Framework */
+require_once 'class-jetpack-cxn-test-base.php';
+/* Jetpack Connection Tests */
+require_once 'class-jetpack-cxn-tests.php';
+/* The "In-Plugin Debugger" admin page. */
+require_once 'class-jetpack-debugger.php';

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -185,6 +185,7 @@ class Jetpack_Cxn_Test_Base {
 	 * Helper function to return consistent responses for a skipped test.
 	 *
 	 * @param string $name Test name.
+	 * @param string $message Reason for skipping the test. Optional.
 	 *
 	 * @return array Test results.
 	 */

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -189,10 +189,7 @@ class Jetpack_Cxn_Test_Base {
 	 *
 	 * @return array Test results.
 	 */
-	public static function skipped_test( $name = 'Unnamed', $message = null ) {
-		if ( ! $message ) {
-			$message = __( 'Test Skipped.', 'jetpack' );
-		}
+	public static function skipped_test( $name = 'Unnamed', $message = false ) {
 		return array(
 			'name'       => $name,
 			'pass'       => 'skipped',
@@ -245,8 +242,12 @@ class Jetpack_Cxn_Test_Base {
 					WP_CLI::log( WP_CLI::colorize( '%gPassed:%n  ' . $test['name'] ) );
 				} elseif ( 'skipped' === $test['pass'] ) {
 					WP_CLI::log( WP_CLI::colorize( '%ySkipped:%n ' . $test['name'] ) );
+					if ( $test['message'] ) {
+						WP_CLI::log( '         ' . $test['message'] ); // Number of spaces to "tab indent" the reason.
+					}
 				} else { // Failed.
 					WP_CLI::log( WP_CLI::colorize( '%rFailed:%n  ' . $test['name'] ) );
+					WP_CLI::log( '         ' . $test['message'] ); // Number of spaces to "tab indent" the reason.
 				}
 			}
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -102,7 +102,8 @@ class Jetpack_Cxn_Test_Base {
 		$results = $this->raw_results();
 
 		foreach ( $results as $result ) {
-			if ( isset( $result['pass'] ) && ! $result['pass'] ) {
+			// 'pass' could be true, false, or 'skipped'. We only want false.
+			if ( isset( $result['pass'] ) && false === $result['pass'] ) {
 				return false;
 			}
 		}
@@ -121,7 +122,7 @@ class Jetpack_Cxn_Test_Base {
 
 		foreach ( $results as $test => $result ) {
 			// We do not want tests that passed or ones that are misconfigured (no pass status or no failure message).
-			if ( ! isset( $result['pass'] ) || true === $result['pass'] || ! isset( $result['message'] ) ) {
+			if ( ! isset( $result['pass'] ) || false !== $result['pass'] || ! isset( $result['message'] ) ) {
 				unset( $results[ $test ] );
 			}
 		}
@@ -159,6 +160,19 @@ class Jetpack_Cxn_Test_Base {
 		return array(
 			'pass'       => true,
 			'message'    => __( 'Test Passed!', 'jetpack' ),
+			'resolution' => false,
+		);
+	}
+
+	/**
+	 * Helper function to return consistent responses for a skipped test
+	 *
+	 * @return array Test results.
+	 */
+	protected function skipped_test() {
+		return array(
+			'pass'       => 'skipped',
+			'message'    => __( 'Test Skipped.', 'jetpack' ),
 			'resolution' => false,
 		);
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -188,11 +188,14 @@ class Jetpack_Cxn_Test_Base {
 	 *
 	 * @return array Test results.
 	 */
-	public static function skipped_test( $name = 'Unnamed' ) {
+	public static function skipped_test( $name = 'Unnamed', $message = null ) {
+		if ( ! $message ) {
+			$message = __( 'Test Skipped.', 'jetpack' );
+		}
 		return array(
 			'name'       => $name,
 			'pass'       => 'skipped',
-			'message'    => __( 'Test Skipped.', 'jetpack' ),
+			'message'    => $message,
 			'resolution' => false,
 		);
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -277,19 +277,7 @@ class Jetpack_Cxn_Test_Base {
 			return false;
 		}
 
-		$cert       = <<<CERT
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm+uLLVoxGCY71LS6KFc6
-1UnF6QGBAsi5XF8ty9kR3/voqfOkpW+gRerM2Kyjy6DPCOmzhZj7BFGtxSV2ZoMX
-9ZwWxzXhl/Q/6k8jg8BoY1QL6L2K76icXJu80b+RDIqvOfJruaAeBg1Q9NyeYqLY
-lEVzN2vIwcFYl+MrP/g6Bc2co7Jcbli+tpNIxg4Z+Hnhbs7OJ3STQLmEryLpAxQO
-q8cbhQkMx+FyQhxzSwtXYI/ClCUmTnzcKk7SgGvEjoKGAmngILiVuEJ4bm7Q1yok
-xl9+wcfW6JAituNhml9dlHCWnn9D3+j8pxStHihKy2gVMwiFRjLEeD8K/7JVGkb/
-EwIDAQAB
------END PUBLIC KEY-----
-
-CERT;
-		$public_key = openssl_get_publickey( $cert );
+		$public_key = openssl_get_publickey( JETPACK__DEBUGGER_PUBLIC_KEY );
 
 		if ( openssl_seal( $data, $encrypted_data, $env_key, array( $public_key ) ) ) {
 			// We are returning base64-encoded values to ensure they're characters we can use in JSON responses without issue.

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -85,7 +85,7 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function run_tests() {
 		foreach ( $this->tests as $test ) {
-			$result = call_user_func( $test );
+			$result          = call_user_func( $test );
 			$this->results[] = $result;
 			if ( false === $result['pass'] ) {
 				$this->pass = false;
@@ -166,7 +166,7 @@ class Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Helper function to return consistent responses for a passing test
+	 * Helper function to return consistent responses for a passing test.
 	 *
 	 * @param string $name Test name.
 	 *
@@ -182,7 +182,7 @@ class Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Helper function to return consistent responses for a skipped test
+	 * Helper function to return consistent responses for a skipped test.
 	 *
 	 * @param string $name Test name.
 	 *
@@ -198,18 +198,36 @@ class Jetpack_Cxn_Test_Base {
 	}
 
 	/**
+	 * Helper function to return consistent responses for a failing test.
+	 *
+	 * @param string $name Test name.
+	 * @param string $message Message detailing the failure.
+	 * @param string $resolution Steps to resolve.
+	 *
+	 * @return array Test results.
+	 */
+	public static function failing_test( $name, $message, $resolution = false ) {
+		return array(
+			'name'       => $name,
+			'pass'       => false,
+			'message'    => $message,
+			'resolution' => $resolution,
+		);
+	}
+
+	/**
 	 * Provide WP_CLI friendly testing results.
 	 */
 	public function output_results_for_cli() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::line( __( 'TEST RESULTS:' ) );
+			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );
 			foreach ( $this->raw_results() as $test ) {
 				if ( true === $test['pass'] ) {
-					WP_CLI::log( WP_CLI::colorize( "%gPassed:%n  " . $test['name'] ) );
-				} else if ( 'skipped' === $test['pass'] ) {
-					WP_CLI::log( WP_CLI::colorize( "%ySkipped:%n " . $test['name'] ) );
-				} else { // Failed
-					WP_CLI::log( WP_CLI::colorize( "%rFailed:%n  " . $test['name'] ) );
+					WP_CLI::log( WP_CLI::colorize( '%gPassed:%n  ' . $test['name'] ) );
+				} elseif ( 'skipped' === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( '%ySkipped:%n ' . $test['name'] ) );
+				} else { // Failed.
+					WP_CLI::log( WP_CLI::colorize( '%rFailed:%n  ' . $test['name'] ) );
 				}
 			}
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -144,31 +144,6 @@ class Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Returns standard resolution steps.
-	 *
-	 * Tests can provide their own messaging, but for any failed tests with the same steps, let's keep it DRY.
-	 *
-	 * @param string $resolution Standard resolution.
-	 *
-	 * @return string Human-readable steps to resolve a failed test.
-	 */
-	public static function serve_message( $resolution = null ) {
-		switch ( $resolution ) {
-			case 'cycle_connection':
-				$message = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
-				break;
-			case 'outbound_requests':
-				$message = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
-				break;
-			case 'support':
-			default:
-				$message = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
-		}
-
-		return $message;
-	}
-
-	/**
 	 * Helper function to return consistent responses for a passing test.
 	 *
 	 * @param string $name Test name.
@@ -210,6 +185,19 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function failing_test( $name, $message, $resolution = false ) {
+		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
+		switch ( $resolution ) {
+			case 'cycle_connection':
+				$resolution = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
+				break;
+			case 'outbound_requests':
+				$resolution = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
+				break;
+			case 'support':
+				$resolution = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
+				break;
+		}
+
 		return array(
 			'name'       => $name,
 			'pass'       => false,

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Jetpack Connection Testing
+ *
+ * Framework for various "unit tests" against the Jetpack connection.
+ *
+ * Individual tests should be added to the class-jetpack-cxn-tests.php file.
+ *
+ * @author Brandon Kraft
+ * @package Jetpack
+ */
+
+/**
+ * "Unit Tests" for the Jetpack connection.
+ */
+class Jetpack_Cxn_Test_Base {
+
+	/**
+	 * The one true instance
+	 *
+	 * @var object $_instance
+	 */
+	private $_instance;
+
+	/**
+	 * Tests to run on the Jetpack connection.
+	 *
+	 * @var array $tests
+	 */
+	protected $tests = array();
+
+	/**
+	 * Results of the Jetpack connection tests.
+	 *
+	 * @var array $results
+	 */
+	protected $results = array();
+
+	/**
+	 * Jetpack_Cxn_Test constructor.
+	 */
+	private function __construct() {
+	}
+
+	/**
+	 * Run this to expose the testing platform
+	 */
+	public function init() {
+		if ( ! isset( $this->_instance ) || ! $this->_instance ) {
+			$this->_instance = new Jetpack_Cxn_Test_Base();
+			$this->tests     = array();
+			$this->results   = array();
+		}
+
+		return $this->_instance;
+	}
+
+	/**
+	 * Adds a new test to the Jetpack Connection Testing suite.
+	 *
+	 * @param callable $callable Test to add to queue.
+	 *
+	 * @return bool True if successfully added. False for a failure.
+	 */
+	public function add_test( $callable ) {
+		if ( is_callable( $callable ) ) {
+			$this->tests[] = $callable;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Runs the Jetpack connection suite.
+	 */
+	public function run_tests() {
+		foreach ( $this->tests as $test ) {
+			$this->results[] = call_user_func( $test );
+		}
+	}
+
+	/**
+	 * Returns the full results array.
+	 *
+	 * @return array Array of test results.
+	 */
+	public function raw_results() {
+		if ( ! $this->results ) {
+			$this->run_tests();
+		}
+
+		return $this->results;
+	}
+
+	/**
+	 * Returns the status of the connection suite.
+	 *
+	 * @return true|array True if all tests pass. Array of failed tests.
+	 */
+	public function pass() {
+		$results = $this->raw_results();
+
+		foreach ( $results as $result ) {
+			if ( isset( $result['pass'] ) && ! $result['pass'] ) {
+				return false;
+			}
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Return array of failed test messages.
+	 *
+	 * @return false|array False if no failed tests. Otherwise, array of failed tests.
+	 */
+	public function list_fails() {
+		$results = $this->raw_results();
+
+		foreach ( $results as $test => $result ) {
+			// We do not want tests that passed or ones that are misconfigured (no pass status or no failure message).
+			if ( ! isset( $result['pass'] ) || true === $result['pass'] || ! isset( $result['message'] ) ) {
+				unset( $results[ $test ] );
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Returns standard resolution steps.
+	 *
+	 * Tests can provide their own messaging, but for any failed tests with the same steps, let's keep it DRY.
+	 *
+	 * @param string $resolution Standard resolution.
+	 *
+	 * @return string Human-readable steps to resolve a failed test.
+	 */
+	protected function serve_message( $resolution = null ) {
+		switch ( $resolution ) {
+			case 'cycle_connection':
+				$message = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
+				break;
+			default:
+				$message = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Helper function to return consistent responses for a passing test
+	 *
+	 * @return array Test results.
+	 */
+	protected function passing_test() {
+		return array(
+			'pass'       => true,
+			'message'    => __( 'Test Passed!', 'jetpack' ),
+			'resolution' => false,
+		);
+	}
+}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -112,7 +112,7 @@ class Jetpack_Cxn_Test_Base {
 		$results = $this->results;
 
 		if ( 'all' === $group ) {
-				return $results;
+			return $results;
 		}
 
 		foreach ( $results as $test => $result ) {
@@ -246,5 +246,35 @@ class Jetpack_Cxn_Test_Base {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Provide single WP Error instance of all failures.
+	 *
+	 * @param string $group Testing group whose failures we want converted. Default "default". Use "all" for all tests.
+	 *
+	 * @return WP_Error|false WP_Error with all failed tests or false if there were no failures.
+	 */
+	public function output_fails_as_wp_error( $group = 'default' ) {
+		if ( $this->pass( $group ) ) {
+			return false;
+		}
+		$fails = $this->list_fails( $group );
+		$error = false;
+
+		foreach ( $fails as $result ) {
+			$code    = 'failed_' . $result['name'];
+			$message = $result['message'];
+			$data    = array(
+				'resolution' => $result['resolution'],
+			);
+			if ( ! $error ) {
+				$error = new WP_Error( $code, $message, $data );
+			} else {
+				$error->add( $code, $message, $data );
+			}
+		}
+
+		return $error;
 	}
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -196,4 +196,22 @@ class Jetpack_Cxn_Test_Base {
 			'resolution' => false,
 		);
 	}
+
+	/**
+	 * Provide WP_CLI friendly testing results.
+	 */
+	public function output_results_for_cli() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::line( __( 'TEST RESULTS:' ) );
+			foreach ( $this->raw_results() as $test ) {
+				if ( true === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( "%gPassed:%n  " . $test['name'] ) );
+				} else if ( 'skipped' === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( "%ySkipped:%n " . $test['name'] ) );
+				} else { // Failed
+					WP_CLI::log( WP_CLI::colorize( "%rFailed:%n  " . $test['name'] ) );
+				}
+			}
+		}
+	}
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -37,6 +37,15 @@ class Jetpack_Cxn_Test_Base {
 	protected $results = array();
 
 	/**
+	 * Status of the testing suite.
+	 *
+	 * Used internally to determine if a test should be skipped since the tests are already failing. Assume passing.
+	 *
+	 * @var bool $pass
+	 */
+	protected $pass = true;
+
+	/**
 	 * Jetpack_Cxn_Test constructor.
 	 */
 	private function __construct() {
@@ -76,7 +85,11 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function run_tests() {
 		foreach ( $this->tests as $test ) {
-			$this->results[] = call_user_func( $test );
+			$result = call_user_func( $test );
+			$this->results[] = $result;
+			if ( false === $result['pass'] ) {
+				$this->pass = false;
+			}
 		}
 	}
 
@@ -139,11 +152,12 @@ class Jetpack_Cxn_Test_Base {
 	 *
 	 * @return string Human-readable steps to resolve a failed test.
 	 */
-	protected function serve_message( $resolution = null ) {
+	public static function serve_message( $resolution = null ) {
 		switch ( $resolution ) {
 			case 'cycle_connection':
 				$message = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
 				break;
+			case 'support':
 			default:
 				$message = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
 		}
@@ -154,10 +168,13 @@ class Jetpack_Cxn_Test_Base {
 	/**
 	 * Helper function to return consistent responses for a passing test
 	 *
+	 * @param string $name Test name.
+	 *
 	 * @return array Test results.
 	 */
-	protected function passing_test() {
+	public static function passing_test( $name = 'Unnamed' ) {
 		return array(
+			'name'       => $name,
 			'pass'       => true,
 			'message'    => __( 'Test Passed!', 'jetpack' ),
 			'resolution' => false,
@@ -167,10 +184,13 @@ class Jetpack_Cxn_Test_Base {
 	/**
 	 * Helper function to return consistent responses for a skipped test
 	 *
+	 * @param string $name Test name.
+	 *
 	 * @return array Test results.
 	 */
-	protected function skipped_test() {
+	public static function skipped_test( $name = 'Unnamed' ) {
 		return array(
+			'name'       => $name,
 			'pass'       => 'skipped',
 			'message'    => __( 'Test Skipped.', 'jetpack' ),
 			'resolution' => false,

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -16,13 +16,6 @@
 class Jetpack_Cxn_Test_Base {
 
 	/**
-	 * The one true instance
-	 *
-	 * @var object $_instance
-	 */
-	private $_instance;
-
-	/**
 	 * Tests to run on the Jetpack connection.
 	 *
 	 * @var array $tests
@@ -48,20 +41,9 @@ class Jetpack_Cxn_Test_Base {
 	/**
 	 * Jetpack_Cxn_Test constructor.
 	 */
-	private function __construct() {
-	}
-
-	/**
-	 * Run this to expose the testing platform
-	 */
-	public function init() {
-		if ( ! isset( $this->_instance ) || ! $this->_instance ) {
-			$this->_instance = new Jetpack_Cxn_Test_Base();
-			$this->tests     = array();
-			$this->results   = array();
-		}
-
-		return $this->_instance;
+	public function __construct() {
+		$this->tests   = array();
+		$this->results = array();
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -157,6 +157,9 @@ class Jetpack_Cxn_Test_Base {
 			case 'cycle_connection':
 				$message = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
 				break;
+			case 'outbound_requests':
+				$message = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
+				break;
 			case 'support':
 			default:
 				$message = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -219,7 +219,8 @@ class Jetpack_Cxn_Test_Base {
 	public function output_results_for_cli( $group = 'default' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			if ( Jetpack::is_development_mode() ){
-				WP_CLI::line( __( 'Jetpack is in development mode. Please deactivate development mode for accurate results. ') );
+				WP_CLI::line( __('Jetpack is in Development Mode:') );
+				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}
 			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );
 			foreach ( $this->raw_results( $group ) as $test ) {
@@ -271,6 +272,8 @@ class Jetpack_Cxn_Test_Base {
 	/**
 	 * Encrypt data for sending to WordPress.com.
 	 *
+	 * @todo When PHP minimum is 5.3+, add cipher detection to use an agreed better cipher than RC4. RC4 should be the last resort.
+	 *
 	 * @param string $data Data to encrypt with the WP.com Public Key.
 	 *
 	 * @return false|array False if functionality not available. Array of encrypted data, encryption key.
@@ -286,8 +289,9 @@ class Jetpack_Cxn_Test_Base {
 		if ( $public_key && openssl_seal( $data, $encrypted_data, $env_key, array( $public_key ) ) ) {
 			// We are returning base64-encoded values to ensure they're characters we can use in JSON responses without issue.
 			$return = array(
-				'data' => base64_encode( $encrypted_data ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-				'key'  => base64_encode( $env_key[0] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'data'   => base64_encode( $encrypted_data ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'key'    => base64_encode( $env_key[0] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'cipher' => 'RC4', // When Jetpack's minimum WP version is at PHP 5.3+, we will add in detecting and using a stronger one.
 			);
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -218,6 +218,9 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function output_results_for_cli( $group = 'default' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			if ( Jetpack::is_development_mode() ){
+				WP_CLI::line( __( 'Jetpack is in development mode. Please deactivate development mode for accurate results. ') );
+			}
 			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );
 			foreach ( $this->raw_results( $group ) as $test ) {
 				if ( true === $test['pass'] ) {

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -218,8 +218,8 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function output_results_for_cli( $group = 'default' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			if ( Jetpack::is_development_mode() ){
-				WP_CLI::line( __('Jetpack is in Development Mode:') );
+			if ( Jetpack::is_development_mode() ) {
+				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack'    ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}
 			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -276,20 +276,23 @@ class Jetpack_Cxn_Test_Base {
 	 * @return false|array False if functionality not available. Array of encrypted data, encryption key.
 	 */
 	public function encrypt_string_for_wpcom( $data ) {
+		$return = false;
 		if ( ! function_exists( 'openssl_get_publickey' ) || ! function_exists( 'openssl_seal' ) ) {
-			return false;
+			return $return;
 		}
 
 		$public_key = openssl_get_publickey( JETPACK__DEBUGGER_PUBLIC_KEY );
 
-		if ( openssl_seal( $data, $encrypted_data, $env_key, array( $public_key ) ) ) {
+		if ( $public_key && openssl_seal( $data, $encrypted_data, $env_key, array( $public_key ) ) ) {
 			// We are returning base64-encoded values to ensure they're characters we can use in JSON responses without issue.
-			return array(
+			$return = array(
 				'data' => base64_encode( $encrypted_data ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				'key'  => base64_encode( $env_key[0] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			);
 		}
 
-		return false;
+		openssl_free_key( $public_key );
+
+		return $return;
 	}
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -219,7 +219,7 @@ class Jetpack_Cxn_Test_Base {
 	public function output_results_for_cli( $group = 'default' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			if ( Jetpack::is_development_mode() ) {
-				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack'    ) );
+				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack' ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}
 			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -28,16 +28,25 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		/**
 		 * Fires after loading default Jetpack Connection tests.
 		 *
-		 * @since 6.8.0
+		 * @since 6.9.0
 		 */
 		do_action( 'jetpack_connection_tests_loaded' );
 
 		/**
-		 * Intentionally added last as it checks for an existing failure state before attempting.
-		 * Generally, any failed location condition would result in the WP.com check to fail too, so
-		 * we will skip it to avoid confusing error messages.
+		 * Determines if the WP.com testing suite should be included.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param bool $run_test To run the WP.com testing suite. Default true.
 		 */
-		$this->add_test( array( $this, 'last__wpcom_self_test' ) );
+		if ( apply_filters( 'jetpack_debugger_run_self_test', true ) ) {
+			/**
+			 * Intentionally added last as it checks for an existing failure state before attempting.
+			 * Generally, any failed location condition would result in the WP.com check to fail too, so
+			 * we will skip it to avoid confusing error messages.
+			 */
+			$this->add_test( array( $this, 'last__wpcom_self_test' ) );
+		}
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -241,7 +241,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function last__wpcom_self_test() {
 		$name = 'test__wpcom_self_test';
 		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
-			return Jetpack_Cxn_Tests::skipped_test( $name );
+			return self::skipped_test( $name );
 		}
 
 		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
@@ -255,7 +255,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		remove_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
 
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
-			return Jetpack_Cxn_Tests::passing_test( $name );
+			return self::passing_test( $name );
 		} else {
 			return array(
 				'name'       => 'WP.com Self Test',

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -28,8 +28,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		/**
 		 * Fires after loading default Jetpack Connection tests.
 		 *
-		 * Tests can be added by calling the $object->add_test( $callable ) format on this hook.
-		 *
 		 * @since 6.8.0
 		 */
 		do_action( 'jetpack_connection_tests_loaded' );
@@ -67,7 +65,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), self::serve_message( 'cycle_connection' ) );
+			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
 		}
 
 		return $result;
@@ -88,7 +86,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $local_user->exists() ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ), self::serve_message( 'cycle_connection' ) );
+			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ), 'cycle_connection' );
 		}
 
 		return $result;
@@ -148,7 +146,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === intval( $code ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), self::serve_message( 'outbound_requests' ) );
+			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), 'outbound_requests');
 		}
 
 		return $result;
@@ -167,7 +165,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === intval( $code ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ), self::serve_message( 'outbound_requests' ) );
+			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ), 'outbound_requests' );
 		}
 
 		return $result;
@@ -191,7 +189,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				$identity_crisis['home'],
 				$identity_crisis['wpcom_home']
 			);
-			$result = self::failing_test( $name, $message, self::serve_message() ); // Contact support for a IDC.
+			$result = self::failing_test( $name, $message, 'support' );
 		}
 		return $result;
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -81,7 +81,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__master_user_exists_on_site() {
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return; // Skip test.
+			return $result = $this->skipped_test(); // Skip test.
 		}
 		$local_user = $this->helper_retrieve_local_master_user();
 
@@ -107,7 +107,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__master_user_can_manage_options() {
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return; // Skip test.
+			return $result = $this->skipped_test(); // Skip test.
 		}
 		$master_user = $this->helper_retrieve_local_master_user();
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -211,7 +211,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				'message'    => $message,
 				'resolution' => $this->serve_message(), // Contact support for now. @todo better message.
 			);
-
 		}
 		return $result;
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -67,12 +67,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'Jetpack is not connected.', 'jetpack' ),
-				'resolution' => self::serve_message( 'cycle_connection' ),
-			);
+			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), self::serve_message( 'cycle_connection' ) );
 		}
 
 		return $result;
@@ -93,12 +88,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $local_user->exists() ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ),
-				'resolution' => self::serve_message( 'cycle_connection' ),
-			);
+			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ), self::serve_message( 'cycle_connection' ) );
 		}
 
 		return $result;
@@ -121,12 +111,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( user_can( $master_user, 'manage_options' ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'The user who setup the Jetpack connection is not an administrator.', 'jetpack' ),
-				'resolution' => __( 'Either upgrade the user or cycle.', 'jetpack' ), // @todo: Provide the user name, link to the right places.
-			);
+			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection is not an administrator.', 'jetpack' ), __( 'Either upgrade the user or cycle.', 'jetpack' ) ); // @todo: Provide the user name, link to the right places.
 		}
 
 		return $result;
@@ -144,12 +129,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( function_exists( 'xml_parser_create' ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'PHP XML manipluation libraries are not available.', 'jetpack' ),
-				'resolution' => __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ),
-			);
+			$result = self::failing_test( $name, __( 'PHP XML manipluation libraries are not available.', 'jetpack' ), __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ) );
 		}
 
 		return $result;
@@ -168,12 +148,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === intval( $code ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ),
-				'resolution' => __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com', 'jetpack' ),
-			);
+			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), self::serve_message( 'outbound_requests' ) );
 		}
 
 		return $result;
@@ -192,12 +167,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === intval( $code ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ),
-				'resolution' => __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com', 'jetpack' ),
-			);
+			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ), self::serve_message( 'outbound_requests' ) );
 		}
 
 		return $result;
@@ -221,12 +191,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				$identity_crisis['home'],
 				$identity_crisis['wpcom_home']
 			);
-			$result = array(
-				'name'       => $name,
-				'pass'       => false,
-				'message'    => $message,
-				'resolution' => self::serve_message(), // Contact support for now. @todo better message.
-			);
+			$result = self::failing_test( $name, $message, self::serve_message() ); // Contact support for a IDC.
 		}
 		return $result;
 	}
@@ -257,12 +222,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
 			return self::passing_test( $name );
 		} else {
-			return array(
-				'name'       => 'WP.com Self Test',
-				'pass'       => false,
-				'message'    => __( 'Jetpack.com detected an error.', 'jetpack' ), // @todo: Direct link to the jetpack.com debugger.
-				'resolution' => __( 'Visit the Jetpack.com debugging page for more information or contact support.', 'jetpack' ), // @todo direct links.
-			);
+			return self::failing_test( $name, __( 'Jetpack.com detected an error.', 'jetpack' ), __( 'Visit the Jetpack.com debugging page for more information or contact support.', 'jetpack' ) ); // @todo direct links.
 		}
 	}
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -79,7 +79,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__master_user_exists_on_site() {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return self::skipped_test( $name ); // Skip test.
+			return self::skipped_test( $name, __( 'Jetpack is not connected. No master user to check.', 'jetpack' ) ); // Skip test.
 		}
 		$local_user = $this->helper_retrieve_local_master_user();
 
@@ -102,7 +102,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__master_user_can_manage_options() {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return self::skipped_test( $name ); // Skip test.
+			return self::skipped_test( $name, __( 'Jetpack is not connected.', 'jetpack' ) ); // Skip test.
 		}
 		$master_user = $this->helper_retrieve_local_master_user();
 
@@ -177,7 +177,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	protected function test__identity_crisis() {
-		$name            = __FUNCTION__;
+		$name = __FUNCTION__;
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			return self::skipped_test( $name, __( 'Jetpack is not connected.', 'jetpack' ) ); // Skip test.
+		}
 		$identity_crisis = Jetpack::check_identity_crisis();
 
 		if ( ! $identity_crisis ) {

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -24,6 +24,15 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			}
 			$this->add_test( array( $this, $method ) );
 		}
+
+		/**
+		 * Fires after loading default Jetpack Connection tests.
+		 *
+		 * Tests can be added by calling the $object->add_test( $callable ) format on this hook.
+		 *
+		 * @since 6.8.0
+		 */
+		do_action( 'jetpack_connection_tests_loaded' );
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -14,7 +14,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * Jetpack_Cxn_Tests constructor.
 	 */
 	public function __construct() {
-		parent::init();
+		parent::__construct();
 
 		$methods = get_class_methods( 'Jetpack_Cxn_Tests' );
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Collection of tests to run on the Jetpack connection locally.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Class Jetpack_Cxn_Tests contains all of the actual tests.
+ */
+class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
+
+	/**
+	 * Jetpack_Cxn_Tests constructor.
+	 */
+	public function __construct() {
+		parent::init();
+
+		$methods = get_class_methods( 'Jetpack_Cxn_Tests' );
+
+		foreach ( $methods as $method ) {
+			if ( false === strpos( $method, 'test__' ) ) {
+				continue;
+			}
+			$this->add_test( array( $this, $method ) );
+		}
+	}
+
+	/**
+	 * Helper function to look up the expected master user and return the local WP_User.
+	 *
+	 * @return WP_User Jetpack's expected master user.
+	 */
+	protected function helper_retrieve_local_master_user() {
+		$master_user = Jetpack_Options::get_option( 'master_user' );
+		return new WP_User( $master_user );
+	}
+
+	/**
+	 * Is Jetpack even connected?
+	 *
+	 * @todo Make this better. Just a quick hack for testing.
+	 */
+	protected function helper_is_jetpack_connected() {
+		if ( Jetpack_Options::get_option( 'master_user' ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Test if Jetpack is connected.
+	 */
+	protected function test__check_if_connected() {
+		if ( $this->helper_is_jetpack_connected() ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'Jetpack is not connected.', 'jetpack' ),
+				'resolution' => $this->serve_message( 'cycle_connection' ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test that the master user still exists on this site.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__master_user_exists_on_site() {
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			return; // Skip test.
+		}
+		$local_user = $this->helper_retrieve_local_master_user();
+
+		if ( $local_user->exists() ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ),
+				'resolution' => $this->serve_message( 'cycle_connection' ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test that the master user has the manage options capability (e.g. is an admin).
+	 *
+	 * Generic calls from WP.com execute on Jetpack as the master user. If it isn't an admin, random things will fail.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__master_user_can_manage_options() {
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			return; // Skip test.
+		}
+		$master_user = $this->helper_retrieve_local_master_user();
+
+		if ( user_can( $master_user, 'manage_options' ) ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'The user who setup the Jetpack connection is not an administrator.', 'jetpack' ),
+				'resolution' => __( 'Either upgrade the user or cycle.', 'jetpack' ), // @todo: Provide the user name, link to the right places.
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test that the PHP's XML library is installed.
+	 *
+	 * While it should be installed by default, increasingly in PHP 7, some OSes require an additional php-xml package.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__xml_parser_available() {
+		if ( function_exists( 'xml_parser_create' ) ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'PHP XML manipluation libraries are not available.', 'jetpack' ),
+				'resolution' => __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test that the server is able to send an outbound http communication.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__outbound_http() {
+		$request = wp_remote_get( preg_replace( '/^https:/', 'http:', JETPACK__API_BASE ) . 'test/1/' );
+		$code    = wp_remote_retrieve_response_code( $request );
+
+		if ( 200 === intval( $code ) ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ),
+				'resolution' => __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com', 'jetpack' ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test that the server is able to send an outbound https communication.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__outbound_https() {
+		$request = wp_remote_get( preg_replace( '/^http:/', 'https:', JETPACK__API_BASE ) . 'test/1/' );
+		$code    = wp_remote_retrieve_response_code( $request );
+
+		if ( 200 === intval( $code ) ) {
+			$result = $this->passing_test();
+		} else {
+			$result = array(
+				'pass'       => false,
+				'message'    => __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ),
+				'resolution' => __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com', 'jetpack' ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Check for an IDC.
+	 *
+	 * @return array Test results.
+	 */
+	protected function test__identity_crisis() {
+		$identity_crisis = Jetpack::check_identity_crisis();
+
+		if ( ! $identity_crisis ) {
+			$result = $this->passing_test();
+		} else {
+			$message = sprintf(
+				/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
+				__( 'Your url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`!', 'jetpack' ),
+				$identity_crisis['home'],
+				$identity_crisis['wpcom_home']
+			);
+			$result = array(
+				'pass'       => false,
+				'message'    => $message,
+				'resolution' => $this->serve_message(), // Contact support for now. @todo better message.
+			);
+
+		}
+		return $result;
+	}
+}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -254,6 +254,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__server_port_value() {
 		$name        = __FUNCTION__;
+		if ( ! isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) && ! isset( $_SERVER['SERVER_PORT'] ) {
+			$message = "The server port values are not defined. This is most common when running PHP via a CLI.";
+			return self::skipped_test( $name, $message );
+		}
 		$site_port   = wp_parse_url( home_url(), PHP_URL_PORT );
 		$server_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? (int) $_SERVER['HTTP_X_FORWARDED_PORT'] : (int) $_SERVER['SERVER_PORT'];
 		$http_ports  = array( 80 );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -146,7 +146,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( 200 === intval( $code ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), 'outbound_requests');
+			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), 'outbound_requests' );
 		}
 
 		return $result;

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -253,9 +253,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * @return array Test results
 	 */
 	protected function test__server_port_value() {
-		$name        = __FUNCTION__;
-		if ( ! isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) && ! isset( $_SERVER['SERVER_PORT'] ) {
-			$message = "The server port values are not defined. This is most common when running PHP via a CLI.";
+		$name = __FUNCTION__;
+		if ( ! isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) && ! isset( $_SERVER['SERVER_PORT'] ) ) {
+			$message = 'The server port values are not defined. This is most common when running PHP via a CLI.';
 			return self::skipped_test( $name, $message );
 		}
 		$site_port   = wp_parse_url( home_url(), PHP_URL_PORT );
@@ -263,11 +263,11 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$http_ports  = array( 80 );
 		$https_ports = array( 80, 443 );
 
-		if ( defined( 'JETPACK_SIGNATURE__HTTP_PORT'  ) ) {
+		if ( defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ) {
 			$http_ports[] = JETPACK_SIGNATURE__HTTP_PORT;
 		}
 
-		if ( defined( 'JETPACK_SIGNATURE__HTTPS_PORT') ) {
+		if ( defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ) {
 			$https_ports[] = JETPACK_SIGNATURE__HTTPS_PORT;
 		}
 
@@ -275,9 +275,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::skipped_test( $name ); // Not currently testing for this situation.
 		}
 
-		if ( is_ssl() && in_array( $server_port, $https_ports ) ) {
+		if ( is_ssl() && in_array( $server_port, $https_ports, true ) ) {
 			return self::passing_test( $name );
-		} else if ( in_array( $server_port, $http_ports) ) {
+		} elseif ( in_array( $server_port, $http_ports, true ) ) {
 			return self::passing_test( $name );
 		} else {
 			if ( is_ssl() ) {
@@ -285,8 +285,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			} else {
 				$needed_constant = 'JETPACK_SIGNATURE__HTTP_PORT';
 			}
-			$message = __( 'The server port value is unexpected.' );
-			$resolution = __( 'Try adding the following to your wp-config.php file:' ) . " define( '$needed_constant', $server_port );";
+			$message    = __( 'The server port value is unexpected.', 'jetpack' );
+			$resolution = __( 'Try adding the following to your wp-config.php file:', 'jetpack' ) . " define( '$needed_constant', $server_port );";
 			return self::failing_test( $name, $message, $resolution );
 		}
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -120,6 +120,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( user_can( $master_user, 'manage_options' ) ) {
 			$result = self::passing_test( $name );
 		} else {
+			/** translators: a WordPress username */
 			$result = self::failing_test( $name, sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login ), __( 'Either upgrade the user or disconnect and reconnect Jetpack.', 'jetpack' ) ); // @todo: Link to the right places.
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -120,7 +120,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( user_can( $master_user, 'manage_options' ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection is not an administrator.', 'jetpack' ), __( 'Either upgrade the user or cycle.', 'jetpack' ) ); // @todo: Provide the user name, link to the right places.
+			$result = self::failing_test( $name, sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login ), __( 'Either upgrade the user or disconnect and reconnect Jetpack.', 'jetpack' ) ); // @todo: Link to the right places.
 		}
 
 		return $result;

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -73,6 +73,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
+		} elseif ( Jetpack::is_development_mode() ) {
+			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __('Disable development mode.', 'jetpack' ) );
 		} else {
 			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -28,14 +28,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		/**
 		 * Fires after loading default Jetpack Connection tests.
 		 *
-		 * @since 6.9.0
+		 * @since 7.1.0
 		 */
 		do_action( 'jetpack_connection_tests_loaded' );
 
 		/**
 		 * Determines if the WP.com testing suite should be included.
 		 *
-		 * @since 6.9.0
+		 * @since 7.1.0
 		 *
 		 * @param bool $run_test To run the WP.com testing suite. Default true.
 		 */

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -74,7 +74,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
 		} elseif ( Jetpack::is_development_mode() ) {
-			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __('Disable development mode.', 'jetpack' ) );
+			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
 			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
 		}

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -1,4 +1,4 @@
-<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+<?php
 /**
  * Jetpack Debugger functionality allowing for self-service diagnostic information.
  *
@@ -84,26 +84,6 @@ class Jetpack_Debugger {
 				exit;
 			}
 		}
-	}
-
-	/**
-	 * Calls to WP.com to run the connection diagnostic testing suite.
-	 *
-	 * @return array|WP_Error Standard WP_HTTP return array: 'headers', 'body', 'response', 'cookies', 'filename' on success.
-	 */
-	public static function run_self_test() {
-		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
-
-		$testsite_url = Jetpack::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
-
-		add_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
-
-		$response = wp_remote_get( $testsite_url . $self_xml_rpc_url );
-
-		remove_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
-
-		return $response;
-
 	}
 
 	/**
@@ -228,7 +208,6 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n\r\nTEST RESULTS:\r\n\r\n";
 
 		$cxntests = new Jetpack_Cxn_Tests();
-
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Debugging Center', 'jetpack' ); ?></h2>
@@ -238,6 +217,7 @@ class Jetpack_Debugger {
 					if ( $cxntests->pass() ) {
 						echo '<div class="jetpack-tests-succeed">' . esc_html__( 'Your Jetpack setup looks a-okay!', 'jetpack' ) . '</div>';
 						$debug_info .= "All tests passed.\r\n";
+						$debug_info .= print_r( $cxntests->raw_results(), true ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					} else {
 						$failures = $cxntests->list_fails();
 						foreach ( $failures as $test => $fail ) {
@@ -247,7 +227,9 @@ class Jetpack_Debugger {
 							echo '<p class="jetpack-test-details">' . esc_html( $fail['resolution'] ) . '</p>';
 							echo '</div>';
 
-							$debug_info .= "$test: " . $fail['message'] . "\r\n";
+							$debug_info .= "FAILED TESTS!\r\n";
+							$debug_info .= $fail['name'] .': ' . $fail['message'] . "\r\n";
+							$debug_info .= print_r( $cxntests->raw_results(), true ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 						}
 					}
 					?>

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -220,7 +220,7 @@ class Jetpack_Debugger {
 						$debug_info .= print_r( $cxntests->raw_results(), true ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					} else {
 						$failures = $cxntests->list_fails();
-						foreach ( $failures as $test => $fail ) {
+						foreach ( $failures as $fail ) {
 							echo '<div class="jetpack-test-error">';
 							echo '<p><a class="jetpack-test-heading" href="#">' . esc_html( $fail['message'] );
 							echo '<span class="noticon noticon-collapse"></span></a></p>';
@@ -228,7 +228,7 @@ class Jetpack_Debugger {
 							echo '</div>';
 
 							$debug_info .= "FAILED TESTS!\r\n";
-							$debug_info .= $fail['name'] .': ' . $fail['message'] . "\r\n";
+							$debug_info .= $fail['name'] . ': ' . $fail['message'] . "\r\n";
 							$debug_info .= print_r( $cxntests->raw_results(), true ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 						}
 					}

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -392,6 +392,11 @@ class Jetpack_Debugger {
 				padding: 0;
 			}
 
+			p.jetpack-test-details {
+				margin: 4px 6px;
+				padding: 10px;
+			}
+
 			.jetpack-test-error a.jetpack-test-heading {
 				padding: 4px 6px;
 				display: block;

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -239,29 +239,29 @@ class Jetpack_Debugger {
 				<h4><?php esc_html_e( 'It may be caused by one of these issues, which you can diagnose yourself:', 'jetpack' ); ?></h4>
 				<ol>
 					<li><b><em>
-					<?php
-					/* translators: URLs to Jetpack support pages. */
-								esc_html_e( 'A known issue.', 'jetpack' );
-					?>
-								</em></b>  
-								<?php
-								echo sprintf(
-									wp_kses(
-										/* translators: URLs to Jetpack support pages. */
-										__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
-										array(
-											'a' => array(
-												'href'   => array(),
-												'target' => array(),
-											),
-										)
+						<?php
+						/* translators: URLs to Jetpack support pages. */
+						esc_html_e( 'A known issue.', 'jetpack' );
+						?>
+					</em></b>
+						<?php
+						echo sprintf(
+							wp_kses(
+								/* translators: URLs to Jetpack support pages. */
+								__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
+								array(
+									'a' => array(
+										'href'   => array(),
+										'target' => array(),
 									),
-									'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
-									'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
-									'http://jetpack.com/support/',
-									'https://wordpress.org/support/plugin/jetpack'
-								);
-								?>
+								)
+							),
+							'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
+							'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
+							'http://jetpack.com/support/',
+							'https://wordpress.org/support/plugin/jetpack'
+						);
+						?>
 						</li>
 					<li><b><em><?php esc_html_e( 'An incompatible plugin.', 'jetpack' ); ?></em></b>  <?php esc_html_e( "Find out by disabling all plugins except Jetpack. If the problem persists, it's not a plugin issue. If the problem is solved, turn your plugins on one by one until the problem pops up again – there's the culprit! Let us know, and we'll try to help.", 'jetpack' ); ?></li>
 					<li>
@@ -280,14 +280,14 @@ class Jetpack_Debugger {
 					</li>
 					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  
 						<?php
-													echo sprintf(
-														wp_kses(
-															/* translators: The URL to the site's xmlrpc.php file. */
-															__( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ),
-															array( 'a' => array( 'href' => array() ) )
-														),
-														esc_attr( site_url( 'xmlrpc.php' ) )
-													);
+						echo sprintf(
+							wp_kses(
+								/* translators: The URL to the site's xmlrpc.php file. */
+								__( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ),
+								array( 'a' => array( 'href' => array() ) )
+							),
+							esc_attr( site_url( 'xmlrpc.php' ) )
+						);
 						?>
 						<ul>
 							<li>- <?php esc_html_e( "If it's not by itself, a theme or plugin is displaying extra characters. Try steps 2 and 3.", 'jetpack' ); ?></li>
@@ -328,16 +328,16 @@ class Jetpack_Debugger {
 				</ol>
 				<h4><?php esc_html_e( 'Still having trouble?', 'jetpack' ); ?></h4>
 				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  
-											<?php
-											echo sprintf(
-												wp_kses(
-													/* translators: URL for Jetpack support. */
-													__( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ),
-													array( 'a' => array( 'href' => array() ) )
-												),
-												'https://jetpack.com/contact-support/'
-											);
-											?>
+				<?php
+				echo sprintf(
+					wp_kses(
+						/* translators: URL for Jetpack support. */
+						__( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ),
+						array( 'a' => array( 'href' => array() ) )
+					),
+					'https://jetpack.com/contact-support/'
+				);
+				?>
 						</p>
 				<hr />
 				<?php if ( Jetpack::is_active() ) : ?>

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -318,8 +318,18 @@ class Jetpack_Debugger {
 					<?php endif; ?>
 				</ol>
 				<h4><?php esc_html_e( 'Still having trouble?', 'jetpack' ); ?></h4>
-				<?php /* translators: URL for Jetpack support. */ ?>
-				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  <?php echo sprintf( wp_kses( __( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ), 'https://jetpack.com/contact-support/', array( 'a' => array( 'href' => array() ) ) ) ); ?></p>
+				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  
+											<?php
+											echo sprintf(
+												wp_kses(
+													/* translators: URL for Jetpack support. */
+													__( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ),
+													array( 'a' => array( 'href' => array() ) )
+												),
+												'https://jetpack.com/contact-support/'
+											);
+											?>
+						</p>
 				<hr />
 				<?php if ( Jetpack::is_active() ) : ?>
 					<div id="connected-user-details">

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -278,8 +278,17 @@ class Jetpack_Debugger {
 						?>
 						<?php esc_html_e( "If this solves the problem, something in your theme is probably broken – let the theme's author know.", 'jetpack' ); ?>
 					</li>
-					<?php /* translators: The URL to the site's xmlrpc.php file. */ ?>
-					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  <?php echo sprintf( wp_kses( __( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ), site_url( 'xmlrpc.php' ), array( 'a' => array( 'href' => array() ) ) ) ); ?>
+					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  
+						<?php
+													echo sprintf(
+														wp_kses(
+															/* translators: The URL to the site's xmlrpc.php file. */
+															__( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ),
+															array( 'a' => array( 'href' => array() ) )
+														),
+														esc_attr( site_url( 'xmlrpc.php' ) )
+													);
+						?>
 						<ul>
 							<li>- <?php esc_html_e( "If it's not by itself, a theme or plugin is displaying extra characters. Try steps 2 and 3.", 'jetpack' ); ?></li>
 							<li>- <?php esc_html_e( 'If you get a 404 message, contact your web host. Their security may block XMLRPC.', 'jetpack' ); ?></li>

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -246,14 +246,20 @@ class Jetpack_Debugger {
 								</em></b>  
 								<?php
 								echo sprintf(
-									/* translators: URLs to Jetpack support pages. */
-									wp_kses( __( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ), 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/', 'https://wordpress.org/support/plugin/jetpack' ),
-									array(
-										'a' => array(
-											'href'   => array(),
-											'target' => array(),
-										),
-									)
+									wp_kses(
+										/* translators: URLs to Jetpack support pages. */
+										__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
+										array(
+											'a' => array(
+												'href'   => array(),
+												'target' => array(),
+											),
+										)
+									),
+									'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
+									'http://jetpack.com/support/getting-started-with-jetpack/known-issues/',
+									'http://jetpack.com/support/',
+									'https://wordpress.org/support/plugin/jetpack'
 								);
 								?>
 						</li>
@@ -283,10 +289,18 @@ class Jetpack_Debugger {
 						<li>
 							<strong><em><?php esc_html_e( 'A connection problem with WordPress.com.', 'jetpack' ); ?></em></strong>
 							<?php
-							echo wp_kses(
-								sprintf(
+							echo sprintf(
+								wp_kses(
 									/* translators: URL to disconnect and reconnect Jetpack. */
 									__( 'Jetpack works by connecting to WordPress.com for a lot of features. Sometimes, when the connection gets messed up, you need to disconnect and reconnect to get things working properly. <a href="%s">Disconnect from WordPress.com</a>', 'jetpack' ),
+									array(
+										'a' => array(
+											'href'  => array(),
+											'class' => array(),
+										),
+									)
+								),
+								esc_attr(
 									wp_nonce_url(
 										Jetpack::admin_url(
 											array(
@@ -297,12 +311,6 @@ class Jetpack_Debugger {
 										'jp_disconnect',
 										'nonce'
 									)
-								),
-								array(
-									'a' => array(
-										'href'  => array(),
-										'class' => array(),
-									),
 								)
 							);
 							?>
@@ -319,13 +327,12 @@ class Jetpack_Debugger {
 						<p>
 						<?php
 						printf(
-
 							wp_kses(
 								/* translators: %s is an e-mail address */
 								__( 'The primary connection is owned by <strong>%s</strong>\'s WordPress.com account.', 'jetpack' ),
-								esc_html( Jetpack::get_master_user_email() ),
 								array( 'strong' => array() )
-							)
+							),
+							esc_html( Jetpack::get_master_user_email() )
 						);
 						?>
 							</p>
@@ -338,9 +345,9 @@ class Jetpack_Debugger {
 							wp_kses(
 								/* translators: Link to a Jetpack support page. */
 								__( 'Would you like to use Jetpack on your local development site? You can do so thanks to <a href="%s">Jetpack\'s development mode</a>.', 'jetpack' ),
-								'https://jetpack.com/support/development-mode/',
 								array( 'a' => array( 'href' => array() ) )
-							)
+							),
+							'https://jetpack.com/support/development-mode/'
 						);
 						?>
 							</p>
@@ -354,13 +361,13 @@ class Jetpack_Debugger {
 					printf(
 						wp_kses(
 							'<p><a href="%1$s">%2$s</a></p>',
-							Jetpack::admin_url( 'page=jetpack_modules' ),
-							esc_html__( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ),
 							array(
 								'a' => array( 'href' => array() ),
 								'p' => array(),
 							)
-						)
+						),
+						esc_attr( Jetpack::admin_url( 'page=jetpack_modules' ) ),
+						esc_html__( 'Access the full list of Jetpack modules available on your site.', 'jetpack' )
 					);
 				}
 				?>

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -240,7 +240,6 @@ class Jetpack_Debugger {
 				<ol>
 					<li><b><em>
 						<?php
-						/* translators: URLs to Jetpack support pages. */
 						esc_html_e( 'A known issue.', 'jetpack' );
 						?>
 					</em></b>

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -245,8 +245,16 @@ class Jetpack_Debugger {
 					?>
 								</em></b>  
 								<?php
-								/* translators: URLs to Jetpack support pages. */
-								echo sprintf( __( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ), 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/', 'https://wordpress.org/support/plugin/jetpack' );
+								echo sprintf(
+									/* translators: URLs to Jetpack support pages. */
+									wp_kses( __( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ), 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/getting-started-with-jetpack/known-issues/', 'http://jetpack.com/support/', 'https://wordpress.org/support/plugin/jetpack' ),
+									array(
+										'a' => array(
+											'href'   => array(),
+											'target' => array(),
+										),
+									)
+								);
 								?>
 						</li>
 					<li><b><em><?php esc_html_e( 'An incompatible plugin.', 'jetpack' ); ?></em></b>  <?php esc_html_e( "Find out by disabling all plugins except Jetpack. If the problem persists, it's not a plugin issue. If the problem is solved, turn your plugins on one by one until the problem pops up again – there's the culprit! Let us know, and we'll try to help.", 'jetpack' ); ?></li>
@@ -265,7 +273,7 @@ class Jetpack_Debugger {
 						<?php esc_html_e( "If this solves the problem, something in your theme is probably broken – let the theme's author know.", 'jetpack' ); ?>
 					</li>
 					<?php /* translators: The URL to the site's xmlrpc.php file. */ ?>
-					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  <?php echo sprintf( __( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ), site_url( 'xmlrpc.php' ) ); ?>
+					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  <?php echo sprintf( wp_kses( __( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ), site_url( 'xmlrpc.php' ), array( 'a' => array( 'href' => array() ) ) ) ); ?>
 						<ul>
 							<li>- <?php esc_html_e( "If it's not by itself, a theme or plugin is displaying extra characters. Try steps 2 and 3.", 'jetpack' ); ?></li>
 							<li>- <?php esc_html_e( 'If you get a 404 message, contact your web host. Their security may block XMLRPC.', 'jetpack' ); ?></li>
@@ -303,7 +311,7 @@ class Jetpack_Debugger {
 				</ol>
 				<h4><?php esc_html_e( 'Still having trouble?', 'jetpack' ); ?></h4>
 				<?php /* translators: URL for Jetpack support. */ ?>
-				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  <?php echo sprintf( __( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ), 'https://jetpack.com/contact-support/' ); ?></p>
+				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  <?php echo sprintf( wp_kses( __( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ), 'https://jetpack.com/contact-support/', array( 'a' => array( 'href' => array() ) ) ) ); ?></p>
 				<hr />
 				<?php if ( Jetpack::is_active() ) : ?>
 					<div id="connected-user-details">
@@ -311,9 +319,13 @@ class Jetpack_Debugger {
 						<p>
 						<?php
 						printf(
-							/* translators: %s is an e-mail address */
-							__( 'The primary connection is owned by <strong>%s</strong>\'s WordPress.com account.', 'jetpack' ),
-							esc_html( Jetpack::get_master_user_email() )
+
+							wp_kses(
+								/* translators: %s is an e-mail address */
+								__( 'The primary connection is owned by <strong>%s</strong>\'s WordPress.com account.', 'jetpack' ),
+								esc_html( Jetpack::get_master_user_email() ),
+								array( 'strong' => array() )
+							)
 						);
 						?>
 							</p>
@@ -323,9 +335,12 @@ class Jetpack_Debugger {
 						<p>
 						<?php
 						printf(
-							/* translators: Link to a Jetpack support page. */
-							__( 'Would you like to use Jetpack on your local development site? You can do so thanks to <a href="%s">Jetpack\'s development mode</a>.', 'jetpack' ),
-							'https://jetpack.com/support/development-mode/'
+							wp_kses(
+								/* translators: Link to a Jetpack support page. */
+								__( 'Would you like to use Jetpack on your local development site? You can do so thanks to <a href="%s">Jetpack\'s development mode</a>.', 'jetpack' ),
+								'https://jetpack.com/support/development-mode/',
+								array( 'a' => array( 'href' => array() ) )
+							)
 						);
 						?>
 							</p>
@@ -337,9 +352,15 @@ class Jetpack_Debugger {
 					&& ( Jetpack::is_development_mode() || Jetpack::is_active() )
 				) {
 					printf(
-						'<p><a href="%1$s">%2$s</a></p>',
-						Jetpack::admin_url( 'page=jetpack_modules' ),
-						esc_html__( 'Access the full list of Jetpack modules available on your site.', 'jetpack' )
+						wp_kses(
+							'<p><a href="%1$s">%2$s</a></p>',
+							Jetpack::admin_url( 'page=jetpack_modules' ),
+							esc_html__( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ),
+							array(
+								'a' => array( 'href' => array() ),
+								'p' => array(),
+							)
+						)
 					);
 				}
 				?>

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -251,6 +251,7 @@ class Jetpack_Admin {
 	}
 
 	function admin_menu_debugger() {
+		jetpack_require_lib( 'debugger' );
 		Jetpack_Debugger::disconnect_and_redirect();
 		$debugger_hook = add_submenu_page(
 			null,
@@ -272,6 +273,7 @@ class Jetpack_Admin {
 	}
 
 	function debugger_page() {
+		jetpack_require_lib( 'debugger' );
 		Jetpack_Debugger::jetpack_debug_display_handler();
 	}
 }

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -31,7 +31,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 */
 	public function status( $args, $assoc_args ) {
-		require_once( JETPACK__PLUGIN_DIR . 'class-jetpack-debugger.php' );
+		jetpack_require_lib( 'debugger' );
 
 		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_home_url() ) ) );
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -31,7 +31,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 */
 	public function status( $args, $assoc_args ) {
-		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php' );
+		require_once( JETPACK__PLUGIN_DIR . 'class-jetpack-debugger.php' );
 
 		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_home_url() ) ) );
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -35,9 +35,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_home_url() ) ) );
 
-		if ( ! Jetpack::is_active() ) {
-			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
-		}
+		//if ( ! Jetpack::is_active() ) {
+		//	WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
+		//}
 
 		if ( isset( $args[0] ) && 'full' !== $args[0] ) {
 			/* translators: %s is a command like "prompt" */
@@ -46,14 +46,24 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$master_user_email = Jetpack::get_master_user_email();
 
-		$jetpack_self_test = Jetpack_Debugger::run_self_test(); // Performs the same tests as jetpack.com/support/debug/
+		$cxntests = new Jetpack_Cxn_Tests();
 
-		if ( ! $jetpack_self_test || ! wp_remote_retrieve_response_code( $jetpack_self_test ) ) {
-			WP_CLI::error( __( 'Jetpack connection status unknown.', 'jetpack' ) );
-		} else if ( 200 == wp_remote_retrieve_response_code( $jetpack_self_test ) ) {
+		if ( $cxntests->pass() ) {
+			foreach ( $cxntests->raw_results() as $test ) {
+				if ( true === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( "%gPassed:%n " . $test['name'] ) );
+				} else if ( 'skipped' === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( "%ySkipped:%n " . $test['name'] ) );
+				}
+			}
 			WP_CLI::success( __( 'Jetpack is currently connected to WordPress.com', 'jetpack' ) );
 		} else {
-			WP_CLI::error( __( 'Jetpack connection is broken.', 'jetpack' ) );
+			$error = array();
+			foreach ( $cxntests->list_fails() as $fail ) {
+				$error[] = $fail['name'] . ': ' . $fail['message'];
+			}
+			WP_CLI::error_multi_line( $error );
+			WP_CLI::error( __('Jetpack connection is broken.', 'jetpack' ) ); // Exit CLI.
 		}
 
 		WP_CLI::line( sprintf( __( 'The Jetpack Version is %s', 'jetpack' ), JETPACK__VERSION ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -35,10 +35,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		WP_CLI::line( sprintf( __( 'Checking status for %s', 'jetpack' ), esc_url( get_home_url() ) ) );
 
-		//if ( ! Jetpack::is_active() ) {
-		//	WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
-		//}
-
 		if ( isset( $args[0] ) && 'full' !== $args[0] ) {
 			/* translators: %s is a command like "prompt" */
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $args[0] ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -49,13 +49,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$cxntests = new Jetpack_Cxn_Tests();
 
 		if ( $cxntests->pass() ) {
-			foreach ( $cxntests->raw_results() as $test ) {
-				if ( true === $test['pass'] ) {
-					WP_CLI::log( WP_CLI::colorize( "%gPassed:%n " . $test['name'] ) );
-				} else if ( 'skipped' === $test['pass'] ) {
-					WP_CLI::log( WP_CLI::colorize( "%ySkipped:%n " . $test['name'] ) );
-				}
-			}
+			$cxntests->output_results_for_cli();
+
 			WP_CLI::success( __( 'Jetpack is currently connected to WordPress.com', 'jetpack' ) );
 		} else {
 			$error = array();
@@ -63,6 +58,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$error[] = $fail['name'] . ': ' . $fail['message'];
 			}
 			WP_CLI::error_multi_line( $error );
+
+			$cxntests->output_results_for_cli();
+
 			WP_CLI::error( __('Jetpack connection is broken.', 'jetpack' ) ); // Exit CLI.
 		}
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Deprecated. No longer needed.
+ *
+ * @package Jetpack
+ */

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -36,6 +36,10 @@ class Jetpack_Signature {
 
 		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $_SERVER['SERVER_PORT'];
 
+		/**
+		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.
+		 * Please update the test if any changes are made in this logic.
+		 */
 		if ( is_ssl() ) {
 			// 443: Standard Port
 			// 80: Assume we're behind a proxy without X-Forwarded-Port. Hardcoding "80" here means most sites

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1727,6 +1727,25 @@ class Jetpack {
 	}
 
 	/**
+	 * Determines reason for Jetpack development mode.
+	 */
+	public static function development_mode_trigger_text() {
+		if ( ! Jetpack::is_development_mode() ) {
+			return __( 'Jetpack is not in Development Mode.', 'jetpack' );
+		}
+
+		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+			$notice =  __( 'The JETPACK_DEV_DEBUG constant is defined in wp-config.php or elsewhere.', 'jetpack' );
+		} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
+			$notice = __( 'The site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
+		} else {
+			$notice = __( 'The jetpack_development_mode filter is set to true.', 'jetpack' );
+		}
+
+		return $notice;
+
+	}
+	/**
 	* Get Jetpack development mode notice text and notice class.
 	*
 	* Mirrors the checks made in Jetpack::is_development_mode
@@ -1734,25 +1753,13 @@ class Jetpack {
 	*/
 	public static function show_development_mode_notice() {
 		if ( Jetpack::is_development_mode() ) {
-			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
-				$notice = sprintf(
-					/* translators: %s is a URL */
-					__( 'In <a href="%s" target="_blank">Development Mode</a>, via the JETPACK_DEV_DEBUG constant being defined in wp-config.php or elsewhere.', 'jetpack' ),
-					'https://jetpack.com/support/development-mode/'
-				);
-			} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
-				$notice = sprintf(
-					/* translators: %s is a URL */
-					__( 'In <a href="%s" target="_blank">Development Mode</a>, via site URL lacking a dot (e.g. http://localhost).', 'jetpack' ),
-					'https://jetpack.com/support/development-mode/'
-				);
-			} else {
-				$notice = sprintf(
-					/* translators: %s is a URL */
-					__( 'In <a href="%s" target="_blank">Development Mode</a>, via the jetpack_development_mode filter.', 'jetpack' ),
-					'https://jetpack.com/support/development-mode/'
-				);
-			}
+			$notice = sprintf(
+			/* translators: %s is a URL */
+				__( 'In <a href="%s" target="_blank">Development Mode</a>:', 'jetpack' ),
+				'https://jetpack.com/support/development-mode/'
+			);
+
+			$notice .= ' ' . Jetpack::development_mode_trigger_text();
 
 			echo '<div class="updated" style="border-color: #f0821e;"><p>' . $notice . '</p></div>';
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2487,7 +2487,7 @@ class Jetpack {
 	 */
 	function handle_deprecated_modules( $modules ) {
 		$deprecated_modules = array(
-			'debug'            => null,  // Closed out and moved to ./class-jetpack-debugger.php
+			'debug'            => null,  // Closed out and moved to the debugger library.
 			'wpcc'             => 'sso', // Closed out in 2.6 -- SSO provides the same functionality.
 			'gplus-authorship' => null,  // Closed out in 3.2 -- Google dropped support.
 		);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2487,7 +2487,7 @@ class Jetpack {
 	 */
 	function handle_deprecated_modules( $modules ) {
 		$deprecated_modules = array(
-			'debug'            => null,  // Closed out and moved to ./class.jetpack-debugger.php
+			'debug'            => null,  // Closed out and moved to ./class-jetpack-debugger.php
 			'wpcc'             => 'sso', // Closed out in 2.6 -- SSO provides the same functionality.
 			'gplus-authorship' => null,  // Closed out in 3.2 -- Google dropped support.
 		);

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "issues": "https://github.com/Automattic/jetpack/issues"
     },
     "require"    : {
-        "composer/installers": "~1.6"
+        "composer/installers": "~1.6",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3eae8bad2fe72ca636c81ba0fa0e72b2",
+    "content-hash": "548bfb20764a2b3befbe77b6f6b81767",
     "packages": [
         {
             "name": "composer/installers",
@@ -196,16 +196,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.0.0",
+            "version": "9.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25"
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
-                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
                 "shasum": ""
             },
             "require": {
@@ -250,20 +250,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-10-07T17:38:02+00:00"
+            "time": "2018-12-30T23:16:27+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "67d89dcef47f351144d24b247aa968f2269162f7"
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/67d89dcef47f351144d24b247aa968f2269162f7",
-                "reference": "67d89dcef47f351144d24b247aa968f2269162f7",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
                 "shasum": ""
             },
             "require": {
@@ -300,7 +300,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2018-10-07T17:59:30+00:00"
+            "time": "2018-12-16T19:10:44+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -401,16 +401,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
                 "shasum": ""
             },
             "require": {
@@ -448,7 +448,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2018-12-19T23:57:18+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -499,6 +499,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-openssl": "*"
+    },
     "platform-dev": []
 }

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -20,7 +20,7 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	# because if running the containers for the first time,
 	# the mysql container will reject connections until it has set the database data
 	# See "No connections until MySQL init completes" in https://hub.docker.com/_/mysql/
-	times=15
+	times=30
 	i=1
 	while [ "$i" -le "$times" ]; do
 		sleep 3

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -20,7 +20,7 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	# because if running the containers for the first time,
 	# the mysql container will reject connections until it has set the database data
 	# See "No connections until MySQL init completes" in https://hub.docker.com/_/mysql/
-	times=30
+	times=15
 	i=1
 	while [ "$i" -le "$times" ]; do
 		sleep 3

--- a/jetpack.php
+++ b/jetpack.php
@@ -94,7 +94,6 @@ if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
-	jetpack_require_lib( 'debugger' );
 }
 
 // Play nice with http://wp-cli.org/

--- a/jetpack.php
+++ b/jetpack.php
@@ -29,6 +29,19 @@ defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API
 
 defined( 'JETPACK__SANDBOX_DOMAIN' ) or define( 'JETPACK__SANDBOX_DOMAIN', '' );
 
+defined( 'JETPACK__DEBUGGER_PUBLIC_KEY' ) or define(
+	'JETPACK__DEBUGGER_PUBLIC_KEY',
+	"\r\n" . '-----BEGIN PUBLIC KEY-----' . "\r\n"
+	. 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm+uLLVoxGCY71LS6KFc6' . "\r\n"
+	. '1UnF6QGBAsi5XF8ty9kR3/voqfOkpW+gRerM2Kyjy6DPCOmzhZj7BFGtxSV2ZoMX' . "\r\n"
+	. '9ZwWxzXhl/Q/6k8jg8BoY1QL6L2K76icXJu80b+RDIqvOfJruaAeBg1Q9NyeYqLY' . "\r\n"
+	. 'lEVzN2vIwcFYl+MrP/g6Bc2co7Jcbli+tpNIxg4Z+Hnhbs7OJ3STQLmEryLpAxQO' . "\r\n"
+	. 'q8cbhQkMx+FyQhxzSwtXYI/ClCUmTnzcKk7SgGvEjoKGAmngILiVuEJ4bm7Q1yok' . "\r\n"
+	. 'xl9+wcfW6JAituNhml9dlHCWnn9D3+j8pxStHihKy2gVMwiFRjLEeD8K/7JVGkb/' . "\r\n"
+	. 'EwIDAQAB' . "\r\n"
+	. '-----END PUBLIC KEY-----' . "\r\n"
+);
+
 /**
  * Returns the location of Jetpack's lib directory. This filter is applied
  * in require_lib().

--- a/jetpack.php
+++ b/jetpack.php
@@ -94,7 +94,7 @@ if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
-	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'  );
+	jetpack_require_lib( 'debugger' );
 }
 
 // Play nice with http://wp-cli.org/


### PR DESCRIPTION
Introduces an "unit testing" suite to Jetpack to check for local conditions known to be problematic. Currently adds a check for the master user existing and still an admin, plus refactoring most the existing tests from the debugger into the new format.

Fixes #10249
#### Changes proposed in this Pull Request:
* Adds a "debugger" library to be a canonical source of truth for local testing of the JP connection.
* Refactors the WP CLI `wp jetpack status` check, the REST API `test-connection` endpoint and the in-plugin debugger (admin.php?page=jetpack-debugger) to use the new testing suite.
* Adds a test-wpcom endpoint that encrypts the result of the debug in order to be consumed by WordPress.com.

#### Testing instructions:
* Check out the in-plugin debugger, make sure tests pass on a regularly connected site. Try on a disconnected site, make sure a test fails.
* Using a different admin user than the one that connected Jetpack, downgrade or delete the connecting admin. Check out the debugger again.
* Check both situations above via `wp jetpack status` and see passing/failing results.
* Only using JN sites: Check the jetpack.com debugger to confirm that a working site passes or a site failing a local test shows the local failure for SA a12s only.

#### Proposed changelog entry for your changes:
* Enhancement: Add additional tests to check when Jetpack isn't working as expected and ensures all current debugging platforms use the same testing list.
