### PR TITLE
Social Icons: only enqueue scrips and styles when needed.

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -9,6 +9,8 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * Widget constructor.
 	 */
 	public function __construct() {
+		global $pagenow;
+
 		$widget_ops = array(
 			'classname'                   => 'jetpack_widget_social_icons',
 			'description'                 => __( 'Add social-media icons to your site.', 'jetpack' ),
@@ -33,10 +35,17 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			),
 		);
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-		add_action( 'admin_print_footer_scripts', array( $this, 'render_admin_js' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_icon_scripts' ) );
-		add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
+		// Enqueue admin scrips and styles, only in the customizer or the old widgets page.
+		if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+			add_action( 'admin_print_footer_scripts', array( $this, 'render_admin_js' ) );
+		}
+
+		// Enqueue scripts and styles for the display of the widget, on the frontend or in the customizer.
+		if ( is_active_widget( false, $this->id, $this->id_base, true ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_icon_scripts' ) );
+			add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
+		}
 	}
 
 	/**
@@ -58,12 +67,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * JavaScript for admin widget form.
 	 */
 	public function render_admin_js() {
-		global $wp_customize;
-		global $pagenow;
-
-		if ( ! isset( $wp_customize ) && 'widgets.php' !== $pagenow ) {
-			return;
-		}
 	?>
 		<script type="text/html" id="tmpl-jetpack-widget-social-icons-template">
 			<?php self::render_icons_template(); ?>
@@ -75,10 +78,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * Add SVG definitions to the footer.
 	 */
 	public function include_svg_icons() {
-		if ( ! is_active_widget( false, $this->id, $this->id_base, true ) ) {
-			return;
-		}
-
 		// Define SVG sprite file in Jetpack
 		$svg_icons = dirname( dirname( __FILE__ ) ) . '/theme-tools/social-menu/social-menu.svg';
 


### PR DESCRIPTION
Fixes #10862

#### Changes proposed in this Pull Request:

We should only enqueue scripts and styles on pages and admin pages where the elements are needed.

#### Testing instructions:

* Start with a theme supporting sidebar widgets, and a site where `SCRIPT_DEBUG` is set to true.
* Add a social icons widget from Appearance > Widgets and Appearance > Customize. Everything should work there.
* Visit a page where the widget is displayed; make sure every script is loaded there.
* Visit a page where the widget is not displayed; you should not see the `social-icons/social-icons.css` file being loaded anywhere, nor the SVG files in the footer.

#### Proposed changelog entry for your changes:
* Social Icons Widget: only load scripts and styles when necessary.
