### PR TITLE
Connection Banner style enhancements

### DIFF
--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -44,7 +44,7 @@ $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
 $alert-purple:           #855DA6;
-$alert-hot-red: 		 #eb0001; // 2019
+$alert-hot-red:          #eb0001; // 2019
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);

--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -44,6 +44,7 @@ $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
 $alert-purple:           #855DA6;
+$alert-hot-red: 		 #eb0001; // 2019
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -170,7 +170,7 @@ class Jetpack_Connection_Banner {
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__container-top-text">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
-				<?php esc_html_e( 'You’re almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?></div>
+					<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to boost your site performance and get dozens of customization, marketing, and security tools.', 'jetpack' ); ?></span></div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -168,6 +168,7 @@ class Jetpack_Connection_Banner {
 	 */
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
+			<?php esc_html_e( 'You&aposre almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -169,8 +169,9 @@ class Jetpack_Connection_Banner {
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__container-top-text">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
-					<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to boost your site performance and get dozens of customization, marketing, and security tools.', 'jetpack' ); ?></span></div>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
+				<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to boost your site performance and get dozens of customization, marketing, and security tools.', 'jetpack' ); ?></span>
+			</div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"
@@ -230,9 +231,9 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'Jetpack simplifies website performance, security, customization, and management.', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-								<img src="<?php echo plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
-									esc_attr_e(
-										'Jetpack premium services offer even more powerful performance, security, and revenue tools to help you keep your site safe, fast, and help generate income.',
+							<img src="<?php echo plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
+								esc_attr_e(
+									'Jetpack premium services offer even more powerful performance, security, and revenue tools to help you keep your site safe, fast, and help generate income.',
 									'jetpack'
 								); ?>" height="auto" width="225" />
 						</div>
@@ -534,8 +535,8 @@ class Jetpack_Connection_Banner {
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
 							<img src="<?php echo plugins_url( 'images/jetpack-welcome.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
-									esc_attr_e(
-										'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it.',
+								esc_attr_e(
+									'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it.',
 									'jetpack'
 								); ?>" height="auto" width="250" />
 						</div>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -227,20 +227,20 @@ class Jetpack_Connection_Banner {
 
 					<!-- slide 1: intro -->
 					<div class="jp-wpcom-connect__slide jp-wpcom-connect__slide-one jp__slide-is-active">
-						<h2><?php esc_html_e( 'Jetpack simplifies site security, customization, and management.', 'jetpack' ) ?></h2>
+						<h2><?php esc_html_e( 'Jetpack simplifies website performance, security, customization, and management.', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'images/jetpack-welcome.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
+								<img src="<?php echo plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
-										'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it.',
+										'Jetpack premium services offer even more powerful performance, security, and revenue tools to help you keep your site safe, fast, and help generate income.',
 									'jetpack'
-								); ?>" height="auto" width="250" />
+								); ?>" height="auto" width="225" />
 						</div>
 
 						<p>
 							<?php
 							esc_html_e(
-								'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it.',
+								'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it. With over 5 million active installations, its one of the most popular plugins for WordPress.',
 								'jetpack'
 							);
 							?>
@@ -249,7 +249,7 @@ class Jetpack_Connection_Banner {
 						<p>
 							<?php
 							esc_html_e(
-								'You get detailed visitor stats, state-of-the-art security services, image performance upgrades, traffic generation tools, and more.',
+								'You get detailed visitor stats, state-of-the-art security services, performance upgrades, traffic generation tools, and more.',
 								'jetpack'
 							);
 							?>
@@ -258,7 +258,7 @@ class Jetpack_Connection_Banner {
 						<p>
 							<?php
 							esc_html_e(
-								'Connect to WordPress.com (free) to get started!',
+								'Connect to WordPress.com (free) to set up Jetpack and get started!',
 								'jetpack'
 							);
 							?>
@@ -533,11 +533,11 @@ class Jetpack_Connection_Banner {
 						<h2><?php esc_html_e( 'All the tools you’ll ever need for a more powerful WordPress site', 'jetpack' ) ?></h2>
 
 						<div class="jp-wpcom-connect__content-icon jp-connect-illo">
-							<img src="<?php echo plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
+							<img src="<?php echo plugins_url( 'images/jetpack-welcome.svg', JETPACK__PLUGIN_FILE ); ?>" alt="<?php
 									esc_attr_e(
-										'Jetpack premium services offer even more powerful performance, security, and revenue tools to help you keep your site safe, fast, and help generate income.',
+										'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it.',
 									'jetpack'
-								); ?>" height="auto" width="225" />
+								); ?>" height="auto" width="250" />
 						</div>
 
 						<p>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -168,7 +168,7 @@ class Jetpack_Connection_Banner {
 	 */
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
-			<?php esc_html_e( 'You&aposre almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?>
+			<div class="jp-wpcom-connect__container-top-text"><?php esc_html_e( 'You are almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?></div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -168,7 +168,9 @@ class Jetpack_Connection_Banner {
 	 */
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
-			<div class="jp-wpcom-connect__container-top-text"><?php esc_html_e( 'You are almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?></div>
+			<div class="jp-wpcom-connect__container-top-text">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
+				<?php esc_html_e( 'You’re almost done. Jetpack needs to be set up to give you dozens of customization, marketing, and security tools.', 'jetpack' ); ?></div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -273,6 +273,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 	justify-content: left;
+	border: 4px #eb0001 solid;
 }
 
 .jp-wpcom-connect__content-container {

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -411,7 +411,7 @@
 		flex-direction: row;
 		align-items: center;
 		border: none;
-		padding: rem( 8px );
+		padding: rem( 12px ) rem( 8px );
 		border-bottom: 1px solid #c8d7e1;
 		border-right: 1px solid #c8d7e1;
 		border-left: 3px solid #F3F6F8;
@@ -428,13 +428,13 @@
 	}
 
 	.vertical-menu__feature-item-is-selected {
-		border-left: 3px solid #0087be;
+		border-left: 3px solid #F3F6F8;
 		border-right: 1px solid #fff;
 		background-color: #fff;
 		color: #2e4453;
 
 		&.jp-feature-intro {
-			border-left: 3px solid $green-primary;
+			border-left: 3px solid #F3F6F8;
 		}
 	}
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -255,21 +255,32 @@
 .updated .notice-dismiss {
 	z-index: 1;
 	text-decoration: none;
+	&:before {
+		color: $white;
+	}
 }
 // end overrides
 
 .jp-wpcom-connect__container-top-text {
-	padding: 20px 15px;
-	background-color: #eb0001; 
-	color: #fff;
+	padding: 15px 15px 20px 15px;
+	background-color: $alert-hot-red; 
+	color: $white;
+	font-weight: 600;
 
 	svg {
 		width: 24px;
 		height: 24px;
-		
+		margin-right: 10px;
+		position: relative;
+		top: 7px;
+
 		path {
 			fill: #fff;
 		}
+	}
+
+	span {
+		display: inline-block;
 	}
 }
 
@@ -277,7 +288,7 @@
 	display: block;
 	position: relative;
 	box-sizing: border-box;
-	background-color: #eb0001; 
+	background-color: $alert-hot-red; 
 }
 
 .jp-wpcom-connect__inner-container > a:first-child {
@@ -289,7 +300,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 	justify-content: left;
-	border: 4px #eb0001 solid;
+	border: 4px $alert-hot-red solid;
 	background: #fff;
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -260,6 +260,17 @@
 
 .jp-wpcom-connect__container-top-text {
 	padding: 20px 15px;
+	background-color: #eb0001; 
+	color: #fff;
+
+	svg {
+		width: 24px;
+		height: 24px;
+		
+		path {
+			fill: #fff;
+		}
+	}
 }
 
 .jp-wpcom-connect__container {

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -258,10 +258,15 @@
 }
 // end overrides
 
+.jp-wpcom-connect__container-top-text {
+	padding: 20px 15px;
+}
+
 .jp-wpcom-connect__container {
 	display: block;
 	position: relative;
 	box-sizing: border-box;
+	background-color: #eb0001; 
 }
 
 .jp-wpcom-connect__inner-container > a:first-child {
@@ -274,6 +279,7 @@
 	flex-wrap: nowrap;
 	justify-content: left;
 	border: 4px #eb0001 solid;
+	background: #fff;
 }
 
 .jp-wpcom-connect__content-container {


### PR DESCRIPTION
Quick visual enhancements to the connection banner to make it catch people's attention and communicate that it's a step that they need to take to get Jetpack started.

- Added new alert hot red border to grab people's attention (new color for 2019 branding). Included a header with language to let them know they aren't done yet.
- Made the banner a little taller so its not missed
- Added new illustration on first slide (swapped with the image on the last slide)
- Changed the verbiage a little on first slide. Including "Over 5 million installations" language for credibility

Before:
<img width="1678" alt="screen shot 2018-12-29 at 5 31 56 pm" src="https://user-images.githubusercontent.com/214813/50542599-acde7600-0b8f-11e9-922b-ec94a0c7bd5c.png">


**Proposed:**

**Large screen:**
<img width="1667" alt="screen shot 2018-12-30 at 12 47 03 pm" src="https://user-images.githubusercontent.com/214813/50549782-11054680-0c31-11e9-97a2-77b6961dd3e7.png">


Video: https://cloudup.com/cb7miIGguD7

Mobile:
![jetpack-connection-banner-after-mobile](https://user-images.githubusercontent.com/214813/50549721-3ba2cf80-0c30-11e9-9eb0-b5a00896e6fd.png)



Testing instructions: 
- Install + activate jetpack. Do NOT connection to wpcom 
- Navigate to /wp-admin/index/php
- check out the connection banner

Proposed changelog entry:
none.