### PR TITLE
Carousel: do not open modal when clicking on a link in a caption

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1450,9 +1450,17 @@ jQuery(document).ready(function($) {
 		if ( ! $(this).jp_carousel( 'testForData', e.currentTarget ) ) {
 			return;
 		}
+
+		// Do not open the modal if we are looking at a gallery caption from before WP5, which may contain a link.
 		if ( $(e.target).parent().hasClass('gallery-caption') ) {
 			return;
 		}
+
+		// Do not open the modal if we are looking at a caption of a gallery block, which may contain a link.
+		if ( $(e.target).parent().is('figcaption') ) {
+			return;
+		}
+
 		e.preventDefault();
 
 		// Stopping propagation in case there are parent elements

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -216,7 +216,7 @@ class Jetpack_Carousel {
 					'modules/carousel/jetpack-carousel.js'
 				),
 				array( 'jquery.spin' ),
-				$this->asset_version( '20170209' ),
+				$this->asset_version( '20181220' ),
 				true
 			);
 


### PR DESCRIPTION
Fixes #10997 

#### Changes proposed in this Pull Request:

The new Core gallery block introduces a different markup for captions.
This PR makes sure that when clicking on a link in a caption inside a core gallery, you get redirected
to that link, instead of having the Carousel modal open.

#### Testing instructions:

* Start from a site with the Carousel module active, and running WP 5.0+
* Create a new gallery using the Gallery block.
* Add a caption to one of your images, with a link like so:
![image](https://user-images.githubusercontent.com/426388/50300564-128e7c00-0485-11e9-9521-cc0a6a2d08a7.png)

* Publish your post
* View post.
* Click on the link in the caption.
* Make sure you are redirected to the link location, instead of having the Carousel modal open.
* Check that clicking on the image itself works.

#### Proposed changelog entry for your changes:

* Carousel: do not open modal when clicking on a link in a caption
