### PR TITLE
Publicize: Register Gutenblock upon initialization

### DIFF
--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -46,6 +46,10 @@ class Jetpack_Publicize {
 			if ( in_array( 'publicize', $active ) && !in_array( 'sharedaddy', $active ) )
 				add_action( 'admin_menu', array( &$publicize_ui, 'sharing_menu' ) );
 		}
+
+		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
+		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
+		jetpack_register_block( 'publicize' );
 	}
 
 	function jetpack_configuration_load() {


### PR DESCRIPTION
Counterpart to https://github.com/Automattic/wp-calypso/pull/28630

#### Changes proposed in this Pull Request:

Register the Publicize Gutenberg Plugin upon module initialization

#### Testing instructions:

- In Jetpack's 'Sharing' settings (`/wp-admin/admin.php?page=jetpack#/sharing`), make sure that `Automatically share your posts to social networks` is disabled.
- Open the Gutenberg editor with an existing or a new post
- Open the browser console, and type `window.Jetpack_Editor_Initial_State`
- Verify that the `publicize` module's `available` property is `false`

![image](https://user-images.githubusercontent.com/96308/48622125-0dca3a00-e9a6-11e8-892a-a9de4310d1d8.png)

- Now go back to  `/wp-admin/admin.php?page=jetpack#/sharing`, and enable `Automatically share your posts to social networks`.
- Go back to the editor
- Open the browser console, and type `window.Jetpack_Editor_Initial_State`
- Verify that the `publicize` module's `available` property is now `true`

![image](https://user-images.githubusercontent.com/96308/48621950-8977b700-e9a5-11e8-8cfb-ce70418ec22b.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

(Probably doesn't need a changelog entry)

