### PR TITLE
Fixes typography issues with Related Posts module

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -302,7 +302,6 @@
 .entry #jp-relatedposts .jp-relatedposts-items p,
 .entry #jp-relatedposts .jp-relatedposts-items-visual
 .entry h4.jp-relatedposts-post-title {
-	font-size: 0.667em;
 	letter-spacing: normal;
 }
 

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -270,7 +270,8 @@
 	opacity: 1;
 }
 
-.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-size: 1em;
 	letter-spacing: -0.02em;
@@ -280,8 +281,15 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title a {
+.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title a,
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post span a {
 	font-weight: 700;
+}
+
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title,
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-excerpt {
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
 }
 
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
@@ -290,6 +298,14 @@
 	font-size: 0.71111em;
 	font-weight: 500;
 }
+
+.entry #jp-relatedposts .jp-relatedposts-items p,
+.entry #jp-relatedposts .jp-relatedposts-items-visual
+.entry h4.jp-relatedposts-post-title {
+	font-size: 0.667em;
+	letter-spacing: normal;
+}
+
 
 /**
  * Stats

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -67,7 +67,7 @@
 /**
  * Responsive Videos
  */
-.hentry .jetpack-video-wrapper {
+.entry .jetpack-video-wrapper {
 	margin-bottom: 1.75em;
 }
 
@@ -185,8 +185,8 @@
 	padding-bottom: 1.125em;
 }
 
-.hentry div.sharedaddy h3.sd-title,
-.hentry h3.sd-title {
+.entry div.sharedaddy h3.sd-title,
+.entry h3.sd-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-size: 1.125em;
 	font-weight: 700;
@@ -197,8 +197,8 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.hentry div.sharedaddy h3.sd-title:before,
-.hentry h3.sd-title:before {
+.entry div.sharedaddy h3.sd-title:before,
+.entry h3.sd-title:before {
 	background: #767676;
 	border-top: none;
 	content: "\020";
@@ -222,19 +222,74 @@
 	margin-bottom: -0.625em !important;
 }
 
-.hentry #sharing_email .sharing_send,
-.hentry .sd-content ul li .option a.share-ustom,
-.hentry .sd-content ul li a.sd-button,
-.hentry .sd-content ul li.advanced a.share-more,
-.hentry .sd-content ul li.preview-item div.option.option-smart-off a,
-.hentry .sd-social-icon .sd-content ul li a.sd-button,
-.hentry .sd-social-icon-text .sd-content ul li a.sd-button,
-.hentry .sd-social-official .sd-content > ul > li .digg_button > a,
-.hentry .sd-social-official .sd-content > ul > li > a.sd-button,
-.hentry .sd-social-text .sd-content ul li a.sd-button {
+.entry #sharing_email .sharing_send,
+.entry .sd-content ul li .option a.share-ustom,
+.entry .sd-content ul li a.sd-button,
+.entry .sd-content ul li.advanced a.share-more,
+.entry .sd-content ul li.preview-item div.option.option-smart-off a,
+.entry .sd-social-icon .sd-content ul li a.sd-button,
+.entry .sd-social-icon-text .sd-content ul li a.sd-button,
+.entry .sd-social-official .sd-content > ul > li .digg_button > a,
+.entry .sd-social-official .sd-content > ul > li > a.sd-button,
+.entry .sd-social-text .sd-content ul li a.sd-button {
 	box-shadow: none;
 }
 
+/**
+ * Related Posts
+ */
+
+.entry #jp-relatedposts h3.jp-relatedposts-headline {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: 1.125em;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	line-height: 1.2;
+	margin-bottom: 0.5em;
+	margin-top: 0.5em;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.entry #jp-relatedposts h3.jp-relatedposts-headline:before {
+	background: #767676;
+	border-top: none;
+	content: "\020";
+	display: block;
+	height: 2px;
+	margin: 1rem 0;
+	width: 1em;
+	min-width: inherit;
+}
+
+.entry #jp-relatedposts h3.jp-relatedposts-headline em:before {
+	display: none;
+}
+
+.entry #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post {
+	opacity: 1;
+}
+
+.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: 1em;
+	letter-spacing: -0.02em;
+	line-height: 1.2;
+	margin-bottom: 0.5em;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title a {
+	font-weight: 700;
+}
+
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
+.entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: 0.71111em;
+	font-weight: 500;
+}
 
 /**
  * Stats


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Addresses typographic issues in #10585

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds fonts and fonts-sizes for Related Post module title, post-titles, and post meta based on theme design.
* Also replaces `.hentry` with `.entry` selectors to prevent unexpected theme overrides (theme now uses `.entry` and so should Jetpack).

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the related posts modules and make sure typography matches the latest version of the theme: https://github.com/WordPress/twentynineteen/

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix typography issues with Related Posts module
