### PR TITLE
Connection Banner: un-dismiss the banner on plugin upgrade 

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3213,7 +3213,7 @@ p {
 		} else {
 			// If a Jetpack is still active but not connected when updating verion, remind them to connect with the banner.
 			if ( ! Jetpack::is_active() ) {
-				Jetpack_Options::update_option( 'dismissed_connection_banner', false );
+				Jetpack_Options::delete_option( 'dismissed_connection_banner' );
 			}
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3207,10 +3207,14 @@ p {
 	 * @return null              [description]
 	 */
 	public static function do_version_bump( $version, $old_version ) {
-
 		if ( ! $old_version ) { // For new sites
 			// Setting up jetpack manage
 			Jetpack::activate_manage();
+		} else {
+			// If a Jetpack is still active but not connected when updating verion, remind them to connect with the banner.
+			if ( ! Jetpack::is_active() ) {
+				Jetpack_Options::update_option( 'dismissed_connection_banner', false );
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->=

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

If someone has dismissed the connection banner but still hasn't connected Jetpack, this PR will reset the connection banner dismiss option. If the site is still upgrading Jetpack plugin versions while still not connected for some reason, the connection banner will re-appear. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Start on a fresh Jetpack site that is not connected to wpcom.
- View the /wp-admin/plugins.php page. See the connection banner. 
- Dismiss the connection banner 
- In `wp shell`, run `do_action( 'updating_jetpack_version', '6.9', '6.7' );`
- Reload the plugins page. The connection banner should be there. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

None needed
