### PR TITLE
Contact Form Block: Add parent field to child blocks

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -248,36 +248,47 @@ class Grunion_Contact_Form_Plugin {
 
 		// Field render methods.
 		jetpack_register_block( 'field-text', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
 		) );
 		jetpack_register_block( 'field-name', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
 		) );
 		jetpack_register_block( 'field-email', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
 		) );
 		jetpack_register_block( 'field-url', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
 		) );
 		jetpack_register_block( 'field-date', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
 		) );
 		jetpack_register_block( 'field-telephone', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
 		) );
 		jetpack_register_block( 'field-textarea', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
 		) );
 		jetpack_register_block( 'field-checkbox', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
 		) );
 		jetpack_register_block( 'field-checkbox-multiple', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
 		) );
 		jetpack_register_block( 'field-radio', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
 		) );
 		jetpack_register_block( 'field-select', array(
+			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
 		) );
 	}


### PR DESCRIPTION
This is information that we're going to need one way or another, sooner or later.
Actually, sooner rather than later: This has been factored out of #11091 (to shrink that PR's diff a bit).

#### Changes proposed in this Pull Request:

Contact Form Block: Add parent field to children

#### Testing instructions:

Verify that the Contact Form block still works, both in the editor, and the frontend.
Specifically, are all child blocks still available?

#### Proposed changelog entry for your changes:

Contact Form Block: Add parent field to child blocks
