### PR TITLE
JS Minification: do not rename files when minificating

### DIFF
--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -92,7 +92,10 @@ function onBuild( done, err, stats ) {
 		log( 'Uglifying JS...' );
 		gulp
 			.src( '_inc/build/admin.js' )
-			.pipe( minify() )
+			.pipe( minify( {
+				noSource: true,
+				ext: { min: '.js' },
+			} ) )
 			.pipe( gulp.dest( '_inc/build' ) )
 			.on( 'end', function() {
 				log( 'Your JS is now uglified!' );
@@ -143,6 +146,8 @@ function onBuild( done, err, stats ) {
 				output: {
 					comments: saveLicense,
 				},
+				noSource: true,
+				ext: { min: '.js' },
 			} )
 		)
 		.pipe( rename( { suffix: '.min' } ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #11079 I replaced `gulp-uglify` by `gulp-minify` to solve some issues.
`gulp-minify` works a bit differently and requires you to specify when you want to create files without the min suffix.

#### Testing instructions:

* Run `yarn build-production-client`
* Make sure the files generated in `_inc/build` are similar to the ones in previous builds:
https://github.com/Automattic/jetpack/tree/branch-6.8-built/_inc/build
https://github.com/Automattic/jetpack/tree/branch-6.8-built/_inc/build/after-the-deadline
* There should be no extra `min` files

#### Proposed changelog entry for your changes:

* None
