### PR TITLE
Add a new endpoint for fetching database row backups

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
@@ -14,6 +14,11 @@ class Jetpack_JSON_API_Get_Database_Object_Backup_Endpoint extends Jetpack_JSON_
 			'id_field'  => 'attribute_id',
 		),
 
+		'woocommerce_downloadable_product_permission' => array(
+			'table'    => 'woocommerce_downloadable_product_permissions',
+			'id_field' => 'permission_id',
+		),
+
 		'woocommerce_order_item' => array(
 			'table'     => 'woocommerce_order_items',
 			'id_field'  => 'order_item_id',

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
@@ -45,7 +45,7 @@ class Jetpack_JSON_API_Get_Database_Object_Backup_Endpoint extends Jetpack_JSON_
 	);
 
 	function validate_input( $object ) {
-		$query_args = $this->query_args();		
+		$query_args = $this->query_args();
 
 		if ( empty( $query_args['object_type'] ) || empty( $query_args['object_id'] ) ) {
 			return new WP_Error( 'invalid_args', __( 'You must specify both an object type and id to fetch', 'jetpack' ), 400 );

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
@@ -1,0 +1,93 @@
+<?php
+
+class Jetpack_JSON_API_Get_Database_Object_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// /sites/%s/database-object/backup      -> $blog_id
+
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
+	protected $object_type;
+	protected $object_id;
+
+	// Full list of database objects that can be retrieved via this endpoint.
+	protected $object_types = array(
+		'woocommerce_attribute' => array(
+			'table'     => 'woocommerce_attribute_taxonomies',
+			'id_field'  => 'attribute_id',
+		),
+
+		'woocommerce_order_item' => array(
+			'table'     => 'woocommerce_order_items',
+			'id_field'  => 'order_item_id',
+			'meta_type' => 'order_item',
+		),
+
+		'woocommerce_payment_token' => array(
+			'table'     => 'woocommerce_payment_tokens',
+			'id_field'  => 'token_id',
+			'meta_type' => 'payment_token',
+		),
+
+		'woocommerce_tax_rate' => array(
+			'table'          => 'woocommerce_tax_rates',
+			'id_field'       => 'tax_rate_id',
+			'child_table'    => 'woocommerce_tax_rate_locations',
+			'child_id_field' => 'tax_rate_id',
+		),
+
+		'woocommerce_webhook' => array(
+			'table'    => 'wc_webhooks',
+			'id_field' => 'webhook_id',
+		),
+	);
+
+	function validate_input( $object ) {
+		global $wpdb;
+		$query_args = $this->query_args();		
+
+		if ( empty( $query_args['object_type'] ) || empty( $query_args['object_id'] ) ) {
+			return new WP_Error( 'invalid_args', __( 'You must specify both an object type and id to fetch', 'jetpack' ), 400 );
+		}
+
+		if ( empty( $this->object_types[ $query_args['object_type'] ] ) ) {
+			return new WP_Error( 'invalid_args', __( 'Specified object_type not recognized', 'jetpack' ), 400 );
+		}
+
+		$this->object_type = $this->object_types[ $query_args['object_type'] ];
+		$this->object_id   = $query_args['object_id'];
+
+		return true;
+	}
+
+	protected function result() {
+		global $wpdb;
+
+		$table    = $wpdb->prefix . $this->object_type['table'];
+		$id_field = $this->object_type['id_field'];
+
+		// Fetch the requested object
+		$query  = $wpdb->prepare( 'select * from `' . $table . '` where `' . $id_field . '` = %d', $this->object_id );
+		$object = $wpdb->get_row( $query );
+
+		if ( empty( $object ) ) {
+			return new WP_Error( 'object_not_found', __( 'Object not found', 'jetpack' ), 404 );
+		}
+
+		$result = array( 'object' => $object );
+
+		// Fetch associated metadata (if this object type has any)
+		if ( ! empty( $this->object_type['meta_type'] ) ) {
+			$result['meta'] = get_metadata( $this->object_type['meta_type'], $this->object_id );
+		}
+
+		// If there is a child linked table (eg: woocommerce_tax_rate_locations), fetch linked records
+		if ( ! empty( $this->object_type['child_table'] ) ) {
+			$child_table    = $wpdb->prefix . $this->object_type['child_table'];
+			$child_id_field = $this->object_type['child_id_field'];
+
+			$query = $wpdb->prepare( 'select * from `' . $child_table . '` where `' . $child_id_field . '` = %d', $this->object_id );
+			$result[ 'children' ] = $wpdb->get_results( $query );
+		}
+
+		return $result;
+	}
+
+}

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
@@ -45,7 +45,6 @@ class Jetpack_JSON_API_Get_Database_Object_Backup_Endpoint extends Jetpack_JSON_
 	);
 
 	function validate_input( $object ) {
-		global $wpdb;
 		$query_args = $this->query_args();		
 
 		if ( empty( $query_args['object_type'] ) || empty( $query_args['object_id'] ) ) {

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -956,6 +956,35 @@ new Jetpack_JSON_API_Cron_Unschedule_Endpoint( array(
 
 //	BACKUPS
 
+// GET /sites/%s/database-object/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-database-object-backup-endpoint.php' );
+new Jetpack_JSON_API_Get_Database_Object_Backup_Endpoint( array(
+	'description'    => 'Fetch a backup of a database object, along with all of its metadata',
+	'group'          => '__do_not_document',
+	'method'         => 'GET',
+	'path'           => '/sites/%s/database-object/backup',
+	'stat'           => 'database-objects:1:backup',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+	),
+	'query_parameters' => array(
+		'object_type' => '(string) Type of object to fetch from the database',
+		'object_id'   => '(int) ID of the database object to fetch',
+	),
+	'response_format' => array(
+		'object'   => '(array) Database object row',
+		'meta'     => '(array) Associative array of key/value metadata associated with the row',
+		'children' => '(array) Where appropriate, child records associated with the object. eg: Woocommerce tax rate locations',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/database-object/backup'
+) );
+
 // GET /sites/%s/comments/%d/backup
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-comment-backup-endpoint.php' );
 new Jetpack_JSON_API_Get_Comment_Backup_Endpoint( array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add a new endpoint for fetching database rows for backups. This PR is based on the existing endpoints for backing up individual posts (`/sites/%s/posts/%d/backup`), but allows backing up rows for a whitelisted set of tables. 

This first version only includes whitelisted tables for backing up Woocommerce's custom tables:
- `woocommerce_attribute_taxonomies`
- `woocommerce_downloadable_product_permissions`
- `woocommerce_order_items` and `woocommerce_order_itemmeta`
- `woocommerce_payment_tokens` and `woocommerce_payment_tokenmeta`
- `woocommerce_tax_rates` and `woocommerce_tax_rate_locations`
- `woocommerce_webhooks`

This PR is designed to pair with D20788-code, which adds this API endpoint to the public rest API.

pa0RFL-7i-p2

#### Testing instructions:
Install Woocommerce, and create some woo-specific objects to backup.

Using a Jetpack site auth token, access the following endpoint: 
`/sites/[your_site]/database-object/backup`

Pass in the following parameters: 
`object_type` - must be one of the whitelisted types. eg: `woocommerce_attribute`
`object_id` - the ID of the object to retrieve

#### Proposed changelog entry for your changes:
- Support for Woocommerce + Jetpack Rewind