### PR TITLE
Jetpack Sync: check that $_SERVER variables are set before using them in current url

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -126,7 +126,7 @@ class Jetpack_Sync_Listener {
 			return;
 		}
 
-		// if we add any items to the queue, we should try to ensure that our script 
+		// if we add any items to the queue, we should try to ensure that our script
 		// can't be killed before they are sent
 		if ( function_exists( 'ignore_user_abort' ) ) {
 			ignore_user_abort( true );
@@ -144,7 +144,7 @@ class Jetpack_Sync_Listener {
 			 *
 			 * @since 4.2.0
 			 *
-			 * @module sync 
+			 * @module sync
 			 *
 			 * @param array The action parameters
 			 */
@@ -202,7 +202,7 @@ class Jetpack_Sync_Listener {
 			return;
 		}
 
-		// if we add any items to the queue, we should try to ensure that our script 
+		// if we add any items to the queue, we should try to ensure that our script
 		// can't be killed before they are sent
 		if ( function_exists( 'ignore_user_abort' ) ) {
 			ignore_user_abort( true );
@@ -304,6 +304,9 @@ class Jetpack_Sync_Listener {
 	}
 
 	function get_request_url() {
-		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+		if ( isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
+			return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+		}
+		return is_admin() ? get_admin_url( get_current_blog_id() ) : home_url();
 	}
 }


### PR DESCRIPTION
Fixes #10717 

#### Changes proposed in this Pull Request:

* Check for server vars before using them in current url
* defaults to home_url() or get_admin_url() if server vars are missing

#### Testing instructions:
- Apply this PR to your site, and ensure the notices described in the issue stop appearing in your error logs

For more detailed testing, see the instructions on how to observe Jetpack Sync data that is sent from Jetpack to a WPCOM sandbox: PCYsg-hnH-p2, and ensure the sync actor looks correct.

#### Proposed changelog entry for your changes:
None
