### PR TITLE
Search: Re-use should_handle_query filter elsewhere in class.

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -308,7 +308,7 @@ class Jetpack_Search {
 	 * @param WP_Query $query A WP_Query instance.
 	 */
 	public function maybe_add_post_type_as_var( WP_Query $query ) {
-		if ( $query->is_main_query() && $query->is_search && ! empty( $_GET['post_type'] ) ) {
+		if ( $this->should_handle_query( $query ) && ! empty( $_GET['post_type'] ) ) {
 			$post_types = ( is_string( $_GET['post_type'] ) && false !== strpos( $_GET['post_type'], ',' ) )
 				? $post_type = explode( ',', $_GET['post_type'] )
 				: (array) $_GET['post_type'];
@@ -442,17 +442,7 @@ class Jetpack_Search {
 	 * @return array Array of matching posts.
 	 */
 	public function filter__posts_pre_query( $posts, $query ) {
-		/**
-		 * Determine whether a given WP_Query should be handled by ElasticSearch.
-		 *
-		 * @module search
-		 *
-		 * @since  5.6.0
-		 *
-		 * @param bool     $should_handle Should be handled by Jetpack Search.
-		 * @param WP_Query $query         The WP_Query object.
-		 */
-		if ( ! apply_filters( 'jetpack_search_should_handle_query', ( $query->is_main_query() && $query->is_search() ), $query ) ) {
+		if ( ! $this->should_handle_query( $query ) ) {
 			return $posts;
 		}
 
@@ -500,7 +490,7 @@ class Jetpack_Search {
 	 * @param WP_Query $query The original WP_Query to use for the parameters of our search.
 	 */
 	public function do_search( WP_Query $query ) {
-		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+		if ( ! $this->should_handle_query( $query ) ) {
 			return;
 		}
 
@@ -1799,6 +1789,27 @@ class Jetpack_Search {
 		if ( $changed ) {
 			wp_set_sidebars_widgets( $sidebars_widgets );
 		}
+	}
+
+	/**
+	 * Determine whether a given WP_Query should be handled by ElasticSearch.
+	 *
+	 * @param WP_Query $query The WP_Query object.
+	 *
+	 * @return bool
+	 */
+	public function should_handle_query( $query ) {
+		/**
+		 * Determine whether a given WP_Query should be handled by ElasticSearch.
+		 *
+		 * @module search
+		 *
+		 * @since  5.6.0
+		 *
+		 * @param bool     $should_handle Should be handled by Jetpack Search.
+		 * @param WP_Query $query         The WP_Query object.
+		 */
+		return apply_filters( 'jetpack_search_should_handle_query', $query->is_main_query() && $query->is_search(), $query );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes N/A (?)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Seemed to be checking the same condition multiple places
(`$query->is_main_query() && $query->is_search()`) but only wrapping it
in a filter on the main `filter__posts_pre_query()`. The upshot of this
means that if someone did want to hook into that and use elasticsearch
outside of a main query or search they can't as it will get stopped
elsewhere by other places not using the filter. Thus rendering the
filter almost pointless (AFAICT).

By re-using the filter in other places that this check is done, the end
user is free to specify that they want to use jetpack search for the
query even if it's not a search query or the main query.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Attempt to override default behaviour of search by using filter `jetpack_search_should_handle_query` observe that query doesn't actually send to Elasticsearch even though you are using the filter.

* Switch to this branch, now do the same and observe (through query monitor for example) that query is indeed being sent to Elasticsearch.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Extend `jetpack_search_should_handle_query` filter so that you are able to use jetpack search if not a main query or not a search query.
