### PR TITLE
JITMs: add component to be used in the Jetpack Dashboard.

### DIFF
--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -38,7 +38,7 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			fetchJitm: () => dispatch( fetchJitm() )
+			fetchJitm: ( message_path ) => dispatch( fetchJitm( message_path ) )
 		};
 	}
 )( QueryJitm );

--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -20,7 +20,7 @@ class QueryJitm extends Component {
 
 	componentWillMount() {
 		//const message_path = `wp:toplevel_page_jetpack${ this.props.route.path }`;
-		const message_path = 'wp:toplevel_page_jetpack';
+		const message_path = 'wp:toplevel_page_jetpack:admin_notices';
 
 		if ( ! this.props.isFetchingJitm ) {
 			this.props.fetchJitm( message_path );

--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -29,7 +29,14 @@ class QueryJitm extends Component {
 
 	// If we move to a different subpage in the Jetpack Dashboard, fetch a new JITM.
 	componentDidUpdate( prevProps ) {
-		const path = this.props.route.path;
+		let path = this.props.route.path;
+
+		// If you are navigating to Jetpack > Settings > Writing, the URL will be wp-admin/admin.php?page=jetpack#/writing
+		// Let's map that to the original wp-admin/admin.php?page=jetpack#/settings
+		if ( '/writing' === path ) {
+			path = '/settings';
+		}
+
 		const message_path = `wp:toplevel_page_jetpack${ path.replace( /\//, '_' ) }:admin_notices`;
 
 		if (

--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -19,10 +19,24 @@ class QueryJitm extends Component {
 	};
 
 	componentWillMount() {
-		//const message_path = `wp:toplevel_page_jetpack${ this.props.route.path }`;
-		const message_path = 'wp:toplevel_page_jetpack:admin_notices';
+		const path = this.props.route.path;
+		const message_path = `wp:toplevel_page_jetpack${ path.replace( /\//, '_' ) }:admin_notices`;
 
 		if ( ! this.props.isFetchingJitm ) {
+			this.props.fetchJitm( message_path );
+		}
+	}
+
+	// If we move to a different subpage in the Jetpack Dashboard, fetch a new JITM.
+	componentDidUpdate( prevProps ) {
+		const path = this.props.route.path;
+		const message_path = `wp:toplevel_page_jetpack${ path.replace( /\//, '_' ) }:admin_notices`;
+		//const message_path = 'wp:toplevel_page_jetpack:admin_notices';
+
+		if (
+			this.props.route.path !== prevProps.route.path &&
+			! this.props.isFetchingJitm
+		) {
 			this.props.fetchJitm( message_path );
 		}
 	}
@@ -33,12 +47,12 @@ class QueryJitm extends Component {
 }
 
 export default connect(
-	( state ) => {
+	state => {
 		return { isFetchingJitm: isFetchingJitm( state ) };
 	},
-	( dispatch ) => {
+	dispatch => {
 		return {
-			fetchJitm: ( message_path ) => dispatch( fetchJitm( message_path ) )
+			fetchJitm: message_path => dispatch( fetchJitm( message_path ) )
 		};
 	}
 )( QueryJitm );

--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchJitm, isFetchingJitm } from 'state/jitm';
+
+class QueryJitm extends Component {
+	static propTypes = { isFetchingJitm: PropTypes.bool };
+
+	static defaultProps = {
+		isFetchingJitm: false,
+		route: { path: '' }
+	};
+
+	componentWillMount() {
+		//const message_path = `wp:toplevel_page_jetpack${ this.props.route.path }`;
+		const message_path = 'wp:toplevel_page_jetpack';
+
+		if ( ! this.props.isFetchingJitm ) {
+			this.props.fetchJitm( message_path );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => {
+		return { isFetchingJitm: isFetchingJitm( state ) };
+	},
+	( dispatch ) => {
+		return {
+			fetchJitm: () => dispatch( fetchJitm() )
+		};
+	}
+)( QueryJitm );

--- a/_inc/client/components/data/query-jitm/index.jsx
+++ b/_inc/client/components/data/query-jitm/index.jsx
@@ -31,7 +31,6 @@ class QueryJitm extends Component {
 	componentDidUpdate( prevProps ) {
 		const path = this.props.route.path;
 		const message_path = `wp:toplevel_page_jetpack${ path.replace( /\//, '_' ) }:admin_notices`;
-		//const message_path = 'wp:toplevel_page_jetpack:admin_notices';
 
 		if (
 			this.props.route.path !== prevProps.route.path &&

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import { getJitm } from 'state/jitm';
+
+class Jitm extends Component {
+	componentDidMount() {
+		analytics.tracks.recordEvent(
+			'jetpack_jitm_view',
+			// replace by unique ID of the JITM.
+			{ version: this.props.version }
+		);
+	}
+
+	render() {
+		const classes = classNames(
+			this.props.className,
+			'jitm-card jitm-banner'
+		);
+		return (
+			<div className={ classes } role="dialog">
+				{ this.props.content }
+			</div>
+		);
+	}
+}
+
+Jitm.propTypes = {
+	content: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.object,
+	] ).isRequired,
+};
+
+Jitm.defaultProps = {
+	content: '',
+};
+
+export default connect(
+	state => {
+		return {
+			Jitm: getJitm( state ),
+		};
+	}
+)( Jitm );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -148,7 +148,7 @@ class Jitm extends Component {
 										className="jitm-button"
 										primary={ activate_module === null && ctaPrimary ? true : false }
 										compact={ true }
-										onClick={ this.trackLearnMore( feature_class ) }s
+										onClick={ this.trackLearnMore( feature_class ) }
 									>
 										{ ctaMessage }
 									</Button>

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -17,7 +17,7 @@ import Button from 'components/button';
 import decodeEntities from 'lib/decode-entities';
 import Gridicon from 'components/gridicon';
 import {
-	isModuleActivated as _isModuleActivated,
+	isModuleActivated,
 	activateModule,
 	isActivatingModule
 } from 'state/modules';
@@ -215,7 +215,7 @@ export default connect(
 		return {
 			isDismissingJitm: isDismissingJitm( state ),
 			isFetchingJitm: isFetchingJitm( state ),
-			isModuleActivated: _isModuleActivated( state, module_slug ),
+			isModuleActivated: isModuleActivated( state, module_slug ),
 			isActivatingModule: isActivatingModule( state, module_slug ),
 			Jitm: jitm
 		};

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -99,7 +99,7 @@ class Jitm extends Component {
 	renderContent = () => {
 		const jitm = this.props.Jitm;
 
-		const activate_module = get( jitm, 'activate_module', null );
+		const module_slug = get( jitm, 'activate_module', null );
 
 		const cta = get( jitm, 'CTA', null );
 		const ctaMessage = get( cta, 'message', null );
@@ -143,13 +143,13 @@ class Jitm extends Component {
 									</div>
 								) }
 							</div>
-							{ activate_module && ! this.props.isModuleActivated &&
+							{ module_slug && ! this.props.isModuleActivated &&
 								<div className="jitm-banner__action" id="jitm-banner__activate">
 									<Button
 										className="jitm-button"
 										primary={ true }
 										compact={ true }
-										onClick={ this.handleModuleActivation( activate_module, id ) }
+										onClick={ this.handleModuleActivation( module_slug, id ) }
 										disabled={ this.props.isActivatingModule }
 									>
 										{this.props.isActivatingModule
@@ -163,7 +163,7 @@ class Jitm extends Component {
 									<a
 										target={ ctaNewWindow === false ? '_self' : '_blank' }
 										href={ url }
-										className={ `jitm-button dops-button is-compact ${ activate_module === null && ctaPrimary ? 'is-primary' : false }` }
+										className={ `jitm-button dops-button is-compact ${ module_slug === null && ctaPrimary ? 'is-primary' : false }` }
 										onClick={ this.trackClick }
 									>
 										{decodeEntities( ctaMessage )}

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -13,10 +13,11 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import decodeEntities from 'lib/decode-entities';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isActivatingModule,
+	isActivatingModule
 } from 'state/modules';
 import Button from 'components/button';
 import { getJitm } from 'state/jitm';
@@ -43,7 +44,7 @@ class Jitm extends Component {
 	renderListItem = ( list, id, feature_class ) => {
 		for ( const listItem of list ) {
 			const { item, url } = listItem;
-			let text = item;
+			let text = decodeEntities( item );
 
 			if ( url ) {
 				// to-do: test this. Could not find an active JITM using lists right now. Tracks is going to have to be reimplemented anyway.
@@ -54,7 +55,7 @@ class Jitm extends Component {
 					data-jptracks-name="nudge_item_click"
 					data-jptracks-prop="jitm-${ id }"
 				>
-					${ item }
+					${ decodeEntities( item ) }
 				</a>`;
 			}
 
@@ -71,7 +72,7 @@ class Jitm extends Component {
 							<path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" />
 						</g>
 					</svg>
-					{ text }
+					{text}
 				</li>
 			);
 		}
@@ -113,7 +114,7 @@ class Jitm extends Component {
 
 		return (
 			<div>
-				{ ! isEmpty( jitm ) && (
+				{! isEmpty( jitm ) && (
 					<div className={ mainClasses }>
 						<div
 							className="jitm-banner__icon-plan"
@@ -122,19 +123,21 @@ class Jitm extends Component {
 						/>
 						<div className="jitm-banner__content">
 							<div className="jitm-banner__info">
-								<div className="jitm-banner__title">{ title }</div>
-								{ description && (
+								<div className="jitm-banner__title">
+									{decodeEntities( title )}
+								</div>
+								{description && (
 									<div className="jitm-banner__description">
-										{ description }
-										{ list.length > 0 && (
+										{decodeEntities( description )}
+										{list.length > 0 && (
 											<ul className="banner__list">
-												{ this.renderListItem( list, id, feature_class ) }
+												{this.renderListItem( list, id, feature_class )}
 											</ul>
-										) }
+										)}
 									</div>
-								) }
+								)}
 							</div>
-							{ activate_module && (
+							{activate_module && (
 								<div className="jitm-banner__action" id="jitm-banner__activate">
 									<Button
 										className="jitm-button"
@@ -143,43 +146,44 @@ class Jitm extends Component {
 										onClick={ this.activateModule( activate_module ) }
 										disabled={ this.props.isActivatingModule( activate_module ) }
 									>
-										{ this.props.isActivatingModule( activate_module )
+										{this.props.isActivatingModule( activate_module )
 											? __( 'Activating' )
-											: __( 'Activate' ) }
+											: __( 'Activate' )}
 									</Button>
 								</div>
-							) }
-							{ ctaMessage && (
+							)}
+							{ctaMessage && (
 								<div className="jitm-banner__action">
-									<Button
-										// to-do: missing the option to open in a new window with the ctaNewWindow const.
+									<Button // to-do: missing the option to open in a new window with the ctaNewWindow const.
 										// target={ ctaNewWindow === false ? '_self' : '_blank' }
 										href={ url }
 										className="jitm-button"
-										primary={ activate_module === null && ctaPrimary ? true : false }
+										primary={
+											activate_module === null && ctaPrimary ? true : false
+										}
 										compact={ true }
 										onClick={ this.trackLearnMore( feature_class ) }
 									>
-										{ ctaMessage }
+										{decodeEntities( ctaMessage )}
 									</Button>
 								</div>
-							) }
-							{ /* to-do: replace a by button or svg icon */ }
+							)}
+							{/* to-do: replace a by button or svg icon */}
 							<a data-module={ feature_class } className="jitm-banner__dismiss" />
 						</div>
 					</div>
-				) }
+				)}
 			</div>
 		);
 	}
 }
 
 Jitm.propTypes = {
-	Jitm: PropTypes.object.isRequired,
+	Jitm: PropTypes.object.isRequired
 };
 
 Jitm.defaultProps = {
-	Jitm: {},
+	Jitm: {}
 };
 
 export default connect(
@@ -187,14 +191,14 @@ export default connect(
 		return {
 			isModuleActivated: module_slug => _isModuleActivated( state, module_slug ),
 			isActivatingModule: module_slug => isActivatingModule( state, module_slug ),
-			Jitm: getJitm( state ),
+			Jitm: getJitm( state )
 		};
 	},
 	dispatch => {
 		return {
 			activateModule: slug => {
 				return dispatch( activateModule( slug ) );
-			},
+			}
 		};
 	}
 )( Jitm );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -21,7 +21,7 @@ import {
 	activateModule,
 	isActivatingModule
 } from 'state/modules';
-import { dismissJitm, getJitm, isDismissingJitm } from 'state/jitm';
+import { getJitmDismissalResponse, getJitm, isDismissingJitm } from 'state/jitm';
 
 require( './../../../../scss/jetpack-admin-jitm.scss' );
 
@@ -43,7 +43,7 @@ class Jitm extends Component {
 		const id = get( jitm, 'id', '' );
 
 		if ( ! this.props.isDismissingJitm ) {
-			this.props.dismissJitm( id, feature_class );
+			this.props.getJitmDismissalResponse( id, feature_class );
 
 			this.setState( { showJitm: false } );
 		}
@@ -216,9 +216,9 @@ export default connect(
 			activateModule: slug => {
 				return dispatch( activateModule( slug ) );
 			},
-			dismissJitm: ( id = '', feature_class = '' ) => {
+			getJitmDismissalResponse: ( id = '', feature_class = '' ) => {
 				if ( '' !== id && '' !== feature_class ) {
-					return dispatch( dismissJitm( id, feature_class ) );
+					return dispatch( getJitmDismissalResponse( id, feature_class ) );
 				}
 			}
 		};

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -41,8 +41,8 @@ class Jitm extends Component {
 	};
 
 	renderListItem = ( list, id, feature_class ) => {
-		for ( const i of list ) {
-			const { item, url } = i;
+		for ( const listItem of list ) {
+			const { item, url } = listItem;
 			let text = item;
 
 			if ( url ) {

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
@@ -16,17 +19,8 @@ import analytics from 'lib/analytics';
 import Button from 'components/button';
 import decodeEntities from 'lib/decode-entities';
 import Gridicon from 'components/gridicon';
-import {
-	isModuleActivated,
-	activateModule,
-	isActivatingModule
-} from 'state/modules';
-import {
-	getJitmDismissalResponse,
-	getJitm,
-	isDismissingJitm,
-	isFetchingJitm
-} from 'state/jitm';
+import { isModuleActivated, activateModule, isActivatingModule } from 'state/modules';
+import { getJitmDismissalResponse, getJitm, isDismissingJitm, isFetchingJitm } from 'state/jitm';
 
 require( './../../../../scss/jetpack-admin-jitm.scss' );
 
@@ -38,7 +32,7 @@ class Jitm extends Component {
 
 		// Track module activation.
 		analytics.tracks.recordEvent( 'jetpack_nudge_click', {
-			click: `jitm-${ id }-activate_module`
+			click: `jitm-${ id }-activate_module`,
 		} );
 	};
 
@@ -59,7 +53,7 @@ class Jitm extends Component {
 		const id = get( jitm, 'id', '' );
 
 		analytics.tracks.recordEvent( 'jetpack_nudge_click', {
-			click: `jitm-${ id }`
+			click: `jitm-${ id }`,
 		} );
 	};
 
@@ -72,7 +66,7 @@ class Jitm extends Component {
 		} );
 	};
 
-	renderListItem = ( listItem ) => {
+	renderListItem = listItem => {
 		const { item, url } = listItem;
 		let text = decodeEntities( item );
 		if ( url ) {
@@ -89,7 +83,7 @@ class Jitm extends Component {
 		}
 
 		return (
-			<li key={ item } >
+			<li key={ item }>
 				<Gridicon icon="checkmark" size={ 16 } />
 				{ text }
 			</li>
@@ -120,7 +114,7 @@ class Jitm extends Component {
 
 		return (
 			<div>
-				{! isEmpty( jitm ) && (
+				{ ! isEmpty( jitm ) && (
 					<div className={ mainClasses }>
 						<div
 							className="jitm-banner__icon-plan"
@@ -129,47 +123,47 @@ class Jitm extends Component {
 						/>
 						<div className="jitm-banner__content">
 							<div className="jitm-banner__info">
-								<div className="jitm-banner__title">
-									{decodeEntities( title )}
-								</div>
-								{description && (
+								<div className="jitm-banner__title">{ decodeEntities( title ) }</div>
+								{ description && (
 									<div className="jitm-banner__description">
 										{ decodeEntities( description ) }
-										{ list && list.length &&
-											<ul className="banner__list">
-												{ list.map( listItem => this.renderListItem( listItem ) ) }
-											</ul>
-										}
+										{ list &&
+											list.length && (
+												<ul className="banner__list">
+													{ list.map( listItem => this.renderListItem( listItem ) ) }
+												</ul>
+											) }
 									</div>
 								) }
 							</div>
-							{ module_slug && ! this.props.isModuleActivated &&
-								<div className="jitm-banner__action" id="jitm-banner__activate">
-									<Button
-										className="jitm-button"
-										primary={ true }
-										compact={ true }
-										onClick={ this.handleModuleActivation( module_slug, id ) }
-										disabled={ this.props.isActivatingModule }
-									>
-										{this.props.isActivatingModule
-											? __( 'Activating' )
-											: __( 'Activate' )}
-									</Button>
-								</div>
-							}
-							{ctaMessage && (
+							{ module_slug &&
+								! this.props.isModuleActivated && (
+									<div className="jitm-banner__action" id="jitm-banner__activate">
+										<Button
+											className="jitm-button"
+											primary={ true }
+											compact={ true }
+											onClick={ this.handleModuleActivation( module_slug, id ) }
+											disabled={ this.props.isActivatingModule }
+										>
+											{ this.props.isActivatingModule ? __( 'Activating' ) : __( 'Activate' ) }
+										</Button>
+									</div>
+								) }
+							{ ctaMessage && (
 								<div className="jitm-banner__action">
 									<a
 										target={ ctaNewWindow === false ? '_self' : '_blank' }
 										href={ url }
-										className={ `jitm-button dops-button is-compact ${ module_slug === null && ctaPrimary ? 'is-primary' : false }` }
+										className={ `jitm-button dops-button is-compact ${
+											module_slug === null && ctaPrimary ? 'is-primary' : false
+										}` }
 										onClick={ this.trackClick }
 									>
-										{decodeEntities( ctaMessage )}
+										{ decodeEntities( ctaMessage ) }
 									</a>
 								</div>
-							)}
+							) }
 							<Gridicon
 								className="jitm-banner__dismiss"
 								onClick={ this.handleDismissal }
@@ -178,7 +172,7 @@ class Jitm extends Component {
 							/>
 						</div>
 					</div>
-				)}
+				) }
 			</div>
 		);
 	};
@@ -197,7 +191,7 @@ Jitm.propTypes = {
 	isDismissingJitm: PropTypes.bool,
 	isFetchingJitm: PropTypes.bool,
 	isModuleActivated: PropTypes.bool,
-	Jitm: PropTypes.object.isRequired
+	Jitm: PropTypes.object.isRequired,
 };
 
 Jitm.defaultProps = {
@@ -205,11 +199,11 @@ Jitm.defaultProps = {
 	isDismissingJitm: false,
 	isFetchingJitm: false,
 	isModuleActivated: false,
-	Jitm: {}
+	Jitm: {},
 };
 
 export default connect(
-	( state ) => {
+	state => {
 		const jitm = getJitm( state );
 		const module_slug = get( jitm, 'activate_module', null );
 		return {
@@ -217,7 +211,7 @@ export default connect(
 			isFetchingJitm: isFetchingJitm( state ),
 			isModuleActivated: isModuleActivated( state, module_slug ),
 			isActivatingModule: isActivatingModule( state, module_slug ),
-			Jitm: jitm
+			Jitm: jitm,
 		};
 	},
 	dispatch => {
@@ -229,7 +223,7 @@ export default connect(
 				if ( '' !== id && '' !== feature_class ) {
 					return dispatch( getJitmDismissalResponse( id, feature_class ) );
 				}
-			}
+			},
 		};
 	}
 )( Jitm );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -28,15 +28,6 @@ require( './../../../../scss/jetpack-admin-jitm.scss' );
 class Jitm extends Component {
 	state = { showJitm: true };
 
-	componentDidMount() {
-		const jitm = this.props.Jitm;
-		const id = get( jitm, 'id', '' );
-
-		if ( '' !== id ) {
-			analytics.tracks.recordEvent( 'jetpack_jitm_view_client', { jitm_id: id } );
-		}
-	}
-
 	handleModuleActivation = ( module_slug, id ) => () => {
 		this.props.activateModule( module_slug );
 
@@ -56,8 +47,6 @@ class Jitm extends Component {
 
 			this.setState( { showJitm: false } );
 		}
-
-		analytics.tracks.recordEvent( 'jetpack_jitm_dismiss_client', { jitm_id: id } );
 	};
 
 	trackClick = () => {

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -105,7 +105,7 @@ class Jitm extends Component {
 
 		const cta = get( jitm, 'CTA', null );
 		const ctaMessage = get( cta, 'message', null );
-		// const ctaNewWindow = get( cta, 'newWindow', null );
+		const ctaNewWindow = get( cta, 'newWindow', null );
 		const ctaPrimary = get( cta, 'primary', null );
 
 		const description = get( jitm, 'content.description', null );
@@ -160,18 +160,14 @@ class Jitm extends Component {
 							)}
 							{ctaMessage && (
 								<div className="jitm-banner__action">
-									<Button // to-do: missing the option to open in a new window with the ctaNewWindow const.
-										// target={ ctaNewWindow === false ? '_self' : '_blank' }
+									<a
+										target={ ctaNewWindow === false ? '_self' : '_blank' }
 										href={ url }
-										className="jitm-button"
-										primary={
-											activate_module === null && ctaPrimary ? true : false
-										}
-										compact={ true }
+										className={ `jitm-button dops-button is-compact ${ activate_module === null && ctaPrimary ? 'is-primary' : false }` }
 										onClick={ this.trackClick }
 									>
 										{decodeEntities( ctaMessage )}
-									</Button>
+									</a>
 								</div>
 							)}
 							<Gridicon

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -117,7 +117,7 @@ class Jitm extends Component {
 			get( jitm, 'content.classes', '' )
 		);
 		const title = get( jitm, 'content.message', '' );
-		const url = get( jitm, 'url', '' );
+		const url = `${ get( jitm, 'url', '' ) }&redirect=%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack`;
 
 		return (
 			<div>

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -127,12 +127,11 @@ class Jitm extends Component {
 								{ description && (
 									<div className="jitm-banner__description">
 										{ decodeEntities( description ) }
-										{ list &&
-											list.length && (
-												<ul className="banner__list">
-													{ list.map( listItem => this.renderListItem( listItem ) ) }
-												</ul>
-											) }
+										{ list && list.length > 0 && (
+											<ul className="banner__list">
+												{ list.map( listItem => this.renderListItem( listItem ) ) }
+											</ul>
+										) }
 									</div>
 								) }
 							</div>

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -1,54 +1,193 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import {
+	isModuleActivated as _isModuleActivated,
+	activateModule,
+	isActivatingModule,
+} from 'state/modules';
+import Button from 'components/button';
 import { getJitm } from 'state/jitm';
+
+// to-do: bring in scss from jetpack-admin-jitm.scss. No need for now, but will be needed once we dequeue JITMs on the JP dashboard.
 
 class Jitm extends Component {
 	componentDidMount() {
 		analytics.tracks.recordEvent(
 			'jetpack_jitm_view',
-			// replace by unique ID of the JITM.
-			{ version: this.props.version }
+			// to-do: this does not work as we do not have the data when the component loads.
+			{ version: this.props.Jitm.id }
 		);
 	}
 
-	render() {
-		const classes = classNames(
-			this.props.className,
-			'jitm-card jitm-banner'
+	trackLearnMore = ( feature_class ) => {
+		analytics.tracks.recordEvent(
+			// to-do: set the right name and prop for that event.
+			'jetpack_jitm_view',
+			{ version: feature_class }
 		);
+	};
+
+	renderListItem = ( list, id, feature_class ) => {
+		for ( const i of list ) {
+			const { item, url } = i;
+			let text = item;
+
+			if ( url ) {
+				// to-do: test this. Could not find an active JITM using lists right now. Tracks is going to have to be reimplemented anyway.
+				text = `<a
+					href=${ url }
+					target="_blank" rel="noopener noreferrer"
+					data-module=${ feature_class }
+					data-jptracks-name="nudge_item_click"
+					data-jptracks-prop="jitm-${ id }"
+				>
+					${ item }
+				</a>`;
+			}
+
+			return (
+				<li>
+					<svg class="gridicon gridicons-checkmark" height="16" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" /></g>
+					</svg>
+					{ text }
+				</li>
+			);
+		}
+	};
+
+	activateModule = ( module_slug ) => {
+		this.props.activateModule( module_slug );
+		// to-do: Maybe add tracking here if needed, not sure if activateModule triggers those already.
+		// something like
+		// analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
+		// 	module: module_slug,
+		// 	toggled: 'on'
+		// } );
+	};
+
+	render() {
+		const jitm = this.props.Jitm;
+
+		// to-do: I am not familiar enough with lodash yet, but there may be a way to combine some of those calls.
+		const activate_module = get( jitm, 'activate_module', null );
+
+		const cta = get( jitm, 'CTA', null );
+		const ctaMessage = get( cta, 'message', null );
+		// const ctaNewWindow = get( cta, 'newWindow', null );
+		const ctaPrimary = get( cta, 'primary', null );
+
+		const description = get( jitm, 'content.description', null );
+		const feature_class = get( jitm, 'feature_class', '' );
+		const icon = get( jitm, 'content.icon', '' );
+		const id = get( jitm, 'id', '' );
+		const list = get( jitm, 'content.list', null );
+		const mainClasses = classnames(
+			'jitm-card jitm-banner is-upgrade-premium',
+			{ 'has-call-to-action': ctaMessage ? true : false },
+			get( jitm, 'content.classes', '' )
+		);
+		const title = get( jitm, 'content.message', '' );
+		const url = get( jitm, 'url', '' );
+
 		return (
-			<div className={ classes } role="dialog">
-				{ this.props.content }
+			<div>
+				{ ! isEmpty( jitm ) &&
+					<div className={ mainClasses }>
+						<div
+							className="jitm-banner__icon-plan"
+							/*eslint-disable react/no-danger*/
+							dangerouslySetInnerHTML={ { __html: icon } }
+						/>
+						<div className="jitm-banner__content">
+							<div className="jitm-banner__info">
+								<div className="jitm-banner__title">{ title }</div>
+								{ description &&
+									<div className="jitm-banner__description">
+										{ description }
+										{ list.length > 0 &&
+											<ul className="banner__list">
+												{ this.renderListItem( list, id, feature_class ) }
+											</ul>
+										}
+									</div>
+								}
+							</div>
+							{ activate_module &&
+								<div className="jitm-banner__action" id="jitm-banner__activate">
+									<Button
+										className="jitm-button"
+										primary={ true }
+										compact={ true }
+										onClick={ this.activateModule( activate_module ) }
+										disabled={ this.props.isActivatingModule( activate_module ) }
+									>
+										{ this.props.isActivatingModule( activate_module ) ? __( 'Activating' ) : __( 'Activate' ) }
+									</Button>
+								</div>
+							}
+							{ ctaMessage &&
+								<div className="jitm-banner__action">
+									<Button
+										// to-do: missing the option to open in a new window with the ctaNewWindow const.
+										// target={ ctaNewWindow === false ? '_self' : '_blank' }
+										href={ url }
+										className="jitm-button"
+										primary={ activate_module === null && ctaPrimary ? true : false }
+										compact={ true }
+										onClick={ this.trackLearnMore( feature_class ) }s
+									>
+										{ ctaMessage }
+									</Button>
+								</div>
+							}
+							{ /* to-do: replace a by button or svg icon */ }
+							<a
+								data-module={ feature_class }
+								className="jitm-banner__dismiss">
+							</a>
+						</div>
+					</div>
+				}
 			</div>
 		);
 	}
 }
 
 Jitm.propTypes = {
-	content: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.object,
-	] ).isRequired,
+	Jitm: PropTypes.object.isRequired,
 };
 
 Jitm.defaultProps = {
-	content: '',
+	Jitm: {},
 };
 
 export default connect(
-	state => {
+	( state ) => {
 		return {
+			isModuleActivated: ( module_slug ) => _isModuleActivated( state, module_slug ),
+			isActivatingModule: ( module_slug ) => isActivatingModule( state, module_slug ),
 			Jitm: getJitm( state ),
+		};
+	},
+	( dispatch ) => {
+		return {
+			activateModule: ( slug ) => {
+				return dispatch( activateModule( slug ) );
+			}
 		};
 	}
 )( Jitm );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -143,16 +143,16 @@ class Jitm extends Component {
 									</div>
 								) }
 							</div>
-							{ activate_module && ! this.props.isModuleActivated( activate_module ) &&
+							{ activate_module && ! this.props.isModuleActivated &&
 								<div className="jitm-banner__action" id="jitm-banner__activate">
 									<Button
 										className="jitm-button"
 										primary={ true }
 										compact={ true }
 										onClick={ this.handleModuleActivation( activate_module, id ) }
-										disabled={ this.props.isActivatingModule( activate_module ) }
+										disabled={ this.props.isActivatingModule }
 									>
-										{this.props.isActivatingModule( activate_module )
+										{this.props.isActivatingModule
 											? __( 'Activating' )
 											: __( 'Activate' )}
 									</Button>
@@ -209,13 +209,15 @@ Jitm.defaultProps = {
 };
 
 export default connect(
-	state => {
+	( state ) => {
+		const jitm = getJitm( state );
+		const module_slug = get( jitm, 'activate_module', null );
 		return {
 			isDismissingJitm: isDismissingJitm( state ),
 			isFetchingJitm: isFetchingJitm( state ),
-			isModuleActivated: module_slug => _isModuleActivated( state, module_slug ),
-			isActivatingModule: module_slug => isActivatingModule( state, module_slug ),
-			Jitm: getJitm( state )
+			isModuleActivated: _isModuleActivated( state, module_slug ),
+			isActivatingModule: isActivatingModule( state, module_slug ),
+			Jitm: jitm
 		};
 	},
 	dispatch => {

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -32,7 +32,7 @@ class Jitm extends Component {
 		);
 	}
 
-	trackLearnMore = ( feature_class ) => {
+	trackLearnMore = feature_class => {
 		analytics.tracks.recordEvent(
 			// to-do: set the right name and prop for that event.
 			'jetpack_jitm_view',
@@ -60,8 +60,16 @@ class Jitm extends Component {
 
 			return (
 				<li>
-					<svg class="gridicon gridicons-checkmark" height="16" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" /></g>
+					<svg
+						class="gridicon gridicons-checkmark"
+						height="16"
+						width="16"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+					>
+						<g>
+							<path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" />
+						</g>
 					</svg>
 					{ text }
 				</li>
@@ -69,7 +77,7 @@ class Jitm extends Component {
 		}
 	};
 
-	activateModule = ( module_slug ) => {
+	activateModule = module_slug => {
 		this.props.activateModule( module_slug );
 		// to-do: Maybe add tracking here if needed, not sure if activateModule triggers those already.
 		// something like
@@ -105,7 +113,7 @@ class Jitm extends Component {
 
 		return (
 			<div>
-				{ ! isEmpty( jitm ) &&
+				{ ! isEmpty( jitm ) && (
 					<div className={ mainClasses }>
 						<div
 							className="jitm-banner__icon-plan"
@@ -115,18 +123,18 @@ class Jitm extends Component {
 						<div className="jitm-banner__content">
 							<div className="jitm-banner__info">
 								<div className="jitm-banner__title">{ title }</div>
-								{ description &&
+								{ description && (
 									<div className="jitm-banner__description">
 										{ description }
-										{ list.length > 0 &&
+										{ list.length > 0 && (
 											<ul className="banner__list">
 												{ this.renderListItem( list, id, feature_class ) }
 											</ul>
-										}
+										) }
 									</div>
-								}
+								) }
 							</div>
-							{ activate_module &&
+							{ activate_module && (
 								<div className="jitm-banner__action" id="jitm-banner__activate">
 									<Button
 										className="jitm-button"
@@ -135,11 +143,13 @@ class Jitm extends Component {
 										onClick={ this.activateModule( activate_module ) }
 										disabled={ this.props.isActivatingModule( activate_module ) }
 									>
-										{ this.props.isActivatingModule( activate_module ) ? __( 'Activating' ) : __( 'Activate' ) }
+										{ this.props.isActivatingModule( activate_module )
+											? __( 'Activating' )
+											: __( 'Activate' ) }
 									</Button>
 								</div>
-							}
-							{ ctaMessage &&
+							) }
+							{ ctaMessage && (
 								<div className="jitm-banner__action">
 									<Button
 										// to-do: missing the option to open in a new window with the ctaNewWindow const.
@@ -153,15 +163,12 @@ class Jitm extends Component {
 										{ ctaMessage }
 									</Button>
 								</div>
-							}
+							) }
 							{ /* to-do: replace a by button or svg icon */ }
-							<a
-								data-module={ feature_class }
-								className="jitm-banner__dismiss">
-							</a>
+							<a data-module={ feature_class } className="jitm-banner__dismiss" />
 						</div>
 					</div>
-				}
+				) }
 			</div>
 		);
 	}
@@ -176,18 +183,18 @@ Jitm.defaultProps = {
 };
 
 export default connect(
-	( state ) => {
+	state => {
 		return {
-			isModuleActivated: ( module_slug ) => _isModuleActivated( state, module_slug ),
-			isActivatingModule: ( module_slug ) => isActivatingModule( state, module_slug ),
+			isModuleActivated: module_slug => _isModuleActivated( state, module_slug ),
+			isActivatingModule: module_slug => isActivatingModule( state, module_slug ),
 			Jitm: getJitm( state ),
 		};
 	},
-	( dispatch ) => {
+	dispatch => {
 		return {
-			activateModule: ( slug ) => {
+			activateModule: slug => {
 				return dispatch( activateModule( slug ) );
-			}
+			},
 		};
 	}
 )( Jitm );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -100,7 +100,6 @@ class Jitm extends Component {
 	renderContent = () => {
 		const jitm = this.props.Jitm;
 
-		// to-do: I am not familiar enough with lodash yet, but there may be a way to combine some of those calls.
 		const activate_module = get( jitm, 'activate_module', null );
 
 		const cta = get( jitm, 'CTA', null );

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -23,7 +23,7 @@ import {
 import Button from 'components/button';
 import { dismissJitm, getJitm, isDismissingJitm } from 'state/jitm';
 
-// to-do: bring in scss from jetpack-admin-jitm.scss. No need for now, but will be needed once we dequeue JITMs on the JP dashboard.
+require( './../../../../scss/jetpack-admin-jitm.scss' );
 
 class Jitm extends Component {
 	state = { showJitm: true };

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -13,6 +13,7 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import Button from 'components/button';
 import decodeEntities from 'lib/decode-entities';
 import Gridicon from 'components/gridicon';
 import {
@@ -20,7 +21,6 @@ import {
 	activateModule,
 	isActivatingModule
 } from 'state/modules';
-import Button from 'components/button';
 import { dismissJitm, getJitm, isDismissingJitm } from 'state/jitm';
 
 require( './../../../../scss/jetpack-admin-jitm.scss' );
@@ -56,6 +56,8 @@ class Jitm extends Component {
 
 			this.setState( { showJitm: false } );
 		}
+
+		analytics.tracks.recordEvent( 'jetpack_jitm_dismiss_client', { jitm_id: id } );
 	};
 
 	trackClick = () => {
@@ -197,11 +199,7 @@ class Jitm extends Component {
 	};
 
 	render() {
-		return (
-			<div>
-				{ this.state.showJitm ? this.renderContent() : null }
-			</div>
-		);
+		return <div>{this.state.showJitm ? this.renderContent() : null}</div>;
 	}
 }
 

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -147,7 +147,7 @@ class Jitm extends Component {
 									</div>
 								)}
 							</div>
-							{activate_module && (
+							{ activate_module && ! this.props.isModuleActivated( activate_module ) &&
 								<div className="jitm-banner__action" id="jitm-banner__activate">
 									<Button
 										className="jitm-button"
@@ -161,7 +161,7 @@ class Jitm extends Component {
 											: __( 'Activate' )}
 									</Button>
 								</div>
-							)}
+							}
 							{ctaMessage && (
 								<div className="jitm-banner__action">
 									<a
@@ -197,14 +197,18 @@ class Jitm extends Component {
 }
 
 Jitm.propTypes = {
+	isActivatingModule: PropTypes.bool,
 	isDismissingJitm: PropTypes.bool,
 	isFetchingJitm: PropTypes.bool,
+	isModuleActivated: PropTypes.bool,
 	Jitm: PropTypes.object.isRequired
 };
 
 Jitm.defaultProps = {
+	isActivatingModule: false,
 	isDismissingJitm: false,
 	isFetchingJitm: false,
+	isModuleActivated: false,
 	Jitm: {}
 };
 

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -68,38 +68,32 @@ class Jitm extends Component {
 		const id = get( jitm, 'id', '' );
 
 		analytics.tracks.recordEvent( 'jetpack_nudge_item_click', {
-			click: `jitm-${ id }`
+			click: `jitm-${ id }`,
 		} );
 	};
 
-	renderListItem = () => {
-		const jitm = this.props.Jitm;
-		const list = get( jitm, 'content.list', null );
-
-		for ( const listItem of list ) {
-			const { item, url } = listItem;
-			let text = decodeEntities( item );
-
-			if ( url ) {
-				text = (
-					<a
-						href={ url }
-						onClick={ this.trackListClick }
-						rel={ 'noopener noreferrer' }
-						target={ '_blank' }
-					>
-						{decodeEntities( item )}
-					</a>
-				);
-			}
-
-			return (
-				<li>
-					<Gridicon icon="checkmark" size={ 16 } />
-					{text}
-				</li>
+	renderListItem = ( listItem ) => {
+		const { item, url } = listItem;
+		let text = decodeEntities( item );
+		if ( url ) {
+			text = (
+				<a
+					href={ url }
+					onClick={ this.trackListClick }
+					rel={ 'noopener noreferrer' }
+					target={ '_blank' }
+				>
+					{ decodeEntities( item ) }
+				</a>
 			);
 		}
+
+		return (
+			<li key={ item } >
+				<Gridicon icon="checkmark" size={ 16 } />
+				{ text }
+			</li>
+		);
 	};
 
 	renderContent = () => {
@@ -140,12 +134,14 @@ class Jitm extends Component {
 								</div>
 								{description && (
 									<div className="jitm-banner__description">
-										{decodeEntities( description )}
-										{list.length > 0 && (
-											<ul className="banner__list">{this.renderListItem}</ul>
-										)}
+										{ decodeEntities( description ) }
+										{ list && list.length &&
+											<ul className="banner__list">
+												{ list.map( listItem => this.renderListItem( listItem ) ) }
+											</ul>
+										}
 									</div>
-								)}
+								) }
 							</div>
 							{ activate_module && ! this.props.isModuleActivated( activate_module ) &&
 								<div className="jitm-banner__action" id="jitm-banner__activate">

--- a/_inc/client/components/jitm/index.jsx
+++ b/_inc/client/components/jitm/index.jsx
@@ -21,7 +21,12 @@ import {
 	activateModule,
 	isActivatingModule
 } from 'state/modules';
-import { getJitmDismissalResponse, getJitm, isDismissingJitm } from 'state/jitm';
+import {
+	getJitmDismissalResponse,
+	getJitm,
+	isDismissingJitm,
+	isFetchingJitm
+} from 'state/jitm';
 
 require( './../../../../scss/jetpack-admin-jitm.scss' );
 
@@ -183,17 +188,23 @@ class Jitm extends Component {
 	};
 
 	render() {
-		return <div>{this.state.showJitm ? this.renderContent() : null}</div>;
+		return (
+			<div>
+				{ this.state.showJitm && ! this.props.isFetchingJitm ? this.renderContent() : null }
+			</div>
+		);
 	}
 }
 
 Jitm.propTypes = {
 	isDismissingJitm: PropTypes.bool,
+	isFetchingJitm: PropTypes.bool,
 	Jitm: PropTypes.object.isRequired
 };
 
 Jitm.defaultProps = {
 	isDismissingJitm: false,
+	isFetchingJitm: false,
 	Jitm: {}
 };
 
@@ -201,6 +212,7 @@ export default connect(
 	state => {
 		return {
 			isDismissingJitm: isDismissingJitm( state ),
+			isFetchingJitm: isFetchingJitm( state ),
 			isModuleActivated: module_slug => _isModuleActivated( state, module_slug ),
 			isActivatingModule: module_slug => isActivatingModule( state, module_slug ),
 			Jitm: getJitm( state )

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -258,7 +258,7 @@ class Main extends React.Component {
 				<Masthead route={ this.props.route } />
 					<div className="jp-lower">
 						{ this.props.isSiteConnected && <QueryRewindStatus /> && <QueryJitm route={ this.props.route } /> }
-						<Jitm />
+						<Jitm key={ this.props.route.path } />
 						<AdminNotices />
 						<JetpackNotices />
 						{ this.renderMainContent( this.props.route.path ) }

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -45,6 +45,8 @@ import { getTracksUserData } from 'state/initial-state';
 import WelcomeNewPlan from 'components/welcome-new-plan';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import { getRewindStatus } from 'state/rewind';
+import QueryJitm from 'components/data/query-jitm';
+import Jitm from 'components/jitm';
 
 class Main extends React.Component {
 	componentWillMount() {
@@ -255,7 +257,8 @@ class Main extends React.Component {
 			<div>
 				<Masthead route={ this.props.route } />
 					<div className="jp-lower">
-						{ this.props.isSiteConnected && <QueryRewindStatus /> }
+						{ this.props.isSiteConnected && <QueryRewindStatus /> && <QueryJitm route={ this.props.route } /> }
+						<Jitm />
 						<AdminNotices />
 						<JetpackNotices />
 						{ this.renderMainContent( this.props.route.path ) }

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -69,7 +69,8 @@ class Jetpack_JITM {
 		if ( ! in_array( $screen->id, array(
 			'jetpack_page_stats',
 			'jetpack_page_akismet-key-config',
-			'admin_page_jetpack_modules'
+			'admin_page_jetpack_modules',
+			'toplevel_page_jetpack'
 		) ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -79,6 +79,7 @@
 		color: darken( $gray, 10% );
 		font-size: rem( 12px );
 		line-height: 1;
+		text-transform: initial;
 
 		&:disabled {
 			color: lighten( $gray, 30% );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

JITMs: add component to be used in the Jetpack Dashboard.

<img width="868" alt="screenshot 2018-12-05 at 17 17 41" src="https://user-images.githubusercontent.com/426388/49527273-db7b7080-f8b1-11e8-8b53-f3cd6a41cc2a.png">
<img width="835" alt="screenshot 2018-12-05 at 17 17 29" src="https://user-images.githubusercontent.com/426388/49527275-dc140700-f8b1-11e8-8ae9-c16768431556.png">
<img width="828" alt="screenshot 2018-12-05 at 17 19 12" src="https://user-images.githubusercontent.com/426388/49527297-e7673280-f8b1-11e8-98af-669bd12946d6.png">
<img width="897" alt="screenshot 2018-12-06 at 11 55 06" src="https://user-images.githubusercontent.com/426388/49579890-d3710e80-f94d-11e8-9a14-160a06a06bd2.png">
<img src="https://user-images.githubusercontent.com/426388/49581453-509e8280-f952-11e8-9561-783cad310e91.gif">

The first part of this PR (the necessary new method in the rest api client and the new redux structure) was merged in #10818. This PR brings the second part: a new Jitm component and a new QueryJitm component, as well as a call to the new Jitm component in the main dashboard.

- [x] Check all the to-dos for things to do. 
- [x] Dequeue regular JITMs on the JP dashboard pages.
- [x] Figure out what to do with existing JITMs; with the current implementation we have no JITMs that are set to be displayed on JP dash. We will most likely need to edit the JITMs on wpcom to add the string matching JP Dash for some messages.
- [x] Some HTML encoding issues with the messages.

#### Testing instructions:

* You'll need a WordPress.com sandbox.
* Start by applying D19944-code.
* Sandbox your Jetpack site with the `JETPACK__SANDBOX_DOMAIN` constant ([reference](https://github.com/Automattic/jetpack/blob/add/jitm-component/docker/README.md#must-use-plugins-directory)). 
    - If you don't have a WordPress.com sandbox, you can sandbox mine. Through a Jurassic Ninja site with that branch, go to Settings > Jetpack Constants, and add `sandboxme.wordpress.com` as the sandbox you want to use.
* Visit Jetpack > Dashboard: a message should appear.
* Visit Jetpack > Settings: the message should disappear.
* Visit Jetpack > Plans: a different message should appear.

#### Known issues / To do:

- `toplevel_page_jetpack` should continue to work as a string one can use to target **all** pages of the Jetpack dashboard at once.
- ~Lists are not displayed properly right now.~
- ~Props warnings for `isActivatingModule` and `isModuleActivated`~
- ~When dismissing a message, and then switching to a different tab, the dismissed message is visible for a few seconds until the new message (or no message at all) is loaded.~
- ~When activating a module via a JITM, the JITM remains in place once the module has been activated. This is related to #9462~ I opted to remove the button once the module has been activated. This way one can still click on the CTA to learn more if they are interested. If they leave the page or refresh, the JITM will disappear for good.
- ~The look of the messages is a bit different from the ones you'll find in other places in wp-admin. The CTA button uses Calypso's button component, and as such the text inside the button is in uppercase. That is not the case with the wp-admin implementation of the button.~

#### Proposed changelog entry for your changes:

* Notices: display more relevant notices depending on the Jetpack dashboard screen you visit.
