### PR TITLE
Add Woocommerce change events to Jetpack Sync

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -54,6 +54,11 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
+		// attributes
+		add_action( 'woocommerce_attribute_added', $callable, 10, 2 );
+		add_action( 'woocommerce_attribute_updated', $callable, 10, 3 );
+		add_action( 'woocommerce_attribute_deleted', $callable, 10, 3 );
+
 		// orders
 		add_action( 'woocommerce_new_order', $callable, 10, 1 );
 		add_action( 'woocommerce_order_status_changed', $callable, 10, 3 );
@@ -62,9 +67,28 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		// order items
 		add_action( 'woocommerce_new_order_item', $callable, 10, 4 );
 		add_action( 'woocommerce_update_order_item', $callable, 10, 4 );
-
-		// order item meta
+		add_action( 'woocommerce_delete_order_item', $callable, 10, 1 );
 		$this->init_listeners_for_meta_type( 'order_item', $callable );
+
+		// payment tokens
+		add_action( 'woocommerce_new_payment_token', $callable, 10, 1 );
+		add_action( 'woocommerce_payment_token_deleted', $callable, 10, 2 );
+		add_action( 'woocommerce_payment_token_updated', $callable, 10, 1 );
+		$this->init_listeners_for_meta_type( 'payment_token', $callable );
+
+		// product downloads
+		add_action( 'woocommerce_downloadable_product_download_log_insert', $callable, 10, 1 );
+		add_action( 'woocommerce_grant_product_download_access', $callable, 10, 1 );
+
+		// tax rates
+		add_action( 'woocommerce_tax_rate_added', $callable, 10, 2 );
+		add_action( 'woocommerce_tax_rate_updated', $callable, 10, 2 );
+		add_action( 'woocommerce_tax_rate_deleted', $callable, 10, 1 );
+
+		// webhooks
+		add_action( 'woocommerce_new_webhook', $callable, 10, 1 );
+		add_action( 'woocommerce_webhook_deleted', $callable, 10, 2 );
+		add_action( 'woocommerce_webhook_updated', $callable, 10, 1 );
 	}
 
 	public function init_full_sync_listeners( $callable ) {


### PR DESCRIPTION
Add Woocommerce change events to Jetpack Sync. This PR also requires changes listed in D20788-code to support receiving Jetpack Sync events.

#### Changes proposed in this Pull Request:
This PR adds actions to the Jetpack Sync Woocommerce module for following changes to:
- Woocommerce Attributes
- Order Items
- Payment Tokens
- Product Downloads
- Tax Rates
- Webhooks

pa0RFL-7i-p2

#### Testing instructions:
Install Woocommerce alongside Jetpack, and verify that changes to the Woocommerce settings and order list are sent to Jetpack Sync. For example: 
- Setup a new Woocommerce Attribute, and verify `woocommerce_attribute_added` is sent
- Create a test Order, add some items and remove them, and verify that `woocommerce_new_order_item` and `woocommerce_delete_order_item` events are sent to JPS
- Configure a new Tax Rate and verify that `woocommerce_tax_rate_added`, `woocommerce_tax_rate_updated`, and `woocommerce_tax_rate_deleted` events are sent to JPS.

#### Proposed changelog entry for your changes:
No change log required.