### PR TITLE
JITMs: Fix styling to work better with a popular plugin, take 2

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -119,6 +119,7 @@
 
 .jitm-card {
 	display: block;
+	clear: both;
 	position: relative;
 	margin: rem( 16px ) 0 0 auto;
 	padding: rem( 16px );
@@ -398,4 +399,8 @@
 
 .jitm-banner__action + .jitm-banner__dismiss {
 	margin-left: rem( 10px );
+}
+
+#dolly + .jitm-card {
+  margin: 3rem 1rem 0 auto;
 }

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -117,6 +117,11 @@
 	margin: rem( 40px ) 1.5385em 0 auto;
 }
 
+// if JITM appears directly below WordPress hello dolly adjust margins
+#dolly+.jitm-card {
+  margin: 3rem 1rem 0 auto;
+}
+
 .jitm-card {
 	display: block;
 	clear: both;
@@ -399,8 +404,4 @@
 
 .jitm-banner__action + .jitm-banner__dismiss {
 	margin-left: rem( 10px );
-}
-
-#dolly + .jitm-card {
-  margin: 3rem 1rem 0 auto;
 }

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -112,21 +112,12 @@
 	}
 }
 
-// if JITM appears directly below WordPress "help" menu adjust margins
-#screen-meta-links+.jitm-card {
-	margin: rem( 40px ) 1.5385em 0 auto;
-}
-
-// if JITM appears directly below WordPress hello dolly adjust margins
-#dolly+.jitm-card {
-  margin: 3rem 1rem 0 auto;
-}
 
 .jitm-card {
 	display: block;
 	clear: both;
 	position: relative;
-	margin: rem( 16px ) 0 0 auto;
+	margin: rem( 48px ) rem( 20px ) 0 auto;
 	padding: rem( 16px );
 	box-sizing: border-box;
 	background: $white;
@@ -153,6 +144,16 @@
 	&.is-card-link {
 		padding-right: rem( 48px );
 	}
+}
+
+// if JITM appears directly below WordPress "help" menu adjust margins
+#screen-meta-links+.jitm-card {
+	margin: rem( 40px ) 1.5385em 0 auto;
+}
+
+// if JITM appears directly below WordPress hello dolly adjust margins
+#dolly+.jitm-card {
+  margin: 3rem 1rem 0 auto;
 }
 
 // remove right margin for jitms in the editor


### PR DESCRIPTION
fixes #9221

#### Changes proposed in this Pull Request:

Another take on #10539, that had to be reverted.

#### Testing instructions:

1. Turn on Hello Dolly on a site with no plan and akismet inactive
2. View the comments page
3. See a jitm that doesn't collide with the hello dolly text
4. Turn off Hello Dolly
5. Make sure the JITMs still look good.

#### Proposed changelog entry for your changes:

* Notices: fix styling to work better with the Hello Dolly plugin
