### PR TITLE
REST API: Add Field Controller

### DIFF
--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -138,8 +138,8 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 		$permission_check = $this->update_permission_check( $value, $object_data, $request );
 
 		if ( ! $permission_check ) {
-			/* translators: %s: get_permission_check() */
-			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must return either true or WP_Error." ), 'update_permission_check' ), 'Jetpack 6.8' );
+			/* translators: %s: update_permission_check() */
+			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must return either true or WP_Error.", 'jetpack' ), 'update_permission_check' ), 'Jetpack 6.8' );
 			return;
 		}
 
@@ -163,7 +163,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get_permission_check( $object_data, $request ) {
 		/* translators: %s: get_permission_check() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -175,7 +175,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get( $object_data, $request ) {
 		/* translators: %s: get() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -188,7 +188,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function update_permission_check( $value, $object_data, $request ) {
 		/* translators: %s: update_permission_check() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -201,7 +201,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function update( $value, $object_data, $request ) {
 		/* translators: %s: update() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -230,7 +230,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get_schema() {
 		/* translators: %s: get_schema() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_schema', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_schema', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -49,13 +49,11 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	/**
 	 * Ensures the response matches the schema and request context.
 	 *
-	 * You shouldn't have to extend this method.
-	 *
 	 * @param mixed $value
 	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
-	function prepare_for_response( $value, $request ) {
+	private function prepare_for_response( $value, $request ) {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$schema = $this->get_schema();
 
@@ -272,7 +270,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 * @param string $context REST API Request context
 	 * @return mixed Filtered $value
 	 */
-	final function filter_response_by_context( $value, $schema, $context ) {
+	final public function filter_response_by_context( $value, $schema, $context ) {
 		if ( ! $this->is_valid_for_context( $schema, $context ) ) {
 			// We use this intentionally odd looking WP_Error object
 			// internally only in this recursive function (see below

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -158,7 +158,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 * Permission Check for the field's getter. Must be implemented in the inheriting class.
 	 *
 	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
-	 * @param WP_REST_Request
+	 * @param WP_REST_Request $request
 	 * @return true|WP_Error
 	 */
 	public function get_permission_check( $object_data, $request ) {
@@ -170,7 +170,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 * The field's "raw" getter. Must be implemented in the inheriting class.
 	 *
 	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
-	 * @param WP_REST_Request
+	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
 	public function get( $object_data, $request ) {
@@ -183,7 +183,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 *
 	 * @param mixed $value The new value for the field.
 	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
-	 * @param WP_REST_Request
+	 * @param WP_REST_Request $request
 	 * @return true|WP_Error
 	 */
 	public function update_permission_check( $value, $object_data, $request ) {
@@ -196,7 +196,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 *
 	 * @param mixed $value The new value for the field.
 	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
-	 * @param WP_REST_Request
+	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
 	public function update( $value, $object_data, $request ) {

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -171,7 +171,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get_permission_check( $object_data, $request ) {
 		/* translators: %s: get_permission_check() */
-				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+		_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -183,7 +183,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get( $object_data, $request ) {
 		/* translators: %s: get() */
-				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+		_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -196,7 +196,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function update_permission_check( $value, $object_data, $request ) {
 		/* translators: %s: update_permission_check() */
-				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+		_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
@@ -209,7 +209,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function update( $value, $object_data, $request ) {
 		/* translators: %s: update() */
-				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+		_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -20,13 +20,13 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	public function __construct() {
 		if ( ! $this->object_type ) {
 			/* translators: %s: object_type */
-	                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$object_type', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'object_type' ), 'Jetpack 6.8' );
+			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$object_type', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'object_type' ), 'Jetpack 6.8' );
 			return;
 		}
 
 		if ( ! $this->field_name ) {
 			/* translators: %s: field_name */
-	                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$field_name', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'field_name' ), 'Jetpack 6.8' );
+			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$field_name', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'field_name' ), 'Jetpack 6.8' );
 			return;
 		}
 
@@ -38,24 +38,28 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function register_fields() {
 		foreach ( (array) $this->object_type as $object_type ) {
-			register_rest_field( $object_type, $this->field_name, array(
-				'get_callback' => array( $this, 'get_for_response' ),
-				'update_callback' => array( $this, 'update_from_request' ),
-				'schema' => $this->get_schema(),
-			) );
+			register_rest_field(
+				$object_type,
+				$this->field_name,
+				array(
+					'get_callback'    => array( $this, 'get_for_response' ),
+					'update_callback' => array( $this, 'update_from_request' ),
+					'schema'          => $this->get_schema(),
+				)
+			);
 		}
 	}
 
 	/**
 	 * Ensures the response matches the schema and request context.
 	 *
-	 * @param mixed $value
+	 * @param mixed           $value
 	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
 	private function prepare_for_response( $value, $request ) {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$schema = $this->get_schema();
+		$schema  = $this->get_schema();
 
 		$is_valid = rest_validate_value_from_schema( $value, $schema, $this->field_name );
 		if ( is_wp_error( $is_valid ) ) {
@@ -92,7 +96,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 			case 'boolean':
 				return false;
 			case 'null':
-			default :
+			default:
 				return null;
 		}
 	}
@@ -102,10 +106,10 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 *
 	 * This cannot be extended: implement `->get()` instead.
 	 *
-	 * @param mixed $object_data Probably an array. Whatever the endpoint returns.
-	 * @param string $field_name Should always match `->field_name`
+	 * @param mixed           $object_data Probably an array. Whatever the endpoint returns.
+	 * @param string          $field_name Should always match `->field_name`
 	 * @param WP_REST_Request $request
-	 * @param $object_type Should always match `->object_type`
+	 * @param string          $object_type Should always match `->object_type`
 	 * @return mixed
 	 */
 	final public function get_for_response( $object_data, $field_name, $request, $object_type ) {
@@ -131,11 +135,11 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 *
 	 * This cannot be extended: implement `->update()` instead.
 	 *
-	 * @param mixed $value The new value for the field.
-	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
-	 * @param string $field_name Should always match `->field_name`
+	 * @param mixed           $value The new value for the field.
+	 * @param mixed           $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param string          $field_name Should always match `->field_name`
 	 * @param WP_REST_Request $request
-	 * @param $object_type Should always match `->object_type`
+	 * @param string          $object_type Should always match `->object_type`
 	 * @return void|WP_Error
 	 */
 	final public function update_from_request( $value, $object_data, $field_name, $request, $object_type ) {
@@ -161,55 +165,56 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	/**
 	 * Permission Check for the field's getter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $object_data Whatever the endpoint would return for its response.
+	 * @param mixed           $object_data Whatever the endpoint would return for its response.
 	 * @param WP_REST_Request $request
 	 * @return true|WP_Error
 	 */
 	public function get_permission_check( $object_data, $request ) {
 		/* translators: %s: get_permission_check() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
 	 * The field's "raw" getter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $object_data Whatever the endpoint would return for its response.
+	 * @param mixed           $object_data Whatever the endpoint would return for its response.
 	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
 	public function get( $object_data, $request ) {
 		/* translators: %s: get() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
 	 * Permission Check for the field's setter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $value The new value for the field.
-	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param mixed           $value The new value for the field.
+	 * @param mixed           $object_data Probably a WordPress object (e.g., WP_Post)
 	 * @param WP_REST_Request $request
 	 * @return true|WP_Error
 	 */
 	public function update_permission_check( $value, $object_data, $request ) {
 		/* translators: %s: update_permission_check() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
 	 * The field's "raw" setter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $value The new value for the field.
-	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param mixed           $value The new value for the field.
+	 * @param mixed           $object_data Probably a WordPress object (e.g., WP_Post)
 	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */
 	public function update( $value, $object_data, $request ) {
 		/* translators: %s: update() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+				_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
 	 * The JSON Schema for the field
+	 *
 	 * @link https://json-schema.org/understanding-json-schema/
 	 * As of WordPress 5.0, Core currently understands:
 	 * * type
@@ -234,11 +239,11 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 */
 	public function get_schema() {
 		/* translators: %s: get_schema() */
-                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_schema', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
+		_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_schema', sprintf( __( "Method '%s' must be overridden.", 'jetpack' ), __METHOD__ ), 'Jetpack 6.8' );
 	}
 
 	/**
-	 * @param array $schema
+	 * @param array  $schema
 	 * @param string $context REST API Request context
 	 * @return bool
 	 */
@@ -265,8 +270,8 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	 *
 	 * This function handles that recursion.
 	 *
-	 * @param mixed $value
-	 * @param array $schema
+	 * @param mixed  $value
+	 * @param array  $schema
 	 * @param string $context REST API Request context
 	 * @return mixed Filtered $value
 	 */
@@ -294,7 +299,6 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 				}
 
 				// Recurse to prune sub-properties of each item.
-
 				$keys = array_keys( $value );
 
 				$items = array_map(
@@ -311,13 +315,13 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 				}
 
 				foreach ( $value as $field_name => $field_value ) {
-					if ( isset( $schema['properties'][$field_name] ) ) {
-						$field_value = $this->filter_response_by_context( $field_value, $schema['properties'][$field_name], $context );
+					if ( isset( $schema['properties'][ $field_name ] ) ) {
+						$field_value = $this->filter_response_by_context( $field_value, $schema['properties'][ $field_name ], $context );
 						if ( is_wp_error( $field_value ) && '__wrong-context__' === $field_value->get_error_code() ) {
-							unset( $value[$field_name] );
+							unset( $value[ $field_name ] );
 						} else {
 							// Respect recursion that pruned sub-properties of each property.
-							$value[$field_name] = $field_value;
+							$value[ $field_name ] = $field_value;
 						}
 					}
 				}

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -1,0 +1,326 @@
+<?php
+
+// @todo - nicer API for array values?
+
+/**
+ * `WP_REST_Controller` is basically a wrapper for `register_rest_route()`
+ * `WPCOM_REST_API_V2_Field_Controller` is a mostly-analogous wrapper for `register_rest_field()`
+ */
+abstract class WPCOM_REST_API_V2_Field_Controller {
+	/**
+	 * @var string|string[] $object_type The REST Object Type(s) to which the field should be added.
+	 */
+	protected $object_type;
+
+	/**
+	 * @var string $field_name The name of the REST API field to add.
+	 */
+	protected $field_name;
+
+	public function __construct() {
+		if ( ! $this->object_type ) {
+			/* translators: %s: object_type */
+	                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$object_type', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'object_type' ), 'Jetpack 6.8' );
+			return;
+		}
+
+		if ( ! $this->field_name ) {
+			/* translators: %s: field_name */
+	                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::$field_name', sprintf( __( "Property '%s' must be overridden.", 'jetpack' ), 'field_name' ), 'Jetpack 6.8' );
+			return;
+		}
+
+		add_action( 'rest_api_init', array( $this, 'register_fields' ) );
+	}
+
+	/**
+	 * Registers the field with the appropriate schema and callbacks.
+	 */
+	public function register_fields() {
+		foreach ( (array) $this->object_type as $object_type ) {
+			register_rest_field( $object_type, $this->field_name, array(
+				'get_callback' => array( $this, 'get_for_response' ),
+				'update_callback' => array( $this, 'update_from_request' ),
+				'schema' => $this->get_schema(),
+			) );
+		}
+	}
+
+	/**
+	 * Ensures the response matches the schema and request context.
+	 *
+	 * You shouldn't have to extend this method.
+	 *
+	 * @param mixed $value
+	 * @param WP_REST_Request $request
+	 * @return mixed
+	 */
+	function prepare_for_response( $value, $request ) {
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$schema = $this->get_schema();
+
+		$is_valid = rest_validate_value_from_schema( $value, $schema, $this->field_name );
+		if ( is_wp_error( $is_valid ) ) {
+			return $is_valid;
+		}
+
+		return $this->filter_response_by_context( $value, $schema, $context );
+	}
+
+	/**
+	 * Returns the schema's default value
+	 *
+	 * If there is no default, returns the type's falsey value.
+	 *
+	 * @param array $schema
+	 * @return mixed
+	 */
+	final public function get_default_value( $schema ) {
+		if ( isset( $schema['default'] ) ) {
+			return $schema['default'];
+		}
+
+		// If you have something more complicated, use $schema['default'];
+		switch ( isset( $schema['type'] ) ? $schema['type'] : 'null' ) {
+			case 'string' :
+				return '';
+			case 'integer' :
+			case 'number' :
+				return 0;
+			case 'object' :
+				return (object) array();
+			case 'array' :
+				return array();
+			case 'boolean' :
+				return false;
+			case 'null' :
+			default :
+				return null;
+		}
+	}
+
+	/**
+	 * The field's wrapped getter. Does permission checks and output preparation.
+	 *
+	 * This cannot be extended: implement `->get()` instead.
+	 *
+	 * @param mixed $object_data Probably an array. Whatever the endpoint returns.
+	 * @param string $field_name Should always match `->field_name`
+	 * @param WP_REST_Request $request
+	 * @param $object_type Should always match `->object_type`
+	 * @return mixed
+	 */
+	final public function get_for_response( $object_data, $field_name, $request, $object_type ) {
+		$permission_check = $this->get_permission_check( $object_data, $request );
+
+		if ( ! $permission_check || is_wp_error( $permission_check ) ) {
+			return $this->get_default_value( $this->get_schema() );
+		}
+
+		$value = $this->get( $object_data, $request );
+
+		return $this->prepare_for_response( $value, $request );
+	}
+
+	/**
+	 * The field's wrapped setter. Does permission checks.
+	 *
+	 * This cannot be extended: implement `->update()` instead.
+	 *
+	 * @param mixed $value The new value for the field.
+	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param string $field_name Should always match `->field_name`
+	 * @param WP_REST_Request $request
+	 * @param $object_type Should always match `->object_type`
+	 * @return void|WP_Error
+	 */
+	final public function update_from_request( $value, $object_data, $field_name, $request, $object_type ) {
+		$permission_check = $this->update_permission_check( $value, $object_data, $request );
+
+		if ( ! $permission_check ) {
+			/* translators: %s: get_permission_check() */
+			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must return either true or WP_Error." ), 'update_permission_check' ), 'Jetpack 6.8' );
+			return;
+		}
+
+		if ( is_wp_error( $permission_check ) ) {
+			return $permission_check;
+		}
+
+		$updated = $this->update( $value, $object_data, $request );
+
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+	}
+
+	/**
+	 * Permission Check for the field's getter. Must be implemented in the inheriting class.
+	 *
+	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
+	 * @param WP_REST_Request
+	 * @return true|WP_Error
+	 */
+	public function get_permission_check( $object_data, $request ) {
+		/* translators: %s: get_permission_check() */
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+	}
+
+	/**
+	 * The field's "raw" getter. Must be implemented in the inheriting class.
+	 *
+	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
+	 * @param WP_REST_Request
+	 * @return mixed
+	 */
+	public function get( $object_data, $request ) {
+		/* translators: %s: get() */
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+	}
+
+	/**
+	 * Permission Check for the field's setter. Must be implemented in the inheriting class.
+	 *
+	 * @param mixed $value The new value for the field.
+	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param WP_REST_Request
+	 * @return true|WP_Error
+	 */
+	public function update_permission_check( $value, $object_data, $request ) {
+		/* translators: %s: update_permission_check() */
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+	}
+
+	/**
+	 * The field's "raw" setter. Must be implemented in the inheriting class.
+	 *
+	 * @param mixed $value The new value for the field.
+	 * @param mixed $object_data Probably a WordPress object (e.g., WP_Post)
+	 * @param WP_REST_Request
+	 * @return mixed
+	 */
+	public function update( $value, $object_data, $request ) {
+		/* translators: %s: update() */
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+	}
+
+	/**
+	 * The JSON Schema for the field
+	 * @link https://json-schema.org/understanding-json-schema/
+	 * As of WordPress 5.0, Core currently understands:
+	 * * type
+	 *   * string - not minLength, not maxLength, not pattern
+	 *   * integer - minimum, maximum, exclusiveMinimum, exclusiveMaximum, not multipleOf
+	 *   * number  - minimum, maximum, exclusiveMinimum, exclusiveMaximum, not multipleOf
+	 *   * boolean
+	 *   * null
+	 *   * object - properties, additionalProperties, not propertyNames, not dependencies, not patternProperties, not required
+	 *   * array: only lists, not tuples - items, not minItems, not maxItems, not uniqueItems, not contains
+	 * * enum
+	 * * format
+	 *   * date-time
+	 *   * email
+	 *   * ip
+	 *   * uri
+	 * As of WordPress 5.0, Core does not support:
+	 * * Multiple type: `type: [ 'string', 'integer' ]`
+	 * * $ref, allOf, anyOf, oneOf, not, const
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		/* translators: %s: get_schema() */
+                _doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_schema', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'Jetpack 6.8' );
+	}
+
+	/**
+	 * @param array $schema
+	 * @param string $context REST API Request context
+	 * @return bool
+	 */
+	private function is_valid_for_context( $schema, $context ) {
+		return empty( $schema['context'] ) || in_array( $context, $schema['context'], true );
+	}
+
+	/**
+	 * Removes properties that should not appear in the current
+	 * request's context
+	 *
+	 * $context is a Core REST API Framework request attribute that is
+	 * always one of:
+	 * * view (what you see on the blog)
+	 * * edit (what you see in an editor)
+	 * * embed (what you see in, e.g., an oembed)
+	 *
+	 * Fields (and sub-fields, and sub-sub-...) can be flagged for a
+	 * set of specific contexts via the field's schema.
+	 *
+	 * The Core API will filter out top-level fields with the wrong
+	 * context, but will not recurse deeply enough into arrays/objects
+	 * to remove all levels of sub-fields with the wrong context.
+	 *
+	 * This function handles that recursion.
+	 *
+	 * @param mixed $value
+	 * @param array $schema
+	 * @param string $context REST API Request context
+	 * @return mixed Filtered $value
+	 */
+	final function filter_response_by_context( $value, $schema, $context ) {
+		if ( ! $this->is_valid_for_context( $schema, $context ) ) {
+			// We use this intentionally odd looking WP_Error object
+			// internally only in this recursive function (see below
+			// in the `object` case). It will never be output by the REST API.
+			// If we return this for the top level object, Core
+			// correctly remove the top level object from the response
+			// for us.
+			return new WP_Error( '__wrong-context__' );
+		}
+
+		switch ( $schema['type'] ) {
+			case 'array' :
+				if ( ! isset( $schema['items'] ) ) {
+					return $value;
+				}
+
+				// Shortcircuit if we know none of the items are valid for this context.
+				// This would only happen in a strangely written schema.
+				if ( ! $this->is_valid_for_context( $schema['items'], $context ) ) {
+					return array();
+				}
+
+				// Recurse to prune sub-properties of each item.
+
+				$keys = array_keys( $value );
+
+				$items = array_map(
+					array( $this, 'filter_response_by_context' ),
+					$value,
+					array_fill( 0, count( $keys ), $schema['items'] ),
+					array_fill( 0, count( $keys ), $context )
+				);
+
+				return array_combine( $keys, $items );
+			case 'object' :
+				if ( ! isset( $schema['properties'] ) ) {
+					return $value;
+				}
+
+				foreach ( $value as $field_name => $field_value ) {
+					if ( isset( $schema['properties'][$field_name] ) ) {
+						$field_value = $this->filter_response_by_context( $field_value, $schema['properties'][$field_name], $context );
+						if ( is_wp_error( $field_value ) && '__wrong-context__' === $field_value->get_error_code() ) {
+							unset( $value[$field_name] );
+						} else {
+							// Respect recursion that pruned sub-properties of each property.
+							$value[$field_name] = $field_value;
+						}
+					}
+				}
+
+				return (object) $value;
+		}
+
+		return $value;
+	}
+}

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -148,7 +148,8 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 		if ( ! $permission_check ) {
 			/* translators: %s: update_permission_check() */
 			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::update_permission_check', sprintf( __( "Method '%s' must return either true or WP_Error.", 'jetpack' ), 'update_permission_check' ), 'Jetpack 6.8' );
-			return;
+			/* translators: %s: the name of an API response field */
+			return new WP_Error( 'invalid_user_permission', sprintf( __( "You are not allowed to access the '%s' field.", 'jetpack' ), $this->field_name ) );
 		}
 
 		if ( is_wp_error( $permission_check ) ) {

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -113,7 +113,13 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	final public function get_for_response( $object_data, $field_name, $request, $object_type ) {
 		$permission_check = $this->get_permission_check( $object_data, $request );
 
-		if ( ! $permission_check || is_wp_error( $permission_check ) ) {
+		if ( ! $permission_check ) {
+			/* translators: %s: get_permission_check() */
+			_doing_it_wrong( 'WPCOM_REST_API_V2_Field_Controller::get_permission_check', sprintf( __( "Method '%s' must return either true or WP_Error.", 'jetpack' ), 'get_permission_check' ), 'Jetpack 6.8' );
+			return $this->get_default_value( $this->get_schema() );
+		}
+
+		if ( is_wp_error( $permission_check ) ) {
 			return $this->get_default_value( $this->get_schema() );
 		}
 

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -163,7 +163,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	/**
 	 * Permission Check for the field's getter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
+	 * @param mixed $object_data Whatever the endpoint would return for its response.
 	 * @param WP_REST_Request $request
 	 * @return true|WP_Error
 	 */
@@ -175,7 +175,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 	/**
 	 * The field's "raw" getter. Must be implemented in the inheriting class.
 	 *
-	 * @param mixed $object_data Whatever the endpoint would returnn for its response.
+	 * @param mixed $object_data Whatever the endpoint would return for its response.
 	 * @param WP_REST_Request $request
 	 * @return mixed
 	 */

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -82,18 +82,18 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 
 		// If you have something more complicated, use $schema['default'];
 		switch ( isset( $schema['type'] ) ? $schema['type'] : 'null' ) {
-			case 'string' :
+			case 'string':
 				return '';
-			case 'integer' :
-			case 'number' :
+			case 'integer':
+			case 'number':
 				return 0;
-			case 'object' :
+			case 'object':
 				return (object) array();
-			case 'array' :
+			case 'array':
 				return array();
-			case 'boolean' :
+			case 'boolean':
 				return false;
-			case 'null' :
+			case 'null':
 			default :
 				return null;
 		}
@@ -278,7 +278,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 		}
 
 		switch ( $schema['type'] ) {
-			case 'array' :
+			case 'array':
 				if ( ! isset( $schema['items'] ) ) {
 					return $value;
 				}
@@ -301,7 +301,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 				);
 
 				return array_combine( $keys, $items );
-			case 'object' :
+			case 'object':
 				if ( ! isset( $schema['properties'] ) ) {
 					return $value;
 				}

--- a/_inc/lib/core-api/load-wpcom-endpoints.php
+++ b/_inc/lib/core-api/load-wpcom-endpoints.php
@@ -33,5 +33,8 @@ function wpcom_rest_api_v2_load_plugin( $class_name ) {
 	}
 }
 
+require dirname( __FILE__ ) . '/class-wpcom-rest-field-controller.php';
+
 // Now load the endpoint files.
 wpcom_rest_api_v2_load_plugin_files( 'wpcom-endpoints/*.php' );
+wpcom_rest_api_v2_load_plugin_files( 'wpcom-fields/*.php' );

--- a/tests/php/core-api/test_class-wpcom-rest-field-controller.php
+++ b/tests/php/core-api/test_class-wpcom-rest-field-controller.php
@@ -1,0 +1,305 @@
+<?php
+
+class Example_WPCOM_REST_API_V2_Field_Controller extends WPCOM_REST_API_V2_Field_Controller {
+	protected $object_type = 'example';
+	protected $field_name = 'example';
+
+	private $test_schema = array();
+
+	public function __construct( $test_schema ) {
+		$this->test_schema = $test_schema;
+
+		parent::__construct();
+	}
+
+	public function get_schema() {
+		return $this->test_schema;
+	}
+
+	public function get_permission_check( $object_data, $request  ) {
+		return new WP_Error( 'nope' );
+	}
+}
+
+/**
+ * @group rest-api
+ */
+class Test_WPCOM_REST_API_V2_Field_Controller extends WP_UnitTestCase {
+	public function provide_type_defaults() {
+		return array(
+			'string'  => array( 'string',  '' ),
+			'integer' => array( 'integer', 0 ),
+			'number'  => array( 'number',  0 ),
+			'array'   => array( 'array',   array() ),
+//			'object'  => [sic] handled separately
+			'boolean' => array( 'boolean', false ),
+			'null'    => array( 'null',    null ),
+		);
+	}
+
+	public function test_default_value_provided_by_schema() {
+		$schema = array(
+			'default' => 'hello',
+		);
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->get_default_value( $schema );
+
+		$this->assertSame( 'hello', $actual );
+	}
+
+	/**
+	 * @dataProvider provide_type_defaults()
+	 */
+	public function test_default_value_guessed_from_type( $type, $expected ) {
+		$schema = array(
+			'type' => $type,
+		);
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->get_default_value( $schema );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_default_value_guessed_from_object_type() {
+		$schema = array(
+			'type' => 'object',
+		);
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->get_default_value( $schema );
+
+		$this->assertInternalType( 'object', $actual );
+		$this->assertEquals( new stdClass, $actual );
+	}
+
+	public function test_get_for_response_returns_default_value_for_users_without_permission() {
+		$schema = array(
+			'default' => 'hello',
+		);
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+		$actual = $controller->get_for_response( 1, 2, 3, 4 );
+
+		$this->assertSame( 'hello', $actual );
+	}
+
+	public function test_filter_response_by_context_for_scalar_with_correct_context() {
+		$value = 1;
+		$schema = array(
+			'type' => 'integer',
+			'context' => array( 'edit' ),
+		);
+		$context = 'edit';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		$this->assertSame( $value, $actual );
+	}
+
+	public function test_filter_response_by_context_for_scalar_with_incorrect_context() {
+		$value = 1;
+		$schema = array(
+			'type' => 'integer',
+			'context' => array( 'edit' ),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		// We expect a root object with incorrect context to return a WP_Error.
+		// The Core REST API will remove root objects with an incorrect context,
+		// so this WP_Error is never seen.
+		$this->assertInstanceOf( 'WP_Error', $actual );
+		$this->assertSame( '__wrong-context__', $actual->get_error_code() );
+	}
+
+	public function test_filter_response_by_context_for_array_of_scalars_with_correct_context() {
+		$value = array( 1, 2 );
+		$schema = array(
+			'type' => 'array',
+			'items' => array(
+				'type' => 'integer',
+				'context' => array( 'edit' ),
+			),
+		);
+		$context = 'edit';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		$this->assertSame( $value, $actual );
+	}
+
+	public function test_filter_response_by_context_for_array_of_scalars_with_incorrect_context() {
+		$value = array( 1, 2 );
+		$schema = array(
+			'type' => 'array',
+			'items' => array(
+				'type' => 'integer',
+				'context' => array( 'edit' ),
+			),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		$this->assertSame( array(), $actual );
+	}
+
+	public function test_filter_response_by_context_for_array_with_incorrect_context() {
+		$value = array( 1, 2 );
+		$schema = array(
+			'type' => 'array',
+			// This is a weird schema - don't do this in real life :)
+			// In real life: the array doesn't need a context - the items schema does.
+			'context' => array( 'edit' ),
+			'items' => array(
+				'type' => 'integer',
+				'context' => array( 'view' ),
+			),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		// We expect a root object with incorrect context to return a WP_Error.
+		// The Core REST API will remove root objects with an incorrect context,
+		// so this WP_Error is never seen.
+		$this->assertInstanceOf( 'WP_Error', $actual );
+		$this->assertSame( '__wrong-context__', $actual->get_error_code() );
+	}
+
+	public function test_filter_response_by_context_for_array_of_arrays_with_correct_context() {
+		$value = array( array( 1 ), array( 2 ) );
+		$schema = array(
+			'type' => 'array',
+			'items' => array(
+				'type' => 'object',
+				// no context - array values should go through
+				'items' => array(
+					'type' => 'integer',
+					// matching context - array values should go through
+					'context' => array( 'edit' ),
+				),
+			),
+		);
+		$context = 'edit';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		$this->assertSame( $value, $actual );
+	}
+
+	public function test_filter_response_by_context_for_array_of_arrays_with_incorrect_context() {
+		$value = array( array( 1 ), array( 2 ) );
+		$schema = array(
+			'type' => 'array',
+			'items' => array(
+				'type' => 'array',
+				// no context - array values should go through
+				'items' => array(
+					'type' => 'integer',
+					// no matching context - array values should be filtered out
+					'context' => array( 'edit' ),
+				),
+			),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		$this->assertSame( array( array(), array() ), $actual );
+	}
+
+	public function test_filter_response_by_context_for_object() {
+		$value = array( 'one' => 1, 'two' => 2 );
+		$schema = array(
+			'type' => 'object',
+			// no context - should go through
+			'properties' => array(
+				'one' => array(
+					'type' => 'integer',
+					// matching context - should go through
+					'context' => array( 'view', 'edit' ),
+				),
+				'two' => array(
+					'type' => 'integer',
+					// no matching context - should be filtered out
+					'context' => array( 'edit' ),
+				),
+			),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		// ->filter_response_by_context() casts to (object)
+		$this->assertInternalType( 'object', $actual );
+
+		$this->assertEquals( (object) array( 'one' => 1 ), $actual );
+	}
+
+	public function test_filter_response_by_context_for_object_of_objects() {
+		$value = array( 'one' => array( 'example' => 1 ), 'two' => array( 'another_example' => 2 ) );
+		$schema = array(
+			'type' => 'object',
+			'properties' => array(
+				'one' => array(
+					'type' => 'object',
+					// no context - should go through
+					'properties' => array(
+						'example' => array(
+							'type' => 'integer',
+							// matching context - should go through
+							'context' => array( 'view', 'edit' ),
+						)
+					)
+				),
+				'two' => array(
+					'type' => 'object',
+					// no context - should go through
+					'properties' => array(
+						'another_example' => array(
+							'type' => 'integer',
+							// no matching context - should be filtered out
+							'context' => array( 'edit' ),
+						)
+					)
+				),
+			),
+		);
+		$context = 'view';
+
+		$controller = new Example_WPCOM_REST_API_V2_Field_Controller( $schema );
+
+		$actual = $controller->filter_response_by_context( $value, $schema, $context );
+
+		// ->filter_response_by_context() casts to (object)
+		$this->assertInternalType( 'object', $actual );
+
+		$this->assertEquals( (object) array(
+			'one' => (object) array( 'example' => 1 ),
+			'two' => (object) array(),
+		), $actual );
+	}
+}


### PR DESCRIPTION
Just as `WP_REST_Controller` is mostly just a fancy wrapper for
`register_rest_route()`, `WPCOM_REST_API_V2_Field_Controller` is a wrapper
for `register_rest_field()`.

#### Changes proposed in this Pull Request:

The new class handles a few conveniences:

* Returning the correct things (errors, default values, etc.) for
  permission check errors.
* Ensuring output is always correctly typecast.
* `?context=...` filtering for nested structures, which core does not
  handle correctly.

#### Testing instructions:
`yarn docker:phpunit --group rest-api`

#### Proposed changelog entry for your changes:

None required.