### PR TITLE
Settings: add descriptions to settings sections

### DIFF
--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -48,11 +48,9 @@ export class Discussion extends React.Component {
 				<QuerySite />
 
 				<Card
-					title={ __( 'Discussion Tools' ) }
+					title={ __( 'Open your site to comments and invite subscribers to get alerts about your latest work.' ) }
 					className="jp-settings-description"
-				>
-					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
-				</Card>
+				/>
 
 				<Comments
 					{ ...commonProps }

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -3,10 +3,12 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
@@ -44,6 +46,14 @@ export class Discussion extends React.Component {
 		return (
 			<div>
 				<QuerySite />
+
+				<Card
+					title={ __( 'Discussion Tools' ) }
+					className="jp-settings-description"
+				>
+					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
+				</Card>
+
 				<Comments
 					{ ...commonProps }
 					isModuleFound={ this.props.isModuleFound }

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -86,11 +86,9 @@ export class Security extends Component {
 				<QuerySite />
 
 				<Card
-					title={ __( 'Security Tools' ) }
+					title={ __( 'Keep your site safe with state-of-the-art security and receive notifications of technical problems.' ) }
 					className="jp-settings-description"
-				>
-					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
-				</Card>
+				/>
 
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundMonitor && <Monitor { ...commonProps } /> }

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -4,10 +4,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
@@ -82,6 +84,14 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
+
+				<Card
+					title={ __( 'Security Tools' ) }
+					className="jp-settings-description"
+				>
+					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
+				</Card>
+
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundMonitor && <Monitor { ...commonProps } /> }
 				{ foundAkismet &&

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -8,12 +8,12 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import Discussion from 'discussion';
-import Security from 'security/index.jsx';
+import Security from 'security';
 import Traffic from 'traffic';
-import Writing from 'writing/index.jsx';
-import Sharing from 'sharing/index.jsx';
-import SearchableModules from 'searchable-modules/index.jsx';
-import Privacy from 'privacy/index.jsx';
+import Writing from 'writing';
+import Sharing from 'sharing';
+import SearchableModules from 'searchable-modules';
+import Privacy from 'privacy';
 
 export default class extends React.Component {
 	static displayName = 'SearchableSettings';

--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -20,7 +20,7 @@
 
 .dops-card.jp-settings-description {
 	margin: 24px 0 8px;
-	padding: 0 16px;
+	padding: 0;
 	background: none;
 	box-shadow: none;
 }

--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -19,12 +19,8 @@
 }
 
 .dops-card.jp-settings-description {
-	margin: 24px 0 16px;
+	margin: 24px 0 8px;
 	padding: 0 16px;
 	background: none;
 	box-shadow: none;
-
-	p {
-		font-size: rem( 14px );
-	}
 }

--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -17,3 +17,14 @@
 		height: 46px;
 	}
 }
+
+.dops-card.jp-settings-description {
+	margin: 24px 0 16px;
+	padding: 0 16px;
+	background: none;
+	box-shadow: none;
+
+	p {
+		font-size: rem( 14px );
+	}
+}

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -3,10 +3,12 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
@@ -51,6 +53,14 @@ class Sharing extends Component {
 		return (
 			<div>
 				<QuerySite />
+
+				<Card
+					title={ __( 'Sharing Tools' ) }
+					className="jp-settings-description"
+				>
+					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
+				</Card>
+
 				{
 					foundPublicize && (
 						<Publicize

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -55,11 +55,9 @@ class Sharing extends Component {
 				<QuerySite />
 
 				<Card
-					title={ __( 'Sharing Tools' ) }
+					title={ __( 'Share your content on social media and increase audience engagement.' ) }
 					className="jp-settings-description"
-				>
-					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
-				</Card>
+				/>
 
 				{
 					foundPublicize && (

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -3,10 +3,12 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
@@ -64,6 +66,14 @@ export class Traffic extends React.Component {
 		return (
 			<div>
 				<QuerySite />
+
+				<Card
+					title={ __( 'Traffic Tools' ) }
+					className="jp-settings-description"
+				>
+					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
+				</Card>
+
 				{
 					foundSearch && (
 						<Search

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -68,11 +68,9 @@ export class Traffic extends React.Component {
 				<QuerySite />
 
 				<Card
-					title={ __( 'Traffic Tools' ) }
+					title={ __( 'Maximize your site’s visibility in search engines and view traffic stats in real time.' ) }
 					className="jp-settings-description"
-				>
-					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
-				</Card>
+				/>
 
 				{
 					foundSearch && (

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -73,11 +73,9 @@ export class Writing extends React.Component {
 				<QuerySite />
 
 				<Card
-					title={ __( 'Writing Tools' ) }
+					title={ __( 'Compose content the way you want to and streamline your publishing experience.' ) }
 					className="jp-settings-description"
-				>
-					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
-				</Card>
+				/>
 
 				{
 					this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -4,11 +4,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { userCanManageModules } from 'state/initial-state';
@@ -71,6 +71,14 @@ export class Writing extends React.Component {
 		return (
 			<div>
 				<QuerySite />
+
+				<Card
+					title={ __( 'Writing Tools' ) }
+					className="jp-settings-description"
+				>
+					<p>{ __( 'This is a placeholder text that will be replaced by a short description of each of the settings pages. The goal is to briefly explain the theme of the settings below.' ) }</p>
+				</Card>
+
 				{
 					this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
 						<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />


### PR DESCRIPTION
Fixes #10688

#### Changes proposed in this Pull Request:

* Adds descriptions to all settings sections headers explaining the theme of the options below.
* Cleans up dependencies paths on `settings/index.jsx`.

![image](https://user-images.githubusercontent.com/390760/49929419-606e1780-feba-11e8-82e2-8da1b914524a.png)

#### Testing instructions:

* Fire up this PR.
* Go to Jetpack settings.
* Read the descriptions on each section.

#### Proposed changelog entry for your changes:

* Settings: add descriptions to settings sections
