### PR TITLE
Blocks: update to latest version of blocks for 6.9 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "11.0.0",
+    "@automattic/jetpack-blocks": "11.1.0",
     "babel-core": "6.26.3",
     "babel-eslint": "6.1.2",
     "babel-loader": "7.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,9 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-11.0.0.tgz#588a7996b6a63c57af2b2926dcf14eaa59d44190"
+"@automattic/jetpack-blocks@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-11.1.0.tgz#780917d46812238944e7505b18b3cb4bb8b87767"
 
 "@babel/code-frame@7.0.0-beta.46":
   version "7.0.0-beta.46"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Blocks: update to latest version of blocks for 6.9 release

The blocks were released here:
https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4011.1.0

#### Testing instructions:

* Open your block editor.
* Do you see blocks?
* 💥

#### Proposed changelog entry for your changes:

* None
