### PR TITLE
Simple Payments: Add generic currency fallback symbol

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -288,6 +288,12 @@ class Jetpack_Simple_Payments {
 			);
 		}
 
+		// Fall back to unspecified currency sign:
+		// https://en.wikipedia.org/wiki/Currency_sign_(typography).
+		if ( ! $currency ) {
+			$currency = '¤';
+		}
+
 		return "$price $currency";
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -294,7 +294,7 @@ class Jetpack_Simple_Payments {
 			$currency = '¤';
 		}
 
-		return "$price $currency";
+		return $currency . number_format_i18n( $price );
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -288,13 +288,13 @@ class Jetpack_Simple_Payments {
 			);
 		}
 
-		// Fall back to unspecified currency sign:
-		// https://en.wikipedia.org/wiki/Currency_sign_(typography).
+		// Fall back to unspecified currency symbol like `¤1,234.05`.
+		// @link https://en.wikipedia.org/wiki/Currency_sign_(typography).
 		if ( ! $currency ) {
-			$currency = '¤';
+			return '¤' . number_format_i18n( $price );
 		}
 
-		return $currency . number_format_i18n( $price );
+		return number_format_i18n( $price ) . ' ' . $currency;
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -291,10 +291,10 @@ class Jetpack_Simple_Payments {
 		// Fall back to unspecified currency symbol like `¤1,234.05`.
 		// @link https://en.wikipedia.org/wiki/Currency_sign_(typography).
 		if ( ! $currency ) {
-			return '¤' . number_format_i18n( $price );
+			return '¤' . number_format_i18n( $price, 2 );
 		}
 
-		return number_format_i18n( $price ) . ' ' . $currency;
+		return number_format_i18n( $price, 2 ) . ' ' . $currency;
 	}
 
 	/**


### PR DESCRIPTION
If a currency were missing from a simple payment, we'd just have a number.

#### Changes proposed in this Pull Request:

* In case of a missing currency, add a [generic fallback symbol](https://en.wikipedia.org/wiki/Currency_sign_(typography)): &curren;
* Update the fallback layout to as `{symbol}{value}`.
* i18n number format the value with 2 decimals.

#### Testing instructions:

It's intentionally not easy to have a missing currency. Simple Payment product should be made via UI and backend sanitization that attempts to ensure the data is well formed.

Try this patch to force the fallback to show:

```patch
diff --git a/modules/simple-payments/simple-payments.php b/modules/simple-payments/simple-payments.php
index a00850e81..31a719981 100644
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -264,6 +264,7 @@ class Jetpack_Simple_Payments {
 	 * @return string           Formatted price.
 	 */
 	private function format_price( $price, $currency ) {
+		$currency = '';
 		$currency_details = self::get_currency( $currency );
 
 		if ( $currency_details ) {
```
```patch
diff --git a/modules/simple-payments/simple-payments.php b/modules/simple-payments/simple-payments.php
index a00850e81..31a719981 100644
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -264,6 +264,7 @@ class Jetpack_Simple_Payments {
 	 * @return string           Formatted price.
 	 */
 	private function format_price( $price, $currency ) {
+		$currency = 'UNKNOWN';
 		$currency_details = self::get_currency( $currency );
 
 		if ( $currency_details ) {
```

#### Proposed changelog entry for your changes:

None.

#### Screens

`es_ES` locale. Uses `.` as thousands marker and `,` as decimal marker.

##### No currency:

![screen shot 2018-11-09 at 14 08 13](https://user-images.githubusercontent.com/841763/48264200-009ecf80-e429-11e8-882b-b32a3479f166.png)


##### Unrecognized currency:

![screen shot 2018-11-09 at 14 08 32](https://user-images.githubusercontent.com/841763/48264198-ff6da280-e428-11e8-9883-6baf973ade42.png)
