### PR TITLE
Sync available Jetpack Gutenberg blocks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -72,6 +72,11 @@ class Jetpack_Gutenberg {
 		self::$blocks_index = apply_filters( 'jetpack_set_available_blocks', array() );
 
 		foreach ( self::$jetpack_blocks as $type => $args ) {
+			if ( 'publicize' === $type ) {
+				// publicize is not actually a block, it's a gutenberg plugin.
+				// We will handle it's registration on the client-side.
+				continue;
+			}
 			if ( isset( $args['availability']['available'] ) && $args['availability']['available'] && in_array( $type, self::$blocks_index ) ) {
 				register_block_type( 'jetpack/' . $type, $args['args'] );
 			}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -240,6 +240,7 @@ class Jetpack_Sync_Defaults {
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
 		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
+		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_block_availability' ),
 	);
 
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -52,6 +52,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function test_sync_callable_whitelist() {
 		// $this->setSyncClientDefaults();
 
+		add_filter( 'jetpack_set_available_blocks',  array( $this, 'add_test_block' ) );
+		jetpack_register_block( 'test' );
+		Jetpack_Gutenberg::load_blocks();
+
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),
 			'is_main_network'                  => Jetpack::is_multi_network(),
@@ -75,7 +79,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'sso_bypass_default_login_form'    => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
 			'wp_version'                       => Jetpack_Sync_Functions::wp_version(),
 			'get_plugins'                      => Jetpack_Sync_Functions::get_plugins(),
-			'get_plugins_action_links'		   => Jetpack_Sync_functions::get_plugins_action_links(),
+			'get_plugins_action_links'         => Jetpack_Sync_functions::get_plugins_action_links(),
 			'active_modules'                   => Jetpack::get_active_modules(),
 			'hosting_provider'                 => Jetpack_Sync_Functions::get_hosting_provider(),
 			'locale'                           => get_locale(),
@@ -83,6 +87,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
 			'roles'                            => Jetpack_Sync_Functions::roles(),
 			'timezone'                         => Jetpack_Sync_Functions::get_timezone(),
+			'available_jetpack_blocks'         => Jetpack_Gutenberg::get_block_availability(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {
@@ -121,6 +126,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$unique_whitelist = array_unique( $whitelist_keys );
 		$this->assertEquals( count( $unique_whitelist ), count( $whitelist_keys ), 'The duplicate keys are: ' . print_r( array_diff_key( $whitelist_keys, array_unique( $whitelist_keys ) ), 1 ) );
 
+	}
+
+	public function add_test_block( $blocks ) {
+		return array_merge( $blocks, array( 'test' ) );
 	}
 
 	function assertCallableIsSynced( $name, $value ) {


### PR DESCRIPTION
This PR syncs available Jetpack Gutenberg blocks via the Callables sync module/mechanism

#### Testing instructions:

With a working Gutenpack environment, disable the Markdown Jetpack module. You should observe a callable sync (PCYsg-hnH-p2) indicating that the Markdown block is unavailable.

#### Proposed changelog entry for your changes:

No changelog entry needed
