### PR TITLE
Tracks: do not enqueue Tracks when disconnected from wpcom.

### DIFF
--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -9,7 +9,10 @@ class JetpackTracking {
 	static $product_name = 'jetpack';
 
 	static function track_jetpack_usage() {
-		if ( ! Jetpack::jetpack_tos_agreed() ) {
+		if (
+			! Jetpack::jetpack_tos_agreed()
+			|| ! Jetpack::is_active()
+		) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Up until now, if you were to disconnect your site from WordPress.com after connecting it, we would keep enqueuing Tracks. I do not think that should be the case.

#### Testing instructions:


* Start with a site that is connected to WordPress.com.
* Go to Posts > Add New
* View source, and notice the `_inc/lib/tracks/tracks-ajax.js` file.
* Go to Jetpack > Dashboard, and disconnect your site from WordPress.com.
* Return to Posts > Add New 

The Tracks file should not be enqueued anymore.

#### Proposed changelog entry for your changes:
* Telemetry: stop enqueuing JavaScript after a site has been disconnected from WordPress.com.
