### PR TITLE
Asset CDN: do not try to serve assets from non-public versions.

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -148,7 +148,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 *
 	 * @param string $plugin plugin slug string.
 	 * @param string $version plugin version number string.
-	 * @return array
+	 * @return array|bool Will return false if not a public version.
 	 */
 	public static function get_plugin_assets( $plugin, $version ) {
 		if ( 'jetpack' === $plugin && JETPACK__VERSION === $version ) {

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -153,7 +153,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	public static function get_plugin_assets( $plugin, $version ) {
 		if ( 'jetpack' === $plugin && JETPACK__VERSION === $version ) {
 			if ( ! self::is_public_version( $version ) ) {
-				return array();
+				return false;
 			}
 
 			$assets = array(); // The variable will be redefined in the included file.
@@ -177,6 +177,10 @@ class Jetpack_Photon_Static_Assets_CDN {
 		$assets = apply_filters( "jetpack_cdn_plugin_assets-{$plugin}", null, $version );
 		if ( is_array( $assets ) ) {
 			return $assets;
+		}
+
+		if ( ! self::is_public_version( $version ) ) {
+			return false;
 		}
 
 		$cache = Jetpack_Options::get_option( 'static_asset_cdn_files', array() );

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -151,7 +151,11 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return array
 	 */
 	public static function get_plugin_assets( $plugin, $version ) {
-		if ( 'jetpack' === $plugin && JETPACK__VERSION === $version ) {
+		if (
+			'jetpack' === $plugin
+			&& JETPACK__VERSION === $version
+			&& self::is_public_version( $version )
+		) {
 			$assets = array(); // The variable will be redefined in the included file.
 
 			include JETPACK__PLUGIN_DIR . 'modules/photon-cdn/jetpack-manifest.php';
@@ -173,10 +177,6 @@ class Jetpack_Photon_Static_Assets_CDN {
 		$assets = apply_filters( "jetpack_cdn_plugin_assets-{$plugin}", null, $version );
 		if ( is_array( $assets ) ) {
 			return $assets;
-		}
-
-		if ( ! self::is_public_version( $version ) ) {
-			return false;
 		}
 
 		$cache = Jetpack_Options::get_option( 'static_asset_cdn_files', array() );

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -151,11 +151,11 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return array
 	 */
 	public static function get_plugin_assets( $plugin, $version ) {
-		if (
-			'jetpack' === $plugin
-			&& JETPACK__VERSION === $version
-			&& self::is_public_version( $version )
-		) {
+		if ( 'jetpack' === $plugin && JETPACK__VERSION === $version ) {
+			if ( ! self::is_public_version( $version ) ) {
+				return array();
+			}
+
 			$assets = array(); // The variable will be redefined in the included file.
 
 			include JETPACK__PLUGIN_DIR . 'modules/photon-cdn/jetpack-manifest.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- When checking for the files in Jetpack, only look for files to cdnize
if Jetpack's version is public (not a development version).

#### Testing instructions:

1. On a local installation of Jetpack (not using the Beta plugin), run this branch. Your Jetpack version will be 6.8-alpha.
2. Go to Jetpack > Settings and enable the Asset CDN feature.
3. Check that once you've done so, after refreshing, no Jetpack files are served from the CDN.

#### Proposed changelog entry for your changes:
* Asset CDN: do not try to serve assets from non-public versions.

Fixes #10633