### PR TITLE
Related Posts: Sync version with the latest one on WP.com

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20181213';
+	const VERSION = '20181228';
 	const SHORTCODE = 'jetpack-related-posts';
 	private static $instance = null;
 	private static $instance_raw = null;


### PR DESCRIPTION
D22685-code syncs to WP.com some Related Posts styles for lists that are missing there, but exist in Jetpack. Since we bump the Related Posts version there, we should sync it back here too.

Part of https://github.com/Automattic/wp-calypso/issues/29771.

See D22685-code for testing instructions.