### PR TITLE
Asset CDN: Fix json translation loading

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -30,7 +30,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		add_action( 'admin_print_scripts', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'admin_print_styles', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'cdnize_assets' ) );
-		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ) );
+		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ), 10, 2 );
 	}
 
 	/**
@@ -85,7 +85,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	}
 
 	/**
-	 * Ensure correct relative path when
+	 * Ensure use of the correct relative path when determining the JavaScript file names.
 	 *
 	 * @param string $relative The relative path of the script. False if it could not be determined.
      * @param string $src      The full source url of the script.

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -30,6 +30,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		add_action( 'admin_print_scripts', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'admin_print_styles', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'cdnize_assets' ) );
+		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ) );
 	}
 
 	/**
@@ -81,6 +82,17 @@ class Jetpack_Photon_Static_Assets_CDN {
 		if ( class_exists( 'WooCommerce' ) ) {
 			self::cdnize_plugin_assets( 'woocommerce', WC_VERSION );
 		}
+	}
+
+	/**
+	 * Ensure correct relative path when
+	 *
+	 * @param string $relative The relative path of the script. False if it could not be determined.
+     * @param string $src      The full source url of the script.
+     * @return string The expected relative path for the CDN-ed URL.
+	 */
+	public static function fix_script_relative_path( $relative, $src ) {
+		return substr( $src, 1 + strpos( $src, '/wp-includes/' ) );
 	}
 
 	/**

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -88,8 +88,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * Ensure correct relative path when
 	 *
 	 * @param string $relative The relative path of the script. False if it could not be determined.
-     * @param string $src      The full source url of the script.
-     * @return string The expected relative path for the CDN-ed URL.
+	 * @param string $src      The full source url of the script.
+	 * @return string The expected relative path for the CDN-ed URL.
 	 */
 	public static function fix_script_relative_path( $relative, $src ) {
 		return substr( $src, 1 + strpos( $src, '/wp-includes/' ) );


### PR DESCRIPTION
When the static asset CDN of Jetpack is loaded, the translations for Gutenberg don'tt load properly because the filename is generated for a wrong path.

Also fixes https://github.com/Automattic/wp-calypso/issues/29309

This has been extensively discussed in https://core.trac.wordpress.org/ticket/45528

#### Changes proposed in this Pull Request:

* This implements the filter that has been introduced into Core.

#### Testing instructions:

Prequisit: WordPress 5.0.2(alpha) or trunk

1. Set your WordPress to another language than English.
2. Activate Jetpack Static Asset CDN.
3. Potentially add a filter to your WordPress if it's running trunk (see #10102)
4. Create a new post to open Gutenberg and observe broken translations.
5. Activate the patch: Translations should now load after a reload.

#### Proposed changelog entry for your changes:

* Fixes loading of the Block Editor UI translations when Static Asset CDN is used (requires WordPress 5.0.2)
