### PR TITLE
Gutenberg: Add "Switch to Classic Editor" button in Calypsoify

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg.php
@@ -1,0 +1,45 @@
+<?php
+
+class WPCOM_REST_API_V2_Endpoint_Gutenberg {
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route( 'wpcom/v2', '/sites/(?P<site>[a-zA-Z0-9\.\-]+)/gutenberg', array(
+			array(
+				'methods'  => WP_REST_Server::CREATABLE,
+				'callback' => array( $this, 'set_editor' ),
+			),
+		) );
+	}
+
+	public function set_editor( $data ) {
+		$site_slug = $data[ 'site' ];
+		$request = Jetpack_Client::wpcom_json_api_request_as_user(
+			"/sites/${site_slug}/gutenberg?platform=web&editor=classic",
+			'2',
+			array(
+				'editor'   => $data[ 'editor' ],
+				'platform' => $data[ 'platform' ],
+				'method'   => 'POST',
+				'headers'  => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+
+			)
+		);
+
+		$body = wp_remote_retrieve_body( $request );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			$data = $body;
+		} else {
+			// something went wrong so we'll just return the response without caching
+			return $body;
+		}
+
+		return $data;
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Gutenberg' );

--- a/modules/calypsoify/mods-gutenberg.js
+++ b/modules/calypsoify/mods-gutenberg.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global wp, calypsoifyGutenberg */
+/* global wp, calypsoifyGutenberg, jQuery */
 
 jQuery( function( $ ) {
 	if ( wp && wp.data && wp.data.select && ! wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) ) {
@@ -19,5 +19,23 @@ jQuery( function( $ ) {
 	$( 'body.revision-php a' ).each( function() {
 		var href = $( this ).attr( 'href' );
 		$( this ).attr( 'href', href.replace( '&classic-editor', '' ) );
+	} );
+
+	// Add a "Switch to Classic Editor" button
+	$( document ).on( 'click', '.edit-post-more-menu button', function() {
+		// We need to wait a few ms until the menu content is rendered
+		setTimeout( function() {
+			$( '.edit-post-more-menu__content .components-menu-group:last-child > div[role=menu]' ).append(
+				'<button type="button" aria-label="' + calypsoifyGutenberg.switchToClassicLabel + '" role="menuitem"' +
+				'class="components-button components-menu-item__button components-menu-item__button-switch">' +
+				calypsoifyGutenberg.switchToClassicLabel +
+				'</button>'
+			);
+
+			$( '.components-menu-item__button-switch' ).on( 'click', function() {
+				$.post( calypsoifyGutenberg.switchToClassicAPIUrl );
+				window.location.replace( calypsoifyGutenberg.switchToClassicRedirectUrl );
+			} );
+		}, 0 );
 	} );
 } );

--- a/modules/class.jetpack-calypsoify.php
+++ b/modules/class.jetpack-calypsoify.php
@@ -182,8 +182,9 @@ class Jetpack_Calypsoify {
 	}
 
 	public function get_switch_to_classic_editor_api_url() {
+		$api_root = esc_url_raw( rest_url() );
 		$site_slug = Jetpack::build_raw_urls( home_url() );
-		return "https://public-api.wordpress.com/wpcom/v2/sites/${site_slug}/gutenberg?platform=web&editor=classic";
+		return "${api_root}wpcom/v2/sites/${site_slug}/gutenberg?platform=web&editor=classic";
 	}
 
 	public function check_param() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds a new button in the "More" menu for switching back to the classic editor when using the Calypsoified Gutenberg editor.

When clicking on it, we do 2 things:
- Make an API request to changing the preferred editor to Classic
- Redirect to the edit post URL in Calypso

The redirect includes a `force` param in the URL, so it can be used for bypassing the preferred editor check, since the API request might not have finished yet.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Make sure Gutenberg is the editor set for your Jetpack site and user:  
  - Call `GET https://public-api.wordpress.com/wpcom/v2/sites/:site/gutenberg`
  - If `editor_web` is not `gutenberg`, call `POST https://public-api.wordpress.com/wpcom/v2/sites/:site/gutenberg?platform=web&editor=gutenberg`
- Edit a post using Calypsoify (by appending `&calypsoify=1` to the edit URL: `<SITE_URL>/wp-admin/post.php?post=<POST_ID>&action=edit&calypsoify=1)`.  
- Check that the "Switch to Classic Editor" option appears in the "More" menu
<img width="357" alt="screen shot 2018-11-07 at 16 24 25" src="https://user-images.githubusercontent.com/1233880/48140715-a5929e80-e2a9-11e8-9f7c-300487331cfd.png">

- Click on it and confirm that it redirects to the Calypso editor, including a `force` param in the URL
- Test that nows the preferred editor is `classic` for the web platform: `GET https://public-api.wordpress.com/wpcom/v2/sites/:site/gutenberg`

Repeat with other post types (page, CPTs)

#### Proposed changelog entry for your changes:
I don't think this is needed given Calypsoify is mainly used internally. Anyway, if needed, this is my proposed changelog:

> Included a new button in the Calypsoified Gutenberg editor for switching back to the Classic editor.
