### PR TITLE
Tiled gallery block: load assets

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -320,6 +320,7 @@ class Jetpack_Gutenberg {
 				'wp-i18n',
 				'wp-keycodes',
 				'wp-plugins',
+				'wp-rich-text',
 				'wp-token-list',
 				'wp-url',
 			),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 99 ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -17,6 +17,30 @@ class Jetpack_Tiled_Gallery {
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
 		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
 
+		jetpack_register_block(
+			'tiled-gallery',
+			array(
+				'render_callback' => array( $this, 'load_block_assets' ),
+			)
+		);
+	}
+
+	/**
+	 * Tiled gallery block registration/dependency declaration.
+	 *
+	 * @param array  $attr - Array containing the block attributes.
+	 * @param string $content - String containing the block content.
+	 *
+	 * @return string
+	 */
+	public function load_block_assets( $attr, $content ) {
+		$dependencies = array(
+			'lodash',
+			'wp-i18n',
+			'wp-token-list',
+		);
+		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
+		return $content;
 	}
 
 	public function tiles_enabled() {


### PR DESCRIPTION
Load Tiled Gallery Gutenberg block assets.

## Testing

- Apply the commit https://github.com/Automattic/jetpack/pull/10739/commits/9e27e5978eab605c6b06f7ad38390c01c69009a3 to fix loading block assets at appropiate loading order. (PR https://github.com/Automattic/jetpack/pull/10739)
- In Calypso, switch to branch `update/tiled-gallery-updates` (PR https://github.com/Automattic/wp-calypso/pull/27458) and build the blocks to get `_inc/blocks/tiled-gallery/view*` files:
    ```
    npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/ \
        --output-dir=~/jetpack/_inc/blocks/
    ```
- Insert tiled gallery block in the editor, add some awesome images and publish the post
- Check the post frontend, you should observe `tiled-gallery/view.*` files load and the gallery shouldn't look too broken. It might look just a tad bit broken because it's work in progress. ;-)
