### PR TITLE
Jetpack Admin: handle a search term on page load

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -38,6 +38,8 @@ export const NavigationSettings = createReactClass( {
 	moduleList: [],
 
 	componentWillMount() {
+		// We need to handle the search term not only on route update but also on page load in case of some external redirects
+		this.onRouteChange( this.context.router.getCurrentLocation() );
 		this.context.router.listen( this.onRouteChange );
 		this.moduleList = Object.keys( this.props.moduleList );
 	},

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -42,7 +42,8 @@ describe( 'NavigationSettings', () => {
 			context: {
 				router: {
 					goBack: () => {},
-					listen: () => {}
+					listen: () => {},
+					getCurrentLocation: () => ( {} ),
 				},
 			},
 			moduleList: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #9260

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fixes the existing bug which does not search for a search term in a route during initial page load.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/admin.php?page=jetpack#/settings?term=ads
* make sure you see the search results
* Try few more search terms

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Admin page: fix a bug preventing search on page load
