### PR TITLE
Gutenberg: Register VR block specifically

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -13,6 +13,8 @@ jetpack_register_block(
 	)
 );
 
+jetpack_register_block( 'vr' );
+
 /**
  * Map block registration/dependency declaration.
  *


### PR DESCRIPTION
Since we are going to offer a VR block soon, we need to specifically register it on the server side, so it makes the VR block available in our block availability endpoint. 

#### Changes proposed in this Pull Request:

* Register the VR block on the server side.

#### Testing instructions:

* Spin this PR up, or start a JN site with this branch.
* Start writing a post.
* Type `window.Jetpack_Editor_Initial_State.available_blocks` in your browser console.
* Verify it contains `vr: { available: true }`

