### PR TITLE
Remove un-used `.npmrc` config file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,7 +46,6 @@ exclude_paths:
   - "**.jshintignore"
   - "**.svnignore"
   - "**.travis.yml"
-  - "**.npmrc"
   - "**.gitignore"
   - "**.eslintrc.js"
   - "**.editorconfig"

--- a/.svnignore
+++ b/.svnignore
@@ -6,7 +6,6 @@
 .jshintrc
 .jshintignore
 .travis.yml
-.npmrc
 .nvmrc
 .eslines.json
 .eslintcache


### PR DESCRIPTION
Remove empty NPM config file.

Since https://github.com/Automattic/jetpack/pull/10777 removed any contents from `.npmrc` file, seems like it isn't needed anymore.

More about this file; https://docs.npmjs.com/files/npmrc

### Testing instructions

🤷‍♂️ 

### Proposed changelog entry

none needed