### PR TITLE
Admin Page: Add actionable card for creating a Testimonial post when the post type is active

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -9,6 +9,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 /**
  * Internal dependencies
  */
+import CompactCard from 'components/card/compact';
 import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModule, getModuleOverride } from 'state/modules';
@@ -99,6 +100,11 @@ export class CustomContentTypes extends React.Component {
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
+				<CompactCard
+					className="jp-settings-card__configure-link"
+					href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }>
+					{ __( 'Add a testimonial' ) }
+				</CompactCard>
 				<SettingsGroup
 					hasChild
 					module={ module }

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -100,11 +100,15 @@ export class CustomContentTypes extends React.Component {
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
-				<CompactCard
-					className="jp-settings-card__configure-link"
-					href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }>
-					{ __( 'Add a testimonial' ) }
-				</CompactCard>
+				{
+					this.props.testimonialActive && (
+						<CompactCard
+							className="jp-settings-card__configure-link"
+							href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }>
+							{ __( 'Add a testimonial' ) }
+						</CompactCard>
+					)
+				}
 				<SettingsGroup
 					hasChild
 					module={ module }
@@ -150,12 +154,15 @@ export class CustomContentTypes extends React.Component {
 	}
 }
 
-export default connect(
-	( state ) => {
+export default withModuleSettingsFormHelpers( connect(
+	( state, ownProps ) => {
+		const testimonialActive = ownProps.getSettingCurrentValue( 'jetpack_testimonial', 'custom-content-types' );
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
-			getModuleOverride: ( module_name ) => getModuleOverride( state, module_name )
+			getModuleOverride: ( module_name ) => getModuleOverride( state, module_name ),
+			testimonialActive,
 		};
 	}
-)( withModuleSettingsFormHelpers( CustomContentTypes ) );
+)( CustomContentTypes ) );
+


### PR DESCRIPTION
Addresses #10690 partially.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds actionable card below the testimonial setting card.

#### Testing instructions:

* Checkout this branch 
* Visit the Jetpack settings page.
* Confirm you see the actionable card if the post type is active.

Or launch a jn site [with this branch](https://jurassic.ninja/create?jetpack-beta&branch=update/make-testimonial-actionable&shortlived&wp-debug-log&gutenberg)
  * Connect the site
  * Check the Jetpack admin page (Writing Settings)
  * Activate deactivate Testimonial and confirm behaviour is the expected one.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added actionable card below the Jetpack settings card for Testimonial post types.


#### Screenshots

Design proposal in #10690

**After**

Testimonials active

![image](https://user-images.githubusercontent.com/746152/49766030-d43dd380-fcb2-11e8-84e3-05679212c98e.png)



