### PR TITLE
Connection banner color update: changing red to green as not to scare people

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -263,7 +263,7 @@
 
 .jp-wpcom-connect__container-top-text {
 	padding: 15px 15px 20px 15px;
-	background-color: $alert-hot-red; 
+	background-color: $green-primary; 
 	color: $white;
 	font-weight: 600;
 
@@ -288,7 +288,7 @@
 	display: block;
 	position: relative;
 	box-sizing: border-box;
-	background-color: $alert-hot-red; 
+	background-color: $green-primary; 
 }
 
 .jp-wpcom-connect__inner-container > a:first-child {
@@ -300,7 +300,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 	justify-content: left;
-	border: 4px $alert-hot-red solid;
+	border: 4px $green-primary solid;
 	background: #fff;
 }
 


### PR DESCRIPTION
update to: https://github.com/Automattic/jetpack/pull/11053

connection banner update: changing red to green as not to scare people. I don't want to use a scare tactic to have them be forced into connecting, but I do want them to notice the banner. 

We'll be updating the connection banner again for the next release. 


before:
<img width="840" alt="screen shot 2019-01-03 at 9 41 18 am" src="https://user-images.githubusercontent.com/214813/50643863-2fbf5200-0f3d-11e9-865e-6492bb3ac308.png">

after:
<img width="1664" alt="screen shot 2019-01-03 at 9 51 25 am" src="https://user-images.githubusercontent.com/214813/50643857-2d5cf800-0f3d-11e9-8d21-540ba95aae3d.png">



<!--- Provide a general summary of your changes in the Title above -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* changing the color of the banner

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* check the connection banner after installing and activating this branch

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* none
