### PR TITLE
Publicize Gutenberg: Move extension registration to a safer location

### DIFF
--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -46,10 +46,6 @@ class Jetpack_Publicize {
 			if ( in_array( 'publicize', $active ) && !in_array( 'sharedaddy', $active ) )
 				add_action( 'admin_menu', array( &$publicize_ui, 'sharing_menu' ) );
 		}
-
-		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
-		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
-		jetpack_register_block( 'publicize' );
 	}
 
 	function jetpack_configuration_load() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -119,6 +119,7 @@ abstract class Publicize_Base {
 
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
+		add_action( 'init', array( $this, 'register_gutenberg_extension' ), 30 );
 	}
 
 /*
@@ -773,6 +774,15 @@ abstract class Publicize_Base {
 	 */
 	function add_post_type_support() {
 		add_post_type_support( 'post', 'publicize' );
+	}
+
+	/**
+	 * Register the Publicize Gutenberg extension
+	 */
+	function register_gutenberg_extension() {
+		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
+		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
+		jetpack_register_block( 'publicize' );
 	}
 
 	/**


### PR DESCRIPTION
I was never able to commit D20970-code, the Fusion-generated WP.com counterpart to #10654. The reason is that it would break my sandbox, complaining that 

```
Uncaught Error: Call to undefined function jetpack_register_block() in /home/wpcom/public_html/wp-content/admin-plugins/publicize.php:58
```

This is probably because I was calling `jetpack_register_block()` too early, and unguarded (even though it did work for Jetpack).

#### Changes proposed in this Pull Request:

I've noticed that all other instances of `jetpack_register_block()` in Jetpack add that function to the `init` hook from somewhere in `modules/${ module_name }/{ $module_name }.php` rather than `modules/${ module_name }.php`, so I'm following that pattern here.

Note that since b195705 reverts #10654 (whose counterpart D20970-code was never committed, as stated above), the Fusion-generated WP.com counterpart diff (D21209-code) doesn't have that change.

This time, I also made sure that D21209-code didn't break my sandbox when applied to it. 

#### Testing instructions:

Verify that Publicize availability works as before:

- In Jetpack's 'Sharing' settings (`/wp-admin/admin.php?page=jetpack#/sharing`), make sure that `Automatically share your posts to social networks` is disabled.
- Open the Gutenberg editor with an existing or a new post
- Open the browser console, and type `window.Jetpack_Editor_Initial_State`
- Verify that the `publicize` module's `available` property is `false`

![image](https://user-images.githubusercontent.com/96308/48622125-0dca3a00-e9a6-11e8-892a-a9de4310d1d8.png)

- Now go back to  `/wp-admin/admin.php?page=jetpack#/sharing`, and enable `Automatically share your posts to social networks`.
- Go back to the editor
- Open the browser console, and type `window.Jetpack_Editor_Initial_State`
- Verify that the `publicize` module's `available` property is now `true`

![image](https://user-images.githubusercontent.com/96308/48621950-8977b700-e9a5-11e8-8cfb-ce70418ec22b.png)

Finally, apply D21209-code to your WP.com sandbox, and make sure it doesn't break (load your sandbox's `/wp-admin` in your browser, and verify that it still works).

#### Proposed changelog entry for your changes:

Probably not needed, since just a fix that updates the Publicize Gutenberg extension's visibility logic, which was introduced for JP 6.8 as well.
