### PR TITLE
Docs: Updates partners documentation to support WooCommerce extension bundles

### DIFF
--- a/docs/partners/README.md
+++ b/docs/partners/README.md
@@ -18,7 +18,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Provisioning status](determining-provisioning-status.md)
 - [Managing modules](managing-modules.md)
 - [Upgrade redirection](upgrade-redirection.md)
-- [Woo Commerce Provisioning](plan-provisioning-woocommerce.md)
+- [WooCommerce Provisioning](plan-provisioning-woocommerce.md)
 
 ## Become a Jetpack Hosting Partner
 

--- a/docs/partners/README.md
+++ b/docs/partners/README.md
@@ -18,7 +18,9 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Provisioning status](determining-provisioning-status.md)
 - [Managing modules](managing-modules.md)
 - [Upgrade redirection](upgrade-redirection.md)
+- [Woo Commerce Provisioning](plan-provisioning-woocommerce.md)
 
 ## Become a Jetpack Hosting Partner
 
 If you're not already a Jetpack Hosting Partner and you'd like some more information, head on over to [https://jetpack.com/for/hosts/](https://jetpack.com/for/hosts/) to get started!
+

--- a/docs/partners/plan-provisioning-woocommerce.md
+++ b/docs/partners/plan-provisioning-woocommerce.md
@@ -1,10 +1,4 @@
 # Provisioning Woo Commerce Extensions
-If your Jetpack hosting partner account supports creating WooCommerce Extensions through the Jetpack hosting partner program this document provides additional information.
+If your Jetpack hosting partner account supports creating WooCommerce Extensions through the Jetpack hosting partner program, this document provides additional information.
 
-All other documentation provided for the Jetpack partner hosting program is the same and valid for WooCommerce extension provisioning however there are a few extra details for provisioning extensions which are outlined below.
-
-## Provisioning Plan
-This relates to information found in [Provisioning a Plan](plan-provisioning-direct-api.md).
-
-In order to provsion a WooCommerce Extension bundle when making a request to the endpoint the `plan` which is the slug representing the plan to be provisioned will need to be set to your hosting partner WooCommerce extension provisioning slug. If you aren't sure what this is or the plan type is identified as invalid please contact us.
-
+All other [documentation](plan-provisioning-direct-api.md) provided for the Jetpack partner hosting program is the same and valid for WooCommerce extension provisioning, except the plan argument on a provisioning request will need to change. At the moment, WooCommerce extension bundles are hosting partner specific, so please get in touch with us to get your plan slug if you do not already have it.

--- a/docs/partners/plan-provisioning-woocommerce.md
+++ b/docs/partners/plan-provisioning-woocommerce.md
@@ -1,0 +1,10 @@
+# Provisioning Woo Commerce Extensions
+If your Jetpack hosting partner account supports creating WooCommerce Extensions through the Jetpack hosting partner program this document provides additional information.
+
+All other documentation provided for the Jetpack partner hosting program is the same and valid for WooCommerce extension provisioning however there are a few extra details for provisioning extensions which are outlined below.
+
+## Provisioning Plan
+This relates to information found in [Provisioning a Plan](plan-provisioning-direct-api.md).
+
+In order to provsion a WooCommerce Extension bundle when making a request to the endpoint the `plan` which is the slug representing the plan to be provisioned will need to be set to your hosting partner WooCommerce extension provisioning slug. If you aren't sure what this is or the plan type is identified as invalid please contact us.
+


### PR DESCRIPTION
Update the Readme.md to include a link to the plan-provisoning-woocommerce.md which has been newly added. This document will be used for information on variances specific to provisioning WooCommerce extensions through the Jetpack hosting partner program.

Fixes N/A

#### Changes proposed in this Pull Request:
No functional changes. Updates to the main Readme.md and adding a new document.

#### Testing instructions:
N/A

#### Proposed changelog entry for your changes:
No changelog entry needed.
