### PR TITLE
Docker: upgrade PHP version in Docker development environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,14 +18,17 @@ RUN \
 		curl \
 		less \
 		libapache2-mod-php7.3 \
+		libsodium23 \
 		mysql-client \
 		nano \
 		php-apcu \
 		php-xdebug \
 		php7.3 \
+		php7.3-bcmath \
 		php7.3-cli \
 		php7.3-curl \
 		php7.3-gd \
+		php7.3-imagick \
 		php7.3-json \
 		php7.3-ldap \
 		php7.3-mbstring \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/build
 	&& chmod +x /usr/local/bin/wp
 
 # Install PHPUnit
-RUN curl https://phar.phpunit.de/phpunit-5.7.5.phar -L -o phpunit.phar \
+RUN curl https://phar.phpunit.de/phpunit-6.phar -L -o phpunit.phar \
 	&& chmod +x phpunit.phar \
 	&& mv phpunit.phar /usr/local/bin/phpunit
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,26 +17,26 @@ RUN \
 		composer \
 		curl \
 		less \
-		libapache2-mod-php7.2 \
+		libapache2-mod-php7.3 \
 		mysql-client \
 		nano \
 		php-apcu \
 		php-xdebug \
-		php7.2 \
-		php7.2-cli \
-		php7.2-curl \
-		php7.2-gd \
-		php7.2-json \
-		php7.2-ldap \
-		php7.2-mbstring \
-		php7.2-mysql \
-		php7.2-opcache \
-		php7.2-pgsql \
-		php7.2-soap \
-		php7.2-sqlite3 \
-		php7.2-xml \
-		php7.2-xsl \
-		php7.2-zip \
+		php7.3 \
+		php7.3-cli \
+		php7.3-curl \
+		php7.3-gd \
+		php7.3-json \
+		php7.3-ldap \
+		php7.3-mbstring \
+		php7.3-mysql \
+		php7.3-opcache \
+		php7.3-pgsql \
+		php7.3-soap \
+		php7.3-sqlite3 \
+		php7.3-xml \
+		php7.3-xsl \
+		php7.3-zip \
 		ssmtp \
 		subversion \
 		sudo \
@@ -51,7 +51,7 @@ RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/build
 	&& chmod +x /usr/local/bin/wp
 
 # Install PHPUnit
-RUN curl https://phar.phpunit.de/phpunit-6.phar -L -o phpunit.phar \
+RUN curl https://phar.phpunit.de/phpunit-7.phar -L -o phpunit.phar \
 	&& chmod +x phpunit.phar \
 	&& mv phpunit.phar /usr/local/bin/phpunit
 
@@ -59,8 +59,8 @@ RUN curl https://phar.phpunit.de/phpunit-6.phar -L -o phpunit.phar \
 COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf
 
 # Copy a default set of settings for PHP (php.ini)
-COPY ./config/php.ini /etc/php/7.2/apache2/conf.d/20-jetpack-wordpress.ini
-COPY ./config/php.ini /etc/php/7.2/cli/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/7.3/apache2/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/7.3/cli/conf.d/20-jetpack-wordpress.ini
 
 # Copy single site htaccess to tmp. run.sh will move it to the site's base dir if there's none present.
 COPY ./config/htaccess /tmp/htaccess

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,26 +9,26 @@ RUN apt-get update && apt-get install -y \
 	composer \
 	curl \
 	less \
-	libapache2-mod-php7.0 \
+	libapache2-mod-php7.2 \
 	mysql-client \
 	nano \
 	php-apcu \
 	php-xdebug \
-	php7.0 \
-	php7.0-cli \
-	php7.0-curl \
-	php7.0-gd \
-	php7.0-json \
-	php7.0-ldap \
-	php7.0-mbstring \
-	php7.0-mysql \
-	php7.0-opcache \
-	php7.0-pgsql \
-	php7.0-soap \
-	php7.0-sqlite3 \
-	php7.0-xml \
-	php7.0-xsl \
-	php7.0-zip \
+	php7.2 \
+	php7.2-cli \
+	php7.2-curl \
+	php7.2-gd \
+	php7.2-json \
+	php7.2-ldap \
+	php7.2-mbstring \
+	php7.2-mysql \
+	php7.2-opcache \
+	php7.2-pgsql \
+	php7.2-soap \
+	php7.2-sqlite3 \
+	php7.2-xml \
+	php7.2-xsl \
+	php7.2-zip \
 	ssmtp \
 	subversion \
 	sudo \
@@ -51,8 +51,8 @@ RUN curl https://phar.phpunit.de/phpunit-5.7.5.phar -L -o phpunit.phar \
 COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf
 
 # Copy a default set of settings for PHP (php.ini)
-COPY ./config/php.ini /etc/php/7.0/apache2/conf.d/20-jetpack-wordpress.ini
-COPY ./config/php.ini /etc/php/7.0/cli/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/7.2/apache2/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/7.2/cli/conf.d/20-jetpack-wordpress.ini
 
 # Copy single site htaccess to tmp. run.sh will move it to the site's base dir if there's none present.
 COPY ./config/htaccess /tmp/htaccess

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,37 +2,45 @@ FROM ubuntu:xenial
 
 VOLUME ["/var/www/html"]
 
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
 # Install required Ubuntu packages for having Apache PHP as a module
 # as well a bunch of other packages
-RUN apt-get update && apt-get install -y \
-	apache2 \
-	composer \
-	curl \
-	less \
-	libapache2-mod-php7.2 \
-	mysql-client \
-	nano \
-	php-apcu \
-	php-xdebug \
-	php7.2 \
-	php7.2-cli \
-	php7.2-curl \
-	php7.2-gd \
-	php7.2-json \
-	php7.2-ldap \
-	php7.2-mbstring \
-	php7.2-mysql \
-	php7.2-opcache \
-	php7.2-pgsql \
-	php7.2-soap \
-	php7.2-sqlite3 \
-	php7.2-xml \
-	php7.2-xsl \
-	php7.2-zip \
-	ssmtp \
-	subversion \
-	sudo \
-	vim \
+RUN \
+	apt-get update \
+	&& apt-get install -y language-pack-en-base software-properties-common \
+	&& add-apt-repository ppa:ondrej/php \
+	&& apt-get update \
+	&& apt-get install -y \
+		apache2 \
+		composer \
+		curl \
+		less \
+		libapache2-mod-php7.2 \
+		mysql-client \
+		nano \
+		php-apcu \
+		php-xdebug \
+		php7.2 \
+		php7.2-cli \
+		php7.2-curl \
+		php7.2-gd \
+		php7.2-json \
+		php7.2-ldap \
+		php7.2-mbstring \
+		php7.2-mysql \
+		php7.2-opcache \
+		php7.2-pgsql \
+		php7.2-soap \
+		php7.2-sqlite3 \
+		php7.2-xml \
+		php7.2-xsl \
+		php7.2-zip \
+		ssmtp \
+		subversion \
+		sudo \
+		vim \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Enable mod_rewrite in Apache

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -30,7 +30,7 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	// VVV
 	$test_root = '/vagrant/www/wordpress-develop/public_html/tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-develop/tests/phpunit/includes/bootstrap.php' ) ) {
-	// Manual checkout
+	// Manual checkout & Jetpack's docker environment
 	$test_root = '/tmp/wordpress-develop/tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	// Legacy tests
@@ -114,4 +114,4 @@ function in_running_uninstall_group() {
 
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist
-require $test_root . '/includes/speed-trap-listener.php';
+require $test_root . '/includes/listener-loader.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -114,4 +114,11 @@ function in_running_uninstall_group() {
 
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist
-require $test_root . '/includes/listener-loader.php';
+// @todo Remove version check when 5.1 is the minimum WP version.
+if ( version_compare( $wp_version, '5.1', '>=' ) ) {
+	require $test_root . '/includes/listener-loader.php';
+} else {
+	require $test_root . '/includes/speed-trap-listener.php';
+}
+
+

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -120,5 +120,3 @@ if ( version_compare( $wp_version, '5.1', '>=' ) ) {
 } else {
 	require $test_root . '/includes/speed-trap-listener.php';
 }
-
-


### PR DESCRIPTION
- Upgrades PHP version to 7.2 from 7.0 on WordPress container in Docker development environment.
  - PHP 7.0 is at the end of its support cycle and security upgrades will stop on Dec 5th 2018. http://php.net/supported-versions.php

- Sets up locale via env vars to avoid this:
    > 'ascii' codec can't decode byte 0xc5 in position 92: ordinal not in range(128)

### Testing

Run `yarn docker:build` to rebuild your containers:

```
db uses an image, skipping
maildev uses an image, skipping
sftp uses an image, skipping
Building wordpress
```

...and give it a few minutes (mine was:  `✨  Done in 295.34s.`)

Confirm PHP version with:
```
yarn docker:sh
php --version
```