### PR TITLE
Simple Payments: Remove BRL currency

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -18,7 +18,6 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			'USD' => '$',
 			'GBP' => '&#163;',
 			'JPY' => '&#165;',
-			'BRL' => 'R$',
 			'EUR' => '&#8364;',
 			'NZD' => 'NZ$',
 			'AUD' => 'A$',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

PayPal documentation states:

Note: This currency is supported as a payment currency and a currency balance for in-country PayPal accounts only.

From https://developer.paypal.com/docs/classic/api/currency_codes/

#### Testing instructions:

* Get a Jetpack site with a Premium or greater plan
* Add a Simple Payment button widget (via the customizer)
* `BRL` currency should no longer be available

#### Proposed changelog entry for your changes:

* Remove support for `BRL` Simple Payment currency.


Companion Calypso PR: https://github.com/Automattic/wp-calypso/pull/28496
Related: https://github.com/Automattic/wp-calypso/pull/28236#issuecomment-436255859