### PR TITLE
Gutenberg: update logic for block registration

### DIFF
--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -27,5 +27,3 @@ function jetpack_markdown_posting_always_on() {
 	}
 }
 add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );
-
-jetpack_register_block( 'markdown' );

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -69,6 +69,9 @@ class WPCom_Markdown {
 		}
 		add_action( 'admin_init', array( $this, 'register_setting' ) );
 		add_action( 'admin_init', array( $this, 'maybe_unload_for_bulk_edit' ) );
+
+		jetpack_register_block( 'markdown' );
+
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -116,6 +116,8 @@ abstract class Publicize_Base {
 
 		// Connection test callback
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
+
+		jetpack_register_block( 'publicize' );
 	}
 
 /*

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -76,4 +76,3 @@ class Jetpack_RelatedPosts_Module {
 
 // Do it.
 Jetpack_RelatedPosts_Module::instance();
-jetpack_register_block( 'related-posts' );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -79,6 +79,9 @@ class Jetpack_RelatedPosts {
 		if ( function_exists( 'register_rest_field' ) ) {
 			add_action( 'rest_api_init',  array( $this, 'rest_register_related_posts' ) );
 		}
+
+
+		jetpack_register_block( 'related-posts' );
 	}
 
 	/**

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -41,6 +41,13 @@ class Jetpack_Simple_Payments {
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
+
+		if ( $this->is_enabled_jetpack_simple_payments() ) {
+			jetpack_register_block( 'simple-payments' );
+		} else {
+			jetpack_register_block( 'simple-payments', array(), array( 'available' => false, 'unavailable_reason' => 'missing_plan' ) );
+		}
+
 	}
 
 	private function register_shortcode() {


### PR DESCRIPTION
This PR changes the way we register both the `related-posts` and `markdown` gutenberg blocks so that we can share the logic with wpcom.

This PR also adds registration for the `simple-payments` and `publicize` blocks so that we can expose their availability data to the post editor.

#### Changes proposed in this Pull Request:

* Exposes block availability data for simple payments and publicize

#### Testing instructions:
- In progress - waiting on a calypso PR

#### Proposed changelog entry for your changes:
None