### PR TITLE
Sitemaps: Update docs to correct object type

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1123,8 +1123,8 @@ class Jetpack_Sitemap_Builder {
 		 *
 		 * @since 3.9.0
 		 *
-		 * @param bool    $skip Current boolean. False by default, so no post is skipped.
-		 * @param WP_POST $post Current post object.
+		 * @param bool   $skip Current boolean. False by default, so no post is skipped.
+		 * @param object $post Current post in the form of a $wpdb result object. Not WP_Post.
 		 */
 		if ( true === apply_filters( 'jetpack_sitemap_skip_post', false, $post ) ) {
 			return array(


### PR DESCRIPTION
Inline documentation on the `jetpack_site_skip_post` filter incorrectly stated it a WP_Post object. It is actually an object returned from WPDB.

The operative difference is the `ID` is a string, whereas when it is a WP_Post, it is typically an int.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updated docbloc.

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* Corrected inline documentation.
