### PR TITLE
Ensure Simple Payments are published when rendering

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -116,7 +116,7 @@ class Jetpack_Simple_Payments {
 		if ( ! $product || is_wp_error( $product ) ) {
 			return;
 		}
-		if ( $product->post_type !== self::$post_type_product || 'trash' === $product->post_status ) {
+		if ( $product->post_type !== self::$post_type_product || 'publish' !== $product->post_status ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Only render Simple Payments buttons for products that are published.

See https://github.com/Automattic/wp-calypso/pull/28815/files#r235933564 for some motivation.

I would expect Simple Payment buttons to always be created with a published status. With the Simple Payments block, we have some motivation for creating `draft` products that may not be published and should not render.

They may have been created here (`publish`):
https://github.com/Automattic/jetpack/blob/6ee14cffce0947b7ddfdeb0b58bdda5b7e7edb35/modules/widgets/simple-payments.php#L196-L215

Need to track down where this goes on WordPress.com:
https://github.com/Automattic/wp-calypso/blob/3878590ff3d4dacff810d5f5fec9f48b79ed7394/client/state/data-layer/wpcom/sites/simple-payments/index.js#L182-L195

#### Testing instructions:

* Simple payments created via classic Calypso editor or a Jetpack site customizer continue to work as expected.

#### Proposed changelog entry for your changes:

None.
