### PR TITLE
Simple payments widget: remove Indian Rupees

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -23,7 +23,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			'NZD' => 'NZ$',
 			'AUD' => 'A$',
 			'CAD' => 'C$',
-			'INR' => '₹',
 			'ILS' => '₪',
 			'RUB' => '₽',
 			'MXN' => 'MX$',


### PR DESCRIPTION
Remove Indian Rupees from the supported currency list in Simple Payments Widget form, since [we don't actually support it](https://github.com/Automattic/jetpack/blob/6c8537f9a57da0154125fc33154cee5f1fec6b6d/modules/simple-payments/simple-payments.php#L376-L414), although PayPal does.

#### Testing instructions:

- Connect Jetpack
- Have a premium+ plan
- Create simple payments widget via Customizer:
    `/wp-admin/customize.php?autofocus[panel]=widgets`


No INR in the dropdown available:

<img width="181" alt="image" src="https://user-images.githubusercontent.com/87168/48253484-0936dc00-e410-11e8-9550-b0f0779d3131.png">

Before the change it's available:

<img width="174" alt="image" src="https://user-images.githubusercontent.com/87168/48253869-12747880-e411-11e8-9fb9-296d8d7be7cd.png">
