### PR TITLE
Jumpstart: switch from a modal to a card.

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -71,7 +71,6 @@ function render() {
 			<Provider store={ store }>
 				<Router history={ history }>
 					<Route path="/" name={ i18n.translate( 'At A Glance', { context: 'Navigation item.' } ) } component={ Main } />
-					<Route path="/jumpstart" component={ Main } />
 					<Route path="/dashboard" name={ i18n.translate( 'At A Glance' ) } component={ Main } />
 					<Route path="/my-plan" name={ i18n.translate( 'My Plan', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path="/plans" name={ i18n.translate( 'Plans', { context: 'Navigation item.' } ) } component={ Main } />

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -71,14 +71,14 @@ class JumpStart extends Component {
 						</h3>
 						<p className="jp-jumpstart-card__description-text">
 							{ __(
-								"We're now collecting stats, securing your site, and speeding up your images. " +
-									"Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard."
+								'We’re now collecting stats, securing your site, and enhancing your editing experience. ' +
+									'Pretty soon you’ll be able to see everything going on with your site right through Jetpack! Welcome aboard.'
 							) }
 						</p>
 						<p className="jp-jumpstart-card__description-text">
 							{ __(
-								"Activate Jetpack's recommended features to get the most out of your site. " +
-									" Don't worry, features can be activated and deactivated at any time. " +
+								'Activate Jetpack’s recommended features to get the most out of your site. ' +
+									'Don’t worry, features can be activated and deactivated at any time. ' +
 									'{{a}}Learn more about recommended features{{/a}}.',
 								{
 									components: {

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -4,112 +4,100 @@
  * @format
  */
 
-import React from 'react';
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Button from 'components/button';
+import onKeyDownCallback from 'utils/onkeydown-callback';
 import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import { imagePath } from 'constants/urls';
 import {
 	jumpStartActivate,
 	jumpStartSkip,
 	isJumpstarting as _isJumpstarting,
 } from 'state/jumpstart';
-import { getModulesByFeature as _getModulesByFeature } from 'state/modules';
-import { imagePath } from 'constants/urls';
-import JetpackDialogue from 'components/jetpack-dialogue';
 
-class JumpStart extends React.Component {
-	static displayName = 'JumpStart';
-
+class JumpStart extends Component {
 	activateButton = () => {
 		return (
-			<div>
-				<Button
-					primary={ true }
-					onClick={ this.props.jumpStartActivate }
-					disabled={ this.props.isJumpstarting }
-				>
-					{ this.props.isJumpstarting
-						? __( 'Activating recommended features…' )
-						: __( 'Activate recommended features' ) }
-				</Button>
-
-				<p>
-					<a
-						href="javascript:void(0)"
-						onClick={ this.props.jumpStartSkip }
-						className="jp-jumpstart__skip-link"
-					>
-						{ __( 'Skip and explore features' ) }
-					</a>
-				</p>
-			</div>
+			<Button
+				primary={ true }
+				onClick={ this.props.jumpStartActivate }
+				disabled={ this.props.isJumpstarting }
+			>
+				{ this.props.isJumpstarting
+					? __( 'Activating recommended features…' )
+					: __( 'Activate recommended features' ) }
+			</Button>
 		);
 	};
 
-	renderInnerContent() {
-		/* eslint-disable react/no-danger */
-		const jumpstartModules = this.props.jumpstartFeatures.map( module => (
-			<div
-				className="jp-jumpstart__feature-list-column"
-				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ }
-			>
-				<div className="jp-jumpstart__feature-content">
-					<h4 className="jp-jumpstart__feature-content-title" title={ module.name }>
-						{ module.name }
-					</h4>
-					<p dangerouslySetInnerHTML={ renderJumpstartDescription( module ) } />
-				</div>
-			</div>
-		) );
-		/* eslint-enable react/no-danger */
-
+	dismissButton = () => {
 		return (
-			<div className="jp-jumpstart">
-				<p>
-					{ __(
-						"We're now collecting stats, securing your site, and speeding up your images. Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard."
-					) }
-				</p>
-
-				{ this.activateButton() }
-
-				<div>
-					<h2 className="jp-jumpstart__feature-heading">
-						{ __( "Jetpack's recommended features include:" ) }
-					</h2>
-
-					<div className="jp-jumpstart__feature-list">{ jumpstartModules }</div>
-
-					{ this.activateButton() }
-
-					<p className="jp-jumpstart__note">
-						{ __( 'Features can be activated or deactivated at any time.' ) }
-					</p>
-				</div>
-			</div>
+			<span
+				role="button"
+				onKeyDown={ onKeyDownCallback( this.props.jumpStartSkip ) }
+				tabIndex="0"
+				className="dops-notice__dismiss"
+				onClick={ this.props.jumpStartSkip }
+			>
+				<Gridicon icon="cross" size={ 18 } />
+				<span className="dops-notice__screen-reader-text screen-reader-text">
+					{ __( 'Dismiss' ) }
+				</span>
+			</span>
 		);
-	}
+	};
 
 	render() {
 		return (
-			<JetpackDialogue
-				svg={
-					<img
-						src={ imagePath + 'man-and-laptop.svg' }
-						width="199"
-						height="153"
-						alt={ __( 'Person with laptop' ) }
-					/>
-				}
-				title={ __( 'Your Jetpack site is ready to go!' ) }
-				content={ this.renderInnerContent() }
-				dismiss={ this.props.jumpStartSkip }
-			/>
+			<div className="jp-jumpstart">
+				<Card className="jp-jumpstart-card__content">
+					<div className="jp-jumpstart-card__img">
+						<img
+							src={ imagePath + 'man-and-laptop.svg' }
+							alt={ __( 'Person with laptop' ) }
+						/>
+					</div>
+					<div className="jp-jumpstart-card__description">
+						<h3 className="jp-jumpstart-card__description-title">
+							{ __( 'Your Jetpack site is ready to go!' ) }
+						</h3>
+						<p className="jp-jumpstart-card__description-text">
+							{ __(
+								"We're now collecting stats, securing your site, and speeding up your images. " +
+									"Pretty soon you'll be able to see everything going on with your site right through Jetpack! Welcome aboard."
+							) }
+						</p>
+						<p className="jp-jumpstart-card__description-text">
+							{ __(
+								"Activate Jetpack's recommended features to get the most out of your site. " +
+									" Don't worry, features can be activated and deactivated at any time. " +
+									'{{a}}Learn more about recommended features{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												href="https://jetpack.com/support/quick-start-guide/#jumpstart"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+						<p>{ this.activateButton() }</p>
+					</div>
+					{ this.dismissButton() }
+				</Card>
+			</div>
 		);
 	}
 }
@@ -118,14 +106,7 @@ export default connect(
 	state => {
 		return {
 			isJumpstarting: _isJumpstarting( state ),
-			jumpstartFeatures: _getModulesByFeature( state, 'Jumpstart' ),
 		};
 	},
 	dispatch => bindActionCreators( { jumpStartActivate, jumpStartSkip }, dispatch )
 )( JumpStart );
-
-function renderJumpstartDescription( module ) {
-	// Rationale behind returning an object and not just the string
-	// https://facebook.github.io/react/tips/dangerously-set-inner-html.html
-	return { __html: module.jumpstart_desc };
-}

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -7,7 +7,6 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import onKeyDownCallback from 'utils/onkeydown-callback';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -15,7 +14,6 @@ import { translate as __ } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 import { imagePath } from 'constants/urls';
 import {
 	jumpStartActivate,
@@ -38,20 +36,15 @@ class JumpStart extends Component {
 		);
 	};
 
-	dismissButton = () => {
+	dismissLink = () => {
 		return (
-			<span
-				role="button"
-				onKeyDown={ onKeyDownCallback( this.props.jumpStartSkip ) }
-				tabIndex="0"
-				className="dops-notice__dismiss"
+			<a
+				href="javascript:void(0)"
 				onClick={ this.props.jumpStartSkip }
+				className="jp-jumpstart__skip-link"
 			>
-				<Gridicon icon="cross" size={ 18 } />
-				<span className="dops-notice__screen-reader-text screen-reader-text">
-					{ __( 'Dismiss' ) }
-				</span>
-			</span>
+				{ __( 'Skip and explore features' ) }
+			</a>
 		);
 	};
 
@@ -94,8 +87,8 @@ class JumpStart extends Component {
 							) }
 						</p>
 						<p>{ this.activateButton() }</p>
+						{ this.dismissLink() }
 					</div>
-					{ this.dismissButton() }
 				</Card>
 			</div>
 		);

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -10,14 +10,39 @@
 	margin-bottom: 0;
 
 	.jp-jumpstart-card__img {
-		width: rem( 200px );
+		display: none;
+
+		@include breakpoint( ">480px" ) {
+			display: block;
+			width: rem( 100px );
+		}
+
+		@include breakpoint( ">660px" ) {
+			width: rem( 200px );
+		}
 	}
 
 	.jp-jumpstart-card__description {
-		margin-left: 2rem;
+
+		@include breakpoint( ">660px" ) {
+			margin-left: 2rem;
+		}
 
 		.jp-jumpstart-card__description-title {
 			margin-top: 0;
+		}
+	}
+
+	.dops-notice__dismiss {
+		align-self: flex-start;
+		margin: -11px -11px 0 32px;
+
+		.gridicon {
+			fill: $gray;
+
+			&:hover {
+				fill: $blue-dark-text;
+			}
 		}
 	}
 }

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -1,141 +1,23 @@
 
 
 .jp-jumpstart {
-	text-align: center;
-	max-width: rem( 600px );
+	text-align: left;
 	margin: 0 auto rem( 32px );
-
-	@include breakpoint( "<660px" ) {
-		text-align: left;
-	}
 }
 
-.jp-jumpstart__cta-container {
-	position: relative; // allows spinner to be positioned
-	padding: 0;
-
-	.dops-spinner {
-		display: flex;
-		justify-content: center;
-		position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-		background: rgba(255, 255, 255, .85);
-		z-index: 1001;
-	}
-	.dops-spinner__image {
-		align-self: center;
-	}
-}
-
-.jp-jumpstart__title {
-	font-weight: 300;
-	text-align: center;
-	font-size: rem( 24px );
-	margin-bottom: rem( 32px );
-}
-
-.jp-jumpstart__description {
+.jp-jumpstart-card__content {
+	display: flex;
 	margin-bottom: 0;
 
-	p {
-		margin: 0;
-		font-size: rem( 14px );
-		color: $gray-text-min;
-	}
-}
-
-.jp-jumpstart__feature-heading {
-	margin-top: 0;
-	margin-bottom: rem( 24px );
-	font-size: rem( 16px );
-	font-weight: 400;
-}
-
-.jp-jumpstart__features {
-	margin: 0;
-	padding: rem( 16px );
-
-	// overriding general FoldableCard styles for special use here
-	&.dops-foldable-card {
-		box-shadow: none;
+	.jp-jumpstart-card__img {
+		width: rem( 200px );
 	}
 
-	&.dops-foldable-card.is-expanded {
-		margin-bottom: 0;
+	.jp-jumpstart-card__description {
+		margin-left: 2rem;
+
+		.jp-jumpstart-card__description-title {
+			margin-top: 0;
+		}
 	}
-
-	.dops-foldable-card__header,
-	&.dops-foldable-card.is-expanded .dops-foldable-card__header {
-		min-height: auto;
-	}
-
-	.dops-foldable-card__main {
-		max-width: 100%;
-		margin-right: 0;
-	}
-
-	.dops-foldable-card__secondary {
-		display: none;
-	}
-
-	.dops-foldable-card__subheader {
-		color: $blue-wordpress;
-		font-style: italic;
-	}
-
-	.dops-foldable-card__content {
-		background-color: lighten( $gray, 35% );
-	}
-}
-
-.jp-jumpstart__feature-list {
-	margin: 0 0 rem( 24px );
-	padding: 0;
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-
-	@include breakpoint( "<660px" ) {
-		margin: 0 rem( -16px ) rem( 24px ); // to avoid altering multiple other elements
-	}
-}
-
-.jp-jumpstart__feature-list-column {
-	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px lighten( $gray, 30% );
-	text-align: left;
-	background: $white;
-
-	@include breakpoint( ">660px" ) {
-		flex-grow: 1;
-		flex-shrink: 0;
-		flex-basis: 50%;
-	}
-
-	@include breakpoint( "<660px" ) {
-		flex-basis: 100%;
-	}
-}
-
-.jp-jumpstart__feature-content {
-	padding: rem( 16px );
-
-	p {
-		margin-top: rem( 8px );
-		margin-bottom: 0;
-	}
-}
-
-.jp-jumpstart__feature-content-title {
-	margin: 0;
-}
-
-.jp-jumpstart__note {
-	margin: 0;
-	padding: rem( 16px ) 0 0;
-	font-size: rem( 14px );
-	clear: both;
-	font-style: italic;
 }

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -33,17 +33,4 @@
 			margin-top: 0;
 		}
 	}
-
-	.dops-notice__dismiss {
-		align-self: flex-start;
-		margin: -11px -11px 0 16px;
-
-		.gridicon {
-			fill: $gray;
-
-			&:hover {
-				fill: $blue-dark-text;
-			}
-		}
-	}
 }

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -9,7 +9,8 @@
 	display: flex;
 	margin-bottom: 0;
 
-	.jp-jumpstart-card__img {
+	.jp-jumpstart-card__img,
+	.jp-jumpstart-card__img img {
 		display: none;
 
 		@include breakpoint( ">480px" ) {
@@ -24,7 +25,7 @@
 
 	.jp-jumpstart-card__description {
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( ">480px" ) {
 			margin-left: 2rem;
 		}
 
@@ -35,7 +36,7 @@
 
 	.dops-notice__dismiss {
 		align-self: flex-start;
-		margin: -11px -11px 0 32px;
+		margin: -11px -11px 0 16px;
 
 		.gridicon {
 			fill: $gray;

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -3,7 +3,6 @@
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
-import { createHistory } from 'history';
 import analytics from 'lib/analytics';
 
 /**
@@ -57,15 +56,12 @@ export const jumpStartActivate = () => {
 	};
 };
 
-const history = createHistory();
-
 export const jumpStartSkip = () => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JUMPSTART_SKIP
 		} );
 		analytics.tracks.recordEvent( 'jetpack_wpa_jumpstart_skip', {} );
-		history.push( window.location.pathname + '?page=jetpack#/dashboard' );
 		return restApi.jumpStart( 'deactivate' ).then( () => {
 			dispatch( {
 				type: JUMPSTART_SKIP_SUCCESS,


### PR DESCRIPTION
Fixes #10584 
#### Changes proposed in this Pull Request:

- Remove special jumpstart route we used to display the modal.
- Remove redirections to and from that route.
- Change the display of the Jumpstart component to a card matching the specs in #10584

![image](https://user-images.githubusercontent.com/426388/49864842-af0caa80-fe03-11e8-8fc8-2e742ce87c51.png)

#### Testing instructions:

* Start with brand new install or by using the link to reset all options at the bottom of the Jetpack menu pages.
* Visit any of the Jetpack pages and notice the new card.
* Make sure the card looks good on any device.
* Make sure the 2 actions (dismiss or jumpstart) work well.

#### Proposed changelog entry for your changes:
* Connection flow: make it clearer that Jetpack offers a set of recommended features when you start using the plugin.
