### PR TITLE
Revert "Jetpack Gutenberg: Kill `$default_blocks` with :fire:"

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -44,6 +44,27 @@ function jetpack_register_plugin( $slug, $availability = array( 'available' => t
  */
 class Jetpack_Gutenberg {
 
+	// BLOCKS
+	private static $default_blocks = array(
+		'map',
+		'markdown',
+		'simple-payments',
+		'related-posts',
+		'contact-form',
+		'field-text',
+		'field-name',
+		'field-email',
+		'field-url',
+		'field-date',
+		'field-telephone',
+		'field-textarea',
+		'field-checkbox',
+		'field-checkbox-multiple',
+		'field-radio',
+		'field-select',
+		'subscriptions',
+	);
+
 	/**
 	 * @var array Array of blocks information.
 	 *
@@ -53,6 +74,11 @@ class Jetpack_Gutenberg {
 
 	private static $availability = array();
 
+	// PLUGINS
+	private static $default_plugins = array(
+		'publicize',
+		'shortlinks',
+	);
 	/**
 	 * @var array Array of plugins information.
 	 *
@@ -142,7 +168,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$blocks = apply_filters( 'jetpack_set_available_blocks', array() );
+		self::$blocks = apply_filters( 'jetpack_set_available_blocks', self::$default_blocks );
 
 		/**
 		 * Filter the list of block editor plugins that are available through jetpack.
@@ -153,7 +179,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param array
 		 */
-		self::$plugins = apply_filters( 'jetpack_set_available_plugins', array() );
+		self::$plugins = apply_filters( 'jetpack_set_available_plugins', self::$default_plugins );
 		self::set_blocks_availability();
 		self::set_plugins_availability();
 		self::register_blocks();


### PR DESCRIPTION
Reverts Automattic/jetpack#11075 (which was only slated for inclusion in 7.0 AFAICS).

#### Changes proposed in this Pull Request:

Quoting https://github.com/Automattic/jetpack/pull/11075#issuecomment-452405367:

> Note that I had to revert the WP.com counterpart, D22788-code, per D22963-code to fix an issue with the Contact Form that was reported at Automattic/wp-calypso#29989. I can reproduce on Jetpack and will file a PR to revert.

The suspected reason (per @enejb) is that we're not registering Contact Form child blocks on the server side.

#### Testing instructions:

To reproduce the issue on `master`:

- Start writing a post, and insert a Contact Form Block
- Publish
- Now edit that post, and modify some of the Contact Form's field labels (e.g. change 'Name' to 'Your Name'). Update the post
- View the post in the frontend.
- Note that the changes don't show up.

Verify that this PR fixes that issue.

#### Proposed changelog entry for your changes:

(Remove the line that says  "Jetpack Gutenberg: Kill `$default_blocks` with :fire:")

#### Follow-up

I'm probably not going to try to produce a revised version of this PR but rather focus on getting #11091 ready (and remove `$default_blocks` there, without any unwanted side effects to block registration)