### PR TITLE
Update Security section links on Jetpack Dashboard

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -63,11 +63,11 @@ class AtAGlance extends Component {
 					settingsPath={ this.props.userCanManageModules ? '#security' : undefined }
 					externalLink={ this.props.isDevMode || ! this.props.userCanManageModules
 						? ''
-						: __( 'Manage security on WordPress.com' )
+						: __( 'Manage security settings' )
 					}
 					externalLinkPath={ this.props.isDevMode
 						? ''
-						: 'https://wordpress.com/settings/security/' + this.props.siteRawUrl
+						: '#security'
 					}
 					externalLinkClick={ trackSecurityClick }
 				/>;

--- a/_inc/client/components/dash-section-header/index.jsx
+++ b/_inc/client/components/dash-section-header/index.jsx
@@ -4,8 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
-import { translate as __ } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 
 export class DashSectionHeader extends React.Component {
@@ -35,7 +33,6 @@ export class DashSectionHeader extends React.Component {
 	};
 
 	render() {
-		let settingsIcon;
 		let externalLink;
 		let children;
 
@@ -43,17 +40,6 @@ export class DashSectionHeader extends React.Component {
 			this.props.className,
 			'jp-dash-section-header'
 		);
-
-		if ( this.props.settingsPath ) {
-			settingsIcon = (
-				<a className="jp-dash-section-header__settings" href={ this.props.settingsPath }>
-					<span className="screen-reader-text">
-						{ __( 'Settings', { context: 'Noun. Displayed to screen readers.' } ) }
-					</span>
-					<Gridicon onClick={ this.trackCogClick } icon="cog" size={ 16 } />
-				</a>
-			);
-		}
 
 		if ( this.props.externalLink ) {
 			externalLink = (
@@ -81,7 +67,6 @@ export class DashSectionHeader extends React.Component {
 					<h2 className="jp-dash-section-header__name">
 						{ this.props.label }
 					</h2>
-					{ settingsIcon }
 				</div>
 				{ externalLink }
 				{ children }

--- a/_inc/client/components/dash-section-header/test/component.js
+++ b/_inc/client/components/dash-section-header/test/component.js
@@ -50,15 +50,6 @@ describe( 'DashSectionHeader', () => {
 
 		const wrapper = shallow( <DashSectionHeader { ...testProps } /> );
 
-		it( 'displays an icon for Security', () => {
-			expect( wrapper.find( 'Gridicon' ) ).to.have.length( 1 );
-		} );
-
-		it( 'the icon is linked to a section', () => {
-			expect( wrapper.find( 'a.jp-dash-section-header__settings' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'a.jp-dash-section-header__settings' ).props().href ).to.be.equal( '#security' );
-		} );
-
 		it( 'there is an external link', () => {
 			expect( wrapper.find( 'a.jp-dash-section-header__external-link' ) ).to.have.length( 1 );
 			expect( wrapper.find( 'a.jp-dash-section-header__external-link' ).props().href ).to.be.equal( externalPath );


### PR DESCRIPTION
Fixes #10687 and #10693 

#### Changes proposed in this Pull Request:
1. Change the wording of the "Manage security on WordPress.com" text link to "Manage security settings"
2. Update destination of the above text link from `https://wordpress.com/settings/security/SITE_URL` (Calypso Settings) to `SITE_URL/wp-admin/admin.php?page=jetpack#security` (wp-admin Jetpack Settings)
3. Remove gear icon.

BEFORE
<img width="709" alt="before" src="https://user-images.githubusercontent.com/204742/49542887-f7701980-f893-11e8-9ef9-b5c9ef28661a.png">

AFTER
<img width="715" alt="after" src="https://user-images.githubusercontent.com/204742/49542897-fc34cd80-f893-11e8-8efe-0e52fed5265d.png">


#### Testing instructions:
* Check out this branch
* Run yarn build
* Visit the Jetpack dashboard in wp-admin on your Jetpack Sandbox site (or whatever site you're testing on)
* Ensure the changes reflect the above "After" mockup and that the text link "Manage security settings" links to the wp-admin Jetpack Security settings page.

#### Proposed changelog entry for your changes:
* Clarify and unify Security settings links on Jetpack Dashboard
