### PR TITLE
Fix checks for serving AMP response and improve AMP compatibility

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -64,18 +64,6 @@ class Jetpack_AMP_Support {
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
 	}
 
-	static function filter_available_widgets( $widgets ) {
-		if ( self::is_amp_request() ) {
-			$widgets = array_filter( $widgets, array( 'Jetpack_AMP_Support', 'is_supported_widget' ) );
-		}
-
-		return $widgets;
-	}
-
-	static function is_supported_widget( $widget_path ) {
-		return substr( $widget_path, -14 ) !== '/milestone.php';
-	}
-
 	/**
 	 * Returns whether the request is not AMP.
 	 *
@@ -332,7 +320,3 @@ add_action( 'init', array( 'Jetpack_AMP_Support', 'init' ), 1 );
 
 add_action( 'admin_init', array( 'Jetpack_AMP_Support', 'admin_init' ), 1 );
 
-// this is necessary since for better or worse Jetpack modules and widget files are loaded during plugins_loaded, which means we must
-// take the opportunity to intercept initialisation before that point, either by adding explicit detection into the module,
-// or preventing it from loading in the first place (better for performance)
-add_action( 'plugins_loaded', array( 'Jetpack_AMP_Support', 'init_filter_jetpack_widgets' ), 1 );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -158,6 +158,10 @@ class Jetpack_Carousel {
 	}
 
 	function check_if_shortcode_processed_and_enqueue_assets( $output ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $output;
+		}
+
 		if (
 			! empty( $output ) &&
 			/**
@@ -200,6 +204,9 @@ class Jetpack_Carousel {
 	}
 
 	function check_content_for_blocks( $content ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $content;
+		}
 		if ( function_exists( 'has_block' ) && has_block( 'gallery', $content ) ) {
 			$this->enqueue_assets();
 			$content = $this->add_data_to_container( $content );
@@ -346,6 +353,9 @@ class Jetpack_Carousel {
 	}
 
 	function set_in_gallery( $output ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $output;
+		}
 		$this->in_gallery = true;
 		return $output;
 	}
@@ -361,6 +371,10 @@ class Jetpack_Carousel {
 	 * @return string Modified HTML content of the post
 	 */
 	function add_data_img_tags_and_enqueue_assets( $content ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $content;
+		}
+
 		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
 			return $content;
 		}
@@ -411,6 +425,10 @@ class Jetpack_Carousel {
 	}
 
 	function add_data_to_images( $attr, $attachment = null ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $attr;
+		}
+
 		$attachment_id = intval( $attachment->ID );
 		if ( ! wp_attachment_is_image( $attachment_id ) ) {
 			return $attr;
@@ -479,6 +497,9 @@ class Jetpack_Carousel {
 
 	function add_data_to_container( $html ) {
 		global $post;
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $html;
+		}
 
 		if ( isset( $post ) ) {
 			$blog_id = (int) get_current_blog_id();

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -958,7 +958,7 @@ function stats_admin_bar_head() {
 }
 #wpadminbar .quicklinks li#wp-admin-bar-stats a img {
 	height: 24px;
-	padding: 4px 0;
+	margin: 4px 0;
 	max-width: none;
 	border: none;
 }
@@ -983,7 +983,15 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 
 	$title = esc_attr( __( 'Views over 48 hours. Click for more Site Stats.', 'jetpack' ) );
 
-	$menu = array( 'id' => 'stats', 'title' => "<div><script type='text/javascript'>var src;if(typeof(window.devicePixelRatio)=='undefined'||window.devicePixelRatio<2){src='$img_src';}else{src='$img_src_2x';}document.write('<img src=\''+src+'\' alt=\'$alt\' title=\'$title\' />');</script></div>", 'href' => $url );
+	$menu = array(
+		'id'   => 'stats',
+		'href' => $url,
+	);
+	if ( Jetpack_AMP_Support::is_amp_request() ) {
+		$menu['title'] = "<amp-img src='$img_src_2x' width=112 height=24 layout=fixed alt='$alt' title='$title'></amp-img>";
+	} else {
+		$menu['title'] = "<div><script type='text/javascript'>var src;if(typeof(window.devicePixelRatio)=='undefined'||window.devicePixelRatio<2){src='$img_src';}else{src='$img_src_2x';}document.write('<img src=\''+src+'\' alt=\'$alt\' title=\'$title\' />');</script></div>";
+	}
 
 	$wp_admin_bar->add_menu( $menu );
 }

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -74,6 +74,10 @@ class Milestone_Widget extends WP_Widget {
 	}
 
 	public static function enqueue_template() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'milestone',
 			Jetpack::get_file_url_for_environment(
@@ -175,6 +179,10 @@ class Milestone_Widget extends WP_Widget {
 	 * Hooks into the "wp_footer" action.
 	 */
 	function localize_script() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		if ( empty( self::$config_js['instances'] ) ) {
 			wp_dequeue_script( 'milestone' );
 			return;


### PR DESCRIPTION
Jetpack stats are currently broken for sites running 1.0 of the AMP plugin. See https://github.com/ampproject/amp-wp/issues/1722 and https://wordpress.org/support/topic/v1-0-has-broken-jetpack-stats-tracking/

The problem is that the plugin was not updated after https://github.com/ampproject/amp-wp/issues/1148#issuecomment-399573472 was done during the AMP plugin's beta releases. 

To fix, Jetpack needs to wait until after `parse_query` action has happened in order to determine whether an AMP response is being served. 

This PR also:

* Eliminates the omission of the Milestone widget in AMP; instead the widget's output is modified to make it AMP compatible.
* Jetpack stats in the admin bar are made AMP compatible.

Closes #9588.
See also #9730.

/cc @gravityrail 