### PR TITLE
Widen dash container: changing mast head and content area max widths

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -18,7 +18,7 @@
 	flex-wrap: wrap;
 	margin: 0 auto;
 	width: 100%;
-	max-width: rem( 720px );
+	max-width: rem( 1040px );
 	padding-bottom: rem( 6px );
 }
 

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -20,6 +20,10 @@
 	width: 100%;
 	max-width: rem( 1040px );
 	padding-bottom: rem( 6px );
+
+	@media (max-width: 1250px) {
+		max-width: 95%;
+	}
 }
 
 .jp-masthead__logo-container {

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -59,7 +59,7 @@
 .jp-lower {
 	margin: 0 auto;
 	text-align: left;
-	max-width: rem( 720px );
+	max-width: rem( 1040px );
 	padding: rem( 24px );
 }
 

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -61,6 +61,11 @@
 	text-align: left;
 	max-width: rem( 1040px );
 	padding: rem( 24px );
+
+	@media (max-width: 1250px) {
+		max-width: 95%;
+	}
+
 }
 
 #contextual-help-link-wrap {


### PR DESCRIPTION
Widen dash container: changing mast head and content area max widths to
match those of calypso.

Fixes https://github.com/Automattic/jetpack/issues/9298


Before:
![screen shot 2018-12-06 at 7 00 57 pm](https://user-images.githubusercontent.com/214813/49619154-506da980-f989-11e8-93aa-5696c9158eeb.png)


After:
![screen shot 2018-12-06 at 6 56 25 pm](https://user-images.githubusercontent.com/214813/49619112-24522880-f989-11e8-88ec-678596215fbc.png)


#### Testing instructions:
1) Run this branch
2) Visit jetpack dashboard and settings areas
3) Enjoy a wider experience on large screens

#### Proposed changelog entry for your changes:
"We've made the Jetpack dashboard wider on large screens for a better experience"