### PR TITLE
Gutenberg: Enqueue social logos style with block assets

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -311,6 +311,7 @@ class Jetpack_Gutenberg {
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 
 		// The social-logos styles are used for Publicize service icons
+		// TODO: Remove when we ship the icons with the Gutenberg blocks build
 		wp_enqueue_style( 'social-logos' );
 	}
 }

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -309,5 +309,8 @@ class Jetpack_Gutenberg {
 		Jetpack::setup_wp_i18n_locale_data();
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+
+		// The social-logos styles are used for Publicize service icons
+		wp_enqueue_style( 'social-logos' );
 	}
 }


### PR DESCRIPTION
Currently, we're missing the `social-logos` styles when displaying the Gutenberg editor, which results in our Publicize extension for Gutenberg to display connections without social icons.

Ideally, we'd want to ship the icons with the build, but this is material for another PR, as it requires changes to how we build and distribute icons from the [social-logos](https://github.com/Automattic/social-logos) repo.

#### Changes proposed in this Pull Request:

* Enqueue `social-logos` styles together with the Gutenberg block assets

#### Preview

**Before**
![](https://cldup.com/Gf5rVgbl6K.png)

**After**
![](https://cldup.com/pFjMx6KhqZ.png)

#### Testing instructions:
* Spin up a JN site with this branch from [this link](https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/social-logos-style-to-gutenberg-assets).
* Connect the site to WP.com.
* Start a new post, write a post title.
* Click the Publish button.
* Connect a Publicize service.
* Refresh the post, or close the additional window that was opened for connecting a service.
* Verify the corresponding service icon appears to the left of the Publicize connection.

#### Proposed changelog entry for your changes:

* Enqueue `social-logos` styles together with the Gutenberg block assets
