### PR TITLE
Revert "Simple payments widget: remove Indian Rupees"

### DIFF
--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			'NZD' => 'NZ$',
 			'AUD' => 'A$',
 			'CAD' => 'C$',
+			'INR' => '₹',
 			'ILS' => '₪',
 			'RUB' => '₽',
 			'MXN' => 'MX$',


### PR DESCRIPTION
Reverts Automattic/jetpack#10581

Before deploying counterpart of https://github.com/Automattic/jetpack/pull/10581 — D20538-code — we've been thinking more about impact of this change and concluded that we might need another approach. We also discovered two more similarly problematic currencies.

Instead of excluding problematic currencies and handling backwards support in Simple Payments Gutenberg block, we could just include them with some UI changes to set user's expectations clear that these might be problematic to use. From [PayPal documentation](https://developer.paypal.com/docs/integration/direct/rest/currency-codes/):

>(BRL, MYR) This currency is supported as a payment currency and a currency balance for in-country PayPal accounts only.
>
> (INR) This currency is supported as a payment currency and a currency balance for in-country PayPal India accounts only.

At any rate, since there are INR Simple payment buttons live now, we need to make more data-informed decision instead of just "this isn't supposed to be here, let's remove it".

Conversations:
p1542099551450500-slack-jetpack-gutenberg
p1542115326483200-slack-jetpack-gutenberg

### Testing

See instructions from #10581 to confirm INR currency is back on the list.