### PR TITLE
Add Subscriber API Endpoint

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -42,7 +42,6 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	public function get_subscriber_count( $request ) {
 		$subscriptions = new Jetpack_Subscriptions_Widget();
 		$subscriber_info = $subscriptions->fetch_subscriber_count();
-		//echo "SUBSCRIBER COUNT: " . $subscriber_info
 		$subscriber_count = $subscriber_info['value'];
 
 		return array(

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -31,7 +31,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 		}
 
 		if ( ! Jetpack::is_module_active( 'subscriptions' ) ) {
-			wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Post_Publicize_Connections_Field' );
+			return new WP_Error( 'not_implemented', 'Please enable the Jetpack Subscriptions feature to enable this endpoint.', array( 'status' => 501 ) );
 		}
 
 		return true;

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -50,6 +50,6 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	}
 }
 
-if ( Jetpack::is_module_active( 'subscriptions ') ) {
+if ( Jetpack::is_module_active( 'subscriptions ') || ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) ) {
 	wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers' );
 }

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+/**
+ * Subscribers: Get subscriber count
+ *
+ * @since 6.8
+ */
+class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
+	function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'subscribers';
+		// This endpoint *does not* need to connect directly to Jetpack sites.
+		$this->wpcom_is_wpcom_only_endpoint = true;
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
+	public function register_routes() {
+		// GET /sites/<blog_id>/subscribers/count - Return number of subscribers for this site.
+		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/count', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_subscriber_count' ),
+				'permission_callback' => array( $this, 'readable_permission_check' ),
+			)
+		) );
+	}
+
+	public function readable_permission_check() {
+		if ( ! current_user_can_for_blog( get_current_blog_id(), 'edit_posts' ) ) {
+			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', [ 'status' => 401 ] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves subscriber count
+	 *
+	 * @param WP_REST_Request $request incoming API request info
+	 * @return array data object containing subscriber count
+	 */
+	public function get_subscriber_count( $request ) {
+		$subscriptions = new Jetpack_Subscriptions_Widget();
+		$subscriber_info = $subscriptions->fetch_subscriber_count();
+		$subscriber_count = $subscriber_info['value'];
+
+		return array(
+			'count' => $subscriber_count
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers' );

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -30,10 +30,6 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', array( 'status' => 401 ) );
 		}
 
-		if ( ! Jetpack::is_module_active( 'subscriptions' ) ) {
-			return new WP_Error( 'not_implemented', 'Please enable the Jetpack Subscriptions feature to enable this endpoint.', array( 'status' => 501 ) );
-		}
-
 		return true;
 	}
 
@@ -54,4 +50,6 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	}
 }
 
-wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers' );
+if ( Jetpack::is_module_active( 'subscriptions ') ) {
+	wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers' );
+}

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * WARNING: This file is distributed verbatim in Jetpack.
- * There should be nothing WordPress.com specific in this file.
- *
- * @hide-in-jetpack
- */
-
 /**
  * Subscribers: Get subscriber count
  *

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -30,6 +30,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', array( 'status' => 401 ) );
 		}
 
+		if ( ! Jetpack::is_module_active( 'subscriptions' ) ) {
+			wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Post_Publicize_Connections_Field' );
+		}
+
 		return true;
 	}
 

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -3,7 +3,7 @@
 /**
  * Subscribers: Get subscriber count
  *
- * @since 6.8
+ * @since 6.9
  */
 class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	function __construct() {

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -18,7 +18,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 		$this->rest_base = 'subscribers';
 		// This endpoint *does not* need to connect directly to Jetpack sites.
 		$this->wpcom_is_wpcom_only_endpoint = true;
-		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	public function register_routes() {
@@ -34,7 +34,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 
 	public function readable_permission_check() {
 		if ( ! current_user_can_for_blog( get_current_blog_id(), 'edit_posts' ) ) {
-			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', [ 'status' => 401 ] );
+			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', array( 'status' => 401 ) );
 		}
 
 		return true;
@@ -49,6 +49,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	public function get_subscriber_count( $request ) {
 		$subscriptions = new Jetpack_Subscriptions_Widget();
 		$subscriber_info = $subscriptions->fetch_subscriber_count();
+		//echo "SUBSCRIBER COUNT: " . $subscriber_info
 		$subscriber_count = $subscriber_info['value'];
 
 		return array(

--- a/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
+
+/**
+ * @group publicize
+ * @group rest-api
+ */
+class Test_WPCOM_REST_API_V2_Subscribers_Endpoint extends WP_Test_Jetpack_REST_Testcase {
+
+	static $editor_user_id;
+	static $subscriber_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		set_transient( 'wpcom_subscribers_total', array('value' => 100, 'status' => 'success' ) );
+	}
+
+	public function test_get_subscriber_count_with_edit_permission() {
+		wp_set_current_user( self::$editor_user_id );
+
+		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/wpcom/v2/subscribers/count' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['count'], 100 );
+	}
+
+	public function test_get_subscriber_count_without_edit_permission() {
+		wp_set_current_user( self::$subscriber_user_id );
+
+		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/wpcom/v2/subscribers/count' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertFalse( isset( $data['count'] ) );
+		$this->assertEquals( $data['data']['status'], 401 );
+	}
+
+}

--- a/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
@@ -13,6 +13,15 @@ class Test_WPCOM_REST_API_V2_Subscribers_Endpoint extends WP_Test_Jetpack_REST_T
 	static $subscriber_user_id;
 
 	public static function wpSetUpBeforeClass( $factory ) {
+
+		Jetpack_Options::update_options( array(
+			'blog_token'  => 1,
+			'id'          => 1001,
+		) );
+		Jetpack::update_user_token( 1, sprintf( '%s.%d', 'token', 1 ), true );
+
+		Jetpack::activate_module( 'subscriptions' );
+
 		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 

--- a/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
@@ -13,15 +13,6 @@ class Test_WPCOM_REST_API_V2_Subscribers_Endpoint extends WP_Test_Jetpack_REST_T
 	static $subscriber_user_id;
 
 	public static function wpSetUpBeforeClass( $factory ) {
-
-		Jetpack_Options::update_options( array(
-			'blog_token'  => 1,
-			'id'          => 1001,
-		) );
-		Jetpack::update_user_token( 1, sprintf( '%s.%d', 'token', 1 ), true );
-
-		Jetpack::activate_module( 'subscriptions' );
-
 		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 

--- a/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
 
 /**
  * @group publicize

--- a/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test_class.subscribers-endpoint.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
-require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
 
 /**
  * @group publicize


### PR DESCRIPTION
This PR adds an API endpoint to get the subscriber count, as required by the Gutenberg Subscription block.

#### Changes proposed in this Pull Request:

This PR adds an API endpoint to get the subscriber count, as required by the Gutenberg Subscription block.

#### Testing instructions:

phpunit tests the new endpoint

#### Proposed changelog entry for your changes:

Addition of Subscriber API endpoint