### PR TITLE
Carousel: add support for the new Tiled Gallery block.

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -43,7 +43,17 @@ if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) )
 			'wp-token-list',
 		);
 		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
-		return $content;
+
+		/**
+		 * Filter the output of the Tiled Galleries content.
+		 *
+		 * @module tiled-gallery
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $content Tiled Gallery block content.
+		 */
+		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
 	}
 }
 

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1446,7 +1446,7 @@ jQuery(document).ready(function($) {
 	};
 
 	// register the event listener for starting the gallery
-	$( document.body ).on( 'click.jp-carousel', 'div.gallery, div.tiled-gallery, ul.wp-block-gallery, a.single-image-gallery', function( e ) {
+	$(document.body).on('click.jp-carousel', 'div.gallery, div.tiled-gallery, ul.wp-block-gallery, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery', function( e ) {
 		if ( ! $(this).jp_carousel( 'testForData', e.currentTarget ) ) {
 			return;
 		}
@@ -1466,7 +1466,7 @@ jQuery(document).ready(function($) {
 		// Stopping propagation in case there are parent elements
 		// with .gallery or .tiled-gallery class
 		e.stopPropagation();
-		$(this).jp_carousel('open', { start_index: $(this).find('.gallery-item, .tiled-gallery-item, .blocks-gallery-item').index($(e.target).parents('.gallery-item, .tiled-gallery-item, .blocks-gallery-item'))});
+		$(this).jp_carousel('open', { start_index: $(this).find('.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item').index($(e.target).parents('.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item'))});
 	});
 
 	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
@@ -1503,7 +1503,7 @@ jQuery(document).ready(function($) {
 		last_known_location_hash = window.location.hash;
 		matches = window.location.hash.match( hashRegExp );
 		attachmentId = parseInt( matches[1], 10 );
-		galleries = $( 'div.gallery, div.tiled-gallery, a.single-image-gallery, ul.wp-block-gallery' );
+		galleries = $( 'div.gallery, div.tiled-gallery, a.single-image-gallery, ul.wp-block-gallery, div.wp-block-jetpack-tiled-gallery' );
 
 		// Find the first thumbnail that matches the attachment ID in the location
 		// hash, then open the gallery that contains it.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/28614
Fixes https://github.com/Automattic/wp-calypso/issues/29774

#### Changes proposed in this Pull Request:

- Add a new filter to the output of the tiled gallery block, to allow us to inject the data needed by
Carousel.
- Add data to gallery container when using the Tiled Gallery block.
- Trigger Carousel modal on clicks on Tiled Gallery blocks


#### Testing instructions:

* Create 4 posts on your site:
    - one with a classic block and a classic gallery in it
    - one with a core gallery block
    - one with a new tiled gallery block
    - one with a classic block and a tiled gallery in it.
* Make sure Carousel works for all 4 posts; you should be able to open the Carousel modal when clicking on an image, and the image that pops up should be the one you clicked on.

#### Proposed changelog entry for your changes:

* Carousel: add support for the new Tiled Gallery block.
