### PR TITLE
Map Block: get the api key via localized data

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -222,10 +222,11 @@ class Jetpack_Gutenberg {
 	 *
 	 * @param string $type slug of the block.
 	 * @param array $script_dependencies An array of view-side Javascript dependencies to be enqueued.
+	 * @param array $localize_data An array of view-side Javascript object accessible though the window object
 	 *
 	 * @return void
 	 */
-	public static function load_assets_as_required( $type, $script_dependencies = array() ) {
+	public static function load_assets_as_required( $type, $script_dependencies = array(), $localize_data = array() ) {
 		if ( is_admin() ) {
 			// A block's view assets will not be required in wp-admin.
 			return;
@@ -253,6 +254,14 @@ class Jetpack_Gutenberg {
 			'Jetpack_Block_Assets_Base_Url',
 			plugins_url( self::get_blocks_directory(), JETPACK__PLUGIN_FILE )
 		);
+		if ( ! empty( $localize_data ) ) {
+			wp_localize_script(
+				'jetpack-block-' . $type,
+				'Jetpack_Block_' . $type . '_data',
+				$localize_data
+			);
+		}
+
 	}
 
 	/**

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -26,8 +26,11 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		'lodash',
 		'wp-element',
 		'wp-i18n',
-		'wp-api-fetch',
 	);
-	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
+
+	$more_data = array(
+		'api_key' => Jetpack_Options::get_option( 'mapbox_api_key' )
+	);
+	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies, $more_data );
 	return $content;
 }


### PR DESCRIPTION
Removes an api call. Make it work on .com without having to fix the api endpoint. 

Related frontend js change https://github.com/Automattic/wp-calypso/pull/28971

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR make the api key endpoint available via the localize data. Which means that the map loads a little quicker since no api call is needed to show the map.

#### Testing instructions:
Build the blocks from https://github.com/Automattic/wp-calypso/pull/28971
Are you able to add a map block?
Are you able to view the map block?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Improved map block performance.
