### PR TITLE
Calypsoify: only build from original file.

### DIFF
--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -73,7 +73,7 @@ function doRTL( files, done ) {
 			success = 'DOPS Components RTL CSS finished.';
 			break;
 		case 'calypsoify':
-			path = './modules/calypsoify/style*.min.css';
+			path = './modules/calypsoify/style.min.css';
 			dest = './modules/calypsoify';
 			success = 'Calypsoify RTL CSS finished.';
 			renameArgs = function( pathx ) {

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -73,7 +73,7 @@ function doRTL( files, done ) {
 			success = 'DOPS Components RTL CSS finished.';
 			break;
 		case 'calypsoify':
-			path = './modules/calypsoify/style*[^rtl].min.css';
+			path = [ './modules/calypsoify/style*.min.css', '!./modules/calypsoify/style*rtl.min.css' ];
 			dest = './modules/calypsoify';
 			success = 'Calypsoify RTL CSS finished.';
 			renameArgs = function( pathx ) {

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -73,7 +73,7 @@ function doRTL( files, done ) {
 			success = 'DOPS Components RTL CSS finished.';
 			break;
 		case 'calypsoify':
-			path = './modules/calypsoify/style.min.css';
+			path = './modules/calypsoify/style*[^rtl].min.css';
 			dest = './modules/calypsoify';
 			success = 'Calypsoify RTL CSS finished.';
 			renameArgs = function( pathx ) {


### PR DESCRIPTION
Fixes #10697

#### Changes proposed in this Pull Request:

* Only create RTL version from original file, not from built files.

#### Testing instructions:

* Checkout branch.
* Run `gulp sass:calypsoify`
* Notice that all files are built under `modules/calypsoify`
* Run it again
* Make sure no other files are built.

#### Proposed changelog entry for your changes:

* None
