### PR TITLE
Twenty Nineteen: second round of compat fixes for Jetpack widgets

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -278,6 +278,20 @@
 	line-height: 1.15;
 }
 
+/* EU cookie law */
+.widget_eu_cookie_law_widget #eu-cookie-law {
+	border-color: #ccc;
+	color: #767676;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: 0.68182em;
+	padding: 0.5rem 1rem;
+}
+
+.widget_eu_cookie_law_widget #eu-cookie-law .accept {
+	font-size: 1em;
+	padding: 10px 12px;
+}
+
 /**
  * Shortcodes
  */

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -252,7 +252,33 @@
 /* Authors Widget */
 .widget.widget_authors ul li > ul {
 	list-style-type: disc;
-	padding-left: 1rem;
+	padding-left: 4.25rem;
+}
+
+.rtl .widget.widget_authors ul li > ul {
+	padding-left: 0;
+	padding-right: 1rem;
+}
+
+.widget_authors > ul > li > a {
+	display: block;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	position: relative;
+}
+
+.widget.widget_authors li a strong {
+	line-height: 1.2;
+	position: absolute;
+	top: 0;
+}
+
+.widget.widget_authors .avatar {
+	float: left;
+	margin-right: 1em;
+}
+
+.widget_authors li > ul {
+	clear: both;
 }
 
 /* Display WordPress Posts */
@@ -290,6 +316,21 @@
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {
 	font-size: 1em;
 	padding: 10px 12px;
+}
+
+/* RSS Links */
+.widget_rss_links ul {
+	list-style: none;
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.widget_rss_links li {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: calc(22px * 1.125);
+	font-weight: bold;
+	line-height: 1.2;
+	padding-bottom: 0.75rem;
 }
 
 /**


### PR DESCRIPTION
Fixes #10335
Fixes #10513
Fixes #10522

#### Changes proposed in this Pull Request:

More changes to the style of some Jetpack widgets when used with the new Twenty Nineteen theme.

This PR focuses on 3 widgets: 
- The Authors widget
- The RSS widget
- The Cookies and Consents Widget

#### Testing instructions:

* Start by downloading the latest version of the theme from [here](https://github.com/WordPress/twentynineteen/archive/master.zip). Unzip it, rename the folder to `twentynineteen`, rezip it, then upload and activate it on your site.
* Add the 3 widgets mentioned above to your sidebar.
* Make sure they look good.

#### Proposed changelog entry for your changes:

* Twenty Nineteen: ensure compatibility with Jetpack's widgets.
