### PR TITLE
Jetpack_Gutenberg: Simplify

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -28,12 +28,6 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( 'Jetpack_Gutenberg', 'get_availability' ),
 				'permission_callback' => array( $this, 'get_items_permission_check' ),
-				'args'                => array(
-					'beta' => array(
-						'required' => false,
-						'type'     => 'boolean',
-					),
-				),
 			),
 			'schema' => array( $this, 'get_item_schema' ),
 		 ) );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -26,16 +26,13 @@ function jetpack_register_block( $slug, $args = array() ) {
  * Helper function to register a Jetpack Gutenberg plugin
  *
  * @param string $slug Slug of the plugin.
- * @param array  $avalibility Arguments that tells us what kind of avalibility the plugin has
- *
- * @see register_block_type
  *
  * @since 6.9.0
  *
  * @return void
  */
-function jetpack_register_plugin( $slug, $availability = array( 'available' => true ) ) {
-	Jetpack_Gutenberg::register_plugin( $slug, $availability );
+function jetpack_register_plugin( $slug ) {
+	Jetpack_Gutenberg::register_plugin( $slug );
 }
 
 /**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -290,20 +290,6 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Check whether conditions indicate Gutenberg blocks should be loaded
-	 *
-	 * Loading blocks is enabled by default and may be disabled via filter:
-	 *   add_filter( 'jetpack_gutenberg', '__return_false' );
-	 *
-	 * @since 6.7.0
-	 * @deprecated
-	 * @return bool
-	 */
-	public static function should_load_blocks() {
-		return self::should_load();
-	}
-
-	/**
 	 * Check whether conditions indicate Gutenberg Extensions (blocks and plugins) should be loaded
 	 *
 	 * Loading blocks and plugins is enabled by default and may be disabled via filter:
@@ -398,7 +384,7 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function enqueue_block_editor_assets() {
-		if ( ! self::should_load_blocks() ) {
+		if ( ! self::should_load() ) {
 			return;
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -180,13 +180,13 @@ class Jetpack_Gutenberg {
 		}
 
 		/**
-		 * Filter the list of block editor blocks that are available through jetpack.
+		 * Filter the whitelist of block editor extensions that are available through Jetpack.
 		 *
 		 * @since 6.8.0
 		 *
 		 * @param array
 		 */
-		self::$extensions = self::get_jetpack_gutenberg_extensions_whitelist(); //apply_filters( 'jetpack_set_available_blocks', array() );
+		self::$extensions = apply_filters( 'jetpack_set_available_blocks', self::get_jetpack_gutenberg_extensions_whitelist() );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -45,8 +45,8 @@ function jetpack_register_plugin( $slug ) {
  *
  * @return void
  */
-function set_jetpack_extension_availability( $slug, $reason ) {
-	Jetpack_Gutenberg::set_jetpack_extension_availability( $slug, $reason );
+function set_extension_unavailability_reason( $slug, $reason ) {
+	Jetpack_Gutenberg::set_extension_unavailability_reason( $slug, $reason );
 }
 
 /**
@@ -114,7 +114,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) || ( isset( $args['parent'] ) && self::share_items( $args['parent'], $prefixed_extensions ) ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
 		} else if ( ! isset( $args['parent'] ) ) { // Don't set availability information for child blocks -- we infer it from their parents
-			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );
+			self::set_extension_unavailability_reason( $slug, 'not_whitelisted' );
 		}
 	}
 
@@ -129,7 +129,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			self::$registered_plugins[] = 'jetpack-' . $slug;
 		} else {
-			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );
+			self::set_extension_unavailability_reason( $slug, 'not_whitelisted' );
 		}
 	}
 
@@ -139,7 +139,7 @@ class Jetpack_Gutenberg {
 	 * @param string $slug Slug of the extension.
 	 * @param string $reason A string representation of why the extension is unavailable
 	 */
-	public static function set_jetpack_extension_availability( $slug, $reason ) {
+	public static function set_extension_unavailability_reason( $slug, $reason ) {
 		self::$availability[ $slug ] = $reason;
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -126,13 +126,6 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * @deprecated
-	 */
-	static function load_blocks() {
-		self::init();
-	}
-
-	/**
 	 * Add a block to the list of blocks to be registered.
 	 *
 	 * @param string $slug Slug of the block.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -336,7 +336,7 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function should_load() {
-		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() && ! defined( 'TESTING_IN_JETPACK' ) ) {
 			return false;
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -262,11 +262,8 @@ class Jetpack_Gutenberg {
 			);
 
 			if ( ! $is_available ) {
-				if ( isset( self::$availability[ $extension ] ) ) {
-					$available_extensions[ $extension ][ 'unavailable_reason' ] = self::$availability[ $extension ];
-				} else {
-					$available_extensions[ $extension ][ 'unavailable_reason' ] = 'missing_module';
-				}
+				$reason = isset( self::$availability[ $extension ] ) ? self::$availability[ $extension ] : 'missing_module';
+				$available_extensions[ $extension ][ 'unavailable_reason' ] = $reason;
 			}
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -88,15 +88,41 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Prepend the 'jetpack/' prefix to a block name
+	 *
+	 * @param string $block_name The block name
+	 *
+	 * @return string The prefixed block name.
+	 */
+	private static function prepend_block_prefix( $block_name ) {
+		return 'jetpack/' . $block_name;
+	}
+
+	/**
+	 * Whether two arrays share at least one item
+	 *
+	 * @param array $a An array
+	 * @param array $b Another array
+	 *
+	 * @return boolean True if $a and $b share at least one item
+	 */
+	protected static function share_items( $a, $b ) {
+		return count( array_intersect( $a, $b ) ) > 0;
+	}
+
+	/**
 	 * Register a block
 	 *
 	 * If the block isn't whitelisted, set its unavailability reason instead.
-	 * 
+	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into register_block_type().
 	 */
 	public static function register_block( $slug, $args ) {
-		if ( in_array( $slug, self::$extensions ) ) {
+		$prefixed_extensions = array_map( array( __CLASS__, 'prepend_block_prefix' ), self::$extensions );
+
+		// Register the block if it's whitelisted, or if it's a child block, and one of its parents is whitelisted.
+		if ( in_array( $slug, self::$extensions ) || ( isset( $args['parent'] ) && self::share_items( $args['parent'], $prefixed_extensions ) ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
 		} else if ( ! isset( $args['parent'] ) ) { // Don't set availability information for child blocks -- we infer it from their parents
 			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -39,16 +39,14 @@ function jetpack_register_plugin( $slug ) {
  * Set the reason why an extension (block or plugin) is unavailable
  *
  * @param string $slug Slug of the block
- * @param array  $avalibility Arguments that tells us what kind of avalibility the block has
- *
- * @see register_block_type
+ * @param string $reason A string representation of why the extension is unavailable
  *
  * @since 7.0.0
  *
  * @return void
  */
-function set_jetpack_extension_availability( $slug, $availability = array( 'available' => true ) ) {
-	Jetpack_Gutenberg::set_jetpack_extension_availability( $slug, $availability );
+function set_jetpack_extension_availability( $slug, $reason ) {
+	Jetpack_Gutenberg::set_jetpack_extension_availability( $slug, $reason );
 }
 
 /**
@@ -88,7 +86,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
 		} else {
-			self::set_jetpack_extension_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
+			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );
 		}
 	}
 
@@ -96,7 +94,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			self::$registered_plugins[] = 'jetpack-' . $slug;
 		} else {
-			self::set_jetpack_extension_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
+			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );
 		}
 	}
 
@@ -104,10 +102,10 @@ class Jetpack_Gutenberg {
 	 * Set the reason why an extension (block or plugin) is unavailable
 	 *
 	 * @param string $slug Slug of the extension.
-	 * @param array $availability array containing if an extension is available and the reason when it is not.
+	 * @param string $reason A string representation of why the extension is unavailable
 	 */
-	public static function set_jetpack_extension_availability( $slug, $availability ) {
-		self::$availability[ $slug ] = $availability;
+	public static function set_jetpack_extension_availability( $slug, $reason ) {
+		self::$availability[ $slug ] = $reason;
 	}
 
 	/**
@@ -250,7 +248,7 @@ class Jetpack_Gutenberg {
 			);
 
 			if ( ! $is_available ) {
-				if ( $reason = self::$availability[ $extension ]['unavailable_reason'] ) {
+				if ( $reason = self::$availability[ $extension ] ) {
 					$available_extensions[ $extension ][ 'unavailable_reason' ] = $reason;
 				} else {
 					$available_extensions[ $extension ][ 'unavailable_reason' ] = 'missing_module';

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -250,7 +250,13 @@ class Jetpack_Gutenberg {
 				}
 			}
 		}
-		return $available_extensions;
+
+		$unwhitelisted = array_fill_keys(
+			array_diff( array_keys( self::$availability ), self::$extensions ),
+			array( 'available' => false, 'unavailable_reason' => 'not_whitelisted' )
+		);
+
+		return array_merge( $available_extensions, $unwhitelisted );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -179,12 +179,16 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Clear the whitelist of allowed block editor extensions
+	 * Resets the class to its original state
+	 *
+	 * Used in unit tests
 	 *
 	 * @return void
 	 */
-	public static function uninit() {
+	public static function reset() {
 		self::$extensions = array();
+		self::$availability = array();
+		self::$registered_plugins = array();
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -171,11 +171,11 @@ class Jetpack_Gutenberg {
 		/**
 		 * Filter the whitelist of block editor extensions that are available through Jetpack.
 		 *
-		 * @since 6.8.0
+		 * @since 7.0.0
 		 *
 		 * @param array
 		 */
-		self::$extensions = apply_filters( 'jetpack_set_available_blocks', self::get_jetpack_gutenberg_extensions_whitelist() );
+		self::$extensions = apply_filters( 'jetpack_set_available_extensions', self::get_jetpack_gutenberg_extensions_whitelist() );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -175,7 +175,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param boolean
 		 */
-		if ( apply_filters( 'jetpack_load_beta_blocks', $is_availability_endpoint_beta ) ) {
+		if ( apply_filters( 'jetpack_load_beta_blocks', false ) ) {
 			Jetpack_Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
 		}
 
@@ -189,8 +189,6 @@ class Jetpack_Gutenberg {
 		 * @param array
 		 */
 		self::$extensions = self::jetpack_set_available_blocks( array() ); //apply_filters( 'jetpack_set_available_blocks', array() );
-
-		return $response;
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -55,14 +55,25 @@ function set_jetpack_extension_availability( $slug, $reason ) {
 class Jetpack_Gutenberg {
 
 	/**
-	 * @var array Array of blocks information.
+	 * @var array Extensions whitelist
 	 *
-	 * For each block we have information about the availability for the current user
+	 * Only these extensions can be registered. Used to control availability of beta blocks.
 	 */
 	private static $extensions = array();
 
+	/**
+	 * @var array Extensions availability information
+	 *
+	 * Keeps track of the reasons why a given extension is unavailable.
+	 */
 	private static $availability = array();
 
+	/**
+	 * @var array Plugin registry
+	 *
+	 * Since there is no `register_plugin()` counterpart to `register_block_type()` in Gutenberg,
+	 * we have to keep track of plugin registration ourselves
+	 */
 	private static $registered_plugins = array();
 
 	// Classic singleton pattern:
@@ -77,10 +88,12 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Add a block to the list of blocks to be registered.
+	 * Register a block
 	 *
+	 * If the block isn't whitelisted, set its unavailability reason instead.
+	 * 
 	 * @param string $slug Slug of the block.
-	 * @param array  $args Arguments that are passed into the register_block_type.
+	 * @param array  $args Arguments that are passed into register_block_type().
 	 */
 	public static function register_block( $slug, $args ) {
 		if ( in_array( $slug, self::$extensions ) ) {
@@ -90,6 +103,13 @@ class Jetpack_Gutenberg {
 		}
 	}
 
+	/**
+	 * Register a plugin
+	 *
+	 * If the plugin isn't whitelisted, set its unavailability reason instead.
+	 * 
+	 * @param string $slug Slug of the plugin.
+	 */
 	public static function register_plugin( $slug ) {
 		if ( in_array( $slug, self::$extensions ) ) {
 			self::$registered_plugins[] = 'jetpack-' . $slug;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -44,27 +44,6 @@ function jetpack_register_plugin( $slug, $availability = array( 'available' => t
  */
 class Jetpack_Gutenberg {
 
-	// BLOCKS
-	private static $default_blocks = array(
-		'map',
-		'markdown',
-		'simple-payments',
-		'related-posts',
-		'contact-form',
-		'field-text',
-		'field-name',
-		'field-email',
-		'field-url',
-		'field-date',
-		'field-telephone',
-		'field-textarea',
-		'field-checkbox',
-		'field-checkbox-multiple',
-		'field-radio',
-		'field-select',
-		'subscriptions',
-	);
-
 	/**
 	 * @var array Array of blocks information.
 	 *
@@ -74,11 +53,6 @@ class Jetpack_Gutenberg {
 
 	private static $availability = array();
 
-	// PLUGINS
-	private static $default_plugins = array(
-		'publicize',
-		'shortlinks',
-	);
 	/**
 	 * @var array Array of plugins information.
 	 *
@@ -168,7 +142,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$blocks = apply_filters( 'jetpack_set_available_blocks', self::$default_blocks );
+		self::$blocks = apply_filters( 'jetpack_set_available_blocks', array() );
 
 		/**
 		 * Filter the list of block editor plugins that are available through jetpack.
@@ -179,7 +153,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$plugins = apply_filters( 'jetpack_set_available_plugins', self::$default_plugins );
+		self::$plugins = apply_filters( 'jetpack_set_available_plugins', array() );
 		self::set_blocks_availability();
 		self::set_plugins_availability();
 		self::register_blocks();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -45,7 +45,7 @@ function jetpack_register_plugin( $slug ) {
  *
  * @return void
  */
-function set_extension_unavailability_reason( $slug, $reason ) {
+function jetpack_set_extension_unavailability_reason( $slug, $reason ) {
 	Jetpack_Gutenberg::set_extension_unavailability_reason( $slug, $reason );
 }
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -50,12 +50,8 @@ function jetpack_register_plugin( $slug, $availability = array( 'available' => t
  *
  * @return void
  */
-function set_block_availability( $slug, $availability = array( 'available' => true ) ) {
-	Jetpack_Gutenberg::set_block_availability( $slug, $availability );
-}
-
-function set_plugin_availability( $slug, $availability = array( 'available' => true ) ) {
-	Jetpack_Gutenberg::set_plugin_availability( $slug, $availability );
+function set_jetpack_extension_availability( $slug, $availability = array( 'available' => true ) ) {
+	Jetpack_Gutenberg::set_jetpack_extension_availability( $slug, $availability );
 }
 
 /**
@@ -95,7 +91,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
 		} else {
-			self::set_block_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
+			self::set_jetpack_extension_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
 		}
 	}
 
@@ -103,7 +99,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			self::$registered_plugins[] = 'jetpack-' . $slug;
 		} else {
-			self::set_plugin_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
+			self::set_jetpack_extension_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
 		}
 	}
 
@@ -113,11 +109,7 @@ class Jetpack_Gutenberg {
 	 * @param string $slug Slug of the extension.
 	 * @param array $availability array containing if an extension is available and the reason when it is not.
 	 */
-	public static function set_block_availability( $slug, $availability ) {
-		self::$availability[ $slug ] = $availability;
-	}
-
-	public static function set_plugin_availability( $slug, $availability ) {
+	public static function set_jetpack_extension_availability( $slug, $availability ) {
 		self::$availability[ $slug ] = $availability;
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -258,8 +258,8 @@ class Jetpack_Gutenberg {
 			);
 
 			if ( ! $is_available ) {
-				if ( $reason = self::$availability[ $extension ] ) {
-					$available_extensions[ $extension ][ 'unavailable_reason' ] = $reason;
+				if ( isset( self::$availability[ $extension ] ) ) {
+					$available_extensions[ $extension ][ 'unavailable_reason' ] = self::$availability[ $extension ];
 				} else {
 					$available_extensions[ $extension ][ 'unavailable_reason' ] = 'missing_module';
 				}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -134,6 +134,23 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Register a block
+	 *
+	 * @deprecated 7.0.0 Use register_block() instead
+	 *
+	 * @param string $slug Slug of the block.
+	 * @param array  $args Arguments that are passed into the register_block_type.
+	 * @param array $availability array containing if a block is available and the reason when it is not.
+	 */
+	public static function register( $slug, $args, $availability ) {
+		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
+			self::set_extension_unavailability_reason( $slug, $availability['unavailable_reason'] );
+		} else {
+			self::register_block( $slug, $args );
+		}
+	}
+
+	/**
 	 * Set the reason why an extension (block or plugin) is unavailable
 	 *
 	 * @param string $slug Slug of the extension.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -167,25 +167,6 @@ class Jetpack_Gutenberg {
 		return $response;
 	}
 
-	static function register_blocks() {
-		/**
-		 * Filter the list of block editor plugins should be passed to register_block_type.
-		 * You can use this to manually register some blocks without Jetpack registering them for you.
-		 *
-		 * This filter is populated by Jetpack_Gutenberg::jetpack_set_available_blocks
-		 *
-		 * @since 6.9.0
-		 *
-		 * @param array
-		 */
-		$blocks = apply_filters( 'jetpack_blocks_to_register', self::$blocks );
-		foreach ( $blocks as $slug ) {
-			if ( self::is_available( $slug ) ) {
-				register_block_type( 'jetpack/' . $slug, self::get_registered_args( $slug ) );
-			}
-		}
-	}
-
 	/**
 	 * Return the Gutenberg extensions (blocks and plugins) directory
 	 *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -182,13 +182,11 @@ class Jetpack_Gutenberg {
 		/**
 		 * Filter the list of block editor blocks that are available through jetpack.
 		 *
-		 * This filter is populated by Jetpack_Gutenberg::jetpack_set_available_blocks
-		 *
 		 * @since 6.8.0
 		 *
 		 * @param array
 		 */
-		self::$extensions = self::jetpack_set_available_blocks( array() ); //apply_filters( 'jetpack_set_available_blocks', array() );
+		self::$extensions = self::jetpack_set_available_blocks(); //apply_filters( 'jetpack_set_available_blocks', array() );
 	}
 
 	/**
@@ -230,19 +228,14 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Filters the results of `apply_filter( 'jetpack_set_available_blocks', array() )`
-	 * using the merged contents of `blocks-manifest.json` ( $preset_extensions )
-	 * and self::$jetpack_blocks ( $internal_blocks )
-	 *
-	 * @param $extensions The default list.
+	 * Returns a whitelist of Jetpack Gutenberg extensions (blocks and plugins), based on index.json
 	 *
 	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
 	 */
-	public static function jetpack_set_available_blocks( $extensions ) {
-		$preset_extensions_manifest =  self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array( 'production' => $extensions );
+	public static function jetpack_set_available_blocks() {
+		$preset_extensions_manifest = self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array();
 
 		$preset_extensions = isset( $preset_extensions_manifest->production ) ? (array) $preset_extensions_manifest->production : array() ;
-		$preset_extensions = array_unique( array_merge( $preset_extensions, $extensions ) );
 
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_extensions = isset( $preset_extensions_manifest->beta ) ? (array) $preset_extensions_manifest->beta : array();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -9,7 +9,7 @@
 /**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @param string $slug Slug of the block
+ * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
  *
  * @see register_block_type
@@ -38,8 +38,8 @@ function jetpack_register_plugin( $slug ) {
 /**
  * Set the reason why an extension (block or plugin) is unavailable
  *
- * @param string $slug Slug of the block
- * @param string $reason A string representation of why the extension is unavailable
+ * @param string $slug Slug of the block.
+ * @param string $reason A string representation of why the extension is unavailable.
  *
  * @since 7.0.0
  *
@@ -55,31 +55,31 @@ function jetpack_set_extension_unavailability_reason( $slug, $reason ) {
 class Jetpack_Gutenberg {
 
 	/**
-	 * @var array Extensions whitelist
-	 *
 	 * Only these extensions can be registered. Used to control availability of beta blocks.
+	 *
+	 * @var array Extensions whitelist
 	 */
 	private static $extensions = array();
 
 	/**
-	 * @var array Extensions availability information
-	 *
 	 * Keeps track of the reasons why a given extension is unavailable.
+	 *
+	 * @var array Extensions availability information
 	 */
 	private static $availability = array();
 
 	/**
-	 * @var array Plugin registry
-	 *
 	 * Since there is no `register_plugin()` counterpart to `register_block_type()` in Gutenberg,
 	 * we have to keep track of plugin registration ourselves
+	 *
+	 * @var array Plugin registry
 	 */
 	private static $registered_plugins = array();
 
 	/**
 	 * Prepend the 'jetpack/' prefix to a block name
 	 *
-	 * @param string $block_name The block name
+	 * @param string $block_name The block name.
 	 *
 	 * @return string The prefixed block name.
 	 */
@@ -90,8 +90,8 @@ class Jetpack_Gutenberg {
 	/**
 	 * Whether two arrays share at least one item
 	 *
-	 * @param array $a An array
-	 * @param array $b Another array
+	 * @param array $a An array.
+	 * @param array $b Another array.
 	 *
 	 * @return boolean True if $a and $b share at least one item
 	 */
@@ -111,9 +111,10 @@ class Jetpack_Gutenberg {
 		$prefixed_extensions = array_map( array( __CLASS__, 'prepend_block_prefix' ), self::$extensions );
 
 		// Register the block if it's whitelisted, or if it's a child block, and one of its parents is whitelisted.
-		if ( in_array( $slug, self::$extensions ) || ( isset( $args['parent'] ) && self::share_items( $args['parent'], $prefixed_extensions ) ) ) {
+		if ( in_array( $slug, self::$extensions, true ) || ( isset( $args['parent'] ) && self::share_items( $args['parent'], $prefixed_extensions ) ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
-		} else if ( ! isset( $args['parent'] ) ) { // Don't set availability information for child blocks -- we infer it from their parents
+		} elseif ( ! isset( $args['parent'] ) ) {
+			// Don't set availability information for child blocks -- we infer it from their parents.
 			self::set_extension_unavailability_reason( $slug, 'not_whitelisted' );
 		}
 	}
@@ -122,11 +123,11 @@ class Jetpack_Gutenberg {
 	 * Register a plugin
 	 *
 	 * If the plugin isn't whitelisted, set its unavailability reason instead.
-	 * 
+	 *
 	 * @param string $slug Slug of the plugin.
 	 */
 	public static function register_plugin( $slug ) {
-		if ( in_array( $slug, self::$extensions ) ) {
+		if ( in_array( $slug, self::$extensions, true ) ) {
 			self::$registered_plugins[] = 'jetpack-' . $slug;
 		} else {
 			self::set_extension_unavailability_reason( $slug, 'not_whitelisted' );
@@ -140,7 +141,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into the register_block_type.
-	 * @param array $availability array containing if a block is available and the reason when it is not.
+	 * @param array  $availability array containing if a block is available and the reason when it is not.
 	 */
 	public static function register( $slug, $args, $availability ) {
 		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
@@ -154,7 +155,7 @@ class Jetpack_Gutenberg {
 	 * Set the reason why an extension (block or plugin) is unavailable
 	 *
 	 * @param string $slug Slug of the extension.
-	 * @param string $reason A string representation of why the extension is unavailable
+	 * @param string $reason A string representation of why the extension is unavailable.
 	 */
 	public static function set_extension_unavailability_reason( $slug, $reason ) {
 		self::$availability[ $slug ] = $reason;
@@ -225,8 +226,8 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function reset() {
-		self::$extensions = array();
-		self::$availability = array();
+		self::$extensions         = array();
+		self::$availability       = array();
 		self::$registered_plugins = array();
 	}
 
@@ -239,7 +240,7 @@ class Jetpack_Gutenberg {
 		/**
 		 * Filter to select Gutenberg blocks directory
 		 *
-		 * @since 6.9
+		 * @since 6.9.0
 		 *
 		 * @param string default: '_inc/blocks/'
 		 */
@@ -249,7 +250,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Checks for a given .json file in the blocks folder.
 	 *
-	 * @param $preset The name of the .json file to look for.
+	 * @param string $preset The name of the .json file to look for.
 	 *
 	 * @return bool True if the file is found.
 	 */
@@ -260,12 +261,12 @@ class Jetpack_Gutenberg {
 	/**
 	 * Decodes JSON loaded from a preset file in the blocks folder
 	 *
-	 * @param $preset The name of the .json file to load.
+	 * @param string $preset The name of the .json file to load.
 	 *
 	 * @return mixed Returns an object if the file is present, or false if a valid .json file is not present.
 	 */
 	public static function get_preset( $preset ) {
-		return json_decode( file_get_contents(  JETPACK__PLUGIN_DIR .self::get_blocks_directory() . $preset . '.json' ) );
+		return json_decode( file_get_contents( JETPACK__PLUGIN_DIR . self::get_blocks_directory() . $preset . '.json' ) );
 	}
 
 	/**
@@ -276,7 +277,7 @@ class Jetpack_Gutenberg {
 	public static function get_jetpack_gutenberg_extensions_whitelist() {
 		$preset_extensions_manifest = self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array();
 
-		$preset_extensions = isset( $preset_extensions_manifest->production ) ? (array) $preset_extensions_manifest->production : array() ;
+		$preset_extensions = isset( $preset_extensions_manifest->production ) ? (array) $preset_extensions_manifest->production : array();
 
 		if ( Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_extensions = isset( $preset_extensions_manifest->beta ) ? (array) $preset_extensions_manifest->beta : array();
@@ -287,14 +288,16 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Get availability of each block / plugin.
+	 *
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
 		$available_extensions = array();
 
-		foreach( self::$extensions as $extension ) {
+		foreach ( self::$extensions as $extension ) {
 			$is_available = WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/' . $extension ) ||
-				in_array( 'jetpack-' . $extension, self::$registered_plugins );
+				in_array( 'jetpack-' . $extension, self::$registered_plugins, true );
 
 			$available_extensions[ $extension ] = array(
 				'available' => $is_available,
@@ -302,13 +305,16 @@ class Jetpack_Gutenberg {
 
 			if ( ! $is_available ) {
 				$reason = isset( self::$availability[ $extension ] ) ? self::$availability[ $extension ] : 'missing_module';
-				$available_extensions[ $extension ][ 'unavailable_reason' ] = $reason;
+				$available_extensions[ $extension ]['unavailable_reason'] = $reason;
 			}
 		}
 
 		$unwhitelisted = array_fill_keys(
 			array_diff( array_keys( self::$availability ), self::$extensions ),
-			array( 'available' => false, 'unavailable_reason' => 'not_whitelisted' )
+			array(
+				'available'          => false,
+				'unavailable_reason' => 'not_whitelisted',
+			)
 		);
 
 		return array_merge( $available_extensions, $unwhitelisted );
@@ -354,7 +360,7 @@ class Jetpack_Gutenberg {
 	 * Only enqueue block assets when needed.
 	 *
 	 * @param string $type slug of the block.
-	 * @param array $script_dependencies An array of view-side Javascript dependencies to be enqueued.
+	 * @param array  $script_dependencies An array of view-side Javascript dependencies to be enqueued.
 	 *
 	 * @return void
 	 */
@@ -424,14 +430,14 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
-		$rtl = is_rtl() ? '.rtl' : '';
-		$beta = Jetpack_Constants::is_true('JETPACK_BETA_BLOCKS' ) ? '-beta' : '';
+		$rtl        = is_rtl() ? '.rtl' : '';
+		$beta       = Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ? '-beta' : '';
 		$blocks_dir = self::get_blocks_directory();
 
 		$editor_script = plugins_url( "{$blocks_dir}editor{$beta}.js", JETPACK__PLUGIN_FILE );
 		$editor_style  = plugins_url( "{$blocks_dir}editor{$beta}{$rtl}.css", JETPACK__PLUGIN_FILE );
 
-		$version       = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.js' )
+		$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.js' )
 			? filemtime( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.js' )
 			: JETPACK__VERSION;
 
@@ -473,7 +479,7 @@ class Jetpack_Gutenberg {
 			'Jetpack_Editor_Initial_State',
 			array(
 				'available_blocks' => self::get_availability(),
-				'jetpack' => array( 'is_active' => Jetpack::is_active() ),
+				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
 			)
 		);
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -40,6 +40,22 @@ function jetpack_register_plugin( $slug, $availability = array( 'available' => t
 }
 
 /**
+ * Set the reason why an extension (block or plugin) is unavailable
+ *
+ * @param string $slug Slug of the block
+ * @param array  $avalibility Arguments that tells us what kind of avalibility the block has
+ *
+ * @see register_block_type
+ *
+ * @since 7.0.0
+ *
+ * @return void
+ */
+function set_extension_unavailability_reason( $slug, $availability = array( 'available' => true ) ) {
+	Jetpack_Gutenberg::set_extension_unavailability_reason( $slug, $availability );
+}
+
+/**
  * General Gutenberg editor specific functionality
  */
 class Jetpack_Gutenberg {
@@ -75,6 +91,16 @@ class Jetpack_Gutenberg {
 	public static function register( $slug, $args, $availability ) {
 		$sanitized_slug = sanitize_title_with_dashes( $slug );
 		self::$registered[ $sanitized_slug ] = array( 'args' => $args, 'availability' => $availability );
+	}
+
+	/**
+	 * Set the reason why an extension (block or plugin) is unavailable
+	 *
+	 * @param string $slug Slug of the extension.
+	 * @param array $availability array containing if an extension is available and the reason when it is not.
+	 */
+	public static function set_extension_unavailability_reason( $slug, $availability ) {
+		self::$registered[ $slug ] = array( 'availability' => $availability );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -273,7 +273,7 @@ class Jetpack_Gutenberg {
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
-		$available_extensions = [];
+		$available_extensions = array();
 
 		foreach( self::$extensions as $extension ) {
 			$is_available = WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/' . $extension ) ||

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -336,7 +336,7 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function should_load() {
-		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() && ! defined( 'TESTING_IN_JETPACK' ) ) {
+		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 			return false;
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles server-side registration and use of all blocks available in Jetpack for the block editor, aka Gutenberg.
+ * Handles server-side registration and use of all blocks and plugins available in Jetpack for the block editor, aka Gutenberg.
  * Works in tandem with client-side block registration via `index.json`
  *
  * @package Jetpack
@@ -10,7 +10,7 @@
  * Helper function to register a Jetpack Gutenberg block
  *
  * @param string $slug Slug of the block
- * @param array  $args Arguments that are passed into the register_block_type.
+ * @param array  $args Arguments that are passed into register_block_type.
  *
  * @see register_block_type
  *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -265,14 +265,6 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * @deprecated
-	 * @return array A list of block-availability information, eg: [ "publicize" => ["available" => true ], "markdown" => [ "available" => false, "unavailable_reason" => 'missing_module' ] ]
-	 */
-	public static function get_block_availability() {
-		return self::get_availability();
-	}
-
-	/**
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
@@ -463,7 +455,7 @@ class Jetpack_Gutenberg {
 			'jetpack-blocks-editor',
 			'Jetpack_Editor_Initial_State',
 			array(
-				'available_blocks' => self::get_block_availability(),
+				'available_blocks' => self::get_availability(),
 				'jetpack' => array( 'is_active' => Jetpack::is_active() ),
 			)
 		);

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -142,12 +142,6 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
-		self::load();
-	}
-
-	static function load( $response = null, $handler = null, $request = null ) {
-		$is_availability_endpoint_beta = ! is_null( $request ) && $request->get_param( 'beta' ) && wp_endswith( $request->get_route(), 'gutenberg/available-extensions' );
-
 		/**
 		 * Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
 		 *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -76,17 +76,6 @@ class Jetpack_Gutenberg {
 	 */
 	private static $registered_plugins = array();
 
-	// Classic singleton pattern:
-	private static $instance;
-	private function __construct() {}
-	static function get_instance() {
-		if ( ! self::$instance ) {
-			self::$instance = new self();
-			self::$instance::init();
-		}
-		return self::$instance;
-	}
-
 	/**
 	 * Prepend the 'jetpack/' prefix to a block name
 	 *
@@ -467,5 +456,3 @@ class Jetpack_Gutenberg {
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 	}
 }
-
-Jetpack_Gutenberg::get_instance();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -272,7 +272,11 @@ class Jetpack_Gutenberg {
 			);
 
 			if ( ! $is_available ) {
-				$available_blocks[ $block ][ 'unavailable_reason' ] = self::$block_availability[ $block ]['unavailable_reason'];
+				if ( $reason = self::$block_availability[ $block ]['unavailable_reason'] ) {
+					$available_blocks[ $block ][ 'unavailable_reason' ] = $reason;
+				} else {
+					$available_blocks[ $block ][ 'unavailable_reason' ] = 'missing_module';
+				}
 			}
 		}
 		return array_merge( $available_blocks, self::$plugin_availability );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -155,7 +155,7 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Register all Jetpack blocks available.
+	 * Set up a whitelist of allowed block editor extensions
 	 *
 	 * @return void
 	 */
@@ -187,6 +187,15 @@ class Jetpack_Gutenberg {
 		 * @param array
 		 */
 		self::$extensions = apply_filters( 'jetpack_set_available_blocks', self::get_jetpack_gutenberg_extensions_whitelist() );
+	}
+
+	/**
+	 * Clear the whitelist of allowed block editor extensions
+	 *
+	 * @return void
+	 */
+	public static function uninit() {
+		self::$extensions = array();
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -176,6 +176,28 @@ class Jetpack_Gutenberg {
 		 * @param array
 		 */
 		self::$extensions = apply_filters( 'jetpack_set_available_extensions', self::get_jetpack_gutenberg_extensions_whitelist() );
+
+		/**
+		 * Filter the whitelist of block editor plugins that are available through Jetpack.
+		 *
+		 * @deprecated 7.0.0 Use jetpack_set_available_extensions instead
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array
+		 */
+		self::$extensions = apply_filters( 'jetpack_set_available_blocks', self::$extensions );
+
+		/**
+		 * Filter the whitelist of block editor plugins that are available through Jetpack.
+		 *
+		 * @deprecated 7.0.0 Use jetpack_set_available_extensions instead
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param array
+		 */
+		self::$extensions = apply_filters( 'jetpack_set_available_plugins', self::$extensions );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -92,7 +92,7 @@ class Jetpack_Gutenberg {
 		if ( in_array( $slug, self::$extensions ) ) {
 			self::set_plugin_availability( $slug, array( 'available' => true ) );
 		} else {
-			self::set_plugin_availability( $slug, array( 'unavailable_reason' => 'not whitelisted' ) );
+			self::set_plugin_availability( $slug, array( 'unavailable_reason' => 'not_whitelisted' ) );
 		}
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -124,11 +124,6 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
-		if ( Jetpack_Constants::is_true( 'REST_API_REQUEST' ) ) {
-			// We defer the loading of the blocks until we have a better scope in reset requests.
-			add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'load' ), 10, 3 );
-			return;
-		}
 		self::load();
 	}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -98,7 +98,7 @@ class Jetpack_Gutenberg {
 	public static function register_block( $slug, $args ) {
 		if ( in_array( $slug, self::$extensions ) ) {
 			register_block_type( 'jetpack/' . $slug, $args );
-		} else {
+		} else if ( ! isset( $args['parent'] ) ) { // Don't set availability information for child blocks -- we infer it from their parents
 			self::set_jetpack_extension_availability( $slug, 'not_whitelisted' );
 		}
 	}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -186,7 +186,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$extensions = self::jetpack_set_available_blocks(); //apply_filters( 'jetpack_set_available_blocks', array() );
+		self::$extensions = self::get_jetpack_gutenberg_extensions_whitelist(); //apply_filters( 'jetpack_set_available_blocks', array() );
 	}
 
 	/**
@@ -232,7 +232,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
 	 */
-	public static function jetpack_set_available_blocks() {
+	public static function get_jetpack_gutenberg_extensions_whitelist() {
 		$preset_extensions_manifest = self::preset_exists( 'index' ) ? self::get_preset( 'index' ) : (object) array();
 
 		$preset_extensions = isset( $preset_extensions_manifest->production ) ? (array) $preset_extensions_manifest->production : array() ;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -78,6 +78,17 @@ class Jetpack_Gutenberg {
 	 */
 	private static $registered = array();
 
+	// Classic singleton pattern:
+	private static $instance;
+	private function __construct() {}
+	static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+			self::$instance::init();
+		}
+		return self::$instance;
+	}
+
 	/**
 	 * Add a block to the list of blocks to be registered.
 	 *
@@ -464,3 +475,5 @@ class Jetpack_Gutenberg {
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 	}
 }
+
+Jetpack_Gutenberg::get_instance();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -73,11 +73,6 @@ class Jetpack_Gutenberg {
 	private static $block_availability = array();
 	private static $plugin_availability = array();
 
-	/**
-	 * @var array Array of extensions we will be registering.
-	 */
-	private static $registered = array();
-
 	// Classic singleton pattern:
 	private static $instance;
 	private function __construct() {}
@@ -164,30 +159,6 @@ class Jetpack_Gutenberg {
 		self::$extensions = self::jetpack_set_available_blocks( array() ); //apply_filters( 'jetpack_set_available_blocks', array() );
 
 		return $response;
-	}
-
-	static function get_extension_availability( $slug ) {
-		if ( ! self::is_registered( $slug ) ) {
-			return array( 'available' => false, 'unavailable_reason' => 'missing_module' );
-		}
-
-		$availability = self::$registered[ $slug ]['availability'];
-
-		if ( isset( $availability['callback'] ) ) {
-			$availability = call_user_func( $availability['callback'] );
-		}
-
-		$availability['available'] = isset( $availability['available'] )
-			? (bool) $availability['available']
-			: true ; // this is the default value
-
-		if ( ! $availability['available'] ) {
-			$availability['unavailable_reason'] = isset( $availability['unavailable_reason'] )
-				? $availability['unavailable_reason']
-				: 'unknown'; //
-		}
-
-		return $availability;
 	}
 
 	static function register_blocks() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -538,7 +538,6 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'init' ), 99 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -540,7 +540,6 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'init', array( 'Jetpack_Gutenberg', 'init' ), 99 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
-		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -538,6 +538,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
+		Jetpack_Gutenberg::init();
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -538,7 +538,7 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'init', array( 'Jetpack_Gutenberg', 'load_blocks' ), 99 ); // Registers all the Jetpack blocks .
+		add_action( 'init', array( 'Jetpack_Gutenberg', 'init' ), 99 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
 

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -39,7 +39,7 @@ if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 }
 
 /* If Gutenberg blocks are enabled, register blocks that aren't associated with modules */
-if ( Jetpack_Gutenberg::should_load_blocks() ) {
+if ( Jetpack_Gutenberg::should_load() ) {
 	$tools[] = 'blocks.php';
 }
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -786,7 +786,7 @@ abstract class Publicize_Base {
 		if ( $this->current_user_can_access_publicize_data() ) {
 			jetpack_register_plugin( 'publicize' );
 		} else {
-			set_jetpack_extension_availability( 'publicize', array( 'unavailable_reason' => 'unauthorized' ) );
+			set_jetpack_extension_availability( 'publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -781,7 +781,7 @@ abstract class Publicize_Base {
 	 */
 	function register_gutenberg_extension() {
 		jetpack_register_plugin( 'publicize' );
-		set_extension_unavailability_reason( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
+		set_plugin_availability( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
 	}
 
 	function get_extension_availability() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -780,7 +780,8 @@ abstract class Publicize_Base {
 	 * Register the Publicize Gutenberg extension
 	 */
 	function register_gutenberg_extension() {
-		jetpack_register_plugin( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
+		jetpack_register_plugin( 'publicize' );
+		set_extension_unavailability_reason( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
 	}
 
 	function get_extension_availability() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -119,7 +119,7 @@ abstract class Publicize_Base {
 
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
-		add_action( 'init', array( $this, 'register_gutenberg_extension' ), 30 );
+		add_action( 'rest_api_init', array( $this, 'register_gutenberg_extension' ), 30 );
 	}
 
 /*
@@ -780,18 +780,15 @@ abstract class Publicize_Base {
 	 * Register the Publicize Gutenberg extension
 	 */
 	function register_gutenberg_extension() {
-		jetpack_register_plugin( 'publicize' );
-		set_jetpack_extension_availability( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
-	}
+		// TODO: The `gutenberg/available-extensions` endpoint currently doesn't accept a post ID,
+		// so we cannot pass one to `$this->current_user_can_access_publicize_data()`.
 
-	function get_extension_availability() {
-		$object_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+		if ( $this->current_user_can_access_publicize_data() ) {
+			jetpack_register_plugin( 'publicize' );
+		} else {
+			set_jetpack_extension_availability( 'publicize', array( 'unavailable_reason' => 'unauthorized' ) );
 
-		if ( ! $this->current_user_can_access_publicize_data( $object_id ) ) {
-			return array( 'available' => false, 'unavailable_reason' => 'unauthorized' );
 		}
-
-		return array( 'available' => true );
 	}
 
 	/**

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -786,7 +786,7 @@ abstract class Publicize_Base {
 		if ( $this->current_user_can_access_publicize_data() ) {
 			jetpack_register_plugin( 'publicize' );
 		} else {
-			set_jetpack_extension_availability( 'publicize', 'unauthorized' );
+			set_extension_unavailability_reason( 'publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -119,7 +119,7 @@ abstract class Publicize_Base {
 
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
-		add_action( 'rest_api_init', array( $this, 'register_gutenberg_extension' ), 30 );
+		add_action( 'init', array( $this, 'register_gutenberg_extension' ), 30 );
 	}
 
 /*

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -781,7 +781,7 @@ abstract class Publicize_Base {
 	 */
 	function register_gutenberg_extension() {
 		jetpack_register_plugin( 'publicize' );
-		set_plugin_availability( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
+		set_jetpack_extension_availability( 'publicize', array( 'callback' => array( $this, 'get_extension_availability' ) ) );
 	}
 
 	function get_extension_availability() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -786,7 +786,7 @@ abstract class Publicize_Base {
 		if ( $this->current_user_can_access_publicize_data() ) {
 			jetpack_register_plugin( 'publicize' );
 		} else {
-			set_extension_unavailability_reason( 'publicize', 'unauthorized' );
+			jetpack_set_extension_unavailability_reason( 'publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/shortcodes/email-subscribe.php
+++ b/modules/shortcodes/email-subscribe.php
@@ -52,25 +52,6 @@ class Jetpack_Email_Subscribe {
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'jetpack_options_whitelist', array( $this, 'filter_whitelisted_options' ), 10, 1 );
-		add_action( 'jetpack_blocks_to_register', array( $this, 'prevent_jetpack_register_block' ), 10, 1 );
-	}
-
-	/**
-	 * There is a structural problem in Jetpack_Gutenberg class that breaks server-side rendered blocks on WPCOM.
-	 * The problem stems from register_blocks being called very late. Too late in fact to WP_REST_Block_Renderer_Controller be aware of them.
-	 * Regular 'register_block_type' call does not register blocks as available from Calypso SDK.
-	 * I tried registering block twice, both with jetpack_register_block and register_block_type, but that produces a notice.
-	 * I introduced this callback and 'jetpack_blocks_to_register' filter as a way of dealing with this issue
-	 * @param $blocks - list of blocks that will be passed to 'register_block_type' call of Jetpack_Gutenberg.
-	 *
-	 * @return array
-	 */
-	public function prevent_jetpack_register_block( $blocks ) {
-		return array_filter( $blocks, array( $this, 'filter_out_this_block' ) );
-	}
-
-	public function filter_out_this_block( $block_name ) {
-		return ( $block_name !== self::$block_name );
 	}
 
 	public function filter_whitelisted_options( $options ) {
@@ -83,39 +64,36 @@ class Jetpack_Email_Subscribe {
 	}
 
 	private function register_gutenberg_block() {
-		if ( Jetpack_Gutenberg::is_gutenberg_available() ) {
-			register_block_type( 'jetpack/' . self::$block_name, array(
-				'attributes' => array(
-					'title' => array(
-						'type' => 'string',
-					),
-					'email_placeholder' => array(
-						'type' => 'string',
-					),
-					'submit_label' => array(
-						'type' => 'string',
-					),
-					'consent_text' => array(
-						'type' => 'string',
-					),
-					'processing_label' => array(
-						'type' => 'string',
-					),
-					'success_label' => array(
-						'type' => 'string',
-					),
-					'error_label' => array(
-						'type' => 'string',
-					),
-					'className' => array(
-						'type' => 'string',
-					),
+		jetpack_register_block( self::$block_name, array(
+			'attributes' => array(
+				'title' => array(
+					'type' => 'string',
 				),
-				'style' => 'jetpack-email-subscribe',
-				'render_callback' => array( $this, 'parse_shortcode' ),
-			) );
-			jetpack_register_block( self::$block_name, array(), array( 'available' => true ) );
-		}
+				'email_placeholder' => array(
+					'type' => 'string',
+				),
+				'submit_label' => array(
+					'type' => 'string',
+				),
+				'consent_text' => array(
+					'type' => 'string',
+				),
+				'processing_label' => array(
+					'type' => 'string',
+				),
+				'success_label' => array(
+					'type' => 'string',
+				),
+				'error_label' => array(
+					'type' => 'string',
+				),
+				'className' => array(
+					'type' => 'string',
+				),
+			),
+			'style' => 'jetpack-email-subscribe',
+			'render_callback' => array( $this, 'parse_shortcode' ),
+		) );
 	}
 
 	public function init_hook_action() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			jetpack_register_block( 'simple-payments' );
 		} else {
-			set_block_availability( 'simple-payments', array( 'unavailable_reason' => 'missing_plan' ) );
+			set_jetpack_extension_availability( 'simple-payments', array( 'unavailable_reason' => 'missing_plan' ) );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -58,7 +58,8 @@ class Jetpack_Simple_Payments {
 
 		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
 
-		jetpack_register_block( 'simple-payments', array(), array( 'callback' => array( $this, 'get_block_availability' ) ) );
+		jetpack_register_block( 'simple-payments' );
+		set_extension_unavailability_reason( 'simple-payments', array( 'callback' => array( $this, 'get_block_availability' ) ) );
 	}
 
 	function get_block_availability() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -40,8 +40,8 @@ class Jetpack_Simple_Payments {
 
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
+		add_action( 'init', array( $this, 'register_gutenberg_block' ), 40 );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
-		add_action( 'rest_api_init', array( $this, 'register_gutenberg_block' ) );
 	}
 
 	private function register_shortcode() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			jetpack_register_block( 'simple-payments' );
 		} else {
-			set_jetpack_extension_availability( 'simple-payments', array( 'unavailable_reason' => 'missing_plan' ) );
+			set_jetpack_extension_availability( 'simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			jetpack_register_block( 'simple-payments' );
 		} else {
-			set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
+			jetpack_set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -41,6 +41,7 @@ class Jetpack_Simple_Payments {
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
+		add_action( 'rest_api_init', array( $this, 'register_gutenberg_block' ) );
 	}
 
 	private function register_shortcode() {
@@ -57,15 +58,14 @@ class Jetpack_Simple_Payments {
 		$this->setup_cpts();
 
 		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
-
-		jetpack_register_block( 'simple-payments' );
-		set_extension_unavailability_reason( 'simple-payments', array( 'callback' => array( $this, 'get_block_availability' ) ) );
 	}
 
-	function get_block_availability() {
-		return $this->is_enabled_jetpack_simple_payments()
-		       ? array( 'available' => true )
-		       : array( 'available' => false, 'unavailable_reason' => 'missing_plan' );
+	function register_gutenberg_block() {
+		if ( $this->is_enabled_jetpack_simple_payments() ) {
+			jetpack_register_block( 'simple-payments' );
+		} else {
+			set_block_availability( 'simple-payments', array( 'unavailable_reason' => 'missing_plan' ) );
+		}
 	}
 
 	function remove_auto_paragraph_from_product_description( $content ) {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			jetpack_register_block( 'simple-payments' );
 		} else {
-			set_jetpack_extension_availability( 'simple-payments', 'missing_plan' );
+			set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -240,7 +240,7 @@ class Jetpack_Sync_Defaults {
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
 		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
-		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ),
+		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins
 	);
 
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -240,7 +240,7 @@ class Jetpack_Sync_Defaults {
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
 		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
-		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_block_availability' ),
+		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ),
 	);
 
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -53,8 +53,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// $this->setSyncClientDefaults();
 
 		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
-		jetpack_register_block( 'test' );
 		Jetpack_Gutenberg::init();
+		jetpack_register_block( 'test' );
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),
@@ -126,10 +126,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$unique_whitelist = array_unique( $whitelist_keys );
 		$this->assertEquals( count( $unique_whitelist ), count( $whitelist_keys ), 'The duplicate keys are: ' . print_r( array_diff_key( $whitelist_keys, array_unique( $whitelist_keys ) ), 1 ) );
 
+		remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
+		Jetpack_Gutenberg::reset();
+		unregister_block_type( 'jetpack/test' );
 	}
 
-	public function add_test_block( $blocks ) {
-		return array_merge( $blocks, array( 'test' ) );
+	public function add_test_block() {
+		return array( 'test' );
 	}
 
 	function assertCallableIsSynced( $name, $value ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -87,7 +87,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
 			'roles'                            => Jetpack_Sync_Functions::roles(),
 			'timezone'                         => Jetpack_Sync_Functions::get_timezone(),
-			'available_jetpack_blocks'         => Jetpack_Gutenberg::get_block_availability(),
+			'available_jetpack_blocks'         => Jetpack_Gutenberg::get_availability(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -128,7 +128,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
 		Jetpack_Gutenberg::reset();
-		unregister_block_type( 'jetpack/test' );
 	}
 
 	public function add_test_block() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -52,7 +52,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function test_sync_callable_whitelist() {
 		// $this->setSyncClientDefaults();
 
-		add_filter( 'jetpack_set_available_blocks',  array( $this, 'add_test_block' ) );
+		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
 		jetpack_register_block( 'test' );
 		Jetpack_Gutenberg::init();
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		add_filter( 'jetpack_set_available_blocks',  array( $this, 'add_test_block' ) );
 		jetpack_register_block( 'test' );
-		Jetpack_Gutenberg::load_blocks();
+		Jetpack_Gutenberg::init();
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -4,14 +4,6 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	public $master_user_id = false;
 
-	public static function setUpBeforeClass() {
-		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
-	}
-
-	public static function tearDownAfterClass() {
-		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
-	}
-
 	public function setUp() {
 		parent::setUp();
 		if ( ! function_exists( 'register_block_type' ) ) {
@@ -29,6 +21,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		Jetpack_Options::update_option( 'master_user', $this->master_user_id );
 		Jetpack_Options::update_option( 'user_tokens', array( $this->master_user_id => "honey.badger.$this->master_user_id" ) );
 
+		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 		Jetpack_Gutenberg::init();
 	}
 
@@ -36,6 +29,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		parent::tearDown();
 
 		Jetpack_Gutenberg::reset();
+		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 
 		if ( $this->master_user_id ) {
 			Jetpack_Options::delete_option( array( 'master_user', 'user_tokens' ) );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -5,11 +5,11 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	public $master_user_id = false;
 
 	public static function setUpBeforeClass() {
-		add_filter( 'jetpack_set_available_blocks', array( __CLASS__, 'get_extensions_whitelist' ) );
+		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 	}
 
 	public static function tearDownAfterClass() {
-		remove_filter( 'jetpack_set_available_blocks', array( __CLASS__, 'get_extensions_whitelist' ) );
+		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 	}
 
 	public function setUp() {

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -4,6 +4,14 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	public $master_user_id = false;
 
+	public static function setUpBeforeClass() {
+		add_filter( 'jetpack_set_available_blocks', array( __CLASS__, 'get_extensions_whitelist' ) );
+	}
+
+	public static function tearDownAfterClass() {
+		remove_filter( 'jetpack_set_available_blocks', array( __CLASS__, 'get_extensions_whitelist' ) );
+	}
+
 	public function setUp() {
 		parent::setUp();
 		if ( ! function_exists( 'register_block_type' ) ) {
@@ -20,10 +28,14 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		// Mock a connection
 		Jetpack_Options::update_option( 'master_user', $this->master_user_id );
 		Jetpack_Options::update_option( 'user_tokens', array( $this->master_user_id => "honey.badger.$this->master_user_id" ) );
+
+		Jetpack_Gutenberg::init();
 	}
 
 	public function tearDown() {
 		parent::tearDown();
+
+		Jetpack_Gutenberg::reset();
 
 		if ( $this->master_user_id ) {
 			Jetpack_Options::delete_option( array( 'master_user', 'user_tokens' ) );
@@ -40,194 +52,75 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		}
 	}
 
-	public function add_test_block( $blocks ) {
-		return array_merge( $blocks, array( 'test' ) );
-	}
-
-	public function add_missing_module_block( $blocks ) {
-		return array_merge( $blocks, array( 'missing' ) );
-	}
-
-	public function add_banana_block( $blocks ) {
-		return array_merge( $blocks, array( 'banana' ) );
-	}
-
-	public function add_coconut_block( $blocks ) {
-		return array_merge( $blocks, array( 'coconut' ) );
-	}
-
-	public function add_foo_plugin( $plugins ) {
-		return array_merge( $plugins, array( 'foo' ) );
-	}
-
-	public function add_unavailable_plugin( $plugins ) {
-		return array_merge( $plugins, array( 'unavailable' ) );
-	}
-
-	public function add_coconut_plugin( $plugins ) {
-		return array_merge( $plugins, array( 'coconut-plugin' ) );
-	}
-
-	public function add_banana_plugin( $plugins ) {
-		return array_merge( $plugins, array( 'banana-plugin' ) );
-	}
-
-	public function add_orange_plugin( $plugins ) {
-		return array_merge( $plugins, array( 'orange-plugin' ) );
+	public static function get_extensions_whitelist() {
+		return array(
+			// Our "Blocks" :)
+			'apple',
+			'banana',
+			'coconut',
+			'grape',
+			// Our "Plugins" :)
+			'onion',
+			'potato',
+			'tomato'
+		);
 	}
 
 	function test_registered_block_is_available() {
-		jetpack_register_block( 'test' );
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		Jetpack_Gutenberg::init();
+		jetpack_register_block( 'apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		$this->assertTrue( $availability['test']['available'] );
+		$this->assertTrue( $availability['apple']['available'] );
 	}
 
 	function test_registered_block_is_not_available() {
-		jetpack_register_block( 'test', array(), array( 'available' => false, 'unavailable_reason' => 'bar' ) );
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		Jetpack_Gutenberg::init();
+		set_jetpack_extension_availability( 'banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		$this->assertFalse( $availability['test']['available'], 'Test is available!' );
-		$this->assertEquals( $availability['test']['unavailable_reason'], 'bar', 'unavailable_reason is not bar' );
+		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
+		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
 	}
 
-	function test_registered_block_is_not_available_when_not_defined_in_avaialable_blocks() {
-		jetpack_register_block( 'rocks' );
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		Jetpack_Gutenberg::init();
+	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
+		jetpack_register_block( 'durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_test_block') );
-
-		// Should not exits in the $availability...
-		$this->assertTrue( ! isset( $availability['rocks']['available'] ), 'Availability info exists' );
+		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
+		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
 	}
 
-	function test_registered_block_is_not_available_when_not_registed_returns_missing_module() {
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_missing_module_block') );
-
-		Jetpack_Gutenberg::init();
+	function test_block_is_not_available_when_not_registered_returns_missing_module() {
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_missing_module_block') );
 
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['missing']['available'], 'Avaiability is not false exists' );
-		$this->assertEquals( $availability['missing']['unavailable_reason'], 'missing_module',  'Availability is not missing_module'  );
-	}
-
-	function test_registered_block_is_not_available_unknown_reason_is_missing_reason() {
-		jetpack_register_block( 'banana', array(), array('available' => false ) );
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_banana_block' ) );
-
-		Jetpack_Gutenberg::init();
-		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_banana_block' ) );
-
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['banana']['available'],  'Avaiability is not false' );
-		$this->assertEquals( $availability['banana']['unavailable_reason'], 'unknown', 'Availability Reason is not unknown' );
-	}
-
-	function get_coconut_availability() {
-		return array( 'available' => false, 'unavailable_reason' => 'roccoconut' );
-	}
-
-	function test_registered_block_supports_callback_availability() {
-		jetpack_register_block( 'coconut', array(), array(
-			'callback' => array( $this, 'get_coconut_availability' ) ) );
-		add_filter( 'jetpack_set_available_blocks', array( $this, 'add_coconut_block' ) );
-
-		Jetpack_Gutenberg::init();
-		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_blocks', array( $this, 'add_coconut_block' ) );
-
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['coconut']['available'],  'Avaiability is not false' );
-		$this->assertEquals( $availability['coconut']['unavailable_reason'], 'roccoconut', 'Availability Reason is not roccoconut' );
+		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
+		$this->assertFalse( $availability['grape']['available'], 'Avaiability is not false exists' );
+		$this->assertEquals( $availability['grape']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
 	}
 
 	// Plugins
 	function test_registered_plugin_is_available() {
-		jetpack_register_plugin( 'foo' );
-		add_filter( 'jetpack_set_available_plugins', array( $this, 'add_foo_plugin' ) );
-
-		Jetpack_Gutenberg::init();
+		jetpack_register_plugin( 'onion' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_plugins', array( $this, 'add_foo_plugin' ) );
-
-		$this->assertTrue( $availability['foo']['available'] );
+		$this->assertTrue( $availability['onion']['available'] );
 	}
 
 	function test_registered_plugin_is_not_available() {
-		jetpack_register_plugin( 'unavailable', array( 'available' => false, 'unavailable_reason' => 'bar' ) );
-		add_filter( 'jetpack_set_available_plugins', array( $this, 'add_unavailable_plugin' ) );
-
-		Jetpack_Gutenberg::init();
+		set_jetpack_extension_availability( 'potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_plugins', array( $this, 'add_unavailable_plugin' ) );
-
-		$this->assertFalse( $availability['unavailable']['available'], 'Foo is available!' );
-		$this->assertEquals( $availability['unavailable']['unavailable_reason'], 'bar', 'unavailable_reason is not bar' );
+		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
+		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
 	}
 
-	function test_registered_plugin_is_not_available_when_not_defined_in_avaialable_plugins() {
-		jetpack_register_plugin( 'rocks-plugin' );
+	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
+		jetpack_register_plugin( 'parsnip' );
+		$availability = Jetpack_Gutenberg::get_availability();
+		$this->assertFalse( $availability['parsnip']['available'], 'durian is available!' );
+		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
 
-		Jetpack_Gutenberg::init();
+	}
+
+	function test_plugin_is_not_available_when_not_registered_returns_missing_module() {
 		$availability = Jetpack_Gutenberg::get_availability();
 
-		// Should not exits in the $availability...
-		$this->assertTrue( ! isset( $availability['rocks-plugin']['available'] ), 'Availability info exists' );
+		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
+		$this->assertFalse( $availability['tomato']['available'], 'Avaiability is not false exists' );
+		$this->assertEquals( $availability['tomato']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
 	}
-
-	function test_registered_plugin_is_not_available_when_not_registed_returns_missing_module() {
-		add_filter( 'jetpack_set_available_plugins', array( $this, 'add_coconut_plugin' ) );
-
-		Jetpack_Gutenberg::init();
-		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_plugins', array( $this, 'add_coconut_plugin' ) );
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['coconut-plugin']['available'], 'Avaiability is not false exists' );
-		$this->assertEquals( $availability['coconut-plugin']['unavailable_reason'], 'missing_module',  'Availability is not missing_module'  );
-	}
-
-	function test_registered_plugin_is_not_available_unknown_reason_is_missing_reason() {
-		jetpack_register_plugin( 'banana-plugin', array( 'available' => false ) );
-		add_filter( 'jetpack_set_available_plugins', array( $this, 'add_banana_plugin' ) );
-
-		Jetpack_Gutenberg::init();
-		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_plugins', array( $this, 'add_banana_plugin' ) );
-
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['banana-plugin']['available'],  'Avaiability is not false' );
-		$this->assertEquals( $availability['banana-plugin']['unavailable_reason'], 'unknown', 'Availability Reason is not unknown' );
-	}
-
-	function orange_availability() {
-		return array( 'available' => false, 'unavailable_reason' => 'orange_you_glad' );
-	}
-
-	function test_registered_plugin_supports_callback_availability() {
-		jetpack_register_plugin( 'orange-plugin', array(
-			'callback' => array( $this, 'orange_availability' ) ) );
-		add_filter( 'jetpack_set_available_plugins', array( $this, 'add_orange_plugin' ) );
-
-		Jetpack_Gutenberg::init();
-		$availability = Jetpack_Gutenberg::get_availability();
-		remove_filter( 'jetpack_set_available_plugins', array( $this, 'add_orange_plugin' ) );
-
-		// Should not exits in the Module is not active
-		$this->assertFalse( $availability['orange-plugin']['available'],  'Avaiability is not false' );
-		$this->assertEquals( $availability['orange-plugin']['unavailable_reason'], 'orange_you_glad', 'Availability Reason is not orange_you_glad' );
-	}
-
 }

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$availability = Jetpack_Gutenberg::get_availability();
 
 		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
-		$this->assertFalse( $availability['grape']['available'], 'Avaiability is not false exists' );
+		$this->assertFalse( $availability['grape']['available'], 'Availability is not false exists' );
 		$this->assertEquals( $availability['grape']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
 	}
 
@@ -120,7 +120,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$availability = Jetpack_Gutenberg::get_availability();
 
 		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
-		$this->assertFalse( $availability['tomato']['available'], 'Avaiability is not false exists' );
+		$this->assertFalse( $availability['tomato']['available'], 'Availability is not false exists' );
 		$this->assertEquals( $availability['tomato']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
 	}
 }

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -73,7 +73,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available() {
-		set_extension_unavailability_reason( 'banana', 'bar' );
+		jetpack_set_extension_unavailability_reason( 'banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
@@ -102,7 +102,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_plugin_is_not_available() {
-		set_extension_unavailability_reason( 'potato', 'bar' );
+		jetpack_set_extension_unavailability_reason( 'potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
 		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -73,7 +73,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available() {
-		set_jetpack_extension_availability( 'banana', 'bar' );
+		set_extension_unavailability_reason( 'banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
@@ -102,7 +102,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_plugin_is_not_available() {
-		set_jetpack_extension_availability( 'potato', 'bar' );
+		set_extension_unavailability_reason( 'potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
 		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );


### PR DESCRIPTION
Refactor `Jetpack_Gutenberg` to get rid of some of its quirks, and make it easier to reason about. Among other things, this allows us to remove the Mailchimp workaround (https://github.com/Automattic/jetpack/pull/10597/files#r245018740) as part of this PR (per 293b373109f49231db13f1c726298d7655115c99).

Some basic ideas:

- Decouple registration, and storing of availability information. Only when a block isn't being registered do we set the latter.
- No need for a duplicated block registry -- simply use Gutenberg's.
- Fewer getters/setters in `Jetpack_Gutenberg`, thus fewer (potentially broken) states. The idea is that `Jetpack_Gutenberg` initializes a whitelist of potentially allowed blocks and plugins once, and upon (attempted) registration of individual blocks and plugins, checks if they're on that list. This is probably best reflected by the changes to the unit test.
- Remove layers of indirection, especially wrt filters. Instead of passing a callback when setting availability in more complex scenarios, we simply move block registration and availability setting to an appropriate filter _inside_ the corresponding module. This should make the order of actions and flow of filters much easier to reason about.
- Removal of asymmetry (there were some methods for plugins that didn't actually do anything).
- Filter child blocks from availability tracking so we don't confuse them with other unwhitelisted blocks.

#### Changes proposed in this Pull Request:

- [x] Introduce and use set_extension_unavailability_reason() (to decouple block registration and availability)
- [x] Update endpoint to directly fetch registration information from GB block registry
- [x] Remove obsolete stuff from `Jetpack_Gutenberg`
- [x] Rebase, remove registration workarounds from #10597
- [x] Fix (and update) tests
- [x] Update comments

#### Testing instructions:

Verify that block availability works as before. Verify that the following extensions's availability changes when doing the following:
- Publicize:
  - Toggle the Publicize module, verify that the Publicize panel only shows when the module is on
  - With a user with 'contributor' role, write a new post, and verify that the Publicize panel doesn't show in the Jetpack sidebar. (If you check `window.Jetpack_Editor_Initial_State`, it should say `unavailable_reason: "unauthorized"` for `publicize`.)
- Simple Payments: Try a free vs a premium plan
- Contact Form:
  - Start writing a post, and insert a Contact Form Block
  - Modify some of the Contact Form's field labels (e.g. change 'Name' to 'Your Name')
  - Publish the post, and view it in the frontend.
  - Verify that your modifications actually show up.

Change the `JETPACK_BETA_BLOCKS` constant and verify that depending on its value, beta blocks are either available or not!

#### Proposed changelog entry for your changes:

* Simplify the `Jetpack_Gutenberg` class
