### PR TITLE
Alternate XML-RPC Endpoint

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -529,7 +529,7 @@ class Jetpack {
 		 * understanding of what is needed at the network level is
 		 * available
 		 */
-		if( is_multisite() ) {
+		if ( is_multisite() ) {
 			Jetpack_Network::init();
 		}
 
@@ -546,6 +546,15 @@ class Jetpack {
 		// Unlink user before deleting the user from .com
 		add_action( 'deleted_user', array( $this, 'unlink_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
+
+		// Alternate XML-RPC, via ?for=jetpack&jetpack=xmlrpc
+		if ( isset( $_GET['jetpack'] ) && 'xmlrpc' == $_GET['jetpack'] ) {
+			if ( ! defined( 'XMLRPC_REQUEST' ) ) {
+				define( 'XMLRPC_REQUEST', true );
+			}
+
+			add_action( 'template_redirect', array( $this, 'alternate_xmlrpc' ) );
+		}
 
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
@@ -771,6 +780,50 @@ class Jetpack {
 		}
 
 		wp_die();
+	}
+
+	/**
+	 * Since a lot of hosts use a hammer approach to "protecting" WordPress sites,
+	 * and just blanket block all requests to /xmlrpc.php, or apply other overly-sensitive
+	 * security/firewall policies, we provide our own alternate XML RPC API endpoint
+	 * which is accessible via a different URI. Most of the below is copied directly
+	 * from /xmlrpc.php so that we're replicating it as closely as possible.
+	 */
+	function alternate_xmlrpc() {
+		global $HTTP_RAW_POST_DATA;
+
+		// Some browser-embedded clients send cookies. We don't want them.
+		$_COOKIE = array();
+
+		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
+		// but we can do it ourself.
+		if ( !isset( $HTTP_RAW_POST_DATA ) ) {
+			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
+		}
+
+		// fix for mozBlog and other cases where '<?xml' isn't on the very first line
+		if ( isset( $HTTP_RAW_POST_DATA ) ) {
+			$HTTP_RAW_POST_DATA = trim( $HTTP_RAW_POST_DATA );
+		}
+
+		include_once( ABSPATH . 'wp-admin/includes/admin.php' );
+		include_once( ABSPATH . WPINC . '/class-IXR.php' );
+		include_once( ABSPATH . WPINC . '/class-wp-xmlrpc-server.php' );
+
+		/**
+		 * Filters the class used for handling XML-RPC requests.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param string $class The name of the XML-RPC server class.
+		 */
+		$wp_xmlrpc_server_class = apply_filters( 'wp_xmlrpc_server_class', 'wp_xmlrpc_server' );
+		$wp_xmlrpc_server = new $wp_xmlrpc_server_class;
+
+		// Fire off the request
+		$wp_xmlrpc_server->serve_request();
+
+		exit;
 	}
 
 	function jetpack_admin_ajax_tracks_callback() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -547,8 +547,8 @@ class Jetpack {
 		add_action( 'deleted_user', array( $this, 'unlink_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
 
-		// Alternate XML-RPC, via ?for=jetpack&jetpack=xmlrpc
-		if ( isset( $_GET['jetpack'] ) && 'comms' == $_GET['jetpack'] ) {
+		// Alternate XML-RPC, via ?for=jetpack&jetpack=comms
+		if ( isset( $_GET['jetpack'] ) && 'comms' == $_GET['jetpack'] && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			if ( ! defined( 'XMLRPC_REQUEST' ) ) {
 				define( 'XMLRPC_REQUEST', true );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -797,7 +797,7 @@ class Jetpack {
 
 		foreach ( $methods as $method => $callback ) {
 			if ( 0 === strpos( $method, 'jetpack.' ) ) {
-				$jetpack_methods[$method] = $callback;
+				$jetpack_methods[ $method ] = $callback;
 			}
 		}
 
@@ -820,7 +820,7 @@ class Jetpack {
 
 		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
 		// but we can do it ourself.
-		if ( !isset( $HTTP_RAW_POST_DATA ) ) {
+		if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
 			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -548,7 +548,7 @@ class Jetpack {
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
 
 		// Alternate XML-RPC, via ?for=jetpack&jetpack=xmlrpc
-		if ( isset( $_GET['jetpack'] ) && 'xmlrpc' == $_GET['jetpack'] ) {
+		if ( isset( $_GET['jetpack'] ) && 'comms' == $_GET['jetpack'] ) {
 			if ( ! defined( 'XMLRPC_REQUEST' ) ) {
 				define( 'XMLRPC_REQUEST', true );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -834,6 +834,7 @@ class Jetpack {
 		$wp_xmlrpc_server = new $wp_xmlrpc_server_class;
 
 		// Fire off the request
+		nocache_headers();
 		$wp_xmlrpc_server->serve_request();
 
 		exit;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -554,6 +554,19 @@ class Jetpack {
 			}
 
 			add_action( 'template_redirect', array( $this, 'alternate_xmlrpc' ) );
+
+			add_filter( 'xmlrpc_methods', function( $methods ) {
+//				remove all but jetpack. methods
+				$jetpack_methods = array();
+
+				foreach ( $methods as $method => $callback ) {
+					if ( 0 === strpos( $method, 'jetpack.' ) ) {
+						$jetpack_methods[$method] = $callback;
+					}
+				}
+
+				return $jetpack_methods;
+			}, PHP_INT_MAX );
 		}
 
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds an experimental alternate XML-RPC endpoint: `/?for=jetpack&jetpack=comms` to use for hosts that proactively block `/xml-rpc.php`.

Only serves Jetpack methods (not Core's or other plugins' methods), so that we don't expose other methods hosts/sites blocking `/xmlrpc.php`.

#### Testing instructions:
##### Make sure the Core Endpoint Works
`curl --silent --dump-header /dev/stderr 'https://localhost.blogwaffe.com/xmlrpc.php' --data-binary '<methodCall><methodName>system.listMethods</methodName></methodCall>'`

You should see HTTP 200 and a bunch of core XML-RPC methods.

##### Make sure the Normal Jetpack Endpoint Works

`curl --silent --dump-header /dev/stderr 'https://localhost.blogwaffe.com/xmlrpc.php?for=jetpack' --data-binary '<methodCall><methodName>system.listMethods</methodName></methodCall>'`

You should see HTTP 200, the `system.*` methods, and some `jetpack.*` methods (which exact Jetpack methods you see depends on your connection state).

##### Make sure the Alternate Jetpack Endpoint Works

`curl --silent --dump-header /dev/stderr 'https://localhost.blogwaffe.com/?for=jetpack&jetpack=comms' --data-binary '<methodCall><methodName>system.listMethods</methodName></methodCall>'`

You should see HTTP 200, the `system.*` methods, and exactly the same `jetpack.*` methods you saw for the Normal Jetpack Endpoint test above.

#### Proposed changelog entry for your changes:

* Improve ability to create and troubleshoot Jetpack connections.