### PR TITLE
Jetpack: Use settings search term as default module configuration URL

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -165,7 +165,7 @@ class Jetpack_Admin {
 					 */
 					apply_filters( 'jetpack_module_configurable_' . $module, false )
 				) {
-					$module_array['configurable'] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( Jetpack::module_configuration_url( $module ) ), __( 'Configure', 'jetpack' ) );
+					$module_array['configurable'] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $module_array['configure_url'] ), __( 'Configure', 'jetpack' ) );
 				}
 
 				$modules[ $module ] = $module_array;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3145,9 +3145,26 @@ class Jetpack {
 		add_filter( 'jetpack_module_configurable_' . $module, '__return_true' );
 	}
 
+	/**
+	 * Composes a module configure URL. It uses Jetpack settings search as default value
+	 * It is possible to redefine resulting URL by using "jetpack_module_configuration_url_$module" filter
+	 *
+	 * @param string $module Module slug
+	 * @return string $url module configuration URL
+	 */
 	public static function module_configuration_url( $module ) {
 		$module = Jetpack::get_module_slug( $module );
-		return Jetpack::admin_url( array( 'page' => 'jetpack', 'configure' => $module ) );
+		$default_url =  Jetpack::admin_url() . "#/settings?term=$module";
+		/**
+		 * Allows to modify configure_url of specific module to be able to redirect to some custom location.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $default_url Default url, which redirects to jetpack settings page.
+		 */
+		$url = apply_filters( 'jetpack_module_configuration_url_' . $module, $default_url );
+
+		return $url;
 	}
 
 	public static function module_configuration_load( $module, $method ) {

--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -49,7 +49,7 @@ add_action( 'jetpack_modules_loaded', 'custom_css_loaded' );
 function custom_css_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 	Jetpack::module_configuration_load( __FILE__, 'custom_css_configuration_load' );
-	add_filter( 'jetpack_module_configuration_url_custom-css', 'jetpack_widgets_configuration_url' );
+	add_filter( 'jetpack_module_configuration_url_custom-css', 'jetpack_custom_css_configuration_url' );
 }
 
 /**
@@ -58,7 +58,7 @@ function custom_css_loaded() {
  * @uses admin_url
  * @return string module settings URL
  */
-function jetpack_widgets_configuration_url() {
+function jetpack_custom_css_configuration_url() {
 	// Redirect to Core's CSS editor in the customizer if the feature is available.
 	if ( function_exists( 'wp_get_custom_css' ) ) {
 		$configuration_link = Jetpack_Custom_CSS_Enhancements::customizer_link(

--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -49,6 +49,28 @@ add_action( 'jetpack_modules_loaded', 'custom_css_loaded' );
 function custom_css_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 	Jetpack::module_configuration_load( __FILE__, 'custom_css_configuration_load' );
+	add_filter( 'jetpack_module_configuration_url_custom-css', 'jetpack_widgets_configuration_url' );
+}
+
+/**
+ * Overrides default configuration url
+ *
+ * @uses admin_url
+ * @return string module settings URL
+ */
+function jetpack_widgets_configuration_url() {
+	// Redirect to Core's CSS editor in the customizer if the feature is available.
+	if ( function_exists( 'wp_get_custom_css' ) ) {
+		$configuration_link = Jetpack_Custom_CSS_Enhancements::customizer_link(
+			array(
+				'return_url' => wp_get_referer(),
+			)
+		);
+	} else {
+		$configuration_link = admin_url( 'themes.php?page=editcss#settingsdiv' );
+	}
+
+	return $configuration_link;
 }
 
 function custom_css_configuration_load() {

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -64,6 +64,7 @@ class Jetpack_Infinite_Scroll_Extras {
 	public function action_jetpack_modules_loaded() {
 		Jetpack::enable_module_configurable( __FILE__ );
 		Jetpack::module_configuration_load( __FILE__, array( $this, 'module_configuration_load' ) );
+		add_filter( 'jetpack_module_configuration_url_infinite-scroll', array( $this, 'configuration_url' ) );
 	}
 
 	/**
@@ -75,6 +76,16 @@ class Jetpack_Infinite_Scroll_Extras {
 	public function module_configuration_load() {
 		wp_safe_redirect( admin_url( 'options-reading.php#infinite-scroll-options' ) );
 		exit;
+	}
+
+	/**
+	 * Overrides default configuration url
+	 *
+	 * @uses admin_url
+	 * @return string module settings URL
+	 */
+	public function configuration_url() {
+		return admin_url( 'options-reading.php#infinite-scroll-options' );
 	}
 
 	/**

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -64,7 +64,7 @@ class Jetpack_Infinite_Scroll_Extras {
 	public function action_jetpack_modules_loaded() {
 		Jetpack::enable_module_configurable( __FILE__ );
 		Jetpack::module_configuration_load( __FILE__, array( $this, 'module_configuration_load' ) );
-		add_filter( 'jetpack_module_configuration_url_infinite-scroll', array( $this, 'configuration_url' ) );
+		add_filter( 'jetpack_module_configuration_url_infinite-scroll', array( $this, 'infinite_scroll_configuration_url' ) );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class Jetpack_Infinite_Scroll_Extras {
 	 * @uses admin_url
 	 * @return string module settings URL
 	 */
-	public function configuration_url() {
+	public function infinite_scroll_configuration_url() {
 		return admin_url( 'options-reading.php#infinite-scroll-options' );
 	}
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -46,6 +46,7 @@ class Jetpack_Likes {
 
 			Jetpack::enable_module_configurable( __FILE__ );
 			Jetpack::module_configuration_load( __FILE__, array( $this, 'configuration_redirect' ) );
+			add_filter( 'jetpack_module_configuration_url_likes', array( $this, 'jetpack_likes_configuration_url' ) );
 
 			add_action( 'admin_print_scripts-settings_page_sharing', array( &$this, 'load_jp_css' ) );
 			add_filter( 'sharing_show_buttons_on_row_start', array( $this, 'configuration_target_area' ) );
@@ -119,6 +120,16 @@ class Jetpack_Likes {
 	function configuration_redirect() {
 		wp_safe_redirect( admin_url( 'options-general.php?page=sharing#likes' ) );
 		die();
+	}
+
+	/**
+	 * Overrides default configuration url
+	 *
+	 * @uses admin_url
+	 * @return string module settings URL
+	 */
+	function jetpack_likes_configuration_url() {
+		return admin_url( 'options-general.php?page=sharing#likes' );
 	}
 
 	/**

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -22,11 +22,22 @@ add_action( 'jetpack_modules_loaded', 'jetpack_tiled_gallery_loaded' );
 function jetpack_tiled_gallery_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 	Jetpack::module_configuration_load( __FILE__, 'jetpack_tiled_gallery_configuration_load' );
+	add_filter( 'jetpack_module_configuration_url_tiled-gallery', 'jetpack_tiled_gallery_configuration_url' );
 }
 
 function jetpack_tiled_gallery_configuration_load() {
 	wp_safe_redirect( admin_url( 'options-media.php' ) );
 	exit;
+}
+
+/**
+ * Overrides default configuration url
+ *
+ * @uses admin_url
+ * @return string module settings URL
+ */
+function jetpack_tiled_gallery_configuration_url() {
+	return admin_url( 'options-media.php' );
 }
 
 jetpack_load_tiled_gallery();

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -41,6 +41,7 @@ add_action( 'jetpack_modules_loaded', 'jetpack_widgets_loaded' );
 function jetpack_widgets_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 	Jetpack::module_configuration_load( __FILE__, 'jetpack_widgets_configuration_load' );
+	add_filter( 'jetpack_module_configuration_url_widgets', 'jetpack_widgets_configuration_url' );
 }
 
 function jetpack_widgets_configuration_load() {
@@ -48,7 +49,15 @@ function jetpack_widgets_configuration_load() {
 	exit;
 }
 
-
+/**
+ * Overrides default configuration url
+ *
+ * @uses admin_url
+ * @return string module settings URL
+ */
+function jetpack_widgets_configuration_url() {
+	return admin_url( 'widgets.php' );
+}
 
 jetpack_load_widgets();
 

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -56,7 +56,7 @@ function jetpack_widgets_configuration_load() {
  * @return string module settings URL
  */
 function jetpack_widgets_configuration_url() {
-	return admin_url( 'widgets.php' );
+	return admin_url( 'customize.php?autofocus[panel]=widgets' );
 }
 
 jetpack_load_widgets();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates `configure_url` to redirect to Jetpack Settings search term by default. Before this - it was redirecting to legacy pre-react configuration pages.

This change required by #10611 to provide flawless UX.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `wp-admin/admin.php?page=jetpack_modules`
* Find a module with 'Configure' button. 
* Make sure it redirects to `wp-admin/admin.php?page=jetpack#/settings?term=$MODULE`
* try some other modules. Some of them might redirect

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Admin Page: Module configuration URLs now redirects to the relevant section in Jetpack settings 
