### PR TITLE
Sync: Consider whitelisted option filters

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -457,7 +457,8 @@ class Jetpack_Sync_Defaults {
 	);
 
 	static function is_whitelisted_option( $option ) {
-		foreach ( self::$default_options_whitelist as $whitelisted_option ) {
+		$whitelisted_options = self::get_options_whitelist();
+		foreach ( $whitelisted_options as $whitelisted_option ) {
 			if ( $whitelisted_option[0] === '/' && preg_match( $whitelisted_option, $option ) ) {
 				return true;
 			} elseif ( $whitelisted_option === $option ) {


### PR DESCRIPTION
Currently, when we check whether an option is whitelisted for syncing, we check against the default list of options. This means that any additional options that we register by using the filters aren't considered. This PR changes this, so now the filters will be considered and any options that have been added by using those filters will be synced.

This PR is a companion to D22745-code

#### Changes proposed in this Pull Request:

* Consider option whitelist filters when checking whether an option is whitelisted.

#### Testing instructions:
* See D22745-code

#### Proposed changelog entry for your changes:

* Consider option whitelist filters when checking whether an option is whitelisted.
