### PR TITLE
Admin Page: hide Related Posts preview when not active.

### DIFF
--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -106,57 +106,61 @@ class RelatedPostsComponent extends React.Component {
 										}
 									</span>
 						</CompactFormToggle>
-						<FormLabel className="jp-form-label-wide">
-							{ __( 'Preview', { context: 'A header for a preview area in the configuration screen.' } ) }
-						</FormLabel>
-						<Card className="jp-related-posts-preview">
-							{
-								this.state.show_headline && (
-									<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
-								)
-							}
-							{
-								[
-									{
-										url: '1-wpios-ipad-3-1-viewsite.png',
-										text: __( 'Big iPhone/iPad Update Now Available' ),
-										context: __( 'In "Mobile"', {
-											comment: 'It refers to the category where a post was found. Used in an example preview.'
-										} )
-									},
-									{
-										url: 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
-										text: __( 'The WordPress for Android App Gets a Big Facelift' ),
-										context: __( 'In "Mobile"', {
-											comment: 'It refers to the category where a post was found. Used in an example preview.'
-										} )
-									},
-									{
-										url: 'videopresswedding.jpg',
-										text: __( 'Upgrade Focus: VideoPress For Weddings' ),
-										context: __( 'In "Upgrade"', {
-											comment: 'It refers to the category where a post was found. Used in an example preview.'
-										} )
-									}
-								].map( ( item, index ) => (
-									<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+						{ isRelatedPostsActive &&
+							<div>
+								<FormLabel className="jp-form-label-wide">
+									{ __( 'Preview', { context: 'A header for a preview area in the configuration screen.' } ) }
+								</FormLabel>
+								<Card className="jp-related-posts-preview">
+								{
+									this.state.show_headline && (
+										<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
+									)
+								}
+								{
+									[
 										{
-											this.state.show_thumbnails && (
-												<img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } alt={ item.text } />
-											)
+											url: '1-wpios-ipad-3-1-viewsite.png',
+											text: __( 'Big iPhone/iPad Update Now Available' ),
+											context: __( 'In "Mobile"', {
+												comment: 'It refers to the category where a post was found. Used in an example preview.'
+											} )
+										},
+										{
+											url: 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
+											text: __( 'The WordPress for Android App Gets a Big Facelift' ),
+											context: __( 'In "Mobile"', {
+												comment: 'It refers to the category where a post was found. Used in an example preview.'
+											} )
+										},
+										{
+											url: 'videopresswedding.jpg',
+											text: __( 'Upgrade Focus: VideoPress For Weddings' ),
+											context: __( 'In "Upgrade"', {
+												comment: 'It refers to the category where a post was found. Used in an example preview.'
+											} )
 										}
-										<h4 className="jp-related-posts-preview__post-title"><a href="#/traffic">{ item.text }</a></h4>
-										<p className="jp-related-posts-preview__post-context">
-											{ item.context }
-										</p>
-									</div>
-								) )
-							}
-						</Card>
+									].map( ( item, index ) => (
+										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+											{
+												this.state.show_thumbnails && (
+													<img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } alt={ item.text } />
+												)
+											}
+											<h4 className="jp-related-posts-preview__post-title"><a href="#/traffic">{ item.text }</a></h4>
+											<p className="jp-related-posts-preview__post-context">
+												{ item.context }
+											</p>
+										</div>
+									) )
+								}
+								</Card>
+							</div>
+						}
 					</FormFieldset>
 				</SettingsGroup>
 				{
-					! this.props.isUnavailableInDevMode( 'related-posts' ) && (
+					! this.props.isUnavailableInDevMode( 'related-posts' ) && isRelatedPostsActive && (
 						<Card compact className="jp-settings-card__configure-link" onClick={ this.trackConfigureClick } href={ this.props.configureUrl }>
 							{ __( 'Configure related posts in the Customizer' ) }
 						</Card>


### PR DESCRIPTION
Fixes #10691

#### Changes proposed in this Pull Request:

* We now hide the Related Posts preview when the module is not active.

![screen recording 2018-12-12 at 12 01 pm](https://user-images.githubusercontent.com/426388/49865823-3eb35880-fe06-11e8-9bc5-4bcf4c6b8fef.gif)

#### Testing instructions:

* Go to Settings > Traffic
* Activate and deactivate the Related Posts module, and make sure the preview appearing below the toggles is updated accordingly.

#### Proposed changelog entry for your changes:

* Admin Page: hide Related Posts preview when not active.
