### PR TITLE
Fix: #10548 AtD / Gutenberg: request is made to AtD when module is deactivated

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -206,11 +206,23 @@ class Jetpack_Gutenberg {
 			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
 		);
 
-		$jp_react_page = new Jetpack_React_Page();
 		wp_localize_script(
 			'jetpack-blocks-editor',
 			'Jetpack_Initial_State',
-			$jp_react_page->get_initial_state()
+			array(
+				'getModules' => array(
+					'markdown'      => array(
+						'name'      => 'markdown',
+						'activated' => Jetpack::is_module_active( 'markdown' ),
+						'override'  => Jetpack_Modules_Overrides::instance()->get_module_override( 'markdown' )
+					),
+					'related-posts' => array(
+						'name'      => 'related-posts',
+						'activated' => Jetpack::is_module_active( 'related-posts' ),
+						'override'  => Jetpack_Modules_Overrides::instance()->get_module_override( 'related-posts' )
+					)
+				)
+			)
 		);
 
 		Jetpack::setup_wp_i18n_locale_data();


### PR DESCRIPTION
Fixes #10548
Fixes #10495
Fixes #10558

#### Changes proposed in this Pull Request:
* Instead of using `get_initial_state()` to shorthand how we get module activation data for block visibility this PR manually builds the needed data.
* `get_initial_state()` calls `get_modules` from `Jetpack_Core_API_Module_List_Endpoint` which doesn't respect module activation and [includes modules files](https://github.com/Automattic/jetpack/blame/496bebd5b1890666afe4fc79f52fd94353d88539/_inc/lib/class.core-rest-api-endpoints.php#L2813) which enqueues JS files ¯\_(ツ)_/¯ 

#### Testing instructions:
* Follow the steps in #10548
* Ideally you wont see any JS errors

#### Proposed changelog entry for your changes:
* Fixes an issue where deactivating ATD causes the post editor to throw JS errors
