### PR TITLE
Mailchimp: only load CSS when needed.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -65,6 +65,7 @@ class Jetpack {
 		'jetpack-search-widget',
 		'jetpack-simple-payments-widget-style',
 		'jetpack-widget-social-icons-styles',
+		'jetpack-email-subscribe',
 	);
 
 	/**

--- a/modules/shortcodes/email-subscribe.php
+++ b/modules/shortcodes/email-subscribe.php
@@ -63,37 +63,44 @@ class Jetpack_Email_Subscribe {
 		add_shortcode( self::$shortcode, array( $this, 'parse_shortcode' ) );
 	}
 
+	/**
+	 * Register our Mailchimp subscription block for the block editor.
+	 *
+	 * @since 6.9.0
+	 */
 	private function register_gutenberg_block() {
-		jetpack_register_block( self::$block_name, array(
-			'attributes' => array(
-				'title' => array(
-					'type' => 'string',
+		jetpack_register_block(
+			self::$block_name,
+			array(
+				'attributes' => array(
+					'title'             => array(
+						'type' => 'string',
+					),
+					'email_placeholder' => array(
+						'type' => 'string',
+					),
+					'submit_label'      => array(
+						'type' => 'string',
+					),
+					'consent_text'      => array(
+						'type' => 'string',
+					),
+					'processing_label'  => array(
+						'type' => 'string',
+					),
+					'success_label'     => array(
+						'type' => 'string',
+					),
+					'error_label'       => array(
+						'type' => 'string',
+					),
+					'className'         => array(
+						'type' => 'string',
+					),
 				),
-				'email_placeholder' => array(
-					'type' => 'string',
-				),
-				'submit_label' => array(
-					'type' => 'string',
-				),
-				'consent_text' => array(
-					'type' => 'string',
-				),
-				'processing_label' => array(
-					'type' => 'string',
-				),
-				'success_label' => array(
-					'type' => 'string',
-				),
-				'error_label' => array(
-					'type' => 'string',
-				),
-				'className' => array(
-					'type' => 'string',
-				),
-			),
-			'style' => 'jetpack-email-subscribe',
-			'render_callback' => array( $this, 'parse_shortcode' ),
-		) );
+				'render_callback' => array( $this, 'parse_shortcode' ),
+			)
+		);
 	}
 
 	public function init_hook_action() {
@@ -175,7 +182,7 @@ class Jetpack_Email_Subscribe {
 			wp_enqueue_script( 'jetpack-email-subscribe' );
 		}
 
-		if ( ! wp_style_is( 'jetpack-email-subscribe', 'enqueue' ) ) {
+		if ( ! wp_style_is( 'jetpack-email-subscribe', 'enqueued' ) ) {
 			wp_enqueue_style( 'jetpack-email-subscribe' );
 		}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -141,7 +141,7 @@ class Jetpack_Simple_Payments {
 
 		$data['id'] = $attrs['id'];
 
-		if( ! wp_style_is( 'jetpack-simple-payments', 'enqueue' ) ) {
+		if( ! wp_style_is( 'jetpack-simple-payments', 'enqueued' ) ) {
 			wp_enqueue_style( 'jetpack-simple-payments' );
 		}
 

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -32,6 +32,7 @@ const concat_list = [
 	'modules/shortcodes/css/slideshow-shortcode.css',
 	'modules/shortcodes/css/style.css', // TODO: Should be renamed to shortcode-presentations
 	'modules/shortcodes/css/quiz.css',
+	'modules/shortcodes/css/jetpack-email-subscribe.css',
 	'modules/subscriptions/subscriptions.css',
 	'modules/theme-tools/responsive-videos/responsive-videos.css',
 	'modules/theme-tools/social-menu/social-menu.css',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR introduces 3 changes:

1. Only enqueue the shortcode / block's CSS file when we need it. It was previously enqueued on all pages, because it was declared as `style` when registering the block. We don't need to declare it there since the style is actually enqueued manually in `parse_shortcode`.
2. Fix typos in 2 files when checking if a file has already been enqueued. `wp_style_is` only accepts 'enqueued', 'registered', 'queue', 'to_do', and 'done'.
3. Add the shortcode / block's CSS file to the concatenated `jetpack.css` file that is automatically generated by Jetpack. This way we don't ever need to load the CSS file separately anymore.

#### Testing instructions:

* Checkout the branch
* Add `add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 );` to your site.
* Load any page. You should not see the `jetpack-email-subscribe` CSS stylesheet loaded anywhere.
* Load a page where you have added the `[jetpack-email-subscribe]` shortcode. You should see the stylesheet loaded there.
* Add `define( 'JETPACK_BETA_BLOCKS', true );` to your site's `wp-config.php` file.
* Load the Gutenberg editor.
* Try to add the Mailchimp block and make sure it looks good.
* Load the page where the block is displayed and make sure the page includes the stylesheet.
* Remove the filter I mentioned in step 1. 
* Run `yarn build`
* Reload the pages with the shortcode and the block. You should not see the stylesheet being loaded anymore, but instead you should see some `jetpack-email-subscribe` styles inside the `jetpack.css` file that is enqueued.

#### Proposed changelog entry for your changes:

* Mailchimp: only load CSS when needed.
