### PR TITLE
Fix Publicize Share Connection Toggle

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -239,12 +239,11 @@ class Publicize extends Publicize_Base {
 	function globalization() {
 		if ( 'on' == $_REQUEST['global'] ) {
 			$globalize_connection = $_REQUEST['connection'];
-
 			if ( ! current_user_can( $this->GLOBAL_CAP ) ) {
 				return;
 			}
 
-			$this->globalize_connection( $connection_id );
+			$this->globalize_connection( $globalize_connection );
 		}
 	}
 


### PR DESCRIPTION
When you first connect a social account via Publicize, you are presented with an option to share the connection among all authors. This will give all authors the ability to share their posts via this social media connection. Unfortunately, even when you enable this option, the setting doesn't save on WPCOM.

<img width="1057" alt="screen shot 2018-12-11 at 2 19 11 pm" src="https://user-images.githubusercontent.com/3246867/49824294-c9854c00-fd4f-11e8-8b1d-0f7efa8a4ccd.png">

Fixes #10930

#### Changes proposed in this Pull Request:

This PR ensures the correct Publicize Connection id is sent in the request to enable all authors to share the connection.

#### Testing instructions:
Spin up a JN site with the branch, [here](https://jurassic.ninja/create/?wp-debug-log&branch=fixpublicize-global-share)
Go to /wp-admin/options-general.php?page=sharing
Click the button to connect any service.
Go through the flow in the popup.
After connecting, enable the setting to make the connection global.
Close the popup
Open https://wordpress.com/sharing/your-domain
Expand the connection.
Ensure that it's set as shared/global.

#### Proposed changelog entry for your changes:

No changelog entry needed
