### PR TITLE
Publicize: Return correct information for Gutenberg extensions availa…

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -782,15 +782,17 @@ abstract class Publicize_Base {
 	function register_gutenberg_extension() {
 		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
 		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
+		jetpack_register_block( 'publicize', array(), array( 'callback' => array( $this, 'get_extension_availability' ) ) );
+	}
+
+	function get_extension_availability() {
 		$object_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
-		if ( $this->current_user_can_access_publicize_data( $object_id ) ) {
-			jetpack_register_block( 'publicize' );
-		} else {
-			jetpack_register_block( 'publicize', array(), array(
-				'available'          => false,
-				'unavailable_reason' => 'unauthorized',
-			) );
+
+		if ( ! $this->current_user_can_access_publicize_data( $object_id ) ) {
+			return array( 'available' => false, 'unavailable_reason' => 'unauthorized' );
 		}
+
+		return array( 'available' => true );
 	}
 
 	/**


### PR DESCRIPTION
…bility endpoint

Code sync for D22500-code

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Previously, the Publicize extension wouldn't show up in Calypso when not proxied, since due to initialization order, the capabilities check would be performed against [private link] rather than the ID of the blog that's being queried. We fix this through indirection (by providing a callback that's invoked at the right point, after initialization has completed).

Props @enej for suggesting this solution!

#### Testing instructions:
TBD

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Return correct information for Gutenberg extensions availability endpoint
