### PR TITLE
Sharing: add WP To Twitter to list of conflicting plugins.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -294,6 +294,7 @@ class Jetpack {
 		                                             // Pure Web Brilliant's Social Graph Twitter Cards Extension
 		'twitter-cards/twitter-cards.php',           // Twitter Cards
 		'twitter-cards-meta/twitter-cards-meta.php', // Twitter Cards Meta
+		'wp-to-twitter/wp-to-twitter.php',           // WP to Twitter
 		'wp-twitter-cards/twitter_cards.php',        // WP Twitter Cards
 	);
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Fixes #10795

This change deactivates Jetpack's Twitter Cards when the WP To Twitter plugin is active.


#### Testing instructions:

* Activate Jetpack's sharing module.
* Activate the WP To Twitter plugin.
* Make sure Jetpack does not output any Twitter Meta Card tags.

#### Proposed changelog entry for your changes:
* Sharing: add WP To Twitter to list of conflicting plugins.
