### PR TITLE
Photon: Do not image_downsize for REST API requests in the edit context

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -473,34 +473,6 @@ class Jetpack_Photon {
 			return $image;
 		}
 
-		// Similar to the need to skip the admin, we should skip the REST API to avoid Photonizing images out of context.
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-			global $wp;
-			if ( false !== strpos( $wp->query_vars['rest_route'], '/wp/v2/media/' ) && ! empty( $_REQUEST['context'] ) && 'edit' === $_REQUEST['context'] && // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-				/**
-				 * Provide plugins a way of running Photon for images for the REST API (media endpoint).
-				 *
-				 * Note: enabling this will result in Photon URLs added to REST API responses in the edit context, which breaks Gutenberg, and possibly other REST API consumers.
-				 *
-				 * @module photon
-				 *
-				 * @since 6.7.1
-				 *
-				 * @param bool false Allow Photon to run on the REST API media endpoint. Default to false.
-				 * @param array $args {
-				 *     Array of image details.
-				 *
-				 *     @type array|bool  $image Image URL or false.
-				 *     @type int          $attachment_id Attachment ID of the image.
-				 *     @type array|string $size Image size. Can be a string (name of the image size, e.g. full) or an array of height and width.
-				 * }
-				 */
-				false === apply_filters( 'photon_restapi_allow_image_downsize', false, compact( 'image', 'attachment_id', 'size' ) )
-			) {
-				return $image;
-			}
-		}
-
 		/**
 		 * Provide plugins a way of preventing Photon from being applied to images retrieved from WordPress Core.
 		 *

--- a/class.photon.php
+++ b/class.photon.php
@@ -1053,7 +1053,7 @@ class Jetpack_Photon {
 	 */
 	public function should_rest_photon_image_downsize( $response, $handler, $request ) {
 		/** This filter is already documented in Core wp-includes/rest-api.php */
-		if ( ! is_a( $handler, apply_filters( 'wp_rest_server_class', 'WP_REST_Server' ) ) || ! is_a( $request , 'WP_REST_Request' ) ) {
+		if ( ! is_a( $request , 'WP_REST_Request' ) ) {
 			return $response; // Something odd is happening. Do nothing and return the response.
 		}
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -45,8 +45,9 @@ class Jetpack_Photon {
 	 * @return null
 	 */
 	private function setup() {
-		if ( ! function_exists( 'jetpack_photon_url' ) )
+		if ( ! function_exists( 'jetpack_photon_url' ) ) {
 			return;
+		}
 
 		// Images in post content and galleries
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );

--- a/class.photon.php
+++ b/class.photon.php
@@ -473,6 +473,34 @@ class Jetpack_Photon {
 			return $image;
 		}
 
+		// Similar to the need to skip the admin, we should skip the REST API to avoid Photonizing images out of context.
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			global $wp;
+			if ( false !== strpos( $wp->query_vars['rest_route'], '/wp/v2/media/' ) && ! empty( $_REQUEST['context'] ) && 'edit' === $_REQUEST['context'] && // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+				/**
+				 * Provide plugins a way of running Photon for images for the REST API (media endpoint).
+				 *
+				 * Note: enabling this will result in Photon URLs added to REST API responses in the edit context, which breaks Gutenberg, and possibly other REST API consumers.
+				 *
+				 * @module photon
+				 *
+				 * @since 6.7.1
+				 *
+				 * @param bool false Allow Photon to run on the REST API media endpoint. Default to false.
+				 * @param array $args {
+				 *     Array of image details.
+				 *
+				 *     @type array|bool  $image Image URL or false.
+				 *     @type int          $attachment_id Attachment ID of the image.
+				 *     @type array|string $size Image size. Can be a string (name of the image size, e.g. full) or an array of height and width.
+				 * }
+				 */
+				false === apply_filters( 'photon_restapi_allow_image_downsize', false, compact( 'image', 'attachment_id', 'size' ) )
+			) {
+				return $image;
+			}
+		}
+
 		/**
 		 * Provide plugins a way of preventing Photon from being applied to images retrieved from WordPress Core.
 		 *

--- a/class.photon.php
+++ b/class.photon.php
@@ -56,7 +56,7 @@ class Jetpack_Photon {
 
 		// Core image retrieval
 		add_filter( 'image_downsize', array( $this, 'filter_image_downsize' ), 10, 3 );
-		add_filter( 'rest_request_before_callbacks', array( $this, 'should_rest_photon_image_downsize', 10, 3 ) );
+		add_filter( 'rest_request_before_callbacks', array( $this, 'should_rest_photon_image_downsize' ), 10, 3 );
 
 
 		// Responsive image srcset substitution

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -13,6 +13,12 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	public function setUp() {
 		parent::setUp();
 
+		// The version of PHPUnit we're using on TravisCI doesn't support @requires
+		// Skip manually.
+		if ( version_compare( phpversion(), '5.3', '<' ) ) {
+			$this->markTestSkipped( 'Testing the Jetpack_Photon singleton requires PHP 5.3' );
+		}
+
 		// Preserving global variables
 		global $content_width;
 		$this->_globals['content_width'] = $content_width;
@@ -27,6 +33,11 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	}
 
 	public function tearDown() {
+		// ::tearDown runs even if the test is skipped.
+		if ( version_compare( phpversion(), '5.3', '<' ) ) {
+			return parent::tearDown();
+		}
+
 		// Restoring global variables
 		global $content_width;
 		$content_width = $this->_globals['content_width'];

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -11,12 +11,29 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		// Preserving global variables
 		global $content_width;
 		$this->_globals['content_width'] = $content_width;
+
+		// Setup the Photon filters.
+		// WP_UnitTestCase resets the action/filter state after
+		// every test:
+		// https://core.trac.wordpress.org/browser/trunk/tests/phpunit/includes/testcase.php?rev=43005#L273
+		// So we need to set these Photon filters for each test.
+		// see ::tearDown() ...
+		Jetpack_Photon::instance();
 	}
 
 	public function tearDown() {
 		// Restoring global variables
 		global $content_width;
 		$content_width = $this->_globals['content_width'];
+
+		// ... see ::setUp()
+		// Unfortunately Jetpack_Photon::instance() won't run Jetpack_Photon->setup()
+		// each time Jetpack_Photon::instance() is called, since it's gated by a
+		// static variable.
+		// l337 h4X0Ring required:
+		$instance = new ReflectionProperty( 'Jetpack_Photon', '__instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null );
 
 		parent::tearDown();
 	}
@@ -869,5 +886,60 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		return array(
 			'w' => '104'
 		);
+	}
+
+	/**
+	 * @group rest-api
+	 */
+	public function test_photon_cdn_in_rest_response_with_view_context() {
+		$test_image = $this->_get_image();
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/media/%d', $test_image ) );
+		$request->set_query_params( array( 'context' => 'view' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
+		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+
+		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
+	}
+
+	/**
+	 * @group rest-api
+	 */
+	public function test_photon_cdn_in_rest_response_with_edit_context() {
+		$test_image = $this->_get_image();
+
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/media/%d', $test_image ) );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
+		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+
+		$this->assertNotContains( '?', $data['media_details']['sizes']['full']['source_url'] );
+
+
+		// Subsequent ?context=view requests should still be Photonized
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/media/%d', $test_image ) );
+		$request->set_query_params( array( 'context' => 'view' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
+		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+
+		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
 	}
 }

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * The tests require PHP 5.3 :( The feature does not.
+ *
+ * @requires PHP 5.3
+ */
 class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	protected static $test_image;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #10580

#### Changes proposed in this Pull Request:
* Return out of image_downsize early for REST API edit context requests to media endpoints

#### Testing instructions:
* See issue above.

#### Proposed changelog entry for your changes:
* Improved compatibility for the image CDN with the new WordPress Block Editor.
