### PR TITLE
Asset CDN: consider Pressable releases Public versions.

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -240,8 +240,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 		if ( preg_match( '/^\d+(\.\d+)+$/', $version ) ) {
 			// matches `1` `1.2` `1.2.3`.
 			return true;
-		} elseif ( $include_beta_and_rc && preg_match( '/^\d+(\.\d+)+(-(beta|rc)\d?)$/i', $version ) ) {
-			// matches `1.2.3` `1.2.3-beta` `1.2.3-beta1` `1.2.3-rc` `1.2.3-rc2`.
+		} elseif ( $include_beta_and_rc && preg_match( '/^\d+(\.\d+)+(-(beta|rc|pressable)\d?)$/i', $version ) ) {
+			// matches `1.2.3` `1.2.3-beta` `1.2.3-pressable` `1.2.3-beta1` `1.2.3-rc` `1.2.3-rc2`.
 			return true;
 		}
 		// unrecognized version.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

We sometimes release versions of the plugin that target Pressable, and that use the same version formatting than the Beta releases, but with the pressable suffix instead.

#### Testing instructions:

Make sure the CDN works for Pressable releases too.

#### Proposed changelog entry for your changes:

* None
