### PR TITLE
REST API: Add /gutenberg/available-extensions endpoint

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -63,7 +63,7 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 	 * @return boolean
 	 */
 	public function get_items_permission_check() {
-		return current_user_can( 'jetpack_manage_modules' );
+		return current_user_can( 'edit_posts' );
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Plugin Name: Available Gutenberg Extensions (Blocks and Plugins) for wpcom/v2 WP-API
+ */
+
+class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_Controller {
+	/**
+	 * Flag to help WordPress.com decide where it should look for
+	 * extenstion availability data. Ignored for direct requests to Jetpack sites.
+	 *
+	 * @var bool $wpcom_is_wpcom_only_endpoint
+	 */
+	public $wpcom_is_wpcom_only_endpoint = true;
+
+	function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'gutenberg/available-extensions';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( 'Jetpack_Gutenberg', 'get_block_availability' ),
+				'permission_callback' => array( $this, 'get_items_permission_check' ),
+			),
+			'schema' => array( $this, 'get_item_schema' ),
+		 ) );
+	}
+
+	/**
+	 * Return the available Gutenberg extensions schema
+	 *
+	 * @return array Available Gutenberg extensions schema
+	 */
+	public function get_public_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'gutenberg-available-extensions',
+			'type'       => 'object',
+			'properties' => array(
+				'available'          => array(
+					'description' => __( 'Whether the extension is available', 'jetpack' ),
+					'type'        => 'boolean',
+				),
+				'unavailable_reason' => array(
+					'description' => __( 'Human readable reason for the extensiongutenberg/available-extensions not being available', 'jetpack' ),
+					'type'        => 'string',
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Ensure the user has proper permissions
+	 *
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permission_check() {
+		return current_user_can( 'edit_posts' );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions' );

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -48,7 +48,7 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 					'type'        => 'boolean',
 				),
 				'unavailable_reason' => array(
-					'description' => __( 'Human readable reason for the extension not being available', 'jetpack' ),
+					'description' => __( 'Reason for the extension not being available', 'jetpack' ),
 					'type'        => 'string',
 				),
 			),

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -5,14 +5,6 @@
  */
 
 class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_Controller {
-	/**
-	 * Flag to help WordPress.com decide where it should look for
-	 * extenstion availability data. Ignored for direct requests to Jetpack sites.
-	 *
-	 * @var bool $wpcom_is_wpcom_only_endpoint
-	 */
-	public $wpcom_is_wpcom_only_endpoint = true;
-
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'gutenberg/available-extensions';

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -6,7 +6,7 @@
  * [
  *   { # Availabilty Object. See schema for more detail.
  *     available:          (boolean) Whether the extension is available
- *     unavailable_reason: (string)  Human readable reason for the extension not being available
+ *     unavailable_reason: (string)  Reason for the extension not being available
  *   },
  *   ...
  * ]

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -1,9 +1,18 @@
 <?php
 
 /*
- * Plugin Name: Available Gutenberg Extensions (Blocks and Plugins) for wpcom/v2 WP-API
+ * Gutenberg: List Available Gutenberg Extensions (Blocks and Plugins)
+ *
+ * [
+ *   { # Availabilty Object. See schema for more detail.
+ *     available:          (boolean) Whether the extension is available
+ *     unavailable_reason: (string)  Human readable reason for the extension not being available
+ *   },
+ *   ...
+ * ]
+ *
+ * @since 6.9
  */
-
 class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_Controller {
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
@@ -39,7 +48,7 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 					'type'        => 'boolean',
 				),
 				'unavailable_reason' => array(
-					'description' => __( 'Human readable reason for the extensiongutenberg/available-extensions not being available', 'jetpack' ),
+					'description' => __( 'Human readable reason for the extension not being available', 'jetpack' ),
 					'type'        => 'string',
 				),
 			),
@@ -51,10 +60,10 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 	/**
 	 * Ensure the user has proper permissions
 	 *
-	 * @return WP_Error|boolean
+	 * @return boolean
 	 */
 	public function get_items_permission_check() {
-		return current_user_can( 'edit_posts' );
+		return current_user_can( 'jetpack_manage_modules' );
 	}
 }
 


### PR DESCRIPTION
Based on @roccotripaldi's D21225-code. As I commented there, 

> Since we'll want to use the same logic to determine block availability in Gutenblocks both on WP.com, and Jetpack (which means using this endpoint and dropping the `Jetpack_Editor_Initial_State` based approach), I think it'd make sense to add this endpoint to Jetpack and sync it to WP.com (similar to what Mike did for the Publicize endpoint(s), see https://github.com/Automattic/jetpack/pull/10605)

#### Changes proposed in this Pull Request:

* Add `/gutenberg/available-extensions` endpoint to expose Gutenberg block and plugin availabilty 

#### Testing instructions:

##### Manual Tests

(stolen from Mike's for #10605)

1. The best way to test is to make REST API requests to a test site. The simplest way to do that is to install either the [REST API Console](https://wordpress.org/plugins/rest-api-console/) plugin or the [Basic Authentication](https://github.com/WP-API/Basic-Auth) plugin.
2. As a user with contributor privileges or higher, make an authenticated REST API request: `GET /wp-json/wpcom/v2/gutenberg/available-extensions`. Verify that you get a list of blocks, with `available` bool attributes (and `unavailable_reason` strings if `available` is `false`). Verify that block/plugin availability corresponds to module activations status/plan/etc (also try changing them and verify that the endpoint's response changes accordingly).
3. As a user with subscriber privileges, make an authenticated REST API request: `GET /wp-json/wpcom/v2/gutenberg/available-extensions`, and verify that you get a 403 error. Try the same unauthenticated

#### Proposed changelog entry for your changes:

* Add `/gutenberg/available-extensions` endpoint to expose Gutenberg block and plugin availabilty 

#### Follow-up TODO

- Sync to dotcom