### PR TITLE
Dashboard: add My Plan page

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -73,6 +73,7 @@ function render() {
 					<Route path="/" name={ i18n.translate( 'At A Glance', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/jumpstart" component={ Main } />
 					<Route path="/dashboard" name={ i18n.translate( 'At A Glance' ) } component={ Main } />
+					<Route path="/my-plan" name={ i18n.translate( 'My Plan', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/plans" name={ i18n.translate( 'Plans', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/settings" name={ i18n.translate( 'Settings', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/discussion" name={ i18n.translate( 'Discussion', { context: 'Navigation item.' } ) } component={ Main } />

--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -59,7 +59,7 @@ export class Masthead extends React.Component {
 					tabIndex={ 0 }
 					title={ `Sandboxing via ${ this.props.sandboxDomain }. Click to test connection.` }>API Sandboxed</code>
 				: '',
-			isDashboardView = includes( [ '/', '/dashboard', '/apps', '/plans' ], this.props.route.path ),
+			isDashboardView = includes( [ '/', '/dashboard', '/apps', '/my-plan', '/plans' ], this.props.route.path ),
 			isStatic = '' === this.props.route.path;
 
 		return (

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -29,6 +29,10 @@ export class Navigation extends React.Component {
 		this.trackNavClick( 'dashboard' );
 	};
 
+	trackMyPlanClick = () => {
+		this.trackNavClick( 'my-plan' );
+	};
+
 	trackPlansClick = () => {
 		this.trackNavClick( 'dashboard' );
 	};
@@ -43,6 +47,12 @@ export class Navigation extends React.Component {
 						onClick={ this.trackDashboardClick }
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#/my-plan"
+						onClick={ this.trackMyPlanClick }
+						selected={ this.props.route.path === '/my-plan' }>
+						{ __( 'My Plan', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
 						path="#/plans"

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -34,7 +34,7 @@ export class Navigation extends React.Component {
 	};
 
 	trackPlansClick = () => {
-		this.trackNavClick( 'dashboard' );
+		this.trackNavClick( 'plans' );
 	};
 
 	render() {

--- a/_inc/client/components/navigation/test/component.js
+++ b/_inc/client/components/navigation/test/component.js
@@ -66,8 +66,8 @@ describe( 'Navigation', () => {
 
 		const wrapperManage = shallow( <Navigation { ...testProps } /> );
 
-		it( 'renders 2 NavItem components', () => {
-			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 2 );
+		it( 'renders 3 NavItem components', () => {
+			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 3 );
 		} );
 
 		it( 'renders tabs with At a Glance, My Plan, Plans', () => {

--- a/_inc/client/components/navigation/test/component.js
+++ b/_inc/client/components/navigation/test/component.js
@@ -70,8 +70,8 @@ describe( 'Navigation', () => {
 			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 2 );
 		} );
 
-		it( 'renders tabs with At a Glance, Plans', () => {
-			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,Plans' );
+		it( 'renders tabs with At a Glance, My Plan, Plans', () => {
+			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,MyPlan,Plans' );
 		} );
 
 	} );

--- a/_inc/client/components/navigation/test/component.js
+++ b/_inc/client/components/navigation/test/component.js
@@ -71,7 +71,7 @@ describe( 'Navigation', () => {
 		} );
 
 		it( 'renders tabs with At a Glance, My Plan, Plans', () => {
-			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,MyPlan,Plans' );
+			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,My Plan,Plans' );
 		} );
 
 	} );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -31,6 +31,7 @@ import {
 import { areThereUnsavedSettings, clearUnsavedSettingsFlag, showWelcomeForNewPlan } from 'state/settings';
 import { getSearchTerm } from 'state/search';
 import AtAGlance from 'at-a-glance/index.jsx';
+import MyPlan from 'my-plan/index.jsx';
 import Plans from 'plans/index.jsx';
 import Footer from 'components/footer';
 import SupportCard from 'components/support-card';
@@ -201,6 +202,12 @@ class Main extends React.Component {
 					siteAdminUrl={ this.props.siteAdminUrl }
 					rewindStatus={ this.props.rewindStatus } />;
 				break;
+			case '/my-plan':
+				pageComponent = <MyPlan
+					siteRawUrl={ this.props.siteRawUrl }
+					siteAdminUrl={ this.props.siteAdminUrl }
+					rewindStatus={ this.props.rewindStatus } />;
+				break;
 			case '/plans':
 				pageComponent = <Plans
 					siteRawUrl={ this.props.siteRawUrl }
@@ -318,7 +325,8 @@ window.wpNavMenuClassChange = function() {
 		dashboardRoutes = [
 			'#/',
 			'#/dashboard',
-			'#/plans'
+			'#/my-plan',
+			'#/plans',
 		];
 
 	// Clear currents
@@ -341,7 +349,7 @@ window.wpNavMenuClassChange = function() {
 
 	const $body = jQuery( 'body' );
 
-	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#/security"], .dops-button[href="#/plans"]', function() {
+	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#/security"], .dops-button[href="#/my-plan"], .dops-button[href="#/plans"]', function() {
 		window.scrollTo( 0, 0 );
 	} );
 

--- a/_inc/client/my-plan/index.jsx
+++ b/_inc/client/my-plan/index.jsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import {
+	getPlanClass,
+	FEATURE_UNLIMITED_PREMIUM_THEMES
+} from 'lib/plans/constants';
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSitePlan,
+	getAvailableFeatures,
+	getActiveFeatures,
+} from 'state/site';
+import QuerySite from 'components/data/query-site';
+import { getSiteConnectionStatus } from 'state/connection';
+import ThemesPromoCard from 'components/themes-promo-card';
+
+import MyPlanHeader from './my-plan-header';
+import MyPlanBody from './my-plan-body';
+
+export class MyPlan extends React.Component {
+	themesPromo = () => {
+		const sitePlan = this.props.sitePlan.product_slug || '';
+		const planClass = 'dev' !== this.props.plan
+			? getPlanClass( sitePlan )
+			: 'dev';
+
+		switch ( planClass ) {
+			case 'is-personal-plan':
+			case 'is-premium-plan':
+			case 'is-free-plan':
+				return <ThemesPromoCard plan={ planClass } siteRawUrl={ this.props.siteRawUrl } />;
+		}
+
+		return null;
+	};
+
+	renderContent = () => {
+		let sitePlan = this.props.sitePlan.product_slug || '',
+			availableFeatures = this.props.availableFeatures,
+			activeFeatures = this.props.activeFeatures,
+			themePromo = '';
+		if ( 'dev' === this.props.getSiteConnectionStatus( this.props ) ) {
+			sitePlan = 'dev';
+			availableFeatures = {};
+			activeFeatures = {};
+		}
+
+		const premiumThemesAvailable = 'undefined' !== typeof this.props.availableFeatures[ FEATURE_UNLIMITED_PREMIUM_THEMES ],
+			premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+			showThemesPromo = premiumThemesAvailable && ! premiumThemesActive;
+
+		if ( showThemesPromo ) {
+			themePromo = this.themesPromo();
+		}
+
+		return (
+			<div>
+				<div className="jp-landing__plans dops-card">
+					<MyPlanHeader plan={ sitePlan } siteRawUrl={ this.props.siteRawUrl } />
+					<MyPlanBody
+						plan={ sitePlan }
+						availableFeatures={ availableFeatures }
+						activeFeatures={ activeFeatures }
+						siteRawUrl={ this.props.siteRawUrl }
+						siteAdminUrl={ this.props.siteAdminUrl }
+						rewindStatus={ this.props.rewindStatus }
+					/>
+				</div>
+				{ themePromo }
+			</div>
+		);
+	};
+
+	render() {
+		return (
+			<div>
+				<QuerySite />
+				{ this.renderContent() }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
+			sitePlan: getSitePlan( state ),
+			availableFeatures: getAvailableFeatures( state ),
+			activeFeatures: getActiveFeatures( state ),
+		};
+	}
+)( MyPlan );

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -32,7 +32,7 @@ import {
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import { showBackups } from 'state/initial-state';
 
-class PlanBody extends React.Component {
+class MyPlanBody extends React.Component {
 	static propTypes = {
 		plan: PropTypes.string
 	};
@@ -490,4 +490,4 @@ export default connect(
 			}
 		};
 	}
-)( PlanBody );
+)( MyPlanBody );

--- a/_inc/client/my-plan/my-plan-header.jsx
+++ b/_inc/client/my-plan/my-plan-header.jsx
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
 import { imagePath } from 'constants/urls';
 import { showBackups } from 'state/initial-state';
 
-class PlanHeader extends React.Component {
+class MyPlanHeader extends React.Component {
 	trackLearnMore = () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'learn-more',
@@ -168,4 +168,4 @@ export default connect(
 			showBackups: showBackups( state ),
 		};
 	}
-)( PlanHeader );
+)( MyPlanHeader );

--- a/_inc/client/my-plan/style.scss
+++ b/_inc/client/my-plan/style.scss
@@ -1,0 +1,231 @@
+.jp-landing__plans.dops-card {
+	padding: 0;
+}
+
+.jp-landing__plans {
+
+	.dops-button {
+		margin-right: 10px;
+	}
+}
+
+.jp-landing-plans__header {
+	background: $gray-dark;
+
+	@include breakpoint( ">660px" ) {
+		padding: rem( 32px ) 0 0;
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: rem( 32px );
+	}
+}
+
+.jp-landing-plans__header-img-container {
+	margin: rem( 32px ) 0 0;
+	overflow: hidden;
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-wrap: nowrap;
+		flex-direction: row;
+		align-items: center;
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 0;
+	}
+}
+
+// clouds are a little hacky, but works for IE11 -jg
+.jp-landing-plans__clouds {
+	position: relative;
+	overflow: hidden;
+	padding-top: rem( 80px );
+
+	img {
+		position: absolute;
+		bottom: -2px;
+		left: -5%;
+		right: -5%;
+		height: auto;
+		width: 110%;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+// end IE11 cloud hack
+
+.jp-landing-plans__header-col-left {
+	flex-basis: 45%;
+
+	@include breakpoint( ">660px" ) {
+		padding-left: rem( 32px );
+	}
+}
+
+.jp-landing-plans__header-col-right {
+	flex-basis: 55%;
+
+	@include breakpoint( ">660px" ) {
+		padding: 0 rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		text-align: center;
+	}
+}
+
+.jp-landing-plans__header-title,
+.jp-landing-plans__header-description {
+	line-height: 1.5;
+
+	@include breakpoint( ">660px" ) {
+		text-align: center;
+	}
+}
+
+.jp-landing-plans__header-title,
+.jp-landing-plans__header-subtitle {
+	color: $white;
+	font-weight: 400;
+	margin: 0;
+}
+
+.jp-landing-plans__header-title {
+	font-size: rem( 20px );
+}
+
+.jp-landing-plans__header-description {
+	font-size: rem( 14px );
+	margin: 0;
+	padding-bottom: rem( 16px );
+}
+
+.jp-landing-plans__header-subtitle {
+	font-size: rem( 16px );
+	line-height: 1.25;
+}
+
+.jp-landing-plans__header-description,
+.jp-landing-plans__header-text {
+	color: lighten($gray, 10%);
+}
+
+.jp-landing-plans__header-text {
+	font-size: rem( 14px );
+	padding: rem( 24px ) 0;
+	margin: 0;
+}
+
+.jp-landing-plans__header-btn-container {
+	margin: 0;
+}
+
+.jp-landing__plan-features-card {
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+	border-radius: 3px;
+
+	@include breakpoint( ">660px" ) {
+		margin-bottom: rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: rem( 16px );
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: rem( 32px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		padding: rem( 16px );
+	}
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+}
+
+.jp-landing__plan-features-title {
+	margin: 0;
+}
+
+.jp-landing__plan-features {
+
+	@include breakpoint( ">660px" ) {
+		padding: 0 rem( 32px ) rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: rem( 16px );
+	}
+}
+
+.jp-landing__plan-card {
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-wrap: nowrap;
+	}
+
+	@include breakpoint( ">660px" ) {
+		padding: rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: rem( 32px ) rem( 32px ) rem( 16px );
+	}
+
+	.jp-landing__plan-features-title,
+	.jp-landing__plan-features-text {
+		padding: 0;
+
+		@include breakpoint( ">660px" ) {
+			margin-left: rem( 32px );
+		}
+	}
+
+	.jp-landing__plan-features-title {
+		margin-bottom: rem( 16px );
+	}
+}
+
+.jp-landing__plan-card-img {
+
+	@include breakpoint( "<660px" ) {
+		margin: 0 0 rem( 32px ) 0;
+	}
+
+	@include breakpoint( "<480px" ) {
+		width: 100%;
+		max-width: 100%;
+		text-align: center;
+	}
+}
+
+.jp-landing__plan-icon {
+	width: rem( 200px );
+}
+
+.jp-landing__plan-card-img.is-placeholder {
+	width: rem( 120px );
+	height: rem( 85px );
+
+	& + .jp-landing__plan-card-current {
+		width: 80%;
+	}
+}
+
+.jp-landing__plan-features-title.is-placeholder {
+	height: rem( 24px );
+	max-width: 50%;
+}
+
+.jp-landing__plan-features-text.is-placeholder {
+	height: rem( 44px );
+	max-width: 75%;
+}

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -13,7 +13,6 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import {
-	getSitePlan,
 	getAvailableFeatures,
 	getActiveFeatures,
 } from 'state/site';
@@ -21,13 +20,10 @@ import QuerySite from 'components/data/query-site';
 import { getSiteConnectionStatus } from 'state/connection';
 import ThemesPromoCard from 'components/themes-promo-card';
 
-import PlanHeader from './plan-header';
-import PlanBody from './plan-body';
 import PlanGrid from './plan-grid';
 
 export class Plans extends React.Component {
 	themesPromo = () => {
-		const sitePlan = this.props.sitePlan.product_slug || '';
 		const planClass = 'dev' !== this.props.plan
 			? getPlanClass( sitePlan )
 			: 'dev';
@@ -43,18 +39,7 @@ export class Plans extends React.Component {
 	};
 
 	renderContent = () => {
-		let sitePlan = this.props.sitePlan.product_slug || '',
-			availableFeatures = this.props.availableFeatures,
-			activeFeatures = this.props.activeFeatures,
-			themePromo = '';
-		const planClass = 'dev' !== this.props.plan
-			? getPlanClass( sitePlan )
-			: 'dev';
-		if ( 'dev' === this.props.getSiteConnectionStatus( this.props ) ) {
-			sitePlan = 'dev';
-			availableFeatures = {};
-			activeFeatures = {};
-		}
+		let themePromo = '';
 
 		const premiumThemesAvailable = 'undefined' !== typeof this.props.availableFeatures[ FEATURE_UNLIMITED_PREMIUM_THEMES ],
 			premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES ),
@@ -62,33 +47,12 @@ export class Plans extends React.Component {
 
 		if ( showThemesPromo ) {
 			themePromo = this.themesPromo();
-
-			// Don't show the rest of the promos if theme promo available and on Free plan.
-			if ( 'is-free-plan' === planClass ) {
-				return (
-					<div>
-						<PlanGrid />
-						{ themePromo }
-					</div>
-				);
-			}
 		}
 
 		return (
 			<div>
-				<PlanGrid />
 				{ themePromo }
-				<div className="jp-landing__plans dops-card">
-					<PlanHeader plan={ sitePlan } siteRawUrl={ this.props.siteRawUrl } />
-					<PlanBody
-						plan={ sitePlan }
-						availableFeatures={ availableFeatures }
-						activeFeatures={ activeFeatures }
-						siteRawUrl={ this.props.siteRawUrl }
-						siteAdminUrl={ this.props.siteAdminUrl }
-						rewindStatus={ this.props.rewindStatus }
-					/>
-				</div>
+				<PlanGrid />
 			</div>
 		);
 	};
@@ -107,7 +71,6 @@ export default connect(
 	( state ) => {
 		return {
 			getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
-			sitePlan: getSitePlan( state ),
 			availableFeatures: getAvailableFeatures( state ),
 			activeFeatures: getActiveFeatures( state ),
 		};

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -13,6 +13,7 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import {
+	getSitePlan,
 	getAvailableFeatures,
 	getActiveFeatures,
 } from 'state/site';
@@ -24,6 +25,7 @@ import PlanGrid from './plan-grid';
 
 export class Plans extends React.Component {
 	themesPromo = () => {
+		const sitePlan = this.props.sitePlan.product_slug || '';
 		const planClass = 'dev' !== this.props.plan
 			? getPlanClass( sitePlan )
 			: 'dev';
@@ -71,6 +73,7 @@ export default connect(
 	( state ) => {
 		return {
 			getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
+			sitePlan: getSitePlan( state ),
 			availableFeatures: getAvailableFeatures( state ),
 			activeFeatures: getActiveFeatures( state ),
 		};

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,278 +1,3 @@
-.jp-landing__plans.dops-card {
-	padding: 0;
-}
-
-.jp-landing__plans {
-
-	.dops-button {
-		margin-right: 10px;
-	}
-}
-
-.plans-mobile-notice {
-	@include breakpoint( ">660px" ) {
-		display: none;
-	}
-	.dops-button:first-of-type {
-		margin-right: 6px;
-		margin-bottom: 6px;
-	}
-}
-
-.plans-mobile-notice.dops-card h2 {
-	margin-top: 0;
-}
-
-.jp-landing-plans__header {
-	background: $gray-dark;
-
-	@include breakpoint( ">660px" ) {
-		padding: rem( 32px ) 0 0;
-	}
-
-	@include breakpoint( "<660px" ) {
-		padding: rem( 32px );
-	}
-}
-
-.jp-landing-plans__header-img-container {
-	margin: rem( 32px ) 0 0;
-	overflow: hidden;
-
-	@include breakpoint( ">660px" ) {
-		display: flex;
-		flex-wrap: nowrap;
-		flex-direction: row;
-		align-items: center;
-	}
-
-	@include breakpoint( "<660px" ) {
-		margin-bottom: 0;
-	}
-}
-
-.jp-landing-plans__header-img {
-	max-width: 100%;
-}
-
-.jp-landing-plans__header-col-left {
-	flex-basis: 45%;
-
-	@include breakpoint( ">660px" ) {
-		padding-left: rem( 32px );
-	}
-}
-
-.jp-landing-plans__header-col-right {
-	flex-basis: 55%;
-
-	@include breakpoint( ">660px" ) {
-		padding: 0 rem( 32px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		text-align: center;
-		padding-top: rem( 32px );
-	}
-}
-
-// clouds are a little hacky, but works for IE11 -jg
-.jp-landing-plans__clouds {
-	position: relative;
-	overflow: hidden;
-	padding-top: rem( 80px );
-
-	img {
-		position: absolute;
-		bottom: -2px;
-		left: -5%;
-		right: -5%;
-		height: auto;
-		width: 110%;
-	}
-
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-// end IE11 cloud hack
-
-.jp-landing-plans__header-img {
-	max-width: 100%;
-}
-
-.jp-landing-plans__header-col-left {
-	flex-basis: 45%;
-
-	@include breakpoint( ">660px" ) {
-		padding-left: rem( 32px );
-	}
-}
-
-.jp-landing-plans__header-col-right {
-	flex-basis: 55%;
-
-	@include breakpoint( ">660px" ) {
-		padding: 0 rem( 32px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		text-align: center;
-	}
-}
-
-.jp-landing-plans__header-title,
-.jp-landing-plans__header-description {
-	line-height: 1.5;
-
-	@include breakpoint( ">660px" ) {
-		text-align: center;
-	}
-}
-
-.jp-landing-plans__header-title,
-.jp-landing-plans__header-subtitle {
-	color: $white;
-	font-weight: 400;
-	margin: 0;
-}
-
-.jp-landing-plans__header-title {
-	font-size: rem( 20px );
-}
-
-.jp-landing-plans__header-description {
-	font-size: rem( 14px );
-	margin: 0;
-	padding-bottom: rem( 16px );
-}
-
-.jp-landing-plans__header-subtitle {
-	font-size: rem( 16px );
-	line-height: 1.25;
-}
-
-.jp-landing-plans__header-description,
-.jp-landing-plans__header-text {
-	color: lighten($gray, 10%);
-}
-
-.jp-landing-plans__header-text {
-	font-size: rem( 14px );
-	padding: rem( 24px ) 0;
-	margin: 0;
-}
-
-.jp-landing-plans__header-btn-container {
-	margin: 0;
-}
-
-.jp-landing__plan-features-card {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
-	border-radius: 3px;
-
-	@include breakpoint( ">660px" ) {
-		margin-bottom: rem( 32px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		margin-bottom: rem( 16px );
-	}
-
-	@include breakpoint( ">480px" ) {
-		padding: rem( 32px );
-	}
-
-	@include breakpoint( "<480px" ) {
-		padding: rem( 16px );
-	}
-
-	&:last-of-type {
-		margin-bottom: 0;
-	}
-}
-
-.jp-landing__plan-features-title {
-	margin: 0;
-}
-
-.jp-landing__plan-features {
-
-	@include breakpoint( ">660px" ) {
-		padding: 0 rem( 32px ) rem( 32px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		padding: rem( 16px );
-	}
-}
-
-.jp-landing__plan-card {
-
-	@include breakpoint( ">660px" ) {
-		display: flex;
-		flex-wrap: nowrap;
-	}
-
-	@include breakpoint( ">660px" ) {
-		padding: rem( 32px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		padding: rem( 32px ) rem( 32px ) rem( 16px );
-	}
-
-	.jp-landing__plan-features-title,
-	.jp-landing__plan-features-text {
-		padding: 0;
-
-		@include breakpoint( ">660px" ) {
-			margin-left: rem( 32px );
-		}
-	}
-
-	.jp-landing__plan-features-title {
-		margin-bottom: rem( 16px );
-	}
-}
-
-.jp-landing__plan-card-img {
-
-	@include breakpoint( "<660px" ) {
-		margin: 0 0 rem( 32px ) 0;
-	}
-
-	@include breakpoint( "<480px" ) {
-		width: 100%;
-		max-width: 100%;
-		text-align: center;
-	}
-}
-
-.jp-landing__plan-icon {
-	width: rem( 200px );
-}
-
-.jp-landing__plan-card-img.is-placeholder {
-	width: rem( 120px );
-	height: rem( 85px );
-
-	& + .jp-landing__plan-card-current {
-		width: 80%;
-	}
-}
-
-.jp-landing__plan-features-title.is-placeholder {
-	height: rem( 24px );
-	max-width: 50%;
-}
-
-.jp-landing__plan-features-text.is-placeholder {
-	height: rem( 44px );
-	max-width: 75%;
-}
-
 // Plans Tables
 
 $plan-features-header-banner-height: 20px;
@@ -373,7 +98,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__table-item.has-partial-border {
-	&::after {
+	&:after {
 		content: '';
 		display: block;
 		height: 1px;
@@ -473,6 +198,21 @@ $plan-features-sidebar-width: 272px;
 	padding-top: 15px;
 	padding-bottom: 15px;
 }
+
 .plan-price__yearly {
 	color: $gray-dark;
+}
+
+.plans-mobile-notice {
+	@include breakpoint( ">660px" ) {
+		display: none;
+	}
+	.dops-button:first-of-type {
+		margin-right: 6px;
+		margin-bottom: 6px;
+	}
+}
+
+.plans-mobile-notice.dops-card h2 {
+	margin-top: 0;
 }

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -51,6 +51,7 @@
 
 // Page Templates
 @import '../at-a-glance/style';
+@import '../my-plan/style';
 @import '../plans/style';
 @import '../settings/style';
 @import '../traffic/style';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a new `My Plan` page that solely focuses on the features for the current plan.
* Adds a new option in the main navigation so people can open this new view.
* Cleans up styles.
* Adds tests for this change.
* Bonus: fix track event name for Plans.

Could be a fix for #10381

![image](https://user-images.githubusercontent.com/390760/48133859-1af17580-e290-11e8-88a5-4618680ac291.png)

**Help!**: I can't get the `Dashboard` option on the split button to remain selected when jumping into this new section, even though I added the new URL param to the `window.wpNavMenuClassChange` function.

![image](https://user-images.githubusercontent.com/390760/48133970-6dcb2d00-e290-11e8-8662-7a9616e2d53a.png)

#### Testing instructions:

* Fire up this PR!
* Go to your Jetpack dashboard.
* Select `My Plan`.
* Ensure the content is correctly split up between that section and `Plans`.

#### Proposed changelog entry for your changes:

* Add My Plan page to the dashboard
