### PR TITLE
Publicize / Subs: do not show pushed message for private posts

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -1040,7 +1040,7 @@ abstract class Publicize_Base {
 		}
 
 		// Bail early if the post is private.
-		if ( 'private' === $post->post_status ) {
+		if ( 'publish' !== $post->post_status ) {
 			return $messages;
 		}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -1038,6 +1038,12 @@ abstract class Publicize_Base {
 		if ( ! $this->post_type_is_publicizeable( $post_type ) ) {
 			return $messages;
 		}
+
+		// Bail early if the post is private.
+		if ( 'private' === $post->post_status ) {
+			return $messages;
+		}
+
 		$view_post_link_html = '';
 		$viewable = is_post_type_viewable( $post_type_object );
 		if ( $viewable ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -211,6 +211,11 @@ class Jetpack_Subscriptions {
 			return false;
 		}
 
+		// Private posts are not sent to subscribers.
+		if ( 'private' === $post->post_status ) {
+			return false;
+		}
+
 		/**
 		 * Array of categories that will never trigger subscription emails.
 		 *


### PR DESCRIPTION
Fixes #11109 

#### Changes proposed in this Pull Request:

In the old editor, we display messages at the top of the editor when a post has been published and sent to subscribers and / or posted to linked Social Media sites.

![image](https://user-images.githubusercontent.com/426388/50906100-a6b88700-1424-11e9-9d0a-c661ff13e1c2.png)

Since our Subscriptions and Publicize modules are not triggered for private posts, let's not show that message when a private post is created.

#### Testing instructions:

* Start on a site with Publicize and Subs active and configured (at least one Social Media profile connected).
* Install the classic editor plugin on your site.
* Write a new post.
* Change its status to Private in the options above the Publish button.
* click update.
* Make sure no message appears at the top of the page about Publicize or Subscriptions.
* Repeat with only Publicize active, and only Subscriptions.
* Repeat with a public post; the message should appear.
* Repeat with a scheduled post; the message should appear.

#### Proposed changelog entry for your changes:

* Publicize / Subscriptions: do not show message at the top of the editor when creating a private post.
