### PR TITLE
Fix some misnamed errors/events

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -229,11 +229,11 @@ class Jetpack_XMLRPC_Server {
 		$user = $this->fetch_and_verify_local_user( $request );
 
 		if ( ! $user ) {
-			return $this->error( new WP_Error( 'input_error', __( 'Valid user is required', 'jetpack' ), 400 ), 'jpc_remote_register_fail' );
+			return $this->error( new WP_Error( 'input_error', __( 'Valid user is required', 'jetpack' ), 400 ), 'jpc_remote_provision_fail' );
 		}
 
 		if ( is_wp_error( $user ) || is_a( $user, 'IXR_Error' ) ) {
-			return $this->error( $user, 'jpc_remote_register_fail' );
+			return $this->error( $user, 'jpc_remote_provision_fail' );
 		}
 
 		$site_icon = ( function_exists( 'has_site_icon' ) && has_site_icon() )
@@ -297,7 +297,7 @@ class Jetpack_XMLRPC_Server {
 					__( 'Jetpack is already connected.', 'jetpack' ),
 					400
 				),
-				'jpc_remote_register_fail'
+				'jpc_remote_connect_fail'
 			);
 		}
 


### PR DESCRIPTION
A couple of provisioning errors had the wrong name for logging.

Probably doesn't need testing, just eyeballing to make sure the event names suit the method names and other events fired within the method.