### PR TITLE
Shortlinks: Register as REST API post field and Gutenberg plugin

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -76,6 +76,7 @@ class Jetpack_Gutenberg {
 	// PLUGINS
 	private static $default_plugins = array(
 		'publicize',
+		'shortlinks',
 	);
 	/**
 	 * @var array Array of plugins information.

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -128,5 +128,5 @@ if ( function_exists( 'register_rest_field' ) ) {
 	add_action( 'rest_api_init', 'wpme_rest_register_shortlinks' );
 }
 
-// Register Gutenberg block
+// Register Gutenberg plugin
 jetpack_register_plugin( 'shortlinks' );

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -87,3 +87,46 @@ function wpme_get_shortlink( $id = 0, $context = 'post', $allow_slugs = true ) {
 function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {
 	return wpme_get_shortlink( $id, $context, $allow_slugs );
 }
+
+/**
+ * Add Shortlinks to the REST API Post response.
+ *
+ * @since 6.9.0
+ *
+ * @action rest_api_init
+ * @uses register_rest_field, wpme_rest_get_shortlink
+ */
+function wpme_rest_register_shortlinks() {
+	register_rest_field(
+		'post',
+		'jetpack_shortlink',
+		array(
+			'get_callback'    => 'wpme_rest_get_shortlink',
+			'update_callback' => null,
+			'schema'          => null,
+		)
+	);
+}
+
+/**
+ * Get the shortlink of a post.
+ *
+ * @since 6.9.0
+ *
+ * @param array $object Details of current post.
+ *
+ * @uses wpme_get_shortlink
+ *
+ * @return string
+ */
+function wpme_rest_get_shortlink( $object ) {
+	return wpme_get_shortlink( $object['id'], array() );
+}
+
+// Add shortlinks to the REST API Post response.
+if ( function_exists( 'register_rest_field' ) ) {
+	add_action( 'rest_api_init', 'wpme_rest_register_shortlinks' );
+}
+
+// Register Gutenberg block
+jetpack_register_plugin( 'shortlinks' );


### PR DESCRIPTION
In the WP.com old editor, we used to have the shortlinks handy in the sidebar. We don't have them in Gutenberg, and they can sometimes be a very handy feature. This PR registers the post shortlink as a REST API field, and as a Gutenberg plugin, which are necessary to be able to build the UI for shortlinks in Gutenberg.

#### Changes proposed in this Pull Request:

* Add shortlinks to the REST API post response.
* Register shortlinks as a Gutenberg plugin, so they're available in our block availability endpoint.

#### Testing instructions:

* Start a JN site with this branch.
* Connect the site, and activate all recommended features.
* Write a post and save it.
* Type `wp.data.select( 'core/editor' ).getCurrentPost().jetpack_shortlink` in your browser console.
* Verify it returns a correct shortlink that leads to the post you just created.
* Type `window.Jetpack_Editor_Initial_State.available_blocks.shortlinks` in your browser console.
* Verify it returns `{available: true}`.
* Want to test the actual Gutenberg extension that uses this? Go to https://github.com/Automattic/wp-calypso/pull/29475 and follow the test instructions there

#### Proposed changelog entry for your changes:

* Shortlinks: Register as REST API post field and Gutenberg plugin

#### Notes

I'm marking this as low priority, as it isn't super important to have. In the same time, I think it's handy to have it, and it's straightforward enough so we could have it ready for the next Jetpack version.