### PR TITLE
Subscription block use new button component

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -694,11 +694,9 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( empty( $instance ) || ! is_array( $instance ) ) {
 		$instance = array();
 	}
-	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
-	$show_only_email_and_button         = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
-	$submit_button_text                 = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
-	$instance['show_only_email_and_button'] = $show_only_email_and_button;
-	$instance['submit_button_text']         = $submit_button_text;
+	$instance['show_subscribers_total']     = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
+	$show_only_email_and_button             = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
+	$submit_button_text                     = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
 
 	// Build up a string with the submit button's classes and styles and set it on the instance
 	$submit_button_classes_and_styles   = isset( $instance['submit_button_classes'] ) ? "class = \"{$instance['submit_button_classes']}\" " : '';
@@ -707,10 +705,10 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( $custom_background_button_color || $custom_text_button_color ) {
 		$submit_button_classes_and_styles .= ' style="';
 		if ( $custom_background_button_color ) {
-			$submit_button_classes_and_styles .= 'background-color: ' . $custom_background_button_color . '; ';
+			$submit_button_classes_and_styles .= 'background-color: ' . esc_attr( $custom_background_button_color ) . '; ';
 		}
 		if ( $custom_text_button_color ) {
-			$submit_button_classes_and_styles .= 'color: ' . $custom_text_button_color . ';';
+			$submit_button_classes_and_styles .= 'color: ' . esc_attr( $custom_text_button_color ) . ';';
 		}
 		$submit_button_classes_and_styles .= '"';
 	}
@@ -721,7 +719,10 @@ function jetpack_do_subscription_form( $instance ) {
 		'jetpack_subscription_form'
 	);
 
-	error_log("CLASSES AND STYLES: " . $submit_button_classes_and_styles);
+	// These must come after the call to shortcode_atts()
+	$instance['submit_button_text']         = $submit_button_text;
+	$instance['show_only_email_and_button'] = $show_only_email_and_button;
+
 	if ( $submit_button_classes_and_styles ) {
 		$instance['submit_button_classes_and_styles'] = $submit_button_classes_and_styles;
 	}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -241,13 +241,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$referer                    = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$source                     = 'widget';
 		$widget_id                  = esc_attr( ! empty( $args['widget_id'] ) ? esc_attr( $args['widget_id'] ) : mt_rand( 450, 550 ) );
-		$subscribe_button           = isset( $instance['submit_button_text'] ) ? $instance['subscribe_button_text'] : $instance['subscribe_button'];
+		$subscribe_button           = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
 		$subscribers_total          = self::fetch_subscriber_count();
 		$subscribe_placeholder      = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
-
-		if ( isset( $instance['submit_button_text'] ) ) {
-			'class="' . esc_attr( $instance['submit_button_classes'] ) . '" style="' . $instance['custom_background_button_color'] )
-		}
+		$submit_button_classes_and_styles = isset( $instance['submit_button_classes_and_styles'] ) ? $instance['submit_button_classes_and_styles'] : '';
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;
@@ -291,7 +288,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
                     <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"/>
+                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?> <?php echo $submit_button_classes_and_styles ?>"/>
                 </p>
             </form>
 			<?php
@@ -343,7 +340,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
 						}
 						?>
-                        <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"
+                        <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>" <?php echo $submit_button_classes_and_styles ?>
                                name="jetpack_subscriptions_widget"/>
                     </p>
 				<?php } ?>
@@ -699,10 +696,24 @@ function jetpack_do_subscription_form( $instance ) {
 	}
 	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
 	$show_only_email_and_button         = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
-	$submit_button_classes              = isset( $instance['submit_button_classes'] ) ? $instance['submit_button_classes'] : '';
+	$submit_button_text                 = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
+	$instance['show_only_email_and_button'] = $show_only_email_and_button;
+	$instance['submit_button_text']         = $submit_button_text;
+
+	// Build up a string with the submit button's classes and styles and set it on the instance
+	$submit_button_classes_and_styles   = isset( $instance['submit_button_classes'] ) ? "class = \"{$instance['submit_button_classes']}\" " : '';
 	$custom_background_button_color     = isset( $instance['custom_background_button_color'] ) ? $instance['custom_background_button_color'] : '';
 	$custom_text_button_color           = isset( $instance['custom_text_button_color'] ) ? $instance['custom_text_button_color'] : '';
-	$submit_button_text                 = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
+	if ( $custom_background_button_color || $custom_text_button_color ) {
+		$submit_button_classes_and_styles .= ' style="';
+		if ( $custom_background_button_color ) {
+			$submit_button_classes_and_styles .= 'background-color: ' . $custom_background_button_color . '; ';
+		}
+		if ( $custom_text_button_color ) {
+			$submit_button_classes_and_styles .= 'color: ' . $custom_text_button_color . ';';
+		}
+		$submit_button_classes_and_styles .= '"';
+	}
 
 	$instance = shortcode_atts(
 		Jetpack_Subscriptions_Widget::defaults(),
@@ -710,11 +721,10 @@ function jetpack_do_subscription_form( $instance ) {
 		'jetpack_subscription_form'
 	);
 
-	$instance['show_only_email_and_button'] = $show_only_email_and_button;
-	$instance['submit_button_classes'] = $submit_button_classes;
-	$instance['custom_background_button_color'] = $custom_background_button_color;
-	$instance['custom_text_button_color'] = $custom_text_button_color;
-	$instance['submit_button_text'] = $submit_button_text;
+	error_log("CLASSES AND STYLES: " . $submit_button_classes_and_styles);
+	if ( $submit_button_classes_and_styles ) {
+		$instance['submit_button_classes_and_styles'] = $submit_button_classes_and_styles;
+	}
 
 	$args = array(
 		'before_widget' => '<div class="jetpack_subscription_widget">',

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -241,9 +241,13 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$referer                    = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$source                     = 'widget';
 		$widget_id                  = esc_attr( ! empty( $args['widget_id'] ) ? esc_attr( $args['widget_id'] ) : mt_rand( 450, 550 ) );
-		$subscribe_button           = stripslashes( $instance['subscribe_button'] );
+		$subscribe_button           = isset( $instance['submit_button_text'] ) ? $instance['subscribe_button_text'] : $instance['subscribe_button'];
 		$subscribers_total          = self::fetch_subscriber_count();
 		$subscribe_placeholder      = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
+
+		if ( isset( $instance['submit_button_text'] ) ) {
+			'class="' . esc_attr( $instance['submit_button_classes'] ) . '" style="' . $instance['custom_background_button_color'] )
+		}
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;
@@ -695,6 +699,10 @@ function jetpack_do_subscription_form( $instance ) {
 	}
 	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
 	$show_only_email_and_button         = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
+	$submit_button_classes              = isset( $instance['submit_button_classes'] ) ? $instance['submit_button_classes'] : '';
+	$custom_background_button_color     = isset( $instance['custom_background_button_color'] ) ? $instance['custom_background_button_color'] : '';
+	$custom_text_button_color           = isset( $instance['custom_text_button_color'] ) ? $instance['custom_text_button_color'] : '';
+	$submit_button_text                 = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
 
 	$instance = shortcode_atts(
 		Jetpack_Subscriptions_Widget::defaults(),
@@ -703,6 +711,10 @@ function jetpack_do_subscription_form( $instance ) {
 	);
 
 	$instance['show_only_email_and_button'] = $show_only_email_and_button;
+	$instance['submit_button_classes'] = $submit_button_classes;
+	$instance['custom_background_button_color'] = $custom_background_button_color;
+	$instance['custom_text_button_color'] = $custom_text_button_color;
+	$instance['submit_button_text'] = $submit_button_text;
 
 	$args = array(
 		'before_widget' => '<div class="jetpack_subscription_widget">',

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -241,10 +241,11 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$referer                    = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$source                     = 'widget';
 		$widget_id                  = esc_attr( ! empty( $args['widget_id'] ) ? esc_attr( $args['widget_id'] ) : mt_rand( 450, 550 ) );
-		$subscribe_button           = isset( $instance['submit_button_text'] ) && ! empty( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
+		$subscribe_button           = ! empty( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
 		$subscribers_total          = self::fetch_subscriber_count();
 		$subscribe_placeholder      = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
-		$submit_button_classes_and_styles = isset( $instance['submit_button_classes_and_styles'] ) ? $instance['submit_button_classes_and_styles'] : '';
+		$submit_button_classes      = isset( $instance['submit_button_classes'] ) ? $instance['submit_button_classes'] : '';
+		$submit_button_styles       = isset( $instance['submit_button_styles'] ) ? $instance['submit_button_styles'] : '';
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;
@@ -288,7 +289,14 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
                     <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>" <?php echo $submit_button_classes_and_styles ?>/>
+                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"
+	                    <?php if ( ! empty( $submit_button_classes ) ) { ?>
+	                        class="<?php echo esc_attr( $submit_button_classes ); ?>"
+	                    <?php }; ?>
+		                <?php if ( ! empty( $submit_button_styles ) ) { ?>
+			                style="<?php echo esc_attr( $submit_button_styles ); ?>"
+		                <?php }; ?>
+	                />
                 </p>
             </form>
 			<?php
@@ -340,8 +348,15 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
 						}
 						?>
-                        <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>" <?php echo $submit_button_classes_and_styles ?>
-                               name="jetpack_subscriptions_widget"/>
+                        <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"
+	                        <?php if ( ! empty( $submit_button_classes ) ) { ?>
+	                            class="<?php echo esc_attr( $submit_button_classes ); ?>"
+                            <?php }; ?>
+		                    <?php if ( ! empty( $submit_button_styles ) ) { ?>
+			                    style="<?php echo esc_attr( $submit_button_styles ); ?>"
+		                    <?php }; ?>
+	                        name="jetpack_subscriptions_widget"
+	                    />
                     </p>
 				<?php } ?>
             </form>
@@ -699,18 +714,13 @@ function jetpack_do_subscription_form( $instance ) {
 	$submit_button_text                     = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
 
 	// Build up a string with the submit button's classes and styles and set it on the instance
-	$submit_button_classes_and_styles   = isset( $instance['submit_button_classes'] ) ? "class = \"{$instance['submit_button_classes']}\" " : '';
-	$custom_background_button_color     = isset( $instance['custom_background_button_color'] ) ? $instance['custom_background_button_color'] : '';
-	$custom_text_button_color           = isset( $instance['custom_text_button_color'] ) ? $instance['custom_text_button_color'] : '';
-	if ( $custom_background_button_color || $custom_text_button_color ) {
-		$submit_button_classes_and_styles .= ' style="';
-		if ( $custom_background_button_color ) {
-			$submit_button_classes_and_styles .= 'background-color: ' . esc_attr( $custom_background_button_color ) . '; ';
-		}
-		if ( $custom_text_button_color ) {
-			$submit_button_classes_and_styles .= 'color: ' . esc_attr( $custom_text_button_color ) . ';';
-		}
-		$submit_button_classes_and_styles .= '"';
+	$submit_button_classes = isset( $instance['submit_button_classes'] ) ? $instance['submit_button_classes'] : '';
+	$submit_button_styles = '';
+	if ( isset( $instance['custom_background_button_color'] ) ) {
+		$submit_button_styles .= 'background-color: ' . $instance['custom_background_button_color'] . '; ';
+	}
+	if ( isset( $instance['custom_text_button_color'] ) ) {
+		$submit_button_styles .= 'color: ' . $instance['custom_text_button_color'] . ';';
 	}
 
 	$instance = shortcode_atts(
@@ -722,9 +732,11 @@ function jetpack_do_subscription_form( $instance ) {
 	// These must come after the call to shortcode_atts()
 	$instance['submit_button_text']         = $submit_button_text;
 	$instance['show_only_email_and_button'] = $show_only_email_and_button;
-
-	if ( $submit_button_classes_and_styles ) {
-		$instance['submit_button_classes_and_styles'] = $submit_button_classes_and_styles;
+	if ( ! empty( $submit_button_classes ) ) {
+		$instance['submit_button_classes'] = $submit_button_classes;
+	}
+	if ( ! empty ( $submit_button_styles ) ) {
+		$instance['submit_button_styles'] = $submit_button_styles;
 	}
 
 	$args = array(

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -288,7 +288,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
                     <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?> <?php echo $submit_button_classes_and_styles ?>"/>
+                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>" <?php echo $submit_button_classes_and_styles ?>/>
                 </p>
             </form>
 			<?php

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -709,9 +709,14 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( empty( $instance ) || ! is_array( $instance ) ) {
 		$instance = array();
 	}
-	$instance['show_subscribers_total']     = empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ? false : true;
+	$instance['show_subscribers_total']     = false;
+	if ( ! empty( $instance['show_subscribers_total'] ) && 'false' !== $instance['show_subscribers_total'] ) {
+		$instance['show_subscribers_total'] = true;
+	}
 	$show_only_email_and_button             = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
 	$submit_button_text                     = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
+
+
 
 	// Build up a string with the submit button's classes and styles and set it on the instance
 	$submit_button_classes = isset( $instance['submit_button_classes'] ) ? $instance['submit_button_classes'] : '';

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -241,7 +241,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$referer                    = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$source                     = 'widget';
 		$widget_id                  = esc_attr( ! empty( $args['widget_id'] ) ? esc_attr( $args['widget_id'] ) : mt_rand( 450, 550 ) );
-		$subscribe_button           = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
+		$subscribe_button           = isset( $instance['submit_button_text'] ) && ! empty( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
 		$subscribers_total          = self::fetch_subscriber_count();
 		$subscribe_placeholder      = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
 		$submit_button_classes_and_styles = isset( $instance['submit_button_classes_and_styles'] ) ? $instance['submit_button_classes_and_styles'] : '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR makes the Subscription widget use the new submit button component.

<img width="563" alt="screen shot 2019-01-10 at 5 00 44 pm" src="https://user-images.githubusercontent.com/3246867/50999842-4e9f8480-14f9-11e9-982f-096105c01e1d.png">

#### Changes proposed in this Pull Request:

This PR makes the Subscription widget use the new submit button component.

#### Testing instructions:

Apply corresponding Calypso branch: https://github.com/Automattic/wp-calypso/pull/30109

Add a subscription form with the Block editor. Click the button, you will have the option to change its colors in the side panel. Click the button and change the button label text.

Ensure these changes manifest on the frontend once you've published.

Also check to ensure that previously created subscription forms continue to render correctly. 

#### Proposed changelog entry for your changes:

Subscription block uses submit button component