### PR TITLE
Store: Seo utils for E-commerce plan

### DIFF
--- a/modules/seo-tools/jetpack-seo-utils.php
+++ b/modules/seo-tools/jetpack-seo-utils.php
@@ -41,7 +41,7 @@ class Jetpack_SEO_Utils {
 				$site_id = get_current_blog_id();
 			}
 
-			return has_any_blog_stickers( [ 'business-plan', 'ecommerce-plan' ], $site_id );
+			return has_any_blog_stickers( array( 'business-plan', 'ecommerce-plan' ), $site_id );
 		}
 
 		// For all Jetpack sites

--- a/modules/seo-tools/jetpack-seo-utils.php
+++ b/modules/seo-tools/jetpack-seo-utils.php
@@ -35,13 +35,13 @@ class Jetpack_SEO_Utils {
 			return false;
 		}
 
-		if ( function_exists( 'has_blog_sticker' ) ) {
+		if ( function_exists( 'has_any_blog_stickers' ) ) {
 			// For WPCOM sites
 			if ( empty( $site_id ) ) {
 				$site_id = get_current_blog_id();
 			}
 
-			return has_blog_sticker( 'business-plan', $site_id );
+			return has_any_blog_stickers( [ 'business-plan', 'ecommerce-plan' ], $site_id );
 		}
 
 		// For all Jetpack sites


### PR DESCRIPTION
Differential Revision: D20871

This commit syncs r183481-wpcom.

Enables SEO Utils for sites on E-commerce plan for WPCOM

I'm not quite sure why this code also goes to Jetpack.

#### Changes proposed in this Pull Request:

The E-commerce plan has another blog sticker.

#### Testing instructions:

Please check D20871-code for testing instructions, I don't think this code will be hit outside of WPCOM environment.

#### Proposed changelog entry for your changes:

No need for a changelog entry
