### PR TITLE
Publicize: Register properly as a Gutenberg extension

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -780,9 +780,7 @@ abstract class Publicize_Base {
 	 * Register the Publicize Gutenberg extension
 	 */
 	function register_gutenberg_extension() {
-		// TODO: Not really a block. The underlying logic doesn't care, so we should rename to
-		// `jetpack_register_gutenberg_extension()` (to account for both Gutenblocks and Gutenplugins).
-		jetpack_register_block( 'publicize', array(), array( 'callback' => array( $this, 'get_extension_availability' ) ) );
+		jetpack_register_plugin( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
 	}
 
 	function get_extension_availability() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Use `jetpack_register_plugin` instead of `jetpack_register_block` for Publicize.

#### Testing instructions:

* Spin up a JN site with this branch.
* Connect the site, activate recommended features
* Start writing a post.
* Click the Jetpack icon in the toolbar.
* Verify you can see the Publicize UI.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Now properly registering Publicize as an extension
