### PR TITLE
Add jetbench for testing transient configuration changes

### DIFF
--- a/jetbench.php
+++ b/jetbench.php
@@ -27,8 +27,6 @@ if ( ! $jetbench_settings ) {
 	return;
 }
 
-error_log(print_r($jetbench_settings,1));
-
 class Jetbench {
 	static $force_module_statuses = array();
 	static $settings;

--- a/jetbench.php
+++ b/jetbench.php
@@ -47,7 +47,6 @@ class Jetbench {
 		$disabled_modules = array();
 
 		foreach ( Jetpack::get_available_modules() as $module ) {
-			error_log("setting status for $module");
 			if ( isset( self::$settings[$module] ) ) {
 				// enable module based on truthiness of configuration value
 				if ( self::$force_module_statuses[$module] = !! self::$settings[$module] ) {

--- a/jetbench.php
+++ b/jetbench.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Jetbench allows dynamic, transient enabling/disabling and some configuration of Jetpack modules based on a cookie.
+ *
+ * This allows us to benchmark and debug the effect of Jetpack configuration changes without making permanent changes
+ * to a site.
+ *
+ * TODO: generate cookie name based on shared secret?
+ */
+
+// basic idea here is to hook super early and change configuration for this request in a transient way
+if ( ! isset( $_COOKIE[JETPACK__BENCHMARK_COOKIE] ) ) {
+	return;
+}
+
+$cookie = $_COOKIE[JETPACK__BENCHMARK_COOKIE];
+
+$jetbench_settings = json_decode( $cookie, true );
+
+if ( ! $jetbench_settings ) {
+	error_log("Could not JSON decode Jetpack Benchmark settings: " . $cookie );
+	unset( $_COOKIE[JETPACK__BENCHMARK_COOKIE] );
+	if ( ! headers_sent() ) {
+		setcookie( JETPACK__BENCHMARK_COOKIE, '', time() - ( 15 * 60 ) );
+	}
+	return;
+}
+
+error_log(print_r($jetbench_settings,1));
+
+class Jetbench {
+	static $force_module_statuses = array();
+	static $settings;
+
+	static function init( $settings ) {
+		self::$settings = $settings;
+
+		// after Jetpack::init is called, but before Jetpack::load_modules is called...
+		add_filter( 'plugins_loaded', array( 'Jetbench', 'set_module_statuses' ) );
+
+		// when we ask for active Jetpack modules, filter the results
+		add_filter( 'option_jetpack_active_modules', array( 'Jetbench', 'filter_active_modules' ) );
+	}
+
+	static function set_module_statuses() {
+		// load configuration into static variables
+		$enabled_modules = array();
+		$disabled_modules = array();
+
+		foreach ( Jetpack::get_available_modules() as $module ) {
+			error_log("setting status for $module");
+			if ( isset( self::$settings[$module] ) ) {
+				// enable module based on truthiness of configuration value
+				if ( self::$force_module_statuses[$module] = !! self::$settings[$module] ) {
+					$enabled_modules[] = $module;
+				} else {
+					$disabled_modules[] = $module;
+				}
+
+				// if ( 'somename' === $module && is_array( $settings[$module] ) ) {
+					// do something special with $settings[$module]
+				// }
+			}
+		}
+
+		if ( ! headers_sent() ) {
+			if ( count( $disabled_modules ) > 0 ) {
+				header( 'X-Jetbench-Module-Disabled: ' . implode( ',', $disabled_modules ) );
+			}
+
+			if ( count( $enabled_modules ) > 0 ) {
+				header( 'X-Jetbench-Module-Enabled: ' . implode( ',', $enabled_modules ) );
+			}
+		}
+	}
+
+	static function filter_active_modules( $modules ) {
+		$disabled = array();
+		$enabled = array();
+
+		foreach( self::$force_module_statuses as $module => $status ) {
+			if ( $status ) {
+				if ( ! in_array( $module, $modules ) ) {
+					$modules[] = $module;
+					$enabled[] = $module;
+				}
+			} else {
+				while ( ( $key = array_search( $module, $modules ) ) !== false ) {
+					unset( $modules[ $key ]);
+					$disabled[] = $module;
+				}
+			}
+		}
+
+		return $modules;
+	}
+}
+
+Jetbench::init( $jetbench_settings );
+
+

--- a/jetpack.php
+++ b/jetpack.php
@@ -29,6 +29,8 @@ defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API
 
 defined( 'JETPACK__SANDBOX_DOMAIN' ) or define( 'JETPACK__SANDBOX_DOMAIN', '' );
 
+defined( 'JETPACK__BENCHMARK_COOKIE' ) or define( 'JETPACK__BENCHMARK_COOKIE', 'jetbench' );
+
 /**
  * Returns the location of Jetpack's lib directory. This filter is applied
  * in require_lib().
@@ -65,6 +67,7 @@ function jetpack_should_use_minified_assets() {
 add_filter( 'jetpack_should_use_minified_assets', 'jetpack_should_use_minified_assets', 9 );
 
 // @todo: Abstract out the admin functions, and only include them if is_admin()
+require_once( JETPACK__PLUGIN_DIR . 'jetbench.php'                    );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack.php'               );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-network.php'       );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client.php'        );


### PR DESCRIPTION
In order to test the effect of Jetpack modules on site functionality and performance, it can be desirable to sandbox configuration changes. This PR enables basic enabling/disabling of Jetpack modules for a specific session based on a cookie value.

This PR is created for discussion purposes - I expect there will be lots of feedback on how we can ensure this is performant, secure, and free of unintended side-effects.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add ability to enable/disable Jetpack modules using a cookie

#### Testing instructions:

- Assuming you have a connected Jetpack site...
- In the Chrome Debugger, go to the "Application" tab and create a cookie for the site's domain called `jetbench`, populated with a JSON value like `{"photon": false, "photon-cdn": true }`
- Load any public or admin page of the site (with debugger still open)
- In Network inspector, select the document request and confirm that you have `X-Jetbench-Module-Enabled` entries for every enabled module, and `X-Jetbench-Module-Disabled` entries for each disabled module.
- Confirm that the functionality you enabled/disabled has had an effect on the rendered page (e.g. images loaded from Photon, or not)

Headers screenshot:

<img width="1232" alt="jetbench-headers" src="https://user-images.githubusercontent.com/51896/48798483-97854a80-ecb9-11e8-8d61-42a179d4f05e.png">

#### Proposed changelog entry for your changes:
* Add support for transient configuration changes to assist with debugging and benchmarking
