### PR TITLE
Protect: jpp_math_pass cookie and transient after generate_math_page form submit

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -60,6 +60,12 @@ class Jetpack_Protect_Module {
 		// This is a backup in case $pagenow fails for some reason
 		add_action( 'login_form', array ( $this, 'check_login_ability' ), 1 );
 
+		// Load math fallback after math page form submission
+		if ( isset( $_POST[ 'jetpack_protect_process_math_form' ] ) ) {
+			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
+			new Jetpack_Protect_Math_Authenticate;
+		}
+
 		// Runs a script every day to clean up expired transients so they don't
 		// clog up our users' databases
 		require_once( JETPACK__PLUGIN_DIR . '/modules/protect/transient-cleanup.php' );

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -31,11 +31,6 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		 * @throws Error message if the math is wrong
 		 */
 		static function math_authenticate() {
-			$salt        = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
-			$ans         = isset( $_POST['jetpack_protect_num'] ) ? (int) $_POST['jetpack_protect_num'] : '' ;
-			$salted_ans  = sha1( $salt . $ans );
-			$correct_ans = isset( $_POST[ 'jetpack_protect_answer' ] ) ? $_POST[ 'jetpack_protect_answer' ] : '' ;
-
 			if( isset( $_COOKIE[ 'jpp_math_pass' ] ) ) {
 				$jetpack_protect = Jetpack_Protect_Module::instance();
 				$transient = $jetpack_protect->get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
@@ -46,7 +41,12 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				return true;
 			}
 
-			if ( ! $correct_ans || !$_POST['jetpack_protect_num'] ) {
+			$salt        = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
+			$ans         = isset( $_POST['jetpack_protect_num'] ) ? (int) $_POST['jetpack_protect_num'] : '' ;
+			$salted_ans  = sha1( $salt . $ans );
+			$correct_ans = isset( $_POST[ 'jetpack_protect_answer' ] ) ? $_POST[ 'jetpack_protect_answer' ] : '' ;
+
+			if ( ! $correct_ans || ! $ans ) {
 				Jetpack_Protect_Math_Authenticate::generate_math_page();
 			} elseif ( $salted_ans != $correct_ans ) {
 				wp_die(
@@ -65,11 +65,6 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		 * @return none, execution stopped
 		 */
 		static function generate_math_page( $error = false ) {
-			$salt = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
-			$num1 = rand( 0, 10 );
-			$num2 = rand( 1, 10 );
-			$sum  = $num1 + $num2;
-			$ans  = sha1( $salt . $sum );
 			ob_start();
 			?>
 			<h2><?php _e( 'Please solve this math problem to prove that you are not a bot.  Once you solve it, you will need to log in again.', 'jetpack' ); ?></h2>
@@ -94,9 +89,9 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 
 		public function process_generate_math_page() {
 			$salt        = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
-			$ans         = (int)$_POST['jetpack_protect_num'];
+			$ans         = isset( $_POST['jetpack_protect_num'] ) ? (int)$_POST['jetpack_protect_num'] : '';
 			$salted_ans  = sha1( $salt . $ans );
-			$correct_ans = $_POST[ 'jetpack_protect_answer' ];
+			$correct_ans = isset( $_POST[ 'jetpack_protect_answer' ] ) ? $_POST[ 'jetpack_protect_answer' ] : '' ;
 
 			if ( $salted_ans != $correct_ans ) {
 				Jetpack_Protect_Math_Authenticate::generate_math_page(true);
@@ -106,6 +101,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				$jetpack_protect = Jetpack_Protect_Module::instance();
 				$jetpack_protect->set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
 				setcookie('jpp_math_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
+				remove_action( 'login_form', array( $this, 'math_form' ) );
 				return true;
 			}
 		}
@@ -116,6 +112,14 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		 * @return VOID outputs html
 		 */
 		static function math_form() {
+			// Check if jpp_math_pass cookie is set and it matches valid transient
+			if( isset( $_COOKIE[ 'jpp_math_pass' ] ) ) {
+				$transient = Jetpack_Protect_Module::get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+				if( $transient && $transient > 0 ) {
+					return '';
+				}
+			}
+
 			$salt = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
 			$num1 = rand( 0, 10 );
 			$num2 = rand( 1, 10 );

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -114,7 +114,9 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		static function math_form() {
 			// Check if jpp_math_pass cookie is set and it matches valid transient
 			if( isset( $_COOKIE[ 'jpp_math_pass' ] ) ) {
-				$transient = Jetpack_Protect_Module::get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+				$jetpack_protect = Jetpack_Protect_Module::instance();
+				$transient = $jetpack_protect->get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+
 				if( $transient && $transient > 0 ) {
 					return '';
 				}


### PR DESCRIPTION
Fixes #5646 manual "rebase" of earlier pull request with same number.

#### Changes proposed in this Pull Request:

protect.php + math-fallback.php

Load math fallback after math page form submission to run Jetpack_Protect_Math_Authenticate::process_generate_math_page()

Add a check if jpp_math_pass cookie is set and it matches valid transient to check_login_ability()

Remove some redundant lines

#### Testing instructions:

Edit protect.php if ( $use_math ) { to if ( true ) { to force the use of the math fallback
Visit login.php in an anonymous browser window (or at least log out and delete jpp_math_pass cookie) and see that there is a math puzzle there
Fill out username and password but leave math puzzle empty, then submit
This will bring up the stand-alone math fallback page
Fill in wrong answer and submit > stand-alone math page again with extra message about answer being wrong. Before fix, this used to be a cold redirect back to the login.php form.
Fill in right answer and submit > redirect back to login.php without math puzzle. Before fix, this used to be login.php with (again) a math puzzle.
At step 6 after correct answer, there is now a cookie jpp_math_pass set as intended, making the second puzzle on the login.php disappear. The old "cold redirect" to login.php after step 5 is fixed by the extra check in Jetpack_Protect_Module constructor.

#### Proposed changelog entry for your changes:

Fix math fallback page flow logic.
