### PR TITLE
Travis: run master tests from the 5.0 branch instead of master

### DIFF
--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -22,7 +22,7 @@ mysql -u root -e "CREATE DATABASE wordpress_tests;"
 echo "Preparing WordPress from \"$WP_BRANCH\" branch...";
 case $WP_BRANCH in
 master)
-	git clone --depth=1 --branch master git://develop.git.wordpress.org/ /tmp/wordpress-master
+	git clone --depth=1 --branch 5.0 git://develop.git.wordpress.org/ /tmp/wordpress-master
 	;;
 latest)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php) git://develop.git.wordpress.org/ /tmp/wordpress-latest


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

All 5.0 development is currently happening in this branch instead of `master`.
Let's test against that branch for now, to catch any regressions earlier.

#### Testing instructions:

* Do the tests pass? Edit: the tests pass. :)

#### Proposed changelog entry for your changes:

* None
