### PR TITLE
Gutenberg block: change initialization for later

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
+		add_action( 'wp_loaded', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -537,7 +537,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'wp_loaded', array( 'Jetpack_Gutenberg', 'load_blocks' ) ); // Registers all the Jetpack blocks .
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 99 ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 


### PR DESCRIPTION
<!-- OUT OF DATE:

Instead of hooking `load_blocks` to `init` action which runs early, hook it to `wp_loaded` action so that registering assets from inside modules that might get loaded later is possible.

https://codex.wordpress.org/Plugin_API/Action_Reference/wp_loaded
https://codex.wordpress.org/Plugin_API/Action_Reference/init

I tried changing the priority of `init` hook but it had no effect.
-->
Change the priority of `init` block loading hook so that it runs after modules are loaded.

This came up when trying to register assets from Tiled gallery module: https://github.com/Automattic/jetpack/pull/10728 — currently blocked by this.

#### Testing instructions:

- Apply the commit to load Tiled gallery assets in Jetpack: https://github.com/Automattic/jetpack/pull/10728/commits/2740f7ab0fb563feca33aff9f9f6ac91fab07fb7 (PR https://github.com/Automattic/jetpack/pull/10728)
- In Calypso, switch to branch `update/tiled-gallery-updates` (PR https://github.com/Automattic/wp-calypso/pull/27458) and build the blocks to get `_inc/blocks/tiled-gallery/view*` files:
    ```
    npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/ \
        --output-dir=~/jetpack/_inc/blocks/
    ```
- Insert tiled gallery block in the editor, add some awesome images and publish the post
- Check the post frontend, you should observe `tiled-gallery/view.*` files load and the gallery shouldn't look too broken. It might look just a tad bit broken because it's work in progress. ;-)