### PR TITLE
Search: Fix fatal error in dev mode, and add a message

### DIFF
--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -266,6 +266,19 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		$display_filters = false;
 
+		if ( Jetpack::is_development_mode() ) {
+			echo $args['before_widget'];
+			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
+				<div class="jetpack-search-sort-wrapper">
+					<label>
+						<?php esc_html_e( 'Jetpack Search not supported in Development Mode', 'jetpack' ); ?>
+					</label>
+				</div>
+			</div><?php
+			echo $args['after_widget'];
+			return;
+		}
+
 		if ( is_search() ) {
 			if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
 				Jetpack_Search::instance()->update_search_results_aggregations();


### PR DESCRIPTION
Fixes #10632 

Also adds a simple message in dev mode to indicate that Jetpack Search is not supported.

See issue for instructions.


**Proposed changelog entry**

- Fixes fatal error when Jetpack Search Widget is enabled while site is in Development Mode.
