### PR TITLE
Tracks: only send event if route has changed.

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -58,6 +58,9 @@ class Main extends React.Component {
 		window.addEventListener( 'beforeunload', this.onBeforeUnload );
 		// Handles transition between routes handled by react-router
 		this.props.router.listenBefore( this.routerWillLeave );
+
+		// Track initial page view
+		this.props.isSiteConnected && analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: this.props.route.path } );
 	}
 
 	/*
@@ -115,6 +118,9 @@ class Main extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		// Track page view on change only
+		prevProps.route.path !== this.props.route.path && this.props.isSiteConnected && analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: this.props.route.path } );
+
 		// Not taking into account development mode here because changing the connection
 		// status without reloading is possible only by disconnecting a live site not
 		// in development mode.
@@ -155,9 +161,6 @@ class Main extends React.Component {
 	};
 
 	renderMainContent = route => {
-		// Track page views
-		this.props.isSiteConnected && analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
-
 		if ( ! this.props.userCanManageModules ) {
 			if ( ! this.props.siteConnectionStatus ) {
 				return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This fixes a problem where we were sending page_view tracks events every time shouldComponentUpdate was true, which was a lot. 



This change will make sure to only send the event on initial page load, as only if the route has changed. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `localStorage.setItem( 'debug', 'dops:analytics' );` in your browser console
- Reload the page
- Click around in the tabs. Make sure the `jetpack_wpa_page_view` event is sent only once per view.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

- None? 
