### PR TITLE
Eslint: Remove eslines 

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -8,15 +8,50 @@ const gitFiles = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
 	.toString()
 	.split( '\n' )
 	.map( name => name.trim() );
-const jsFiles = gitFiles.filter( name => name.startsWith( '_inc/client' ) )
-	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
+
+/**
+ * Parses the output of a git diff command into javascript file paths.
+ *
+ * @param   {String} command Command to run. Expects output like `git diff --name-only […]`
+ * @returns {Array}          Paths output from git command
+ */
+function parseGitDiffToPathArray( command ) {
+	return execSync( command, { encoding: 'utf8' } )
+		.split( '\n' )
+		.map( name => name.trim() )
+		.filter( name => /\.(jsx?|scss)$/.test( name ) );
+}
+
+const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
+const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
 const phpFiles = gitFiles.filter( name => name.endsWith( '.php' ) );
 
+dirtyFiles.forEach( file =>
+	// eslint-disable-next-line no-console
+	console.log(
+		chalk.red( `${ file } will not be auto-formatted because it has unstaged changes.` )
+	)
+);
+
 // linting should happen after formatting
-const jsLintResult = spawnSync( 'eslint-eslines', [ ...jsFiles, '--', '--diff=index' ], {
-	shell: true,
-	stdio: 'inherit',
-} );
+const toLint = files.filter( file => ! file.endsWith( '.scss' ) );
+if ( toLint.length ) {
+	const lintResult = spawnSync( './node_modules/.bin/eslint', [ '--quiet', ...toLint ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+	if ( lintResult.status ) {
+		// eslint-disable-next-line no-console
+		console.log(
+			chalk.red( 'COMMIT ABORTED:' ),
+			'The linter reported some problems. ' +
+				'If you are aware of them and it is OK, ' +
+				'repeat the commit command with --no-verify to avoid this check.'
+		);
+		// eslint-disable-next-line no-process-exit
+		process.exit( 1 );
+	}
+}
 
 let phpLintResult;
 if ( phpFiles.length > 0 ) {
@@ -26,12 +61,14 @@ if ( phpFiles.length > 0 ) {
 	} );
 }
 
-if ( jsLintResult.status || ( phpLintResult && phpLintResult.status ) ) {
+if ( ( phpLintResult && phpLintResult.status ) ) {
+	// eslint-disable-next-line no-console
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
 			'If you are aware of them and it is OK, ' +
 			'repeat the commit command with --no-verify to avoid this check.'
 	);
+	// eslint-disable-next-line no-process-exit
 	process.exit( 1 );
 }

--- a/package.json
+++ b/package.json
@@ -141,8 +141,6 @@
     "danger": "6.1.9",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-15": "1.2.0",
-    "eslines": "1.1.0",
-    "eslint-eslines": "1.0.0",
     "glob": "7.1.3",
     "gulp-delete-lines": "0.0.7",
     "husky": "0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,20 +2668,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslines@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslines/-/eslines-1.1.0.tgz#780dd8204e5b96e05bdc8f01502cd5275abfc464"
-  dependencies:
-    jest-docblock "20.0.3"
-    optionator "0.8.1"
-
 eslint-config-wpcalypso@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/eslint-config-wpcalypso/-/eslint-config-wpcalypso-0.8.0.tgz#e097552997bebef0d8256d9163741267c6ab510b"
-
-eslint-eslines@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-eslines/-/eslint-eslines-1.0.0.tgz#9ce1a95a33ba13ff2b393c05bbac2598c7453558"
 
 eslint-loader@1.9.0:
   version "1.9.0"
@@ -2983,10 +2972,6 @@ fast-deep-equal@^2.0.1:
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-
-fast-levenshtein@^1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz#e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -4359,10 +4344,6 @@ jade@0.26.3:
 jed@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/jed/-/jed-1.1.1.tgz#7a549bbd9ffe1585b0cd0a191e203055bee574b4"
-
-jest-docblock@20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.9"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Removes eslint-eslines and eslines from the toolchain to provide a pre commit hook that's able to lint the admin page ES6 code.

Similar to Automattic/wp-calypso#27503.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Removes `etlint-eslines` and `eslines` from package.json and lock file

#### Testing instructions:

1. Checkout this branch
2. Edit `/Users/osk/checkouts/jetpack/_inc/client/main.jsx`
3. add this line as first line of the `componentWillMount` method.
    ```
    let a =2;
   ```
4. Attempt to commit
5. Expect to see an error due to `a` being unused and not changed.

#### Proposed changelog entry for your changes:
None needed