### PR TITLE
Fix the autoloading of our options

### DIFF
--- a/modules/theme-tools/content-options/post-details.php
+++ b/modules/theme-tools/content-options/post-details.php
@@ -132,11 +132,11 @@ function jetpack_post_details_should_run() {
 		return $void;
 	}
 
-	$date_option       = get_option( 'jetpack_content_post_details_date', 1 );
-	$categories_option = get_option( 'jetpack_content_post_details_categories', 1 );
-	$tags_option       = get_option( 'jetpack_content_post_details_tags', 1 );
-	$author_option     = get_option( 'jetpack_content_post_details_author', 1 );
-	$comment_option    = get_option( 'jetpack_content_post_details_comment', 1 );
+	$date_option       = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_content_post_details_date', 1 );
+	$categories_option = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_content_post_details_categories', 1 );
+	$tags_option       = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_content_post_details_tags', 1 );
+	$author_option     = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_content_post_details_author', 1 );
+	$comment_option    = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_content_post_details_comment', 1 );
 
 	$options  = array( $date_option, $categories_option, $tags_option, $author_option, $comment_option );
 	$definied = array( $date, $categories, $tags, $author, $comment );


### PR DESCRIPTION
While looking at a clean install I noticed some options being used on every frontend page load that were generating queries even though I have object caching available.

This means they are not set to be autoloaded.

#### Changes proposed in this Pull Request:

* Adds options used by the post-details content options to be autoloaded

#### Testing instructions:

* Setup a clean install with Jetpack and a Theme like Independent Publisher 2 which uses the content options
* Install the Debug Bar plugin and configure query debugging to track queries
* Look at the root frontend page view and see a bunch of individual options queries
* Apply this PR and see that the first page load sets the options to default autoloaded values and future requests don't have individual queries for the options.

#### Proposed changelog entry for your changes:

* Improve autoloading of Jetpack options
