### PR TITLE
Jetpack Live Branches: Remove feature wordpress-5-beta from Jetpack Live Branches script

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.7
+// @version      1.8
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -29,7 +29,6 @@
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
-			<li class="task-list-item enabled"><input type="checkbox" name="wordpress-5-beta" class="task-list-item-checkbox">Launch with WordPress 5.0 Beta</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>


### PR DESCRIPTION
WordPress 5.0 is released on Friday December 6th 2018, we don't need this anymore. This feature will be also removed from Jurassic Ninja

Related: Automattic/jurassic.ninja#149


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Removes the ability to launch with a beta version of WordPress 5.0
* Bumps Jetpack Live Branches script version to `1.8`.

#### Testing instructions:

This is a straightforward change.

#### Proposed changelog entry for your changes:


* None needed
