### PR TITLE
Tiled Galleries: do not rely on the Tiled Gallery module.

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -16,6 +16,38 @@ jetpack_register_block(
 jetpack_register_block( 'vr' );
 
 /**
+ * Tiled Gallery block. Depends on the Photon module.
+ *
+ * @since 6.9.0
+*/
+if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+	jetpack_register_block(
+		'tiled-gallery',
+		array(
+			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
+		)
+	);
+
+	/**
+	 * Tiled gallery block registration/dependency declaration.
+	 *
+	 * @param array  $attr - Array containing the block attributes.
+	 * @param string $content - String containing the block content.
+	 *
+	 * @return string
+	 */
+	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
+		$dependencies = array(
+			'lodash',
+			'wp-i18n',
+			'wp-token-list',
+		);
+		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
+		return $content;
+	}
+}
+
+/**
  * Map block registration/dependency declaration.
  *
  * @param array  $attr - Array containing the map block attributes.

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -16,31 +16,6 @@ class Jetpack_Tiled_Gallery {
 		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
 		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
-
-		jetpack_register_block(
-			'tiled-gallery',
-			array(
-				'render_callback' => array( $this, 'load_block_assets' ),
-			)
-		);
-	}
-
-	/**
-	 * Tiled gallery block registration/dependency declaration.
-	 *
-	 * @param array  $attr - Array containing the block attributes.
-	 * @param string $content - String containing the block content.
-	 *
-	 * @return string
-	 */
-	public function load_block_assets( $attr, $content ) {
-		$dependencies = array(
-			'lodash',
-			'wp-i18n',
-			'wp-token-list',
-		);
-		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
-		return $content;
 	}
 
 	public function tiles_enabled() {


### PR DESCRIPTION
Fixes #10753

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

With this PR, one can use the Tiled Gallery block on their site even
if the Tiled Gallery module is not active. The block, however, relies
on the Photon module.

#### Testing instructions:

* Go to Jetpack > Settings
* Disable the "Speed up image load times" option
* Load the block editor.
* The tiled gallery block should not be available.
* If, however, you go back and enable the "Speed up image load times" option, the block will become available.

#### Proposed changelog entry for your changes:

* Tiled Gallery block: do not rely on the Tiled Gallery module.
