### PR TITLE
Settings: add new card for managing plugins.

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -27,8 +30,11 @@ class DashPluginUpdates extends Component {
 
 	activateAndRedirect( e ) {
 		e.preventDefault();
-		this.props.activateManage()
-			.then( window.location = 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl );
+		this.props
+			.activateManage()
+			.then(
+				( window.location = 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl )
+			);
 	}
 
 	getContent() {
@@ -36,17 +42,15 @@ class DashPluginUpdates extends Component {
 		const pluginUpdates = this.props.pluginUpdates;
 
 		const support = {
-			text: __( 'Jetpack’s Plugin Updates allows you to choose which plugins update automatically.' ),
+			text: __(
+				'Jetpack’s Plugin Updates allows you to choose which plugins update automatically.'
+			),
 			link: 'https://jetpack.com/support/site-management/',
 		};
 
 		if ( 'N/A' === pluginUpdates ) {
 			return (
-				<DashItem
-					label={ labelName }
-					module="manage"
-					support={ support }
-					status="is-working" >
+				<DashItem label={ labelName } module="manage" support={ support } status="is-working">
 					<QueryPluginUpdates />
 					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 				</DashItem>
@@ -64,30 +68,27 @@ class DashPluginUpdates extends Component {
 				module="manage"
 				support={ support }
 				status={ updatesAvailable ? 'is-warning' : workingOrInactive }
-				>
-				{
-					updatesAvailable && (
-						<h2 className="jp-dash-item__count">
-							{
-								__( '%(number)s', '%(number)s', {
-									count: pluginUpdates.count,
-									args: { number: pluginUpdates.count }
-								} )
-							}
-						</h2>
-					)
-				}
+			>
+				{ updatesAvailable && (
+					<h2 className="jp-dash-item__count">
+						{ __( '%(number)s', '%(number)s', {
+							count: pluginUpdates.count,
+							args: { number: pluginUpdates.count },
+						} ) }
+					</h2>
+				) }
 				<p className="jp-dash-item__description">
-					{
-						updatesAvailable
-							? [
-								__( 'Plugin needs updating.', 'Plugins need updating.', { count: pluginUpdates.count } ) + ' ',
-								! this.props.isDevMode && __( '{{a}}Turn on plugin autoupdates{{/a}}', {
-									components: { a: <a href={ managePluginsUrl } /> }
-								} )
-							]
-							: __( 'All plugins are up-to-date. Awesome work!' )
-					}
+					{ updatesAvailable
+						? [
+							__( 'Plugin needs updating.', 'Plugins need updating.', {
+								count: pluginUpdates.count,
+							} ) + ' ',
+							! this.props.isDevMode &&
+									__( '{{a}}Turn on plugin autoupdates{{/a}}', {
+										components: { a: <a href={ managePluginsUrl } /> },
+									} ),
+						]
+						: __( 'All plugins are up-to-date. Awesome work!' ) }
 				</p>
 			</DashItem>,
 			! this.props.isDevMode && (
@@ -96,27 +97,28 @@ class DashPluginUpdates extends Component {
 					className="jp-dash-item__manage-in-wpcom"
 					compact
 					href={ managePluginsUrl }
+					target="_blank"
 				>
 					{ __( 'Manage your plugins' ) }
 				</Card>
-			)
+			),
 		];
 	}
 
 	render() {
-		return this.props.isModuleAvailable && (
-			<div>
-				<QueryPluginUpdates />
-				{ this.getContent() }
-			</div>
+		return (
+			this.props.isModuleAvailable && (
+				<div>
+					<QueryPluginUpdates />
+					{ this.getContent() }
+				</div>
+			)
 		);
 	}
 }
 
-export default connect(
-	state => ( {
-		pluginUpdates: getPluginUpdates( state ),
-		isDevMode: isDevMode( state ),
-		isModuleAvailable: isModuleAvailable( state, 'manage' ),
-	} )
-)( DashPluginUpdates );
+export default connect( state => ( {
+	pluginUpdates: getPluginUpdates( state ),
+	isDevMode: isDevMode( state ),
+	isModuleAvailable: isModuleAvailable( state, 'manage' ),
+} ) )( DashPluginUpdates );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
@@ -17,6 +20,7 @@ import QuerySite from 'components/data/query-site';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
 import BackupsScan from './backups-scan';
 import Antispam from './antispam';
+import { ManagePlugins } from './manage-plugins';
 import { Monitor } from './monitor';
 import { Protect } from './protect';
 import { SSO } from './sso';
@@ -69,13 +73,21 @@ export class Security extends Component {
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
-			foundMonitor = this.props.isModuleFound( 'monitor' );
+			foundMonitor = this.props.isModuleFound( 'monitor' ),
+			foundManage = this.props.isModuleFound( 'manage' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor ) {
+		if (
+			! foundSso &&
+			! foundProtect &&
+			! foundAkismet &&
+			! foundBackups &&
+			! foundMonitor &&
+			! foundManage
+		) {
 			return null;
 		}
 
@@ -84,11 +96,13 @@ export class Security extends Component {
 				<QuerySite />
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundMonitor && <Monitor { ...commonProps } /> }
-				{ foundAkismet &&
+				{ foundAkismet && (
 					<div>
 						<Antispam { ...commonProps } />
 						<QueryAkismetKeyCheck />
-					</div> }
+					</div>
+				) }
+				{ foundManage && <ManagePlugins { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
 			</div>

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+
+export const ManagePlugins = moduleSettingsForm(
+	class extends Component {
+		trackOpenCard = () => {
+			analytics.tracks.recordJetpackClick( {
+				target: 'foldable-settings-open',
+				feature: 'manage-plugins',
+			} );
+		};
+
+		trackClickConfigure() {
+			analytics.tracks.recordJetpackClick( {
+				target: 'configure-plugins',
+				page: 'plugins-manage',
+			} );
+		}
+
+		render() {
+			const configLink = () => {
+				if ( this.props.isUnavailableInDevMode( 'manage' ) ) {
+					return;
+				}
+
+				return (
+					<Card
+						compact
+						className="jp-settings-card__configure-link"
+						onClick={ this.trackClickConfigure }
+						target="_blank"
+						rel="noopener noreferrer"
+						href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl }
+					>
+						{ __( 'Manage plugins' ) }
+					</Card>
+				);
+			};
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="manage"
+					header={ __( 'Plugin Autoupdates', { context: 'Settings header' } ) }
+					hideButton
+				>
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'manage' ) } >
+						<p>
+							{ __(
+								'When a plugin update is released, the best practice is to update that plugin right away. ' +
+									"Choose which plugins you'd like to autoupdate so that your site stays secure."
+							) }
+						</p>
+					</SettingsGroup>
+					{ configLink() }
+				</SettingsCard>
+			);
+		}
+	}
+);

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -46,7 +46,7 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 					rel="noopener noreferrer"
 					href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl }
 				>
-					{ __( 'Manage plugins' ) }
+					{ __( 'Manage your plugins' ) }
 				</Card>
 			);
 		};

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -12,11 +12,11 @@ import { translate as __ } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import Card from 'components/card';
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
-export const ManagePlugins = moduleSettingsForm(
+export const ManagePlugins = withModuleSettingsFormHelpers(
 	class extends Component {
 		trackOpenCard = () => {
 			analytics.tracks.recordJetpackClick( {
@@ -59,7 +59,7 @@ export const ManagePlugins = moduleSettingsForm(
 					header={ __( 'Plugin Autoupdates', { context: 'Settings header' } ) }
 					hideButton
 				>
-					<SettingsGroup disableInDevMode module={ this.props.getModule( 'manage' ) } >
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'manage' ) }>
 						<p>
 							{ __(
 								'When a plugin update is released, the best practice is to update that plugin right away. ' +

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -32,26 +32,26 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 			} );
 		}
 
+		configLink = () => {
+			if ( this.props.isUnavailableInDevMode( 'manage' ) ) {
+				return;
+			}
+
+			return (
+				<Card
+					compact
+					className="jp-settings-card__configure-link"
+					onClick={ this.trackClickConfigure }
+					target="_blank"
+					rel="noopener noreferrer"
+					href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl }
+				>
+					{ __( 'Manage plugins' ) }
+				</Card>
+			);
+		};
+
 		render() {
-			const configLink = () => {
-				if ( this.props.isUnavailableInDevMode( 'manage' ) ) {
-					return;
-				}
-
-				return (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						onClick={ this.trackClickConfigure }
-						target="_blank"
-						rel="noopener noreferrer"
-						href={ 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl }
-					>
-						{ __( 'Manage plugins' ) }
-					</Card>
-				);
-			};
-
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -67,7 +67,7 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 							) }
 						</p>
 					</SettingsGroup>
-					{ configLink() }
+					{ this.configLink() }
 				</SettingsCard>
 			);
 		}


### PR DESCRIPTION
Fixes #10694 

#### Changes proposed in this Pull Request:

This PR adds a new card for managing plugins.

**When connected**
<img width="904" alt="screenshot 2018-12-10 at 22 36 23" src="https://user-images.githubusercontent.com/426388/49764315-605df400-fccf-11e8-85f5-dafbc0012fd9.png">

**When in dev mode**

<img width="845" alt="screenshot 2018-12-10 at 22 49 55" src="https://user-images.githubusercontent.com/426388/49764326-65bb3e80-fccf-11e8-91de-fdcaa3715419.png">

#### Testing instructions:

* Go to Jetpack > Settings while your site is in dev mode, with Manage active, or with Manage off.
* Make sure the new card in the Security tab looks good.

#### Proposed changelog entry for your changes:
* Settings: add new card for plugins management.