### PR TITLE
Lazy Images: Also check that HTML element has js class as a fallback for our class being overridden

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -281,7 +281,8 @@ class Jetpack_Lazy_Images {
 	public function add_nojs_fallback() {
 		?>
 			<style type="text/css">
-				html:not( .jetpack-lazy-images-js-enabled ) .jetpack-lazy-image {
+				/* If html does not have either class, do not show lazy loaded images. */
+				html:not( .jetpack-lazy-images-js-enabled ):not( .js ) .jetpack-lazy-image {
 					display: none;
 				}
 			</style>


### PR DESCRIPTION
Fixes 3304-gh-jpop-issues.

Specifically, the Infinity child theme for Genesis was setting the classes for the `html` tag to `js`, which overwrote a class we had previously added. Here's an example of where the issue occurred in the the `infinity-pro/js/front-page.js` file from the Infinity theme:

```js
/**
 * This script adds the jquery effects to the front page of the Infinity Pro Theme.
 *
 * @package Infinity\JS
 * @author StudioPress
 * @license GPL-2.0+
 */

// Fadeup effect for front page sections.
(function( $ ) {

	// Make sure JS is enabled.
	document.documentElement.className = 'js';
```

The issue here occurs because the theme is setting `className` instead of **adding** a class.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* See JPOP issue 3304
* This PR will now look for the `js` class as well as the `jetpack-lazy-images-js-enabled` class on `html`

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack master or 6.8
* Ensure lazy images is activated
* Install Genesis and Infinity theme (see JPOP issue)
* Go to Customizer > Widgets and add a couple of image widgets to the one of the front page sections
* Load the front page and ensure lazy loaded images do not load
* Checkout this branch
* Reload home page and ensure that images load

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fixed a compatibility issue between lazy images and themes that overwrite classes on html.
