### PR TITLE
Update simple payments code to work with E-commerce plan

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -99,9 +99,9 @@ class Jetpack_Simple_Payments {
 		}
 
 		// For WPCOM sites
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'has_blog_sticker' ) ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'has_any_blog_stickers' ) ) {
 			$site_id = $this->get_blog_id();
-			return has_blog_sticker( 'premium-plan', $site_id ) || has_blog_sticker( 'business-plan', $site_id );
+			return has_any_blog_stickers( array( 'premium-plan', 'business-plan', 'ecommerce-plan' ), $site_id );
 		}
 
 		// For all Jetpack sites


### PR DESCRIPTION
Differential Revision: D20883-code

This commit syncs r183568-wpcom.

Add the E-commerce plan sticker to the list of stickers that support Simple Payments
Fixes #

#### Changes proposed in this Pull Request:

This is a WPCOM-specific change

#### Testing instructions:

The way I tested was by adding debugs in the code. Since it runs on every single page load, just add a few debugs around the usage of the method (except in the shortcode), and load any page.

#### Proposed changelog entry for your changes:

No entry