### PR TITLE
Secondary users: update notices to indicate a Jetpack account is needed

### DIFF
--- a/_inc/client/components/banner/style.scss
+++ b/_inc/client/components/banner/style.scss
@@ -1,5 +1,5 @@
 @import '../../scss/layout';
-@import "../../scss/calypso-colors";
+@import "../../scss/variables/colors";
 @import "../../scss/color-functions";
 
 @mixin banner-color( $color ) {
@@ -29,7 +29,7 @@
 	@include banner-color( $blue-wordpress );
 
 	&.is-jetpack-info {
-		@include banner-color( $alert-green );
+		@include banner-color( $green-primary );
 	}
 
 	&.is-upgrade-personal {

--- a/_inc/client/components/banner/style.scss
+++ b/_inc/client/components/banner/style.scss
@@ -28,6 +28,10 @@
 
 	@include banner-color( $blue-wordpress );
 
+	&.is-jetpack-info {
+		@include banner-color( $alert-green );
+	}
+
 	&.is-upgrade-personal {
 		@include banner-color( $alert-yellow );
 	}

--- a/_inc/client/components/button/style.scss
+++ b/_inc/client/components/button/style.scss
@@ -110,6 +110,7 @@
 	}
 	&.is-compact {
 		color: $white;
+		white-space: nowrap;
 	}
 }
 

--- a/_inc/client/components/gridicon/index.jsx
+++ b/_inc/client/components/gridicon/index.jsx
@@ -74,6 +74,7 @@ const Gridicon = createReactClass( {
 			'gridicons-my-sites',
 			'gridicons-notice-outline',
 			'gridicons-notice',
+			'gridicons-plans',
 			'gridicons-plus-small',
 			'gridicons-plus',
 			'gridicons-popout',
@@ -461,6 +462,9 @@ const Gridicon = createReactClass( {
 				break;
 			case 'gridicons-phone':
 				svg = <svg className={ iconClass } height={ this.props.size } width={ this.props.size } onClick={ this.props.onClick } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 2H8c-1.104 0-2 .896-2 2v16c0 1.104.896 2 2 2h8c1.104 0 2-.896 2-2V4c0-1.104-.896-2-2-2zm-3 19h-2v-1h2v1zm3-2H8V5h8v14z" /></g></svg>;
+				break;
+			case 'gridicons-plans':
+				svg = <svg className={ iconClass } height={ this.props.size } width={ this.props.size } onClick={ this.props.onClick } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-1 12H6l5-10v10zm2 6V10h5l-5 10z" /></g></svg>;
 				break;
 			case 'gridicons-plugins':
 				svg = <svg className={ iconClass } height={ this.props.size } width={ this.props.size } onClick={ this.props.onClick } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 8V3c0-.552-.448-1-1-1s-1 .448-1 1v5h-4V3c0-.552-.448-1-1-1s-1 .448-1 1v5H5v4c0 2.79 1.637 5.193 4 6.317V22h6v-3.683c2.363-1.124 4-3.527 4-6.317V8h-3z" /></g></svg>;

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -168,7 +168,7 @@ export class UserUnlinked extends React.Component {
 			return (
 				<div className="jp-unlinked-notice">
 					<JetpackBanner
-						title={ __( 'Jetpack is powering your site, but to access all of its features you’ll need to create a Jetpack account.' ) }
+						title={ __( 'Jetpack is powering your site, but to access all of its features you’ll need to create an account.' ) }
 						callToAction={ __( 'Create account' ) }
 						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
 						icon="plans"

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -168,10 +168,11 @@ export class UserUnlinked extends React.Component {
 			return (
 				<div className="jp-unlinked-notice">
 					<JetpackBanner
-						title={ __( 'Connect your account to get the most out of Jetpack' ) }
-						callToAction={ __( 'Connect to WordPress.com' ) }
+						title={ __( 'Jetpack is powering your site, but to access all of its features you’ll need to create a Jetpack account.' ) }
+						callToAction={ __( 'Create account' ) }
 						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
-						icon="my-sites"
+						icon="plans"
+						className="is-jetpack-info"
 					/>
 				</div>
 			);

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -171,7 +171,7 @@ export class UserUnlinked extends React.Component {
 						title={ __( 'Jetpack is powering your site, but to access all of its features you’ll need to create an account.' ) }
 						callToAction={ __( 'Create account' ) }
 						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
-						icon="plans"
+						icon="my-sites"
 						className="is-jetpack-info"
 					/>
 				</div>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -65,7 +65,7 @@ class SubscriptionsComponent extends React.Component {
 
 			return this.props.isLinked
 				? <Card compact className="jp-settings-card__configure-link" onClick={ this.trackConfigureClick } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</Card>
-				: <Card compact className="jp-settings-card__configure-link" href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }>{ __( 'Connect your user account to WordPress.com to view your email followers' ) } </Card>;
+				: <Card compact className="jp-settings-card__configure-link" href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }>{ __( 'Create a Jetpack account to view your email followers' ) } </Card>;
 		};
 
 		return (

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -55,7 +55,7 @@ export const Publicize = moduleSettingsForm(
 							target="_blank"
 							rel="noopener noreferrer"
 							href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>
-							{ __( 'Connect your user account to WordPress.com to use this feature' ) }
+							{ __( 'Create a Jetpack account to use this feature' ) }
 						</Card>
 					);
 			};

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -68,7 +68,7 @@ export const ShareButtons = moduleSettingsForm(
 						href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }
 					>
 						{__(
-							'Connect your user account to WordPress.com to use this feature'
+							'Create a Jetpack account to use this feature'
 						)}
 					</Card>
 				);

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -59,7 +59,7 @@ export const Masterbar = moduleSettingsForm(
 								href={ `${ this.props.connectUrl }&from=unlinked-user-masterbar` }
 							>
 								{
-									__( 'Connect your user account to WordPress.com to use this feature' )
+									__( 'Create a Jetpack account to use this feature' )
 								}
 							</Card>
 						)

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -117,7 +117,7 @@ class PostByEmail extends React.Component {
 							href={ `${ this.props.connectUrl }&from=unlinked-user-pbe` }
 						>
 							{
-								__( 'Connect your user account to WordPress.com to use this feature' )
+								__( 'Create a Jetpack account to use this feature' )
 							}
 						</Card>
 					)


### PR DESCRIPTION
Fixes #6293

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates notices for secondary users to indicate a Jetpack account is needed.
* Modifies main banner to incorporate Jetpack branding.
* Adds plans gridicon (Jetpack icon).

#### Before

![image](https://user-images.githubusercontent.com/390760/49732293-04b34c80-fc76-11e8-87ce-2fd421aabee7.png)

#### After

![image](https://user-images.githubusercontent.com/390760/50000042-3d159c00-ff90-11e8-8122-17fe23323599.png)

#### Testing instructions:

* Fire up this PR.
* Login to your site using a secondary account (as opposed to the primary one used to connect Jetpack).
* Go to the Dashboard and Settings, and ensure you see the updates notices.

#### Proposed changelog entry for your changes:

* Secondary users: update notices to indicate a Jetpack account is needed.