### PR TITLE
JITM: hide message 3 seconds after clicking the module act. CTA

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -119,8 +119,8 @@ jQuery( document ).ready( function( $ ) {
 				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
 
 				// Hide the JITM after 3 seconds.
-				setTimeout( function() {
-					$template.hide();
+				setTimeout( function () {
+					$template.fadeOut( 'slow' );
 				}, 3000 );
 			} );
 		} );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -118,10 +118,10 @@ jQuery( document ).ready( function( $ ) {
 				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );
 				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
 
-				// Hide the JITM after 3 seconds.
+				// Hide the JITM after 2 seconds.
 				setTimeout( function () {
 					$template.fadeOut( 'slow' );
-				}, 3000 );
+				}, 2000 );
 			} );
 		} );
 	};

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -117,6 +117,11 @@ jQuery( document ).ready( function( $ ) {
 			} ).done( function() {
 				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );
 				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
+
+				// Hide the JITM after 3 seconds.
+				setTimeout( function() {
+					$template.hide();
+				}, 3000 );
 			} );
 		} );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This will address part of #9462

I picked 3 seconds to give folks time to see that the button changed to an "Activated" status.

![screen recording 2018-12-12 at 05 49 pm](https://user-images.githubusercontent.com/426388/49885503-acc44380-fe37-11e8-9433-78d4047ea118.gif)


#### Testing instructions:

* Go to Jetpack > Settings and deactivate the Asset CDN.
* Refresh the page; you should see a JITM offering you to activate the feature.
* Click activate, and notice the message going through the different phases of the process (activating, activated), before to disappear.

#### Proposed changelog entry for your changes:
* Dashboard notices: automatically dismiss notices once a feature has been activated.
