### PR TITLE
Admin Page: Add actionable card for creating a Portfolio item when the post type is active

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -149,6 +149,15 @@ export class CustomContentTypes extends React.Component {
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
+				{
+					this.props.portfolioActive && (
+						<CompactCard
+							className="jp-settings-card__configure-link"
+							href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-portfolio` }>
+							{ __( 'Add a portfolio' ) }
+						</CompactCard>
+					)
+				}
 			</SettingsCard>
 		);
 	}
@@ -156,13 +165,14 @@ export class CustomContentTypes extends React.Component {
 
 export default withModuleSettingsFormHelpers( connect(
 	( state, ownProps ) => {
+		const portfolioActive = ownProps.getSettingCurrentValue( 'jetpack_portfolio', 'custom-content-types' );
 		const testimonialActive = ownProps.getSettingCurrentValue( 'jetpack_testimonial', 'custom-content-types' );
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			getModuleOverride: ( module_name ) => getModuleOverride( state, module_name ),
+			portfolioActive,
 			testimonialActive,
 		};
 	}
 )( CustomContentTypes ) );
-

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -148,7 +148,7 @@ export class CustomContentTypes extends React.Component {
 						className="jp-settings-card__configure-link"
 						href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-portfolio` }
 					>
-						{ __( 'Add a portfolio' ) }
+						{ __( 'Add a portfolio item' ) }
 					</CompactCard>
 				) }
 			</SettingsCard>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -40,8 +40,8 @@ export class CustomContentTypes extends React.Component {
 	};
 
 	linkIfActiveCPT = type => {
-		return this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' ) ? (
-			<a href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type } />
+		return this.props.getSettingCurrentValue( `jetpack_${ type }`, 'custom-content-types' ) ? (
+			<a href={ `${ this.props.siteAdminUrl }edit.php?post_type=jetpack-${ type }` } />
 		) : (
 			<span />
 		);

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
@@ -20,34 +23,37 @@ import SettingsGroup from 'components/settings-group';
 export class CustomContentTypes extends React.Component {
 	state = {
 		testimonial: this.props.getOptionValue( 'jetpack_testimonial', 'custom-content-types' ),
-		portfolio: this.props.getOptionValue( 'jetpack_portfolio', 'custom-content-types' )
+		portfolio: this.props.getOptionValue( 'jetpack_portfolio', 'custom-content-types' ),
 	};
 
 	updateCPTs = type => {
-		const deactivate = 'testimonial' === type
-			? ! ( ( ! this.state.testimonial ) || this.state.portfolio )
-			: ! ( ( ! this.state.portfolio ) || this.state.testimonial );
+		const deactivate =
+			'testimonial' === type
+				? ! ( ! this.state.testimonial || this.state.portfolio )
+				: ! ( ! this.state.portfolio || this.state.testimonial );
 
 		this.props.updateFormStateModuleOption( 'custom-content-types', 'jetpack_' + type, deactivate );
 
 		this.setState( {
-			[ type ]: ! this.state[ type ]
+			[ type ]: ! this.state[ type ],
 		} );
 	};
 
 	linkIfActiveCPT = type => {
-		return this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
-			? <a href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type } />
-			: <span />;
+		return this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' ) ? (
+			<a href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type } />
+		) : (
+			<span />
+		);
 	};
 
 	handleTestimonialToggleChange = () => {
 		this.updateCPTs( 'testimonial' );
-	}
+	};
 
 	handlePortfolioToggleChange = () => {
 		this.updateCPTs( 'portfolio' );
-	}
+	};
 
 	render() {
 		if ( ! this.props.isModuleFound( 'custom-content-types' ) ) {
@@ -55,20 +61,19 @@ export class CustomContentTypes extends React.Component {
 		}
 
 		const module = this.props.module( 'custom-content-types' );
-		const disabledByOverride = ( 'inactive' === this.props.getModuleOverride( 'custom-content-types' ) );
-		const disabledReason = disabledByOverride && __( 'This feature has been disabled by a site administrator.' );
+		const disabledByOverride =
+			'inactive' === this.props.getModuleOverride( 'custom-content-types' );
+		const disabledReason =
+			disabledByOverride && __( 'This feature has been disabled by a site administrator.' );
 		return (
-			<SettingsCard
-				{ ...this.props }
-				module="custom-content-types"
-				hideButton>
+			<SettingsCard { ...this.props } module="custom-content-types" hideButton>
 				<SettingsGroup
 					hasChild
 					module={ module }
 					support={ {
 						link: 'https://jetpack.com/support/custom-content-types/',
 					} }
-					>
+				>
 					<p>
 						{ __(
 							'Add {{testimonialLink}}testimonials{{/testimonialLink}} to ' +
@@ -77,8 +82,8 @@ export class CustomContentTypes extends React.Component {
 								'shortcode to display them on your site.',
 							{
 								components: {
-									testimonialLink: this.linkIfActiveCPT( 'testimonial' )
-								}
+									testimonialLink: this.linkIfActiveCPT( 'testimonial' ),
+								},
 							}
 						) }
 					</p>
@@ -87,12 +92,8 @@ export class CustomContentTypes extends React.Component {
 						disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) || disabledByOverride }
 						onChange={ this.handleTestimonialToggleChange }
 						disabledReason={ disabledReason }
-						>
-						<span className="jp-form-toggle-explanation">
-							{
-								__( 'Testimonials' )
-							}
-						</span>
+					>
+						<span className="jp-form-toggle-explanation">{ __( 'Testimonials' ) }</span>
 					</CompactFormToggle>
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
@@ -100,22 +101,21 @@ export class CustomContentTypes extends React.Component {
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
-				{
-					this.props.testimonialActive && (
-						<CompactCard
-							className="jp-settings-card__configure-link"
-							href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }>
-							{ __( 'Add a testimonial' ) }
-						</CompactCard>
-					)
-				}
+				{ this.props.testimonialActive && (
+					<CompactCard
+						className="jp-settings-card__configure-link"
+						href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }
+					>
+						{ __( 'Add a testimonial' ) }
+					</CompactCard>
+				) }
 				<SettingsGroup
 					hasChild
 					module={ module }
 					support={ {
 						link: 'https://jetpack.com/support/custom-content-types/',
 					} }
-					>
+				>
 					<p>
 						{ __(
 							'Use {{portfolioLink}}portfolios{{/portfolioLink}} on your ' +
@@ -124,8 +124,8 @@ export class CustomContentTypes extends React.Component {
 								'display them on your site.',
 							{
 								components: {
-									portfolioLink: this.linkIfActiveCPT( 'portfolio' )
-								}
+									portfolioLink: this.linkIfActiveCPT( 'portfolio' ),
+								},
 							}
 						) }
 					</p>
@@ -134,45 +134,44 @@ export class CustomContentTypes extends React.Component {
 						disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) || disabledByOverride }
 						onChange={ this.handlePortfolioToggleChange }
 						disabledReason={ disabledReason }
-						>
-						<span className="jp-form-toggle-explanation">
-							{
-								__( 'Portfolios' )
-							}
-						</span>
+					>
+						<span className="jp-form-toggle-explanation">{ __( 'Portfolios' ) }</span>
 					</CompactFormToggle>
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
-							{
-								__( 'Portfolios shortcode: [portfolio]' )
-							}
+							{ __( 'Portfolios shortcode: [portfolio]' ) }
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
-				{
-					this.props.portfolioActive && (
-						<CompactCard
-							className="jp-settings-card__configure-link"
-							href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-portfolio` }>
-							{ __( 'Add a portfolio' ) }
-						</CompactCard>
-					)
-				}
+				{ this.props.portfolioActive && (
+					<CompactCard
+						className="jp-settings-card__configure-link"
+						href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-portfolio` }
+					>
+						{ __( 'Add a portfolio' ) }
+					</CompactCard>
+				) }
 			</SettingsCard>
 		);
 	}
 }
 
-export default withModuleSettingsFormHelpers( connect(
-	( state, ownProps ) => {
-		const portfolioActive = ownProps.getSettingCurrentValue( 'jetpack_portfolio', 'custom-content-types' );
-		const testimonialActive = ownProps.getSettingCurrentValue( 'jetpack_testimonial', 'custom-content-types' );
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		const portfolioActive = ownProps.getSettingCurrentValue(
+			'jetpack_portfolio',
+			'custom-content-types'
+		);
+		const testimonialActive = ownProps.getSettingCurrentValue(
+			'jetpack_testimonial',
+			'custom-content-types'
+		);
 		return {
-			module: ( module_name ) => getModule( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
-			getModuleOverride: ( module_name ) => getModuleOverride( state, module_name ),
+			module: module_name => getModule( state, module_name ),
+			isModuleFound: module_name => _isModuleFound( state, module_name ),
+			getModuleOverride: module_name => getModuleOverride( state, module_name ),
 			portfolioActive,
 			testimonialActive,
 		};
-	}
-)( CustomContentTypes ) );
+	} )( CustomContentTypes )
+);


### PR DESCRIPTION
Closes #10690.


#### Changes proposed in this Pull Request:

* Adds actionable card below the portfolios setting card. (mostly same change as in #10926 but it may be a bit scrambled after prettier was run on this file.
* Applies prettier on the file. 

#### Testing instructions:

* Checkout this branch 
* Visit the Jetpack settings page.
* Confirm you see the actionable card if the post type is active.

Or launch a jn site [with this branch](https://jurassic.ninja/create?jetpack-beta&branch=update/make-portfolios-actionable&shortlived&wp-debug-log&gutenberg)
  * Connect the site
  * Check the Jetpack admin page (Writing Settings)
  * Activate deactivate Portfolios and confirm behaviour is the expected one.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added actionable card below the Jetpack settings card for Porfolio post types.


#### Screenshots

Design proposal in #10690

**After**

![image](https://user-images.githubusercontent.com/746152/49806955-b6ff1880-fd37-11e8-9aa4-d73ccd22d8c7.png)



