### PR TITLE
Fix checks for serving AMP response and improve AMP compatibility

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -64,18 +64,6 @@ class Jetpack_AMP_Support {
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
 	}
 
-	static function filter_available_widgets( $widgets ) {
-		if ( self::is_amp_request() ) {
-			$widgets = array_filter( $widgets, array( 'Jetpack_AMP_Support', 'is_supported_widget' ) );
-		}
-
-		return $widgets;
-	}
-
-	static function is_supported_widget( $widget_path ) {
-		return substr( $widget_path, -14 ) !== '/milestone.php';
-	}
-
 	/**
 	 * Returns whether the request is not AMP.
 	 *
@@ -332,7 +320,3 @@ add_action( 'init', array( 'Jetpack_AMP_Support', 'init' ), 1 );
 
 add_action( 'admin_init', array( 'Jetpack_AMP_Support', 'admin_init' ), 1 );
 
-// this is necessary since for better or worse Jetpack modules and widget files are loaded during plugins_loaded, which means we must
-// take the opportunity to intercept initialisation before that point, either by adding explicit detection into the module,
-// or preventing it from loading in the first place (better for performance)
-add_action( 'plugins_loaded', array( 'Jetpack_AMP_Support', 'init_filter_jetpack_widgets' ), 1 );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -158,6 +158,10 @@ class Jetpack_Carousel {
 	}
 
 	function check_if_shortcode_processed_and_enqueue_assets( $output ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $output;
+		}
+
 		if (
 			! empty( $output ) &&
 			/**
@@ -200,6 +204,9 @@ class Jetpack_Carousel {
 	}
 
 	function check_content_for_blocks( $content ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $content;
+		}
 		if ( function_exists( 'has_block' ) && has_block( 'gallery', $content ) ) {
 			$this->enqueue_assets();
 			$content = $this->add_data_to_container( $content );
@@ -346,6 +353,9 @@ class Jetpack_Carousel {
 	}
 
 	function set_in_gallery( $output ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $output;
+		}
 		$this->in_gallery = true;
 		return $output;
 	}
@@ -361,6 +371,10 @@ class Jetpack_Carousel {
 	 * @return string Modified HTML content of the post
 	 */
 	function add_data_img_tags_and_enqueue_assets( $content ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $content;
+		}
+
 		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
 			return $content;
 		}
@@ -411,6 +425,10 @@ class Jetpack_Carousel {
 	}
 
 	function add_data_to_images( $attr, $attachment = null ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $attr;
+		}
+
 		$attachment_id = intval( $attachment->ID );
 		if ( ! wp_attachment_is_image( $attachment_id ) ) {
 			return $attr;
@@ -479,6 +497,9 @@ class Jetpack_Carousel {
 
 	function add_data_to_container( $html ) {
 		global $post;
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $html;
+		}
 
 		if ( isset( $post ) ) {
 			$blog_id = (int) get_current_blog_id();

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -29,7 +29,7 @@ class Jetpack_Carousel {
 	public $single_image_gallery_enabled_media_file = false;
 
 	function __construct() {
-		add_action( 'init', array( $this, 'init' ) );
+		add_action( 'wp', array( $this, 'init' ), 99 );
 	}
 
 	function init() {
@@ -44,7 +44,7 @@ class Jetpack_Carousel {
 
 		if ( is_admin() ) {
 			// Register the Carousel-related related settings
-			add_action( 'admin_init', array( $this, 'register_settings' ), 5 );
+			$this->register_settings();
 			if ( ! $this->in_jetpack ) {
 				if ( 0 == $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) ) {
 					return; // Carousel disabled, abort early, but still register setting so user can switch it back on

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -38,7 +38,7 @@ class Jetpack_Comment_Likes {
 		$this->url_parts = parse_url( $this->url );
 		$this->domain    = $this->url_parts['host'];
 
-		add_action( 'init', array( $this, 'frontend_init' ) );
+		add_action( 'template_redirect', array( $this, 'frontend_init' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
 		if ( ! Jetpack::is_module_active( 'likes' ) ) {
@@ -117,10 +117,6 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function frontend_init() {
-		if ( is_admin() ) {
-			return;
-		}
-
 		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -103,7 +103,7 @@ class Jetpack_Lazy_Images {
 		}
 
 		// Don't lazyload for amp-wp content
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return $content;
 		}
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -37,8 +37,9 @@ class Jetpack_Likes {
 		$this->in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
 		$this->settings = new Jetpack_Likes_Settings();
 
-		add_action( 'init', array( &$this, 'action_init' ) );
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		// We need to run on wp hook rather than init because we check is_amp_endpoint()
+		// when bootstrapping hooks
+		add_action( 'wp', array( &$this, 'action_init' ), 99 );
 
 		if ( $this->in_jetpack ) {
 			add_action( 'jetpack_activate_module_likes',   array( $this, 'set_social_notifications_like' ) );

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -41,6 +41,8 @@ class Jetpack_Likes {
 		// when bootstrapping hooks
 		add_action( 'wp', array( &$this, 'action_init' ), 99 );
 
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
 		if ( $this->in_jetpack ) {
 			add_action( 'jetpack_activate_module_likes',   array( $this, 'set_social_notifications_like' ) );
 			add_action( 'jetpack_deactivate_module_likes', array( $this, 'delete_social_notifications_like' ) );

--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -11,6 +11,16 @@
  * Additional Search Queries: adminbar, masterbar
  */
 
-include dirname( __FILE__ ) . '/masterbar/masterbar.php';
+require dirname( __FILE__ ) . '/masterbar/masterbar.php';
 
-new A8C_WPCOM_Masterbar;
+// In order to be able to tell if it's an AMP request or not we have to hook into parse_query at a later priority.
+add_action( 'parse_query', 'jetpack_initialize_masterbar', 99 );
+
+/**
+ * Initializes the Masterbar in case the request is not AMP.
+ */
+function jetpack_initialize_masterbar() {
+	if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+		new A8C_WPCOM_Masterbar();
+	}
+}

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -958,7 +958,7 @@ function stats_admin_bar_head() {
 }
 #wpadminbar .quicklinks li#wp-admin-bar-stats a img {
 	height: 24px;
-	padding: 4px 0;
+	margin: 4px 0;
 	max-width: none;
 	border: none;
 }
@@ -983,7 +983,15 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 
 	$title = esc_attr( __( 'Views over 48 hours. Click for more Site Stats.', 'jetpack' ) );
 
-	$menu = array( 'id' => 'stats', 'title' => "<div><script type='text/javascript'>var src;if(typeof(window.devicePixelRatio)=='undefined'||window.devicePixelRatio<2){src='$img_src';}else{src='$img_src_2x';}document.write('<img src=\''+src+'\' alt=\'$alt\' title=\'$title\' />');</script></div>", 'href' => $url );
+	$menu = array(
+		'id'   => 'stats',
+		'href' => $url,
+	);
+	if ( Jetpack_AMP_Support::is_amp_request() ) {
+		$menu['title'] = "<amp-img src='$img_src_2x' width=112 height=24 layout=fixed alt='$alt' title='$title'></amp-img>";
+	} else {
+		$menu['title'] = "<div><script type='text/javascript'>var src;if(typeof(window.devicePixelRatio)=='undefined'||window.devicePixelRatio<2){src='$img_src';}else{src='$img_src_2x';}document.write('<img src=\''+src+'\' alt=\'$alt\' title=\'$title\' />');</script></div>";
+	}
 
 	$wp_admin_bar->add_menu( $menu );
 }

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -74,6 +74,10 @@ class Milestone_Widget extends WP_Widget {
 	}
 
 	public static function enqueue_template() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'milestone',
 			Jetpack::get_file_url_for_environment(
@@ -175,6 +179,10 @@ class Milestone_Widget extends WP_Widget {
 	 * Hooks into the "wp_footer" action.
 	 */
 	function localize_script() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		if ( empty( self::$config_js['instances'] ) ) {
 			wp_dequeue_script( 'milestone' );
 			return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #9588
Fixes #9588
Fixes #10973

Based on #10918

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes --> 
* Make AMP checks later in boot sequence - AMP 1.0 requires that `is_amp_endpoint()` be called after `parse_query`.

This avoids messages like this being printed to the screen or debug.log:

```
[11-Dec-2018 18:10:52 UTC] PHP Notice:  is_amp_endpoint was called <strong>incorrectly</strong>. is_amp_endpoint() was called before the &#039;parse_query&#039; hook was called. This function will always return &#039;false&#039; before the &#039;parse_query&#039; hook is called. Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 0.4.2.) in /srv/www/wordpress-default/public_html/wp-includes/functions.php on line 4169
```

It also ensures that the stats pixel is loaded

#### Testing instructions:
* Ensure `WP_DEBUG` and `WP_DEBUG_DISPLAY` are enabled
* Ensure AMP 1.x is installed and active
* Configure AMP for "Native" mode (should also try with "Paired" mode and "Classic" mode)
* Enable Jetpack features and load pages with those features
* Check that no errors are printed, and features are either working or hidden
* Load pages with AMP disabled (or load regular pages with AMP not in "Native" mode) and ensure features still work correctly

Good features to check: Carousel, Likes, Gallery, social widgets

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Compatibility improvements with AMP plugin 1.0 (working stats pixel, remove warnings)

cc @westonruter 
