### PR TITLE
Simple Payments: Improve price formatting

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -468,12 +468,6 @@ class Jetpack_Simple_Payments {
 				'desc'    => _x( 'Canadian Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
-			'INR' => array(
-				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
-				'symbol'  => '₹',
-				'desc'    => _x( 'Indian Rupees', 'currency', 'jetpack' ),
-				'decimal' => 0,
-			),
 			'ILS' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => '₪',

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -239,7 +239,7 @@ class Jetpack_Simple_Payments {
 			esc_attr( "${css_prefix}-description" ),
 			$data['description'],
 			esc_attr( "${css_prefix}-price" ),
-			$data['price'], // Escaped by format_price
+			esc_html( $data['price'] ),
 			esc_attr( "${css_prefix}-purchase-message" ),
 			esc_attr( "{$data['dom_id']}-message-container" ),
 			esc_attr( "${css_prefix}-purchase-box" ),
@@ -250,26 +250,20 @@ class Jetpack_Simple_Payments {
 	}
 
 	/**
-	 * HTML format price for display
+	 * Format a price with currency
 	 *
-	 * Uses currency-aware formatting to output a formatted price for HTML with a simple fallback.
+	 * Uses currency-aware formatting to output a formatted price with a simple fallback.
 	 *
 	 * Largely inspired by WordPress.com's Store_Price::display_currency
 	 *
 	 * @param  string $price    Price.
 	 * @param  string $currency Currency.
-	 * @return string           HTML-ready price to display
+	 * @return string           Formatted price.
 	 */
 	private function format_price( $price, $currency ) {
 		$currency_details = self::get_currency( $currency );
 
 		if ( $currency_details ) {
-			$symbol = sprintf(
-				'<abbr title="%s">%s</abbr>',
-				esc_attr( $currency_details['desc'] ),
-				esc_html( $currency_details['symbol'] )
-			);
-
 			// Ensure USD displays as 1234.56 even in non-US locales.
 			$amount = 'USD' === $currency
 				? number_format( $price, $currency_details['decimal'], '.', ',' )
@@ -277,12 +271,12 @@ class Jetpack_Simple_Payments {
 
 			return sprintf(
 				$currency_details['format'],
-				$symbol,
-				esc_html( $amount )
+				$currency_details['symbol'],
+				$amount
 			);
 		}
 
-		return esc_html( "$price $currency" );
+		return "$price $currency";
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -492,6 +492,12 @@ class Jetpack_Simple_Payments {
 				'desc'    => _x( 'Mexican Pesos', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
+			'MYR' => array(
+				'format'  => '%2$s%1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'RM',
+				'desc'    => _x( 'Malaysian ringgit', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
 			'SEK' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Skr',

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -377,5 +377,173 @@ class Jetpack_Simple_Payments {
 		register_post_type( self::$post_type_product, $product_args );
 	}
 
+	/**
+	 * Format a price for display
+	 *
+	 * Largely taken from WordPress.com Store_Price class
+	 *
+	 * The currency array will have the shape:
+	 *   format  => string sprintf format with placeholders `%1$s`: Symbol `%2$s`: Price.
+	 *   symbol  => string Symbol string
+	 *   desc    => string Text description of currency
+	 *   decimal => int    Number of decimal places
+	 *
+	 * @param  string $the_currency The desired currency, e.g. 'USD'.
+	 * @return ?array               Currency object or null if not found.
+	 */
+	private static function get_currency( $the_currency ) {
+		$currencies = array(
+			'USD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => '$',
+				'desc'    => _x( 'United States Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'GBP' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => '&#163;',
+				'desc'    => _x( 'British Pounds', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'JPY' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => '&#165;',
+				'desc'    => _x( 'Japanese Yen', 'currency', 'jetpack' ),
+				'decimal' => 0,
+			),
+			'BRL' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'R$',
+				'desc'    => _x( 'Brazilian real', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'EUR' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => '&#8364;',
+				'desc'    => _x( 'Euro', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'NZD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'NZ$',
+				'desc'    => _x( 'New Zealand Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'AUD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'A$',
+				'desc'    => _x( 'Australian Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'CAD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'C$',
+				'desc'    => _x( 'Canadian Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'INR' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => '₹',
+				'desc'    => _x( 'Indian Rupees', 'currency', 'jetpack' ),
+				'decimal' => 0,
+			),
+			'ILS' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => '₪',
+				'desc'    => _x( 'New Israeli Shekels', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'RUB' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => '₽',
+				'desc'    => _x( 'Russian Rubles', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'MXN' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'MX$',
+				'desc'    => _x( 'Mexican Pesos', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'SEK' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'Skr',
+				'desc'    => _x( 'Swedish Kronor', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'HUF' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'Ft',
+				'desc'    => _x( 'Hungarian Forints', 'currency', 'jetpack' ),
+				'decimal' => 0, // Decimals are supported by Stripe but not by PayPal.
+			),
+			'CHF' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'CHF',
+				'desc'    => _x( 'Swiss Francs', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'CZK' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'Kč',
+				'desc'    => _x( 'Czech Koruna', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'DKK' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'Dkr',
+				'desc'    => _x( 'Denmark Kroner', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'HKD' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'HK$',
+				'desc'    => _x( 'Hong Kong Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'NOK' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'Kr',
+				'desc'    => _x( 'Norway Kroner', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'PHP' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => '₱',
+				'desc'    => _x( 'Philippine Peso', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'PLN' => array(
+				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
+				'symbol'  => 'PLN',
+				'desc'    => _x( 'Polish Zloty', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'SGD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'S$',
+				'desc'    => _x( 'Singapore Dollars', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+			'TWD' => array(
+				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
+				'symbol'  => 'NT$',
+				'desc'    => _x( 'New Taiwan Dollars', 'currency', 'jetpack' ),
+				'decimal' => 0, // Decimals are supported by Stripe but not by PayPal.
+			),
+			'THB' => array(
+				'format'  => '%2$s%1$s', // 1: Symbol 2: currency value
+				'symbol'  => '฿',
+				'desc'    => _x( 'Thai Baht', 'currency', 'jetpack' ),
+				'decimal' => 2,
+			),
+
+		);
+
+		if ( isset( $currencies[ $the_currency ] ) ) {
+			return $currencies[ $the_currency ];
+		}
+		return null;
+	}
 }
 Jetpack_Simple_Payments::getInstance();

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -417,148 +417,123 @@ class Jetpack_Simple_Payments {
 			'USD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => '$',
-				'desc'    => _x( 'United States Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'GBP' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => '&#163;',
-				'desc'    => _x( 'British Pounds', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'JPY' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => '&#165;',
-				'desc'    => _x( 'Japanese Yen', 'currency', 'jetpack' ),
 				'decimal' => 0,
 			),
 			'BRL' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'R$',
-				'desc'    => _x( 'Brazilian real', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'EUR' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => '&#8364;',
-				'desc'    => _x( 'Euro', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'NZD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'NZ$',
-				'desc'    => _x( 'New Zealand Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'AUD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'A$',
-				'desc'    => _x( 'Australian Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'CAD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'C$',
-				'desc'    => _x( 'Canadian Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'ILS' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => '₪',
-				'desc'    => _x( 'New Israeli Shekels', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'RUB' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => '₽',
-				'desc'    => _x( 'Russian Rubles', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'MXN' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'MX$',
-				'desc'    => _x( 'Mexican Pesos', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'MYR' => array(
 				'format'  => '%2$s%1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'RM',
-				'desc'    => _x( 'Malaysian ringgit', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'SEK' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Skr',
-				'desc'    => _x( 'Swedish Kronor', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'HUF' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Ft',
-				'desc'    => _x( 'Hungarian Forints', 'currency', 'jetpack' ),
 				'decimal' => 0, // Decimals are supported by Stripe but not by PayPal.
 			),
 			'CHF' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'CHF',
-				'desc'    => _x( 'Swiss Francs', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'CZK' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Kč',
-				'desc'    => _x( 'Czech Koruna', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'DKK' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Dkr',
-				'desc'    => _x( 'Denmark Kroner', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'HKD' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'HK$',
-				'desc'    => _x( 'Hong Kong Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'NOK' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'Kr',
-				'desc'    => _x( 'Norway Kroner', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'PHP' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => '₱',
-				'desc'    => _x( 'Philippine Peso', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'PLN' => array(
 				'format'  => '%2$s %1$s', // 1: Symbol 2: currency value
 				'symbol'  => 'PLN',
-				'desc'    => _x( 'Polish Zloty', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'SGD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'S$',
-				'desc'    => _x( 'Singapore Dollars', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
 			'TWD' => array(
 				'format'  => '%1$s%2$s', // 1: Symbol 2: currency value
 				'symbol'  => 'NT$',
-				'desc'    => _x( 'New Taiwan Dollars', 'currency', 'jetpack' ),
 				'decimal' => 0, // Decimals are supported by Stripe but not by PayPal.
 			),
 			'THB' => array(
 				'format'  => '%2$s%1$s', // 1: Symbol 2: currency value
 				'symbol'  => '฿',
-				'desc'    => _x( 'Thai Baht', 'currency', 'jetpack' ),
 				'decimal' => 2,
 			),
-
 		);
 
 		if ( isset( $currencies[ $the_currency ] ) ) {


### PR DESCRIPTION
With the Simple Payments block work, it was decided that the client sending a formatted price meta was not an appropriate way to store the price to be displayed.

This PR adds improved price formatters largely based on some used in WordPress.com and renders the price for display when the shortcode is processed.

Extracted from #10402

##### Some examples

###### Yen / es_ES locale
![screen shot 2018-11-07 at 13 02 03](https://user-images.githubusercontent.com/841763/48130610-7e2dd880-e28d-11e8-8da8-6af60905f806.png)

###### Yen / en_US locale
![screen shot 2018-11-07 at 13 02 53](https://user-images.githubusercontent.com/841763/48130614-8128c900-e28d-11e8-9ec7-d964d3caac80.png)

###### USD / en_US
![screen shot 2018-11-07 at 13 05 52](https://user-images.githubusercontent.com/841763/48130737-e67cba00-e28d-11e8-8e62-42346d41b403.png)

###### GBP / en_US (hovering)

![screen shot 2018-11-07 at 13 07 17](https://user-images.githubusercontent.com/841763/48130790-175cef00-e28e-11e8-9984-bbfe031ce006.png)


#### Changes proposed in this Pull Request:

* Add improved Simple Payments price formatting in the shortcode.

#### Testing instructions:

* With a Jetpack site and a Premium or greater plan, add a Simple Payments button.
* Verify that a variety of currencies display well when the Simple Payment is rendered on the frontend.


#### Proposed changelog entry for your changes:

* Improve Simple Payments frontend formatting.
