### PR TITLE
Stats: update look of dashboard widget

### DIFF
--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -5,11 +5,13 @@
 
 	h2.hndle {
 		span {
-			&#js-toggle-stats_dashboard_widget_control {
-				float: right;
+			&.js-toggle-stats_dashboard_widget_control {
+				position: absolute;
+				top: 8px;
+				right: 36px;
 			}
 
-			&:not(#js-toggle-stats_dashboard_widget_control) {
+			&:not(.js-toggle-stats_dashboard_widget_control) {
 				display: flex;
 				align-items:center;
 			}

--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -3,6 +3,24 @@
 		box-sizing: border-box;
 	}
 
+	h2.hndle {
+		span {
+			&#js-toggle-stats_dashboard_widget_control {
+				float: right;
+			}
+
+			&:not(#js-toggle-stats_dashboard_widget_control) {
+				display: flex;
+				align-items:center;
+			}
+		}
+
+		svg {
+			height: 20px;
+			margin: .15em 0 0 .5em;
+		}
+	}
+
 	.inside {
 		margin: 0;
 		padding: 0;

--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -24,6 +24,11 @@
 	.inside {
 		margin: 0;
 		padding: 0;
+
+		.stats-view-all {
+			text-align: center;
+			margin: 1em 0;
+		}
 	}
 
 	.stats,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7090,9 +7090,14 @@ p {
 		}
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
+			$widget_title = sprintf(
+				esc_html__( 'Stats by %s', 'jetpack' ),
+				Jetpack::get_jp_emblem( true )
+			);
+
 			wp_add_dashboard_widget(
 				'jetpack_summary_widget',
-				esc_html__( 'Site Stats', 'jetpack' ),
+				$widget_title,
 				array( __CLASS__, 'dashboard_widget' )
 			);
 			wp_enqueue_style( 'jetpack-dashboard-widget', plugins_url( 'css/dashboard-widget.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
@@ -7187,10 +7192,27 @@ p {
 	 *
 	 * @since 3.9.0
 	 *
+	 * @param bool $logotype Should we use the full logotype (logo + text). Default to false.
+	 *
 	 * @return string
 	 */
-	public static function get_jp_emblem() {
-		return '<svg id="jetpack-logo__icon" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 32 32"><path fill="#00BE28" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16c8.8,0,16-7.2,16-16S24.8,0,16,0z M15.2,18.7h-8l8-15.5V18.7z M16.8,28.8 V13.3h8L16.8,28.8z"/></svg>';
+	public static function get_jp_emblem( $logotype = false ) {
+		$logo = '<path fill="#00BE28" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16c8.8,0,16-7.2,16-16S24.8,0,16,0z M15.2,18.7h-8l8-15.5V18.7z M16.8,28.8 V13.3h8L16.8,28.8z"/>';
+		$text = '
+<path d="M41.3,26.6c-0.5-0.7-0.9-1.4-1.3-2.1c2.3-1.4,3-2.5,3-4.6V8h-3V6h6v13.4C46,22.8,45,24.8,41.3,26.6z" />
+<path d="M65,18.4c0,1.1,0.8,1.3,1.4,1.3c0.5,0,2-0.2,2.6-0.4v2.1c-0.9,0.3-2.5,0.5-3.7,0.5c-1.5,0-3.2-0.5-3.2-3.1V12H60v-2h2.1V7.1 H65V10h4v2h-4V18.4z" />
+<path d="M71,10h3v1.3c1.1-0.8,1.9-1.3,3.3-1.3c2.5,0,4.5,1.8,4.5,5.6s-2.2,6.3-5.8,6.3c-0.9,0-1.3-0.1-2-0.3V28h-3V10z M76.5,12.3 c-0.8,0-1.6,0.4-2.5,1.2v5.9c0.6,0.1,0.9,0.2,1.8,0.2c2,0,3.2-1.3,3.2-3.9C79,13.4,78.1,12.3,76.5,12.3z" />
+<path d="M93,22h-3v-1.5c-0.9,0.7-1.9,1.5-3.5,1.5c-1.5,0-3.1-1.1-3.1-3.2c0-2.9,2.5-3.4,4.2-3.7l2.4-0.3v-0.3c0-1.5-0.5-2.3-2-2.3 c-0.7,0-2.3,0.5-3.7,1.1L84,11c1.2-0.4,3-1,4.4-1c2.7,0,4.6,1.4,4.6,4.7L93,22z M90,16.4l-2.2,0.4c-0.7,0.1-1.4,0.5-1.4,1.6 c0,0.9,0.5,1.4,1.3,1.4s1.5-0.5,2.3-1V16.4z" />
+<path d="M104.5,21.3c-1.1,0.4-2.2,0.6-3.5,0.6c-4.2,0-5.9-2.4-5.9-5.9c0-3.7,2.3-6,6.1-6c1.4,0,2.3,0.2,3.2,0.5V13 c-0.8-0.3-2-0.6-3.2-0.6c-1.7,0-3.2,0.9-3.2,3.6c0,2.9,1.5,3.8,3.3,3.8c0.9,0,1.9-0.2,3.2-0.7V21.3z" />
+<path d="M110,15.2c0.2-0.3,0.2-0.8,3.8-5.2h3.7l-4.6,5.7l5,6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z" />
+<path d="M58.5,21.3c-1.5,0.5-2.7,0.6-4.2,0.6c-3.6,0-5.8-1.8-5.8-6c0-3.1,1.9-5.9,5.5-5.9s4.9,2.5,4.9,4.9c0,0.8,0,1.5-0.1,2h-7.3 c0.1,2.5,1.5,2.8,3.6,2.8c1.1,0,2.2-0.3,3.4-0.7C58.5,19,58.5,21.3,58.5,21.3z M56,15c0-1.4-0.5-2.9-2-2.9c-1.4,0-2.3,1.3-2.4,2.9 C51.6,15,56,15,56,15z" />
+		';
+
+		return sprintf(
+			'<svg id="jetpack-logo__icon" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 %1$s 32">%2$s</svg>',
+			( true === $logotype ? '118' : '32' ),
+			( true === $logotype ? $logo . $text : $logo )
+		);
 	}
 
 	/*

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1447,7 +1447,9 @@ function stats_dashboard_widget_content() {
 	}
 
 ?>
-<a class="button" href="admin.php?page=stats"><?php  esc_html_e( 'View All', 'jetpack' ); ?></a>
+<div class="stats-view-all">
+	<a class="button" href="admin.php?page=stats"><?php  esc_html_e( 'View all stats', 'jetpack' ); ?></a>
+</div>
 <div id="stats-info">
 	<div id="top-posts" class='stats-section'>
 		<div class="stats-section-inner">

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1196,7 +1196,7 @@ function stats_jetpack_dashboard_widget() {
 		<input type="hidden" name="widget_id" value="dashboard_stats" />
 		<?php submit_button( __( 'Submit', 'jetpack' ) ); ?>
 	</form>
-	<span id="js-toggle-stats_dashboard_widget_control">
+	<span class="js-toggle-stats_dashboard_widget_control">
 		<?php esc_html_e( 'Configure', 'jetpack' ); ?>
 	</span>
 	<div id="dashboard_stats">
@@ -1206,7 +1206,7 @@ function stats_jetpack_dashboard_widget() {
 	</div>
 	<script>
 		jQuery(document).ready(function($){
-			var $toggle = $('#js-toggle-stats_dashboard_widget_control');
+			var $toggle = $('.js-toggle-stats_dashboard_widget_control');
 
 			$toggle.parent().prev().append( $toggle );
 			$toggle.show().click(function(e){
@@ -1218,7 +1218,7 @@ function stats_jetpack_dashboard_widget() {
 		});
 	</script>
 	<style>
-		#js-toggle-stats_dashboard_widget_control {
+		.js-toggle-stats_dashboard_widget_control {
 			display: none;
 			float: right;
 			margin-top: 0.2em;

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1448,7 +1448,13 @@ function stats_dashboard_widget_content() {
 
 ?>
 <div class="stats-view-all">
-	<a class="button" href="admin.php?page=stats"><?php  esc_html_e( 'View all stats', 'jetpack' ); ?></a>
+<?php
+	printf(
+		'<a class="button" target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
+		esc_url( "https://wordpress.com/stats/day/" . Jetpack::build_raw_urls( get_home_url() ) ),
+		esc_html__( 'View all stats', 'jetpack' )
+	);
+?>
 </div>
 <div id="stats-info">
 	<div id="top-posts" class='stats-section'>

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1485,9 +1485,12 @@ function stats_dashboard_widget_content() {
 			<p class="nothing"><?php  esc_html_e( 'Sorry, nothing to report.', 'jetpack' ); ?></p>
 			<?php
 	} else {
-?>
-			<p><?php echo join( ',&nbsp; ', $searches );?></p>
-			<?php
+		foreach ( $searches as $search_term_item ) {
+			printf(
+				'<p>%s</p>',
+				$search_term_item
+			);
+		}
 	}
 ?>
 		</div>

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1503,6 +1503,7 @@ function stats_dashboard_widget_content() {
 	);
 ?>
 </div>
+<div class="clear"></div>
 <?php
 	exit;
 }

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1447,15 +1447,6 @@ function stats_dashboard_widget_content() {
 	}
 
 ?>
-<div class="stats-view-all">
-<?php
-	printf(
-		'<a class="button" target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
-		esc_url( "https://wordpress.com/stats/day/" . Jetpack::build_raw_urls( get_home_url() ) ),
-		esc_html__( 'View all stats', 'jetpack' )
-	);
-?>
-</div>
 <div id="stats-info">
 	<div id="top-posts" class='stats-section'>
 		<div class="stats-section-inner">
@@ -1503,6 +1494,15 @@ function stats_dashboard_widget_content() {
 	</div>
 </div>
 <div class="clear"></div>
+<div class="stats-view-all">
+<?php
+	printf(
+		'<a class="button" target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
+		esc_url( "https://wordpress.com/stats/day/" . Jetpack::build_raw_urls( get_home_url() ) ),
+		esc_html__( 'View all stats', 'jetpack' )
+	);
+?>
+</div>
 <?php
 	exit;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes #10553

This update updates the look of the Stats dashboard widget to be cleaner and Jetpack-branded.

![image](https://user-images.githubusercontent.com/426388/49873081-44ffff80-fe1b-11e8-9081-a5c82e5dbf9f.png)

#### Testing instructions:

* You'll need a site with some traffic, or you will need to fake some traffic to get some data in the stats widget.
* Open your dashboard and check the Stats widget.

#### Proposed changelog entry for your changes:

* Stats: improve the design of the Stats dashboard widget.
