### PR TITLE
Giphy Block Registration

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -87,7 +87,7 @@ function jetpack_giphy_block_load_assets( $attr ) {
 			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>
 		<?php if ( $caption ) : ?>
-			<p class="wp-block-jetpack-giphy-caption"><?php echo esc_html( $caption ); ?></p>
+			<p class="wp-block-jetpack-giphy-caption"><?php echo wp_kses_post( $caption ); ?></p>
 		<?php endif; ?>
 	</div>
 	<?php

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -96,7 +96,7 @@ function jetpack_gif_block_load_assets( $attr ) {
 	?>
 	<div class="<?php echo esc_attr( implode( $classes, ' ' ) ); ?>">
 		<figure style="<?php echo esc_attr( $style ); ?>">
-			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
+			<iframe src="<?php echo esc_url( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>
 		<?php if ( $caption ) : ?>
 			<p class="wp-block-jetpack-gif-caption"><?php echo wp_kses_post( $caption ); ?></p>

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -75,7 +75,7 @@ if (
  */
 function jetpack_giphy_block_load_assets( $attr ) {
 	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
-	$style       = 'padding-top:' . $attr['topPadding'] . '%';
+	$style       = 'padding-top:' . $attr['paddingTop'];
 	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv';
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -81,7 +81,7 @@ function jetpack_gif_block_render( $attr ) {
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 
-	if ( ! $giphy_url ) {
+	if ( ! $giphy_url || ! $padding_top ) {
 		return null;
 	}
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -80,9 +80,17 @@ function jetpack_gif_block_load_assets( $attr ) {
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 
+	$classes = array(
+		'wp-block-jetpack-gif',
+		'align' . $align,
+	);
+	if ( isset( $attr['className'] ) ) {
+		array_push( $classes, $attr['className'] );
+	}
+
 	ob_start();
 	?>
-	<div class="wp-block-jetpack-gif align<?php echo esc_attr( $align ); ?>">
+	<div class="<?php echo esc_attr( implode( $classes, ' ' ) ); ?>">
 		<figure style="<?php echo esc_attr( $style ); ?>">
 			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -75,7 +75,8 @@ if (
  */
 function jetpack_gif_block_load_assets( $attr ) {
 	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
-	$style       = 'padding-top:' . $attr['paddingTop'];
+	$padding_top = isset( $attr['paddingTop'] ) ? $attr['paddingTop'] : 0;
+	$style       = 'padding-top:' . $padding_top;
 	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : null;
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -81,7 +81,7 @@ function jetpack_gif_block_render( $attr ) {
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 
-	if ( ! $giphy_url || ! $padding_top ) {
+	if ( ! $giphy_url ) {
 		return null;
 	}
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -79,18 +79,20 @@ function jetpack_giphy_block_load_assets( $attr ) {
 	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv';
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
+
 	ob_start();
 	?>
-	<div class="wp-block-jetpack-giphy align<?php echo( esc_attr( $align ) ); ?>">
-		<figure style=<?php echo( esc_attr( $style ) ); ?>>
-			<iframe src='<?php echo( esc_attr( $giphy_url ) ); ?>' title='<?php echo( esc_attr( $search_text ) ); ?>'></iframe>
+	<div class="wp-block-jetpack-giphy align<?php echo esc_attr( $align ); ?>">
+		<figure style="<?php echo esc_attr( $style ); ?>">
+			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>
 		<?php if ( $caption ) : ?>
-			<figcaption class="caption"><?php echo( esc_html( $caption ) ); ?></figcaption>
+			<figcaption class="caption"><?php echo esc_html( $caption ); ?></figcaption>
 		<?php endif; ?>
 	</div>
 	<?php
 	$html = ob_get_clean();
+
 	Jetpack_Gutenberg::load_assets_as_required( 'giphy' );
 	return $html;
 }

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -3,8 +3,14 @@
  * Load code specific to Gutenberg blocks which are not tied to a module.
  * This file is unusual, and is not an actual `module` as such.
  * It is included in ./module-extras.php
- *
  */
+
+jetpack_register_block(
+	'giphy',
+	array(
+		'render_callback' => 'jetpack_giphy_block_load_assets',
+	)
+);
 
 jetpack_register_block(
 	'map',
@@ -58,6 +64,35 @@ if (
 		 */
 		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
 	}
+}
+
+/**
+ * Giphy block registration/dependency declaration.
+ *
+ * @param array $attr - Array containing the map block attributes.
+ *
+ * @return string
+ */
+function jetpack_giphy_block_load_assets( $attr ) {
+	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
+	$style       = 'padding-top:' . $attr['topPadding'] . '%';
+	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv';
+	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
+	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
+	ob_start();
+	?>
+	<div class="wp-block-jetpack-giphy align<?php echo( esc_attr( $align ) ); ?>">
+		<figure style=<?php echo( esc_attr( $style ) ); ?>>
+			<iframe src='<?php echo( esc_attr( $giphy_url ) ); ?>' title='<?php echo( esc_attr( $search_text ) ); ?>'></iframe>
+		</figure>
+		<?php if ( $caption ) : ?>
+			<figcaption class="caption"><?php echo( esc_html( $caption ) ); ?></figcaption>
+		<?php endif; ?>
+		</div>
+	<?php
+	$html = ob_get_clean();
+	Jetpack_Gutenberg::load_assets_as_required( 'giphy' );
+	return $html;
 }
 
 /**

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -6,9 +6,9 @@
  */
 
 jetpack_register_block(
-	'giphy',
+	'gif',
 	array(
-		'render_callback' => 'jetpack_giphy_block_load_assets',
+		'render_callback' => 'jetpack_gif_block_load_assets',
 	)
 );
 
@@ -67,13 +67,13 @@ if (
 }
 
 /**
- * Giphy block registration/dependency declaration.
+ * Gif block registration/dependency declaration.
  *
  * @param array $attr - Array containing the map block attributes.
  *
  * @return string
  */
-function jetpack_giphy_block_load_assets( $attr ) {
+function jetpack_gif_block_load_assets( $attr ) {
 	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
 	$style       = 'padding-top:' . $attr['paddingTop'];
 	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv';
@@ -82,18 +82,18 @@ function jetpack_giphy_block_load_assets( $attr ) {
 
 	ob_start();
 	?>
-	<div class="wp-block-jetpack-giphy align<?php echo esc_attr( $align ); ?>">
+	<div class="wp-block-jetpack-gif align<?php echo esc_attr( $align ); ?>">
 		<figure style="<?php echo esc_attr( $style ); ?>">
 			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>
 		<?php if ( $caption ) : ?>
-			<p class="wp-block-jetpack-giphy-caption"><?php echo wp_kses_post( $caption ); ?></p>
+			<p class="wp-block-jetpack-gif-caption"><?php echo wp_kses_post( $caption ); ?></p>
 		<?php endif; ?>
 	</div>
 	<?php
 	$html = ob_get_clean();
 
-	Jetpack_Gutenberg::load_assets_as_required( 'giphy' );
+	Jetpack_Gutenberg::load_assets_as_required( 'gif' );
 	return $html;
 }
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -76,9 +76,13 @@ if (
 function jetpack_gif_block_load_assets( $attr ) {
 	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
 	$style       = 'padding-top:' . $attr['paddingTop'];
-	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv';
+	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : null;
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
+
+	if ( ! $giphy_url ) {
+		return null;
+	}
 
 	$classes = array(
 		'wp-block-jetpack-gif',

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -87,7 +87,7 @@ function jetpack_giphy_block_load_assets( $attr ) {
 			<iframe src="<?php echo esc_attr( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
 		</figure>
 		<?php if ( $caption ) : ?>
-			<figcaption class="caption"><?php echo esc_html( $caption ); ?></figcaption>
+			<p class="wp-block-jetpack-giphy-caption"><?php echo esc_html( $caption ); ?></p>
 		<?php endif; ?>
 	</div>
 	<?php

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -88,7 +88,7 @@ function jetpack_giphy_block_load_assets( $attr ) {
 		<?php if ( $caption ) : ?>
 			<figcaption class="caption"><?php echo( esc_html( $caption ) ); ?></figcaption>
 		<?php endif; ?>
-		</div>
+	</div>
 	<?php
 	$html = ob_get_clean();
 	Jetpack_Gutenberg::load_assets_as_required( 'giphy' );

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -8,7 +8,7 @@
 jetpack_register_block(
 	'gif',
 	array(
-		'render_callback' => 'jetpack_gif_block_load_assets',
+		'render_callback' => 'jetpack_gif_block_render',
 	)
 );
 
@@ -73,7 +73,7 @@ if (
  *
  * @return string
  */
-function jetpack_gif_block_load_assets( $attr ) {
+function jetpack_gif_block_render( $attr ) {
 	$align       = isset( $attr['align'] ) ? $attr['align'] : 'center';
 	$padding_top = isset( $attr['paddingTop'] ) ? $attr['paddingTop'] : 0;
 	$style       = 'padding-top:' . $padding_top;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Registers the Giphy block and handles Server-Side Rendering. SSR approach is being used because IFRAME element will be stripped out of post content on WP.com. Discussion of this here: p5TWut-gm-p2. 

Companion `wp-calypso` PR: https://github.com/Automattic/wp-calypso/pull/29638

#### Changes proposed in this Pull Request:
- Registers the Giphy block 
- Callback to render the Giphy block. 

#### Testing instructions:

- Connect Jetpack
- Navigate to Settings->Jetpack Constants, check `JETPACK_BETA_BLOCKS`, and Save.

1) Add the block
2) Go to Giphy, find any Gif you like, copy the URL and paste into the block. The gif should show up.
3) Paste in a Giphy URL following this syntax: http://i.giphy.com/4ZFekt94LMhNK.gif. Past the URL into the block. The gif should show up.
4) Type any text in to the search field. DIfferent Gifs should show up for anything you search for. 
5) Verify that the text field appears when you click on the block. 
6) Verify that the text field disappears after 3.5 seconds of inactivity, unless no search text has been provided in which case it remains visible.
7) Verify caption behaves much like the core Image block.
8) Verify block alignment options all work as expected.


Complete testing instructions found here: https://github.com/Automattic/wp-calypso/pull/29638

#### Changelog

* Block editor: addition of a new Giphy block.