### PR TITLE
Map Block View-Side Path Handling

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -207,7 +207,7 @@ class Jetpack_Gutenberg {
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( self::block_has_asset( $style_relative_path ) ) {
 			$style_version = self::get_asset_version( $style_relative_path );
-			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_DIR );
+			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
 		}
 
@@ -218,6 +218,12 @@ class Jetpack_Gutenberg {
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
 		}
+
+		wp_localize_script(
+			'jetpack-block-' . $type,
+			'Jetpack_Block_Assets_Base_Url',
+			plugins_url( '_inc/blocks/', JETPACK__PLUGIN_FILE )
+		);
 	}
 
 	/**

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -23,6 +23,7 @@ jetpack_register_block(
  */
 function jetpack_map_block_load_assets( $attr, $content ) {
 	$dependencies = array(
+		'lodash',
 		'wp-element',
 		'wp-i18n',
 		'wp-api-fetch',


### PR DESCRIPTION
This PR resolves a couple of view-side path issues that break the Map block. The block uses [Webpack Dynamic Imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports) to load the Mapbox library, so a base URL needs to be set so that the import paths are correct. A second fix resolves an issue around the view-side stylesheet path for blocks. 

#### Testing instructions:

Try the Map block using Jetpack `master`. It should work fine in the editor, but when you publish or preview you should see either nothing or the placeholder content (bulleted list of marker locations). Switch to `try/block-view-fixes` and the block should load normally. 

JN link: https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=master&branch=try/block-view-fixes

In JN, after setting up Jetpack and switching on `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`, you should be able to use the Map block normally, publish and see it render properly in the view.

#### Proposed changelog entry for your changes:

No need for a changelog entry