### PR TITLE
JITM: make sure no JITMs can ever be displayed at the same time.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -92,6 +92,13 @@ jQuery( document ).ready( function( $ ) {
 		if ( $( '#jp-admin-notices' ).length > 0 ) {
 			// Add to Jetpack notices within the Jetpack settings app.
 			$el.innerHTML = $template;
+
+			// If we already have a message, replace it.
+			if ( $('#jp-admin-notices').find( '.jitm-card' ) ) {
+				$( '.jitm-card' ).replaceWith( $template );
+			}
+
+			// No existing JITM? Add ours to the top of the Jetpack admin notices.
 			$template.prependTo( $( '#jp-admin-notices' ) );
 		} else {
 			// Replace placeholder div on other pages.


### PR DESCRIPTION
Fixes #11045 

#### Changes proposed in this Pull Request:

Before to insert a JITM into the admin notices, we now check if one exists first. If we have one, we replace it.

#### Testing instructions:

* Start from a site that was never connected to WordPress.com before (JN is a great tool for that)
* Connect to WordPress.com
* Make sure that when you are sent back to the Jetpack dashboard, only one JITM gets displayed.
* Navigate to the Plans tab; another JITM should appear.
* Navigate to the main dashboard. You should see a message there as well.
* There should never be 2 messages.

#### Proposed changelog entry for your changes:

* None.
