### PR TITLE
Bump minimum required version of WordPress to 4.9

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '4.8' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '4.9' );
 
 define( 'JETPACK__VERSION',            '6.9-alpha' );
 define( 'JETPACK_MASTER_USER',         true );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates `jetpack.php` to read `define( 'JETPACK__MINIMUM_WP_VERSION', '4.9' );`

#### Testing instructions:

* Incoming

#### Proposed changelog entry

* We updated the minimum WordPress version required to run Jetpack to WordPress 4.9