### PR TITLE
Dashboard: ensure window is scrolled to the top when changing view

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -67,7 +67,7 @@ class AtAGlance extends Component {
 					}
 					externalLinkPath={ this.props.isDevMode
 						? ''
-						: '#security'
+						: '#/security'
 					}
 					externalLinkClick={ trackSecurityClick }
 				/>;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -313,7 +313,7 @@ window.wpNavMenuClassChange = function() {
 
 	const $body = jQuery( 'body' );
 
-	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#/security"], .dops-button[href="#/my-plan"], .dops-button[href="#/plans"]', function() {
+	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#/security"], .dops-button[href="#/my-plan"], .dops-button[href="#/plans"], .jp-dash-section-header__external-link[href="#/security"]', function() {
 		window.scrollTo( 0, 0 );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/10847

#### Changes proposed in this Pull Request:

* Force window to scroll up when clicking “Manage security settings” in the Dashboard.

#### Testing instructions:

* Fire up this branch and connect Jetpack.
* Go to your dashboard and scroll until you see the option “Manage security settings”.
* Click the link and make sure the window scrolls all the way to the top in the Security settings.

#### Before

![securitylink](https://user-images.githubusercontent.com/204742/49559518-45087880-f8cc-11e8-905a-468c60063bc4.gif)

#### After

![jp-settings-jump](https://user-images.githubusercontent.com/390760/50106647-53d62000-0228-11e9-8a41-b226e9f13612.gif)

#### Proposed changelog entry for your changes:

* Dashboard: ensure window is scrolled to the top when clicking “Manage security settings”.
