### PR TITLE
Scope a test to pre-5.0 WordPress versions

### DIFF
--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -208,7 +208,7 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 	}
 
 	function test_compat_with_wp_kses_post() {
-                global $wp_version;
+		global $wp_version;
 		if ( version_compare( $wp_version, 5.0, '>=' ) ) {
 			$this->markTestSkipped( 'WP 5.0 allow all data attributes' );
 			return;

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -208,6 +208,11 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 	}
 
 	function test_compat_with_wp_kses_post() {
+                global $wp_version;
+		if ( version_compare( $wp_version, 5.0, '>=' ) ) {
+			$this->markTestSkipped( 'WP 5.0 allow all data attributes' );
+			return;
+		}
 		$instance = Jetpack_Lazy_Images::instance();
 		remove_filter( 'wp_kses_allowed_html', array( $instance, 'allow_lazy_attributes' ) );
 


### PR DESCRIPTION
In WordPress 5.0 all data- attributes are allowed so we no longer need this code (and test).

Related https://core.trac.wordpress.org/ticket/33121

#### Changes proposed in this Pull Request:
* Lets skip the test in 5.0 and we can review the code need later.

#### Testing instructions:
* Travis tests

#### Proposed changelog entry for your changes:
No changelog needed
