### PR TITLE
Maps Block: Add an new api endpoint 

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -3082,6 +3082,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	/**
 	 * Deprecated - Get third party plugin API keys.
+	 * @deprecated
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
@@ -3096,6 +3097,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	/**
 	 * Deprecated - Update third party plugin API keys.
+	 * @deprecated
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
@@ -3110,6 +3112,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	/**
 	 * Deprecated - Delete a third party plugin API key.
+	 * @deprecated
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
@@ -3127,6 +3130,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * To add a service to these endpoints, add the service name to $valid_services
 	 * and add '{service name}_api_key' to the non-compact return array in get_option_names(),
 	 * in class-jetpack-options.php
+	 * @deprecated
 	 *
 	 * @param string $service The service the API key is for.
 	 * @return string Returns the service name if valid, null if invalid.
@@ -3146,7 +3150,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	/**
 	 * Deprecated - Validate API Key
-	 *
+	 * @deprecated
 	 *
 	 * @param string $key The API key to be validated.
 	 * @param string $service The service the API key is for.
@@ -3160,6 +3164,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Deprecated - Validate Mapbox API key
 	 * Based loosely on https://github.com/mapbox/geocoding-example/blob/master/php/MapboxTest.php
+	 * @deprecated
 	 *
 	 * @param string $key The API key to be validated.
 	 */

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -3090,7 +3090,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * }
 	 */
 	public static function get_service_api_key( $request ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::get_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key( $request );
 	}
 
@@ -3101,11 +3101,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
-	 * depreacted in 6.9
 	 * }
 	 */
 	public static function update_service_api_key( $request ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::update_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::update_service_api_key' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::update_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::update_service_api_key( $request ) ;
 	}
 
@@ -3119,7 +3118,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * }
 	 */
 	public static function delete_service_api_key( $request ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::delete_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::delete_service_api_key' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::delete_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::delete_service_api_key( $request );
 	}
 
@@ -3133,7 +3132,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return string Returns the service name if valid, null if invalid.
 	 */
 	public static function validate_service_api_service( $service = null ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_service', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_service' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_service' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_service( $service );
 	}
 
@@ -3141,7 +3140,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Error response for invalid service API key requests with an invalid service.
 	 */
 	public static function service_api_invalid_service_response() {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::service_api_invalid_service_response', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::service_api_invalid_service_response' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::service_api_invalid_service_response' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::service_api_invalid_service_response();
 	}
 
@@ -3154,7 +3153,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 */
 	public static function validate_service_api_key( $key = null, $service = null ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key( $key , $service  );
 	}
 
@@ -3165,7 +3164,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @param string $key The API key to be validated.
 	 */
 	public static function validate_service_api_key_mapbox( $key ) {
-		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
+		_deprecated_function( __METHOD__, 'jetpack-6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key_mapbox( $key );
 
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -3081,7 +3081,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Get third party plugin API keys.
+	 * Deprecated - Get third party plugin API keys.
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
@@ -3090,24 +3090,27 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * }
 	 */
 	public static function get_service_api_key( $request ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::get_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key( $request );
 	}
 
 	/**
-	 * Update third party plugin API keys.
+	 * Deprecated - Update third party plugin API keys.
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
+	 * depreacted in 6.9
 	 * }
 	 */
 	public static function update_service_api_key( $request ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::update_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::update_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::update_service_api_key( $request ) ;
 	}
 
 	/**
-	 * Delete a third party plugin API key.
+	 * Deprecated - Delete a third party plugin API key.
 	 *
 	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
@@ -3116,11 +3119,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * }
 	 */
 	public static function delete_service_api_key( $request ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::delete_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::delete_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::delete_service_api_key( $request );
 	}
 
 	/**
-	 * Validate the service provided in /service-api-keys/ endpoints.
+	 * Deprecated - Validate the service provided in /service-api-keys/ endpoints.
 	 * To add a service to these endpoints, add the service name to $valid_services
 	 * and add '{service name}_api_key' to the non-compact return array in get_option_names(),
 	 * in class-jetpack-options.php
@@ -3129,6 +3133,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return string Returns the service name if valid, null if invalid.
 	 */
 	public static function validate_service_api_service( $service = null ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_service', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_service' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_service( $service );
 	}
 
@@ -3136,26 +3141,31 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Error response for invalid service API key requests with an invalid service.
 	 */
 	public static function service_api_invalid_service_response() {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::service_api_invalid_service_response', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::service_api_invalid_service_response' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::service_api_invalid_service_response();
 	}
 
 	/**
-	 * Validate API Key
+	 * Deprecated - Validate API Key
+	 *
 	 *
 	 * @param string $key The API key to be validated.
 	 * @param string $service The service the API key is for.
+	 *
 	 */
 	public static function validate_service_api_key( $key = null, $service = null ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key( $key , $service  );
 	}
 
 	/**
-	 * Validate Mapbox API key
+	 * Deprecated - Validate Mapbox API key
 	 * Based loosely on https://github.com/mapbox/geocoding-example/blob/master/php/MapboxTest.php
 	 *
 	 * @param string $key The API key to be validated.
 	 */
 	public static function validate_service_api_key_mapbox( $key ) {
+		_deprecated_function( 'Jetpack_Core_Json_Api_Endpoints::validate_service_api_key', '6.9.0', 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key' );
 		return WPCOM_REST_API_V2_Endpoint_Service_API_Keys::validate_service_api_key_mapbox( $key );
 
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Service API Keys: Exposes 3rd party api keys that are used on a site.
  *
@@ -16,6 +15,7 @@
  * @since 6.9
  */
 class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
+
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'service-api-keys';
@@ -138,10 +138,12 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		if ( ! $service ) {
 			return self::service_api_invalid_service_response();
 		}
-		$params     = $request->get_json_params();
+		$json_params = $request->get_json_params();
+		$params     = ! empty( $json_params ) ? $json_params : $request->get_body_params();
 		$service_api_key    = trim( $params['service_api_key'] );
 		$option     = self::key_for_api_service( $service );
-		$validation = self::validate_service_api_key( $service_api_key, $service );
+
+		$validation = self::validate_service_api_key( $service_api_key, $service, $params );
 		if ( ! $validation['status'] ) {
 			return new WP_Error( 'invalid_key', esc_html__( 'Invalid API Key', 'jetpack' ), array( 'status' => 404 ) );
 		}

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -30,12 +30,12 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( __CLASS__, 'get_service_api_key' ), // todo move the methods to this class..
+					'callback'            => array( __CLASS__, 'get_service_api_key' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( __CLASS__, 'update_service_api_key' ),  // todo move the methods to this class..
-					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),  // todo move the methods to this class..
+					'callback'            => array( __CLASS__, 'update_service_api_key' ),
+					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),
 					'args'                => array(
 						'service_api_key' => array(
 							'required' => true,
@@ -45,8 +45,8 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( __CLASS__, 'delete_service_api_key' ),  // todo move the methods to this class..
-					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),  // todo move the methods to this class..
+					'callback'            => array( __CLASS__, 'delete_service_api_key' ),
+					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),
 				),
 			)
 		);

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -1,0 +1,279 @@
+<?php
+
+/*
+ * Service API Keys: Exposes 3rd party api keys that are used on a site.
+ *
+ * [
+ *   { # Availabilty Object. See schema for more detail.
+ *      code:            (string) Displays success if the oppration was successfully executed and an error code if it was not
+ *      service:         (string) The name of the service in question
+ *      service_api_key: (string) The API key used by the service empty if one is not set yet
+ *      message:         (string) User friendly message
+ *   },
+ *   ...
+ * ]
+ *
+ * @since 6.9
+ */
+class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
+	function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'service-api-keys';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route(
+			'wpcom/v2',
+			'/service-api-keys/(?P<service>[a-z\-_]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( __CLASS__, 'get_service_api_key' ), // todo move the methods to this class..
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( __CLASS__, 'update_service_api_key' ),  // todo move the methods to this class..
+					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),  // todo move the methods to this class..
+					'args'                => array(
+						'service_api_key' => array(
+							'required' => true,
+							'type'     => 'text',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( __CLASS__, 'delete_service_api_key' ),  // todo move the methods to this class..
+					'permission_callback' => array( __CLASS__, 'edit_others_posts_check' ),  // todo move the methods to this class..
+				),
+			)
+		);
+	}
+
+	public static function edit_others_posts_check() {
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			return true;
+		}
+
+		$user_permissions_error_msg = esc_html__(
+			'You do not have the correct user permissions to perform this action.
+			Please contact your site admin if you think this is a mistake.',
+			'jetpack'
+		);
+
+		return new WP_Error( 'invalid_user_permission_edit_others_posts', $user_permissions_error_msg, rest_authorization_required_code() );
+	}
+
+	/**
+	 * Return the available Gutenberg extensions schema
+	 *
+	 * @return array Service API Key schema
+	 */
+	public function get_public_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'service-api-keys',
+			'type'       => 'object',
+			'properties' => array(
+				'code'          => array(
+					'description' => __( 'Displays success if the oppration was successfully executed and an error code if it was not', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'service' => array(
+					'description' => __( 'The name of the service in question', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'service_api_key'          => array(
+					'description' => __( 'The API key used by the service empty if one is not set yet', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'message'          => array(
+					'description' => __( 'User friendly message', 'jetpack' ),
+					'type'        => 'string',
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get third party plugin API keys.
+	 *
+	 * @param WP_REST_Request $request {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
+	 * }
+	 */
+	public static function get_service_api_key( $request ) {
+
+		$service = self::validate_service_api_service( $request['service'] );
+		if ( ! $service ) {
+			return self::service_api_invalid_service_response();
+		}
+		$option  = self::key_for_api_service( $service );
+		$message = esc_html__( 'API key retrieved successfully.', 'jetpack' );
+		return array(
+			'code'            => 'success',
+			'service'         => $service,
+			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
+			'message'         => $message,
+		);
+	}
+
+	/**
+	 * Update third party plugin API keys.
+	 *
+	 * @param WP_REST_Request $request {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
+	 * }
+	 */
+	public static function update_service_api_key( $request ) {
+		$service = self::validate_service_api_service( $request['service'] );
+		if ( ! $service ) {
+			return self::service_api_invalid_service_response();
+		}
+		$params     = $request->get_json_params();
+		$service_api_key    = trim( $params['service_api_key'] );
+		$option     = self::key_for_api_service( $service );
+		$validation = self::validate_service_api_key( $service_api_key, $service );
+		if ( ! $validation['status'] ) {
+			return new WP_Error( 'invalid_key', esc_html__( 'Invalid API Key', 'jetpack' ), array( 'status' => 404 ) );
+		}
+		$message = esc_html__( 'API key updated successfully.', 'jetpack' );
+		Jetpack_Options::update_option( $option, $service_api_key );
+		return array(
+			'code'            => 'success',
+			'service'         => $service,
+			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
+			'message'         => $message,
+		);
+	}
+
+	/**
+	 * Delete a third party plugin API key.
+	 *
+	 * @param WP_REST_Request $request {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
+	 * }
+	 */
+	public static function delete_service_api_key( $request ) {
+		$service = self::validate_service_api_service( $request['service'] );
+		if ( ! $service ) {
+			return self::service_api_invalid_service_response();
+		}
+		$option = self::key_for_api_service( $service );
+		Jetpack_Options::delete_option( $option );
+		$message = esc_html__( 'API key deleted successfully.', 'jetpack' );
+		return array(
+			'code'            => 'success',
+			'service'         => $service,
+			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
+			'message'         => $message,
+		);
+	}
+
+	/**
+	 * Validate the service provided in /service-api-keys/ endpoints.
+	 * To add a service to these endpoints, add the service name to $valid_services
+	 * and add '{service name}_api_key' to the non-compact return array in get_option_names(),
+	 * in class-jetpack-options.php
+	 *
+	 * @param string $service The service the API key is for.
+	 * @return string Returns the service name if valid, null if invalid.
+	 */
+	public static function validate_service_api_service( $service = null ) {
+		$valid_services = array(
+			'mapbox',
+		);
+		return in_array( $service, $valid_services, true ) ? $service : null;
+	}
+
+	/**
+	 * Error response for invalid service API key requests with an invalid service.
+	 */
+	public static function service_api_invalid_service_response() {
+		return new WP_Error(
+			'invalid_service',
+			esc_html__( 'Invalid Service', 'jetpack' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	/**
+	 * Validate API Key
+	 *
+	 * @param string $key The API key to be validated.
+	 * @param string $service The service the API key is for.
+	 */
+	public static function validate_service_api_key( $key = null, $service = null ) {
+		$validation = false;
+		switch ( $service ) {
+			case 'mapbox':
+				$validation = self::validate_service_api_key_mapbox( $key );
+				break;
+		}
+		return $validation;
+	}
+
+	/**
+	 * Validate Mapbox API key
+	 * Based loosely on https://github.com/mapbox/geocoding-example/blob/master/php/MapboxTest.php
+	 *
+	 * @param string $key The API key to be validated.
+	 */
+	public static function validate_service_api_key_mapbox( $key ) {
+		$status          = true;
+		$msg             = null;
+		$mapbox_url      = sprintf(
+			'https://api.mapbox.com?%s',
+			$key
+		);
+		$mapbox_response = wp_safe_remote_get( esc_url_raw( $mapbox_url ) );
+		$mapbox_body     = wp_remote_retrieve_body( $mapbox_response );
+		if ( '{"api":"mapbox"}' !== $mapbox_body ) {
+			$status = false;
+			$msg    = esc_html__( 'Can\'t connect to Mapbox', 'jetpack' );
+			return array(
+				'status'        => $status,
+				'error_message' => $msg,
+			);
+		}
+		$mapbox_geocode_url      = esc_url_raw(
+			sprintf(
+				'https://api.mapbox.com/geocoding/v5/mapbox.places/%s.json?access_token=%s',
+				'1+broadway+new+york+ny+usa',
+				$key
+			)
+		);
+		$mapbox_geocode_response = wp_safe_remote_get( esc_url_raw( $mapbox_geocode_url ) );
+		$mapbox_geocode_body     = wp_remote_retrieve_body( $mapbox_geocode_response );
+		$mapbox_geocode_json     = json_decode( $mapbox_geocode_body );
+		if ( isset( $mapbox_geocode_json->message ) && ! isset( $mapbox_geocode_json->query ) ) {
+			$status = false;
+			$msg    = $mapbox_geocode_json->message;
+		}
+		return array(
+			'status'        => $status,
+			'error_message' => $msg,
+		);
+	}
+
+	/**
+	 * Create site option key for service
+	 *
+	 * @param string $service The service  to create key for.
+	 */
+	private static function key_for_api_service( $service ) {
+		return $service . '_api_key';
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys' );

--- a/tests/php/core-api/wpcom-fields/test_class.service-api-keys.php
+++ b/tests/php/core-api/wpcom-fields/test_class.service-api-keys.php
@@ -1,0 +1,137 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
+/**
+ * @group publicize
+ * @group rest-api
+ */
+class Test_WPCOM_REST_API_V2_Service_API_Keys_Endpoint extends WP_Test_Jetpack_REST_Testcase {
+
+	static $editor_user_id;
+	static $subscriber_user_id;
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		Jetpack_Options::update_option( 'mapbox_api_key', 'ABC' );
+
+		add_filter( 'pre_http_request', array( __CLASS__, 'do_not_verify_mapbox' ), 10, 3 );
+
+	}
+	// GET
+	public function test_get_services_api_key_mapbox() {
+		wp_set_current_user( self::$subscriber_user_id );
+		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/service-api-keys/mapbox' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'success' );
+		$this->assertEquals( $data['service'], 'mapbox' );
+		$this->assertEquals( $data['service_api_key'], 'ABC' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_get_404_services_api_key_unknow_service() {
+		wp_set_current_user( self::$editor_user_id );
+		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/service-api-keys/foo' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_service' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	// UPDATE
+	public function test_update_services_api_key_mapbox_with_permission() {
+		wp_set_current_user( self::$editor_user_id );
+		$request  = new WP_REST_Request( 'POST', '/wpcom/v2/service-api-keys/mapbox' );
+		$request->set_body_params( array(
+			'service_api_key' => 'ABC'
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_key' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_update_services_api_key_mapbox_without_permission() {
+		wp_set_current_user( self::$subscriber_user_id );
+		$request  = new WP_REST_Request( 'POST', '/wpcom/v2/service-api-keys/mapbox' );
+		$request->set_body_params( array(
+			'service_api_key' => 'ABC'
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_user_permission_edit_others_posts' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_update_404_update_services_api_key_unknow_service_with_permission() {
+		wp_set_current_user( self::$editor_user_id );
+		$request  = new WP_REST_Request( 'POST', '/wpcom/v2/service-api-keys/foo' );
+		$request->set_body_params( array(
+			'service_api_key' => 'ABC'
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_service' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_update_404_services_api_key_unknow_service_without_permission() {
+		wp_set_current_user( self::$subscriber_user_id );
+		$request  = new WP_REST_Request( 'POST', '/wpcom/v2/service-api-keys/foo' );
+		$request->set_body_params( array(
+			'service_api_key' => 'ABC'
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_user_permission_edit_others_posts' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	// DELETE
+	public function test_delete_service_api_key_mapbox_with_permission() {
+		wp_set_current_user( self::$editor_user_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wpcom/v2/service-api-keys/mapbox' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'success' );
+		$this->assertEquals( $data['service'], 'mapbox' );
+		$this->assertEquals( $data['service_api_key'], '' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_delete_service_api_key_mapbox_without_permission() {
+		wp_set_current_user( self::$subscriber_user_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wpcom/v2/service-api-keys/mapbox' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_user_permission_edit_others_posts' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public function test_delete_404_services_api_key_unknow_service_with_permission() {
+		wp_set_current_user( self::$editor_user_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wpcom/v2/service-api-keys/foo' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( $data['code'], 'invalid_service' );
+		$this->assertTrue( isset( $data['message'] ) );
+	}
+
+	public static function do_not_verify_mapbox( $return, $r, $url ) {
+		//  shortcut the api call...
+		if( $url === 'https://api.mapbox.com?ABC' ) {
+			return true;
+		}
+		return $return;
+	}
+}


### PR DESCRIPTION
Update the service-api-keys api endpoint to have the wpcom/v2 name space. 

Required for this https://github.com/Automattic/wp-calypso/pull/28927 change to work and to make the whole block work on .com 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* This PR implements the same service-api-keys but with the new wpcom/v2 namespace. 
* It preserves the old name space and public methods. 
Do we need to do that? @dereksmart They shipped only in one version 6.8 and are used inthe gutenberg editor. 


#### Testing instructions:
Without any changes to JS does the MAP Block still work as expected? 
Does it load on the front-end. Are you able to set and remove the api key? 

Patch your block code with https://github.com/Automattic/wp-calypso/pull/28927 
Does it load on the front-end. Are you able to set and remove the api key? 


#### Related 
D21501-code implements the code on the .com side of things. 

