### PR TITLE
Shorten subscriber widget show_subscribers_check

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -695,7 +695,7 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( empty( $instance ) || ! is_array( $instance ) ) {
 		$instance = array();
 	}
-	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
+	$instance['show_subscribers_total'] = ! empty( $instance['show_subscribers_total'] ) && 'false' !== $instance['show_subscribers_total'];
 	$show_only_email_and_button         = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
 
 	$instance = shortcode_atts(


### PR DESCRIPTION
This PR shortens the logic for determining whether to show the subscriber count in the subscription widget.

#### Changes proposed in this Pull Request:

This PR shortens the logic for determining whether to show the subscriber count in the subscription widget.

#### Testing instructions:

Add a Subscription widget. Toggle whether to show the subscriber count and ensure the published page reflects the setting as per the screen shots above.

#### Proposed changelog entry for your changes:

No changelog entry needed.