### PR TITLE
Fix AMP integration by deferring masterbar setup to wp action

### DIFF
--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -14,7 +14,7 @@
 require dirname( __FILE__ ) . '/masterbar/masterbar.php';
 
 // In order to be able to tell if it's an AMP request or not we have to hook into parse_query at a later priority.
-add_action( 'wp', 'jetpack_initialize_masterbar', 99 );
+add_action( 'admin_bar_init', 'jetpack_initialize_masterbar', 99 );
 
 /**
  * Initializes the Masterbar in case the request is not AMP.

--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -14,7 +14,7 @@
 require dirname( __FILE__ ) . '/masterbar/masterbar.php';
 
 // In order to be able to tell if it's an AMP request or not we have to hook into parse_query at a later priority.
-add_action( 'parse_query', 'jetpack_initialize_masterbar', 99 );
+add_action( 'wp', 'jetpack_initialize_masterbar', 99 );
 
 /**
  * Initializes the Masterbar in case the request is not AMP.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11082 
Fixes #11081

#### Changes proposed in this Pull Request:

* Defer masterbar setup until the `wp` action, instead of doing the setup at the `init` action. This is needed because the `is_amp_endpoint()` function cannot be called before the `wp` action, as it needs access to the queried object.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure Jetpack's masterbar module is active.
2. Activate the AMP plugin v1.0.1
3. Enable the new paired mode via the AMP settings.
4. Navigate to a singular post.

Without the changes in this PR, there should be two PHP notices being raised:

```
( ! ) Notice: Trying to get property 'post_type' of non-object in .../amp/includes/class-amp-post-type-support.php on line 80

( ! ) Notice: Trying to get property 'ID' of non-object in .../amp/includes/class-amp-post-type-support.php on line 101
```

See also https://github.com/ampproject/amp-wp/pull/1794 which will catch the incorrect usage of `is_amp_endpoint()`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix AMP integration with masterbar module.
