### PR TITLE
Admin Page: Update reference to window object for Redux Dev tools

### DIFF
--- a/_inc/client/state/redux-store.js
+++ b/_inc/client/state/redux-store.js
@@ -19,7 +19,7 @@ function createJetpackStore() {
 	const finalCreateStore = compose(
 		applyMiddleware( thunk ),
 		applyMiddleware( history ),
-		typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
+		typeof window === 'object' && typeof window.__REDUX_DEVTOOLS_EXTENSION__ !== 'undefined' ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f
 	)( createStore );
 	return finalCreateStore( reducer );
 }


### PR DESCRIPTION
The reference to the middleware high order function is now `__REDUX_DEVTOOLS_EXTENSION__ `.


<!--- Provide a general summary of your changes in the Title above -->

Fixes warning in the console when Redux dev tools are available.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates reference from `window.devToolsExtension` to `window.__REDUX_DEVTOOLS_EXTENSION__`.

#### Testing instructions:

1. Checkout this branch
2. Load the admin page with the Redux dev tools extension installed
3. Confirm you don't see a warning like `window.devToolsExtension is deprecated in favor of window.__REDUX_DEVTOOLS_EXTENSION__, and will be removed in next version of Redux DevTools: https://git.io/fpEJZ`


#### Proposed changelog entry for your changes:

<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed 
