### PR TITLE
Publicize: Deprecate Google+

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -102,7 +102,7 @@ add_filter( 'jetpack_learn_more_button_publicize', 'publicize_load_more_link' );
 
 function publicize_more_info() { ?>
 	<?php esc_html_e(
-		'Automatically share and promote newly published posts to Facebook, Twitter, Tumblr, Google+,
+		'Automatically share and promote newly published posts to Facebook, Twitter, Tumblr,
 		and LinkedIn. You can add connections for yourself or for all users on your site.'
 		, 'jetpack' );
 }

--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -9,7 +9,7 @@
  * Auto Activate: Yes
  * Module Tags: Social, Recommended
  * Feature: Engagement
- * Additional Search Queries: facebook, twitter, google+, googleplus, google, tumblr, linkedin, social, tweet, connections, sharing
+ * Additional Search Queries: facebook, twitter, tumblr, linkedin, social, tweet, connections, sharing
  */
 
 class Jetpack_Publicize {

--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -85,7 +85,7 @@ div.publicize-service-entry {
 	overflow: hidden;
 }
 
-.right div.publicize-service-entry:last-of-type{
+.right div.publicize-service-entry:last-of-type {
 	border-width: 0px;
 }
 
@@ -96,8 +96,13 @@ div.publicize-service-left {
 	min-height: 35px;
 }
 
-div.publicize-service-left a{
+div.publicize-service-left :first-child {
 	font-size: 18px;
+	text-decoration: none;
+}
+
+div.publicize-service-right .dashicons {
+	font-size: 16px;
 	text-decoration: none;
 }
 
@@ -119,6 +124,10 @@ div.publicize-service-right ul {
 div.publicize-service-right li {
 	list-style-type: none;
 	font-size: 14px;
+}
+
+.publicize-disabled-service-message {
+	margin-top: 10px;
 }
 
 .pub-disconnect-button {

--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -101,11 +101,6 @@ div.publicize-service-left :first-child {
 	text-decoration: none;
 }
 
-div.publicize-service-right .dashicons {
-	font-size: 16px;
-	text-decoration: none;
-}
-
 div.publicize-service-left a:hover{
 	text-decoration: underline;
 }
@@ -126,8 +121,9 @@ div.publicize-service-right li {
 	font-size: 14px;
 }
 
-.publicize-disabled-service-message {
-	margin-top: 10px;
+.publicize-disabled-service-message .dashicons {
+	font-size: 16px;
+	text-decoration: none;
 }
 
 .pub-disconnect-button {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -140,6 +140,10 @@ abstract class Publicize_Base {
 	 */
 	abstract function get_services( $filter = 'all', $_blog_id = false, $_user_id = false );
 
+	function can_connect_service( $service_name ) {
+		return 'google_plus' !== $service_name;
+	}
+
 	/**
 	 * Does the given user have a connection to the service on the given blog?
 	 *

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -502,7 +502,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.' );
+						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.', 'jetpack' );
 					}
 				}
 

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -188,14 +188,20 @@ class Publicize_UI {
 
 				<?php
 				foreach ( $services as $service_name => $service ) :
-					$connect_url = $this->publicize->connect_url( $service_name );
+					$connect_url = $this->publicize->can_connect_service( $service_name ) ?
+						$this->publicize->connect_url( $service_name ) :
+						null;
 					if ( $service_num == ( round ( ( $total_num_of_services / 2 ), 0 ) ) )
 						echo "</div><div class='right'>";
 					$service_num++;
 					?>
 					<div class="publicize-service-entry" <?php if ( $service_num > 0 ): ?>class="connected"<?php endif; ?> >
 						<div id="<?php echo esc_attr( $service_name ); ?>" class="publicize-service-left">
-							<a href="<?php echo esc_url( $connect_url ); ?>" id="service-link-<?php echo esc_attr( $service_name ); ?>" target="_top"><?php echo $this->publicize->get_service_label( $service_name ); ?></a>
+							<?php if ( $connect_url ): ?>
+								<a href="<?php echo esc_url( $connect_url ); ?>" id="service-link-<?php echo esc_attr( $service_name ); ?>" target="_top"><?php echo $this->publicize->get_service_label( $service_name ); ?></a>
+							<?php else: ?>
+								<span><?php echo $this->publicize->get_service_label( $service_name ); ?></span>
+							<?php endif; ?>
 						</div>
 
 
@@ -263,12 +269,18 @@ class Publicize_UI {
 
 
 							<?php
-								$connections = $this->publicize->get_connections( $service_name );
-								if ( empty ( $connections ) ) { ?>
-									<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
+								if ( $connect_url ) {
+									$connections = $this->publicize->get_connections( $service_name );
+									if ( empty ( $connections ) ) { ?>
+										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
+									<?php } else { ?>
+										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
+									<?php } ?>
 								<?php } else { ?>
-									<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
-			  					<?php } ?>
+									<a class="publicize-add-connection button disabled">Unavailable</a>
+									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="https://jetpack.com/tbd" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
+								<?php }
+							?>
 			  			</div>
 			  		</div>
 				<?php endforeach; ?>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -105,6 +105,10 @@ class Publicize_UI {
 		Jetpack_Admin_Page::load_wrapper_styles();
 		wp_enqueue_style( 'social-logos' );
 
+		// for deprecation tooltip
+		wp_enqueue_style( 'wp-pointer' );
+		wp_enqueue_script( 'wp-pointer' );
+
 		add_thickbox();
 	}
 
@@ -131,10 +135,6 @@ class Publicize_UI {
 		<div class='updated'>
 			<p><?php _e ( "You have chosen not to connect your blog. Please click 'accept' when prompted if you wish to connect your accounts.", 'jetpack' ); ?></p>
 		</div><?php
-	}
-
-	public static function google_plus_removal_doc_url() {
-		return "https://jetpack.com/support/removed-gdocs";
 	}
 
 	/**
@@ -281,7 +281,7 @@ class Publicize_UI {
 										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
 									<?php } ?>
 								<?php } else { ?>
-									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="<?php echo esc_url( self::google_plus_removal_doc_url() ); ?>" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
+									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="#" id="jetpack-gplus-deprecated-notice" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
 								<?php }
 							?>
 			  			</div>
@@ -296,7 +296,23 @@ class Publicize_UI {
 							e.preventDefault();
 							return false;
 						}
-					})
+					});
+
+					// deprecation tooltip
+					var setup = function() {
+						$('#jetpack-gplus-deprecated-notice').first().pointer(
+							{
+								content: "<h3>Google Plus support is being removed<\/h3><p>Google recently <a href=\"https://www.blog.google/technology/safety-security/expediting-changes-google-plus/\">announced</a> that Google Plus is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.<\/p><p>For now, you can still post to Google Plus using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.<\/p>","position":{"edge":"right","align":"bottom"},
+								pointerClass: "wp-pointer arrow-bottom",
+								pointerWidth: 420
+							}
+						).click( function( e ) {
+							e.preventDefault();
+							$( this ).pointer( 'open' );
+						} );
+					};
+
+					$(document).ready( setup );
 				})(jQuery);
 				</script>
 			</div>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -133,6 +133,10 @@ class Publicize_UI {
 		</div><?php
 	}
 
+	public static function google_plus_removal_doc_url() {
+		return "https://jetpack.com/support/removed-gdocs";
+	}
+
 	/**
 	 * Lists the current user's publicized accounts for the blog
 	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
@@ -277,8 +281,7 @@ class Publicize_UI {
 										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
 									<?php } ?>
 								<?php } else { ?>
-									<a class="publicize-add-connection button disabled">Unavailable</a>
-									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="https://jetpack.com/tbd" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
+									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="<?php echo esc_url( self::google_plus_removal_doc_url() ); ?>" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
 								<?php }
 							?>
 			  			</div>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -321,7 +321,11 @@ class Publicize_UI {
 					var setup = function() {
 						$('#jetpack-gplus-deprecated-notice').first().pointer(
 							{
-								content: "<?php echo wp_slash( $google_plus_exp_msg ); ?>","position":{"edge":"right","align":"bottom"},
+								content: decodeURIComponent( "<?php echo rawurlencode( $google_plus_exp_msg ); ?>" ),
+								position: {
+									edge: "right",
+									align: "bottom"
+								},
 								pointerClass: "wp-pointer arrow-bottom",
 								pointerWidth: 420
 							}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -294,7 +294,7 @@ class Publicize_UI {
 								echo '<div class="publicize-disabled-service-message">';
 								esc_html_e( 'Google+ support is being removed.', 'jetpack' );
 								printf(
-									' <a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice" target="_blank">%1$s<span class="dashicons dashicons-info"></span></a>',
+									' <a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice">%1$s<span class="dashicons dashicons-info"></span></a>',
 									esc_html__( 'Why?', 'jetpack' )
 								);
 								echo '</div>';
@@ -304,9 +304,6 @@ class Publicize_UI {
 					</div>
 				<?php endforeach; ?>
 				</div>
-				<?php
-				$google_plus_exp_msg = $this->google_plus_shut_down_notice();
-				?>
 				<script>
 				(function($){
 					$('.pub-disconnect-button').on('click', function(e){ if ( confirm( '<?php echo esc_js( __( 'Are you sure you want to stop Publicizing posts to this connection?', 'jetpack' ) ); ?>' ) ) {
@@ -316,28 +313,9 @@ class Publicize_UI {
 							return false;
 						}
 					});
-
-					// deprecation tooltip
-					var setup = function() {
-						$('#jetpack-gplus-deprecated-notice').first().pointer(
-							{
-								content: decodeURIComponent( "<?php echo rawurlencode( $google_plus_exp_msg ); ?>" ),
-								position: {
-									edge: "right",
-									align: "bottom"
-								},
-								pointerClass: "wp-pointer arrow-bottom",
-								pointerWidth: 420
-							}
-						).click( function( e ) {
-							e.preventDefault();
-							$( this ).pointer( 'open' );
-						} );
-					};
-
-					$(document).ready( setup );
 				})(jQuery);
 				</script>
+				<?php $this->google_plus_shut_down_tooltip_script(); ?>
 			</div>
 
 			<?php wp_nonce_field( "wpas_posts_{$_blog_id}", "_wpas_posts_{$_blog_id}_nonce" ); ?>
@@ -409,6 +387,12 @@ class Publicize_UI {
 
 		$max_length = defined( 'JETPACK_PUBLICIZE_TWITTER_LENGTH' ) ? JETPACK_PUBLICIZE_TWITTER_LENGTH : 280;
 		$max_length = $max_length - 24; // t.co link, space
+
+		// for deprecation tooltip
+		wp_enqueue_style( 'wp-pointer' );
+		wp_enqueue_script( 'wp-pointer' );
+
+		$this->google_plus_shut_down_tooltip_script();
 
 		?>
 
@@ -666,6 +650,10 @@ jQuery( function($) {
 .wpas-twitter-length-limit {
 	color: red;
 }
+.publicize-disabled-service-message .dashicons {
+	font-size: 16px;
+	text-decoration: none;
+}
 </style><?php
 	}
 
@@ -714,9 +702,14 @@ jQuery( function($) {
 					$publicize_form = $this->get_metabox_form_connected( $connections_data );
 
 					$labels = array();
+					$has_google_plus = false;
 					foreach ( $connections_data as $connection_data ) {
 						if ( ! $connection_data['enabled'] ) {
 							continue;
+						}
+
+						if ( 'google_plus' === $connection_data['service_name'] ) {
+							$has_google_plus = true;
 						}
 
 						$labels[] = sprintf(
@@ -727,6 +720,17 @@ jQuery( function($) {
 
 				?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
+				<?php if ( $has_google_plus ) : ?>
+					<div class="notice inline notice-warning publicize-disabled-service-message">
+						<p>
+							<strong><?php esc_html_e( 'Google+ support is being removed', 'jetpack' ); ?></strong>
+							<a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice">
+								<?php esc_html_e( 'Why?', 'jetpack' ); ?>
+								<span class="dashicons dashicons-info"></span>
+							</a>
+						</p>
+					</div>
+				<?php endif; ?>
 					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
 
@@ -887,5 +891,33 @@ jQuery( function($) {
 				'p'  => true,
 			)
 		);
+	}
+
+	private function google_plus_shut_down_tooltip_script() {
+		$google_plus_exp_msg = $this->google_plus_shut_down_notice();
+	?>
+		<script>
+		// deprecation tooltip
+		(function($){
+			var setup = function() {
+				$('#jetpack-gplus-deprecated-notice').first().pointer(
+					{
+						content: decodeURIComponent( "<?php echo rawurlencode( $google_plus_exp_msg ); ?>" ),
+						position: {
+							edge: "right",
+							align: "bottom"
+						},
+						pointerClass: "wp-pointer arrow-bottom",
+						pointerWidth: 420
+					}
+				).click( function( e ) {
+					e.preventDefault();
+					$( this ).pointer( 'open' );
+				} );
+			};
+			$(document).ready( setup );
+		})(jQuery);
+		</script>
+	<?php
 	}
 }

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -192,9 +192,11 @@ class Publicize_UI {
 
 				<?php
 				foreach ( $services as $service_name => $service ) :
+					// do not display any service that cannot be connected anymore (deprecated).
 					$connect_url = $this->publicize->can_connect_service( $service_name ) ?
 						$this->publicize->connect_url( $service_name ) :
 						null;
+
 					if ( $service_num == ( round ( ( $total_num_of_services / 2 ), 0 ) ) )
 						echo "</div><div class='right'>";
 					$service_num++;
@@ -270,24 +272,57 @@ class Publicize_UI {
 								</ul>
 							<?php endif; ?>
 
-
-
 							<?php
-								if ( $connect_url ) {
-									$connections = $this->publicize->get_connections( $service_name );
-									if ( empty ( $connections ) ) { ?>
-										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
-									<?php } else { ?>
-										<a id="<?php echo esc_attr( $service_name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
-									<?php } ?>
-								<?php } else { ?>
-									<div class="publicize-disabled-service-message">Google Plus support is being removed. <a href="#" id="jetpack-gplus-deprecated-notice" target="_blank">Why?<span class="dashicons dashicons-external"></span></a></div>
-								<?php }
+							if ( $connect_url ) {
+								$connections = $this->publicize->get_connections( $service_name );
+								if ( empty( $connections ) ) {
+									printf(
+										'<a id="%1$s" class="publicize-add-connection button" href="%2$s" target="_top">%3$s</a>',
+										esc_attr( $service_name ),
+										esc_url( $connect_url ),
+										esc_html__( 'Connect', 'jetpack' )
+									);
+								} else {
+									printf(
+										'<a id="%1$s" class="publicize-add-connection button add-new" href="%2$s" target="_top">%3$s</a>',
+										esc_attr( $service_name ),
+										esc_url( $connect_url ),
+										esc_html__( 'Add New', 'jetpack' )
+									);
+								}
+							} else {
+								echo '<div class="publicize-disabled-service-message">';
+								esc_html_e( 'Google+ support is being removed.', 'jetpack' );
+								printf(
+									' <a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice" target="_blank">%1$s<span class="dashicons dashicons-external"></span></a>',
+									esc_html__( 'Why?', 'jetpack' )
+								);
+								echo '</div>';
+							}
 							?>
-			  			</div>
-			  		</div>
+						</div>
+					</div>
 				<?php endforeach; ?>
 				</div>
+				<?php
+				$google_plus_exp_msg = wp_kses(
+					sprintf(
+						/* Translators: placeholder is a link to an announcement post on Google's blog. */
+						__(
+							'<h3>Google+ Support is being removed</h3><p>Google recently <a href="%1$s">announced</a> that Google+ is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.</p><p>For now, you can still post to Google+ using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.</p>',
+							'jetpack'
+						),
+						esc_url( 'https://www.blog.google/technology/safety-security/expediting-changes-google-plus/' )
+					),
+					array(
+						'a'  => array(
+							'href' => array(),
+						),
+						'h3' => true,
+						'p'  => true,
+					)
+				);
+				?>
 				<script>
 				(function($){
 					$('.pub-disconnect-button').on('click', function(e){ if ( confirm( '<?php echo esc_js( __( 'Are you sure you want to stop Publicizing posts to this connection?', 'jetpack' ) ); ?>' ) ) {
@@ -302,7 +337,7 @@ class Publicize_UI {
 					var setup = function() {
 						$('#jetpack-gplus-deprecated-notice').first().pointer(
 							{
-								content: "<h3>Google Plus support is being removed<\/h3><p>Google recently <a href=\"https://www.blog.google/technology/safety-security/expediting-changes-google-plus/\">announced</a> that Google Plus is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.<\/p><p>For now, you can still post to Google Plus using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.<\/p>","position":{"edge":"right","align":"bottom"},
+								content: "<?php echo wp_slash( $google_plus_exp_msg ); ?>","position":{"edge":"right","align":"bottom"},
 								pointerClass: "wp-pointer arrow-bottom",
 								pointerWidth: 420
 							}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -305,23 +305,7 @@ class Publicize_UI {
 				<?php endforeach; ?>
 				</div>
 				<?php
-				$google_plus_exp_msg = wp_kses(
-					sprintf(
-						/* Translators: placeholder is a link to an announcement post on Google's blog. */
-						__(
-							'<h3>Google+ Support is being removed</h3><p>Google recently <a href="%1$s">announced</a> that Google+ is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.</p><p>For now, you can still post to Google+ using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.</p>',
-							'jetpack'
-						),
-						esc_url( 'https://www.blog.google/technology/safety-security/expediting-changes-google-plus/' )
-					),
-					array(
-						'a'  => array(
-							'href' => array(),
-						),
-						'h3' => true,
-						'p'  => true,
-					)
-				);
+				$google_plus_exp_msg = $this->google_plus_shut_down_notice();
 				?>
 				<script>
 				(function($){
@@ -878,5 +862,26 @@ jQuery( function($) {
 			<a href="#" class="hide-if-no-js button" id="publicize-disconnected-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
 		</div><?php // #publicize-form
 		return ob_get_clean();
+	}
+
+	private function google_plus_shut_down_notice() {
+		return wp_kses(
+			sprintf(
+				/* Translators: placeholder is a link to an announcement post on Google's blog. */
+				__(
+					'<h3>Google+ Support is being removed</h3><p>Google recently <a href="%1$s" target="_blank">announced</a> that Google+ is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.</p><p>For now, you can still post to Google+ using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.</p>',
+					'jetpack'
+				),
+				esc_url( 'https://www.blog.google/technology/safety-security/expediting-changes-google-plus/' )
+			),
+			array(
+				'a'  => array(
+					'href' => true,
+					'target' => true,
+				),
+				'h3' => true,
+				'p'  => true,
+			)
+		);
 	}
 }

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -294,7 +294,7 @@ class Publicize_UI {
 								echo '<div class="publicize-disabled-service-message">';
 								esc_html_e( 'Google+ support is being removed.', 'jetpack' );
 								printf(
-									' <a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice" target="_blank">%1$s<span class="dashicons dashicons-external"></span></a>',
+									' <a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice" target="_blank">%1$s<span class="dashicons dashicons-info"></span></a>',
 									esc_html__( 'Why?', 'jetpack' )
 								);
 								echo '</div>';


### PR DESCRIPTION
See #10950

#### Changes proposed in this Pull Request:
- [x] Disable creation of new G+ Connections in Sharing -> Publicize
- [x] Show warning about G+ shutdown in Sharing -> Publicize
- [x] Show a warning for G+ Connections in the Classic Editor
- [ ] Show a warning for G+ Connections in Gutenberg

#### Testing instructions:
Sharing Screen:
* Head to `/wp-admin/options-general.php?page=sharing`
* Instead of saying "Add New" or "Connect", the button should be disabled and say "Unavailable"
* Sharing via existing Google Plus connections should still work
* Be sure to test on sites that have 0, 1, and multiple existing Google Plus connections

Classic Editor
1. Go to wp-admin/post-new.php. Ensure you're using the Classic Editor.
2. See the warning about Google+. Make sure the tooltip "Why?" link works.

#### Screenshot

Sharing Screen with no connections:

<img width="954" alt="gplus-no-connections" src="https://user-images.githubusercontent.com/51896/49835836-51218980-fd55-11e8-8607-6187181f8e59.png">

Sharing Screen ith existing connections:

<img width="950" alt="gplus-with-connections" src="https://user-images.githubusercontent.com/51896/49835832-4a931200-fd55-11e8-920b-8ca8372d5064.png">

Sharing Screen "Why?" tooltip:

<img width="958" alt="tooltip" src="https://user-images.githubusercontent.com/51896/49899219-fa2cba80-fe0f-11e8-9bbe-5651b2fcf89e.png">

Classic Editor with existing connection:
<img width="291" alt="screen shot 2019-01-24 at 2 31 20 pm" src="https://user-images.githubusercontent.com/125994/51712810-d18a0a00-1fe4-11e9-9a1a-220986f476cc.png">

Classic Editor tooltip:

<img width="643" alt="screen shot 2019-01-24 at 2 31 26 pm" src="https://user-images.githubusercontent.com/125994/51712817-d77feb00-1fe4-11e9-972b-095d99501ec8.png">

#### Proposed changelog entry for your changes:
* Remove ability to add Google Plus connections in anticipation of service shutdown
