### PR TITLE
CLI: Jetpack Start: Fix issue where user token didn't always save properly

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1036,12 +1036,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'A non-empty token argument must be passed.', 'jetpack' ) );
 		}
 
-		$token = sanitize_text_field( $named_args['token'] );
-
 		$is_master_user  = ! Jetpack::is_active();
 		$current_user_id = get_current_user_id();
 
-		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $named_args['token'], $current_user_id ), $is_master_user );
 
 		WP_CLI::log( wp_json_encode( $named_args ) );
 


### PR DESCRIPTION
In testing some provisioning for JN today with @oskosk and @lezama I noticed that the secret returned in JPS provisioning wasn't being set correctly. After testing, I realized that the issue was we were calling `sanitize_text_field()` which was changing the secret. Since this secret is being saved via WP-CLI and since the value eventually gets sanitized by `sanitize_option()` in `update_option()`, I've opted to remove the `sanitize_text_field()` call.

#### Changes proposed in this Pull Request:

- Remove overzealous sanitizing of secret when authorizing user via WP CLI

#### Testing instructions:

User the partner ID and secret for JN. See PCYsg-eDL-p2 for information about finding that information.

- Checkout branch
- Use the following command, replacing partner the arguments :
    - `sh jetpack/bin/partner-provision.sh --partner_id={PARTNER_ID} --partner_secret={PARTNER_SECRET} --user={LOCAL_WP_USER_ID} --plan=professional` --wpcom_user_id={WHITELISTED_WPCOM_JN_USER}
- Ensure that `wp jetpack status` is successful


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Remove sanitizing of secret when authorizing user via WP CLI which sometimes modified the secret unnecessarily.
