### PR TITLE
Unlaunched sites: Set a blog option of "unlaunched" to sites that are created private

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -50,6 +50,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'jetpack_modules'   => '(array) A list of active Jetpack modules.',
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
+		'launch_status'     => '(string) A string describing the launch status of a site',
 	);
 
 	protected static $no_member_fields = array(
@@ -68,6 +69,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_private',
 		'is_following',
 		'meta',
+		'launch_status',
 	);
 
 	protected static $site_options_format = array(
@@ -125,7 +127,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'has_pending_automated_transfer',
 		'woocommerce_is_active',
 		'design_type',
-		'site_goals'
+		'site_goals',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -363,6 +365,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'quota' :
 				$response[ $key ] = $this->site->get_quota();
+				break;
+			case 'launch_status' : 
+				$response[ $key ] = $this->site->get_launch_status();
 				break;
 		}
 

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -628,4 +628,8 @@ abstract class SAL_Site {
 		$options = get_option( 'options' );
 		return empty( $options[ 'siteGoals'] ) ? null : $options[ 'siteGoals' ];
 	}
+
+	function get_launch_status() {
+		return false;
+	}
 }


### PR DESCRIPTION

This will enable us to distinguish sites that are created private from sites that are deliberately private, so that we can show a coming soon page on them and a pre-launch banner.

This diff does several things:

It sets a blog option of launch-status to unlaunched when users create a site which is private.
It enables users to publish posts and pages to sites which have the launch-status blog option, even if their email address is unverified (this is OK because sites which are  unlaunched aren't public, so there's no spam concerns, and they can't update the status to be launched without verifying their email address)
It returns the launch-status of a site in the API
Moves the functionality into a lib so we can use it in multiple places

Differential Revision: D19586-code

This commit syncs r182320-wpcom.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

*

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
