### PR TITLE
Jetpack Gutenberg: Kill `$default_blocks` with :fire:

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -53,11 +53,6 @@ class Jetpack_Gutenberg {
 
 	private static $availability = array();
 
-	// PLUGINS
-	private static $default_plugins = array(
-		'publicize',
-		'shortlinks',
-	);
 	/**
 	 * @var array Array of plugins information.
 	 *
@@ -158,7 +153,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$plugins = apply_filters( 'jetpack_set_available_plugins', self::$default_plugins );
+		self::$plugins = apply_filters( 'jetpack_set_available_plugins', array() );
 		self::set_blocks_availability();
 		self::set_plugins_availability();
 		self::register_blocks();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -44,27 +44,6 @@ function jetpack_register_plugin( $slug, $availability = array( 'available' => t
  */
 class Jetpack_Gutenberg {
 
-	// BLOCKS
-	private static $default_blocks = array(
-		'map',
-		'markdown',
-		'simple-payments',
-		'related-posts',
-		'contact-form',
-		'field-text',
-		'field-name',
-		'field-email',
-		'field-url',
-		'field-date',
-		'field-telephone',
-		'field-textarea',
-		'field-checkbox',
-		'field-checkbox-multiple',
-		'field-radio',
-		'field-select',
-		'subscriptions',
-	);
-
 	/**
 	 * @var array Array of blocks information.
 	 *
@@ -168,7 +147,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$blocks = apply_filters( 'jetpack_set_available_blocks', self::$default_blocks );
+		self::$blocks = apply_filters( 'jetpack_set_available_blocks', array() );
 
 		/**
 		 * Filter the list of block editor plugins that are available through jetpack.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Quoting pafL3P-cY-p2:

> Pretty much everyone keeps wondering if they need to add their block to [`$default_blocks`](https://github.com/Automattic/jetpack/blob/d545d4f5dfd9c77b01055a7adaab05ad76656dce/class.jetpack-gutenberg.php#L48-L66) when they first start writing one. Also, is that a list of beta blocks? Production blocks? The answer is that this is a fallback: Jetpack will usually look for an index.json block manifest in the blocks directory that lists production and beta blocks separately, but it will also check `$default_blocks` and also register those. This has confused so many people that I’m determined to kill `$default_blocks` with fire.
(And to pre-empt @enej’s counterargument: I know that `index.json` doesn’t support child-block granularity yet. But I’m 100% convinced that it’s better to lose a feature that we’ve so far not needed and to implement it once we do (YAGNI!) than to continue to confuse people.

#### Testing instructions:

Verify that blocks still work as before. If you're missing a block, it probably needs to be added to `index.json`.

#### Proposed changelog entry for your changes:

Jetpack Gutenberg: Kill `$default_blocks` with :fire:
