### PR TITLE
Post Images: add new method to detect images from Gutenberg blocks

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -348,11 +348,11 @@ class Jetpack_PostImages {
 			}
 
 			/**
-			 * Parse content from Core Gallery blocks.
+			 * Parse content from Core Gallery blocks and Jetpack's Tiled Gallery blocks.
 			 * Gallery blocks include the ID of each one of the images in the gallery.
 			 */
 			if (
-				'core/gallery' === $block['blockName']
+				( 'core/gallery' === $block['blockName'] || 'jetpack/tiled-gallery' === $block['blockName'] )
 				&& ! empty( $block['attrs']['ids'] )
 			) {
 				foreach ( $block['attrs']['ids'] as $img_id ) {

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -717,13 +717,13 @@ class Jetpack_PostImages {
 			}
 
 			$html_info = array(
-				'html'    => $post->post_content, // DO NOT apply the_content filters here, it will cause loops.
-				'post_url'=> get_permalink( $post->ID ),
+				'html'     => $post->post_content, // DO NOT apply the_content filters here, it will cause loops.
+				'post_url' => get_permalink( $post->ID ),
 			);
 		} else {
 			$html_info = array(
-				'html'    => $html_or_id,
-				'post_url'=> '',
+				'html'     => $html_or_id,
+				'post_url' => '',
 			);
 		}
 		return $html_info;

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -710,7 +710,7 @@ class Jetpack_PostImages {
 			$post = get_post( $html_or_id );
 
 			if ( empty( $post ) || ! empty( $post->post_password ) ) {
-				return $images;
+				return '';
 			}
 
 			$html     = $post->post_content; // DO NOT apply the_content filters here, it will cause loops.

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -314,7 +314,6 @@ class Jetpack_PostImages {
 	 */
 	static function from_blocks( $html_or_id, $width = 200, $height = 200 ) {
 		$images   = array();
-		$post_url = '';
 
 		// Bail early if the site does not support the block editor.
 		if ( ! function_exists( 'parse_blocks' ) ) {

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -187,23 +187,7 @@ class Jetpack_PostImages {
 		$permalink = get_permalink( $post_id );
 
 		foreach ( $post_images as $post_image ) {
-			$meta = wp_get_attachment_metadata( $post_image->ID );
-			// Must be larger than 200x200
-			if ( !isset( $meta['width'] ) || $meta['width'] < $width )
-				continue;
-			if ( !isset( $meta['height'] ) || $meta['height'] < $height )
-				continue;
-
-			$url = wp_get_attachment_url( $post_image->ID );
-
-			$images[] = array(
-				'type'       => 'image',
-				'from'       => 'attachment',
-				'src'        => $url,
-				'src_width'  => $meta['width'],
-				'src_height' => $meta['height'],
-				'href'       => $permalink,
-			);
+			$images[] = self::get_attachment_data( $post_image->ID, $permalink, $width, $height );
 		}
 
 		/*

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -187,7 +187,10 @@ class Jetpack_PostImages {
 		$permalink = get_permalink( $post_id );
 
 		foreach ( $post_images as $post_image ) {
-			$images[] = self::get_attachment_data( $post_image->ID, $permalink, $width, $height );
+			$current_image = self::get_attachment_data( $post_image->ID, $permalink, $width, $height );
+			if ( false !== $current_image ) {
+				$images[] = $current_image;
+			}
 		}
 
 		/*

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -360,7 +360,7 @@ class Jetpack_PostImages {
 				'core/image' === $block['blockName']
 				&& ! empty( $block['attrs']['id'] )
 			) {
-				$images[] =  self::get_attachment_data( $block['attrs']['id'], $post_url, $width, $height );
+				$images[] = self::get_attachment_data( $block['attrs']['id'], $post_url, $width, $height );
 			}
 		}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -312,8 +312,8 @@ class Jetpack_PostImages {
 	 * @param int   $width      Minimum Image width.
 	 * @param int   $height     Minimum Image height.
 	 */
-	static function from_blocks( $html_or_id, $width = 200, $height = 200 ) {
-		$images   = array();
+	public static function from_blocks( $html_or_id, $width = 200, $height = 200 ) {
+		$images = array();
 
 		// Bail early if the site does not support the block editor.
 		if ( ! function_exists( 'parse_blocks' ) ) {
@@ -360,7 +360,11 @@ class Jetpack_PostImages {
 			}
 		}
 
-		return $images;
+		/**
+		 * Returning a filtered array because get_attachment_data returns false
+		 * for unsuccessful attempts.
+		 */
+		return array_filter( $images );
 	}
 
 	/**
@@ -737,20 +741,21 @@ class Jetpack_PostImages {
 	 * @param string $post_url      URL of the post, if we have one.
 	 * @param int    $width         Minimum Image width.
 	 * @param int    $height        Minimum Image height.
+	 * @return array|bool           Image data or false if unavailable.
 	 */
-	static function get_attachment_data( $attachment_id, $post_url = '', $width, $height ) {
+	public static function get_attachment_data( $attachment_id, $post_url = '', $width, $height ) {
 		if ( empty( $attachment_id ) ) {
-			return array();
+			return false;
 		}
 
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
-		// The image must be larger than 200x200
+		// The image must be larger than 200x200.
 		if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
-			return array();
+			return false;
 		}
 		if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
-			return array();
+			return false;
 		}
 
 		$url = wp_get_attachment_url( $attachment_id );

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -335,7 +335,7 @@ class Jetpack_PostImages {
 
 		foreach ( $blocks as $block ) {
 			/**
-			 * Only parse content from Core Image blocks.
+			 * Parse content from Core Image blocks.
 			 * If it is an image block for an image hosted on our site, it will have an ID.
 			 * If it does not have an ID, let `from_html` parse that content later,
 			 * and extract an image if it has size parameters.
@@ -345,6 +345,19 @@ class Jetpack_PostImages {
 				&& ! empty( $block['attrs']['id'] )
 			) {
 				$images[] = self::get_attachment_data( $block['attrs']['id'], $post_url, $width, $height );
+			}
+
+			/**
+			 * Parse content from Core Gallery blocks.
+			 * Gallery blocks include the ID of each one of the images in the gallery.
+			 */
+			if (
+				'core/gallery' === $block['blockName']
+				&& ! empty( $block['attrs']['ids'] )
+			) {
+				foreach ( $block['attrs']['ids'] as $img_id ) {
+					$images[] = self::get_attachment_data( $img_id, $post_url, $width, $height );
+				}
 			}
 		}
 

--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -91,4 +91,84 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$this->assertEquals( $images[ 0 ][ 'src' ], $img_url );
 	}
 
+	/**
+	 * Create a post with an image block containing a large image attached to another post.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array $post_info {
+	 * An array of information about our post.
+	 * 	@type int $post_id Post ID.
+	 * 	@type string $img_url Image URL we'll look to extract.
+	 * }
+	 */
+	protected function get_post_with_image_block() {
+		$img_name = 'image.jpg';
+		$img_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . $img_name;
+		$img_dimensions = array( 'width' => 250, 'height' => 250 );
+
+		$post_id = $this->factory->post->create();
+		$attachment_id = $this->factory->attachment->create_object( $img_name, $post_id, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_type' => 'attachment'
+		) );
+		wp_update_attachment_metadata( $attachment_id, $img_dimensions );
+
+		// Create another post with that picture.
+		$post_html = sprintf(
+			'<!-- wp:image {"id":%2$d} --><div class="wp-block-image"><figure class="wp-block-image"><img src="%1$s" alt="" class="wp-image-%2$d"/></figure></div><!-- /wp:image -->',
+			$img_url,
+			$attachment_id
+		);
+		$second_post_id = $this->factory->post->create( array(
+			'post_content' => $post_html,
+		) );
+
+		return array(
+			'post_id' => $second_post_id,
+			'img_url' => $img_url,
+		);
+	}
+
+	/**
+	 * Test if an array of images can be extracted from Image blocks in the new block editor.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 * @since 6.9.0
+	 */
+	public function test_from_blocks_from_post_id_is_array() {
+		$post_info = $this->get_post_with_image_block();
+
+		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
+
+		$this->assertEquals( count( $images ), 1 );
+	}
+
+	/**
+	 * Test if the array extracted from Image blocks include the image URL.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 * @since 6.9.0
+	 */
+	public function test_from_blocks_from_post_id_is_correct_array() {
+		$post_info = $this->get_post_with_image_block();
+
+		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
+
+		$this->assertEquals( $images[ 0 ][ 'src' ], $post_info['img_url'] );
+	}
+
+	/**
+	 * Test if an image block with an externally hosted image is not extracted by Post Images.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 * @since 6.9.0
+	 */
+	public function test_from_blocks_from_html_is_empty_array() {
+		$html = '<!-- wp:image --><div class="wp-block-image"><figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure></div><!-- /wp:image -->';
+
+		$images = Jetpack_PostImages::from_blocks( $html );
+
+		$this->assertEmpty( $images );
+	}
 } // end class

--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -264,4 +264,22 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		$this->assertEquals( $images[0]['src'], $post_info['img_urls'][0] );
 		$this->assertEquals( $images[1]['src'], $post_info['img_urls'][1] );
 	}
+
+	/**
+	 * Test if the array extracted from Gallery blocks include the image URL.
+	 *
+	 * @covers Jetpack_PostImages::get_attachment_data
+	 * @since 6.9.0
+	 */
+	public function test_get_attachment_data_returns_false_on_unavailable_data() {
+		$this->assertEquals( false, Jetpack_PostImages::get_attachment_data( PHP_INT_MAX, '', 200, 200 ) );
+
+		$post = $this->get_post_with_image_block();
+
+		// Testing the height condition.
+		$this->assertEquals( false, Jetpack_PostImages::get_attachment_data( $post['post_id'], '', 200, PHP_INT_MAX ) );
+
+		// Testing the width condition.
+		$this->assertEquals( false, Jetpack_PostImages::get_attachment_data( $post['post_id'], '', PHP_INT_MAX, 200 ) );
+	}
 } // end class

--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -137,6 +137,11 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 6.9.0
 	 */
 	public function test_from_blocks_from_post_id_is_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
 		$post_info = $this->get_post_with_image_block();
 
 		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
@@ -151,6 +156,11 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 6.9.0
 	 */
 	public function test_from_blocks_from_post_id_is_correct_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
 		$post_info = $this->get_post_with_image_block();
 
 		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
@@ -165,6 +175,11 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 6.9.0
 	 */
 	public function test_from_blocks_from_html_is_empty_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
 		$html = '<!-- wp:image --><div class="wp-block-image"><figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure></div><!-- /wp:image -->';
 
 		$images = Jetpack_PostImages::from_blocks( $html );


### PR DESCRIPTION
Fixes #10501

#### Changes proposed in this Pull Request:

- This new method parses all HTML content using WP's `parse_blocks`.
- We look for Core image blocks, Core Gallery blocks, and Tiled Gallery blocks.
- We also remove any image blocks that do not include a post ID. This is because image blocks that do not have a post ID are currently inserted using the "from image URL" option in the image block picker. As such, all the info in that block is the image URL; we have no data about image size for those images.
- This PR also includes tests for such content.

#### Testing instructions:

* Start from a site using no other Open Graph / Sharing plugins
* Activate Jetpack's sharing module.
* Create a new post using the new block editor.
* Do not specify any Featured image
* Do not upload any image to that post.
* Instead, insert a new image block and choose from an image you've already uploaded, for another post (this is so `Jetpack_PostImages` does not pick images from attachments to your post)
* Publish your post.
* View source when looking at the post.
* You should see your image used in the Open Graph Meta tags.
* Repeat with an image that is smaller than the requirements (200x200): it should not be picked.
* Repeat by inserting an image from another site, e.g. `https://jeremy.hu/wp-content/uploads/watson-5818.jpg`: it should not be picked.
* Repeat by inserting a gallery block instead.
* Repeat by inserting a tiled gallery block instead (note that this will only work once https://github.com/Automattic/wp-calypso/pull/29559/ is brought to Jetpack).

#### Proposed changelog entry for your changes:

* Images: ensure that images inserted with new block editor can be used in Open Graph Meta tags, Related Posts, and Publicized posts.
