### PR TITLE
Gutenberg: Expose block availability data for `simple-payments` block

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -57,6 +57,12 @@ class Jetpack_Simple_Payments {
 		$this->setup_cpts();
 
 		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
+
+		if ( $this->is_enabled_jetpack_simple_payments() ) {
+			jetpack_register_block( 'simple-payments' );
+		} else {
+			jetpack_register_block( 'simple-payments', array(), array( 'available' => false, 'unavailable_reason' => 'missing_plan' ) );
+		}
 	}
 
 	function remove_auto_paragraph_from_product_description( $content ) {


### PR DESCRIPTION
This PR exposes availability data for the simple payments gutenberg block
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* The Simple Payments Gutenberg block will no longer appear if the site does not have access to the feature.

#### Testing instructions:

* Run this branch locally
* Ensure you are running blocks from [this Calypso PR](https://github.com/Automattic/wp-calypso/pull/28571)
* If your site is on a paid plan, you should be able to use the simple payments block in the post editor
* If your site is not on a paid plan, the block should not appear in the list of blocks in the post editor

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
