### PR TITLE
Fixing eu cookie law widget close button being hidden

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -56,6 +56,7 @@
  */
 #eu-cookie-law form {
 	margin-bottom: 0;
+	position: static;
 }
 
 /**


### PR DESCRIPTION
If the `#eu-cookie-law form` element has a non-static position property, the close button will be inaccessible on mobile devices. This may be added by the theme applying a position globaly, or by another form plugin with poorly defined scope.

#### Changes proposed in this Pull Request:
* Adds `position: static` to `#eu-cookie-law form`

#### Testing instructions:
- Add a style like `form { position: relative; }` to your theme
- Resize your browser to a width below 601px
Before applying the PR, the close button is hidden. After applying it, the close button is visible and clickable.

#### Proposed changelog entry for your changes:
* Added explicit CSS position property to the EU cookie law widget form 
