### PR TITLE
Fix: Unnecessary query calls without WooCommerce - PR ready for review

### DIFF
--- a/modules/woocommerce-analytics/wp-woocommerce-analytics.php
+++ b/modules/woocommerce-analytics/wp-woocommerce-analytics.php
@@ -38,6 +38,14 @@ class Jetpack_WooCommerce_Analytics {
 	 * @return bool
 	 */
 	public static function shouldTrackStore() {
+		/**
+		 * Make sure WooCommerce is installed and active
+		 *
+		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
+		 */
+		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ) ) ) {
+			return false;
+		}
 		// Tracking only Site pages
 		if ( is_admin() ) {
 			return false;
@@ -50,15 +58,6 @@ class Jetpack_WooCommerce_Analytics {
 		if ( ! Jetpack::is_active() ) {
 			return false;
 		}
-		/**
-		 * Make sure WooCommerce is installed and active
-		 *
-		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
-		 */
-		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ) ) ) {
-			return false;
-		}
-
 		// Ensure the WooCommerce class exists and is a valid version
 		$minimum_woocommerce_active = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.0', '>=' );
 		if ( ! $minimum_woocommerce_active ) {

--- a/modules/woocommerce-analytics/wp-woocommerce-analytics.php
+++ b/modules/woocommerce-analytics/wp-woocommerce-analytics.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once plugin_basename( 'classes/wp-woocommerce-analytics-universal.php' );
-require_once( ABSPATH .'wp-admin/includes/plugin.php' );
 
 /**
  * Class Jetpack_WooCommerce_Analytics
@@ -44,7 +43,7 @@ class Jetpack_WooCommerce_Analytics {
 		 *
 		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
 		 */
-		if ( !is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ) ) ) {
 			return false;
 		}
 		// Tracking only Site pages

--- a/modules/woocommerce-analytics/wp-woocommerce-analytics.php
+++ b/modules/woocommerce-analytics/wp-woocommerce-analytics.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once plugin_basename( 'classes/wp-woocommerce-analytics-universal.php' );
+require_once( ABSPATH .'wp-admin/includes/plugin.php' );
 
 /**
  * Class Jetpack_WooCommerce_Analytics
@@ -43,7 +44,7 @@ class Jetpack_WooCommerce_Analytics {
 		 *
 		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
 		 */
-		if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ) ) ) {
+		if ( !is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 			return false;
 		}
 		// Tracking only Site pages


### PR DESCRIPTION
As the issue #9736 states, there are a number of unnecessary query calls from the wp-woocommerce-analytics.php.

#### Changes proposed in this Pull Request:

I have changed the order of the calling of the functions, to make the check if WooCommerce is installed/active to avoid other functions calls that result in unnecessary query calls. As it was mentioned in the issue description there might be other ways to check if the plugin is active, I have changed (and tested) the function to is_plugin_active() . Not sure if it has any effect on the performance, but it's less code and works well. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
I recommend testing with the Query Monitor Plugin.
Check the **Query Monitor > Queries by Component > Plugin: jetpack menu**, with WooCommerce activated and deactivated. The mentioned queries should only show up when it's activated.

WooCommerce Activated:
<img width="938" alt="queryoriginal17" src="https://user-images.githubusercontent.com/31791243/48685294-891f2c00-ebf0-11e8-9edd-1c89a7096249.png">

WooCommerce Deactivated:
<img width="819" alt="queryafterfix" src="https://user-images.githubusercontent.com/31791243/48685285-81f81e00-ebf0-11e8-8cac-6534aa4e2625.png">

#### Proposed changelog entry for your changes:

None required.