### PR TITLE
Contact form: Add jetpack-contact-form-shortcode-preview for styling …

### DIFF
--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -106,7 +106,7 @@ class Grunion_Editor_View {
 	public static function editor_view_js_templates() {
 		?>
 <script type="text/html" id="tmpl-grunion-contact-form">
-	<form class="card" action='#' method='post' class='contact-form commentsblock' onsubmit="return false;">
+	<form class="card jetpack-contact-form-shortcode-preview" action='#' method='post' class='contact-form commentsblock' onsubmit="return false;">
 		{{{ data.body }}}
 		<p class='contact-submit'>
 			<input type='submit' value='{{ data.submit_button_text }}' class='pushbutton-wide'/>


### PR DESCRIPTION
…in the editor

<!--- Provide a general summary of your changes in the Title above -->

Fixes broken styling in the Gutenberg editor together with the following PR 
https://github.com/Automattic/wp-calypso/pull/28735

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes --> 
* Adds a class so that we can better target the styles. 
In the classic edior the styles are loaded in a iframe so they can be more generic. 
in the gutenberg editor they need to be more specific so that we don't conflict with the existing plugins. 

#### Testing instructions:
Follow the testing instructions found in https://github.com/Automattic/wp-calypso/pull/28735

