### PR TITLE
Post-purchase warm welcome: add got it button

### DIFF
--- a/_inc/client/components/welcome-new-plan/personal.jsx
+++ b/_inc/client/components/welcome-new-plan/personal.jsx
@@ -16,10 +16,26 @@ import { imagePath } from 'constants/urls';
 import MonitorAkismetBackupsPrompt from './monitor-akismet-backups-prompt';
 
 class WelcomePersonal extends Component {
+	constructor( props ) {
+		super( props );
+
+		// Preparing event handlers once to avoid calling bind on every render
+		this.clickCtaDismissGetStarted = this.clickCtaDismiss.bind( this, 'get-started' );
+	}
+
 	componentDidMount() {
 		analytics.tracks.recordEvent( 'jetpack_warm_welcome_plan_view', {
 			planClass: this.props.planClass,
 		} );
+	}
+
+	clickCtaDismiss( cta ) {
+		analytics.tracks.recordEvent( 'jetpack_warm_welcome_plan_click', {
+			planClass: this.props.planClass,
+			cta: cta,
+		} );
+
+		this.props.dismiss();
 	}
 
 	renderInnerContent() {
@@ -30,6 +46,11 @@ class WelcomePersonal extends Component {
 						'scanning for security threats.'
 					) }
 				</p>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Get started' ) }
+					</Button>
+				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Personal, you have access to more than 100 free, professionally-designed WordPress ' +

--- a/_inc/client/components/welcome-new-plan/personal.jsx
+++ b/_inc/client/components/welcome-new-plan/personal.jsx
@@ -67,7 +67,7 @@ class WelcomePersonal extends Component {
 		return (
 			<JetpackDialogue
 				svg={ <img src={ imagePath + 'connect-jetpack.svg' } width="160" alt={ __( 'Welcome personal' ) } style={ { paddingLeft: '60px' } } /> }
-				title={ __( 'Your Jetpack Personal plan is powering up!' ) }
+				title={ __( 'Explore your Jetpack Personal plan!' ) }
 				content={ this.renderInnerContent() }
 				dismiss={ this.props.dismiss }
 				className="jp-welcome-new-plan is-personal"

--- a/_inc/client/components/welcome-new-plan/personal.jsx
+++ b/_inc/client/components/welcome-new-plan/personal.jsx
@@ -46,11 +46,6 @@ class WelcomePersonal extends Component {
 						'scanning for security threats.'
 					) }
 				</p>
-				<div className="jp-welcome-new-plan__button">
-					<Button onClick={ this.clickCtaDismissGetStarted }>
-						{ __( 'Get started' ) }
-					</Button>
-				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Personal, you have access to more than 100 free, professionally-designed WordPress ' +
@@ -59,14 +54,11 @@ class WelcomePersonal extends Component {
 					) }
 				</p>
 				<MonitorAkismetBackupsPrompt />
-				<Button
-					className="jp-welcome-new-plan__button"
-					href={ '#/traffic' }
-					onClick={ this.props.dismiss }
-					primary
-				>
-					{ __( 'Got it!' ) }
-				</Button>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Got it' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Button from 'components/button';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
 
@@ -24,6 +25,7 @@ class WelcomePremium extends Component {
 		// Preparing event handlers once to avoid calling bind on every render
 		this.clickCtaDismissVideo = this.clickCtaDismiss.bind( this, 'video' );
 		this.clickCtaDismissAds = this.clickCtaDismiss.bind( this, 'ads' );
+		this.clickCtaDismissGetStarted = this.clickCtaDismiss.bind( this, 'get-started' );
 	}
 	componentDidMount() {
 		analytics.tracks.recordEvent( 'jetpack_warm_welcome_plan_view', {
@@ -43,6 +45,9 @@ class WelcomePremium extends Component {
 	renderInnerContent() {
 		return (
 			<div>
+				<Button onClick={ this.clickCtaDismissGetStarted }>
+					{ __( 'Get started' ) }
+				</Button>
 				<p>
 					{ __( 'Thanks for choosing Jetpack Premium. Jetpack is now backing up your site, scanning for ' +
 						' security threats, and enabling monetization features.'

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import Card from 'components/card';
 import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
 import JetpackDialogue from 'components/jetpack-dialogue';
 import { imagePath } from 'constants/urls';
 import VideoPressPrompt from './videopress-prompt';

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -45,14 +45,16 @@ class WelcomePremium extends Component {
 	renderInnerContent() {
 		return (
 			<div>
-				<Button onClick={ this.clickCtaDismissGetStarted }>
-					{ __( 'Get started' ) }
-				</Button>
 				<p>
 					{ __( 'Thanks for choosing Jetpack Premium. Jetpack is now backing up your site, scanning for ' +
 						' security threats, and enabling monetization features.'
 					) }
 				</p>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Get started' ) }
+					</Button>
+				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Premium, you can create the perfect site, no matter its purpose. Customize your site’s' +

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -99,7 +99,7 @@ class WelcomePremium extends Component {
 		return (
 			<JetpackDialogue
 				svg={ <img src={ imagePath + 'generating-cash-2.svg' } width="250" alt={ __( 'Welcome Premium' ) } /> }
-				title={ __( 'Your Jetpack Premium plan is powering up!' ) }
+				title={ __( 'Explore your Jetpack Premium plan!' ) }
 				content={ this.renderInnerContent() }
 				belowContent={ this.renderBelowContent() }
 				dismiss={ this.props.dismiss }

--- a/_inc/client/components/welcome-new-plan/premium.jsx
+++ b/_inc/client/components/welcome-new-plan/premium.jsx
@@ -50,11 +50,6 @@ class WelcomePremium extends Component {
 						' security threats, and enabling monetization features.'
 					) }
 				</p>
-				<div className="jp-welcome-new-plan__button">
-					<Button onClick={ this.clickCtaDismissGetStarted }>
-						{ __( 'Get started' ) }
-					</Button>
-				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Premium, you can create the perfect site, no matter its purpose. Customize your site’s' +
@@ -76,6 +71,11 @@ class WelcomePremium extends Component {
 				<p>
 					{ __( 'Start exploring Jetpack Premium now to see all the benefits of your new plan.' ) }
 				</p>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Got it' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}

--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Button from 'components/button';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
 
@@ -26,6 +27,7 @@ class WelcomeProfessional extends Component {
 		this.clickCtaDismissAds = this.clickCtaDismiss.bind( this, 'ads' );
 		this.clickCtaDismissSearch = this.clickCtaDismiss.bind( this, 'search' );
 		this.clickCtaDismissSeo = this.clickCtaDismiss.bind( this, 'seo' );
+		this.clickCtaDismissGetStarted = this.clickCtaDismiss.bind( this, 'get-started' );
 	}
 
 	componentDidMount() {
@@ -51,6 +53,11 @@ class WelcomeProfessional extends Component {
 						' indexing your content for search, scanning for security threats, and granting access to premium themes.'
 					) }
 				</p>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Get started' ) }
+					</Button>
+				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Professional, you can create the perfect site with one of over 300 professionally-designed' +

--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import Card from 'components/card';
 import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
 import JetpackDialogue from 'components/jetpack-dialogue';
 import { imagePath } from 'constants/urls';
 import MonitorAkismetBackupsPrompt from './monitor-akismet-backups-prompt';

--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -132,7 +132,7 @@ class WelcomeProfessional extends Component {
 		return (
 			<JetpackDialogue
 				svg={ <img src={ imagePath + 'people-around-page.svg' } width="250" alt={ __( 'Welcome Professional' ) } /> }
-				title={ __( 'Your Jetpack Professional plan is taking care of business!' ) }
+				title={ __( 'Explore your Jetpack Professional plan!' ) }
 				content={ this.renderInnerContent() }
 				belowContent={ this.renderBelowContent() }
 				dismiss={ this.props.dismiss }

--- a/_inc/client/components/welcome-new-plan/professional.jsx
+++ b/_inc/client/components/welcome-new-plan/professional.jsx
@@ -53,11 +53,6 @@ class WelcomeProfessional extends Component {
 						' indexing your content for search, scanning for security threats, and granting access to premium themes.'
 					) }
 				</p>
-				<div className="jp-welcome-new-plan__button">
-					<Button onClick={ this.clickCtaDismissGetStarted }>
-						{ __( 'Get started' ) }
-					</Button>
-				</div>
 				<img src={ imagePath + 'customize-theme.svg' } className="jp-welcome__svg" alt={ __( 'Themes' ) } />
 				<p>
 					{ __( 'With Jetpack Professional, you can create the perfect site with one of over 300 professionally-designed' +
@@ -85,6 +80,11 @@ class WelcomeProfessional extends Component {
 				<p>
 					{ __( 'Start exploring Jetpack Professional now to see all the benefits of your new plan.' ) }
 				</p>
+				<div className="jp-welcome-new-plan__button">
+					<Button onClick={ this.clickCtaDismissGetStarted }>
+						{ __( 'Got it' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #10657

#### Changes proposed in this Pull Request:

* Adds a “Got it” button at the bottom of the post-purchase warm welcome to make it easier to dismiss the modal.
* Tweaks the header copy to make it more imperative and exciting.

![image](https://user-images.githubusercontent.com/390760/50002579-718d5600-ff98-11e8-8679-af4a398bdbc0.png)

![image](https://user-images.githubusercontent.com/390760/50002587-7a7e2780-ff98-11e8-9944-7ed8175b4480.png)

#### Testing instructions:

* Start with a free site.
* Upgrade to a Premium/Professional plan.
* When redirected to wp-admin, make sure you can dismiss the plan warm welcome message by pressing the button.

#### Proposed changelog entry for your changes:

*  Adds a button to the post-purchase warm welcome to make it easier to dismiss the modal.
