### PR TITLE
Sharing: update Tumblr official sharing button.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1440,7 +1440,28 @@ class Share_Tumblr extends Sharing_Source {
 				$target = '_blank';
 			}
 
-			return '<a target="' . $target . '" href="https://www.tumblr.com/share/link/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&name=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" title="' . __( 'Share on Tumblr', 'jetpack' ) . '" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:62px; height:20px; background:url(\'https://platform.tumblr.com/v1/share_2.png\') top left no-repeat transparent;">' . __( 'Share on Tumblr', 'jetpack' ) . '</a>';
+			/**
+			 * If we are looking at a single post, let Tumblr figure out the post type (text, photo, link, quote, chat, or video)
+			 * based on the content available on the page.
+			 * If we are not looking at a single post, content from other posts can appear on the page and Tumblr will pick that up.
+			 * In this case, we want Tumblr to focus on our current post, so we will limit the post type to link, where we can give Tumblr a link to our post.
+			 */
+			if ( ! is_single() ) {
+				$posttype = 'data-posttype="link"';
+			} else {
+				$posttype = '';
+			}
+
+			// Documentation: https://www.tumblr.com/docs/en/share_button
+			return sprintf(
+				'<a class="tumblr-share-button" target="%1$s" href="%2$s" data-title="%3$s" data-content="%4$s" title="%5$s"%6$s>%5$s</a>',
+				$target,
+				'https://www.tumblr.com/share',
+				$this->get_share_title( $post->ID ),
+				$this->get_share_url( $post->ID ),
+				__( 'Share on Tumblr', 'jetpack' ),
+				$posttype
+			);
 		 } else {
 			return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Tumblr', 'share to', 'jetpack' ), __( 'Click to share on Tumblr', 'jetpack' ), 'share=tumblr' );
 		}
@@ -1455,10 +1476,10 @@ class Share_Tumblr extends Sharing_Source {
 		wp_redirect( $url );
 		die();
 	}
-	// http://www.tumblr.com/share?v=3&u=URL&t=TITLE&s=
+
 	public function display_footer() {
 		if ( $this->smart ) {
-			?><script type="text/javascript" src="https://platform.tumblr.com/v1/share.js"></script><?php
+			?><script id="tumblr-js" type="text/javascript" src="https://assets.tumblr.com/share-button.js"></script><?php
 		} else {
 			$this->js_dialog( $this->shortname, array( 'width' => 450, 'height' => 450 ) );
 		}


### PR DESCRIPTION
Fixes #10754

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- The Tumblr js file we used for Tumblr's official sharing button does not exist anymore, it returns a
404
- This PR updates the button to use the method now recommended here:
https://www.tumblr.com/docs/en/share_button
- The new button method gives you the option to define a post type when sharing. If you don't define
any, Tumblr parses the page to try to figure it out on its own. Let's not allow it to do that when the
button appears on the home page or archive pages, where tumblr could find other elements that do not
belong to our post.

#### Testing instructions:

* Log in to your Tumblr account.
* Go to settings > sharing
* Add a tumblr button to your sharing buttons, choose the official button type, and display the buttons on the home page as well as single posts.
* Visit a post with a video and click the sharing button: it should open a pop up with the video post type auto picked.
* Visit your home page, and make sure that home page displays the video from your video post. 
* Click the sharing button for a post other than the video post.
* Make sure the pop up shows info about the post you intent to share, not any other.

#### Proposed changelog entry for your changes:
* Sharing: update Tumblr official sharing button.