### PR TITLE
Fix WooCommerce comment type handling in the API

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -634,9 +634,10 @@ class WPCOM_JSON_API {
 		);
 
 		/**
-		 * Exclude certain comment types from comment counts.
+		 * Exclude certain comment types from comment counts in the REST API.
 		 *
-		 * @since 6.8.1
+		 * @since 6.9.0
+		 * @module json-api
 		 *
 		 * @param array Array of comment types to exclude (default: 'order_note', 'webhook_delivery', 'review', 'action_log')
 		 */

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -617,6 +617,84 @@ class WPCOM_JSON_API {
 	}
 
 	/**
+	 * Counts the number of comments on a site, excluding certain comment types.
+	 *
+	 * @param $post_id int Post ID.
+	 * @return array Array of counts, matching the output of https://developer.wordpress.org/reference/functions/get_comment_count/.
+	 */
+	public function wp_count_comments( $post_id ) {
+		global $wpdb;
+		if ( 0 !== $post_id ) {
+			return wp_count_comments( $post_id );
+		}
+
+		$counts = array(
+			'total_comments' => 0,
+			'all'            => 0,
+		);
+
+		/**
+		 * Exclude certain comment types from comment counts.
+		 *
+		 * @since 6.8.1
+		 *
+		 * @param array Array of comment types to exclude (default: 'order_note', 'webhook_delivery', 'review', 'action_log')
+		 */
+		$exclude = apply_filters( 'jetpack_api_exclude_comment_types_count',
+			array( 'order_note', 'webhook_delivery', 'review', 'action_log' )
+		);
+
+		if ( empty( $exclude ) ) {
+			return wp_count_comments( $post_id );
+		}
+
+		$where = 'WHERE comment_type NOT IN (';
+		foreach( $exclude as $excluded_type ) {
+			$where .= "'" . $excluded_type . "',";
+		}
+		$where = rtrim( $where, ',' );
+		$where .= ')';
+
+
+		$count = $wpdb->get_results( "SELECT comment_approved, COUNT(*) AS num_comments
+			FROM {$wpdb->comments}
+			{$where}
+			GROUP BY comment_approved"
+		);
+
+		$approved = array(
+			'0'            => 'moderated',
+			'1'            => 'approved',
+			'spam'         => 'spam',
+			'trash'        => 'trash',
+			'post-trashed' => 'post-trashed',
+		);
+
+		// https://developer.wordpress.org/reference/functions/get_comment_count/#source
+		foreach ( $count as $row ) {
+			if ( ! in_array( $row->comment_approved, array( 'post-trashed', 'trash', 'spam' ), true ) ) {
+				$counts['all']            += $row->num_comments;
+				$counts['total_comments'] += $row->num_comments;
+			} elseif ( ! in_array( $row->comment_approved, array( 'post-trashed', 'trash' ), true ) ) {
+				$counts['total_comments'] += $row->num_comments;
+			}
+			if ( isset( $approved[ $row->comment_approved ] ) ) {
+				$counts[ $approved[ $row->comment_approved ] ] = $row->num_comments;
+			}
+		}
+
+		foreach ( $approved as $key ) {
+			if ( empty( $counts[ $key ] ) ) {
+				$counts[ $key ] = 0;
+			}
+		}
+
+		$counts = (object) $counts;
+
+		return $counts;
+	}
+
+	/**
 	 * traps `wp_die()` calls and outputs a JSON response instead.
 	 * The result is always output, never returned.
 	 *

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -649,18 +649,18 @@ class WPCOM_JSON_API {
 			return wp_count_comments( $post_id );
 		}
 
-		$where = 'WHERE comment_type NOT IN (';
-		foreach( $exclude as $excluded_type ) {
-			$where .= "'" . $excluded_type . "',";
-		}
-		$where = rtrim( $where, ',' );
-		$where .= ')';
+		array_walk( $exclude, 'esc_sql' );
+		$where = sprintf(
+			"WHERE comment_type NOT IN ( '%s' )",
+			implode( "','", $exclude )
+		);
 
-
-		$count = $wpdb->get_results( "SELECT comment_approved, COUNT(*) AS num_comments
-			FROM {$wpdb->comments}
-			{$where}
-			GROUP BY comment_approved"
+		$count = $wpdb->get_results(
+			"SELECT comment_approved, COUNT(*) AS num_comments
+				FROM $wpdb->comments
+				{$where}
+				GROUP BY comment_approved
+			"
 		);
 
 		$approved = array(

--- a/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
@@ -55,7 +55,7 @@ class WPCOM_JSON_API_GET_Comment_Counts_Endpoint extends WPCOM_JSON_API_Endpoint
 			return new WP_Error( 'invalid_input', 'Provided post_id does not exist', 400 );
 		}
 
-		$comment_counts = get_object_vars( wp_count_comments( $post_id ) );
+		$comment_counts = get_object_vars( $this->api->wp_count_comments( $post_id ) );
 
 		// Keys coming from wp_count_comments don't match the ones that we use in
 		// wp-admin and Calypso and are not consistent. Let's normalize the response.

--- a/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -165,7 +165,7 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 		if ( !$comment_id ) {
 			// We can get comment counts for the whole site or for a single post, but only for certain queries
 			if ( 'any' === $args['type'] && !isset( $args['after'] ) && !isset( $args['before'] ) ) {
-				$count = wp_count_comments( $post_id );
+				$count = $this->api->wp_count_comments( $post_id );
 			}
 		}
 
@@ -194,11 +194,16 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 			}
 		}
 
+		/** This filter is documented in class.json-api.php */
+		$exclude = apply_filters( 'jetpack_api_exclude_comment_types',
+			array( 'order_note', 'webhook_delivery', 'review', 'action_log' )
+		);
+
 		$query = array(
 			'order'        => $args['order'],
 			'type'         => 'any' === $args['type'] ? false : $args['type'],
 			'status'       => $status,
-			'type__not_in' => array( 'review' ),
+			'type__not_in' => $exclude,
 		);
 
 		if ( isset( $args['page'] ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/28858


#### Changes proposed in this Pull Request:

There are issues with the general comment count endpoints, where reviews are included in the count of the comments page, but omitted from the actual. See Automattic/wp-calypso#28858.

This PR updates the comment-counts and total count responses in the API to not include WooCommerce comment types.

#### Testing instructions:

* Apply this PR/change.
* Make a request to `GET /sites/:site/comments` and verify reviews, store order notes, etc are not included in the list.
* Make a request to `GET /sites/:site/count-comments` and verify reviews and other WC comment types are not included in the count.

#### Proposed changelog entry for your changes:

* The `comment-counts` endpoint no longer includes comments not returned by the comments listing endpoint.
