### PR TITLE
Jetpack Affiliate: add affiliate code to JITM links if it exists

### DIFF
--- a/class.jetpack-affiliate.php
+++ b/class.jetpack-affiliate.php
@@ -57,6 +57,22 @@ class Jetpack_Affiliate {
 		 */
 		return apply_filters( 'jetpack_affiliate_code', get_option( 'jetpack_affiliate_code', '' ) );
 	}
+
+	/**
+	 * Returns the passed URL with the affiliate code added as a URL query arg.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $url The URL where the code will be added.
+	 *
+	 * @return string The passed URL with the code added.
+	 */
+	public function add_code_as_query_arg( $url ) {
+		if ( '' !== ( $aff = $this->get_affiliate_code() ) ) {
+			$url = add_query_arg( 'aff', $aff, $url );
+		}
+		return $url;
+	}
 }
 
 add_action( 'init', array( 'Jetpack_Affiliate', 'init' ) );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -332,7 +332,15 @@ class Jetpack_JITM {
 			) );
 
 			$normalized_site_url      = Jetpack::build_raw_urls( get_home_url() );
-			$envelope->url            = 'https://jetpack.com/redirect/?source=jitm-' . $envelope->id . '&site=' . $normalized_site_url . '&u=' . $user->ID;
+
+			if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
+				require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
+			}
+			// Get affiliate code and append it to the URL as aff=abc123
+			$envelope->url = Jetpack_Affiliate::init()->add_code_as_query_arg(
+				"https://jetpack.com/redirect/?source=jitm-{$envelope->id}&site={$normalized_site_url}&u={$user->ID}"
+			);
+
 			$envelope->jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => $envelope->id ) );
 
 			if ( $envelope->CTA->hook ) {

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -331,15 +331,23 @@ class Jetpack_JITM {
 				'jitm_id' => $envelope->id,
 			) );
 
-			$normalized_site_url      = Jetpack::build_raw_urls( get_home_url() );
+			$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
+
+			$url_params = array(
+				'source' => "jitm-$envelope->id",
+				'site' => $normalized_site_url,
+				'u' => $user->ID,
+			);
 
 			if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
 				require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 			}
-			// Get affiliate code and append it to the URL as aff=abc123
-			$envelope->url = Jetpack_Affiliate::init()->add_code_as_query_arg(
-				"https://jetpack.com/redirect/?source=jitm-{$envelope->id}&site={$normalized_site_url}&u={$user->ID}"
-			);
+			// Get affiliate code and add it to the array of URL parameters
+			if ( '' !== ( $aff = Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
+				$url_params['aff'] = $aff;
+			}
+
+			$envelope->url = add_query_arg( $url_params, 'https://jetpack.com/redirect/' );
 
 			$envelope->jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => $envelope->id ) );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4796,9 +4796,7 @@ p {
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 		}
 		// Get affiliate code and add it to the URL
-		if ( '' !== ( $aff = Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
-			$url = add_query_arg( 'aff', $aff, $url );
-		}
+		$url = Jetpack_Affiliate::init()->add_code_as_query_arg( $url );
 
 		if ( isset( $_GET['calypso_env'] ) ) {
 			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );

--- a/tests/php/test_class.jetpack-affiliate.php
+++ b/tests/php/test_class.jetpack-affiliate.php
@@ -5,6 +5,7 @@
 
 // Load required class to get the affiliate code
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack.php';
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 
 class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
@@ -25,5 +26,21 @@ class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
 	function test_affiliate_connect_url_exists() {
 		add_option( 'jetpack_affiliate_code', 'abc123' );
 		$this->assertContains( 'aff=abc123', Jetpack::init()->build_connect_url() );
+	}
+
+	function test_affiliate_add_code_to_url() {
+		add_option( 'jetpack_affiliate_code', 'abc123' );
+
+		$source = 'somesource123';
+		$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
+		$user = 123;
+		$url = Jetpack_Affiliate::init()->add_code_as_query_arg(
+			"https://jetpack.com/redirect/?source={$source}&site={$normalized_site_url}&u={$user}"
+		);
+
+		$this->assertContains( "source={$source}", $url );
+		$this->assertContains( "site={$normalized_site_url}", $url );
+		$this->assertContains( "u=$user", $url );
+		$this->assertContains( 'aff=abc123', $url );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Introduce method add_code_as_query_arg In Jetpack_Affiliate class to fetch and add the affiliate code in a single call and avoid repeating it
* Refactor code in Jetpack class to use this method instead of inline code
* Added new unit test to check the correct behavior of the new method

#### Testing instructions:

a. manually
    1. do `yarn docker:wp option add jetpack_affiliate_code abc123`
    2. verify that the URL in a JITM has `aff=abc123`
    3. since the Jetpack class was updated, also verify that the URL of the Set up Jetpack button still has the `aff` parameter with the right value

b. run the unit tests for Jetpack_Affiliate
    1. run `phpunit --testsuite=affiliate` or `yarn docker:phpunit --testsuite=affiliate`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No need to include this change in changelog since those who need to be aware of it will be notified.
