### PR TITLE
Affiliates: introduce class to get the affiliate code

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -231,6 +231,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			? get_permalink( $last_post[0]->ID )
 			: get_home_url();
 
+		// Ensure that class to get the affiliate code is loaded
+		if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
+			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
+		}
+
 		return array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
 			'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
@@ -267,6 +272,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 				'roles' => $stats_roles,
 			),
+			'aff' => Jetpack_Affiliate::init()->get_affiliate_code(),
 			'settings' => $this->get_flattened_settings( $modules ),
 			'userData' => array(
 //				'othersLinked' => Jetpack::get_other_linked_admins(),

--- a/class.jetpack-affiliate.php
+++ b/class.jetpack-affiliate.php
@@ -1,0 +1,62 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly
+	exit;
+}
+
+/**
+ * This class introduces routines to get an affiliate code, that might be obtained from:
+ * - an `jetpack_affiliate_code` option in the WP database
+ * - an affiliate code returned by a filter bound to the `jetpack_affiliate_code` filter hook
+ *
+ * @since 6.9.0
+ */
+class Jetpack_Affiliate {
+
+	/**
+	 * @since 6.9.0
+	 * @var Jetpack_Affiliate This class instance.
+	 **/
+	private static $instance = null;
+
+	private function __construct() {
+		if ( Jetpack::is_development_mode() ) {
+			return;
+		}
+	}
+
+	/**
+	 * Initializes the class or returns the singleton
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return Jetpack_Affiliate | false
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Jetpack_Affiliate;
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Returns the affiliate code from database after filtering it.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return string The affiliate code.
+	 */
+	public function get_affiliate_code() {
+		/**
+		 * Allow to filter the affiliate code.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $aff_code The affiliate code, blank by default.
+		 */
+		return apply_filters( 'jetpack_affiliate_code', get_option( 'jetpack_affiliate_code', '' ) );
+	}
+}
+
+add_action( 'init', array( 'Jetpack_Affiliate', 'init' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4778,7 +4778,7 @@ p {
 					'site_icon'     => $site_icon,
 					'site_lang'     => get_locale(),
 					'_ui'           => $tracks_identity['_ui'],
-					'_ut'           => $tracks_identity['_ut']
+					'_ut'           => $tracks_identity['_ut'],
 				)
 			);
 
@@ -4791,6 +4791,14 @@ p {
 			$url = add_query_arg( 'from', $from, $url );
 		}
 
+		// Ensure that class to get the affiliate code is loaded
+		if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
+			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
+		}
+		// Get affiliate code and add it to the URL
+		if ( '' !== ( $aff = Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
+			$url = add_query_arg( 'aff', $aff, $url );
+		}
 
 		if ( isset( $_GET['calypso_env'] ) ) {
 			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );

--- a/jetpack.php
+++ b/jetpack.php
@@ -93,6 +93,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
+	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'  );
 }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -89,6 +89,9 @@
 		<testsuite name="jitm">
 			<file>tests/php/test_class.jetpack-jitm.php</file>
 		</testsuite>
+		<testsuite name="affiliate">
+			<file>tests/php/test_class.jetpack-affiliate.php</file>
+		</testsuite>
 		<testsuite name="3rd-party">
 			<directory prefix="test_" suffix=".php">tests/php/3rd-party</directory>
 		</testsuite>

--- a/tests/php/test_class.jetpack-affiliate.php
+++ b/tests/php/test_class.jetpack-affiliate.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Tests for Jetpack_Affiliate
+ */
+
+// Load required class to get the affiliate code
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack.php';
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
+
+class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
+
+	function test_affiliate_code_missing() {
+		$this->assertEmpty( Jetpack_Affiliate::init()->get_affiliate_code() );
+	}
+
+	function test_affiliate_code_exists() {
+		add_option( 'jetpack_affiliate_code', 'abc123' );
+		$this->assertEquals( 'abc123', Jetpack_Affiliate::init()->get_affiliate_code() );
+	}
+
+	function test_affiliate_connect_url_missing() {
+		$this->assertNotContains( 'aff=', Jetpack::init()->build_connect_url() );
+	}
+
+	function test_affiliate_connect_url_exists() {
+		add_option( 'jetpack_affiliate_code', 'abc123' );
+		$this->assertContains( 'aff=abc123', Jetpack::init()->build_connect_url() );
+	}
+}


### PR DESCRIPTION
This PR seeks to introduce affiliate codes in Jetpack creating a class that allows to get an affiliate code from a database option `jetpack_affiliate_code`, and filtering it. There are two ways to set this code in the website:
1. Partners that can setup an affiliate code through WP CLI when deploying a site, can issue:
    `wp option add jetpack_affiliate_code abc123`
2. other partners like agencies that don't have this control from the beginning can add a filter:
    `add_filter( 'jetpack_affiliate_code', function() { return 'abc123'; } );`

Additionally, this PR will also:
- add the affiliate code, if found, to the connect url, as the query parameter `aff`
- send it to Jetpack UI in the `Initial_State` object as the property `aff`
    _it will be added to upgrade links in a follow up PR, since we need to refactor how upgrade links are written (right now they're inline) to be able to add the affiliate code or another param in the future in a consistent way using a function that given some params, returns the upgrade link._

### Testing instructions

a. manually
1. do `wp option add jetpack_affiliate_code abc123` (or `yarn docker:wp option add jetpack_affiliate_code abc123`)
2. verify that the URL of the Set up Jetpack button has the `aff` parameter with the right value
3. verify that the `Initial_Setup.aff` property has the right value

b. running unit tests. There's a new test suite named `affiliate`
1. run `phpunit --testsuite=affiliate` or `yarn docker:phpunit --testsuite=affiliate`

### Proposed changelog entry
Not necessary to mention this change since it will be known for those that have to know about it.