### PR TITLE
Fix module layout issues with Twenty Nineteen theme

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -210,6 +210,15 @@
 
 
 /**
+ * Comments
+ */
+
+.comments-area .comments-title-wrap + .comment-respond .comment-reply-title {
+	display: none;
+}
+
+
+/**
  * Widgets
  */
 

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -305,21 +305,6 @@
 }
 
 /**
- * Shortcodes
- */
-.entry-content .jetpack-recipe,
-.entry-content .presentation-wrapper {
-	margin: 32px 1rem;
-}
-
-@media only screen and (min-width: 768px) {
-	.entry-content .jetpack-recipe,
-	.entry-content .presentation-wrapper {
-		margin: 32px calc(2 * (100vw / 12));
-	}
-}
-
-/**
  * Content Options
  */
 .twentynineteen-customizer .entry .entry-meta > span,

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -129,9 +129,16 @@
 	box-shadow: none;
 }
 
+
 /**
  * Related Posts
  */
+
+.entry #jp-relatedposts {
+	padding-top: 0;
+	margin-top: 32px;
+	margin-bottom: 32px;
+}
 
 .entry #jp-relatedposts h3.jp-relatedposts-headline {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -140,7 +147,6 @@
 	letter-spacing: -0.02em;
 	line-height: 1.2;
 	margin-bottom: 0.5em;
-	margin-top: 0.5em;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -189,7 +195,7 @@
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-size: 0.71111em;
+	font-size: 13px;
 	font-weight: 500;
 }
 

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -72,43 +72,6 @@
 }
 
 /**
- * Related Posts
- */
-
-.entry-content > #jp-relatedposts {
-	margin: 32px 1rem;
-	max-width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-	.entry-content > #jp-relatedposts {
-		margin: 32px calc(2 * (100vw / 12));
-		max-width: calc(8 * (100vw / 12));
-	}
-}
-
-@media only screen and (min-width: 1168px) {
-	.entry-content > #jp-relatedposts {
-		max-width: calc(6 * (100vw / 12));
-	}
-}
-
-/**
- * Akismet Comment Privacy Notice
- */
-
-.akismet_comment_form_privacy_notice {
-	margin: calc(2 * 1rem) 1rem;
-}
-
-@media only screen and (min-width: 768px) {
-	.akismet_comment_form_privacy_notice {
-		margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-		max-width: calc(6 * (100vw / 12));
-	}
-}
-
-/**
  * Sharing
  */
 

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -75,15 +75,8 @@
  * Sharing
  */
 
-.sharedaddy {
-}
-
 .sd-block {
 	line-height: 1;
-}
-
-.sd-like {
-	padding-bottom: 1.125em;
 }
 
 .entry div.sharedaddy h3.sd-title,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #10585
Fixes #10587

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- [x] Removes margin styles from Related Posts module, Recipe shortcodes and Presentation shortcodes.
- [x] Layout margin styles now come from the theme to prevent layout issues with other plugins. See: https://github.com/WordPress/twentynineteen/pull/502 and https://github.com/WordPress/twentynineteen/pull/534
- [x] Also remove margin styles from Akismet privacy notice since it also gets fixed by the theme here: https://github.com/WordPress/twentynineteen/pull/533

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the Recipe or Presentation shortcode with the latest version of Twenty Nineteen: https://github.com/WordPress/twentynineteen/
* Test the layout against the Akismet notice with the latest version of Twenty Nineteen: https://github.com/WordPress/twentynineteen/

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix layout issues in Jetpack modules and shortcodes for Twenty Nineteen theme
