### PR TITLE
Jetpack Live Branches: Update script to include WordPress 4

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -30,6 +30,7 @@
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wordpress-4" class="task-list-item-checkbox">Launch with latest WordPress 4.9 instead</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="classic-editor" class="task-list-item-checkbox">Launch with Classic Editor plugin</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -29,6 +29,7 @@
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="wordpress-4" class="task-list-item-checkbox">Launch with latest WordPress 4.9 instead</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="woocommerce" class="task-list-item-checkbox">Launch with WooCommerce installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="code-snippets" class="task-list-item-checkbox">Launch with Code Snippets installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-rollback" class="task-list-item-checkbox">Launch with WP Rollback installed</li>

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -18,7 +18,7 @@
 		const branchIsMerged = $( '.gh-header-meta .State' ).text().trim() === 'Merged';
 		const isGutenbergPr = $( ".discussion-sidebar .sidebar-labels .labels a[title='Gutenberg']" ).length;
 		const base = 'https://jurassic.ninja/create?';
-		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log&gutenberg${ isGutenbergPr ? '&gutenpack' : '' }`;
+		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log${ isGutenbergPr ? '&gutenpack' : '' }`;
 		let link = base + query;
 		const canLiveTestText =
 			`<div id="jetpack-live-branches">
@@ -27,7 +27,7 @@
 			<ul>
 			<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
-			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" checked class="task-list-item-checkbox">Launch with Gutenberg installed</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wordpress-4" class="task-list-item-checkbox">Launch with latest WordPress 4.9 instead</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="classic-editor" class="task-list-item-checkbox">Launch with Classic Editor plugin</li>

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.8
+// @version      1.9
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Updates the Jetpack Live Brances script to better suit the WordPress 5.0 release

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds a checkbox for launching with WordPress 4.
* Adds a checkbox for launching with the Classic Editor plugin.
* Makes gutenberg not be a default.
* Bumps script version to `1.9`.

![image](https://user-images.githubusercontent.com/746152/49816776-62669800-fd4d-11e8-8c6f-3e689f09fa51.png)


#### Testing instructions:

* Install ths 1.5 version of the script by clicking [here](https://github.com/Automattic/jetpack/raw/update/jetpack-live-branches-include-wordpress-4/tools/jetpack-live-branches/jetpack-live-branches.user.js).
*  Visit a Pull Request.
* Expect Gutenberg to not be checked by default
* Check the classic editor and WordPress 4 checkboxes and launch a site
* Expect it to be carrying WordPress 4.9.8 and the classic editor plugin.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
