### PR TITLE
REST API: G'berg Available Extensions: Set Site Specific Endpoint Flag

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -17,6 +17,7 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'gutenberg';
+		$this->wpcom_is_site_specific_endpoint = true;
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -16,13 +16,13 @@
 class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_Controller {
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
-		$this->rest_base = 'gutenberg/available-extensions';
+		$this->rest_base = 'gutenberg';
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route( $this->namespace, $this->rest_base . '/available-extensions', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( 'Jetpack_Gutenberg', 'get_block_availability' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Set `$this->wpcom_is_site_specific_endpoint = true`. (Only really relavant for WP.com)
* Some minor cleanup wrt `$rest_base`

#### Testing instructions:

(stolen from Mike's for #10605)

1. The best way to test is to make REST API requests to a test site. The simplest way to do that is to install either the [REST API Console](https://wordpress.org/plugins/rest-api-console/) plugin or the [Basic Authentication](https://github.com/WP-API/Basic-Auth) plugin.
2. As a user with contributor privileges or higher, make an authenticated REST API request: `GET /wp-json/wpcom/v2/gutenberg/available-extensions`. Verify that you get a list of blocks, with `available` bool attributes (and `unavailable_reason` strings if `available` is `false`). Verify that block/plugin availability corresponds to module activations status/plan/etc (also try changing them and verify that the endpoint's response changes accordingly).
3. As a user with subscriber privileges, make an authenticated REST API request: `GET /wp-json/wpcom/v2/gutenberg/available-extensions`, and verify that you get a 403 error. Try the same unauthenticated

#### Proposed changelog entry for your changes:

* REST API: Gutenberg Available Extensions: Set Site Specific Endpoint Flag
