### PR TITLE
Map Block: Add api key dynmically via data attribute

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -26,8 +26,10 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		'lodash',
 		'wp-element',
 		'wp-i18n',
-		'wp-api-fetch',
 	);
+
+	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
+
 	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
-	return $content;
+	return preg_replace( '/<div /', '<div data-api-key="'. $api_key .'"', $content, 1 );
 }

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -31,5 +31,5 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
-	return preg_replace( '/<div /', '<div data-api-key="'. $api_key .'"', $content, 1 );
+	return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
 }


### PR DESCRIPTION
This PR adds the api key required by the map via the data attribute.

requires a building the following PR https://github.com/Automattic/wp-calypso/pull/29005

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/Automattic/wp-calypso/issues/28996  

#### Changes proposed in this Pull Request:
* 

#### Testing instructions:
Use this calypso branch... 
Create a map block. 
Does it show up on the front end? 

#### Proposed changelog entry
Removes an api call on the front-end to load the map block.

Fixes https://github.com/Automattic/wp-calypso/issues/28996

