### PR TITLE
Jetpack blocks: Update bundle for Jetpack 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "6.8.0-beta.1",
+    "@automattic/jetpack-blocks": "6.8.0",
     "ansi-colors": "^1.0.1",
     "babel-core": "6.8.0",
     "babel-eslint": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "6.8.0",
+    "@automattic/jetpack-blocks": "10.0.0",
     "ansi-colors": "^1.0.1",
     "babel-core": "6.8.0",
     "babel-eslint": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "10.0.0",
+    "@automattic/jetpack-blocks": "10.1.0",
     "ansi-colors": "^1.0.1",
     "babel-core": "6.8.0",
     "babel-eslint": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,10 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@6.8.0-beta.1":
-  version "6.8.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-6.8.0-beta.1.tgz#36521e32da0c1a4f8c957dfe25db93c06de8b760"
+"@automattic/jetpack-blocks@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-10.0.0.tgz#ee347edbdfbe8cbe17babb18640ec7b08ac70bb0"
+  integrity sha512-2K8gM+UJiwaw3WhDqHGlW/mWwIMfgppvLl/RuCeXgCkYdBi6vXRUdNxOnc8kwvATsOAGds4u803rr842DQflPw==
 
 "@babel/parser@^7.0.0-beta.48":
   version "7.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,9 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-10.0.0.tgz#ee347edbdfbe8cbe17babb18640ec7b08ac70bb0"
-  integrity sha512-2K8gM+UJiwaw3WhDqHGlW/mWwIMfgppvLl/RuCeXgCkYdBi6vXRUdNxOnc8kwvATsOAGds4u803rr842DQflPw==
+"@automattic/jetpack-blocks@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-10.1.0.tgz#77ab35a7bdf0f3eb6e76d41f16d6f9bb2dec1b68"
 
 "@babel/parser@^7.0.0-beta.48":
   version "7.1.3"


### PR DESCRIPTION
Placeholder until package is published from <del> https://github.com/Automattic/wp-calypso/pull/28465 </del> <del> https://github.com/Automattic/wp-calypso/pull/28714 </del> https://github.com/Automattic/wp-calypso/pull/28746

- [x] package publish
- [x] run `yarn` to update `yarn.lock`

#### Changes proposed in this Pull Request:

* Bump to recently published Jetpack Blocks v10.0.0

#### Testing instructions:

* Confirm blocks are present and working
* Confirm beta blocks are present and working

#### Proposed changelog entry for your changes:

* None
