### PR TITLE
Publicize: Add REST API Take 3

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -3,7 +3,7 @@
 require_once dirname( __FILE__ ) . '/publicize-connections.php';
 
 /**
- * Publicize: List Conection Test Result Data
+ * Publicize: List Connection Test Result Data
  *
  * All the same data as the Publicize Connections Endpoint, plus test results.
  *

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -21,46 +21,51 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 	 * Called automatically on `rest_api_init()`.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permission_check' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
 	 * Adds the test results properties to the Connection schema.
+	 *
 	 * @return array
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title' => 'jetpack-publicize-connection-test-results',
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-publicize-connection-test-results',
+			'type'       => 'object',
 			'properties' => $this->get_connection_schema_properties() + array(
 				'test_success' => array(
 					'description' => __( 'Did the Publicize Connection test pass?', 'jetpack' ),
-					'type' => 'boolean'
+					'type'        => 'boolean',
 				),
 				'test_message' => array(
 					'description' => __( 'Publicize Connection success or error message', 'jetpack' ),
-					'type' => 'string',
+					'type'        => 'string',
 				),
-				'can_refresh' => array(
+				'can_refresh'  => array(
 					'description' => __( 'Can the current user refresh the Publicize Connection?', 'jetpack' ),
-					'type' => 'boolean',
+					'type'        => 'boolean',
 				),
 				'refresh_text' => array(
 					'description' => __( 'Message instructing the user to refresh their Connection to the Publicize Service', 'jetpack' ),
-					'type' => 'string',
+					'type'        => 'string',
 				),
-				'refresh_url' => array(
+				'refresh_url'  => array(
 					'description' => __( 'URL for refreshing the Connection to the Publicize Service', 'jetpack' ),
-					'type' => 'string',
-					'format' => 'uri',
+					'type'        => 'string',
+					'format'      => 'uri',
 				),
 			),
 		);
@@ -78,10 +83,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 
 		$items = $this->get_connections();
 
-		$test_results = $publicize->get_publicize_conns_test_results();
+		$test_results              = $publicize->get_publicize_conns_test_results();
 		$test_results_by_unique_id = array();
 		foreach ( $test_results as $test_result ) {
-			$test_results_by_unique_id[$test_result['unique_id']] = $test_result;
+			$test_results_by_unique_id[ $test_result['unique_id'] ] = $test_result;
 		}
 
 		$mapping = array(
@@ -93,10 +98,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 		);
 
 		foreach ( $items as &$item ) {
-			$test_result = $test_results_by_unique_id[$item['id']];
+			$test_result = $test_results_by_unique_id[ $item['id'] ];
 
 			foreach ( $mapping as $field => $test_result_field ) {
-				$item[$field] = $test_result[$test_result_field];
+				$item[ $field ] = $test_result[ $test_result_field ];
 			}
 		}
 

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -33,6 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 
 	/**
 	 * Adds the test results properties to the Connection schema.
+	 * @return array
 	 */
 	public function get_item_schema() {
 		$schema = array(

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/publicize-connections.php';
+
+/**
+ * Publicize: List Conection Test Result Data
+ *
+ * All the same data as the Publicize Connections Endpoint, plus test results.
+ *
+ * @since 6.8
+ */
+class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections {
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'publicize/connection-test-results';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permission_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Adds the test results properties to the Connection schema.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title' => 'jetpack-publicize-connection-test-results',
+			'type' => 'object',
+			'properties' => $this->get_connection_schema_properties() + array(
+				'test_success' => array(
+					'description' => __( 'Did the Publicize Connection test pass?', 'jetpack' ),
+					'type' => 'boolean'
+				),
+				'test_message' => array(
+					'description' => __( 'Publicize Connection success or error message', 'jetpack' ),
+					'type' => 'string',
+				),
+				'can_refresh' => array(
+					'description' => __( 'Can the current user refresh the Publicize Connection?', 'jetpack' ),
+					'type' => 'boolean',
+				),
+				'refresh_text' => array(
+					'description' => __( 'Message instructing the user to refresh their Connection to the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+				),
+				'refresh_url' => array(
+					'description' => __( 'URL for refreshing the Connection to the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+					'format' => 'uri',
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * @param WP_REST_Request
+	 * @see Publicize::get_publicize_conns_test_results()
+	 * @return WP_REST_Response suitable for 1-page collection
+	 */
+	public function get_items( $request ) {
+		global $publicize;
+
+		$items = $this->get_connections();
+
+		$test_results = $publicize->get_publicize_conns_test_results();
+		$test_results_by_unique_id = array();
+		foreach ( $test_results as $test_result ) {
+			$test_results_by_unique_id[$test_result['unique_id']] = $test_result;
+		}
+
+		$mapping = array(
+			'test_success' => 'connectionTestPassed',
+			'test_message' => 'connectionTestMessage',
+			'can_refresh'  => 'userCanRefresh',
+			'refresh_text' => 'refreshText',
+			'refresh_url'  => 'refreshURL',
+		);
+
+		foreach ( $items as &$item ) {
+			$test_result = $test_results_by_unique_id[$item['id']];
+
+			foreach ( $mapping as $field => $test_result_field ) {
+				$item[$field] = $test_result[$test_result_field];
+			}
+		}
+
+		$response = rest_ensure_response( $items );
+
+		$response->header( 'X-WP-Total', count( $items ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results' );

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -139,6 +139,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 * @return array filtered $connection
 	 */
 	public function prepare_item_for_response( $connection, $request ) {
+		if ( ! is_callable( array( $this, 'get_fields_for_response' ) ) ) {
+			return $connection;
+		}
+
 		$fields = $this->get_fields_for_response( $request );
 
 		$response_data = array();

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -41,6 +41,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 * Connection Test Result endpoint.
 	 *
 	 * @internal
+	 * @return array
 	 */
 	protected function get_connection_schema_properties() {
 		return array(
@@ -63,6 +64,9 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 		);
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_item_schema() {
 		$schema = array(
 			'$schema' => 'http://json-schema.org/draft-04/schema#',
@@ -79,6 +83,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 * the Connection Test Result endpoint.
 	 *
 	 * @internal
+	 * @return array
 	 */
 	protected function get_connections() {
 		global $publicize;

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -12,6 +12,7 @@
  *   },
  *   ...
  * ]
+ *
  * @since 6.8
  */
 class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Controller {
@@ -26,14 +27,18 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 * Called automatically on `rest_api_init()`.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permission_check' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -45,21 +50,21 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 */
 	protected function get_connection_schema_properties() {
 		return array(
-			'id' => array(
+			'id'           => array(
 				'description' => __( 'Unique identifier for the Publicize Connection', 'jetpack' ),
-				'type' => 'string',
+				'type'        => 'string',
 			),
 			'service_name' => array(
 				'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
-				'type' => 'string',
+				'type'        => 'string',
 			),
 			'display_name' => array(
 				'description' => __( 'Username of the connected account', 'jetpack' ),
-				'type' => 'string',
+				'type'        => 'string',
 			),
-			'global' => array(
+			'global'       => array(
 				'description' => __( 'Is this connection available to all users?', 'jetpack' ),
-				'type' => 'boolean',
+				'type'        => 'boolean',
 			),
 		);
 	}
@@ -69,9 +74,9 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title' => 'jetpack-publicize-connection',
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-publicize-connection',
+			'type'       => 'object',
 			'properties' => $this->get_connection_schema_properties(),
 		);
 
@@ -129,7 +134,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	/**
 	 * Filters out data based on ?_fields= request parameter
 	 *
-	 * @param array $connection
+	 * @param array           $connection
 	 * @param WP_REST_Request $request
 	 * @return array filtered $connection
 	 */
@@ -139,7 +144,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 		$response_data = array();
 		foreach ( $connection as $field => $value ) {
 			if ( in_array( $field, $fields, true ) ) {
-				$response_data[$field] = $value;
+				$response_data[ $field ] = $value;
 			}
 		}
 

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -133,7 +133,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 	 * @param WP_REST_Request $request
 	 * @return array filtered $connection
 	 */
-	function prepare_item_for_response( $connection, $request ) {
+	public function prepare_item_for_response( $connection, $request ) {
 		$fields = $this->get_fields_for_response( $request );
 
 		$response_data = array();

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -114,8 +114,8 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 		}
 
 		$response = rest_ensure_response( $items );
-                $response->header( 'X-WP-Total', count( $items ) );
-                $response->header( 'X-WP-TotalPages', 1 );
+		$response->header( 'X-WP-Total', count( $items ) );
+		$response->header( 'X-WP-TotalPages', 1 );
 
 		return $response;
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Publicize: List Connections
+ *
+ * [
+ *   { # Connnection Object. See schema for more detail.
+ *     id:           (string)  Connection unique_id
+ *     service_name: (string)  Service slug
+ *     display_name: (string)  User name/display name of user/connection on Service
+ *     global:       (boolean) Is the Connection available to all users of the site?
+ *   },
+ *   ...
+ * ]
+ * @since 6.8
+ */
+class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'publicize/connections';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permission_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Helper for generating schema. Used by this endpoint and by the
+	 * Connection Test Result endpoint.
+	 *
+	 * @internal
+	 */
+	protected function get_connection_schema_properties() {
+		return array(
+			'id' => array(
+				'description' => __( 'Unique identifier for the Publicize Connection', 'jetpack' ),
+				'type' => 'string',
+			),
+			'service_name' => array(
+				'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
+				'type' => 'string',
+			),
+			'display_name' => array(
+				'description' => __( 'Username of the connected account', 'jetpack' ),
+				'type' => 'string',
+			),
+			'global' => array(
+				'description' => __( 'Is this connection available to all users?', 'jetpack' ),
+				'type' => 'boolean',
+			),
+		);
+	}
+
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title' => 'jetpack-publicize-connection',
+			'type' => 'object',
+			'properties' => $this->get_connection_schema_properties(),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Helper for retrieving Connections. Used by this endpoint and by
+	 * the Connection Test Result endpoint.
+	 *
+	 * @internal
+	 */
+	protected function get_connections() {
+		global $publicize;
+
+		$items = array();
+
+		foreach ( (array) $publicize->get_services( 'connected' ) as $service_name => $connections ) {
+			foreach ( $connections as $connection ) {
+				$connection_meta = $publicize->get_connection_meta( $connection );
+				$connection_data = $connection_meta['connection_data'];
+
+				$items[] = array(
+					'id' => $publicize->get_connection_unique_id( $connection ),
+					'service_name' => $service_name,
+					'display_name' => $publicize->get_display_name( $service_name, $connection ),
+					'global' => 0 == $connection_data['user_id'],
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response suitable for 1-page collection
+	 */
+	public function get_items( $request ) {
+		$items = array();
+
+		foreach ( $this->get_connections() as $item ) {
+			$items[] = $this->prepare_item_for_response( $item, $request );
+		}
+
+		$response = rest_ensure_response( $items );
+                $response->header( 'X-WP-Total', count( $items ) );
+                $response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
+	}
+
+	/**
+	 * Filters out data based on ?_fields= request parameter
+	 *
+	 * @param array $connection
+	 * @param WP_REST_Request $request
+	 * @return array filtered $connection
+	 */
+	function prepare_item_for_response( $connection, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+
+		$response_data = array();
+		foreach ( $connection as $field => $value ) {
+			if ( in_array( $field, $fields, true ) ) {
+				$response_data[$field] = $value;
+			}
+		}
+
+		return $response_data;
+	}
+
+	/**
+	 * Verify that user can access Publicize data
+	 *
+	 * @return true|WP_Error
+	 */
+	public function get_items_permission_check() {
+		global $publicize;
+
+		if ( $publicize->current_user_can_access_publicize_data() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'invalid_user_permission_publicize',
+			__( 'Sorry, you are not allowed to access Publicize data on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections' );

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -96,10 +96,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 				$connection_data = $connection_meta['connection_data'];
 
 				$items[] = array(
-					'id' => (string) $publicize->get_connection_unique_id( $connection ),
+					'id'           => (string) $publicize->get_connection_unique_id( $connection ),
 					'service_name' => $service_name,
 					'display_name' => $publicize->get_display_name( $service_name, $connection ),
-					'global' => 0 == $connection_data['user_id'],
+					'global'       => 0 == $connection_data['user_id'],
 				);
 			}
 		}

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -99,6 +99,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 					'id'           => (string) $publicize->get_connection_unique_id( $connection ),
 					'service_name' => $service_name,
 					'display_name' => $publicize->get_display_name( $service_name, $connection ),
+					// We expect an integer, but do loose comparison below in case some other type is stored
 					'global'       => 0 == $connection_data['user_id'],
 				);
 			}

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -96,7 +96,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 				$connection_data = $connection_meta['connection_data'];
 
 				$items[] = array(
-					'id' => $publicize->get_connection_unique_id( $connection ),
+					'id' => (string) $publicize->get_connection_unique_id( $connection ),
 					'service_name' => $service_name,
 					'display_name' => $publicize->get_display_name( $service_name, $connection ),
 					'global' => 0 == $connection_data['user_id'],

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -112,6 +112,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	 * @return array filtered $service
 	 */
 	public function prepare_item_for_response( $service, $request ) {
+		if ( ! is_callable( array( $this, 'get_fields_for_response' ) ) ) {
+			return $service;
+		}
+
 		$fields = $this->get_fields_for_response( $request );
 
 		$response_data = array();

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -26,14 +26,18 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	 * Called automatically on `rest_api_init()`.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permission_check' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -41,22 +45,22 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title' => 'jetpack-publicize-service',
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-publicize-service',
+			'type'       => 'object',
 			'properties' => array(
-				'name' => array(
+				'name'  => array(
 					'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
-					'type' => 'string',
+					'type'        => 'string',
 				),
 				'label' => array(
 					'description' => __( 'Human readable label for the Publicize Service', 'jetpack' ),
-					'type' => 'string',
+					'type'        => 'string',
 				),
-				'url' => array(
+				'url'   => array(
 					'description' => __( 'The URL used to connect to the Publicize Service', 'jetpack' ),
-					'type' => 'string',
-					'format' => 'uri',
+					'type'        => 'string',
+					'format'      => 'uri',
 				),
 			),
 		);
@@ -81,7 +85,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 		 * We also need add_submenu_page(), as the URLs for connecting each service
 		 * rely on the `sharing` menu subpage being present.
 		 */
-		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		// The `sharing` submenu page must exist for service connect URLs to be correct.
 		add_submenu_page( 'options-general.php', '', '', 'manage_options', 'sharing', '__return_empty_string' );
@@ -103,7 +107,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	/**
 	 * Filters out data based on ?_fields= request parameter
 	 *
-	 * @param array $service
+	 * @param array           $service
 	 * @param WP_REST_Request $request
 	 * @return array filtered $service
 	 */
@@ -113,7 +117,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 		$response_data = array();
 		foreach ( $service as $field => $value ) {
 			if ( in_array( $field, $fields, true ) ) {
-				$response_data[$field] = $value;
+				$response_data[ $field ] = $value;
 			}
 		}
 

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -36,6 +36,9 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 		) );
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_item_schema() {
 		$schema = array(
 			'$schema' => 'http://json-schema.org/draft-04/schema#',

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -107,7 +107,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	 * @param WP_REST_Request $request
 	 * @return array filtered $service
 	 */
-	function prepare_item_for_response( $service, $request ) {
+	public function prepare_item_for_response( $service, $request ) {
 		$fields = $this->get_fields_for_response( $request );
 
 		$response_data = array();

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Publicize: List Publicize Services
+ *
+ * [
+ *   { # Service Object. See schema for more detail.
+ *     name:  (string) Service slug
+ *     label: (string) Human readable label for the Service
+ *     url:   (string) Connect URL
+ *   },
+ *   ...
+ * ]
+ *
+ * @since 6.8
+ */
+class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'publicize/services';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permission_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title' => 'jetpack-publicize-service',
+			'type' => 'object',
+			'properties' => array(
+				'name' => array(
+					'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+				),
+				'label' => array(
+					'description' => __( 'Human readable label for the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+				),
+				'url' => array(
+					'description' => __( 'The URL used to connect to the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+					'format' => 'uri',
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Retrieves available Publicize Services.
+	 *
+	 * @see Publicize::get_available_service_data()
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response suitable for 1-page collection
+	 */
+	public function get_items( $request ) {
+		global $publicize;
+		/**
+		 * We need this because Publicize::get_available_service_data() uses `Jetpack_Keyring_Service_Helper`
+		 * and `Jetpack_Keyring_Service_Helper` relies on `menu_page_url()`.
+		 *
+		 * We also need add_submenu_page(), as the URLs for connecting each service
+		 * rely on the `sharing` menu subpage being present.
+		 */
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+		// The `sharing` submenu page must exist for service connect URLs to be correct.
+		add_submenu_page( 'options-general.php', '', '', 'manage_options', 'sharing', '__return_empty_string' );
+
+		$services_data = $publicize->get_available_service_data();
+
+		$services = array();
+		foreach ( $services_data as $service_data ) {
+			$services[] = $this->prepare_item_for_response( $service_data, $request );
+		}
+
+		$response = rest_ensure_response( $services );
+		$response->header( 'X-WP-Total', count( $services ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
+	}
+
+	/**
+	 * Filters out data based on ?_fields= request parameter
+	 *
+	 * @param array $service
+	 * @param WP_REST_Request $request
+	 * @return array filtered $service
+	 */
+	function prepare_item_for_response( $service, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+
+		$response_data = array();
+		foreach ( $service as $field => $value ) {
+			if ( in_array( $field, $fields, true ) ) {
+				$response_data[$field] = $value;
+			}
+		}
+
+		return $response_data;
+	}
+
+	/**
+	 * Verify that user can access Publicize data
+	 *
+	 * @return true|WP_Error
+	 */
+	public function get_items_permission_check() {
+		global $publicize;
+
+		if ( $publicize->current_user_can_access_publicize_data() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'invalid_user_permission_publicize',
+			__( 'Sorry, you are not allowed to access Publicize data on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_List_Publicize_Services' );

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Add per-post Publicize Connection data.
+ *
+ * { # Post Object
+ *   ...
+ *   jetpack_publicize_connections: { # Defined below in this file. See schema for more detail.
+ *     id:           (string)  Connection unique_id
+ *     service_name: (string)  Service slug
+ *     display_name: (string)  User name/display name of user/connection on Service
+ *     enabled:      (boolean) Is this connection slated to be shared to? context=edit only
+ *     done:         (boolean) Is this post (or connection) done sharing? context=edit only
+ *     toggleable:   (boolean) Can the current user change the `enabled` setting for this Connection+Post? context=edit only
+ *   }
+ *   ...
+ *   meta: { # Not defined in this file. Handled in modules/publicize/publicize.php via `register_meta()`
+ *     jetpack_publicize_message: (string) The message to use instead of the post's title when sharing.
+ *   }
+ *   ...
+ * }
+ *
+ * @since 6.8.0
+ */
+class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_V2_Field_Controller {
+	protected $object_type = 'post';
+	protected $field_name = 'jetpack_publicize_connections';
+
+	/**
+	 * Registers the jetpack_publicize_connections field. Called
+	 * automatically on `rest_api_init()`.
+	 */
+	public function register_fields() {
+		$this->object_type = get_post_types_by_support( 'publicize' );
+
+		foreach ( $this->object_type as $post_type ) {
+			// Adds meta support for those post types that don't already have it.
+			// Only runs during REST API requests, so it doesn't impact UI.
+			if ( ! post_type_supports( $post_type, 'custom-fields' ) ) {
+				add_post_type_support( $post_type, 'custom-fields' );
+			}
+		}
+
+		parent::register_fields();
+	}
+
+	/**
+	 * Defines data structure and what elements are visible in which contexts
+	 */
+	public function get_schema() {
+		return array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title' => 'jetpack-publicize-post-connections',
+			'type' => 'array',
+			'context' => array( 'view', 'edit' ),
+			'items' => $this->post_connection_schema(),
+			'default' => array(),
+		);
+	}
+
+	private function post_connection_schema() {
+		return array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title' => 'jetpack-publicize-post-connection',
+			'type' => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the Publicize Connection', 'jetpack' ),
+					'type' => 'string',
+					'context' => array( 'view', 'edit' ),
+					'readonly' => true,
+				),
+				'service_name' => array(
+					'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
+					'type' => 'string',
+					'context' => array( 'view', 'edit' ),
+					'readonly' => true,
+				),
+				'display_name' => array(
+					'description' => __( 'Username of the connected account', 'jetpack' ),
+					'type' => 'string',
+					'context' => array( 'view', 'edit' ),
+					'readonly' => true,
+				),
+				'enabled' => array(
+					'description' => __( 'Whether to share to this connection', 'jetpack' ),
+					'type' => 'boolean',
+					'context' => array( 'edit' ),
+				),
+				'done' => array(
+					'description' => __( 'Whether Publicize has already finished sharing for this post', 'jetpack' ),
+					'type' => 'boolean',
+					'context' => array( 'edit' ),
+					'readonly' => true,
+				),
+				'toggleable' => array(
+					'description' => __( 'Whether `enable` can be changed for this post/connection', 'jetpack' ),
+					'type' => 'boolean',
+					'context' => array( 'edit' ),
+					'readonly' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param int $post_id
+	 * @return true|WP_Error
+	 */
+	function permission_check( $post_id ) {
+		global $publicize;
+
+		if ( $publicize->current_user_can_access_publicize_data( $post_id ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'invalid_user_permission_publicize',
+			__( 'Sorry, you are not allowed to access Publicize data for this post.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Getter permission check
+	 * @param array $post_array Response data from Post Endpoint
+	 * @return true|WP_Error
+	 */
+	function get_permission_check( $post_array, $request ) {
+		return $this->permission_check( $post_array['id'] );
+
+	}
+
+	/**
+	 * Setter permission check
+	 * @param WP_Post $post
+	 * @return true|WP_Error
+	 */
+	public function update_permission_check( $value, $post, $request ) {
+		return $this->permission_check( $post->ID );
+	}
+
+	/**
+	 * Getter: Retrieve current list of connected social accounts for a given post.
+	 *
+	 * @see Publicize::get_filtered_connection_data()
+	 *
+	 * @param array $post_array Response from Post Endpoint
+	 * @param WP_REST_Request
+	 *
+	 * @return array List of connections
+	 */
+	public function get( $post_array, $request ) {
+		global $publicize;
+
+		$schema = $this->post_connection_schema();
+		$properties = array_keys( $schema['properties'] );
+
+		$connections = $publicize->get_filtered_connection_data( $post_array['id'] );
+
+		$output_connections = array();
+		foreach ( $connections as $connection ) {
+			$output_connection = array();
+			foreach ( $properties as $property  ) {
+				if ( isset( $connection[$property] ) ) {
+					$output_connection[$property] = $connection[$property];
+				}
+			}
+
+			$output_connection['id'] = (string) $connection['unique_id'];
+
+			$output_connections[] = $output_connection;
+		}
+
+		return $output_connections;
+	}
+
+	/**
+	 * Update the connections slated to be shared to.
+	 *
+	 * @param array $requested_connections
+	 *              Items are eitheer `{ id: (string) }` or `{ service_name: (string) }`
+	 * @param WP_Post $post
+	 * @param WP_REST_Request
+	 */
+	public function update( $requested_connections, $post, $request ) {
+		global $publicize;
+
+		$available_connections = $publicize->get_filtered_connection_data( $post->ID );
+
+		$changed_connections = array();
+
+		// Build lookup mappings
+		$available_connections_by_unique_id = array();
+		$available_connections_by_service_name = array();
+		foreach ( $available_connections as $available_connection ) {
+			$available_connections_by_unique_id[$available_connection['unique_id']] = $available_connection;
+
+			if ( ! isset( $available_connections_by_service_name[$available_connection['service_name']] ) ) {
+				$available_connections_by_service_name[$available_connection['service_name']] = array();
+			}
+			$available_connections_by_service_name[$available_connection['service_name']][] = $available_connection;
+		}
+
+		// Handle { service_name: $service_name, enabled: (bool) }
+		foreach ( $requested_connections as $requested_connection ) {
+			if ( ! isset( $requested_connection['service_name'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $available_connections_by_service_name[$requested_connection['service_name']] ) ) {
+				continue;
+			}
+
+			foreach ( $available_connections_by_service_name[$requested_connection['service_name']] as $available_connection ) {
+				$changed_connections[$available_connection['unique_id']] = $requested_connection['enabled'];
+			}
+		}
+
+		// Handle { id: $id, enabled: (bool) }
+		// These override the service_name settings
+		foreach ( $requested_connections as $requested_connection ) {
+			if ( ! isset( $requested_connection['id'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $available_connections_by_unique_id[$requested_connection['id']] ) ) {
+				continue;
+			}
+
+			$changed_connections[$requested_connection['id']] = $requested_connection['enabled'];
+		}
+
+		// Set all changed connections to their new value
+		foreach ( $changed_connections as $unique_id => $enabled ) {
+			$connection = $available_connections_by_unique_id[$unique_id];
+
+			if ( $connection['done'] || ! $connection['toggleable'] ) {
+				continue;
+			}
+
+			$available_connections_by_unique_id[$unique_id]['enabled'] = $enabled;
+		}
+
+		// For all connections, ensure correct post_meta
+		foreach ( $available_connections_by_unique_id as $unique_id => $available_connection ) {
+			if ( $available_connection['enabled'] ) {
+				delete_post_meta( $post->ID, $publicize->POST_SKIP . $unique_id );
+			} else {
+				update_post_meta( $post->ID, $publicize->POST_SKIP . $unique_id, 1 );
+			}
+		}
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Post_Publicize_Connections_Field' );

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -179,7 +179,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	 * Update the connections slated to be shared to.
 	 *
 	 * @param array $requested_connections
-	 *              Items are eitheer `{ id: (string) }` or `{ service_name: (string) }`
+	 *              Items are either `{ id: (string) }` or `{ service_name: (string) }`
 	 * @param WP_Post $post
 	 * @param WP_REST_Request
 	 */

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -24,7 +24,7 @@
  */
 class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_V2_Field_Controller {
 	protected $object_type = 'post';
-	protected $field_name = 'jetpack_publicize_connections';
+	protected $field_name  = 'jetpack_publicize_connections';
 
 	/**
 	 * Registers the jetpack_publicize_connections field. Called
@@ -50,54 +50,54 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	public function get_schema() {
 		return array(
 			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title' => 'jetpack-publicize-post-connections',
-			'type' => 'array',
+			'title'   => 'jetpack-publicize-post-connections',
+			'type'    => 'array',
 			'context' => array( 'view', 'edit' ),
-			'items' => $this->post_connection_schema(),
+			'items'   => $this->post_connection_schema(),
 			'default' => array(),
 		);
 	}
 
 	private function post_connection_schema() {
 		return array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title' => 'jetpack-publicize-post-connection',
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-publicize-post-connection',
+			'type'       => 'object',
 			'properties' => array(
-				'id' => array(
+				'id'           => array(
 					'description' => __( 'Unique identifier for the Publicize Connection', 'jetpack' ),
-					'type' => 'string',
-					'context' => array( 'view', 'edit' ),
-					'readonly' => true,
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'service_name' => array(
 					'description' => __( 'Alphanumeric identifier for the Publicize Service', 'jetpack' ),
-					'type' => 'string',
-					'context' => array( 'view', 'edit' ),
-					'readonly' => true,
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'display_name' => array(
 					'description' => __( 'Username of the connected account', 'jetpack' ),
-					'type' => 'string',
-					'context' => array( 'view', 'edit' ),
-					'readonly' => true,
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
-				'enabled' => array(
+				'enabled'      => array(
 					'description' => __( 'Whether to share to this connection', 'jetpack' ),
-					'type' => 'boolean',
-					'context' => array( 'edit' ),
+					'type'        => 'boolean',
+					'context'     => array( 'edit' ),
 				),
-				'done' => array(
+				'done'         => array(
 					'description' => __( 'Whether Publicize has already finished sharing for this post', 'jetpack' ),
-					'type' => 'boolean',
-					'context' => array( 'edit' ),
-					'readonly' => true,
+					'type'        => 'boolean',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
 				),
-				'toggleable' => array(
+				'toggleable'   => array(
 					'description' => __( 'Whether `enable` can be changed for this post/connection', 'jetpack' ),
-					'type' => 'boolean',
-					'context' => array( 'edit' ),
-					'readonly' => true,
+					'type'        => 'boolean',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);
@@ -123,6 +123,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 
 	/**
 	 * Getter permission check
+	 *
 	 * @param array $post_array Response data from Post Endpoint
 	 * @return true|WP_Error
 	 */
@@ -133,6 +134,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 
 	/**
 	 * Setter permission check
+	 *
 	 * @param WP_Post $post
 	 * @return true|WP_Error
 	 */
@@ -145,7 +147,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	 *
 	 * @see Publicize::get_filtered_connection_data()
 	 *
-	 * @param array $post_array Response from Post Endpoint
+	 * @param array           $post_array Response from Post Endpoint
 	 * @param WP_REST_Request
 	 *
 	 * @return array List of connections
@@ -153,7 +155,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	public function get( $post_array, $request ) {
 		global $publicize;
 
-		$schema = $this->post_connection_schema();
+		$schema     = $this->post_connection_schema();
 		$properties = array_keys( $schema['properties'] );
 
 		$connections = $publicize->get_filtered_connection_data( $post_array['id'] );
@@ -161,9 +163,9 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 		$output_connections = array();
 		foreach ( $connections as $connection ) {
 			$output_connection = array();
-			foreach ( $properties as $property  ) {
-				if ( isset( $connection[$property] ) ) {
-					$output_connection[$property] = $connection[$property];
+			foreach ( $properties as $property ) {
+				if ( isset( $connection[ $property ] ) ) {
+					$output_connection[ $property ] = $connection[ $property ];
 				}
 			}
 
@@ -178,9 +180,9 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	/**
 	 * Update the connections slated to be shared to.
 	 *
-	 * @param array $requested_connections
+	 * @param array           $requested_connections
 	 *              Items are either `{ id: (string) }` or `{ service_name: (string) }`
-	 * @param WP_Post $post
+	 * @param WP_Post         $post
 	 * @param WP_REST_Request
 	 */
 	public function update( $requested_connections, $post, $request ) {
@@ -191,15 +193,15 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 		$changed_connections = array();
 
 		// Build lookup mappings
-		$available_connections_by_unique_id = array();
+		$available_connections_by_unique_id    = array();
 		$available_connections_by_service_name = array();
 		foreach ( $available_connections as $available_connection ) {
-			$available_connections_by_unique_id[$available_connection['unique_id']] = $available_connection;
+			$available_connections_by_unique_id[ $available_connection['unique_id'] ] = $available_connection;
 
-			if ( ! isset( $available_connections_by_service_name[$available_connection['service_name']] ) ) {
-				$available_connections_by_service_name[$available_connection['service_name']] = array();
+			if ( ! isset( $available_connections_by_service_name[ $available_connection['service_name'] ] ) ) {
+				$available_connections_by_service_name[ $available_connection['service_name'] ] = array();
 			}
-			$available_connections_by_service_name[$available_connection['service_name']][] = $available_connection;
+			$available_connections_by_service_name[ $available_connection['service_name'] ][] = $available_connection;
 		}
 
 		// Handle { service_name: $service_name, enabled: (bool) }
@@ -208,12 +210,12 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 				continue;
 			}
 
-			if ( ! isset( $available_connections_by_service_name[$requested_connection['service_name']] ) ) {
+			if ( ! isset( $available_connections_by_service_name[ $requested_connection['service_name'] ] ) ) {
 				continue;
 			}
 
-			foreach ( $available_connections_by_service_name[$requested_connection['service_name']] as $available_connection ) {
-				$changed_connections[$available_connection['unique_id']] = $requested_connection['enabled'];
+			foreach ( $available_connections_by_service_name[ $requested_connection['service_name'] ] as $available_connection ) {
+				$changed_connections[ $available_connection['unique_id'] ] = $requested_connection['enabled'];
 			}
 		}
 
@@ -224,22 +226,22 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 				continue;
 			}
 
-			if ( ! isset( $available_connections_by_unique_id[$requested_connection['id']] ) ) {
+			if ( ! isset( $available_connections_by_unique_id[ $requested_connection['id'] ] ) ) {
 				continue;
 			}
 
-			$changed_connections[$requested_connection['id']] = $requested_connection['enabled'];
+			$changed_connections[ $requested_connection['id'] ] = $requested_connection['enabled'];
 		}
 
 		// Set all changed connections to their new value
 		foreach ( $changed_connections as $unique_id => $enabled ) {
-			$connection = $available_connections_by_unique_id[$unique_id];
+			$connection = $available_connections_by_unique_id[ $unique_id ];
 
 			if ( $connection['done'] || ! $connection['toggleable'] ) {
 				continue;
 			}
 
-			$available_connections_by_unique_id[$unique_id]['enabled'] = $enabled;
+			$available_connections_by_unique_id[ $unique_id ]['enabled'] = $enabled;
 		}
 
 		// For all connections, ensure correct post_meta

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -442,6 +442,10 @@ abstract class Publicize_Base {
 	 * @return void
 	 */
 	function test_publicize_conns() {
+		wp_send_json_success( $this->get_publicize_conns_test_results );
+	}
+
+	function get_publicize_conns_test_results() {
 		$test_results = array();
 
 		foreach ( (array) $this->get_services( 'connected' ) as $service_name => $connections ) {
@@ -498,7 +502,7 @@ abstract class Publicize_Base {
 			}
 		}
 
-		wp_send_json_success( $test_results );
+		return $test_results;
 	}
 
 	/**

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -116,6 +116,8 @@ abstract class Publicize_Base {
 
 		// Connection test callback
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
+
+		add_action( 'init', array( $this, 'add_post_type_support' ) );
 	}
 
 /*
@@ -761,6 +763,15 @@ abstract class Publicize_Base {
 	 * @return void
 	 */
 	abstract function flag_post_for_publicize( $new_status, $old_status, $post );
+
+	/**
+	 * Ensures the Post internal post-type supports `publicize`
+	 *
+	 * This feature support flag is used by the REST API.
+	 */
+	function add_post_type_support() {
+		add_post_type_support( 'post', 'publicize' );
+	}
 
 	/**
 	 * Can the current user access Publicize Data.

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -763,6 +763,31 @@ abstract class Publicize_Base {
 	abstract function flag_post_for_publicize( $new_status, $old_status, $post );
 
 	/**
+	 * Can the current user access Publicize Data.
+	 *
+	 * @param int $post_id. 0 for general access. Post_ID for specific access.
+	 * @return bool
+	 */
+	function current_user_can_access_publicize_data( $post_id = 0 ) {
+		/**
+		 * Filter what user capability is required to use the publicize form on the edit post page. Useful if publish post capability has been removed from role.
+		 *
+		 * @module publicize
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param string $capability User capability needed to use publicize
+		 */
+		$capability = apply_filters( 'jetpack_publicize_capability', 'publish_posts' );
+
+		if ( 'publish_posts' === $capability && $post_id ) {
+			return current_user_can( 'publish_post', $post_id );
+		}
+
+		return current_user_can( $capability );
+	}
+
+	/**
 	 * Fires when a post is saved, checks conditions and saves state in postmeta so that it
 	 * can be picked up later by @see ::publicize_post() on WordPress.com codebase.
 	 *

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -445,6 +445,21 @@ abstract class Publicize_Base {
 		wp_send_json_success( $this->get_publicize_conns_test_results );
 	}
 
+	/**
+	 * Run connection tests on all Connections
+	 * @return array {
+	 *     Array of connection test results.
+	 *
+	 *     @type string 'connectionID'          Connection identifier string that is unique for each connection
+	 *     @type string 'serviceName'           Slug of the connection's service (facebook, twitter, ...)
+	 *     @type bool   'connectionTestPassed'  Whether the connection test was successful
+	 *     @type string 'connectionTestMessage' Test success or error message
+	 *     @type bool   'userCanRefresh'        Whether the user can re-authenticate their connection to the service
+	 *     @type string 'refreshText'           Message instructing user to re-authenticate their connection to the service
+	 *     @type string 'refreshURL'            URL, which, when visited by the user, re-authenticates their connection to the service.
+	 *     @type string 'unique_id'             ID string representing connection
+	 * }
+	 */
 	function get_publicize_conns_test_results() {
 		$test_results = array();
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -442,7 +442,7 @@ abstract class Publicize_Base {
 	 * @return void
 	 */
 	function test_publicize_conns() {
-		wp_send_json_success( $this->get_publicize_conns_test_results );
+		wp_send_json_success( $this->get_publicize_conns_test_results() );
 	}
 
 	/**

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -33,17 +33,7 @@ class Publicize_UI {
 		);
 
 		// Show only to users with the capability required to manage their Publicize connections.
-		/**
-		 * Filter what user capability is required to use the publicize form on the edit post page. Useful if publish post capability has been removed from role.
-		 *
-		 * @module publicize
-		 *
-		 * @since 4.1.0
-		 *
-		 * @param string $capability User capability needed to use publicize
-		 */
-		$capability = apply_filters( 'jetpack_publicize_capability', 'publish_posts' );
-		if ( ! current_user_can( $capability ) ) {
+		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
 			return;
 		}
 

--- a/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections.php
@@ -1,0 +1,170 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
+
+/**
+ * @group publicize
+ * @group rest-api
+ */
+class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Jetpack_REST_Testcase {
+	static private $user_id = 0;
+
+	private $draft_id = 0;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		register_post_type( 'example-with', array(
+			'show_in_rest' => true,
+			'supports' => array( 'publicize', 'custom-fields' )
+		) );
+
+		register_post_type( 'example-without', array(
+			'show_in_rest' => true,
+			'supports' => array( 'publicize' )
+		) );
+
+		add_post_type_support( 'post', 'publicize' );
+
+		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		Jetpack_Options::update_options( array(
+			'publicize_connections' => array(
+				// Normally connected facebook
+				'facebook' => array(
+					'id_number' => array(
+						'connection_data' => array(
+							'user_id'  => self::$user_id,
+							'token_id' => 'test-unique-id456',
+							'meta'     => array(
+								'display_name' => 'test-display-name456',
+							),
+						),
+					),
+				),
+				// Globally connected tumblr
+				'tumblr' => array(
+					'id_number' => array(
+						'connection_data' => array(
+							'user_id'  => 0,
+							'token_id' => 'test-unique-id123',
+							'meta'     => array(
+								'display_name' => 'test-display-name123',
+							),
+						),
+					),
+				),
+			),
+		) );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::$user_id );
+
+		// Not sure why this needs to be done in ->setUp() instead of in ::wpSetUpBeforeClass(),
+		// but it does. Otherwise, test_update_message passes when:
+		// phpunit --filter=Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field
+		// but fails when:
+		// phpunit --group=rest-api
+		global $publicize;
+		$publicize->register_post_meta();
+
+		$this->draft_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+	}
+
+	public function test_register_fields_posts() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
+	}
+
+	public function test_register_fields_custom_post_type_with_custom_fields_support() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/example-with' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
+		$this->assertArrayHasKey( 'meta', $schema['properties'] );
+		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
+	}
+
+	public function test_register_fields_custom_post_type_without_custom_fields_support() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/example-without' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
+		$this->assertArrayHasKey( 'meta', $schema['properties'] );
+		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
+	}
+
+	public function test_response() {
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'jetpack_publicize_connections', $data );
+		$this->assertInternalType( 'array', $data['jetpack_publicize_connections'] );
+		$this->assertSame( array( 'test-unique-id456', 'test-unique-id123' ), wp_list_pluck( $data['jetpack_publicize_connections'], 'id' ) );
+
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayHasKey( 'jetpack_publicize_message', $data['meta'] );
+		$this->assertInternalType( 'string', $data['meta']['jetpack_publicize_message'] );
+		$this->assertEmpty( $data['meta']['jetpack_publicize_message'] );
+	}
+
+	public function test_update_message() {
+		$request  = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$request->set_body_params( array(
+			'meta' => array(
+				'jetpack_publicize_message' => 'example',
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 'example', $data['meta']['jetpack_publicize_message'] );
+	}
+
+	public function test_update_connections_by_id() {
+		$request  = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$request->set_body_params( array(
+			'jetpack_publicize_connections' => array(
+				array(
+					'id' => 'test-unique-id123',
+					'enabled' => false,
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		foreach ( $data['jetpack_publicize_connections'] as $connection ) {
+			$this->assertSame( 'test-unique-id123' !== $connection->id, $connection->enabled );
+		}
+	}
+
+	public function test_update_connections_by_service_name() {
+		$request  = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$request->set_body_params( array(
+			'jetpack_publicize_connections' => array(
+				array(
+					'service_name' => 'facebook',
+					'enabled' => false,
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		foreach ( $data['jetpack_publicize_connections'] as $connection ) {
+			$this->assertSame( 'facebook' !== $connection->service_name, $connection->enabled );
+		}
+	}
+}

--- a/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections.php
@@ -57,6 +57,11 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		) );
 	}
 
+	public static function wpTearDownAfterClass() {
+		unregister_post_type( 'example-with' );
+		unregister_post_type( 'example-without' );
+	}
+
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -1,6 +1,9 @@
 <?php
 require dirname( __FILE__ ) . '/../../../../modules/publicize.php';
 
+/**
+ * @group publicize
+ */
 class WP_Test_Publicize extends WP_UnitTestCase {
 
 


### PR DESCRIPTION
Built on top of #10600.

Obsoletes #10487, #10398.

@tyxla has a PR for the client side that makes the Gutenberg extension work with this PR: Automattic/wp-calypso#28463

#### Changes proposed in this Pull Request:

Adds REST API endpoints for Publicize data:
* Services
* Connections
* Connection Test Results
* A Post's Connections

#### Testing instructions:

##### Automated Tests
1. `phpunit --group rest-api`
2. `phpunit --group publicize`

##### Manual Tests

The best way to test is to make REST API requests to a test site. The simplest way to do that is to install either the [REST API Console](https://wordpress.org/plugins/rest-api-console/) plugin or the [Basic Authentication](https://github.com/WP-API/Basic-Auth) plugin.

###### As an Admin:

1. In the Classic (non-Gutenberg editor) create a post, but do not publish it.
2. Add a custom Publicize message. Save as Draft.
3. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/services`. You should see Facebook, Twitter, etc.
4. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/connections`. You should see the Publicize Connections you have forged for your site+user.
5. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/connection-test-results`.  You should see something very similar to the previous request but with additional properties detailing the results of the connection test for each connection.
6. Make an authenticated REST API request: `GET /wp-json/wp/v2/posts/{the-post-you-drafted}/`. You should see a new field: `jetpack_publicize_connections` detailing the connection settings for that post. You should also see the custom Publicize Message in a new `meta` field: `jetpack_publicize_message`.

###### As a Contributor:
1. In the Classic (non-Gutenberg editor) create a post, but do not publish it.
2. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/services`. You should see an HTTP 403.
3. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/connections`. You should see an HTTP 403.
4. Make an authenticated REST API request: `GET /wp-json/wpcom/v2/publicize/connection-test-results`.  You should see an HTTP 403.
5. Make an authenticated REST API request: `GET /wp-json/wp/v2/posts/{the-post-you-drafted}/`. You should see a new field: `jetpack_publicize_connections` **that is an empty array**, and a new `meta` field: `jetpack_publicize_message` **that is an empty string**.

Needs testing back to WordPress 4.8.

#### Proposed changelog entry for your changes:

Provide API for accessing Publicize data.