### PR TITLE
Revert "Update dependency react-tap-event-plugin to v3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-router": "3.2.1",
     "react-router-redux": "4.0.8",
     "react-tagsinput": "3.19.0",
-    "react-tap-event-plugin": "3.0.3",
+    "react-tap-event-plugin": "2.0.1",
     "redux": "4.0.1",
     "redux-thunk": "2.3.0",
     "sass-loader": "7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6659,9 +6659,9 @@ react-tagsinput@3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/react-tagsinput/-/react-tagsinput-3.19.0.tgz#6e3b45595f2d295d4657bf194491988f948caabf"
 
-react-tap-event-plugin@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-3.0.3.tgz#bc5fd0ee3fd3ab5224c1c2ff6f0750204ae89802"
+react-tap-event-plugin@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
   dependencies:
     fbjs "^0.8.6"
 


### PR DESCRIPTION
Reverts Automattic/jetpack#10933

To test:
- Spin up JN site
- go visit Jetpack Settings. Makes your it's loading. 
- Check DevTools. Makes sure there is no errors such as
`Uncaught TypeError: Cannot read property 'EventPluginHub' of undefined`