### PR TITLE
Gutenberg: Load beta blocks when proxied and sync back D22261-code

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -26,8 +26,14 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 		register_rest_route( $this->namespace, $this->rest_base . '/available-extensions', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( 'Jetpack_Gutenberg', 'get_block_availability' ),
+				'callback'            => array( 'Jetpack_Gutenberg', 'get_availability' ),
 				'permission_callback' => array( $this, 'get_items_permission_check' ),
+				'args'                => array(
+					'beta' => array(
+						'required' => false,
+						'type'     => 'boolean',
+					),
+				),
 			),
 			'schema' => array( $this, 'get_item_schema' ),
 		 ) );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -118,11 +118,9 @@ class Jetpack_Gutenberg {
 
 		if ( Jetpack_Constants::is_true( 'REST_API_REQUEST' ) ) {
 			// We defer the loading of the blocks until we have a better scope in reset requests.
-
-			add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'load' ) );
+			add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'load' ), 10, 3 );
 			return;
 		}
-
 		self::load();
 	}
 
@@ -146,7 +144,7 @@ class Jetpack_Gutenberg {
 		self::register( $type, $args, $availability );
 	}
 
-	static function load( $request = null ) {
+	static function load( $response = null, $handler = null, $request = null ) {
 		// We display beta blocks in available Gutenberg extensions endpoint requests
 		$is_availability_endpoint_beta = ! is_null( $request ) && $request->get_param( 'beta' ) && wp_endswith( $request->get_route(), 'gutenberg/available-extensions' );
 		// We display beta blocks in proxied requests
@@ -180,7 +178,7 @@ class Jetpack_Gutenberg {
 		self::set_blocks_availability();
 		self::set_plugins_availability();
 		self::register_blocks();
-		return $request;
+		return $response;
 	}
 
 	static function is_registered( $slug ) {

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -148,6 +148,13 @@ class Jetpack_Gutenberg {
 	static function load( $response = null, $handler = null, $request = null ) {
 		$is_availability_endpoint_beta = ! is_null( $request ) && $request->get_param( 'beta' ) && wp_endswith( $request->get_route(), 'gutenberg/available-extensions' );
 
+		/**
+		 * Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param boolean
+		 */
 		if ( apply_filters( 'jetpack_load_beta_blocks', $is_availability_endpoint_beta ) ) {
 			Jetpack_Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
 		}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -146,12 +146,9 @@ class Jetpack_Gutenberg {
 	}
 
 	static function load( $response = null, $handler = null, $request = null ) {
-		// We display beta blocks in available Gutenberg extensions endpoint requests
 		$is_availability_endpoint_beta = ! is_null( $request ) && $request->get_param( 'beta' ) && wp_endswith( $request->get_route(), 'gutenberg/available-extensions' );
-		// We display beta blocks in proxied requests
-		$is_proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
 
-		if ( $is_availability_endpoint_beta || $is_proxied ) {
+		if ( apply_filters( 'jetpack_load_beta_blocks', $is_availability_endpoint_beta ) ) {
 			Jetpack_Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -147,6 +147,15 @@ class Jetpack_Gutenberg {
 	}
 
 	static function load( $request = null ) {
+		// We display beta blocks in available Gutenberg extensions endpoint requests
+		$is_availability_endpoint_beta = ! is_null( $request ) && $request->get_param( 'beta' ) && wp_endswith( $request->get_route(), 'gutenberg/available-extensions' );
+		// We display beta blocks in proxied requests
+		$is_proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
+
+		if ( $is_availability_endpoint_beta || $is_proxied ) {
+			Jetpack_Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
+		}
+
 		/**
 		 * Filter the list of block editor blocks that are available through jetpack.
 		 *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -61,7 +61,8 @@ class Jetpack_Gutenberg {
 		'field-checkbox',
 		'field-checkbox-multiple',
 		'field-radio',
-		'field-select'
+		'field-select',
+		'subscriptions',
 	);
 
 	/**

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -30,10 +30,12 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 			wp_delete_user( $this->master_user_id );
 		}
 
-		$blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
-		foreach ( $blocks as $block_name => $block ) {
-			if ( strpos( $block_name, 'jetpack/' ) !== false ) {
-				unregister_block_type( $block_name );
+		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
+			$blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+			foreach ( $blocks as $block_name => $block ) {
+				if ( strpos( $block_name, 'jetpack/' ) !== false ) {
+					unregister_block_type( $block_name );
+				}
 			}
 		}
 	}

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -29,6 +29,13 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 			Jetpack_Options::delete_option( array( 'master_user', 'user_tokens' ) );
 			wp_delete_user( $this->master_user_id );
 		}
+
+		$blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		foreach ( $blocks as $block_name => $block ) {
+			if ( strpos( $block_name, 'jetpack/' ) !== false ) {
+				unregister_block_type( $block_name );
+			}
+		}
 	}
 
 	public function add_test_block( $blocks ) {


### PR DESCRIPTION
This PR enables beta blocks for proxied requests - applicable when running blocks on WP.com. It also syncs back to Jetpack the changes we forgot to sync in D22261-code.

#### Changes proposed in this Pull Request:

* Load beta blocks when proxied
* Sync back changes that were introduced in D22261-code

#### Testing instructions:

* Spin up a JN site with this branch. 
* Make sure beta blocks are not loaded.
* Enable the `JETPACK_BETA_BLOCKS` constant in JN settings.
* Make sure beta blocks are loaded.
* Test the corresponding WP.com diff - changes suggested here have more impact in Calypso and WP.com wp-admin (diff and instructions coming soon).
