### PR TITLE
Gutenberg: adds feature content support

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -706,17 +706,17 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 	}
 	add_action( 'restapi_theme_action_copy_dirs', 'wpcom_rest_api_featured_content_copy_plugin_actions' );
 
+	/**
+	 * Delayed initialization for API Requests.
+	 */
 	function wpcom_rest_request_before_callbacks( $request ) {
 		Featured_Content::init();
 		return $request;
 	}
 
-	/**
-	 * Delayed initialization for API Requests.
-	 */
-	if ( Jetpack_Constants::is_true( 'REST_API_REQUEST' ) ) {
+	if ( Jetpack_Constants::is_true( 'IS_WPCOM' ) && Jetpack_Constants::is_true( 'REST_API_REQUEST' ) ) {
 		add_filter( 'rest_request_before_callbacks', 'wpcom_rest_request_before_callbacks');
-	} else {
-		Featured_Content::setup();
 	}
+
+	Featured_Content::setup();
 } // end if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -693,8 +693,6 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		}
 	}
 
-	Featured_Content::setup();
-
 	/**
 	 * Adds the featured content plugin to the set of files for which action
 	 * handlers should be copied when the theme context is loaded by the REST API.
@@ -708,4 +706,17 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 	}
 	add_action( 'restapi_theme_action_copy_dirs', 'wpcom_rest_api_featured_content_copy_plugin_actions' );
 
+	function wpcom_rest_request_before_callbacks( $request ) {
+		Featured_Content::init();
+		return $request;
+	}
+
+	/**
+	 * Delayed initialization for API Requests.
+	 */
+	if ( Jetpack_Constants::is_true( 'REST_API_REQUEST' ) ) {
+		add_filter( 'rest_request_before_callbacks', 'wpcom_rest_request_before_callbacks');
+	} else {
+		Featured_Content::setup();
+	}
 } // end if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/Automattic/wp-calypso/issues/28975

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR adds delayed initialization of the _Featured Content_ module for REST API requests on WordPress.com.

This does not affect Jetpack, because theme initialization is slightly different

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You'll find detailed testing instructions for WordPress.com on D22398-code.

For Jetpack:

* Apply this branch to a Jetpack site, or use Jurassic Ninja to create a ephemeral instance:
  * https://jurassic.ninja/create?gutenberg&jetpack-beta&branch=fix/gutenberg-feature-content-tags-on-pages
* Activate Jetpack. You don't need a paid plan to test this.
* Go to _Pages_ > _Add New_ to load the editor.
  * Verify that there's no _Tags_ panel on the sidebar.
* Install and Activate a theme that supports __Featured Content With Pages__.
  * Not all themes that support featured content support tags on pages. Some only support posts. One theme that supports tags on pages is [`Dara`](https://wordpress.com/theme/dara).
* Go to _Pages_ > _Add New_ to load the editor.
  * Verify that the _Tags_ panel on the sidebar loads correctly.
