### PR TITLE
Gutenberg: jetpack_set_available_blocks revert to get data only from manifest file

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -46,22 +46,22 @@ class Jetpack_Gutenberg {
 
 	// BLOCKS
 	private static $default_blocks = array(
-		"contact-form",
-			"field-text",
-			"field-name",
-			"field-email",
-			"field-url",
-			"field-date",
-			"field-telephone",
-			"field-textarea",
-			"field-checkbox",
-			"field-checkbox-multiple",
-			"field-radio",
-			"field-select",
-	    "map",
-	    "markdown",
-	    "publicize",
-	    "simple-payments"
+		'contact-form',
+			'field-text',
+			'field-name',
+			'field-email',
+			'field-url',
+			'field-date',
+			'field-telephone',
+			'field-textarea',
+			'field-checkbox',
+			'field-checkbox-multiple',
+			'field-radio',
+			'field-select',
+		'map',
+		'markdown',
+		'publicize',
+		'simple-payments'
 	);
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -46,22 +46,22 @@ class Jetpack_Gutenberg {
 
 	// BLOCKS
 	private static $default_blocks = array(
-		'map',
-		'markdown',
-		'simple-payments',
-		'related-posts',
-		'contact-form',
-		'field-text',
-		'field-name',
-		'field-email',
-		'field-url',
-		'field-date',
-		'field-telephone',
-		'field-textarea',
-		'field-checkbox',
-		'field-checkbox-multiple',
-		'field-radio',
-		'field-select'
+		"contact-form",
+			"field-text",
+			"field-name",
+			"field-email",
+			"field-url",
+			"field-date",
+			"field-telephone",
+			"field-textarea",
+			"field-checkbox",
+			"field-checkbox-multiple",
+			"field-radio",
+			"field-select",
+	    "map",
+	    "markdown",
+	    "publicize",
+	    "simple-payments"
 	);
 
 	/**
@@ -275,20 +275,17 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Filters the results of `apply_filter( 'jetpack_set_available_blocks', array() )`
-	 * using the merged contents of `blocks-manifest.json` ( $preset_blocks )
-	 * and self::$jetpack_blocks ( $internal_blocks )
+	 * Filters the results of `apply_filter( 'jetpack_set_available_blocks', self::$default_blocks )`
+	 * using the contents of `index.json`
 	 *
 	 * @param $blocks The default list.
 	 *
 	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
 	 */
 	public static function jetpack_set_available_blocks( $blocks ) {
-		$preset_blocks_manifest =  self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array( 'blocks' => $blocks );
-		// manifest shouldn't remove default blocks...
 
+		$preset_blocks_manifest =  self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array( 'blocks' => $blocks );
 		$preset_blocks = isset( $preset_blocks_manifest->production ) ? (array) $preset_blocks_manifest->production : array() ;
-		$preset_blocks = array_unique( array_merge( $preset_blocks, $blocks ) );
 
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_blocks = isset( $preset_blocks_manifest->beta ) ? (array) $preset_blocks_manifest->beta : array();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -149,7 +149,7 @@ class Jetpack_Gutenberg {
 		/**
 		 * Filter the list of block editor blocks that are available through jetpack.
 		 *
-		 * This filter is populated by Jetpack_Gutenberg::jetpack_set_available_blocks
+		 * This filter is populated by Jetpack_Gutenberg::jetpack_set_available_blocks in develpment mode
 		 *
 		 * @since 6.8.0
 		 *
@@ -275,18 +275,17 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Filters the results of `apply_filter( 'jetpack_set_available_blocks', self::$default_blocks )`
-	 * using the contents of `index.json`
+	 * Add the blocks as specified in the `_inc/blocks/index.json`
+	 * This filters gets applied if `JETPACK_BETA_BLOCKS` is set or Jetpack::is_development_mode() is set.
 	 *
 	 * @param $blocks The default list.
 	 *
 	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
 	 */
 	public static function jetpack_set_available_blocks( $blocks ) {
-
 		$preset_blocks_manifest =  self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array( 'blocks' => $blocks );
 		$preset_blocks = isset( $preset_blocks_manifest->production ) ? (array) $preset_blocks_manifest->production : array() ;
-
+		
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_blocks = isset( $preset_blocks_manifest->beta ) ? (array) $preset_blocks_manifest->beta : array();
 			return array_unique( array_merge( $preset_blocks, $beta_blocks ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -541,7 +541,7 @@ class Jetpack {
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) || self::is_development_mode() ) {
 			add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
-        }
+		}
 
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -539,7 +539,10 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 99 ); // Registers all the Jetpack blocks .
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
-		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
+		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) || self::is_development_mode() ) {
+			add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
+        }
+
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 


### PR DESCRIPTION
Simplifies the logic in what blocks are available by pulling the data from a single place the `block-manifest.json`. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This simplifies how blocks are loaded.

#### Testing instructions:

* Load the https://github.com/Automattic/wp-calypso/pull/29150 branch.
* Make sure that contact form works as expected.

cc: @roccotripaldi, @simison 