### PR TITLE
Typo - remove left-over right angle bracket

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -151,7 +151,7 @@ class Jetpack_Sitemap_Builder {
 			if ( ! class_exists( 'DOMDocument' ) ) {
 				$this->logger->report(
 					__(
-						'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our >server requirements at https://jetpack.com/support/server-requirements/ .',
+						'Jetpack can not load necessary XML manipulation libraries. Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ .',
 						'jetpack'
 					),
 					true


### PR DESCRIPTION
The right angle bracket in front of `… >server requirements …` seems to be a left-over from a previous iteration of the string. 
> `… <a href="%s">server requirements</a>. …`
see https://github.com/Automattic/jetpack/pull/10477#pullrequestreview-169398142 for details.

#### Proposed changelog entry for your changes:
*typo fixed
