### PR TITLE
Add review to the list of allowed comment types for the /comments/$comment_id

### DIFF
--- a/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -23,6 +23,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 			'comment'   => 'The comment is a regular comment.',
 			'trackback' => 'The comment is a trackback.',
 			'pingback'  => 'The comment is a pingback.',
+			'review'    => 'The comment is a product review.',
 		),
 		'like_count'   => '(int) The number of likes for this comment.',
 		'i_like'       => '(bool) Does the current user like this comment?',
@@ -47,7 +48,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'unknown_comment', 'Unknown comment', 404 );
 		}
 
-		$types = array( '', 'comment', 'pingback', 'trackback' );
+		$types = array( '', 'comment', 'pingback', 'trackback', 'review' );
 		if ( !in_array( $comment->comment_type, $types ) ) {
 			return new WP_Error( 'unknown_comment', 'Unknown comment', 404 );
 		}

--- a/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -195,9 +195,10 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 		}
 
 		$query = array(
-			'order'  => $args['order'],
-			'type'   => 'any' === $args['type'] ? false : $args['type'],
-			'status' => $status,
+			'order'        => $args['order'],
+			'type'         => 'any' === $args['type'] ? false : $args['type'],
+			'status'       => $status,
+			'type__not_in' => array( 'review' ),
 		);
 
 		if ( isset( $args['page'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

See p90Yrv-Tz-p2.

Prior to WooCommerce 3.5, product reviews were stored as comments with an empty comment type (''). After 3.5, these are now marked with the review type.

A few things relied on being able to update comment status using the WordPress.com REST API, such as the mobile apps and web notifications.

This PR whitelists the review type to restore that behavior. 

This was originally part of #10786 -- but separated out since it is a separate fix for the mobile apps.

#### Testing instructions:
* Apply this PR/change.
* Make sure you have WooCommerce with a product setup. Create a product review notification. Take note of the ID.
* Go to https://developer.wordpress.com/docs/api/console/ and point towards your test Jetpack site.
* Make a request to GET /sites/:site/comments/:comment (find via the dropdown) and verify that it does not 404.

#### Proposed changelog entry for your changes:
N/A
