### PR TITLE
connection banner: updating verbiage

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -170,7 +170,7 @@ class Jetpack_Connection_Banner {
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__container-top-text">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
-				<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to boost your site performance and get dozens of customization, marketing, and security tools.', 'jetpack' ); ?></span>
+				<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to boost your site performance and unlock powerful customization, marketing, and security tools.', 'jetpack' ); ?></span>
 			</div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -262,7 +262,7 @@
 // end overrides
 
 .jp-wpcom-connect__container-top-text {
-	padding: 15px 15px 20px 15px;
+	padding: 15px 15px 25px 15px;
 	background-color: $green-primary; 
 	color: $white;
 	font-weight: 600;
@@ -300,7 +300,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 	justify-content: left;
-	border: 4px $green-primary solid;
+	// border: 4px $green-primary solid;
 	background: #fff;
 }
 


### PR DESCRIPTION
connection banner: updating verbiage

<!--- Provide a general summary of your changes in the Title above -->

Fixes # https://github.com/Automattic/jetpack/issues/11089

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* no functional changes. just text change in the header of the connection banner and some colors / border

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before:
<img width="1664" alt="screen shot 2019-01-03 at 9 51 25 am" src="https://user-images.githubusercontent.com/214813/50707943-9e310c80-1030-11e9-9fbc-47fb0ce9c8d5.png">


After:
<img width="1498" alt="screen shot 2019-01-04 at 3 04 15 pm" src="https://user-images.githubusercontent.com/214813/50708370-13511180-1032-11e9-9a00-af1ed224b54b.png">


* install + activate jetpack
* view connection banner on plugins page or wp-admin dashboard

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* no changes to changelog
