### PR TITLE
Upgrade jetpack-blocks to 10.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "10.1.0",
+    "@automattic/jetpack-blocks": "10.1.1",
     "ansi-colors": "^1.0.1",
     "babel-core": "6.8.0",
     "babel-eslint": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,10 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-10.1.0.tgz#77ab35a7bdf0f3eb6e76d41f16d6f9bb2dec1b68"
+"@automattic/jetpack-blocks@10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-10.1.1.tgz#be8b8304b5854b4d79791db1726604a11353d69b"
+  integrity sha512-RFAgFis4ijT0bLykUUvW9iRsyVQBXVLWDl5+XtiRlN6mgliSiM3+l1aJ5ys9r7jh/fEZR3QEw6feJvI6+LOaCg==
 
 "@babel/parser@^7.0.0-beta.48":
   version "7.1.3"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates to blocks bundle v10.1.1

#### Testing instructions:

* Verify the bundle works well.
* Check against WP 5 beta. The previous bundle was discovered to have an issue that broke WP 5 beta. It's unclear at this time what caused the issue with the 10.1.0 bundle.

#### Proposed changelog entry for your changes:

* None
