### PR TITLE
Tiled gallery block: add wp-blob dependency

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -471,6 +471,7 @@ class Jetpack_Gutenberg {
 			array(
 				'lodash',
 				'wp-api-fetch',
+				'wp-blob',
 				'wp-blocks',
 				'wp-components',
 				'wp-compose',

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -39,6 +39,7 @@ if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) )
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
 		$dependencies = array(
 			'lodash',
+			'wp-blob',
 			'wp-i18n',
 			'wp-token-list',
 		);

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -39,7 +39,6 @@ if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) )
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
 		$dependencies = array(
 			'lodash',
-			'wp-blob',
 			'wp-i18n',
 			'wp-token-list',
 		);


### PR DESCRIPTION
Adds `@wordpress/blob` dependency for Tiled gallery since the block depends to it as of https://github.com/Automattic/wp-calypso/pull/29559

## Testing

- Switch to `update/g7g-tg-consistent-layout` branch in Calypso
- Build blocks: `npm run sdk -- gutenberg ./client/gutenberg/extensions/presets/jetpack/ /PATH_TO_JETPACK/_inc/blocks/`
- Insert tiled gallery block
- **Upload** images to gallery. Blob URLs are URLs for images that are still uploading.
- The block can feel little broken due other issues but it shouldn't complain about missing dependency. ✨ (both editor and when publishing and looking at the page/post)