### PR TITLE
Gutenpack: Include full jetpack-blocks bundle build

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -280,7 +280,7 @@ gulp.task( 'languages:extract', function( done ) {
  * Gutenberg Blocks for Jetpack
  */
 gulp.task( 'gutenberg:blocks', function() {
-	return gulp.src( [ 'node_modules/@automattic/jetpack-blocks/build/*.{js,css}' ] )
+	return gulp.src( [ 'node_modules/@automattic/jetpack-blocks/build/**/*' ] )
 		.pipe( gulp.dest( '_inc/blocks' ) );
 } );
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
-    "clean-client": "rm -rf _inc/build/ css/",
+    "clean-client": "rm -rf _inc/build/ _inc/blocks/ css/",
     "install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn install-if-deps-outdated && yarn clean-client && yarn build-client",


### PR DESCRIPTION
Companion to https://github.com/Automattic/wp-calypso/pull/28378

Supersedes https://github.com/Automattic/wp-calypso/pull/28360 and https://github.com/Automattic/jetpack/pull/10559

Fixes https://github.com/Automattic/wp-calypso/issues/27838


#### Changes proposed in this Pull Request:

* Include all built `jetpack-blocks` assets on build
* Clean `_inc/blocks` on clean

#### Testing instructions:

* Build the bundle from  https://github.com/Automattic/wp-calypso/pull/28378
* Replace the contents of `node_modules/@automattic/jetpack-blocks/build` with the built contents
* Build (`yarn build-client`)
* Add a Simple Payment button to a post in Gutenberg
* Verify that the Paypal button images are included correctly.

https://jurassic.ninja/create?jetpack-beta&branch=update/gutenpack-include-full-build&shortlived&wp-debug-log&gutenberg&gutenpack&calypsobranch=update/import-static-assets-gberg-simplepay

#### Proposed changelog entry for your changes:

None.
