### PR TITLE
Admin Page: Make settings updates have better notice messages

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import get from 'lodash/get';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -55,11 +56,17 @@ export function connectModuleOptions( Component ) {
 			};
 		},
 		( dispatch ) => ( {
-			updateOptions: ( newOptions ) => {
-				return dispatch( updateSettings( newOptions ) );
+			updateOptions: ( newOptions, messages = {} ) => {
+				return dispatch( updateSettings( newOptions, messages ) );
 			},
-			regeneratePostByEmailAddress: newOptions => {
-				return dispatch( updateSettings( newOptions, 'regeneratePbE' ) );
+			regeneratePostByEmailAddress: () => {
+				const messages = {
+					progress: __( 'Updating Post by Email address…' ),
+					success: __( 'Regenerated Post by Email address.' ),
+					error: error => __( 'Error regenerating Post by Email address. %(error)s', { args: { error: error } } )
+				};
+
+				return dispatch( updateSettings( { post_by_email_address: 'regenerate' }, messages ) );
 			},
 			setUnsavedSettingsFlag: () => {
 				return dispatch( setUnsavedSettingsFlag() );

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
+import get from 'lodash/get';
 import { translate as __ } from 'i18n-calypso';
 import some from 'lodash/some';
 
@@ -82,31 +83,26 @@ export const updateSetting = ( updatedOption ) => {
 	};
 };
 
-export const updateSettings = ( newOptionValues, type = '' ) => {
+export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 	return ( dispatch ) => {
-		let messages = {
-				progress: __( 'Updating settings…' ),
-				success: __( 'Updated settings.' ),
-				// We try to get a message or an error code if this is an unexpected WP_Error coming from the API.
-				// Otherwise we try to show error.name (coming from the custom errors defined in rest-api/index.js and if that's not useful
-				// then we try to let Javascript stringify the error object.
-				error: error => __( 'Error updating settings. %(error)s', { args: { error: error.message || error.code || error.name || error } } )
-			},
-			updatedOptionsSuccess = () => newOptionValues;
+		const messages = {
+			progress: __( 'Updating settings…' ),
+			success: __( 'Updated settings.' ),
+			// We try to get a message or an error code if this is an unexpected WP_Error coming from the API.
+			// Otherwise we try to show error.name (coming from the custom errors defined in rest-api/index.js and if that's not useful
+			// then we try to let Javascript stringify the error object.
+			error: error => __( 'Error updating settings. %(error)s', { args: { error: error.message || error.code || error.name || error } } ),
+			... noticeMessages,
+		};
+		let updatedOptionsSuccess = () => newOptionValues;
 
 		// Adapt messages and data when regenerating Post by Email address
-		if ( 'regeneratePbE' === type ) {
-			messages = {
-				progress: __( 'Updating Post by Email address…' ),
-				success: __( 'Regenerated Post by Email address.' ),
-				error: error => __( 'Error regenerating Post by Email address. %(error)s', { args: { error: error } } )
-			};
+		if ( get( newOptionValues, 'post_by_email_address' ) === 'regenerate' ) {
 			updatedOptionsSuccess = success => {
 				return {
 					post_by_email_address: success.post_by_email_address
 				};
 			};
-			newOptionValues = { post_by_email_address: 'regenerate' };
 		}
 
 		// Changes to these options affect WordPress.com Toolbar appearance,

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -47,6 +47,12 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 
 			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
 			if ( true === siteAcceleratorStatus ) {
+				const messages = {
+					progress: __( 'Disabling Site accelerator…' ),
+					success: __( 'Site accelerator is no longer speeding up your site!' ),
+					error: error => __( 'Error disabling Site accelerator. %(error)s', { args: { error: error } } )
+				};
+
 				if ( false === ! newPhotonStatus && 'active' !== photonStatus ) {
 					newPhotonStatus = false;
 
@@ -54,16 +60,21 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 						photon: false,
 						'tiled-gallery': false,
 						tiled_galleries: false
-					} );
+					}, messages );
 				}
 				if ( false === ! newAssetCdnStatus && 'active' !== assetCdnStatus ) {
 					newAssetCdnStatus = false;
 
 					this.props.updateOptions( {
 						'photon-cdn': false
-					} );
+					}, messages );
 				}
 			} else {
+				const messages = {
+					progress: __( 'Enabling Site accelerator…' ),
+					success: __( 'Site accelerator is now speeding up your site!' ),
+					error: error => __( 'Error enabling Site accelerator. %(error)s', { args: { error: error } } )
+				};
 				if ( false === newPhotonStatus && 'inactive' !== photonStatus ) {
 					newPhotonStatus = true;
 
@@ -71,14 +82,14 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 						photon: true,
 						'tiled-gallery': true,
 						tiled_galleries: true
-					} );
+					}, messages );
 				}
 				if ( false === newAssetCdnStatus && 'inactive' !== assetCdnStatus ) {
 					newAssetCdnStatus = true;
 
 					this.props.updateOptions( {
 						'photon-cdn': true
-					} );
+					}, messages );
 				}
 			}
 

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -48,9 +48,9 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
 			if ( true === siteAcceleratorStatus ) {
 				const messages = {
-					progress: __( 'Disabling Site accelerator…' ),
+					progress: __( 'Disabling site accelerator…' ),
 					success: __( 'Site accelerator is no longer speeding up your site!' ),
-					error: error => __( 'Error disabling Site accelerator. %(error)s', { args: { error: error } } )
+					error: error => __( 'Error disabling site accelerator. %(error)s', { args: { error: error } } )
 				};
 				let settings = {};
 

--- a/_inc/client/writing/speed-up-site.jsx
+++ b/_inc/client/writing/speed-up-site.jsx
@@ -52,45 +52,49 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 					success: __( 'Site accelerator is no longer speeding up your site!' ),
 					error: error => __( 'Error disabling Site accelerator. %(error)s', { args: { error: error } } )
 				};
+				let settings = {};
 
 				if ( false === ! newPhotonStatus && 'active' !== photonStatus ) {
 					newPhotonStatus = false;
-
-					this.props.updateOptions( {
+					settings = {
 						photon: false,
 						'tiled-gallery': false,
 						tiled_galleries: false
-					}, messages );
+					};
 				}
 				if ( false === ! newAssetCdnStatus && 'active' !== assetCdnStatus ) {
 					newAssetCdnStatus = false;
-
-					this.props.updateOptions( {
+					settings = {
+						...settings,
 						'photon-cdn': false
-					}, messages );
+					};
 				}
+				this.props.updateOptions( settings, messages );
 			} else {
 				const messages = {
 					progress: __( 'Enabling Site accelerator…' ),
 					success: __( 'Site accelerator is now speeding up your site!' ),
 					error: error => __( 'Error enabling Site accelerator. %(error)s', { args: { error: error } } )
 				};
+				let settings = {};
+
 				if ( false === newPhotonStatus && 'inactive' !== photonStatus ) {
 					newPhotonStatus = true;
 
-					this.props.updateOptions( {
+					settings = {
 						photon: true,
 						'tiled-gallery': true,
 						tiled_galleries: true
-					}, messages );
+					};
 				}
 				if ( false === newAssetCdnStatus && 'inactive' !== assetCdnStatus ) {
 					newAssetCdnStatus = true;
-
-					this.props.updateOptions( {
+					settings = {
+						...settings,
 						'photon-cdn': true
-					}, messages );
+					};
 				}
+				this.props.updateOptions( settings, messages );
 			}
 
 			// If at least one of the modules is now on, let's reflect that with the status of our main toggle.


### PR DESCRIPTION
Addresses #10640 partially. The scope of the messaging updates needs the structure introduced in this PR but has a wider reach than just the accelerator message.

#### Changes proposed in this Pull Request:

* Adds custom notice message when updating settings via  the Site accelerator toggle. d35b2a76a1dc4be71fcf6e2476203e976d44b15a
* Refactors the Redux action creator `updateSettings` to handle the custom message in a tidier way. With a api response mapping function. 7464fadfcc3afb0bc7c5917608e06d292aee080b
* Also the action creator is updated to accept a `messages` parameter with an object holding the notice messages as strings.  Refactors the High Order component `connect-module-options` to better handle the `regeneratePostByEmailAddress()` request and also to accept the `messages` parameter for the `updateOptions` method. 4a19c58da9e126f26df458df9af8fdca2d454b72

#### Testing instructions

for designers

1. Check this branch, or launch a [JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=update/make-settings-update-have-better-notice-messages&shortlived&wp-debug-log)
2. Connect the site.
3. Jumpstart the site
4. On the Wirting settings tab, enable and disable site accelerator from the main toggle.
5. Check the notice messages.

#### Testing instructions for developers

As this PR refactors stuff affecting other settings please check the above, but also

1. Regenerating a post by email address and expecting the same messages as currently
2. Updating any other setting, and seeing the generic message for settings update.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added better message for settings notices.


#### Screeshots

![activation](https://user-images.githubusercontent.com/746152/49971756-4f4ef600-ff0e-11e8-8525-f8d0bd175fa8.gif)
