### PR TITLE
My plan: left align compare plans by default

### DIFF
--- a/_inc/client/my-plan/style.scss
+++ b/_inc/client/my-plan/style.scss
@@ -241,5 +241,8 @@
 
 .jp-landing__plan-features-link {
 	width: 100%;
-	text-align: center;
+
+	@include breakpoint( ">660px" ) {
+		text-align: center;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Left align “Compare plans” button by default in My Plans page.

h/t @aheckler for reporting this!

#### Testing instructions:

* Spin up a new site, select free plan.
* Go to My Plan page.
* Make sure the button aligns to the left on smaller screens (660px and below).

#### Before

![image](https://user-images.githubusercontent.com/390760/50353390-09161a00-0540-11e9-89f4-9c9ec5e29b07.png)


#### After

![image](https://user-images.githubusercontent.com/390760/50353357-f69be080-053f-11e9-92d1-168328e8eefe.png)


#### Proposed changelog entry for your changes:

* My plan: left align compare plans by default
