### PR TITLE
PHP 7.3: avoid warnings from continue inside a switch statement

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -820,7 +820,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						 */
 						$value = apply_filters( 'site_settings_endpoint_update_' . $key, $value );
 						$updated[ $key ] = $value;
-						continue;
+						continue 2;
 					}
 
 					// no worries, we've already whitelisted and casted arguments above

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -759,7 +759,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					case 'add':
 
 						if ( ! empty( $meta->id ) || ! empty( $meta->previous_value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->value ) && ( current_user_can( 'add_post_meta', $post_id, $unslashed_meta_key ) ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) {
 							add_post_meta( $post_id, $meta->key, $meta->value );
 						}
@@ -768,7 +768,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					case 'update':
 
 						if ( ! isset( $meta->value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->id ) && ! empty( $existing_meta_item->meta_key ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_existing_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {
 							update_metadata_by_mid( 'post', $meta->id, $meta->value );
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->previous_value ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -825,7 +825,6 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 
 				switch ( $meta->operation ) {
 					case 'delete':
-
 						if ( ! empty( $meta->id ) && ! empty( $existing_meta_item->meta_key ) && current_user_can( 'delete_post_meta', $post_id, $unslashed_existing_meta_key ) ) {
 							delete_metadata_by_mid( 'post', $meta->id );
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->previous_value ) && current_user_can( 'delete_post_meta', $post_id, $unslashed_meta_key ) ) {
@@ -836,18 +835,16 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 
 						break;
 					case 'add':
-
 						if ( ! empty( $meta->id ) || ! empty( $meta->previous_value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->value ) && ( current_user_can( 'add_post_meta', $post_id, $unslashed_meta_key ) ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) {
 							add_post_meta( $post_id, $meta->key, $meta->value );
 						}
 
 						break;
 					case 'update':
-
 						if ( ! isset( $meta->value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->id ) && ! empty( $existing_meta_item->meta_key ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_existing_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {
 							update_metadata_by_mid( 'post', $meta->id, $meta->value );
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->previous_value ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {
@@ -858,7 +855,6 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 
 						break;
 				}
-
 			}
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -518,7 +518,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				default :
 					// Several images - 3 column gallery
 					$insert['post_content'] = $input['content'] = sprintf(
-						"[gallery ids='%s']\n\n", 
+						"[gallery ids='%s']\n\n",
 						$media_id_string
 					) . $input['content'];
 					break;
@@ -796,7 +796,6 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 				switch ( $meta->operation ) {
 					case 'delete':
-
 						if ( ! empty( $meta->id ) && ! empty( $existing_meta_item->meta_key ) && current_user_can( 'delete_post_meta', $post_id, $unslashed_existing_meta_key ) ) {
 							delete_metadata_by_mid( 'post', $meta->id );
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->previous_value ) && current_user_can( 'delete_post_meta', $post_id, $unslashed_meta_key ) ) {
@@ -807,18 +806,16 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 						break;
 					case 'add':
-
 						if ( ! empty( $meta->id ) || ! empty( $meta->previous_value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->value ) && ( current_user_can( 'add_post_meta', $post_id, $unslashed_meta_key ) ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) {
 							add_post_meta( $post_id, $meta->key, $meta->value );
 						}
 
 						break;
 					case 'update':
-
 						if ( ! isset( $meta->value ) ) {
-							continue;
+							continue 2;
 						} elseif ( ! empty( $meta->id ) && ! empty( $existing_meta_item->meta_key ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_existing_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {
 							update_metadata_by_mid( 'post', $meta->id, $meta->value );
 						} elseif ( ! empty( $meta->key ) && ! empty( $meta->previous_value ) && ( current_user_can( 'edit_post_meta', $post_id, $unslashed_meta_key ) || WPCOM_JSON_API_Metadata::is_public( $meta->key ) ) ) {
@@ -829,7 +826,6 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 						break;
 				}
-
 			}
 		}
 

--- a/modules/custom-css/csstidy/class.csstidy.php
+++ b/modules/custom-css/csstidy/class.csstidy.php
@@ -855,7 +855,7 @@ class csstidy {
 						$this->str_char[] = $string{$i} == "(" ? ")" : $string{$i};
 						$this->from[] = 'instr';
 						$this->quoted_string[] = !($string{$i} === "(");
-						continue;
+						continue 2;
 					}
 
 					if ($_str_char !== ")" && ($string{$i} === "\n" || $string{$i} === "\r") && !($string{$i - 1} === '\\' && !csstidy::escaped($string, $i - 1))) {
@@ -1027,7 +1027,7 @@ class csstidy {
 			return $media;
 		}
 		end($this->css);
-		list($at,) = each($this->css);
+		$at = current( $this->css );
 		if ($at == $media){
 			return $media;
 		}
@@ -1066,7 +1066,7 @@ class csstidy {
 
 			// if last is the same, keep it
 			end($this->css[$media]);
-			list($sel,) = each($this->css[$media]);
+			$sel = current( $this->css[$media] );
 			if ($sel == $selector){
 				return $selector;
 			}


### PR DESCRIPTION
Fixes #10730

#### Changes proposed in this Pull Request:

* Fixes the warnings mentioned in #10730

#### Testing instructions:

* If you have a PHP 7.3 install, make sure you find no warnings in logs.

#### Proposed changelog entry for your changes:

* PHP 7.3: fix warnings.
