### PR TITLE
REST API Field Controller: Simplify Array Recursion

### DIFF
--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -300,16 +300,11 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 				}
 
 				// Recurse to prune sub-properties of each item.
-				$keys = array_keys( $value );
+				foreach ( $value as $key => $item ) {
+					$value[$key] = $this->filter_response_by_context( $item, $schema['items'], $context );
+				}
 
-				$items = array_map(
-					array( $this, 'filter_response_by_context' ),
-					$value,
-					array_fill( 0, count( $keys ), $schema['items'] ),
-					array_fill( 0, count( $keys ), $context )
-				);
-
-				return array_combine( $keys, $items );
+				return $value;
 			case 'object':
 				if ( ! isset( $schema['properties'] ) ) {
 					return $value;

--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -301,7 +301,7 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 
 				// Recurse to prune sub-properties of each item.
 				foreach ( $value as $key => $item ) {
-					$value[$key] = $this->filter_response_by_context( $item, $schema['items'], $context );
+					$value[ $key ] = $this->filter_response_by_context( $item, $schema['items'], $context );
 				}
 
 				return $value;


### PR DESCRIPTION
Fixes #10649

#### Changes proposed in this Pull Request:
* Replace complicated `array_map()` with `foreach`.
* Fixes PHP Warning for PHP < 5.6 when there are no items in the array.

#### Testing instructions:
##### Automated Tests
* `phpunit --group publicize`
* `phpunit --group rest-api`

##### Manual Tests
1. Create a site using this branch, WordPress 4.9.8, Gutenberg, **PHP 5.4**
2. Connect Jetpack.
3. Go to wp-admin/ -> Posts -> New

Prior to this patch: see PHP Warnings.

After this patch: see no PHP Warnings.

#### Proposed changelog entry for your changes:

None required.