### PR TITLE
Publicize: Use the right capability for toggling global connections

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -40,7 +40,7 @@ abstract class Publicize_Base {
 	 * All users with this cap can un-globalize all other global connections, and globalize any of their own
 	 * Globalized connections cannot be unselected by users without this capability when publishing
 	 */
-	public $GLOBAL_CAP = 'edit_others_posts';
+	public $GLOBAL_CAP = 'publish_posts';
 
 	/**
 	* Sets up the basics of Publicize


### PR DESCRIPTION
Use `publish_posts` instead of `edit_others_posts` to determine whether a Publicize connection can be toggled by a user. This makes the behavior consistent with WP.com, where we also use `publish_posts`.

Fixes #10913.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Use `publish_posts` instead of `edit_others_posts` to determine whether a connection is toggleable

#### Testing instructions:

* Spin up a JN site with this branch - use [this link](https://jurassic.ninja/create?shortlived&jetpack-beta&gutenpack&branch=fix/gutenberg-publicize-use-proper-capability-global).
* Connect the site, and activate the recommended features.
* Start writing a post.
* Click the Publish button.
* Connect a service, make it globally available for other users.
* Verify you can toggle the service before posting.
* Create a user with the Author role.
* Login as that new user.
* Connect the user.
* Start writing a new post.
* Click the Publish button.
* Verify you can toggle the service before posting.

#### Proposed changelog entry for your changes:

* Author users can now toggle globally available Publicize connections.
