### PR TITLE
Added another exception to the PHP linter.

### DIFF
--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -14,6 +14,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 			. 'grep -v "No syntax errors detected" | '
 			. 'grep -v "./tools/" | '
 			. 'grep -v "./tests/" | '
+			. 'grep -v "./vendor/" | '
 			. 'grep -v "jetpack-cli.php" | '
 			. 'grep -v "./_inc/class.jetpack-provision.php" | '
 			. 'grep -v -e \'^$\'; '


### PR DESCRIPTION
This change makes sure that the vendor folder is not taken into account when linting. Some of the libraries when installed add code that does not pass linter tests.

<!--- Provide a general summary of your changes in the Title above -->

Fixes lint errors for phpunit when installing composer packages.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a vendor folder as an exception for the PHP linter.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install composer packages.
* Run `phpunit --testsuite=php-lint`, make sure tests pass

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry needed.
