### PR TITLE
Jetpack Gutenberg: fix #10665

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -205,6 +205,11 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function load_assets_as_required( $type, $script_dependencies = array() ) {
+		if ( is_admin() ) {
+			// A block's view assets will not be required in wp-admin.
+			return;
+		}
+
 		$type = sanitize_title_with_dashes( $type );
 		// Enqueue styles.
 		$style_relative_path = '_inc/blocks/' . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';


### PR DESCRIPTION
Enqueuing a block's view assets in wp-admin is not needed.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #10665

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* We'll no longer enqueue a block's view assets in the Gutenberg post editor

#### Testing instructions:

1. Requires https://github.com/Automattic/wp-calypso/pull/28702
2. Try this [Jurassic Ninja Link](https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/sdk-remove-view-scripts-from-editor-bundles&branch=fix/10665-do-not-enqueue-block-view-assets-in-the-post-editor)
2. Ensure `JETPACK_BETA_BLOCKS` is set to `true`.
3. Open the Gutenberg editor
4. Add a map block. Note that the map view assets are not present.
5. Save and refresh the page, the map view assets should still be absent.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
