### PR TITLE
Connection banner: display banner inside React page.

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -182,7 +182,7 @@ class Main extends React.Component {
 			);
 		}
 
-		if ( ! this.props.siteConnectionStatus && this.props.userCanConnectSite ) {
+		if ( false === this.props.siteConnectionStatus && this.props.userCanConnectSite ) {
 			return <div className="jp-jetpack-connect__container" aria-live="assertive" />;
 		}
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -284,7 +284,7 @@ class Main extends React.Component {
 					<AdminNotices />
 					<JetpackNotices />
 					{ this.renderMainContent( this.props.route.path ) }
-					{ <SupportCard path={ this.props.route.path } /> }
+					{ this.props.isSiteConnected && <SupportCard path={ this.props.route.path } /> }
 					{ <AppsCard /> }
 				</div>
 				<Footer siteAdminUrl={ this.props.siteAdminUrl } />

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -67,6 +67,16 @@ class Main extends React.Component {
 			analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: this.props.route.path } );
 	}
 
+	componentDidMount() {
+		// If we have a div that's only found on the Jetpack dashboard when not connected,
+		// let's move the connection banner inside that div, inside the React page.
+		const connectReactContainer = jQuery( '.jp-jetpack-connect__container' );
+		const fullScreenContainer = jQuery( '.jp-connect-full__container' );
+		if ( connectReactContainer && fullScreenContainer.length > 0 ) {
+			fullScreenContainer.prependTo( connectReactContainer );
+		}
+	}
+
 	/*
 	 * Returns a string if there are unsaved module settings thus showing a confirm dialog to the user
 	 * according to the `beforeunload` event handling specification
@@ -170,6 +180,10 @@ class Main extends React.Component {
 					<NonAdminView { ...this.props } />
 				</div>
 			);
+		}
+
+		if ( ! this.props.siteConnectionStatus && this.props.userCanConnectSite ) {
+			return <div className="jp-jetpack-connect__container" aria-live="assertive" />;
 		}
 
 		const settingsNav = (

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -864,17 +864,20 @@ class Jetpack_Connection_Banner {
 		?>
 		<div class="jp-connect-full__container"><div class="jp-connect-full__container-card">
 
-			<img
-				class="jetpack-logo"
-				src="<?php echo plugins_url( 'images/jetpack-logo-green.svg', JETPACK__PLUGIN_FILE ); ?>"
-				alt="<?php
-					esc_attr_e(
-						'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it',
-						'jetpack'
-				); ?>"
-			/>
-
 			<?php if ( 'plugins' === $current_screen->base ) : ?>
+				<img
+					class="jetpack-logo"
+					src="<?php echo plugins_url( 'images/jetpack-logo-green.svg', JETPACK__PLUGIN_FILE ); ?>"
+					alt="
+					<?php
+						esc_attr_e(
+							'Jetpack is a free plugin that utilizes powerful WordPress.com servers to enhance your site and simplify managing it',
+							'jetpack'
+						);
+					?>
+					"
+				/>
+
 				<div class="jp-connect-full__dismiss">
 					<svg class="jp-connect-full__svg-dismiss" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>Dismiss Jetpack Connection Window</title><rect x="0" fill="none" /><g><path d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/></g></svg>
 				</div>

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -84,6 +84,8 @@
 	&.toplevel_page_jetpack .jp-connect-full__container {
 		position: relative;
 		bottom: 0;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+			0 1px 2px lighten( $gray, 30% );
 
 		.jp-connect-full__container-card {
 			margin: 0;

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -80,8 +80,14 @@
 
 	}
 
+	// Full page connection banner in the Jetpack dashboard.
 	&.toplevel_page_jetpack .jp-connect-full__container {
+		position: relative;
 		bottom: 0;
+
+		.jp-connect-full__container-card {
+			margin: 0;
+		}
 
 		@include minbreakpoint(tablet) {
 			left: 0;
@@ -90,6 +96,16 @@
 		@include breakpoint(tablet) {
 			top: 46px;
 		};
+
+		// hide the notice by default. Only display it when it is injected in the middle of the page.
+		display: none;
+	}
+
+	// Only display the banner when it is injected in the middle of the page.
+	&.toplevel_page_jetpack .jp-jetpack-connect__container {
+		.jp-connect-full__container {
+			display: block;
+		}
 	}
 }
 
@@ -263,7 +279,7 @@
 
 .jp-wpcom-connect__container-top-text {
 	padding: 15px 15px 25px 15px;
-	background-color: $green-primary; 
+	background-color: $green-primary;
 	color: $white;
 	font-weight: 600;
 
@@ -288,7 +304,7 @@
 	display: block;
 	position: relative;
 	box-sizing: border-box;
-	background-color: $green-primary; 
+	background-color: $green-primary;
 }
 
 .jp-wpcom-connect__inner-container > a:first-child {


### PR DESCRIPTION
Fixes #11071

#### Changes proposed in this Pull Request:

- The fullscreen connection banner appearing on Jetpack > Dashboard previously overlaid all other information on the page. This included useful information like footer links, but also potential error messages.
- This PR adds a new empty div to the main react admin page structure when a site is not connected to WordPress.com, and then moves the content from the notice that contains the connection banner to inside that empty div, in the middle of the page.

This creates a difference between the fullscreen connection banner in the plugins menu and the one in Jetpack > Dashboard: since the Jetpack dashboard already includes a masthead with a Jetpack logo, I removed the logo from the connection banner there.

#### Screenshots

**Plugins screen**

<img width="1461" alt="screenshot 2019-01-08 at 21 16 24" src="https://user-images.githubusercontent.com/426388/50856529-41648780-138b-11e9-8af6-cd1a318bedaa.png">

**Jetpack > Dashboard before**

<img width="1464" alt="screenshot 2019-01-08 at 21 21 12" src="https://user-images.githubusercontent.com/426388/50856582-5f31ec80-138b-11e9-86a1-da8e542fbc2b.png">

**Jetpack > Dashboard after**

<img width="1466" alt="screenshot 2019-01-08 at 21 16 47" src="https://user-images.githubusercontent.com/426388/50856544-4b868600-138b-11e9-9b7f-80d60ae89609.png">

### Testing instructions:

1. Deactivate the Jetpack plugin on a site running this branch.
2. Activate the plugin again.
3. View the fullscreen connection banner under the Plugins menu
4. Go to Jetpack > Dashboard and view the new fullscreen connection banner. Make sure it looks good in all browsers.
5. Add some random characters before the opening `<?php` tag in your site's `wp-config.php` file
6. Attempt to connect the site to WordPress.com.
7. Notice that you can see the error message when the connection fails.

#### Proposed changelog entry for your changes:

None.