### PR TITLE
Gutenberg blocks: sync code with wpcom

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -20,7 +20,10 @@ jetpack_register_block( 'vr' );
  *
  * @since 6.9.0
 */
-if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+if (
+	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
+	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
+) {
 	jetpack_register_block(
 		'tiled-gallery',
 		array(


### PR DESCRIPTION
Syncs with changes in D22751-code that weren't included in https://github.com/Automattic/jetpack/pull/11061

### Testing
- Confirm that adding Tiled gallery block in the editor still works