### PR TITLE
REST API: Remove core API related posts endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -184,13 +184,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => array( $site_endpoint , 'can_request' ),
 		) );
 
-		// Get related posts of a certain site post
-		register_rest_route( 'jetpack/v4', '/site/posts/related', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => array( $site_endpoint, 'get_related_posts' ),
-			'permission_callback' => array( $site_endpoint , 'can_request' ),
-		) );
-
 		// Confirm that a site in identity crisis should be in staging mode
 		register_rest_route( 'jetpack/v4', '/identity-crisis/confirm-safe-mode', array(
 			'methods' => WP_REST_Server::EDITABLE,

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -48,69 +48,6 @@ class Jetpack_Core_API_Site_Endpoint {
 	}
 
 	/**
-	 * Returns the result of `/sites/%s/posts/%d/related` endpoint call.
-	 * Results are not cached and are retrieved in real time.
-	 *
-	 * @since 6.7.0
-	 *
-	 * @param int ID of the post to get related posts of
-	 *
-	 * @return array
-	 */
-	public static function get_related_posts( $api_request ) {
-		$params = $api_request->get_params();
-		$post_id = ! empty( $params['post_id'] ) ? absint( $params['post_id'] ) : 0;
-
-		if ( ! $post_id ) {
-			return new WP_Error(
-				'incorrect_post_id',
-				esc_html__( 'You need to specify a correct ID of a post to return related posts for.', 'jetpack' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Make the API request
-		$request = sprintf( '/sites/%d/posts/%d/related', Jetpack_Options::get_option( 'id' ), $post_id );
-		$request_args = array(
-			'headers' => array(
-				'Content-Type' => 'application/json',
-			),
-			'timeout'    => 10,
-			'method' => 'POST',
-		);
-		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1', $request_args );
-
-		// Bail if there was an error or malformed response
-		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
-			return new WP_Error(
-				'failed_to_fetch_data',
-				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Decode the results
-		$results = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		$related_posts = array();
-		if ( isset( $results['hits'] ) && is_array( $results['hits'] ) ) {
-			$related_posts_ids = array_map( array( 'Jetpack_Core_API_Site_Endpoint', 'get_related_post_id' ), $results['hits'] );
-
-			$related_posts_instance = Jetpack_RelatedPosts::init();
-			foreach ( $related_posts_ids as $related_post_id ) {
-				$related_posts[] = $related_posts_instance->get_related_post_data_for_post( $related_post_id, 0, 0 );
-			}
-		}
-
-		return rest_ensure_response( array(
-				'code' => 'success',
-				'message' => esc_html__( 'Related posts retrieved successfully.', 'jetpack' ),
-				'posts' => $related_posts,
-			)
-		);
-	}
-
-	/**
 	 * Check that the current user has permissions to request information about this site.
 	 *
 	 * @since 5.1.0
@@ -119,17 +56,5 @@ class Jetpack_Core_API_Site_Endpoint {
 	 */
 	public static function can_request() {
 		return current_user_can( 'jetpack_manage_modules' );
-	}
-
-	/**
-	 * Returns the post ID out of a related post entry from the
-	 * `/sites/%s/posts/%d/related` WP.com endpoint.
-	 *
-	 * @since 6.7.0
-	 *
-	 * @return int
-	 */
-	public static function get_related_post_id( $item ) {
-		return $item['fields']['post_id'];
 	}
 }


### PR DESCRIPTION
The Related Posts block was the only use case of the `/jetpack/v4` related posts endpoint I am aware of. Since https://github.com/Automattic/wp-calypso/pull/29439 suggests that we remove that usage and rely on the core posts endpoint that has the related posts information, I suggest that we delete this unused endpoint.

#### Changes proposed in this Pull Request:

* Remove the unused `/site/posts/related` endpoint.

#### Testing instructions:

* Verify this endpoint is indeed not used anywhere anymore.
* Verify we're removing everything unused that this endpoint was introducing.

#### Proposed changelog entry for your changes:

* Removed the unused `/site/posts/related` endpoint.
