### PR TITLE
Revert "Update dependency history to v4"

### DIFF
--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -3,7 +3,7 @@
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
-import { createBrowserHistory } from 'history';
+import { createHistory } from 'history';
 import analytics from 'lib/analytics';
 
 /**
@@ -57,7 +57,7 @@ export const jumpStartActivate = () => {
 	};
 };
 
-const history = createBrowserHistory();
+const history = createHistory();
 
 export const jumpStartSkip = () => {
 	return ( dispatch ) => {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "gulp-sourcemaps": "2.6.4",
     "gulp-tap": "0.1.3",
     "gulp-uglify": "3.0.1",
-    "history": "4.7.2",
+    "history": "3.3.0",
     "i18n-calypso": "3.0.0",
     "jsdom": "9.12.0",
     "jsdom-global": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,17 +3870,7 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-history@4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
-  dependencies:
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    resolve-pathname "^2.2.0"
-    value-equal "^0.4.0"
-    warning "^3.0.0"
-
-history@^3.0.0:
+history@3.3.0, history@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
   dependencies:
@@ -7051,10 +7041,6 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-pathname@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -8208,10 +8194,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-value-equal@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
 value-or-function@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Reverts Automattic/jetpack#10852

This one broke `yarn build`.

Fixes #10921.

#### Testing instructions

* Checkout this branch
* Make sure you can `yarn build` successfully

#### Proposed changelog entry

None needed