### PR TITLE
JITMs: display more relevant notices depending on the Jetpack dashboard screen you visit.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -1,41 +1,4 @@
 jQuery( document ).ready( function( $ ) {
-	var reFetch = function() {
-		$( '.jetpack-jitm-message' ).each( function() {
-			var $el = $( this );
-
-			var message_path = $el.data( 'message-path' );
-			var query = $el.data( 'query' );
-			var redirect = $el.data( 'redirect' );
-			var hash = location.hash;
-
-			hash = hash.replace( /#\//, '_' );
-			message_path = message_path.replace( 'toplevel_page_jetpack', 'toplevel_page_jetpack' + hash );
-
-			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
-				message_path: message_path,
-				query: query,
-				_wpnonce: $el.data( 'nonce' )
-			} ).then( function( response ) {
-				if ( 'object' === typeof response && response['1'] ) {
-					response = [ response['1'] ];
-				}
-
-				// properly handle the case of an empty array or no content set
-				if ( 0 === response.length || ! response[ 0 ].content ) {
-					return;
-				}
-
-				// for now, always take the first response
-				setJITMContent( $el, response[ 0 ], redirect );
-			} );
-		} );
-	};
-
-	$( window ).bind( 'hashchange', function() {
-		document.querySelector( '.jitm-card' ).remove();
-		reFetch();
-	} );
-
 	var templates = {
 		'default': function( envelope ) {
 			var html = '<div class="jitm-card jitm-banner ' + (
@@ -163,5 +126,42 @@ jQuery( document ).ready( function( $ ) {
 		} );
 	};
 
+	var reFetch = function() {
+		$( '.jetpack-jitm-message' ).each( function() {
+			var $el = $( this );
+
+			var message_path = $el.data( 'message-path' );
+			var query = $el.data( 'query' );
+			var redirect = $el.data( 'redirect' );
+			var hash = location.hash;
+
+			hash = hash.replace( /#\//, '_' );
+			message_path = message_path.replace( 'toplevel_page_jetpack', 'toplevel_page_jetpack' + hash );
+
+			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
+				message_path: message_path,
+				query: query,
+				_wpnonce: $el.data( 'nonce' )
+			} ).then( function( response ) {
+				if ( 'object' === typeof response && response['1'] ) {
+					response = [ response['1'] ];
+				}
+
+				// properly handle the case of an empty array or no content set
+				if ( 0 === response.length || ! response[ 0 ].content ) {
+					return;
+				}
+
+				// for now, always take the first response
+				setJITMContent( $el, response[ 0 ], redirect );
+			} );
+		} );
+	};
+
 	reFetch();
+
+	$( window ).bind( 'hashchange', function() {
+		document.querySelector( '.jitm-card' ).remove();
+		reFetch();
+	} );
 } );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -1,4 +1,41 @@
 jQuery( document ).ready( function( $ ) {
+	var reFetch = function() {
+		$( '.jetpack-jitm-message' ).each( function() {
+			var $el = $( this );
+
+			var message_path = $el.data( 'message-path' );
+			var query = $el.data( 'query' );
+			var redirect = $el.data( 'redirect' );
+			var hash = location.hash;
+
+			hash = hash.replace( /#\//, '_' );
+			message_path = message_path.replace( 'toplevel_page_jetpack', 'toplevel_page_jetpack' + hash );
+
+			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
+				message_path: message_path,
+				query: query,
+				_wpnonce: $el.data( 'nonce' )
+			} ).then( function( response ) {
+				if ( 'object' === typeof response && response['1'] ) {
+					response = [ response['1'] ];
+				}
+
+				// properly handle the case of an empty array or no content set
+				if ( 0 === response.length || ! response[ 0 ].content ) {
+					return;
+				}
+
+				// for now, always take the first response
+				setJITMContent( $el, response[ 0 ], redirect );
+			} );
+		} );
+	};
+
+	$( window ).bind( 'hashchange', function() {
+		document.querySelector( '.jitm-card' ).remove();
+		reFetch();
+	} );
+
 	var templates = {
 		'default': function( envelope ) {
 			var html = '<div class="jitm-card jitm-banner ' + (
@@ -89,7 +126,7 @@ jQuery( document ).ready( function( $ ) {
 		var $template = templates[ template ]( response );
 		$template.find( '.jitm-banner__dismiss' ).click( render( $template ) );
 
-		$el.replaceWith( $template );
+		$el.innerHTML = $template;
 
 		// Add to Jetpack notices within the Jetpack settings app.
 		$template.prependTo( $( '#jp-admin-notices' ) );
@@ -126,29 +163,5 @@ jQuery( document ).ready( function( $ ) {
 		} );
 	};
 
-	$( '.jetpack-jitm-message' ).each( function() {
-		var $el = $( this );
-
-		var message_path = $el.data( 'message-path' );
-		var query = $el.data( 'query' );
-		var redirect = $el.data( 'redirect' );
-
-		$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
-			message_path: message_path,
-			query: query,
-			_wpnonce: $el.data( 'nonce' )
-		} ).then( function( response ) {
-			if ( 'object' === typeof response && response['1'] ) {
-				response = [ response['1'] ];
-			}
-
-			// properly handle the case of an empty array or no content set
-			if ( 0 === response.length || ! response[ 0 ].content ) {
-				return;
-			}
-
-			// for now, always take the first response
-			setJITMContent( $el, response[ 0 ], redirect );
-		} );
-	} );
+	reFetch();
 } );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -136,7 +136,9 @@ jQuery( document ).ready( function( $ ) {
 			var hash = location.hash;
 
 			hash = hash.replace( /#\//, '_' );
-			message_path = message_path.replace( 'toplevel_page_jetpack', 'toplevel_page_jetpack' + hash );
+			if ( '_dashboard' !== hash ) {
+				message_path = message_path.replace( 'toplevel_page_jetpack', 'toplevel_page_jetpack' + hash );
+			}
 
 			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
 				message_path: message_path,

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -162,11 +162,15 @@ jQuery( document ).ready( function( $ ) {
 
 	reFetch();
 
-	$( window ).bind( 'hashchange', function() {
-		var jitm_card = document.querySelector( '.jitm-card' );
-	 	if ( jitm_card ) {
-			jitm_card.remove();
-	 	}
-		reFetch();
+	$( window ).bind( 'hashchange', function( e ) {
+		var newURL = e.originalEvent.newURL;
+
+		if ( newURL.indexOf( 'jetpack#/' ) >= 0 ) {
+			var jitm_card = document.querySelector( '.jitm-card' );
+			if ( jitm_card ) {
+				jitm_card.remove();
+			}
+			reFetch();
+		}
 	} );
 } );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -161,7 +161,10 @@ jQuery( document ).ready( function( $ ) {
 	reFetch();
 
 	$( window ).bind( 'hashchange', function() {
-		document.querySelector( '.jitm-card' ).remove();
+		var jitm_card = document.querySelector( '.jitm-card' );
+	 	if ( jitm_card ) {
+			jitm_card.remove();
+	 	}
 		reFetch();
 	} );
 } );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -89,10 +89,14 @@ jQuery( document ).ready( function( $ ) {
 		var $template = templates[ template ]( response );
 		$template.find( '.jitm-banner__dismiss' ).click( render( $template ) );
 
-		$el.innerHTML = $template;
-
-		// Add to Jetpack notices within the Jetpack settings app.
-		$template.prependTo( $( '#jp-admin-notices' ) );
+		if ( $( '#jp-admin-notices' ).length > 0 ) {
+			// Add to Jetpack notices within the Jetpack settings app.
+			$el.innerHTML = $template;
+			$template.prependTo( $( '#jp-admin-notices' ) );
+		} else {
+			// Replace placeholder div on other pages.
+			$el.replaceWith($template);
+		}
 
 		// Handle Module activation button if it exists.
 		$template.find( '#jitm-banner__activate a' ).click( function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Display more relevant notices depending on the Jetpack dashboard screen you visit.

#### Testing instructions:

* You'll need a WordPress.com sandbox.
* Start by applying D19944-code.
* Sandbox your Jetpack site with the `JETPACK__SANDBOX_DOMAIN` constant ([reference](https://github.com/Automattic/jetpack/blob/add/jitm-component/docker/README.md#must-use-plugins-directory)). 
    - If you don't have a WordPress.com sandbox, you can sandbox mine. Through a Jurassic Ninja site with that branch, go to Settings > Jetpack Constants, and add `sandboxme.wordpress.com` as the sandbox you want to use.
* Visit Jetpack > Dashboard: a message should appear.
* Visit Jetpack > Settings: the message should disappear.
* Visit Jetpack > Plans: a different message should appear.

#### Proposed changelog entry for your changes:
* Notices: display more relevant notices depending on the Jetpack dashboard screen you visit.

