### PR TITLE
Related Posts: Remove unused  var

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -16,7 +16,6 @@ class Jetpack_RelatedPosts {
 				self::$instance = WPCOM_RelatedPosts::init();
 			} else {
 				self::$instance = new Jetpack_RelatedPosts(
-					get_current_blog_id(),
 					Jetpack_Options::get_option( 'id' )
 				);
 			}
@@ -36,7 +35,6 @@ class Jetpack_RelatedPosts {
 				self::$instance_raw = WPCOM_RelatedPosts::init_raw();
 			} else {
 				self::$instance_raw = new Jetpack_RelatedPosts_Raw(
-					get_current_blog_id(),
 					Jetpack_Options::get_option( 'id' )
 				);
 			}
@@ -45,7 +43,6 @@ class Jetpack_RelatedPosts {
 		return self::$instance_raw;
 	}
 
-	protected $_blog_id_local;
 	protected $_blog_id_wpcom;
 	protected $_options;
 	protected $_allow_feature_toggle;
@@ -57,13 +54,11 @@ class Jetpack_RelatedPosts {
 	/**
 	 * Constructor for Jetpack_RelatedPosts.
 	 *
-	 * @param int $blog_id_local
 	 * @param int $blog_id_wpcom
 	 * @uses get_option, add_action, apply_filters
 	 * @return null
 	 */
-	public function __construct( $blog_id_local, $blog_id_wpcom ) {
-		$this->_blog_id_local = $blog_id_local;
+	public function __construct( $blog_id_wpcom ) {
 		$this->_blog_id_wpcom = $blog_id_wpcom;
 		$this->_blog_charset = get_option( 'blog_charset' );
 		$this->_convert_charset = ( function_exists( 'iconv' ) && ! preg_match( '/^utf\-?8$/i', $this->_blog_charset ) );


### PR DESCRIPTION
Originally filed against WP.com as D22688-code.

#### Changes proposed in this Pull Request:
This was introduced as part of r93661-wpcom, but only set and never actually read.
This is a preparatory step before also removing `$blog_id_wpcom` (and instead inferring the relevant blog ID dynamically -- see D22689), which is needed when using Related Posts from a REST API context -- i.e. to fix https://github.com/Automattic/wp-calypso/issues/29750.

#### Testing instructions:
Verify that Related Posts work as well as before. Try WP.com and Jetpack sites.
Verify (by grepping) that no other file references `$blog_id_local`.
Verify that all consructors of Jetpack_RelatedPosts, and their _Raw counterparts (sigh) have been correctly modified to remove the first argument.

#### Proposed changelog entry

Related Posts: Remove unused var.