### PR TITLE
Upgrade notice: switch to checking if Gutenberg is available

### DIFF
--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -96,7 +96,6 @@ Action types dispatched during the UI lifecycle are listed in `state/action-type
 * **getApiRootUrl( state )**
 * **getConnectUrl( state )**
 * **getCurrentVersion( state )**
-* **getWpCurrentVersion( state )**
 * **getInitialStateStatsData( state )**
 * **getJetpackNotices( state )**
 * **getJetpackStateNoticesErrorCode( state )**
@@ -126,6 +125,7 @@ Action types dispatched during the UI lifecycle are listed in `state/action-type
 * **getUserWpComEmail( state )**
 * **getUserWpComLogin( state )**
 * **getUsername( state )**
+* **isGutenbergAvailable( state )**
 
 ### Available action creators (thunks)
 

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -10,7 +10,7 @@ import SimpleNotice from 'components/notice';
  * Internal dependencies
  */
 
-import { getCurrentVersion, getWpCurrentVersion } from 'state/initial-state';
+import { getCurrentVersion, isGutenbergAvailable } from 'state/initial-state';
 import {
 	getJetpackStateNoticesErrorCode,
 	getJetpackStateNoticesMessageCode,
@@ -239,7 +239,7 @@ class JetpackStateNotices extends React.Component {
 					dismiss={ this.dismissJetpackStateNotice }
 					isUnavailableInDevMode={ this.props.isUnavailableInDevMode }
 					version={ match[ '1' ] }
-					wpVersion={ this.props.wpCurrentVersion }
+					isGutenbergAvailable={ this.props.isGutenbergAvailable }
 				/>
 			);
 		}
@@ -275,7 +275,7 @@ export default connect(
 	( state ) => {
 		return {
 			currentVersion: getCurrentVersion( state ),
-			wpCurrentVersion: getWpCurrentVersion( state ),
+			isGutenbergAvailable: isGutenbergAvailable( state ),
 			jetpackStateNoticesErrorCode: getJetpackStateNoticesErrorCode( state ),
 			jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
 			jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state ),

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -229,10 +229,10 @@ class JetpackStateNotices extends React.Component {
 		}
 
 		// Show custom message for upgraded Jetpack
-		const currentVersion = this.props.currentVersion;
+		const { currentVersion, gutenbergAvailable } = this.props;
 		const versionForUpgradeNotice = /(6\.8).*/;
 		const match = currentVersion.match( versionForUpgradeNotice );
-		if ( 'modules_activated' === message && match && true === isGutenbergAvailable ) {
+		if ( 'modules_activated' === message && match && gutenbergAvailable ) {
 			return (
 				<UpgradeNoticeContent
 					adminUrl={ this.props.adminUrl }
@@ -274,7 +274,7 @@ export default connect(
 	( state ) => {
 		return {
 			currentVersion: getCurrentVersion( state ),
-			isGutenbergAvailable: isGutenbergAvailable( state ),
+			gutenbergAvailable: isGutenbergAvailable( state ),
 			jetpackStateNoticesErrorCode: getJetpackStateNoticesErrorCode( state ),
 			jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
 			jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state ),

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -232,14 +232,13 @@ class JetpackStateNotices extends React.Component {
 		const currentVersion = this.props.currentVersion;
 		const versionForUpgradeNotice = /(6\.8).*/;
 		const match = currentVersion.match( versionForUpgradeNotice );
-		if ( 'modules_activated' === message && match ) {
+		if ( 'modules_activated' === message && match && true === isGutenbergAvailable ) {
 			return (
 				<UpgradeNoticeContent
 					adminUrl={ this.props.adminUrl }
 					dismiss={ this.dismissJetpackStateNotice }
 					isUnavailableInDevMode={ this.props.isUnavailableInDevMode }
 					version={ match[ '1' ] }
-					isGutenbergAvailable={ this.props.isGutenbergAvailable }
 				/>
 			);
 		}

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -32,13 +32,6 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			} );
 		};
 
-		trackUpdateClick = () => {
-			analytics.tracks.recordJetpackClick( {
-				target: 'warm_welcome_update_wordpress',
-				version: this.props.version
-			} );
-		};
-
 		dismissNotice = () => {
 			analytics.tracks.recordJetpackClick( {
 				target: 'warm_welcome_dismiss',
@@ -48,34 +41,8 @@ const UpgradeNoticeContent = moduleSettingsForm(
 			this.props.dismiss();
 		};
 
-		renderLearnMore = () => {
-			const { isGutenbergAvailable } = this.props;
-			const blockEditorUrl = `${ this.props.adminUrl }post-new.php`;
-			const updateUrl = `${ this.props.adminUrl }update-core.php`;
-
-			if ( isGutenbergAvailable ) {
-				return (
-					<Button
-						primary={ true }
-						href={ blockEditorUrl }
-						onClick={ this.trackLearnMoreClick }
-					>
-						{ __( 'Take me to the new editor' ) }
-					</Button>
-				);
-			}
-			return (
-				<Button
-					primary={ true }
-					href={ updateUrl }
-					onClick={ this.trackUpdateClick }
-				>
-					{ __( 'Update to get the new editor' ) }
-				</Button>
-			);
-		};
-
 		renderInnerContent() {
+			const blockEditorUrl = `${ this.props.adminUrl }post-new.php`;
 			return (
 				<div className="jp-upgrade-notice__content">
 					<p>
@@ -108,7 +75,13 @@ const UpgradeNoticeContent = moduleSettingsForm(
 							alt={ __( 'Jetpack is ready for the new WordPress editor' ) } />
 					</p>
 					<div className="jp-dialogue__cta-container">
-						{ this.renderLearnMore() }
+						<Button
+							primary={ true }
+							href={ blockEditorUrl }
+							onClick={ this.trackLearnMoreClick }
+						>
+							{ __( 'Take me to the new editor' ) }
+						</Button>
 						<Button onClick={ this.dismissNotice }>
 							{ __( 'Okay, got it!' ) }
 						</Button>
@@ -136,7 +109,6 @@ JetpackDialogue.propTypes = {
 	dismiss: PropTypes.func,
 	isUnavailableInDevMode: PropTypes.func,
 	version: PropTypes.string,
-	isGutenbergAvailable: PropTypes.bool,
 };
 
 export default UpgradeNoticeContent;

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -49,12 +49,11 @@ const UpgradeNoticeContent = moduleSettingsForm(
 		};
 
 		renderLearnMore = () => {
-			const versionSupportsGutenberg = /(5\.0).*/;
-			const match = this.props.wpVersion.match( versionSupportsGutenberg );
+			const { isGutenbergAvailable } = this.props;
 			const blockEditorUrl = `${ this.props.adminUrl }post-new.php`;
 			const updateUrl = `${ this.props.adminUrl }update-core.php`;
 
-			if ( match ) {
+			if ( isGutenbergAvailable ) {
 				return (
 					<Button
 						primary={ true }
@@ -137,7 +136,7 @@ JetpackDialogue.propTypes = {
 	dismiss: PropTypes.func,
 	isUnavailableInDevMode: PropTypes.func,
 	version: PropTypes.string,
-	wpVersion: PropTypes.string,
+	isGutenbergAvailable: PropTypes.bool,
 };
 
 export default UpgradeNoticeContent;

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -48,10 +48,6 @@ export function getCurrentVersion( state ) {
 	return get( state.jetpack.initialState, 'currentVersion', '' );
 }
 
-export function getWpCurrentVersion( state ) {
-	return get( state.jetpack.initialState, 'wpCurrentVersion', '' );
-}
-
 export function getSiteRoles( state ) {
 	return get( state.jetpack.initialState.stats, 'roles', {} );
 }
@@ -74,6 +70,10 @@ export function getSiteAdminUrl( state ) {
 
 export function isSitePublic( state ) {
 	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
+}
+
+export function isGutenbergAvailable( state ) {
+	return get( state.jetpack.initialState, 'is_gutenberg_available', '' );
 }
 
 export function userIsSubscriber( state ) {

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -73,7 +73,7 @@ export function isSitePublic( state ) {
 }
 
 export function isGutenbergAvailable( state ) {
-	return get( state.jetpack.initialState, 'is_gutenberg_available', '' );
+	return get( state.jetpack.initialState, 'is_gutenberg_available', false );
 }
 
 export function userIsSubscriber( state ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -252,7 +252,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),
 			'currentVersion' => JETPACK__VERSION,
-			'wpCurrentVersion' => $GLOBALS['wp_version'],
+			'is_gutenberg_available' => Jetpack_Gutenberg::is_gutenberg_available(),
 			'getModules' => $modules,
 			'showJumpstart' => jetpack_show_jumpstart(),
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Instead of checking if the site runs WP 5.0, let's check if the site has Gutenberg.
This way it includes sites using WP 4.9.8 and the Gutenberg, as well as the sites running WP
5.0.

Follow-up from #10672 based on feedback here:
https://github.com/Automattic/jetpack/pull/10672/files#r235197513

#### Testing instructions:

* Start from a site running WP 5.0, or WP 4.9.8 with the Gutenberg plugin, or 4.9.8 without the plugin. Remember the status of your site (Gutenberg available or not).
* Check out this branch.
* Change `JETPACK__VERSION` in `jetpack.php` to `6.8`.
* Load the Jetpack dashboard in wp-admin.
* You should see the upgrade notice and the Learn more button will change and lead to a different page depending on whether Gutenberg is available on your site or not.

#### Proposed changelog entry for your changes:

* None
