### PR TITLE
Adds rest endpoint for importing posts

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/import-posts.php
+++ b/_inc/lib/core-api/wpcom-endpoints/import-posts.php
@@ -1,0 +1,64 @@
+<?php
+
+class WPCOM_REST_API_V2_Endpoint_Import_Posts extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = '/wpcom/v2';
+		$this->rest_base = '/import';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/posts',
+			array(
+				'methods'  => WP_REST_Server::CREATABLE,
+				'callback' => array( $this, 'import_posts' ),
+				'permission_callback' => array( $this, 'import_permission_check' ),
+				'args' => array(
+					'posts' => array(
+						'required' => true,
+						'sanitize_callback' => array( $this, 'sanitize_posts' ),
+					),
+				),
+			)
+		);
+	}
+
+	public function import_posts( $request ) {
+		$posts = isset( $request['posts'] ) ? $request['posts'] : array();
+
+		if ( count( $posts ) < 1 ) {
+			return new WP_Error( 'rest_invalid_param', __( 'posts param must contain at least 1 post.', 'jetpack' ) );
+		}
+
+		$post_ids = array();
+
+		foreach ( $posts as $post ) {
+			$post_ids[] = wp_insert_post( $post );
+		}
+
+		return new WP_REST_Response( $post_ids, 200 );
+	}
+
+	public function import_permission_check() {
+		return current_user_can( 'import' )
+			? true
+			: new WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to import as this user.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+	}
+
+	public function sanitize_posts( $posts ) {
+		$sanitized_posts = array_map( array( $this, 'sanitize_post' ), $posts );
+		return $sanitized_posts;
+	}
+
+	public function sanitize_post( $post ) {
+		return sanitize_post( $post, 'db' );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Import_Posts' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

DO NOT MERGE

This is part of an experiment in using the wpcom infrastructure for imports and then sending imported data through the REST API.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Used in conjunction with

- https://github.com/Automattic/wp-calypso/pull/29515
- D22651-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

None.
