### PR TITLE
Server Side: Business Hours block from George's Random Blocks

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -8,17 +8,17 @@
 class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	function __construct() {
 		$this->namespace = 'wpcom/v2';
-		$this->rest_base = 'bussiness-hours';
+		$this->rest_base = 'business-hours';
 		// This endpoint *does not* need to connect directly to Jetpack sites.
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	public function register_routes() {
 		// GET /sites/<blog_id>/subscribers/count - Return number of subscribers for this site.
-		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/count', array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/localized-week', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_business_hours' ),
+				'callback'            => array( $this, 'get_localized_week' ),
 			)
 		) );
 	}
@@ -28,7 +28,7 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	 *
 	 * @return array data object containing information about business hours
 	 */
-	public function get_business_hours() {
+	public function get_localized_week() {
 		global $wp_locale;
 		return array(
 			'days' => array(
@@ -40,7 +40,7 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 				'Fri' => $wp_locale->get_weekday( 5 ),
 				'Sat' => $wp_locale->get_weekday( 6 ),
 			),
-			'start_of_week' => (int) get_option( 'start_of_week', 0 ),
+			'startOfWeek' => (int) get_option( 'start_of_week', 0 ),
 		);
 	}
 }

--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Subscribers: Get subscriber count
+ *
+ * @since 6.9
+ */
+class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
+	function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'bussiness-hours';
+		// This endpoint *does not* need to connect directly to Jetpack sites.
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		// GET /sites/<blog_id>/subscribers/count - Return number of subscribers for this site.
+		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/count', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_business_hours' ),
+			)
+		) );
+	}
+
+	/**
+	 * Retreives localized business hours
+	 *
+	 * @return array data object containing information about business hours
+	 */
+	public function get_business_hours() {
+		global $wp_locale;
+		return array(
+			'days' => array(
+				'Sun' => $wp_locale->get_weekday( 0 ),
+				'Mon' => $wp_locale->get_weekday( 1 ),
+				'Tue' => $wp_locale->get_weekday( 2 ),
+				'Wed' => $wp_locale->get_weekday( 3 ),
+				'Thu' => $wp_locale->get_weekday( 4 ),
+				'Fri' => $wp_locale->get_weekday( 5 ),
+				'Sat' => $wp_locale->get_weekday( 6 ),
+			),
+			'start_of_week' => (int) get_option( 'start_of_week', 0 ),
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Business_Hours' );

--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Subscribers: Get subscriber count
+ * Business Hours: Localized week
  *
- * @since 6.9
+ * @since 7.1
  */
 class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	function __construct() {
@@ -14,7 +14,7 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	}
 
 	public function register_routes() {
-		// GET /sites/<blog_id>/business-hours/localize-week - Return the localized
+		// GET /sites/<blog_id>/business-hours/localized-week - Return the localized
 		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/localized-week', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,

--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -14,7 +14,7 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	}
 
 	public function register_routes() {
-		// GET /sites/<blog_id>/subscribers/count - Return number of subscribers for this site.
+		// GET /sites/<blog_id>/business-hours/localize-week - Return the localized
 		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/localized-week', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,

--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -15,10 +15,10 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 
 	public function register_routes() {
 		// GET /sites/<blog_id>/business-hours/localized-week - Return the localized
-		register_rest_route( $this->namespace, '/' . $this->rest_base  . '/localized-week', array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/localized-week', array(
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_localized_week' ),
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => array( $this, 'get_localized_week' ),
 			)
 		) );
 	}
@@ -30,8 +30,9 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 	 */
 	public function get_localized_week() {
 		global $wp_locale;
+
 		return array(
-			'days' => array(
+			'days'        => array(
 				'Sun' => $wp_locale->get_weekday( 0 ),
 				'Mon' => $wp_locale->get_weekday( 1 ),
 				'Tue' => $wp_locale->get_weekday( 2 ),

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -232,14 +232,14 @@ function jetpack_business_hours_render( $attributes, $content ) {
 				$now = strtotime( current_time( 'H:i' ) );
 				if ( $now < $opening ) {
 					$content .= '<br />';
-					$content .= esc_html( sprintf( __( 'Opening in %s', 'random-blocks' ), human_time_diff( $now, $opening ) ) );
+					$content .= esc_html( sprintf( __( 'Opening in %s', 'jetpack' ), human_time_diff( $now, $opening ) ) );
 				} elseif ( $now >= $opening && $now < $closing ) {
 					$content .= '<br />';
-					$content .= esc_html( sprintf( __( 'Closing in %s', 'random-blocks' ), human_time_diff( $now, $closing ) ) );
+					$content .= esc_html( sprintf( __( 'Closing in %s', 'jetpack' ), human_time_diff( $now, $closing ) ) );
 				}
 			}
 		} else {
-			$content .= esc_html__( 'CLOSED', 'random-blocks' );
+			$content .= esc_html__( 'CLOSED', 'jetpack' );
 		}
 		$content .= '</dd>';
 	}

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -192,11 +192,21 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	return $content;
 }
 
+/**
+ * Business Hours Block.
+ */
 jetpack_register_block(
 	'business-hours',
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );
-
+/**
+ * Business Hours Block dynamic rending of the glock.
+ *
+ * @param array  $attr - Array containing the business hours block attributes.
+ * @param string $content - String containing the business hours block content.
+ *
+ * @return string
+ */
 function jetpack_business_hours_render( $attributes, $content ) {
 	global $wp_locale;
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -192,12 +192,10 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	return $content;
 }
 
-function jetpack_business_hours_init() {
-	jetpack_register_block(
-		'business-hours',
-		array( 'render_callback' => 'jetpack_business_hours_render' )
-	);
-}
+jetpack_register_block(
+	'business-hours',
+	array( 'render_callback' => 'jetpack_business_hours_render' )
+);
 
 function jetpack_business_hours_render( $attributes, $content ) {
 	global $wp_locale;
@@ -250,4 +248,3 @@ function jetpack_business_hours_render( $attributes, $content ) {
 
 	return $content;
 }
-add_action( 'init', 'jetpack_business_hours_init' );

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -38,6 +38,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
 }
 
+
 /**
  * Tiled Gallery block. Depends on the Photon module.
  *
@@ -190,3 +191,63 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( 'slideshow', $dependencies );
 	return $content;
 }
+
+function jetpack_business_hours_init() {
+	jetpack_register_block(
+		'business-hours',
+		array( 'render_callback' => 'jetpack_business_hours_render' )
+	);
+}
+
+function jetpack_business_hours_render( $attributes, $content ) {
+	global $wp_locale;
+
+	if ( empty( $attributes['hours'] ) || ! is_array( $attributes['hours'] ) ) {
+		return $content;
+	}
+
+	$start_of_week = (int) get_option( 'start_of_week', 0 );
+	$time_format = get_option( 'time_format' );
+	$today = current_time( 'D' );
+	$content = '<dl class="business-hours built-by-php">';
+
+	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
+
+	if ( $start_of_week ) {
+		$chunk1 = array_slice( $attributes['hours'], 0, $start_of_week );
+		$chunk2 = array_slice( $attributes['hours'], $start_of_week );
+		$attributes['hours'] = array_merge( $chunk2, $chunk1 );
+	}
+
+	foreach ( $attributes['hours'] as $day => $hours ) {
+		$opening = strtotime( $hours['opening'] );
+		$closing = strtotime( $hours['closing'] );
+
+		$content .= '<dt class="' . esc_attr( $day ) . '">' . $wp_locale->get_weekday( array_search( $day, $days ) ) . '</dt>';
+		$content .= '<dd class="' . esc_attr( $day ) . '">';
+		if ( $hours['opening'] && $hours['closing'] ) {
+			$content .= date( $time_format, $opening );
+			$content .= '&nbsp;&mdash;&nbsp;';
+			$content .= date( $time_format, $closing );
+
+			if ( $today === $day ) {
+				$now = strtotime( current_time( 'H:i' ) );
+				if ( $now < $opening ) {
+					$content .= '<br />';
+					$content .= esc_html( sprintf( __( 'Opening in %s', 'random-blocks' ), human_time_diff( $now, $opening ) ) );
+				} elseif ( $now >= $opening && $now < $closing ) {
+					$content .= '<br />';
+					$content .= esc_html( sprintf( __( 'Closing in %s', 'random-blocks' ), human_time_diff( $now, $closing ) ) );
+				}
+			}
+		} else {
+			$content .= esc_html__( 'CLOSED', 'random-blocks' );
+		}
+		$content .= '</dd>';
+	}
+
+	$content .= '</dl>';
+
+	return $content;
+}
+add_action( 'init', 'jetpack_business_hours_init' );

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -218,7 +218,10 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$time_format = get_option( 'time_format' );
 	$today = current_time( 'D' );
 	$custom_class_name = isset( $attributes['className'] ) ? $attributes['className'] : '';
-	$content = "<dl class='jetpack-business-hours $custom_class_name'>";
+	$content = sprintf(
+		'<dl class="jetpack-business-hours %s">',
+		! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : ''
+	);
 
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -217,7 +217,8 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$start_of_week = (int) get_option( 'start_of_week', 0 );
 	$time_format = get_option( 'time_format' );
 	$today = current_time( 'D' );
-	$content = '<dl class="business-hours built-by-php">';
+	$custom_class_name = isset( $attributes['className'] ) ? $attributes['className'] : '';
+	$content = "<dl class='jetpack-business-hours $custom_class_name'>";
 
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 
@@ -231,21 +232,31 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		$opening = strtotime( $hours['opening'] );
 		$closing = strtotime( $hours['closing'] );
 
-		$content .= '<dt class="' . esc_attr( $day ) . '">' . $wp_locale->get_weekday( array_search( $day, $days ) ) . '</dt>';
+		$content .= '<dt class="' . esc_attr( $day ) . '">' .
+                    ucfirst( $wp_locale->get_weekday( array_search( $day, $days ) ) ) .
+                    '</dt>';
 		$content .= '<dd class="' . esc_attr( $day ) . '">';
 		if ( $hours['opening'] && $hours['closing'] ) {
-			$content .= date( $time_format, $opening );
-			$content .= '&nbsp;&mdash;&nbsp;';
-			$content .= date( $time_format, $closing );
+		    $content .= sprintf(
+		            _x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),
+                    date( $time_format, $opening ),
+                    date( $time_format, $closing )
+            );
 
 			if ( $today === $day ) {
 				$now = strtotime( current_time( 'H:i' ) );
 				if ( $now < $opening ) {
 					$content .= '<br />';
-					$content .= esc_html( sprintf( __( 'Opening in %s', 'jetpack' ), human_time_diff( $now, $opening ) ) );
+					$content .= esc_html( sprintf(
+					        _x( 'Opening in %s', 'Amount of time until business opens', 'jetpack' ),
+                            human_time_diff( $now, $opening )
+                    ) );
 				} elseif ( $now >= $opening && $now < $closing ) {
 					$content .= '<br />';
-					$content .= esc_html( sprintf( __( 'Closing in %s', 'jetpack' ), human_time_diff( $now, $closing ) ) );
+					$content .= esc_html( sprintf(
+					        _x( 'Closing in %s', 'Amount of time until business closes', 'jetpack' ),
+                            human_time_diff( $now, $closing )
+                    ) );
 				}
 			}
 		} else {

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -20,7 +20,7 @@ jetpack_register_block(
 /**
  * Map block registration/dependency declaration.
  *
- * @param array  $attr - Array containing the map block attributes.
+ * @param array $attr - Array containing the map block attributes.
  * @param string $content - String containing the map block content.
  *
  * @return string
@@ -35,7 +35,8 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
-	return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
+
+	return preg_replace( '/<div /', '<div data-api-key="' . esc_attr( $api_key ) . '" ', $content, 1 );
 }
 
 
@@ -43,7 +44,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
  * Tiled Gallery block. Depends on the Photon module.
  *
  * @since 6.9.0
-*/
+ */
 if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
@@ -125,20 +126,23 @@ function jetpack_gif_block_render( $attr ) {
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( implode( $classes, ' ' ) ); ?>">
-		<figure>
-			<div class="wp-block-jetpack-gif-wrapper" style="<?php echo esc_attr( $style ); ?>">
-				<iframe src="<?php echo esc_url( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
-			</div>
+    <div class="<?php echo esc_attr( implode( $classes, ' ' ) ); ?>">
+        <figure>
+            <div class="wp-block-jetpack-gif-wrapper" style="<?php echo esc_attr( $style ); ?>">
+                <iframe src="<?php echo esc_url( $giphy_url ); ?>"
+                        title="<?php echo esc_attr( $search_text ); ?>"></iframe>
+            </div>
 			<?php if ( $caption ) : ?>
-				<figcaption class="wp-block-jetpack-gif-caption gallery-caption"><?php echo wp_kses_post( $caption ); ?></figcaption>
+                <figcaption
+                        class="wp-block-jetpack-gif-caption gallery-caption"><?php echo wp_kses_post( $caption ); ?></figcaption>
 			<?php endif; ?>
-		</figure>
-	</div>
+        </figure>
+    </div>
 	<?php
 	$html = ob_get_clean();
 
 	Jetpack_Gutenberg::load_assets_as_required( 'gif' );
+
 	return $html;
 }
 
@@ -177,7 +181,7 @@ jetpack_register_block(
 /**
  * Slideshow block registration/dependency declaration.
  *
- * @param array  $attr - Array containing the map block attributes.
+ * @param array $attr - Array containing the map block attributes.
  * @param string $content - String containing the map block content.
  *
  * @return string
@@ -189,6 +193,7 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 		'wp-i18n',
 	);
 	Jetpack_Gutenberg::load_assets_as_required( 'slideshow', $dependencies );
+
 	return $content;
 }
 
@@ -202,7 +207,7 @@ jetpack_register_block(
 /**
  * Business Hours Block dynamic rending of the glock.
  *
- * @param array  $attr - Array containing the business hours block attributes.
+ * @param array $attr - Array containing the business hours block attributes.
  * @param string $content - String containing the business hours block content.
  *
  * @return string
@@ -214,11 +219,11 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		return $content;
 	}
 
-	$start_of_week = (int) get_option( 'start_of_week', 0 );
-	$time_format = get_option( 'time_format' );
-	$today = current_time( 'D' );
+	$start_of_week     = (int) get_option( 'start_of_week', 0 );
+	$time_format       = get_option( 'time_format' );
+	$today             = current_time( 'D' );
 	$custom_class_name = isset( $attributes['className'] ) ? $attributes['className'] : '';
-	$content = sprintf(
+	$content           = sprintf(
 		'<dl class="jetpack-business-hours %s">',
 		! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : ''
 	);
@@ -226,8 +231,8 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 
 	if ( $start_of_week ) {
-		$chunk1 = array_slice( $attributes['hours'], 0, $start_of_week );
-		$chunk2 = array_slice( $attributes['hours'], $start_of_week );
+		$chunk1              = array_slice( $attributes['hours'], 0, $start_of_week );
+		$chunk2              = array_slice( $attributes['hours'], $start_of_week );
 		$attributes['hours'] = array_merge( $chunk2, $chunk1 );
 	}
 
@@ -236,30 +241,30 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		$closing = strtotime( $hours['closing'] );
 
 		$content .= '<dt class="' . esc_attr( $day ) . '">' .
-                    ucfirst( $wp_locale->get_weekday( array_search( $day, $days ) ) ) .
-                    '</dt>';
+		            ucfirst( $wp_locale->get_weekday( array_search( $day, $days ) ) ) .
+		            '</dt>';
 		$content .= '<dd class="' . esc_attr( $day ) . '">';
 		if ( $hours['opening'] && $hours['closing'] ) {
-		    $content .= sprintf(
-		            _x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),
-                    date( $time_format, $opening ),
-                    date( $time_format, $closing )
-            );
+			$content .= sprintf(
+				_x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),
+				date( $time_format, $opening ),
+				date( $time_format, $closing )
+			);
 
 			if ( $today === $day ) {
 				$now = strtotime( current_time( 'H:i' ) );
 				if ( $now < $opening ) {
 					$content .= '<br />';
 					$content .= esc_html( sprintf(
-					        _x( 'Opening in %s', 'Amount of time until business opens', 'jetpack' ),
-                            human_time_diff( $now, $opening )
-                    ) );
+						_x( 'Opening in %s', 'Amount of time until business opens', 'jetpack' ),
+						human_time_diff( $now, $opening )
+					) );
 				} elseif ( $now >= $opening && $now < $closing ) {
 					$content .= '<br />';
 					$content .= esc_html( sprintf(
-					        _x( 'Closing in %s', 'Amount of time until business closes', 'jetpack' ),
-                            human_time_diff( $now, $closing )
-                    ) );
+						_x( 'Closing in %s', 'Amount of time until business closes', 'jetpack' ),
+						human_time_diff( $now, $closing )
+					) );
 				}
 			}
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the post editor, which may seem broken to business owners who have no way to add business hours to their web site.

#### Changes proposed in this Pull Request:

* Adds server-side code for the business hours block from https://github.com/georgestephanis/random-blocks

#### Testing instructions:

1. On a local docker instance git this branch running
2. Use [this wp-calypso branch ](https://github.com/Automattic/wp-calypso/pull/29549)to build the blocks into your local docker
2. [Or use this jurasic.ninja link](https://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&calypsobranch=try/jetpack-business-hours-block&branch=try/business-hours-block)
3. In the post editor on your site, try publishing a post with the Business Hours block

Editor:
![screen shot 2019-02-04 at 5 42 55 pm](https://user-images.githubusercontent.com/2694219/52242388-93260200-28a4-11e9-9094-0147f93c9171.png)



Front end:

![screen shot 2019-02-01 at 3 29 17 pm](https://user-images.githubusercontent.com/2694219/52147901-27d6f880-2636-11e9-84eb-682ac10e8844.png)


#### Proposed changelog entry for your changes:

* Business hours block: business owners can easily let their customers know when the in-real-life shop is open or closed
