### PR TITLE
Publicize: Correctly set a post's connections on/off switches during REST requests

### DIFF
--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -201,13 +201,8 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 			return $permission_check;
 		}
 
-		$meta_to_update = $this->get_meta_to_update( $request['jetpack_publicize_connections'], isset( $post->ID ) ? $post->ID : 0 );
-
-		if ( ! isset( $post->meta_input ) ) {
-			$post->meta_input = array();
-		}
-
-		$post->meta_input = array_merge( $post->meta_input, $meta_to_update );
+		// memoize
+		$this->get_meta_to_update( $request['jetpack_publicize_connections'], isset( $post->ID ) ? $post->ID : 0 );
 
 		return $post;
 	}

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -184,7 +184,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 
 	/**
 	 * Prior to updating the post, first calculate which Services to
-	 * Publicze to and which to skip.
+	 * Publicize to and which to skip.
 	 *
 	 * @param object $post Post data to insert/update.
 	 * @param WP_REST_Request $request

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -231,7 +231,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 			return;
 		}
 
-		$this->memoized_updates[$post->ID] = $this->memoized_updates[0];
+		$this->memoized_updates[ $post->ID ] = $this->memoized_updates[0];
 		unset( $this->memoized_updates[0] );
 	}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -837,7 +837,31 @@ abstract class Publicize_Base {
 			$args['object_subtype'] = $post_type;
 
 			register_meta( 'post', $this->POST_MESS, $args );
+
+			add_filter( 'rest_pre_insert_' . $post_type, array( $this, 'rest_pre_insert' ), 10, 2 );
 		}
+	}
+
+	/**
+	 * Insert the Publicize Message post_meta prior directly in the wp_insert_post() call.
+	 * This ensures the post_meta is set before any wp_insert_post actions.
+	 *
+	 * @param object $post Post data to insert/update.
+	 * @param WP_REST_Request $request
+	 * @return Filtered $post
+	 */
+	function rest_pre_insert( $post, $request ) {
+		if ( ! isset( $request['meta'] ) || ! isset( $request['meta']['jetpack_publicize_message'] ) ) {
+			return $post;
+		}
+
+		if ( ! isset( $post->meta_input ) ) {
+			$post->meta_input = array();
+		}
+
+		$post->meta_input[$this->POST_MESS] = $request['meta']['jetpack_publicize_message'];
+
+		return $post;
 	}
 
 	/**

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -837,31 +837,7 @@ abstract class Publicize_Base {
 			$args['object_subtype'] = $post_type;
 
 			register_meta( 'post', $this->POST_MESS, $args );
-
-			add_filter( 'rest_pre_insert_' . $post_type, array( $this, 'rest_pre_insert' ), 10, 2 );
 		}
-	}
-
-	/**
-	 * Insert the Publicize Message post_meta prior directly in the wp_insert_post() call.
-	 * This ensures the post_meta is set before any wp_insert_post actions.
-	 *
-	 * @param object $post Post data to insert/update.
-	 * @param WP_REST_Request $request
-	 * @return Filtered $post
-	 */
-	function rest_pre_insert( $post, $request ) {
-		if ( ! isset( $request['meta'] ) || ! isset( $request['meta']['jetpack_publicize_message'] ) ) {
-			return $post;
-		}
-
-		if ( ! isset( $post->meta_input ) ) {
-			$post->meta_input = array();
-		}
-
-		$post->meta_input[$this->POST_MESS] = $request['meta']['jetpack_publicize_message'];
-
-		return $post;
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/28669

#### Changes proposed in this Pull Request:
The results of `Publicize_Base::get_filtered_connection_data()` are used to determine which Publicize Services a post is Publicized to by default.

The return value of `Publicize_Base::get_filtered_connection_data()` changes depending on the status of the post: if `status: publish`, the Connections to the Services are always `enabled: false`.

In Core's REST API, "additional fields" like `jetpack_publicize_connections` are processed after all the core fields (like `status`). This means that, if a REST API request alters the post's `jetpack_publicize_connections` data and sets `status: publish` during the same request, `Publicize_Base::get_filtered_connection_data()` will always return `enabled: false` for all of the Post's Connections since the post has already been updated to `status: publish`, and we will use the wrong Publicize defaults.

This PR stores the value of `Publicize_Base::get_filtered_connection_data()` prior to the post being published.

(As you can see in this PR's history, an early version also *updated* the post meta as early as possible rather than simply remembering the correct values for use in the normal Core data flow. This alternate fix may prove useful if there are more bugs.)

**Depends on** D21118-code.

#### Testing instructions:
##### In Gutenberg
1. On a test site, connect multiple Publicize Services.
2. Apply D21118-code to your WordPress.com sandbox.
3. Set `JETPACK__SANDBOX_DOMAIN` to your WordPress.com sandbox.
4. With Gutenberg, create a new post.
5. Click Publish, change the Publicize settings (both the message and which Services to Publicize to).
6. Publish the post.
7. Make sure the Publicize settings were respected.

##### Direct API Request
1. On a test site, connect multiple Publicize Services.
2. Apply D21118-code to your WordPress.com sandbox.
3. Set `JETPACK__SANDBOX_DOMAIN` to your WordPress.com sandbox.
4. Install https://github.com/WP-API/Basic-Auth
5. Run the curl command below, replacing your username, password, and test site domain. Also replace `facebook` with the slug of one of the connected Services.
```
curl --silent --dump-header /dev/stderr \
 -H 'Content-Type: application/json' \
 -u 'YOUR_USERNAME:YOUR_PASSWORD' \
 'https://YOUR_TEST_SITE/wp-json/wp/v2/posts?context=edit' \
 --data-binary '{ "meta": { "jetpack_publicize_message": "yay-custom" }, "jetpack_publicize_connections": [ { "service_name": "facebook", "enabled": false } ], "title": "title", "content": "content", "status": "publish" }' 
```

Ensure the post is published, and that it is Publicized to the Service you did not set to `enabled: false`, and that the correct custom message was used.

#### Proposed changelog entry for your changes:
None required.