### PR TITLE
Publicize API: Sync with WordPress.com

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -16,6 +16,14 @@
  * @since 6.8
  */
 class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Controller {
+	/**
+	 * Flag to help WordPress.com decide where it should look for
+	 * Publicize data. Ignored for direct requests to Jetpack sites.
+	 *
+	 * @var bool $wpcom_is_wpcom_only_endpoint
+	 */
+	public $wpcom_is_wpcom_only_endpoint = true;
+
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'publicize/connections';

--- a/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -15,6 +15,14 @@
  * @since 6.8
  */
 class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Controller {
+	/**
+	 * Flag to help WordPress.com decide where it should look for
+	 * Publicize data. Ignored for direct requests to Jetpack sites.
+	 *
+	 * @var bool $wpcom_is_wpcom_only_endpoint
+	 */
+	public $wpcom_is_wpcom_only_endpoint = true;
+
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'publicize/services';


### PR DESCRIPTION
D20948-code.

#### Changes proposed in this Pull Request:

The flag added in this PR is ignored on Jetpack sites. On WordPress.com, it helps decide where to find the Publicize data needed in order to respond to these requests.

This PR is for code sync purposes only.

#### Testing instructions:
* `phpunit --group publicize`

#### Proposed changelog entry for your changes:

None required.