### PR TITLE
Contact form: Add a check that to make sure that we have deaeling with an array

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2153,7 +2153,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$type = isset( $attributes['type'] ) ? $attributes['type'] : null;
 				$attributes['label'] = self::get_default_label_from_type( $type );
 			}
-			foreach ( $attributes as $att => $val ) {
+			foreach ( (array) $attributes as $att => $val ) {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
 					$att_strs[] = esc_html( $val );
 				} elseif ( isset( $val ) ) { // A regular attr - value pair


### PR DESCRIPTION
This removes a PHP warning when null is being passed as an attribute.

<!--- Provide a general summary of your changes in the Title above -->

Fixes a php warning that I saw. While testing this on .com

#### Changes proposed in this Pull Request:
* Adds a check on the attributes so that we are iterating over an array. 

#### Testing instructions:
Create a contact form via using shortcodes as well as gutenberg. 
Make a fields not have any attributes. 
Make sure no php warning are being created.

cc: @jeherve. 

