### PR TITLE
Tweak how we rsync in our deploy tools.

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -59,8 +59,8 @@ for file in $(find $JETPACK_SVN_DIR/trunk/* -not -path "*.svn*"); do
 done
 echo "Done!"
 
-echo "Rsync'ing everything over from Git except for .git stuffs"
-rsync -r --exclude='*.git*' $JETPACK_GIT_DIR/* $JETPACK_SVN_DIR/trunk
+echo "Rsync'ing everything over from Git except for .git stuffs and stuff in .svnignore"
+rsync -r --exclude-from "$JETPACK_GIT_DIR/.svnignore" $JETPACK_GIT_DIR/* $JETPACK_SVN_DIR/trunk
 echo "Done!"
 
 echo "Purging .po files"


### PR DESCRIPTION
Let's use rsync-ignore-from to just ditch stuff from the rsync instead of rsyncing and then deleting.
