### PR TITLE
Admin: introduce affiliate code in upgrade links in admin UI

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -15,6 +15,7 @@ import get from 'lodash/get';
  */
 import Card from 'components/card';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
+import UpgradeLink from 'components/upgrade-link';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
@@ -114,8 +115,7 @@ class DashBackups extends Component {
 				status: 'no-pro-uninstalled-or-inactive',
 				content: __( 'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.', {
 					components: {
-						a:
-							<a href={ `https://jetpack.com/redirect/?source=aag-backups&site=${ siteRawUrl }` } target="_blank" rel="noopener noreferrer" />
+						a: <UpgradeLink source="aag-backups" />
 					}
 				} ),
 			} );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -12,6 +12,7 @@ import { getPlanClass } from 'lib/plans/constants';
  */
 import Card from 'components/card';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
+import UpgradeLink from 'components/upgrade-link';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import {
@@ -77,7 +78,6 @@ class DashScan extends Component {
 	getVPContent() {
 		const {
 			sitePlan,
-			siteRawUrl,
 			fetchingSiteData,
 		} = this.props;
 		const hasSitePlan = false !== sitePlan;
@@ -146,7 +146,7 @@ class DashScan extends Component {
 				} )
 				: __( 'For automated, comprehensive scanning of security threats, please {{a}}upgrade your account{{/a}}.', {
 					components: {
-						a: <a href={ 'https://jetpack.com/redirect/?source=aag-scan&site=' + siteRawUrl } target="_blank" rel="noopener noreferrer" />
+						a: <UpgradeLink source="aag-scan" />
 					}
 				} )
 		} );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -44,6 +44,7 @@ import ProStatus from 'pro-status';
 import JetpackBanner from 'components/jetpack-banner';
 import ModuleOverridenBanner from 'components/module-overridden-banner';
 import { getModuleOverride, getModule } from 'state/modules';
+import { getUpgradeUrl } from 'components/upgrade-link';
 
 export const SettingsCard = props => {
 	const trackBannerClick = ( feature ) => {
@@ -101,7 +102,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-video-premium&site=' + siteRawUrl }
+						href={ getUpgradeUrl( 'settings-video-premium' ) }
 					/>
 				);
 

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -44,7 +44,7 @@ import ProStatus from 'pro-status';
 import JetpackBanner from 'components/jetpack-banner';
 import ModuleOverridenBanner from 'components/module-overridden-banner';
 import { getModuleOverride, getModule } from 'state/modules';
-import { getUpgradeUrl } from 'components/upgrade-link';
+import { getUpgradeUrl } from 'state/initial-state';
 
 export const SettingsCard = props => {
 	const trackBannerClick = ( feature ) => {
@@ -102,7 +102,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ getUpgradeUrl( 'settings-video-premium' ) }
+						href={ props.videoPremiumUpgradeUrl }
 					/>
 				);
 
@@ -368,6 +368,7 @@ export default connect(
 			getModuleOverride: module_name => getModuleOverride( state, module_name ),
 			getModule: module_name => getModule( state, module_name ),
 			activeFeatures: getActiveFeatures( state ),
+			videoPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-video-premium' )
 		};
 	}
 )( SettingsCard );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -28,7 +28,11 @@ import {
 	getPlanClass
 } from 'lib/plans/constants';
 
-import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
+import {
+	getSiteAdminUrl,
+	userCanManageModules,
+	getUpgradeUrl
+} from 'state/initial-state';
 import {
 	isAkismetKeyValid,
 	isCheckingAkismetKey,
@@ -44,7 +48,6 @@ import ProStatus from 'pro-status';
 import JetpackBanner from 'components/jetpack-banner';
 import ModuleOverridenBanner from 'components/module-overridden-banner';
 import { getModuleOverride, getModule } from 'state/modules';
-import { getUpgradeUrl } from 'state/initial-state';
 
 export const SettingsCard = props => {
 	const trackBannerClick = ( feature ) => {
@@ -75,8 +78,7 @@ export const SettingsCard = props => {
 	const isSaving = props.saveDisabled,
 		feature = props.feature
 			? props.feature
-			: false,
-		siteRawUrl = props.siteRawUrl;
+			: false;
 	let header = props.header
 			? props.header
 			: '';
@@ -122,7 +124,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-ads&site=' + siteRawUrl }
+						href={ props.adsUpgradeUrl }
 					/>
 				);
 
@@ -139,7 +141,7 @@ export const SettingsCard = props => {
 							callToAction={ upgradeLabel }
 							feature={ feature }
 							onClick={ handleClickForTracking( feature ) }
-							href={ 'https://jetpack.com/redirect/?source=settings-security-pro&site=' + siteRawUrl }
+							href={ props.securityProUpgradeUrl }
 						/>
 					);
 				}
@@ -151,7 +153,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-security-premium&site=' + siteRawUrl }
+						href={ props.securityPremiumUpgradeUrl }
 					/>
 				);
 
@@ -167,7 +169,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-ga&site=' + siteRawUrl }
+						href={ props.gaUpgradeUrl }
 					/>
 				);
 			case FEATURE_SEO_TOOLS_JETPACK:
@@ -182,7 +184,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-seo&site=' + siteRawUrl }
+						href={ props.seoUpgradeUrl }
 					/>
 				);
 
@@ -198,7 +200,7 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ 'https://jetpack.com/redirect/?source=settings-search&site=' + siteRawUrl }
+						href={ props.searchUpgradeUrl }
 					/>
 				);
 
@@ -214,7 +216,7 @@ export const SettingsCard = props => {
 						title={ __( 'Protect your site from spam.' ) }
 						plan={ PLAN_JETPACK_PERSONAL }
 						feature={ feature }
-						href={ 'https://jetpack.com/redirect/?source=settings-spam&site=' + siteRawUrl }
+						href={ props.spamUpgradeUrl }
 					/>
 				);
 
@@ -359,7 +361,6 @@ export default connect(
 		return {
 			sitePlan: getSitePlan( state ),
 			fetchingSiteData: isFetchingSiteData( state ),
-			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			userCanManageModules: userCanManageModules( state ),
 			isAkismetKeyValid: isAkismetKeyValid( state ),
@@ -368,7 +369,14 @@ export default connect(
 			getModuleOverride: module_name => getModuleOverride( state, module_name ),
 			getModule: module_name => getModule( state, module_name ),
 			activeFeatures: getActiveFeatures( state ),
-			videoPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-video-premium' )
+			videoPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-video-premium' ),
+			adsUpgradeUrl: getUpgradeUrl( state, 'settings-ads' ),
+			securityProUpgradeUrl: getUpgradeUrl( state, 'settings-security-pro' ),
+			securityPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-security-premium' ),
+			gaUpgradeUrl: getUpgradeUrl( state, 'settings-ga' ),
+			seoUpgradeUrl: getUpgradeUrl( state, 'settings-seo' ),
+			searchUpgradeUrl: getUpgradeUrl( state, 'settings-search' ),
+			spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		};
 	}
 )( SettingsCard );

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -17,8 +17,8 @@ import {
 	PLAN_JETPACK_PERSONAL
 } from 'lib/plans/constants';
 import {
-	getSiteRawUrl,
 	isAtomicSite,
+	getUpgradeUrl,
 } from 'state/initial-state';
 import {
 	getSitePlan,
@@ -118,7 +118,7 @@ class SupportCard extends React.Component {
 							plan={ PLAN_JETPACK_PERSONAL }
 							callToAction={ __( 'Upgrade' ) }
 							onClick={ this.trackBannerClick }
-							href={ 'https://jetpack.com/redirect/?source=support&site=' + this.props.siteRawUrl }
+							href={ this.props.supportUpgradeUrl }
 						/>
 					)
 				}
@@ -136,10 +136,10 @@ export default connect(
 	state => {
 		return {
 			sitePlan: getSitePlan( state ),
-			siteRawUrl: getSiteRawUrl( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isFetchingSiteData: isFetchingSiteData( state ),
-			isAtomicSite: isAtomicSite( state )
+			isAtomicSite: isAtomicSite( state ),
+			supportUpgradeUrl: getUpgradeUrl( state, 'support' ),
 		};
 	}
 )( SupportCard );

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { imagePath } from 'constants/urls';
-import { showBackups } from 'state/initial-state';
+import { getUpgradeUrl, showBackups } from 'state/initial-state';
 
 class ThemesPromoCard extends React.Component {
 	static displayName = 'ThemesPromoCard';
@@ -42,11 +42,6 @@ class ThemesPromoCard extends React.Component {
 				this.props.className,
 				'jp-themes-card'
 		);
-
-		// Plan classes come through as `is-whatever-plan`, we need to strip off `is-` and `-plan` from the string to pass to the URL
-		const plan = this.props.plan;
-		const regex = /(?![is-])(.*)(?=-plan)/g;
-		const urlFriendlyPlan = Array.isArray( plan.match( regex ) ) ? plan.match( regex )[ 0 ] : '';
 
 		return (
 			<div className={ classes }>
@@ -83,13 +78,13 @@ class ThemesPromoCard extends React.Component {
 							<Button
 								className="is-primary"
 								onClick={ this.trackGetStarted }
-								href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }>
+								href={ this.props.proUpgradeUrl }>
 								{ __( 'Explore Professional' ) }
 							</Button>
 							&nbsp;
 							<Button
 								onClick={ this.trackComparePlans }
-								href={ 'https://jetpack.com/redirect/?source=plans-compare-free' + '&site=' + this.props.siteRawUrl }>
+								href={ this.props.plansCompareFreeUpgradeUrl }>
 								{ __( 'Compare All Plans' ) }
 							</Button>
 						</p>
@@ -106,9 +101,15 @@ ThemesPromoCard.propTypes = {
 };
 
 export default connect(
-	( state ) => {
+	( state, { plan } ) => {
+		// Plan classes come through as `is-whatever-plan`, we need to strip off `is-` and `-plan` from the string to pass to the URL
+		const regex = /(?![is-])(.*)(?=-plan)/g;
+		const urlFriendlyPlan = Array.isArray( plan.match( regex ) ) ? plan.match( regex )[ 0 ] : '';
+
 		return {
 			showBackups: showBackups( state ),
+			proUpgradeUrl: getUpgradeUrl( state, 'upgrade-pro-' + urlFriendlyPlan ),
+			plansCompareFreeUpgradeUrl: getUpgradeUrl( state, 'plans-compare-free' ),
 		};
 	}
 )( ThemesPromoCard );

--- a/_inc/client/components/upgrade-link/README.md
+++ b/_inc/client/components/upgrade-link/README.md
@@ -1,0 +1,35 @@
+UpgradeLink
+=======
+
+UpgradeLink is a React component that renders a link so user can jump to Calypso and acquire an upgrade through the purchase of a Jetpack plan. The link will open Calypso in a new tab.
+
+The component only needs the source where this link was clicked, for tracking purposes. It will compose the URL and append the source parameter and the site raw URL on its own. If an affiliate link exists, it will be also append to the link.
+
+## Usage
+
+```jsx
+
+import React, { Component } from 'react';
+import UpgradeLink from 'components/upgrade-link';
+
+class UpgradeTest extends Component {
+
+	render() {
+		return <UpgradeLink source="aag-backups">;
+	}
+	
+}
+```
+
+## Props
+The following props can be passed to the UpgradeLink component:
+
+### `source`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+Pass a string describing the context where this link was found and clicked.
+

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -4,39 +4,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import store from 'state/redux-store';
 
 /**
  * Internal dependencies
  */
-import { getSiteRawUrl, getAffiliateCode } from 'state/initial-state';
-
-/**
- * Build the upgrade URL
- *
- * @param {string} source        Context where this URL is clicked.
- * @param {string} siteRawUrl    RAW Url for this site.
- * @param {string} affiliateCode The affiliate code.
- *
- * @return {string} Upgrade URL with source, site, and affiliate code added.
- */
-const buildUpgradeUrl = ( source, siteRawUrl, affiliateCode ) => `https://jetpack.com/redirect/?${ [
-	`source=${ source }`,
-	`site=${ siteRawUrl }`,
-	...( '' === affiliateCode ? [] : [ `aff=${ affiliateCode }` ] ),
-].join( '&' ) }`;
-
-/**
- * Return an upgrade URL
- *
- * @param {string} source Context where this URL is clicked.
- *
- * @return {string} Upgrade URL with source, site, and affiliate code added.
- */
-export const getUpgradeUrl = source => {
-	const state = store.getState();
-	return buildUpgradeUrl( source, getSiteRawUrl( state ), getAffiliateCode( state ) );
-};
+import { getUpgradeUrl } from 'state/initial-state';
 
 /**
  * Component to render a link.
@@ -54,7 +26,7 @@ class UpgradeLink extends PureComponent {
 	render() {
 		return (
 			<a
-				href={ buildUpgradeUrl( this.props.source, this.props.siteRawUrl, this.props.affiliateCode ) }
+				href={ this.props.upgradeUrl }
 				target="_blank"
 				rel="noopener noreferrer"
 				>
@@ -65,8 +37,7 @@ class UpgradeLink extends PureComponent {
 }
 
 export default connect(
-	state => ( {
-		siteRawUrl: getSiteRawUrl( state ),
-		affiliateCode: getAffiliateCode( state ),
+	( state, ownProps ) => ( {
+		upgradeUrl: getUpgradeUrl( state, ownProps.source ),
 	} )
 )( UpgradeLink );

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import store from 'state/redux-store';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteRawUrl, getAffiliateCode } from 'state/initial-state';
+
+/**
+ * Build the upgrade URL
+ *
+ * @param {string} source        Context where this URL is clicked.
+ * @param {string} siteRawUrl    RAW Url for this site.
+ * @param {string} affiliateCode The affiliate code.
+ *
+ * @return {string} Upgrade URL with source, site, and affiliate code added.
+ */
+const buildUpgradeUrl = ( source, siteRawUrl, affiliateCode ) => `https://jetpack.com/redirect/?${ [
+	`source=${ source }`,
+	`site=${ siteRawUrl }`,
+	...( '' === affiliateCode ? [] : [ `aff=${ affiliateCode }` ] ),
+].join( '&' ) }`;
+
+/**
+ * Return an upgrade URL
+ *
+ * @param {string} source Context where this URL is clicked.
+ *
+ * @return {string} Upgrade URL with source, site, and affiliate code added.
+ */
+export const getUpgradeUrl = source => {
+	const state = store.getState();
+	return buildUpgradeUrl( source, getSiteRawUrl( state ), getAffiliateCode( state ) );
+};
+
+/**
+ * Component to render a link.
+ */
+class UpgradeLink extends PureComponent {
+
+	static propTypes = {
+		source: PropTypes.string.isRequired,
+
+		// Connected
+		siteRawUrl: PropTypes.string.isRequired,
+		affiliateCode: PropTypes.string.isRequired,
+	};
+
+	render() {
+		return (
+			<a
+				href={ buildUpgradeUrl( this.props.source, this.props.siteRawUrl, this.props.affiliateCode ) }
+				target="_blank"
+				rel="noopener noreferrer"
+				>
+					{ this.props.children }
+			</a>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		siteRawUrl: getSiteRawUrl( state ),
+		affiliateCode: getAffiliateCode( state ),
+	} )
+)( UpgradeLink );

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -19,8 +19,7 @@ class UpgradeLink extends PureComponent {
 		source: PropTypes.string.isRequired,
 
 		// Connected
-		siteRawUrl: PropTypes.string.isRequired,
-		affiliateCode: PropTypes.string.isRequired,
+		upgradeUrl: PropTypes.string.isRequired,
 	};
 
 	render() {
@@ -37,7 +36,7 @@ class UpgradeLink extends PureComponent {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		upgradeUrl: getUpgradeUrl( state, ownProps.source ),
+	( state, { source } ) => ( {
+		upgradeUrl: getUpgradeUrl( state, source ),
 	} )
 )( UpgradeLink );

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -30,7 +30,7 @@ import {
 	getModuleOverride
 } from 'state/modules';
 import QuerySitePlugins from 'components/data/query-site-plugins';
-import { showBackups } from 'state/initial-state';
+import { getUpgradeUrl, showBackups } from 'state/initial-state';
 
 class MyPlanBody extends React.Component {
 	static propTypes = {
@@ -51,7 +51,7 @@ class MyPlanBody extends React.Component {
 
 	handleButtonClickForTracking = target => {
 		return () => this.trackPlansClick( target );
-	}
+	};
 
 	activateAds = () => {
 		this.props.activateModule( 'wordads' );
@@ -367,8 +367,12 @@ class MyPlanBody extends React.Component {
 								<p>{ __( 'Always-on security including real-time backups, malware scanning, and automatic threat resolution.' ) }</p>
 								<p>{ __( 'Grow your traffic and revenue with social media scheduling, enhanced site search, SEO tools, PayPal payments, and an ad program.' ) }</p>
 								<p>
-									<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + this.props.siteRawUrl } className="is-primary">
-										{ __( 'Compare Plans' ) }
+									<Button
+										onClick={ this.handleButtonClickForTracking( 'compare_plans' ) }
+										href={ this.props.comparePlansUpgradeUrl }
+										className="is-primary"
+										>
+											{ __( 'Compare plans' ) }
 									</Button>
 								</p>
 							</div>
@@ -382,8 +386,12 @@ class MyPlanBody extends React.Component {
 								<p>{ __( 'Unlimited access to hundreds of premium WordPress themes with dedicated support directly from the theme authors.' ) }</p>
 								<p>{ __( 'A superior search experience powered by Elasticsearch providing your users with faster and more relevant search results. Previously only available to WordPress.com VIP customers and trusted by industry-leading brands.' ) }</p>
 								<p>
-									<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-premium&site=' + this.props.siteRawUrl } className="is-primary">
-										{ __( 'Explore Jetpack Professional' ) }
+									<Button
+										onClick={ this.handleButtonClickForTracking( 'compare_plans' ) }
+										href={ this.props.plansComparePremiumUpgradeUrl }
+										className="is-primary"
+										>
+											{ __( 'Explore Jetpack Professional' ) }
 									</Button>
 								</p>
 							</div>
@@ -429,10 +437,14 @@ class MyPlanBody extends React.Component {
 						</div>
 
 						<p>
-							<Button onClick={ this.handleButtonClickForTracking( 'compare_plans' ) } href={ 'is-free-plan' === planClass
-								? 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl
-								: 'https://jetpack.com/redirect/?source=plans-main-bottom-dev-mode' } className="is-primary">
-								{ __( 'Compare Plans' ) }
+							<Button
+								onClick={ this.handleButtonClickForTracking( 'compare_plans' ) }
+								href={ 'is-free-plan' === planClass
+									? this.props.plansMainBottomUpgradeUrl
+									: this.props.plansMainBottomDevModeUpgradeUrl }
+								className="is-primary"
+								>
+									{ __( 'Compare plans' ) }
 							</Button>
 						</p>
 					</div>
@@ -480,6 +492,10 @@ export default connect(
 			isActivatingModule: ( module_slug ) => isActivatingModule( state, module_slug ),
 			getModuleOverride: ( module_slug ) => getModuleOverride( state, module_slug ),
 			showBackups: showBackups( state ),
+			comparePlansUpgradeUrl: getUpgradeUrl( state, 'plans-compare-personal' ),
+			plansMainBottomUpgradeUrl: getUpgradeUrl( state, 'plans-main-bottom' ),
+			plansMainBottomDevModeUpgradeUrl: getUpgradeUrl( state, 'plans-main-bottom-dev-mode' ),
+			plansComparePremiumUpgradeUrl: getUpgradeUrl( state, 'plans-compare-premium' ),
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/my-plan/my-plan-header.jsx
+++ b/_inc/client/my-plan/my-plan-header.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { imagePath } from 'constants/urls';
-import { showBackups } from 'state/initial-state';
+import { getUpgradeUrl, showBackups } from 'state/initial-state';
 
 class MyPlanHeader extends React.Component {
 	trackLearnMore = () => {
@@ -49,7 +49,7 @@ class MyPlanHeader extends React.Component {
 										{ __( 'Upgrade to a weekly coffee and fully protect your site from malware, infiltrations, and security loopholes with automated malware scanning.' ) }
 									</p>
 									<p className="jp-landing-plans__header-btn-container">
-										<Button href={ 'https://jetpack.com/redirect/?source=plans-main-top&site=' + this.props.siteRawUrl } className="is-primary">
+										<Button href={ this.props.plansMainTopUpgradeUrl } className="is-primary">
 											{ __( 'Learn more' ) }
 										</Button>
 									</p>
@@ -166,6 +166,7 @@ export default connect(
 	( state ) => {
 		return {
 			showBackups: showBackups( state ),
+			plansMainTopUpgradeUrl: getUpgradeUrl( state, 'plans-main-top' ),
 		};
 	}
 )( MyPlanHeader );

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -12,7 +12,7 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { getSiteRawUrl, getUserId } from 'state/initial-state';
+import { getSiteRawUrl, getUpgradeUrl, getUserId } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
 import analytics from 'lib/analytics';
 import { getPlanClass } from 'lib/plans/constants';
@@ -216,7 +216,7 @@ class PlanGrid extends React.Component {
 			const isActivePlan = this.isCurrentPlanType( planType );
 			const url = isActivePlan
 				? `https://wordpress.com/plans/my-plan/${ this.props.siteRawUrl }`
-				: `https://jetpack.com/redirect/?source=plans-${ planType }&site=${ this.props.siteRawUrl }&u=${ this.props.userId }`;
+				: this.props.plansUpgradeUrl( planType );
 			const isPrimary = this.isPrimary( planType, plan );
 			const className = classNames(
 				'plan-features__table-item',
@@ -255,7 +255,7 @@ class PlanGrid extends React.Component {
 	/**
 	 * Check if a plan should be highlighted as primary in the CTAs
 	 * @param {string} planType the plan type to check for primariness
-	 * @param {objcet} plan the plan object to check for primariness
+	 * @param {object} plan the plan object to check for primariness
 	 * @return {boolean} plan is primary
 	 */
 	isPrimary( planType, plan ) {
@@ -277,10 +277,9 @@ class PlanGrid extends React.Component {
 	 */
 	renderBottomButtons() {
 		return map( this.getPlans(), ( plan, planType ) => {
-			const url = `https://jetpack.com/redirect/?source=plans-learn-more&site=${ this.props.siteRawUrl }&u=${ this.props.userId }`;
 			return (
 				<td key={ 'bottom-' + planType } className="plan-features__table-item is-bottom-buttons has-border-bottom">
-					<Button href={ url }>{ plan.strings.see_all }</Button>
+					<Button href={ this.props.plansLearnMoreUpgradeUrl }>{ plan.strings.see_all }</Button>
 				</td>
 			);
 		} );
@@ -372,12 +371,18 @@ class PlanGrid extends React.Component {
 
 }
 
-export default connect( ( state ) => {
-	return {
-		plans: getAvailablePlans( state ),
-		siteRawUrl: getSiteRawUrl( state ),
-		sitePlan: getSitePlan( state ),
-		userId: getUserId( state ),
-		showBackups: showBackups( state ),
-	};
-}, null, )( PlanGrid );
+export default connect(
+	( state ) => {
+		const userId = getUserId( state );
+		return {
+			plans: getAvailablePlans( state ),
+			siteRawUrl: getSiteRawUrl( state ),
+			sitePlan: getSitePlan( state ),
+			userId,
+			showBackups: showBackups( state ),
+			plansUpgradeUrl: planType => getUpgradeUrl( state, `plans-${ planType }`, userId ),
+			plansLearnMoreUpgradeUrl: getUpgradeUrl( state, 'plans-learn-more', userId ),
+		};
+	},
+	null
+)( PlanGrid );

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -13,7 +13,11 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
+import {
+	getSiteRawUrl,
+	getSiteAdminUrl,
+	getUpgradeUrl
+} from 'state/initial-state';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
@@ -95,13 +99,13 @@ class ProStatus extends React.Component {
 					message = __( 'No scanning', { context: 'Short warning message about site having no security scan.' } );
 				}
 				action = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
-				actionUrl = 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl;
+				actionUrl = this.props.paidFeatureUpgradeUrl;
 				break;
 			case 'pro':
 				type = 'upgrade';
 				status = 'is-warning';
 				action = __( 'Upgrade', { context: 'Caption for a button to purchase a pro plan.' } );
-				actionUrl = 'https://jetpack.com/redirect/?source=plans-business&site=' + this.props.siteRawUrl;
+				actionUrl = this.props.planProUpgradeUrl;
 				break;
 			case 'secure':
 				status = 'is-success';
@@ -267,7 +271,9 @@ export default connect(
 			isDevMode: isDevMode( state ),
 			fetchingSiteData: isFetchingSiteData( state ),
 			isAkismetKeyValid: isAkismetKeyValid( state ),
-			fetchingAkismetData: isFetchingAkismetData( state )
+			fetchingAkismetData: isFetchingAkismetData( state ),
+			paidFeatureUpgradeUrl: getUpgradeUrl( state, 'upgrade' ),
+			planProUpgradeUrl: getUpgradeUrl( state, 'plans-business' ),
 		};
 	}
 )( ProStatus );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -259,3 +259,21 @@ export function showBackups( state ) {
 export function getAffiliateCode( state ) {
 	return get( state.jetpack.initialState, 'aff', '' );
 }
+
+/**
+ * Return an upgrade URL
+ *
+ * @param {object} state Global state tree
+ * @param {string} source Context where this URL is clicked.
+ *
+ * @return {string} Upgrade URL with source, site, and affiliate code added.
+ */
+export const getUpgradeUrl = ( state, source ) => {
+	const siteRawUrl = getSiteRawUrl( state );
+	const affiliateCode = getAffiliateCode( state );
+	const parameters =
+		`source=${ source }` +
+		`&site=${ siteRawUrl }` +
+		( affiliateCode ? `&aff=${ affiliateCode }` : '' );
+	return `https://jetpack.com/redirect/?${ parameters }`;
+};

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -248,3 +248,14 @@ export function currentThemeSupports( state, feature ) {
 export function showBackups( state ) {
 	return get( state.jetpack.initialState.siteData, 'showBackups', true );
 }
+
+/**
+ * Returns the affiliate code, if it exists. Otherwise an empty string.
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {string} The affiliate code.
+ */
+export function getAffiliateCode( state ) {
+	return get( state.jetpack.initialState, 'aff', '' );
+}

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -265,15 +265,14 @@ export function getAffiliateCode( state ) {
  *
  * @param {object} state Global state tree
  * @param {string} source Context where this URL is clicked.
+ * @param {string} userId Current user id.
  *
  * @return {string} Upgrade URL with source, site, and affiliate code added.
  */
-export const getUpgradeUrl = ( state, source ) => {
-	const siteRawUrl = getSiteRawUrl( state );
+export const getUpgradeUrl = ( state, source, userId = '' ) => {
 	const affiliateCode = getAffiliateCode( state );
-	const parameters =
-		`source=${ source }` +
-		`&site=${ siteRawUrl }` +
-		( affiliateCode ? `&aff=${ affiliateCode }` : '' );
-	return `https://jetpack.com/redirect/?${ parameters }`;
+	return `https://jetpack.com/redirect/?source=${ source }&site=${ getSiteRawUrl( state ) }` +
+		( affiliateCode ? `&aff=${ affiliateCode }` : '' ) +
+		( userId ? `&u=${ userId }` : '' )
+	;
 };


### PR DESCRIPTION
This PR updates the upgrade links in admin UI like inline text links, Upgrade badges in AAG, or Upgrade buttons in banners to include, if it exists, an affiliate code.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR introduces a new component UpgradeLink which is used to create a link so user can jump to Calypso and acquire an upgrade through the purchase of a Jetpack plan. The link will open Calypso in a new tab.

The component only needs the source where this link was clicked, for tracking purposes. It will compose the URL and append the source parameter and the site raw URL on its own. If an affiliate link exists, it will be also append to the link.

It also introduces a function to create a URL for certain cases where the string must be passed instead of the complete `<a>` element.


#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an affiliate code with `wp option add jetpack_affiliate_code abc123`
* Go to Jetpack UI and ensure calls to upgrade have the affiliate code as the `aff` parameter.

#### Proposed changelog entry for your changes:
* No necessary to log this change since those that need to know about it will be notified.
