### PR TITLE
Search: Add a hook on returning filters.

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1610,7 +1610,20 @@ class Jetpack_Search {
 			} // End foreach().
 		} // End foreach().
 
-		return $aggregation_data;
+		/**
+		 * Modify the aggregation filters returned by get_filters().
+		 *
+		 * Useful if you are setting custom filters outside of the supported filters (taxonomy, post_type etc.) and
+		 * want to hook them up so they're returned when you call `get_filters()`.
+		 *
+		 * @module search
+		 *
+		 * @since  6.9.0
+		 *
+		 * @param array    $aggregation_data The array of filters keyed on label.
+		 * @param WP_Query $query            The WP_Query object.
+		 */
+		return apply_filters( 'jetpack_search_get_filters', $aggregation_data, $query );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes N/A(?)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

I recently had a use case where I wanted to add custom filters (i.e. not
a taxonomy, post type or date histogram) and found I could set the
filter no problem but `get_filters()` would ignore it as it wasn't
supported.

I'd like to be able to easily support custom filters through a hook into
`get_filters()`.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add custom filters using `set_filters()` e.g. 

```php
Jetpack_Search::instance()->set_filters(
	[
		'Price Range' => [
			'type' => 'range',
			'label' => 'price_range',
			'field' => 'price',
			'ranges' => $ranges,
			'count' => count( $ranges ),
		],
	]
);
```

Call `get_filters()` and observe that the added (unsupported) filter is not available.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added hook to `get_filters()` to allow the use of custom filters.
