### PR TITLE
Jumpstart: update "Skip" link to point to Settings page.

### DIFF
--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -39,7 +39,7 @@ class JumpStart extends Component {
 	dismissLink = () => {
 		return (
 			<a
-				href="javascript:void(0)"
+				href={ '#/settings' }
 				onClick={ this.props.jumpStartSkip }
 				className="jp-jumpstart__skip-link"
 			>


### PR DESCRIPTION
@see https://github.com/Automattic/jetpack/pull/10954#issuecomment-447809236

#### Changes proposed in this Pull Request:

When one clicks on the "Skip and explore features" link in the new Jumpstart modal, they should be redirected to the Settings page.

#### Testing instructions:

* Start from a brand new site, or run `yarn docker:wp jetpack options delete jumpstart` on your local site.
* Connect your site to WordPress.com.
* See the modal in the Jetpack dashboard.
* Click on "Skip and explore features"
* You should be redirected to the Jetpack settings page.

#### Proposed changelog entry for your changes:

* None