### PR TITLE
Plans: Make sure the option we store plan info in is autoloaded in the single autoload options query when not in the cache.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1256,7 +1256,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				update_option( 'show_welcome_for_new_plan', true ) ;
 			}
 
-			update_option( 'jetpack_active_plan', $results['plan'] );
+			update_option( 'jetpack_active_plan', $results['plan'], true );
 		}
 		$body = wp_remote_retrieve_body( $response );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1548,7 +1548,7 @@ class Jetpack {
 		}
 
 		// Store the option and return true if updated
-		return update_option( 'jetpack_active_plan', $results['plan'] );
+		return update_option( 'jetpack_active_plan', $results['plan'], true );
 	}
 
 	/**


### PR DESCRIPTION
This ensures that we can't end up with a cached notoption if we try and query the option before it is set.

#### Changes proposed in this Pull Request:

* Sets autoload=true when updating the option value

#### Testing instructions:
* Check that we no longer make individual options queries for this option

#### Proposed changelog entry for your changes:

Not needed
