### PR TITLE
SSO: set option when someone sees a JITM helping them to discover SSO.

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -317,6 +317,15 @@ class Jetpack_JITM {
 		$hidden_jitms = Jetpack_Options::get_option( 'hide_jitm' );
 		unset( $envelopes['last_response_time'] );
 
+		/**
+		 * Allow adding your own custom JITMs after a set of JITMs has been received.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param array $envelopes array of existing JITMs.
+		 */
+		$envelopes = apply_filters( 'jetpack_jitm_received_envelopes', $envelopes );
+
 		foreach ( $envelopes as $idx => &$envelope ) {
 
 			$dismissed_feature = isset( $hidden_jitms[ $envelope->feature_class ] ) && is_array( $hidden_jitms[ $envelope->feature_class ] ) ? $hidden_jitms[ $envelope->feature_class ] : null;

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -92,6 +92,7 @@ class Jetpack_Options {
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
 			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget
+			'sso_first_login',              // (bool)   Is this the first time the user logins via SSO.
 		);
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -23,16 +23,17 @@ class Jetpack_SSO {
 
 		self::$instance = $this;
 
-		add_action( 'admin_init',             array( $this, 'maybe_authorize_user_after_sso' ), 1 );
-		add_action( 'admin_init',             array( $this, 'register_settings' ) );
-		add_action( 'login_init',             array( $this, 'login_init' ) );
-		add_action( 'delete_user',            array( $this, 'delete_connection_for_user' ) );
-		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
-		add_action( 'init',                   array( $this, 'maybe_logout_user' ), 5 );
-		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
-		add_action( 'login_form_logout',      array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
-		add_action( 'jetpack_unlinked_user',  array( $this, 'delete_connection_for_user') );
-		add_action( 'wp_login',               array( 'Jetpack_SSO', 'clear_cookies_after_login' ) );
+		add_action( 'admin_init',                     array( $this, 'maybe_authorize_user_after_sso' ), 1 );
+		add_action( 'admin_init',                     array( $this, 'register_settings' ) );
+		add_action( 'login_init',                     array( $this, 'login_init' ) );
+		add_action( 'delete_user',                    array( $this, 'delete_connection_for_user' ) );
+		add_filter( 'jetpack_xmlrpc_methods',         array( $this, 'xmlrpc_methods' ) );
+		add_action( 'init',                           array( $this, 'maybe_logout_user' ), 5 );
+		add_action( 'jetpack_modules_loaded',         array( $this, 'module_configure_button' ) );
+		add_action( 'login_form_logout',              array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
+		add_action( 'jetpack_unlinked_user',          array( $this, 'delete_connection_for_user') );
+		add_action( 'wp_login',                       array( 'Jetpack_SSO', 'clear_cookies_after_login' ) );
+		add_action( 'jetpack_jitm_received_envelopes', array( $this, 'inject_sso_jitm' ) );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -370,6 +371,12 @@ class Jetpack_SSO {
 					add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 					$reauth = ! empty( $_GET['force_reauth'] );
 					$sso_url = $this->get_sso_url_or_die( $reauth );
+
+					// Is this our first SSO Login. Set an option.
+					if ( ! Jetpack_Options::get_option( 'sso_first_login' ) ) {
+						Jetpack_options::update_option( 'sso_first_login', true );
+					}
+
 					JetpackTracking::record_user_event( 'sso_login_redirect_success' );
 					wp_safe_redirect( $sso_url );
 					exit;
@@ -1086,6 +1093,51 @@ class Jetpack_SSO {
 	 **/
 	public function get_user_data( $user_id ) {
 		return get_user_meta( $user_id, 'wpcom_user_data', true );
+	}
+
+	/**
+	 * Mark SSO as discovered when an SSO JITM is viewed.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $jitm_id ID of the JITM being displayed.
+	 *
+	 * @return void
+	 */
+	public function inject_sso_jitm( $envelopes ) {
+		// Bail early if that's not the first time the user uses SSO.
+		if ( true != Jetpack_Options::get_option( 'sso_first_login' ) ) {
+			return $envelopes;
+		}
+
+		// Build our custom SSO JITM.
+		$discover_sso_message = array(
+			'content'         => array(
+				'message'     => esc_html__( "You've successfully signed in with WordPress.com Secure Sign On!", 'jetpack' ),
+				'icon'        => 'jetpack',
+				'list'        => array(),
+				'description' => esc_html__( 'Logging in with the same log-in credentials you use for WordPress.com ensures you always sign in to self-hosted WordPress.org sites quickly and securely.', 'jetpack' ),
+				'classes'     => '',
+			),
+			'CTA'             => array(
+				'message'   => esc_html__( 'Learn More', 'jetpack' ),
+				'hook'      => '',
+				'newWindow' => true,
+				'primary'   => true,
+			),
+			'template'        => 'default',
+			'ttl'             => 300,
+			'id'              => 'sso_discover',
+			'feature_class'   => 'sso',
+			'expires'         => 3628800,
+			'max_dismissal'   => 1,
+			'activate_module' => null,
+		);
+
+		// Update our option to mark that SSO was discovered.
+		Jetpack_Options::update_option( 'sso_first_login', false );
+
+		return array( json_decode( json_encode( $discover_sso_message ) ) );
 	}
 }
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1130,7 +1130,7 @@ class Jetpack_SSO {
 				'message'     => esc_html__( "You've successfully signed in with WordPress.com Secure Sign On!", 'jetpack' ),
 				'icon'        => 'jetpack',
 				'list'        => array(),
-				'description' => esc_html__( 'Logging in with the same log-in credentials you use for WordPress.com ensures you always sign in to self-hosted WordPress.org sites quickly and securely.', 'jetpack' ),
+				'description' => esc_html__( 'Interested in learning more about how Secure Sign on keeps your site safer?', 'jetpack' ),
 				'classes'     => '',
 			),
 			'CTA'             => array(


### PR DESCRIPTION
Fixes #10692

#### Changes proposed in this Pull Request:

- At first SSO login, set an option
- If that option is true, display an SSO JITM.
- Once the SSO JITM has been displayed, set the option to false so it can never be displayed again

<img width="1260" alt="screenshot 2018-12-14 at 22 21 25" src="https://user-images.githubusercontent.com/426388/50028047-a0361b80-ffee-11e8-950e-696738e1f8fe.png">

#### Testing instructions:

* Enable SSO on your site.
* Log out.
* Log back in, using SSO.
* See the banner in the screenshot above.
* Never see it again if you refresh / log out and log back in.

Note that for the CTA link to work, we still need to add the link on WordPress.com (see discussion in D22220-code)

#### Proposed changelog entry for your changes:

* SSO: offer message introducing the feature to new users.
