### PR TITLE
Ensure the subscription form respects whether to show subscriber count

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -695,7 +695,7 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( empty( $instance ) || ! is_array( $instance ) ) {
 		$instance = array();
 	}
-	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) ? false : true;
+	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
 	$show_only_email_and_button         = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
 
 	$instance = shortcode_atts(


### PR DESCRIPTION
The subscription widget appears to have suffered a regression and no longer respects the setting to show subscriber count.

Before:

<img width="612" alt="screen shot 2019-01-08 at 5 56 25 pm" src="https://user-images.githubusercontent.com/3246867/50864072-df962480-136e-11e9-9cfc-cbdaef9341a2.png">

After:

<img width="549" alt="screen shot 2019-01-08 at 5 56 53 pm" src="https://user-images.githubusercontent.com/3246867/50864094-f2a8f480-136e-11e9-93f4-b570897a1d95.png">

#### Changes proposed in this Pull Request:

This PR ensures the subscription widget conditionally displays the subscriber count.

#### Testing instructions:

Add a Subscription widget. Toggle whether to show the subscriber count and ensure the published page reflects the setting as per the screen shots above.

#### Proposed changelog entry for your changes:
No changelog entry needed
