### PR TITLE
Carousel: modal should open clicked image, and not 1st img in gallery

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1458,7 +1458,7 @@ jQuery(document).ready(function($) {
 		// Stopping propagation in case there are parent elements
 		// with .gallery or .tiled-gallery class
 		e.stopPropagation();
-		$(this).jp_carousel('open', {start_index: $(this).find('.gallery-item, .tiled-gallery-item').index($(e.target).parents('.gallery-item, .tiled-gallery-item'))});
+		$(this).jp_carousel('open', { start_index: $(this).find('.gallery-item, .tiled-gallery-item, .blocks-gallery-item').index($(e.target).parents('.gallery-item, .tiled-gallery-item, .blocks-gallery-item'))});
 	});
 
 	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
@@ -1495,7 +1495,7 @@ jQuery(document).ready(function($) {
 		last_known_location_hash = window.location.hash;
 		matches = window.location.hash.match( hashRegExp );
 		attachmentId = parseInt( matches[1], 10 );
-		galleries = $( 'div.gallery, div.tiled-gallery, a.single-image-gallery' );
+		galleries = $( 'div.gallery, div.tiled-gallery, a.single-image-gallery, ul.wp-block-gallery' );
 
 		// Find the first thumbnail that matches the attachment ID in the location
 		// hash, then open the gallery that contains it.

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -216,7 +216,7 @@ class Jetpack_Carousel {
 					'modules/carousel/jetpack-carousel.js'
 				),
 				array( 'jquery.spin' ),
-				$this->asset_version( '20170209' ),
+				$this->asset_version( '20181220' ),
 				true
 			);
 


### PR DESCRIPTION
Fixes #10747

#### Changes proposed in this Pull Request:

* This PR allows Carousel to detect the clicked image in any gallery block, not just old galleries.

#### Testing instructions:

* Start with a site where the Carousel module is active.
* Go to Posts > Add New
* Create a post with a new Gallery block, and publish.
* Go to the post and click on any image in the gallery.
* That image should open in the Carousel modal.
* Test the same thing, but with a regular gallery inserted into a Classic block.

#### Proposed changelog entry for your changes:

* Carousel: ensure that Carousel works well with the Gallery block in the new block editor.
