### PR TITLE
Give contact form submit button inline block styling

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2040,7 +2040,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			if ( ! empty( $attributes['customTextButtonColor'] ) ) {
 				$submit_button_styles .= 'color: ' . $attributes['customTextButtonColor'] . ';';
 			}
-			if ( isset( $attributes['submitButtonText'] ) && $attributes['submitButtonText'] ) {
+			if ( ! empty( $attributes['submitButtonText'] ) ) {
 				$submit_button_text = $attributes['submitButtonText'];
 			} else {
 				$submit_button_text = $form->get_attribute( 'submit_button_text' );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2046,7 +2046,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$submit_button_text = $form->get_attribute( 'submit_button_text' );
 			}
 
-			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . esc_attr( $submit_button_class ) . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
+			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . esc_attr( $submit_button_class ) . "'";
+			if ( ! empty( $submit_button_styles ) ) {
+				$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
+			}
+			$r .= "/>\n";
+			
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2046,7 +2046,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$submit_button_text = $form->get_attribute( 'submit_button_text' );
 			}
 
-			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . $submit_button_class . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
+			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . esc_attr( $submit_button_class ) . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2037,7 +2037,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			if ( ! empty( $attributes['customBackgroundButtonColor'] ) ) {
 				$submit_button_styles .= 'background-color: ' . $attributes['customBackgroundButtonColor'] . '; ';
 			}
-			if ( isset( $attributes['customTextButtonColor'] ) && $attributes['customTextButtonColor'] ) {
+			if ( ! empty( $attributes['customTextButtonColor'] ) ) {
 				$submit_button_styles .= 'color: ' . $attributes['customTextButtonColor'] . ';';
 			}
 			if ( isset( $attributes['submitButtonText'] ) && $attributes['submitButtonText'] ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2034,7 +2034,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$submit_button_class = apply_filters( 'jetpack_contact_form_submit_button_class', 'pushbutton-wide' . $gutenberg_submit_button_classes );
 
 			$submit_button_styles = '';
-			if ( isset( $attributes['customBackgroundButtonColor'] ) && $attributes['customBackgroundButtonColor'] ) {
+			if ( ! empty( $attributes['customBackgroundButtonColor'] ) ) {
 				$submit_button_styles .= 'background-color: ' . $attributes['customBackgroundButtonColor'] . '; ';
 			}
 			if ( isset( $attributes['customTextButtonColor'] ) && $attributes['customTextButtonColor'] ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2035,8 +2035,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			if ( isset( $attributes['customTextButtonColor'] ) && $attributes['customTextButtonColor'] ) {
 				$submit_button_styles .= 'color: ' . $attributes['customTextButtonColor'] . ';';
 			}
+			if ( isset( $attributes['submitButtonText'] ) && $attributes['submitButtonText'] ) {
+				$submit_button_text = $attributes['submitButtonText'];
+			} else {
+				$submit_button_text = $form->get_attribute( 'submit_button_text' );
+			}
 
-			$r .= "\t\t<input type='submit' value='" . esc_attr( $form->get_attribute( 'submit_button_text' ) ) . "' class='" . $submit_button_class . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
+			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . $submit_button_class . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2017,6 +2017,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$r .= $form->body;
 			$r .= "\t<p class='contact-submit'>\n";
 
+			$gutenberg_submit_button_classes = '';
+			if ( isset( $attributes['submitButtonClasses'] ) && $attributes['submitButtonClasses'] ) {
+				$gutenberg_submit_button_classes = ' ' . $attributes['submitButtonClasses'];
+			}
+
 			/**
 			 * Filter the contact form submit button class attribute.
 			 *
@@ -2026,7 +2031,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			 *
 			 * @param string $class Additional CSS classes for button attribute.
 			 */
-			$submit_button_class = apply_filters( 'jetpack_contact_form_submit_button_class', 'pushbutton-wide jetpack-contact-form-button' );
+			$submit_button_class = apply_filters( 'jetpack_contact_form_submit_button_class', 'pushbutton-wide' . $gutenberg_submit_button_classes );
 
 			$submit_button_styles = '';
 			if ( isset( $attributes['customBackgroundButtonColor'] ) && $attributes['customBackgroundButtonColor'] ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2026,9 +2026,17 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			 *
 			 * @param string $class Additional CSS classes for button attribute.
 			 */
-			$submit_button_class = apply_filters( 'jetpack_contact_form_submit_button_class', 'pushbutton-wide' );
+			$submit_button_class = apply_filters( 'jetpack_contact_form_submit_button_class', 'pushbutton-wide jetpack-contact-form-button' );
 
-			$r .= "\t\t<input type='submit' value='" . esc_attr( $form->get_attribute( 'submit_button_text' ) ) . "' class='" . $submit_button_class . "'/>\n";
+			$submit_button_styles = '';
+			if ( isset( $attributes['customBackgroundButtonColor'] ) && $attributes['customBackgroundButtonColor'] ) {
+				$submit_button_styles .= 'background-color: ' . $attributes['customBackgroundButtonColor'] . '; ';
+			}
+			if ( isset( $attributes['customTextButtonColor'] ) && $attributes['customTextButtonColor'] ) {
+				$submit_button_styles .= 'text-color: ' . $attributes['customTextButtonColor'] . ';';
+			}
+
+			$r .= "\t\t<input type='submit' value='" . esc_attr( $form->get_attribute( 'submit_button_text' ) ) . "' class='" . $submit_button_class . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2033,7 +2033,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$submit_button_styles .= 'background-color: ' . $attributes['customBackgroundButtonColor'] . '; ';
 			}
 			if ( isset( $attributes['customTextButtonColor'] ) && $attributes['customTextButtonColor'] ) {
-				$submit_button_styles .= 'text-color: ' . $attributes['customTextButtonColor'] . ';';
+				$submit_button_styles .= 'color: ' . $attributes['customTextButtonColor'] . ';';
 			}
 
 			$r .= "\t\t<input type='submit' value='" . esc_attr( $form->get_attribute( 'submit_button_text' ) ) . "' class='" . $submit_button_class . "' style='" . esc_attr( $submit_button_styles ) . "'/>\n";

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2018,7 +2018,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$r .= "\t<p class='contact-submit'>\n";
 
 			$gutenberg_submit_button_classes = '';
-			if ( isset( $attributes['submitButtonClasses'] ) && $attributes['submitButtonClasses'] ) {
+			if ( ! empty( $attributes['submitButtonClasses'] ) ) {
 				$gutenberg_submit_button_classes = ' ' . $attributes['submitButtonClasses'];
 			}
 


### PR DESCRIPTION
This PR gives the contact form submit button the styling specified in the Gutenberg block editor.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR makes the contact form submit button look the way it's supposed to as per the Gutenberg form block, https://github.com/Automattic/wp-calypso/pull/29722

#### Testing instructions:
Currently, apply https://github.com/Automattic/wp-calypso/pull/29722, apply this PR, add a form block, ensure your submit button has the correct background and text color.

#### Proposed changelog entry for your changes:
Contact form submit button view updated to apply block colors.