### PR TITLE
Resp. videos: don't load if theme supports core responsive embeds

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -10,6 +10,11 @@ function jetpack_responsive_videos_init() {
 		return;
 	}
 
+	/* If the theme bundles support for Gutenberg Responsive Embeds, let's let it take over. */
+	if ( current_theme_supports( 'responsive-embeds' ) ) {
+		return;
+	}
+
 	/* If the theme does support 'jetpack-responsive-videos', wrap the videos */
 	add_filter( 'wp_video_shortcode', 'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html', 'jetpack_responsive_videos_embed_html' );


### PR DESCRIPTION
Fixes #10678
Fixes https://github.com/Automattic/wp-calypso/issues/28323

#### Changes proposed in this Pull Request:

If a theme already includes support for Core's Responsive Embeds feature, they don't need our implementation.

#### Testing instructions:

* Install Twenty Nineteen on your site.
* Follow the steps in #10678
* Make sure the videos you insert in new posts are displayed as you've set them in the block editor.

#### Proposed changelog entry for your changes:
* Responsive videos: don't load if theme supports core responsive embeds
