### PR TITLE
JITM styles: fixing improper margin within jetpack dash

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -158,7 +158,7 @@
 
 // if JITM appears inside of the jetpack dashboard
 .jp-lower .jitm-card {
-  margin: 3rem 0 auto;
+  margin: 3rem 0 rem( 24px );
 }
 
 // remove right margin for jitms in the editor

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -156,6 +156,11 @@
   margin: 3rem 1rem 0 auto;
 }
 
+// if JITM appears inside of the jetpack dashboard
+.jp-lower .jitm-card {
+  margin: 3rem 0 auto;
+}
+
 // remove right margin for jitms in the editor
 .post-php .jitm-card {
 	margin-right: 0;


### PR DESCRIPTION
Just fixing an improper margin on the right side of the JITM when displayed within the jetpack dashboard.

Fixes: https://github.com/Automattic/jetpack/issues/10999

**Before:**
![screen shot 2018-12-18 at 1 27 09 pm](https://user-images.githubusercontent.com/214813/50174771-107fbe00-02c9-11e9-8666-ab2998d0208f.png)


**After:**
![screen shot 2018-12-18 at 1 28 29 pm](https://user-images.githubusercontent.com/214813/50174756-0958b000-02c9-11e9-9222-bfabab1b0ae3.png)

Testing instructions:
1) Spin up this branch with the beta plugin in jurassic ninja
2) Start with a jetpack paid plan
3) View the JITM in the jetpack dashboard

Proposed changelog entry:

None