### PR TITLE
Writing: Copy a post.

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -42,6 +42,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 			// Only should be features that don't already have a UI, and we want to reveal in search.
 			const whitelist = [
 				'contact-form',
+				'copy-post',
 				'custom-css',
 				'enhanced-distribution',
 				'json-api',

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -294,13 +294,25 @@ class Jetpack_Copy_Post {
 
 		// Insert the Copy action before the Trash action.
 		$edit_offset = array_search( 'trash', array_keys( $actions ), true );
-		$actions     = array_merge(
+		$updated_actions     = array_merge(
 			array_slice( $actions, 0, $edit_offset ),
 			$edit_action,
 			array_slice( $actions, $edit_offset )
 		);
 
-		return $actions;
+		/**
+		 * Fires after the new Copy action has been added to the row actions.
+		 * Allows changes to the action presentation, or other final checks.
+		 *
+		 * @module copy-post
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param array   $updated_actions Updated row actions with the Copy Post action.
+		 * @param array   $actions Original row actions passed to this filter.
+		 * @param WP_Post $post Post object of current post in listing.
+		 */
+		return apply_filters( 'jetpack_copy_post_row_actions', $updated_actions, $actions, $post );
 	}
 }
 

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -52,7 +52,7 @@ class Jetpack_Copy_Post {
 		}
 
 		$source_post = get_post( $_GET['jetpack-copy'] );
-		if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
+		if ( ! $source_post || ! $this->user_can_access_post( $source_post->ID ) ) {
 			return;
 		}
 
@@ -74,11 +74,11 @@ class Jetpack_Copy_Post {
 	/**
 	 * Determine if the current user has access to the source post.
 	 *
-	 * @param WP_Post $post Source post object (the post being copied).
-	 * @return bool         True if current user is the post author, or has permissions for `edit_others_posts`; false otherwise.
+	 * @param int $post_id Source post ID (the post being copied).
+	 * @return bool True if user has the meta cap of `read_post` for the given post ID, false otherwise.
 	 */
-	protected function user_can_edit_post( $post ) {
-		return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
+	protected function user_can_access_post( $post_id ) {
+		return current_user_can( 'read_post', $post_id );
 	}
 
 	/**
@@ -186,6 +186,10 @@ class Jetpack_Copy_Post {
 	 * @return array           Array of updated row actions.
 	 */
 	public function add_row_action( $actions, $post ) {
+		if ( ! $this->user_can_access_post( $post->ID ) ) {
+			return $actions;
+		}
+
 		$edit_url    = add_query_arg(
 			array(
 				'post_type'    => $post->post_type,

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -14,12 +14,17 @@
 
 class Jetpack_Copy_Post_By_Param {
     function __construct() {
-        if ( ! empty( $_GET[ 'copy' ] ) ) {
-            add_filter( 'wp_insert_post_data', array( $this, 'filter_post_data' ) );
+        // Add row actions to post/page/CPT listing screens.
+        if ( 'edit.php' === $GLOBALS[ 'pagenow' ] ) {
+            add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+            add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+            return;
         }
 
-        add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
-        add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+        // Process any `?copy` param if on a create new post/page/CPT screen.
+        if ( ! empty( $_GET[ 'copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
+            add_filter( 'wp_insert_post_data', array( $this, 'filter_post_data' ) );
+        }
     }
 
     protected function user_can_edit_post( $post ) {

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -28,7 +28,7 @@ class Jetpack_Copy_Post {
             return;
         }
 
-        if ( ! empty( $_GET[ 'copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
+        if ( ! empty( $_GET[ 'jetpack-copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
             add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
         }
     }
@@ -47,7 +47,7 @@ class Jetpack_Copy_Post {
             return;
         }
 
-        $source_post = get_post( $_GET['copy'] );
+        $source_post = get_post( $_GET['jetpack-copy'] );
         if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
             return;
         }
@@ -160,11 +160,11 @@ class Jetpack_Copy_Post {
     function add_row_action( $actions, $post ) {
         $edit_url = add_query_arg( array(
             'post_type' => $post->post_type,
-            'copy' => $post->ID,
+            'jetpack-copy' => $post->ID,
             '_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
         ), admin_url( 'post-new.php' ) );
         $edit_action = array(
-            'copy' => sprintf(
+            'jetpack-copy' => sprintf(
                 '<a href="%s" aria-label="%s">%s</a>',
                 esc_url( $edit_url ),
                 esc_attr( __( 'Copy this post.' ) ),

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -59,11 +59,11 @@ class Jetpack_Copy_Post {
 		}
 
 		$update_results = array(
-			'update_content'                => $this->update_content( $source_post, $target_post_id ),
-			'update_featured_image'         => $this->update_featured_image( $source_post, $target_post_id ),
-			'update_post_format'            => $this->update_post_format( $source_post, $target_post_id ),
-			'update_likes_sharing'          => $this->update_likes_sharing( $source_post, $target_post_id ),
-			'update_custom_post_type_terms' => $this->update_custom_post_type_terms( $source_post, $target_post_id ),
+			'update_content'         => $this->update_content( $source_post, $target_post_id ),
+			'update_featured_image'  => $this->update_featured_image( $source_post, $target_post_id ),
+			'update_post_format'     => $this->update_post_format( $source_post, $target_post_id ),
+			'update_likes_sharing'   => $this->update_likes_sharing( $source_post, $target_post_id ),
+			'update_post_type_terms' => $this->update_post_type_terms( $source_post, $target_post_id ),
 		);
 
 		// Required to satify get_default_post_to_edit(), which has these filters after post creation.
@@ -132,15 +132,17 @@ class Jetpack_Copy_Post {
 	}
 
 	/**
-	 * Update terms for custom post types.
+	 * Update terms for post types.
 	 *
 	 * @param WP_Post $source_post Post object to be copied.
 	 * @param int     $target_post_id Target post ID.
 	 * @return array Results of attempts to set each term to the target (new) post.
 	 */
-	protected function update_custom_post_type_terms( $source_post, $target_post_id ) {
+	protected function update_post_type_terms( $source_post, $target_post_id ) {
 		$results = array();
-		if ( in_array( $source_post->post_type, array( 'post', 'page' ), true ) ) {
+
+		$bypassed_post_types = apply_filters( 'jetpack_copy_post_bypassed_post_types', array( 'post', 'page' ), $source_post, $target_post_id );
+		if ( in_array( $source_post->post_type, $bypassed_post_types, true ) ) {
 			return $results;
 		}
 

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -41,11 +41,6 @@ class Jetpack_Copy_Post_By_Param {
             return;
         }
 
-        // Required to satify get_default_post_to_edit(), which has these filters after post creation.
-        add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
-        add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
-        add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
-
         $data = apply_filters( 'jetpack_copy_post_data', array(
             'ID' => $post_ID,
             'post_title' => $source_post->post_title,
@@ -57,6 +52,11 @@ class Jetpack_Copy_Post_By_Param {
 
         do_action( 'jetpack_copy_post' );
         wp_update_post( $data );
+
+        // Required to satify get_default_post_to_edit(), which has these filters after post creation.
+        add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
+        add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
+        add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
     }
 
     function filter_title( $post_title, $post ) {

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -68,6 +68,18 @@ class Jetpack_Copy_Post {
 		add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
 		add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
 
+		/**
+		 * Fires after all updates have been performed, and default content filters have been added.
+		 * Allows for any cleanup or post operations, and default content filters can be removed or modified.
+		 *
+		 * @module copy-post
+		 *
+		 * @since 7.0
+		 *
+		 * @param WP_Post $source_post Post object that was copied.
+		 * @param int     $target_post_id Target post ID.
+		 * @param array   $update_results Results of the four update operations, allowing action to be taken.
+		 */
 		do_action( 'jetpack_copy_post', $source_post, $target_post_id, $update_results );
 	}
 
@@ -99,6 +111,19 @@ class Jetpack_Copy_Post {
 			'post_category'  => $source_post->post_category,
 			'tags_input'     => $source_post->tags_input,
 		);
+
+		/**
+		 * Fires just before the target post is updated with its new data.
+		 * Allows for final data adjustments before updating the target post.
+		 *
+		 * @module copy-post
+		 *
+		 * @since 7.0
+		 *
+		 * @param array $data Post data with which to update the target (new) post.
+		 * @param WP_Post $source_post Post object being copied.
+		 * @param int     $target_post_id Target post ID.
+		 */
 		$data = apply_filters( 'jetpack_copy_post_data', $data, $source_post, $target_post_id );
 		return wp_update_post( $data );
 	}

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -46,7 +46,7 @@ class Jetpack_Copy_Post {
 	 * @return void
 	 */
 	public function update_post_data( $target_post_id, $post, $update ) {
-		// This avoids infinite loops of trying to update our updated post.
+		// This `$update` check avoids infinite loops of trying to update our updated post.
 		if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-copy-post' ) || $update ) {
 			return;
 		}

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Module Name: Copy Post
+ * Module Description: Copy an existing post's content into a new post.
+ * Jumpstart Description: Copy an existing post's content into a new post.
+ * Sort Order: 15
+ * First Introduced: 6.9
+ * Requires Connection: No
+ * Auto Activate: Yes
+ * Module Tags: Writing
+ * Feature: Writing
+ * Additional Search Queries: copy, duplicate
+ */
+
+if ( empty( $_GET['copy'] ) ) {
+    return;
+}
+
+class Jetpack_Copy_Post_By_Param {
+    private $post;
+
+    function __construct() {
+        $post = get_post( $_GET['copy'] );
+        error_log($post);
+        if ( ! $post || ! $this->user_can_edit_post( $post ) ) {
+            return;
+        }
+
+        $this->post = $post;
+
+        add_filter( 'default_title', array( $this, 'default_title' ) );
+        add_filter( 'default_content', array( $this, 'default_content' ) );
+        add_filter( 'default_excerpt', array( $this, 'default_excerpt' ) );
+
+        do_action( 'jetpack_post_copy_post' );
+    }
+
+    function default_title() {
+        return $this->post->post_title;
+    }
+
+    function default_content() {
+        return $this->post->post_content;
+    }
+
+    function default_excerpt() {
+        return $this->post->post_excerpt;
+    }
+
+    protected function user_can_edit_post( $post ) {
+        return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
+    }
+}
+
+function jetpack_copy_post_by_param_init() {
+    new Jetpack_Copy_Post_By_Param();
+}
+add_action( 'init', 'jetpack_copy_post_by_param_init' );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -13,178 +13,177 @@
  */
 
 class Jetpack_Copy_Post {
+	/**
+	 * Jetpack_Copy_Post_By_Param constructor.
+	 * Add row actions to post/page/CPT listing screens.
+	 * Process any `?copy` param if on a create new post/page/CPT screen.
+	 *
+	 * @return void
+	 */
+	protected function __construct() {
+		if ( 'edit.php' === $GLOBALS[ 'pagenow' ] ) {
+			add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+			add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+			return;
+		}
 
-    /**
-     * Jetpack_Copy_Post_By_Param constructor.
-     * Add row actions to post/page/CPT listing screens.
-     * Process any `?copy` param if on a create new post/page/CPT screen.
-     *
-     * @return void
-     */
-    function __construct() {
-        if ( 'edit.php' === $GLOBALS[ 'pagenow' ] ) {
-            add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
-            add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
-            return;
-        }
+		if ( ! empty( $_GET[ 'jetpack-copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
+			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
+		}
+	}
 
-        if ( ! empty( $_GET[ 'jetpack-copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
-            add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
-        }
-    }
-
-    /**
-     * Update the new (target) post data with the source post data.
-     *
-     * @param int     $target_post_id Target post ID.
+	/**
+	 * Update the new (target) post data with the source post data.
+	 *
+	 * @param int     $target_post_id Target post ID.
 	 * @param WP_Post $post           Target post object (not used).
 	 * @param bool    $update         Whether this is an existing post being updated or not.
-     * @return void
-     */
-    function update_post_data( $target_post_id, $post, $update ) {
-        // This avoids infinite loops of trying to update our updated post.
-        if ( $update ) {
-            return;
-        }
+	 * @return void
+	 */
+	public function update_post_data( $target_post_id, $post, $update ) {
+		// This avoids infinite loops of trying to update our updated post.
+		if ( $update ) {
+			return;
+		}
 
-        $source_post = get_post( $_GET['jetpack-copy'] );
-        if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
-            return;
-        }
+		$source_post = get_post( $_GET['jetpack-copy'] );
+		if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
+			return;
+		}
 
-        $update_content = $this->update_content_and_taxonomies( $source_post, $target_post_id );
-        $update_featured_image = $this->update_featured_image( $source_post, $target_post_id );
-        $update_post_format = $this->update_post_format( $source_post, $target_post_id );
+		$update_content = $this->update_content_and_taxonomies( $source_post, $target_post_id );
+		$update_featured_image = $this->update_featured_image( $source_post, $target_post_id );
+		$update_post_format = $this->update_post_format( $source_post, $target_post_id );
 
-        // Required to satify get_default_post_to_edit(), which has these filters after post creation.
-        add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
-        add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
-        add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
+		// Required to satify get_default_post_to_edit(), which has these filters after post creation.
+		add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
+		add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
+		add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
 
-        do_action( 'jetpack_copy_post', $source_post, $target_post_id, $update_content, $update_featured_image, $update_post_format );
-    }
+		do_action( 'jetpack_copy_post', $source_post, $target_post_id, $update_content, $update_featured_image, $update_post_format );
+	}
 
-    /**
-     * Determine if the current user has access to the source post.
-     *
+	/**
+	 * Determine if the current user has access to the source post.
+	 *
 	 * @param WP_Post $post Source post object (the post being copied).
-     * @return bool         True if current user is the post author, or has permissions for `edit_others_posts`; false otherwise.
-     */
-    protected function user_can_edit_post( $post ) {
-        return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
-    }
+	 * @return bool         True if current user is the post author, or has permissions for `edit_others_posts`; false otherwise.
+	 */
+	protected function user_can_edit_post( $post ) {
+		return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
+	}
 
-    /**
-     * Update the target post's title, content, excerpt, categories, and tags.
-     *
+	/**
+	 * Update the target post's title, content, excerpt, categories, and tags.
+	 *
 	 * @param WP_Post $source_post Post object to be copied.
-     * @param int     $target_post_id Target post ID.
-     * @return int    0 on failure, or the updated post ID on success.
-     */
-    protected function update_content_and_taxonomies( $source_post, $target_post_id ) {
-        $data = apply_filters( 'jetpack_copy_post_data', array(
-            'ID' => $target_post_id,
-            'post_title' => $source_post->post_title,
-            'post_content' => $source_post->post_content,
-            'post_excerpt' => $source_post->post_excerpt,
-            'post_category' => $source_post->post_category,
-            'tags_input' => $source_post->tags_input,
-        ) );
-        return wp_update_post( $data );
-    }
+	 * @param int     $target_post_id Target post ID.
+	 * @return int    0 on failure, or the updated post ID on success.
+	 */
+	protected function update_content_and_taxonomies( $source_post, $target_post_id ) {
+		$data = apply_filters( 'jetpack_copy_post_data', array(
+			'ID' => $target_post_id,
+			'post_title' => $source_post->post_title,
+			'post_content' => $source_post->post_content,
+			'post_excerpt' => $source_post->post_excerpt,
+			'post_category' => $source_post->post_category,
+			'tags_input' => $source_post->tags_input,
+		) );
+		return wp_update_post( $data );
+	}
 
-    /**
-     * Update the target post's featured image.
-     *
+	/**
+	 * Update the target post's featured image.
+	 *
 	 * @param WP_Post   $source_post Post object to be copied.
-     * @param int       $target_post_id Target post ID.
-     * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure.
-     */
-    protected function update_featured_image( $source_post, $target_post_id ) {
-        $featured_image_id = get_post_thumbnail_id( $source_post );
-        return update_post_meta( $target_post_id, '_thumbnail_id', $featured_image_id );
-    }
+	 * @param int       $target_post_id Target post ID.
+	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure.
+	 */
+	protected function update_featured_image( $source_post, $target_post_id ) {
+		$featured_image_id = get_post_thumbnail_id( $source_post );
+		return update_post_meta( $target_post_id, '_thumbnail_id', $featured_image_id );
+	}
 
-    /**
-     * Update the target post's post format.
-     *
-     * @param WP_Post               $source_post Post object to be copied.
-     * @param int                   $target_post_id Target post ID.
-     * @return array|WP_Error|false WP_Error on error, array of affected term IDs on success.
-     */
-    protected function update_post_format( $source_post, $target_post_id ) {
-        $post_format = get_post_format( $source_post );
-        return set_post_format( $target_post_id, $post_format );
-    }
+	/**
+	 * Update the target post's post format.
+	 *
+	 * @param WP_Post               $source_post Post object to be copied.
+	 * @param int                   $target_post_id Target post ID.
+	 * @return array|WP_Error|false WP_Error on error, array of affected term IDs on success.
+	 */
+	protected function update_post_format( $source_post, $target_post_id ) {
+		$post_format = get_post_format( $source_post );
+		return set_post_format( $target_post_id, $post_format );
+	}
 
-    /**
-     * Update the target post's title.
-     *
-     * @param string  $post_title Post title determined by `get_default_post_to_edit()`.
-     * @param WP_Post $post       Post object of newly-inserted post.
-     * @return string             Updated post title from source post.
-     */
-    function filter_title( $post_title, $post ) {
-        return $post->post_title;
-    }
+	/**
+	 * Update the target post's title.
+	 *
+	 * @param string  $post_title Post title determined by `get_default_post_to_edit()`.
+	 * @param WP_Post $post       Post object of newly-inserted post.
+	 * @return string             Updated post title from source post.
+	 */
+	public function filter_title( $post_title, $post ) {
+		return $post->post_title;
+	}
 
-    /**
-     * Update the target post's content (`post_content`).
-     *
-     * @param string  $post_content Post content determined by `get_default_post_to_edit()`.
-     * @param WP_Post $post         Post object of newly-inserted post.
-     * @return string               Updated post content from source post.
-     */
-    function filter_content( $post_content, $post ) {
-        return $post->post_content;
-    }
+	/**
+	 * Update the target post's content (`post_content`).
+	 *
+	 * @param string  $post_content Post content determined by `get_default_post_to_edit()`.
+	 * @param WP_Post $post         Post object of newly-inserted post.
+	 * @return string               Updated post content from source post.
+	 */
+	public function filter_content( $post_content, $post ) {
+		return $post->post_content;
+	}
 
-    /**
-     * Update the target post's excerpt.
-     *
-     * @param string  $post_excerpt Post excerpt determined by `get_default_post_to_edit()`.
-     * @param WP_Post $post         Post object of newly-inserted post.
-     * @return string               Updated post excerpt from source post.
-     */
-    function filter_excerpt( $post_excerpt, $post ) {
-        return $post->post_excerpt;
-    }
+	/**
+	 * Update the target post's excerpt.
+	 *
+	 * @param string  $post_excerpt Post excerpt determined by `get_default_post_to_edit()`.
+	 * @param WP_Post $post         Post object of newly-inserted post.
+	 * @return string               Updated post excerpt from source post.
+	 */
+	public function filter_excerpt( $post_excerpt, $post ) {
+		return $post->post_excerpt;
+	}
 
-    /**
-     * Add a "Copy" row action to posts/pages/CPTs on list views.
-     *
-     * @param array   $actions Existing actions.
-     * @param WP_Post $post    Post object of current post in list.
-     * @return array           Array of updated row actions.
-     */
-    function add_row_action( $actions, $post ) {
-        $edit_url = add_query_arg( array(
-            'post_type' => $post->post_type,
-            'jetpack-copy' => $post->ID,
-            '_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
-        ), admin_url( 'post-new.php' ) );
-        $edit_action = array(
-            'jetpack-copy' => sprintf(
-                '<a href="%s" aria-label="%s">%s</a>',
-                esc_url( $edit_url ),
-                esc_attr__( 'Copy this post.', 'jetpack' ),
-                esc_html__( 'Copy', 'jetpack' )
-            ),
-        );
+	/**
+	 * Add a "Copy" row action to posts/pages/CPTs on list views.
+	 *
+	 * @param array   $actions Existing actions.
+	 * @param WP_Post $post    Post object of current post in list.
+	 * @return array           Array of updated row actions.
+	 */
+	public function add_row_action( $actions, $post ) {
+		$edit_url = add_query_arg( array(
+			'post_type' => $post->post_type,
+			'jetpack-copy' => $post->ID,
+			'_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
+		), admin_url( 'post-new.php' ) );
+		$edit_action = array(
+			'jetpack-copy' => sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				esc_url( $edit_url ),
+				esc_attr__( 'Copy this post.', 'jetpack' ),
+				esc_html__( 'Copy', 'jetpack' )
+			),
+		);
 
-        // Insert the Copy action before the Trash action.
-        $edit_offset = array_search( 'trash', array_keys( $actions ), true );
-        $actions = array_merge(
-            array_slice( $actions, 0, $edit_offset ),
-            $edit_action,
-            array_slice( $actions, $edit_offset )
-        );
+		// Insert the Copy action before the Trash action.
+		$edit_offset = array_search( 'trash', array_keys( $actions ), true );
+		$actions = array_merge(
+			array_slice( $actions, 0, $edit_offset ),
+			$edit_action,
+			array_slice( $actions, $edit_offset )
+		);
 
-        return $actions;
-    }
+		return $actions;
+	}
 }
 
 function jetpack_copy_post_init() {
-    new Jetpack_Copy_Post();
+	new Jetpack_Copy_Post();
 }
 add_action( 'admin_init', 'jetpack_copy_post_init' );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -53,7 +53,15 @@ class Jetpack_Copy_Post_By_Param {
 
         // Featured Image
         $featured_image_id = get_post_thumbnail_id( $source_post );
-        update_post_meta( $post_ID, '_thumbnail_id', $featured_image_id );
+        if ( $featured_image_id ) {
+            update_post_meta( $post_ID, '_thumbnail_id', $featured_image_id );
+        }
+
+        // Post Formats
+        $post_format = get_post_format( $source_post );
+        if ( $post_format ) {
+            set_post_format( $post_ID, $post_format );
+        }
 
         do_action( 'jetpack_copy_post' );
 

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -56,7 +56,7 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
-		$update_content        = $this->update_content_and_taxonomies( $source_post, $target_post_id );
+		$update_content        = $this->update_content( $source_post, $target_post_id );
 		$update_featured_image = $this->update_featured_image( $source_post, $target_post_id );
 		$update_post_format    = $this->update_post_format( $source_post, $target_post_id );
 
@@ -85,14 +85,16 @@ class Jetpack_Copy_Post {
 	 * @param int     $target_post_id Target post ID.
 	 * @return int    0 on failure, or the updated post ID on success.
 	 */
-	protected function update_content_and_taxonomies( $source_post, $target_post_id ) {
+	protected function update_content( $source_post, $target_post_id ) {
 		$data = array(
-			'ID'            => $target_post_id,
-			'post_title'    => $source_post->post_title,
-			'post_content'  => $source_post->post_content,
-			'post_excerpt'  => $source_post->post_excerpt,
-			'post_category' => $source_post->post_category,
-			'tags_input'    => $source_post->tags_input,
+			'ID'             => $target_post_id,
+			'post_title'     => $source_post->post_title,
+			'post_content'   => $source_post->post_content,
+			'post_excerpt'   => $source_post->post_excerpt,
+			'comment_status' => $source_post->comment_status,
+			'ping_status'    => $source_post->ping_status,
+			'post_category'  => $source_post->post_category,
+			'tags_input'     => $source_post->tags_input,
 		);
 		$data = apply_filters( 'jetpack_copy_post_data', $data, $source_post, $target_post_id );
 		return wp_update_post( $data );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -12,6 +12,9 @@
  * Additional Search Queries: copy, duplicate
  */
 
+/**
+ * Copy Post class.
+ */
 class Jetpack_Copy_Post {
 	/**
 	 * Jetpack_Copy_Post_By_Param constructor.
@@ -21,13 +24,13 @@ class Jetpack_Copy_Post {
 	 * @return void
 	 */
 	protected function __construct() {
-		if ( 'edit.php' === $GLOBALS[ 'pagenow' ] ) {
+		if ( 'edit.php' === $GLOBALS['pagenow'] ) {
 			add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 			add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 			return;
 		}
 
-		if ( ! empty( $_GET[ 'jetpack-copy' ] ) && 'post-new.php' === $GLOBALS[ 'pagenow' ] ) {
+		if ( ! empty( $_GET['jetpack-copy'] ) && 'post-new.php' === $GLOBALS['pagenow'] ) {
 			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
 		}
 	}
@@ -51,9 +54,9 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
-		$update_content = $this->update_content_and_taxonomies( $source_post, $target_post_id );
+		$update_content        = $this->update_content_and_taxonomies( $source_post, $target_post_id );
 		$update_featured_image = $this->update_featured_image( $source_post, $target_post_id );
-		$update_post_format = $this->update_post_format( $source_post, $target_post_id );
+		$update_post_format    = $this->update_post_format( $source_post, $target_post_id );
 
 		// Required to satify get_default_post_to_edit(), which has these filters after post creation.
 		add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
@@ -81,22 +84,23 @@ class Jetpack_Copy_Post {
 	 * @return int    0 on failure, or the updated post ID on success.
 	 */
 	protected function update_content_and_taxonomies( $source_post, $target_post_id ) {
-		$data = apply_filters( 'jetpack_copy_post_data', array(
-			'ID' => $target_post_id,
-			'post_title' => $source_post->post_title,
-			'post_content' => $source_post->post_content,
-			'post_excerpt' => $source_post->post_excerpt,
+		$data = array(
+			'ID'            => $target_post_id,
+			'post_title'    => $source_post->post_title,
+			'post_content'  => $source_post->post_content,
+			'post_excerpt'  => $source_post->post_excerpt,
 			'post_category' => $source_post->post_category,
-			'tags_input' => $source_post->tags_input,
-		) );
+			'tags_input'    => $source_post->tags_input,
+		);
+		$data = apply_filters( 'jetpack_copy_post_data', $data, $source_post, $target_post_id );
 		return wp_update_post( $data );
 	}
 
 	/**
 	 * Update the target post's featured image.
 	 *
-	 * @param WP_Post   $source_post Post object to be copied.
-	 * @param int       $target_post_id Target post ID.
+	 * @param WP_Post $source_post Post object to be copied.
+	 * @param int     $target_post_id Target post ID.
 	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure.
 	 */
 	protected function update_featured_image( $source_post, $target_post_id ) {
@@ -107,8 +111,8 @@ class Jetpack_Copy_Post {
 	/**
 	 * Update the target post's post format.
 	 *
-	 * @param WP_Post               $source_post Post object to be copied.
-	 * @param int                   $target_post_id Target post ID.
+	 * @param WP_Post $source_post Post object to be copied.
+	 * @param int     $target_post_id Target post ID.
 	 * @return array|WP_Error|false WP_Error on error, array of affected term IDs on success.
 	 */
 	protected function update_post_format( $source_post, $target_post_id ) {
@@ -157,11 +161,14 @@ class Jetpack_Copy_Post {
 	 * @return array           Array of updated row actions.
 	 */
 	public function add_row_action( $actions, $post ) {
-		$edit_url = add_query_arg( array(
-			'post_type' => $post->post_type,
-			'jetpack-copy' => $post->ID,
-			'_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
-		), admin_url( 'post-new.php' ) );
+		$edit_url    = add_query_arg(
+			array(
+				'post_type'    => $post->post_type,
+				'jetpack-copy' => $post->ID,
+				'_wpnonce'     => wp_create_nonce( 'jetpack-copy-post' ),
+			),
+			admin_url( 'post-new.php' )
+		);
 		$edit_action = array(
 			'jetpack-copy' => sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
@@ -173,7 +180,7 @@ class Jetpack_Copy_Post {
 
 		// Insert the Copy action before the Trash action.
 		$edit_offset = array_search( 'trash', array_keys( $actions ), true );
-		$actions = array_merge(
+		$actions     = array_merge(
 			array_slice( $actions, 0, $edit_offset ),
 			$edit_action,
 			array_slice( $actions, $edit_offset )
@@ -183,6 +190,9 @@ class Jetpack_Copy_Post {
 	}
 }
 
+/**
+ * Instantiate an instance of Jetpack_Copy_Post on the `admin_init` hook.
+ */
 function jetpack_copy_post_init() {
 	new Jetpack_Copy_Post();
 }

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -167,8 +167,8 @@ class Jetpack_Copy_Post {
             'jetpack-copy' => sprintf(
                 '<a href="%s" aria-label="%s">%s</a>',
                 esc_url( $edit_url ),
-                esc_attr( __( 'Copy this post.' ) ),
-                __( 'Copy' )
+                esc_attr__( 'Copy this post.', 'jetpack' ),
+                esc_html__( 'Copy', 'jetpack' )
             ),
         );
 

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -77,6 +77,7 @@ class Jetpack_Copy_Post_By_Param {
 
     function add_row_action( $actions, $post ) {
         $edit_url = add_query_arg( array(
+            'post_type' => $post->post_type,
             'copy' => $post->ID,
             '_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
         ), admin_url( 'post-new.php' ) );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -49,9 +49,13 @@ class Jetpack_Copy_Post_By_Param {
             'post_category' => $source_post->post_category,
             'tags_input' => $source_post->tags_input,
         ) );
+        wp_update_post( $data );
+
+        // Featured Image
+        $featured_image_id = get_post_thumbnail_id( $source_post );
+        update_post_meta( $post_ID, '_thumbnail_id', $featured_image_id );
 
         do_action( 'jetpack_copy_post' );
-        wp_update_post( $data );
 
         // Required to satify get_default_post_to_edit(), which has these filters after post creation.
         add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -23,7 +23,7 @@ class Jetpack_Copy_Post {
 	 *
 	 * @return void
 	 */
-	protected function __construct() {
+	public function __construct() {
 		if ( 'edit.php' === $GLOBALS['pagenow'] ) {
 			add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 			add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -30,7 +30,9 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
-		if ( ! empty( $_GET['jetpack-copy'] ) && 'post-new.php' === $GLOBALS['pagenow'] ) {
+		if ( ! empty( $_GET['jetpack-copy'] ) &&
+			wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-copy-post' ) &&
+			'post-new.php' === $GLOBALS['pagenow'] ) {
 			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
 		}
 	}

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -30,9 +30,7 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
-		if ( ! empty( $_GET['jetpack-copy'] ) &&
-			wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-copy-post' ) &&
-			'post-new.php' === $GLOBALS['pagenow'] ) {
+		if ( ! empty( $_GET['jetpack-copy'] ) && 'post-new.php' === $GLOBALS['pagenow'] ) {
 			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
 		}
 	}
@@ -47,7 +45,7 @@ class Jetpack_Copy_Post {
 	 */
 	public function update_post_data( $target_post_id, $post, $update ) {
 		// This `$update` check avoids infinite loops of trying to update our updated post.
-		if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-copy-post' ) || $update ) {
+		if ( $update ) {
 			return;
 		}
 
@@ -279,7 +277,6 @@ class Jetpack_Copy_Post {
 			array(
 				'post_type'    => $post->post_type,
 				'jetpack-copy' => $post->ID,
-				'_wpnonce'     => wp_create_nonce( 'jetpack-copy-post' ),
 			),
 			admin_url( 'post-new.php' )
 		);

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -6,53 +6,91 @@
  * Sort Order: 15
  * First Introduced: 6.9
  * Requires Connection: No
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Writing
  * Feature: Writing
  * Additional Search Queries: copy, duplicate
  */
 
-if ( empty( $_GET['copy'] ) ) {
-    return;
-}
-
 class Jetpack_Copy_Post_By_Param {
-    private $post;
-
     function __construct() {
-        $post = get_post( $_GET['copy'] );
-        error_log($post);
-        if ( ! $post || ! $this->user_can_edit_post( $post ) ) {
-            return;
+        if ( ! empty( $_GET[ 'copy' ] ) ) {
+            add_filter( 'wp_insert_post_data', array( $this, 'filter_post_data' ) );
         }
 
-        $this->post = $post;
-
-        add_filter( 'default_title', array( $this, 'default_title' ) );
-        add_filter( 'default_content', array( $this, 'default_content' ) );
-        add_filter( 'default_excerpt', array( $this, 'default_excerpt' ) );
-
-        do_action( 'jetpack_post_copy_post' );
-    }
-
-    function default_title() {
-        return $this->post->post_title;
-    }
-
-    function default_content() {
-        return $this->post->post_content;
-    }
-
-    function default_excerpt() {
-        return $this->post->post_excerpt;
+        add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+        add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );
     }
 
     protected function user_can_edit_post( $post ) {
-        return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
+        return get_current_user_id() === (int) $post[ 'post_author' ] || current_user_can( 'edit_others_posts' );
+    }
+
+    function filter_post_data( $data ) {
+        $source_post = get_post( $_GET['copy'], ARRAY_A );
+        if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
+            return $data;
+        }
+
+        // Required to satify get_default_post_to_edit(), which has these filters after post creation.
+        add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
+        add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
+        add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
+
+        $data = array_merge(
+            $data,
+            array(
+                'post_title' => $source_post[ 'post_title' ],
+                'post_content' => $source_post[ 'post_content' ],
+                'post_excerpt' => $source_post[ 'post_excerpt' ],
+            )
+        );
+
+        $data = apply_filters( 'jetpack_copy_post_data', $data );
+
+        do_action( 'jetpack_copy_post' );
+        return $data;
+    }
+
+    function filter_title( $post_title, $post ) {
+        return $post->post_title;
+    }
+
+    function filter_content( $post_content, $post ) {
+        return $post->post_content;
+    }
+
+    function filter_excerpt( $post_excerpt, $post ) {
+        return $post->post_excerpt;
+    }
+
+    function add_row_action( $actions, $post ) {
+        $edit_url = add_query_arg( array(
+            'copy' => $post->ID,
+            '_wpnonce' => wp_create_nonce( 'jetpack-copy-post' ),
+        ), admin_url( 'post-new.php' ) );
+        $edit_action = array(
+            'copy' => sprintf(
+                '<a href="%s" aria-label="%s">%s</a>',
+                esc_url( $edit_url ),
+                esc_attr( __( 'Copy this post.' ) ),
+                __( 'Copy' )
+            ),
+        );
+
+        // Insert the Copy action before the Trash action.
+        $edit_offset = array_search( 'trash', array_keys( $actions ), true );
+        $actions = array_merge(
+            array_slice( $actions, 0, $edit_offset ),
+            $edit_action,
+            array_slice( $actions, $edit_offset )
+        );
+
+        return $actions;
     }
 }
 
 function jetpack_copy_post_by_param_init() {
     new Jetpack_Copy_Post_By_Param();
 }
-add_action( 'init', 'jetpack_copy_post_by_param_init' );
+add_action( 'admin_init', 'jetpack_copy_post_by_param_init' );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -77,7 +77,7 @@ class Jetpack_Copy_Post {
 		 *
 		 * @module copy-post
 		 *
-		 * @since 7.0
+		 * @since 7.0.0
 		 *
 		 * @param WP_Post $source_post Post object that was copied.
 		 * @param int     $target_post_id Target post ID.
@@ -121,7 +121,7 @@ class Jetpack_Copy_Post {
 		 *
 		 * @module copy-post
 		 *
-		 * @since 7.0
+		 * @since 7.0.0
 		 *
 		 * @param array $data Post data with which to update the target (new) post.
 		 * @param WP_Post $source_post Post object being copied.
@@ -249,7 +249,7 @@ class Jetpack_Copy_Post {
 		 *
 		 * @module copy-post
 		 *
-		 * @since 7.0
+		 * @since 7.0.0
 		 *
 		 * @param bool  $post_type_supported If the given post type is a valid supported psot type.
 		 * @param array $valid_post_types Supported post types.

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -28,7 +28,7 @@ class Jetpack_Copy_Post_By_Param {
     }
 
     protected function user_can_edit_post( $post ) {
-        return get_current_user_id() === (int) $post[ 'post_author' ] || current_user_can( 'edit_others_posts' );
+        return get_current_user_id() === (int) $post->post_author || current_user_can( 'edit_others_posts' );
     }
 
     function update_post_data( $post_ID, $post, $update ) {
@@ -36,7 +36,7 @@ class Jetpack_Copy_Post_By_Param {
             return;
         }
 
-        $source_post = get_post( $_GET['copy'], ARRAY_A );
+        $source_post = get_post( $_GET['copy'] );
         if ( ! $source_post || ! $this->user_can_edit_post( $source_post ) ) {
             return;
         }
@@ -48,11 +48,11 @@ class Jetpack_Copy_Post_By_Param {
 
         $data = apply_filters( 'jetpack_copy_post_data', array(
             'ID' => $post_ID,
-            'post_title' => $source_post[ 'post_title' ],
-            'post_content' => $source_post[ 'post_content' ],
-            'post_excerpt' => $source_post[ 'post_excerpt' ],
-            'post_category' => $source_post[ 'post_category' ],
-            'tags_input' => $source_post[ 'tags_input' ],
+            'post_title' => $source_post->post_title,
+            'post_content' => $source_post->post_content,
+            'post_excerpt' => $source_post->post_excerpt,
+            'post_category' => $source_post->post_category,
+            'tags_input' => $source_post->tags_input,
         ) );
 
         do_action( 'jetpack_copy_post' );

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -4,7 +4,7 @@
  * Module Description: Copy an existing post's content into a new post.
  * Jumpstart Description: Copy an existing post's content into a new post.
  * Sort Order: 15
- * First Introduced: 6.9
+ * First Introduced: 7.0
  * Requires Connection: No
  * Auto Activate: No
  * Module Tags: Writing

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -237,14 +237,6 @@ class Jetpack_Copy_Post {
 	 * @return bool True if the post type is in a list of supported psot types; false otherwise.
 	 */
 	protected function validate_post_type( $post ) {
-		$valid_post_types    = array(
-			'post',
-			'page',
-			'jetpack-testimonial',
-			'jetpack-portfolio',
-		);
-		$post_type_supported = in_array( $post->post_type, $valid_post_types, true );
-
 		/**
 		 * Fires when determining if the "Copy" row action should be made available.
 		 * Allows overriding supported post types.
@@ -253,11 +245,20 @@ class Jetpack_Copy_Post {
 		 *
 		 * @since 7.0.0
 		 *
-		 * @param bool  $post_type_supported If the given post type is a valid supported psot type.
-		 * @param array $valid_post_types Supported post types.
+		 * @param array   Post types supported by default.
 		 * @param WP_Post $post Post object of current post in listing.
 		 */
-		return apply_filters( 'jetpack_copy_post_post_types', $post_type_supported, $valid_post_types, $post );
+		$valid_post_types = apply_filters(
+			'jetpack_copy_post_post_types',
+			array(
+				'post',
+				'page',
+				'jetpack-testimonial',
+				'jetpack-portfolio',
+			),
+			$post
+		);
+		return in_array( $post->post_type, $valid_post_types, true );
 	}
 
 	/**

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -45,7 +45,7 @@ class Jetpack_Copy_Post {
 	 */
 	public function update_post_data( $target_post_id, $post, $update ) {
 		// This avoids infinite loops of trying to update our updated post.
-		if ( $update ) {
+		if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-copy-post' ) || $update ) {
 			return;
 		}
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -39,6 +39,12 @@ function jetpack_get_module_i18n( $key ) {
 				'recommended description' => _x( 'Adds a button to your post and page editors, allowing you to build simple forms to help visitors stay in touch.', 'Jumpstart Description', 'jetpack' ),
 			),
 
+			'copy-post' => array(
+				'name' => _x( 'Copy Post', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Copy an existing post\'s content into a new post.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Copy an existing post\'s content into a new post.', 'Jumpstart Description', 'jetpack' ),
+			),
+
 			'custom-content-types' => array(
 				'name' => _x( 'Custom content types', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Display different types of content on your site with custom content types.', 'Module Description', 'jetpack' ),
@@ -265,6 +271,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 
 			// Modules with `Writing` tag:
 			//  - modules/after-the-deadline.php
+			//  - modules/copy-post.php
 			//  - modules/custom-content-types.php
 			//  - modules/enhanced-distribution.php
 			//  - modules/json-api.php

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -699,3 +699,11 @@ function jetpack_assetcdn_more_info() {
 	);
 }
 add_action( 'jetpack_module_more_info_photon-cdn', 'jetpack_assetcdn_more_info' );
+
+/**
+ * Copy A Post
+ */
+function jetpack_more_info_copy_post() {
+	esc_html_e( 'Create a new post based on an existing post.', 'jetpack' );
+}
+add_action( 'jetpack_module_more_info_copy-post', 'jetpack_more_info_copy_post' );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -701,7 +701,7 @@ function jetpack_assetcdn_more_info() {
 add_action( 'jetpack_module_more_info_photon-cdn', 'jetpack_assetcdn_more_info' );
 
 /**
- * Copy A Post
+ * Copy Post
  */
 function jetpack_more_info_copy_post() {
 	esc_html_e( 'Create a new post based on an existing post.', 'jetpack' );


### PR DESCRIPTION
This PR adds the Copy Post feature, already available on WordPress.com (as "Duplicate" in the post edit More menu). It is added as a searchable module (not autoactivated), part of the main Writing feature.

#### Changes proposed in this Pull Request:

A new `Copy` item is added to row actions in the post list view. Clicking the link redirects to `/wp-admin/post-new.php?jetpack-copy=postId`, and loads the new draft post with the following properties of the source post:  **title, content, except, featured image, post type, post format, categories, and tags**.

<img width="396" alt="screen shot 2019-01-04 at 1 14 55 pm" src="https://user-images.githubusercontent.com/349751/50861782-96ce7380-134e-11e9-95aa-ed50700a411e.png">

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the module by searching for it in `/wp-admin/admin.php?page=jetpack#/settings`.
* Create a test post that has the following: title, content, except, featured image, post format, categories, and tags (be sure the theme supports Post Formats, like Twenty Seventeen; Twenty Nineteen does not).
* From `/wp-admin/edit.php`, hover over the test post and then click `Copy`.
* Verify the draft post that loads contains all of the data from the existing post.
* Publish, and verify all information was saved without errors.
* Repeat the same with pages and a custom post type.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* new feature: Copy Post. Add a new post based on an existing post.
