### PR TITLE
Markdown: Leave Gutenberg content intact

### DIFF
--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -573,6 +573,11 @@ jQuery( function() {
 	 * @return string        Markdown-processed content
 	 */
 	public function transform( $text, $args = array() ) {
+		// If this contains Gutenberg content, let's keep it intact.
+		if ( function_exists( 'has_blocks' ) && has_blocks( $text ) ) {
+			return $text;
+		}
+
 		$args = wp_parse_args( $args, array(
 			'id' => false,
 			'unslash' => true,


### PR DESCRIPTION
This PR updates the Markdown module to leave any Gutenberg content untouched, in order to not mess up the block markup validation and parsing.

Fixes #10634

#### Changes proposed in this Pull Request:

* Update the Markdown module to leave untouched any content that contains Gutenberg blocks.

#### Testing instructions:

* Make sure you have the latest WordPress 5.0 beta.
* Checkout this branch.
* Make sure your site is connected.
* Make sure Markdown is enabled.
* Write a Gutenberg post with various blocks.
* After saving and refreshing, verify there are no validation errors.
* Try the Markdown block.
* Verify it works well with various content.
* Install and activate the Classic Editor plugin.
* Write a post in the classic editor and verify Markdown still works well there.

#### Proposed changelog entry for your changes:

* Make Markdown module compatible with the Gutenberg editor in WordPress 5.0.
