### PR TITLE
Form: fade placeholder when user rolls the mouse over an input field

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -2,6 +2,16 @@
 	clear: both;
 }
 
+.contact-form input::placeholder {
+	transition: opacity .3s ease-out;
+}
+.contact-form input:hover::placeholder {
+	opacity: 0.5;
+}
+.contact-form input:focus::placeholder {
+	opacity: 0.3;
+}
+
 .contact-form input[type='text'],
 .contact-form input[type='email'],
 .contact-form input[type='url'] {


### PR DESCRIPTION
This PR seeks to make clear that a text input placeholder is not regular text by fading it when the user rolls the mouse over an input field, and then fade it a bit more when user clicks on the input field.

### Before

![before-before](https://user-images.githubusercontent.com/1041600/48877063-3a37e900-ede0-11e8-85c4-3b62930d4646.gif)

### After

![before](https://user-images.githubusercontent.com/1041600/48877055-360bcb80-ede0-11e8-855e-38bcf2ef5968.gif)

