### PR TITLE
Settings: Add custom error notice for 2 step authentication SSO toggle.

### DIFF
--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -25,7 +25,7 @@ import Antispam from './antispam';
 import { ManagePlugins } from './manage-plugins';
 import { Monitor } from './monitor';
 import { Protect } from './protect';
-import { SSO } from './sso';
+import SSO from './sso';
 
 export class Security extends Component {
 	static displayName = 'SecuritySettings';

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -9,6 +9,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import {
@@ -19,7 +20,16 @@ import SettingsGroup from 'components/settings-group';
 
 class SSO extends Component {
 	handleTwoStepToggleChange = () => {
-		this.props.updateOptions( { jetpack_sso_require_two_step: ! this.props.requireTwoStepAuth } );
+		const messages = {
+			error: () => __( 'An unexpected error occured while setting up 2-step authentication. {{a}}Please try again{{/a}}',
+				{
+					components: {
+						a: <ExternalLink target="_blank" rel="noopener noreferrer" href="https://wordpress.com/me/security/two-step" />
+					}
+				}
+			)
+		};
+		this.props.updateOptions( { jetpack_sso_require_two_step: ! this.props.requireTwoStepAuth }, messages );
 	}
 
 	handleMatchByEmailToggleChange = () => {

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 
@@ -16,111 +17,95 @@ import {
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
-export const SSO = withModuleSettingsFormHelpers(
-	class extends Component {
-		/**
-		 * Get options for initial state.
-		 *
-		 * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
-		 */
-		state = {
-			jetpack_sso_match_by_email: this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso' ),
-			jetpack_sso_require_two_step: this.props.getOptionValue(
-				'jetpack_sso_require_two_step',
-				'sso'
-			),
-		};
+class SSO extends Component {
+	handleTwoStepToggleChange = () => {
+		this.props.updateOptions( { jetpack_sso_require_two_step: ! this.props.requireTwoStepAuth } );
+	}
 
-		handleTwoStepToggleChange = () => {
-			this.updateOptions( 'jetpack_sso_require_two_step' );
-		}
+	handleMatchByEmailToggleChange = () => {
+		this.props.updateOptions( { jetpack_sso_match_by_email: ! this.props.matchByEmail } );
+	}
 
-		handleMatchByEmailToggleChange = () => {
-			this.updateOptions( 'jetpack_sso_match_by_email' );
-		}
-
-		/**
-		 * Update state so toggles are updated.
-		 *
-		 * @param {string} optionName The slug of the option to update
-		 */
-		updateOptions = optionName => {
-			this.setState(
-				{
-					[ optionName ]: ! this.state[ optionName ],
-				},
-				this.props.updateFormStateModuleOption( 'sso', optionName )
-			);
-		};
-
-		render() {
-			const isSSOActive = this.props.getOptionValue( 'sso' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'sso' );
-			return (
-				<SettingsCard
-					{ ...this.props }
-					hideButton
-					module="sso"
-					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }
-				>
-					<SettingsGroup
-						hasChild
-						disableInDevMode
-						module={ this.props.getModule( 'sso' ) }
-						support={ {
-							text: __( 'Allows registered users to log in to your site with their WordPress.com accounts.' ),
-							link: 'https://jetpack.com/support/sso/',
-						} }
-						>
-						<p>
-							{ __(
-							'Add an extra layer of security to your website by enabling WordPress.com log in and secure ' +
-							'authentication. If you have multiple sites with this option enabled, you will be able to log into every ' +
-							'one of them with the same credentials.'
-							) }
-						</p>
-						<ModuleToggle
-							slug="sso"
-							disabled={ unavailableInDevMode }
-							activated={ isSSOActive }
-							toggling={ this.props.isSavingAnyOption( 'sso' ) }
-							toggleModule={ this.props.toggleModuleNow }
+	render() {
+		const isSSOActive = this.props.getOptionValue( 'sso' ),
+			unavailableInDevMode = this.props.isUnavailableInDevMode( 'sso' );
+		return (
+			<SettingsCard
+				{ ...this.props }
+				hideButton
+				module="sso"
+				header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }
+			>
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ this.props.getModule( 'sso' ) }
+					support={ {
+						text: __( 'Allows registered users to log in to your site with their WordPress.com accounts.' ),
+						link: 'https://jetpack.com/support/sso/',
+					} }
+					>
+					<p>
+						{ __(
+						'Add an extra layer of security to your website by enabling WordPress.com log in and secure ' +
+						'authentication. If you have multiple sites with this option enabled, you will be able to log into every ' +
+						'one of them with the same credentials.'
+						) }
+					</p>
+					<ModuleToggle
+						slug="sso"
+						disabled={ unavailableInDevMode }
+						activated={ isSSOActive }
+						toggling={ this.props.isSavingAnyOption( 'sso' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ this.props.getModule( 'sso' ).description }
+						</span>
+					</ModuleToggle>
+					<FormFieldset>
+						<CompactFormToggle
+							checked={ this.props.matchByEmail }
+							disabled={
+								! isSSOActive ||
+									unavailableInDevMode ||
+									this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] )
+							}
+							onChange={ this.handleMatchByEmailToggleChange }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ this.props.getModule( 'sso' ).description }
+								{ __( 'Match accounts using email addresses' ) }
 							</span>
-						</ModuleToggle>
-						<FormFieldset>
-							<CompactFormToggle
-								checked={ this.state.jetpack_sso_match_by_email }
-								disabled={
-									! isSSOActive ||
-										unavailableInDevMode ||
-										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] )
-								}
-								onChange={ this.handleMatchByEmailToggleChange }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Match accounts using email addresses' ) }
-								</span>
-							</CompactFormToggle>
-							<CompactFormToggle
-								checked={ this.state.jetpack_sso_require_two_step }
-								disabled={
-									! isSSOActive ||
-										unavailableInDevMode ||
-										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] )
-								}
-								onChange={ this.handleTwoStepToggleChange }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Require accounts to use WordPress.com Two-Step Authentication' ) }
-								</span>
-							</CompactFormToggle>
-						</FormFieldset>
-					</SettingsGroup>
-				</SettingsCard>
-			);
-		}
+						</CompactFormToggle>
+						<CompactFormToggle
+							checked={ this.props.requireTwoStepAuth }
+							disabled={
+								! isSSOActive ||
+									unavailableInDevMode ||
+									this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] )
+							}
+							onChange={ this.handleTwoStepToggleChange }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Require accounts to use WordPress.com Two-Step Authentication' ) }
+							</span>
+						</CompactFormToggle>
+					</FormFieldset>
+				</SettingsGroup>
+			</SettingsCard>
+		);
 	}
-);
+}
+
+export default withModuleSettingsFormHelpers( connect(
+	( state, ownProps ) => ( {
+		matchByEmail: ownProps.getOptionValue(
+			'jetpack_sso_match_by_email',
+			'sso'
+		),
+		requireTwoStepAuth: ownProps.getOptionValue(
+			'jetpack_sso_require_two_step',
+			'sso'
+		),
+	} )
+)( SSO ) );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Refactors the component a bit to use a less complicated state handling logic.
* Makes the two step authentication toggle for SSO have a custom error notice.

Note for the code reviewer. It's best to check the code here in the [files view hiding whitespace changes](https://github.com/Automattic/jetpack/pull/11004/files?utf8=%E2%9C%93&diff=unified&w=1). 

#### Testing instructions:

* Checkout this branch
* Visit the settings page for SSO.
* Open the network console
* Toggle the two step authentication toggle on the Security tab. 
* Block the network request.
* Toggle the two step authentication toggle on the Security tab again and confirm that the custom error message is there. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added custom error notice for the two step authentication requirment toggle in the SSO settings card.
