### PR TITLE
Slideshare: remove custom embed

### DIFF
--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -1,10 +1,5 @@
 <?php
-
-// guarantee use of https
-wp_oembed_remove_provider( '#https?://(www\.)?slideshare\.net/.*#i' );
-wp_oembed_add_provider( '#https?://(www\.)?slideshare\.net/.*#i', 'https://www.slideshare.net/api/oembed/2', true );
-
-/*
+/**
  * Slideshare shortcode format:
  * Old style (still compatible): [slideshare id=5342235&doc=camprock-101002163655-phpapp01&w=300&h=200]
  * New style: [slideshare id=5342235&w=300&h=200&fb=0&mw=0&mh=0&sc=no]


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Core now offers support for Slideshare oEmbed, using HTTPS.
https://core.trac.wordpress.org/ticket/28507

#### Testing instructions:

* Try to embed slideshare slideshows into your posts, as explained here: https://en.support.wordpress.com/slideshare/
* Also make sure to try to embed slideshows by just pasting the URL on its own line, in both the classic block and the embed block.
* Everything should keep working.

#### Proposed changelog entry for your changes:

* SlideShare: rely on WordPress Core to handle slideshow embeds.
