### PR TITLE
Adds unit tests and is_module_active method to SAL.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -355,9 +355,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->get_capabilities();
 				break;
 			case 'jetpack_modules':
-				$jetpack_modules = $this->site->get_jetpack_modules();
-				if ( ! is_null( $jetpack_modules ) ) {
-					$response[ $key ] = $jetpack_modules;
+				if ( is_user_member_of_blog() ) {
+					$response[ $key ] = $this->site->get_jetpack_modules();
 				}
 				break;
 			case 'plan' :

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,7 @@
 		</testsuite>
 		<testsuite name="json-api">
 			<file>tests/php/test_class.json-api-jetpack-endpoints.php</file>
+			<directory prefix="test_" suffix=".php">tests/php/sal</directory>
 		</testsuite>
 		<testsuite name="infinite-scroll">
 			<directory prefix="test_" suffix=".php">tests/php/modules/infinite-scroll</directory>

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -77,6 +77,8 @@ abstract class SAL_Site {
 
 	abstract public function get_jetpack_modules();
 
+	abstract public function is_module_active( $module );
+
 	abstract public function is_vip();
 
 	abstract public function is_multisite();

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -89,19 +89,11 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 	}
 
 	function get_jetpack_modules() {
-		if ( is_user_member_of_blog() ) {
-			return array_values( Jetpack_Options::get_option( 'active_modules', array() ) );
-		}
-
-		return null;
+		return array_values( Jetpack_Options::get_option( 'active_modules', array() ) );
 	}
 
 	function is_module_active( $module ) {
-		if ( is_user_member_of_blog() ) {
-			return in_array ( $module, Jetpack_Options::get_option( 'active_modules', array() ), true );
-		}
-
-		return false;
+		return in_array ( $module, Jetpack_Options::get_option( 'active_modules', array() ), true );
 	}
 
 	function is_vip() {

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -96,6 +96,14 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 		return null;
 	}
 
+	function is_module_active( $module ) {
+		if ( is_user_member_of_blog() ) {
+			return in_array ( $module, Jetpack_Options::get_option( 'active_modules', array() ), true );
+		}
+
+		return false;
+	}
+
 	function is_vip() {
 		return false; // this may change for VIP Go sites, which sync using Jetpack
 	}

--- a/tests/php/sal/test_class.json-api-platform-jetpack.php
+++ b/tests/php/sal/test_class.json-api-platform-jetpack.php
@@ -9,21 +9,21 @@ class SalSiteTest extends WP_UnitTestCase {
 	static function setUpBeforeClass( ) {
 		parent::setUpBeforeClass();
 
-		static::$token = (object) array(
+		self::$token = (object) array(
 			'blog_id'          => get_current_blog_id(),
 			'user_id'          => get_current_user_id(),
 			'external_user_id' => 2,
 			'role'             => 'administrator'
 		);
 
-		$platform = wpcom_get_sal_platform( static::$token );
+		$platform = wpcom_get_sal_platform( self::$token );
 
-		static::$site = $platform->get_site( static::$token->blog_id );
+		self::$site = $platform->get_site( self::$token->blog_id );
 	}
 
 	function test_uses_synced_api_post_type_whitelist_if_available() {
 
-		$this->assertFalse( static::$site->is_post_type_allowed( 'my_new_type' ) );
+		$this->assertFalse( self::$site->is_post_type_allowed( 'my_new_type' ) );
 	}
 
 	function test_is_module_active() {
@@ -36,14 +36,14 @@ class SalSiteTest extends WP_UnitTestCase {
 
 			$this->assertEquals(
 				Jetpack::is_module_active( $module ),
-				static::$site->is_module_active( $module )
+				self::$site->is_module_active( $module )
 			);
 
 			Jetpack::activate_module( $module );
 
 			$this->assertEquals(
 				Jetpack::is_module_active( $module ),
-				static::$site->is_module_active( $module )
+				self::$site->is_module_active( $module )
 			);
 		}
 	}

--- a/tests/php/sal/test_class.json-api-platform-jetpack.php
+++ b/tests/php/sal/test_class.json-api-platform-jetpack.php
@@ -34,4 +34,30 @@ class SalSiteTest extends WP_UnitTestCase {
 
 		$this->assertFalse( static::$site->is_post_type_allowed( 'my_new_type' ) );
 	}
+
+	function test_is_module_active() {
+
+		// Picking random 5 modules from an array of existing ones to not slow down the test
+		$modules = array_rand( Jetpack::get_available_modules(), 3 );
+
+		foreach ( $modules as $module ) {
+			Jetpack::deactivate_module( $module );
+
+			$this->assertEquals(
+				Jetpack::is_module_active( $module ),
+				static::$site->is_module_active( $module )
+			);
+
+			Jetpack::activate_module( $module );
+
+			$this->assertEquals(
+				Jetpack::is_module_active( $module ),
+				static::$site->is_module_active( $module )
+			);
+		}
+	}
+
+	function test_interface() {
+		$this->assertTrue( method_exists( 'SAL_Site', 'is_module_active' ) );
+	}
 }

--- a/tests/php/sal/test_class.json-api-platform-jetpack.php
+++ b/tests/php/sal/test_class.json-api-platform-jetpack.php
@@ -9,9 +9,6 @@ class SalSiteTest extends WP_UnitTestCase {
 	static function setUpBeforeClass( ) {
 		parent::setUpBeforeClass();
 
-		// temporarily disable https
-		$_SERVER['HTTPS'] = 'off';
-
 		static::$token = (object) array(
 			'blog_id'          => get_current_blog_id(),
 			'user_id'          => get_current_user_id(),
@@ -24,12 +21,6 @@ class SalSiteTest extends WP_UnitTestCase {
 		static::$site = $platform->get_site( static::$token->blog_id );
 	}
 
-	static function tearDownAfterClass() {
-		// renable https
-		$_SERVER['HTTPS'] = 'on';
-		parent::tearDownAfterClass();
-	}
-
 	function test_uses_synced_api_post_type_whitelist_if_available() {
 
 		$this->assertFalse( static::$site->is_post_type_allowed( 'my_new_type' ) );
@@ -37,7 +28,7 @@ class SalSiteTest extends WP_UnitTestCase {
 
 	function test_is_module_active() {
 
-		// Picking random 5 modules from an array of existing ones to not slow down the test
+		// Picking random 3 modules from an array of existing ones to not slow down the test
 		$modules = array_rand( Jetpack::get_available_modules(), 3 );
 
 		foreach ( $modules as $module ) {

--- a/tests/php/sal/test_class.json-api-platform-jetpack.php
+++ b/tests/php/sal/test_class.json-api-platform-jetpack.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/../../../sal/class.json-api-platform.php';
+
+class SalSiteTest extends WP_UnitTestCase {
+	static $token;
+	static $site;
+
+	static function setUpBeforeClass( ) {
+		parent::setUpBeforeClass();
+
+		// temporarily disable https
+		$_SERVER['HTTPS'] = 'off';
+
+		static::$token = (object) array(
+			'blog_id'          => get_current_blog_id(),
+			'user_id'          => get_current_user_id(),
+			'external_user_id' => 2,
+			'role'             => 'administrator'
+		);
+
+		$platform = wpcom_get_sal_platform( static::$token );
+
+		static::$site = $platform->get_site( static::$token->blog_id );
+	}
+
+	static function tearDownAfterClass() {
+		// renable https
+		$_SERVER['HTTPS'] = 'on';
+		parent::tearDownAfterClass();
+	}
+
+	function test_uses_synced_api_post_type_whitelist_if_available() {
+
+		$this->assertFalse( static::$site->is_post_type_allowed( 'my_new_type' ) );
+	}
+}

--- a/tests/php/sal/test_class.json-api-post-jetpack.php
+++ b/tests/php/sal/test_class.json-api-post-jetpack.php
@@ -9,16 +9,16 @@ class SalPostsTest extends WP_UnitTestCase {
 	static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		static::$token = (object) array(
+		self::$token = (object) array(
 			'blog_id'          => get_current_blog_id(),
 			'user_id'          => get_current_user_id(),
 			'external_user_id' => 2,
 			'role'             => 'administrator'
 		);
 
-		$platform = wpcom_get_sal_platform( static::$token );
+		$platform = wpcom_get_sal_platform( self::$token );
 
-		static::$site = $platform->get_site( static::$token->blog_id );
+		self::$site = $platform->get_site( self::$token->blog_id );
 	}
 
 	function test_returns_content_wrapped_in_a_post_object() {
@@ -32,7 +32,7 @@ class SalPostsTest extends WP_UnitTestCase {
 
 		$post = get_post( $post_id );
 
-		$wrapped_post = static::$site->wrap_post( $post, 'display' );
+		$wrapped_post = self::$site->wrap_post( $post, 'display' );
 
 		$this->assertEquals( $post->post_type, $wrapped_post->get_type() );
 	}

--- a/tests/php/sal/test_class.json-api-post-jetpack.php
+++ b/tests/php/sal/test_class.json-api-post-jetpack.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/../../../sal/class.json-api-platform.php';
+
+class SalPostsTest extends WP_UnitTestCase {
+	static $token;
+	static $site;
+
+	static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		static::$token = (object) array(
+			'blog_id'          => get_current_blog_id(),
+			'user_id'          => get_current_user_id(),
+			'external_user_id' => 2,
+			'role'             => 'administrator'
+		);
+
+		$platform = wpcom_get_sal_platform( static::$token );
+
+		static::$site = $platform->get_site( static::$token->blog_id );
+	}
+
+	function test_returns_content_wrapped_in_a_post_object() {
+		// Insert the post into the database
+		$post_id = wp_insert_post( array(
+			'post_title'    => 'Title',
+			'post_content'  => 'The content.',
+			'post_status'   => 'publish',
+			'post_author'   => get_current_user_id()
+		) );
+
+		$post = get_post( $post_id );
+
+		$wrapped_post = static::$site->wrap_post( $post, 'display' );
+
+		$this->assertEquals( $post->post_type, $wrapped_post->get_type() );
+	}
+}


### PR DESCRIPTION
In order to synchronize code between Jetpack and WordPress.com better one of the little pieces we needed was the `is_module_active` method present in the Site Abstraction Layer. This change adds it as well as enforcing its existence in all extending classes.

#### Changes proposed in this Pull Request:
* Adds unit tests that will run on SAL classes.
* Adds the `is_module_active` method for SAL Sites.

#### Testing instructions:
* Functionally there's nothing to change, just run the tests.
* This should fail on wpcom check after being created, this is expected, because the method needs to be added on the other side as well.

#### Proposed changelog entry for your changes:
* Added base unit test suites for the SAL library.

This blocks #10945 