### PR TITLE
Gutenberg: Check for Publicize capabilities at registration

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -782,7 +782,15 @@ abstract class Publicize_Base {
 	function register_gutenberg_extension() {
 		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
 		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
-		jetpack_register_block( 'publicize' );
+		$object_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+		if ( $this->current_user_can_access_publicize_data( $object_id ) ) {
+			jetpack_register_block( 'publicize' );
+		} else {
+			jetpack_register_block( 'publicize', array(), array(
+				'available'          => false,
+				'unavailable_reason' => 'unauthorized',
+			) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently, we're registering the Publicize extension for Gutenberg, regardless of whether the current user has enough permissions to work with it. Instead, we should register as available only when the current user has the necessary capability. See #10910 for more details.

Fixes #10910.

#### Changes proposed in this Pull Request:

* Check for the needed capabilities when registering the Publicize extension, and conditionally register it as available based on the presence/absence of these capabilities.

#### Testing instructions:
* Spin up a JN site with this branch - use [this link](https://jurassic.ninja/create?shortlived&jetpack-beta&gutenpack&branch=fix/gutenberg-publicize-registration-capabilities).
* Connect the site, and activate the recommended features.
* Start writing a post.
* Click the Publish button.
* Verify you can see the Publicize UI, the Jetpack icon in the toolbar, and the Jetpack sidebar when you click that icon.
* Create a user with the Contributor role.
* Login as that new user.
* Start writing a new post.
* Verify you can't see the Publicize UI anywhere.

#### Proposed changelog entry for your changes:

* Now properly conditionally displaying the Gutenberg Publicize UI based on the permissions of the current user.
