### PR TITLE
Typo – Conncetion → Connection

### DIFF
--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -38,7 +38,7 @@ export const fetchSiteConnectionStatus = () => {
 
 export const fetchSiteConnectionTest = () => {
 	return ( dispatch ) => {
-		dispatch( createNotice( 'is-info', __( 'Testing Jetpack Conncetion' ), { id: 'test-jetpack-connection' } ) );
+		dispatch( createNotice( 'is-info', __( 'Testing Jetpack Connection' ), { id: 'test-jetpack-connection' } ) );
 		return restApi.fetchSiteConnectionTest().then( connectionTest => {
 			dispatch( {
 				type: JETPACK_CONNECTION_TEST_FETCH,


### PR DESCRIPTION
fixing "Conncetion" to "Connection"; small typo

`… __( 'Testing Jetpack Conncetion' ) …` → `… __( 'Testing Jetpack Connection' ) …`

#### Proposed changelog entry for your changes:
none