### PR TITLE
Whitelisting WooCommerce's comment.rating field

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -44,6 +44,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_order_item', array( $this, 'filter_order_item' ) );
@@ -137,6 +138,10 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 	public function add_woocommerce_post_meta_whitelist( $list ) {
 		return array_merge( $list, self::$wc_post_meta_whitelist );
+	}
+
+	public function add_woocommerce_comment_meta_whitelist( $list ) {
+		return array_merge( $list, self::$wc_comment_meta_whitelist );
 	}
 
 	private static $wc_options_whitelist = array(
@@ -298,5 +303,9 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_order_version',
 		'_prices_include_tax',
 		'_payment_tokens',
+	);
+
+	private static $wc_comment_meta_whitelist = array(
+		'rating',
 	);
 }


### PR DESCRIPTION
### Details:
This PR is whitelisting the **comment.meta**'s **Rating** field (used by WooCommerce Product Reviews).

@timmyc may i bug you with this one?

Thanks a lot in advance!!


#### Testing instructions:
1. Setup a WooCommerce store, in a Self Hosted site
2. Install the patched `class.jetpack-sync-module-woocommerce.php` file
3. Connect the Store to a WordPress.com account
4. Receive a Product Review

- [ ] Verify that a Product Review Notification is generated
- [ ] Verify that the Rating shows up (the ratings field is rendered by means of stars!)


#### Proposed changelog entry for your changes:
No change log required.