### PR TITLE
Update/gutenberg block registration logic

### DIFF
--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -27,5 +27,3 @@ function jetpack_markdown_posting_always_on() {
 	}
 }
 add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );
-
-jetpack_register_block( 'markdown' );

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -72,6 +72,7 @@ class WPCom_Markdown {
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}
+		jetpack_register_block( 'markdown' );
 	}
 
 	/**

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -76,4 +76,3 @@ class Jetpack_RelatedPosts_Module {
 
 // Do it.
 Jetpack_RelatedPosts_Module::instance();
-jetpack_register_block( 'related-posts' );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -79,6 +79,8 @@ class Jetpack_RelatedPosts {
 		if ( function_exists( 'register_rest_field' ) ) {
 			add_action( 'rest_api_init',  array( $this, 'rest_register_related_posts' ) );
 		}
+
+		jetpack_register_block( 'related-posts' );
 	}
 
 	/**


### PR DESCRIPTION
This PR is a minor refactor in how we register the `related-posts` and `markdown` 

Previously we registered them in files that are not synced with wordpress.com, now will move the registration to files that are shared with wordpress.com so we can share the logic.


#### Changes proposed in this Pull Request:

* Nothing should change, as it is just a re-factor

#### Testing instructions:

* Ensure you are running the latest blocks from wp-calypso
* Ensure that the markdown and related posts gutenberg blocks continue to function as expected
( they are available in the post editor when module is active, and unavailable when the module is deactivate )

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
