### PR TITLE
Add lodash as map view dependency

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -23,6 +23,7 @@ jetpack_register_block(
  */
 function jetpack_map_block_load_assets( $attr, $content ) {
 	$dependencies = array(
+		'lodash',
 		'wp-element',
 		'wp-i18n',
 		'wp-api-fetch',


### PR DESCRIPTION
Companion to https://github.com/Automattic/wp-calypso/pull/28559

The SDK builds will remove `lodash` from the bundle, expecting the library to be available where used. In this case, we need to ensure that `lodash` is available as it's used for the map view.

#### Changes proposed in this Pull Request:

* Add `lodash` dep to map view

#### Testing instructions:

* Does this work with blocks built from https://github.com/Automattic/wp-calypso/pull/28559 ?

#### Proposed changelog entry for your changes:
None