### PR TITLE
Gutenberg/Publicize: Don't enqueue social logos anymore

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -484,9 +484,5 @@ class Jetpack_Gutenberg {
 		Jetpack::setup_wp_i18n_locale_data();
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-
-		// The social-logos styles are used for Publicize service icons
-		// TODO: Remove when we ship the icons with the Gutenberg blocks build
-		wp_enqueue_style( 'social-logos' );
 	}
 }


### PR DESCRIPTION
Don't enqueue social logos anymore, since they're now taken care of on the client side (per https://github.com/Automattic/wp-calypso/pull/29317)


#### Changes proposed in this Pull Request:

Remove `wp_enqueue_style( 'social-logos' );` from `class.jetpack-gutenberg.php`.

#### Testing instructions:

- Start writing a new post
- Click 'Publish'
- Make sure you have a couple of Publicize connections 
- Verify that the social logos next to each connections are still there

![image](https://user-images.githubusercontent.com/96308/50794495-917c1500-12cb-11e9-85be-e61fa217e168.png)

#### Proposed changelog entry for your changes:

Don't enqueue social logos for Publicize anymore.