### PR TITLE
Jumpstart: add link to dismiss Jumpstart inside modal.

### DIFF
--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -13,7 +16,7 @@ import { translate as __ } from 'i18n-calypso';
 import {
 	jumpStartActivate,
 	jumpStartSkip,
-	isJumpstarting as _isJumpstarting
+	isJumpstarting as _isJumpstarting,
 } from 'state/jumpstart';
 import { getModulesByFeature as _getModulesByFeature } from 'state/modules';
 import { imagePath } from 'constants/urls';
@@ -23,25 +26,40 @@ class JumpStart extends React.Component {
 	static displayName = 'JumpStart';
 
 	activateButton = () => {
-		return <Button
-			primary={ true }
-			onClick={ this.props.jumpStartActivate }
-			disabled={ this.props.isJumpstarting }
-		>
-			{ this.props.isJumpstarting ? __( 'Activating recommended features…' ) : __( 'Activate recommended features' ) }
-		</Button>;
+		return (
+			<div>
+				<Button
+					primary={ true }
+					onClick={ this.props.jumpStartActivate }
+					disabled={ this.props.isJumpstarting }
+				>
+					{ this.props.isJumpstarting
+						? __( 'Activating recommended features…' )
+						: __( 'Activate recommended features' ) }
+				</Button>
+
+				<p>
+					<a
+						href="javascript:void(0)"
+						onClick={ this.props.jumpStartSkip }
+						className="jp-jumpstart__skip-link"
+					>
+						{ __( 'Skip and explore features' ) }
+					</a>
+				</p>
+			</div>
+		);
 	};
 
 	renderInnerContent() {
 		/* eslint-disable react/no-danger */
-		const jumpstartModules = this.props.jumpstartFeatures.map( ( module ) => (
+		const jumpstartModules = this.props.jumpstartFeatures.map( module => (
 			<div
 				className="jp-jumpstart__feature-list-column"
-				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ } >
+				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ }
+			>
 				<div className="jp-jumpstart__feature-content">
-					<h4
-						className="jp-jumpstart__feature-content-title"
-						title={ module.name }>
+					<h4 className="jp-jumpstart__feature-content-title" title={ module.name }>
 						{ module.name }
 					</h4>
 					<p dangerouslySetInnerHTML={ renderJumpstartDescription( module ) } />
@@ -53,21 +71,19 @@ class JumpStart extends React.Component {
 		return (
 			<div className="jp-jumpstart">
 				<p>
-					{ __( "We're now collecting stats, securing your site, and speeding up your images. Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard." ) }
+					{ __(
+						"We're now collecting stats, securing your site, and speeding up your images. Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard."
+					) }
 				</p>
 
-				<p>
-					{ this.activateButton() }
-				</p>
+				<p>{ this.activateButton() }</p>
 
 				<div>
 					<h2 className="jp-jumpstart__feature-heading">
 						{ __( "Jetpack's recommended features include:" ) }
 					</h2>
 
-					<div className="jp-jumpstart__feature-list">
-						{ jumpstartModules }
-					</div>
+					<div className="jp-jumpstart__feature-list">{ jumpstartModules }</div>
 
 					{ this.activateButton() }
 
@@ -82,7 +98,14 @@ class JumpStart extends React.Component {
 	render() {
 		return (
 			<JetpackDialogue
-				svg={ <img src={ imagePath + 'man-and-laptop.svg' } width="199" height="153" alt={ __( 'Person with laptop' ) } /> }
+				svg={
+					<img
+						src={ imagePath + 'man-and-laptop.svg' }
+						width="199"
+						height="153"
+						alt={ __( 'Person with laptop' ) }
+					/>
+				}
 				title={ __( 'Your Jetpack site is ready to go!' ) }
 				content={ this.renderInnerContent() }
 				dismiss={ this.props.jumpStartSkip }
@@ -95,7 +118,7 @@ export default connect(
 	state => {
 		return {
 			isJumpstarting: _isJumpstarting( state ),
-			jumpstartFeatures: _getModulesByFeature( state, 'Jumpstart' )
+			jumpstartFeatures: _getModulesByFeature( state, 'Jumpstart' ),
 		};
 	},
 	dispatch => bindActionCreators( { jumpStartActivate, jumpStartSkip }, dispatch )

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -76,7 +76,7 @@ class JumpStart extends React.Component {
 					) }
 				</p>
 
-				<p>{ this.activateButton() }</p>
+				{ this.activateButton() }
 
 				<div>
 					<h2 className="jp-jumpstart__feature-heading">


### PR DESCRIPTION
Fixes #10686

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add a link to skip Jumpstart inside the modal:

<img width="787" alt="screenshot 2018-12-10 at 20 22 00" src="https://user-images.githubusercontent.com/426388/49756076-dce5d800-fcb9-11e8-958e-4562a01f2200.png">

#### Testing instructions:

* checkout this branch.
* Start from a site with a brand new Jetpack installation.
* Connect your site to WordPress.com
* As you come back to your dashboard, check the modal that pops up.

#### Proposed changelog entry for your changes:

* Connection flow: make it easier to skip recommendations when connecting the plugin to WordPress.com.
