### PR TITLE
Update is_vip() to return the value of the WPCOM_IS_VIP_ENV constant or false

### DIFF
--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -97,7 +97,7 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 	}
 
 	function is_vip() {
-		return false; // this may change for VIP Go sites, which sync using Jetpack
+		return defined( 'WPCOM_IS_VIP_ENV' ) ? (bool) WPCOM_IS_VIP_ENV : false;
 	}
 
 	function featured_images_enabled() {

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -97,7 +97,7 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 	}
 
 	function is_vip() {
-		return defined( 'WPCOM_IS_VIP_ENV' ) ? (bool) WPCOM_IS_VIP_ENV : false;
+		return defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV;
 	}
 
 	function featured_images_enabled() {


### PR DESCRIPTION
Previously, the `is_vip()` method in `Abstract_Jetpack_Site` returned `false` without checking anything. This was causing VIP Go sites to not be caught by the [new sites filter](https://github.com/Automattic/wp-calypso/pull/28434) in Calypso's Gutenberg route. See D20666-code for more details.

`wpcom_is_vip()` is deprecated on VIP Go and the `WPCOM_IS_VIP_ENV` constant is now the recommended way of checking if the if the current site is VIP.

<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Makes the `is_vip()` method on `Abstract_Jetpack_Site` return the value of the `WPCOM_IS_VIP_ENV` constant if it exists, otherwise `false`.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm unsure of testing steps because I think the `is_vip()` function is rarely used in Jetpack. This change is mainly to keep this function in step with WordPress.com.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None required.