### PR TITLE
Simple Payments Block: Fix availability

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -58,11 +58,13 @@ class Jetpack_Simple_Payments {
 
 		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
 
-		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			jetpack_register_block( 'simple-payments' );
-		} else {
-			jetpack_register_block( 'simple-payments', array(), array( 'available' => false, 'unavailable_reason' => 'missing_plan' ) );
-		}
+		jetpack_register_block( 'simple-payments', array(), array( 'callback' => array( $this, 'get_block_availability' ) ) );
+	}
+
+	function get_block_availability() {
+		return $this->is_enabled_jetpack_simple_payments()
+		       ? array( 'available' => true )
+		       : array( 'available' => false, 'unavailable_reason' => 'missing_plan' );
 	}
 
 	function remove_auto_paragraph_from_product_description( $content ) {


### PR DESCRIPTION
**Untested** Counterpart to @enejb's D21761-code, to get files back in sync. Copying that diff's description:

> Previously when we called the load blocks methods the call is being done too early in the rest api context. Which resulted in the api returnig the wrong data because we haven't switched to the correct blog contexts. We were always returning the availability as if we from the public-api.wordpress.com domain.

#### Changes proposed in this Pull Request:

> This PR fixes this by making sure we load/register the blocks in the right context. And by allowing the blocks to pass a callback that gets called once in the right context ensuring that the data is as expected.

#### Testing instructions:

- Start with a Jetpack test site with a free plan
- Install either the [REST API Console](https://wordpress.org/plugins/rest-api-console/) plugin or the [Basic Authentication](https://github.com/WP-API/Basic-Auth) plugin.
- Use either plugin to run a `GET` request to `/wp-json/wpcom/v2/gutenberg/available-extensions`
- the simple payments block should be unavailable
- Now buy a Jetpack Premium plan
- Run the same `GET` request again
- the simple payments block should be available

