### PR TITLE
Travis: run master tests from master instead of the 5.0 branch

### DIFF
--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -22,7 +22,7 @@ mysql -u root -e "CREATE DATABASE wordpress_tests;"
 echo "Preparing WordPress from \"$WP_BRANCH\" branch...";
 case $WP_BRANCH in
 master)
-	git clone --depth=1 --branch 5.0 git://develop.git.wordpress.org/ /tmp/wordpress-master
+	git clone --depth=1 --branch master git://develop.git.wordpress.org/ /tmp/wordpress-master
 	;;
 latest)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php) git://develop.git.wordpress.org/ /tmp/wordpress-latest


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This reverts commit ce968d74d7a363cbe2b466c61df787c62027d08a.
Core is now back to developing from trunk. Let's test against that.

#### Testing instructions:

* Do the tests pass?
* Do a happy dance.

#### Proposed changelog entry for your changes:

* None
