### PR TITLE
Travis CI: test in PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
 - "5.6"
 - "7.0"
 - "7.2"
+- "7.3"
 
 env:
   # Global variable is re-defined in matrix-include -list

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
 - "5.6"
 - "7.0"
 - "7.2"
-- "7.3"
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -46,6 +45,15 @@ matrix:
     env: WP_TRAVISCI="yarn lint"
   - language: node_js
     env: WP_TRAVISCI="yarn test-dangerci-and-adminpage"
+  # We can't test PHP 7.3 with WP_BRANCH=previous just yet, as previous is currently 4.9.9.
+  # Running PHP 7.3 tests on 4.9.9 will fail as it does not include https://core.trac.wordpress.org/changeset/44166#file6.
+  # We can remove these 3 specific tests and add 7.3 to the global PHP list above when 5.1 is released.
+  - php: "7.3"
+    env: WP_MODE=single WP_BRANCH=master
+  - php: "7.3"
+    env: WP_MODE=single WP_BRANCH=latest
+  - php: "7.3"
+    env: WP_MODE=multi  WP_BRANCH=master
 
 cache:
   directories:

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -48,10 +48,18 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_updating_a_plugin_is_synced() {
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
+
 		$skins = array(
-			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+			new Plugin_Upgrader_Skin( $plugin_defaults ),
+			new Automatic_Upgrader_Skin( $plugin_defaults ),
+			new WP_Ajax_Upgrader_Skin( $plugin_defaults ),
 		);
 		foreach( $skins as $skin ) {
 			$this->update_the_plugin( $skin );
@@ -64,11 +72,18 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_updating_plugin_in_bulk_is_synced() {
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
 		$skins = array(
-			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
-			new Bulk_Plugin_Upgrader_Skin( compact( 'nonce', 'url' ) ),
+			new Plugin_Upgrader_Skin( $plugin_defaults ),
+			new Automatic_Upgrader_Skin( $plugin_defaults ),
+			new WP_Ajax_Upgrader_Skin( $plugin_defaults ),
+			new Bulk_Plugin_Upgrader_Skin( $plugin_defaults ),
 		);
 		foreach ( $skins as $skin ) {
 			$this->update_bulk_plugins( $skin );
@@ -87,10 +102,17 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->markTestIncomplete( "Right now this doesn't work on PHP 5.2" );
 
 		$this->server_event_storage->reset();
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
 		$skins = array(
-			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
+			new Plugin_Upgrader_Skin( $plugin_defaults ),
+			new Automatic_Upgrader_Skin( $plugin_defaults ),
+			new WP_Ajax_Upgrader_Skin( $plugin_defaults ),
 		);
 		foreach( $skins as $skin ) {
 			$this->set_error();
@@ -104,11 +126,18 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_updating_plugin_error_in_bulk_is_synced() {
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
 		$skins = array(
-			new Plugin_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ),
-			new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' )  ),
-			new Bulk_Plugin_Upgrader_Skin( compact( 'nonce', 'url' ) ),
+			new Plugin_Upgrader_Skin( $plugin_defaults ),
+			new Automatic_Upgrader_Skin( $plugin_defaults ),
+			new WP_Ajax_Upgrader_Skin( $plugin_defaults ),
+			new Bulk_Plugin_Upgrader_Skin( $plugin_defaults ),
 		);
 		foreach ( $skins as $skin ) {
 			$this->set_error();
@@ -122,10 +151,18 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_updating_error_with_autoupdate_constant_results_in_proper_state() {
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
+
 		Jetpack_Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 
 		$this->set_error();
-		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ) );
+		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( $plugin_defaults ) );
 		$this->remove_error();
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugin_update_failed' );
@@ -134,8 +171,16 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_updating_with_autoupdate_constant_results_in_proper_state() {
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
+
 		Jetpack_Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
-		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ) );
+		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( $plugin_defaults ) );
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
 		$this->assertTrue( $updated_plugin->args[1]['is_autoupdate'] );

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -194,8 +194,16 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
+		$plugin_defaults = array(
+			'title'  => '',
+			'url'    => '',
+			'nonce'  => '',
+			'plugin' => '',
+			'api'    => '',
+		);
+
 		$upgrader = new Plugin_Upgrader(
-			new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) )
+			new Automatic_Upgrader_Skin( $plugin_defaults )
 		);
 		// 'https://downloads.wordpress.org/plugin/the.1.1.zip' Install it from local disk
 		$upgrader->install( ABSPATH . self::PLUGIN_ZIP );

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -421,6 +421,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		require_once ABSPATH . 'wp-admin/includes/theme-install.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
+		$theme_defaults = array(
+			'title'  => '',
+			'nonce'    => '',
+			'url'  => '',
+			'theme' => '',
+		);
+
 		$api = themes_api(
 			'theme_information',
 			array(
@@ -432,7 +439,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			wp_die( $api );
 		}
 
-		$upgrader = new Theme_Upgrader( new Test_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'theme' ) ) );
+		$upgrader = new Theme_Upgrader( new Test_Upgrader_Skin( $theme_defaults ) );
 		$upgrader->install( $api->download_link );
 	}
 }


### PR DESCRIPTION
### Add 7.3
Adds PHP v7.3 containers for CI testing. PHP v7.3 is scheduled for December 6th.

Note that 7.3 is aliassed to RC versions in Travis and it's currently running RC5:
> $ php --version
> PHP 7.3.0RC5 (cli) (built: Nov 12 2018 00:13:27) ( ZTS )

- Latest (final) RC6: https://secure.php.net/archive/2018.php#id2018-11-22-1
- v7.3 timeline: https://wiki.php.net/todo/php73
- v7.3 available in Travis, aliassed to RC versions: https://github.com/travis-ci/travis-ci/issues/9717#issuecomment-429564626 (

### Dropping 7.0?
With this, should we drop testing in 7.0 as security updates for it will end on Dec 5th 2018 (in a few days)?
http://php.net/supported-versions.php

<img width="1357" alt="image" src="https://user-images.githubusercontent.com/87168/49078364-7d61e400-f246-11e8-8512-b5b054210320.png">
