### PR TITLE
SVN: do not ship .map or .scss files in the .org releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tests/php/files/jetpack-150x150.jpg
 yarn-error.log
 .phpcs.xml
 phpcs.xml
+/modules/**/*.min.css.map
 
 ## Things for docker-composer
 /docker/data/mysql/*
@@ -40,7 +41,6 @@ phpcs.xml
 /_inc/blocks
 /_inc/build
 /modules/**/*.min.css
-/modules/**/*.min.css.map
 /modules/**/*-rtl.css
 /css
 _inc/jetpack-strings.php

--- a/.svnignore
+++ b/.svnignore
@@ -26,8 +26,8 @@ node_modules
 languages/jetpack.pot
 LICENSE.txt
 modules/widgets/follow-button.php
-modules/**/*.css.map
-modules/**/*.scss
+modules/calypsoify/*.css.map
+modules/calypsoify/*.scss
 to-test.md
 webpack.config.js
 .editorconfig

--- a/.svnignore
+++ b/.svnignore
@@ -26,6 +26,8 @@ node_modules
 languages/jetpack.pot
 LICENSE.txt
 modules/widgets/follow-button.php
+modules/**/*.css.map
+modules/**/*.scss
 to-test.md
 webpack.config.js
 .editorconfig


### PR DESCRIPTION
Fixes #10626

#### Changes proposed in this Pull Request:

Do not ship .map or .scss files in the .org releases.

#### Testing instructions:

* When building a branch for release, make sure no .scss or .map files are included.

#### Proposed changelog entry for your changes:
 
* None.
