### PR TITLE
Sync: add fastcgi finish request to sync

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -201,6 +201,11 @@ class Jetpack_Sync_Sender {
 			ignore_user_abort( true );
 		}
 
+		/* Don't make the request block till we finish, if possible. */
+		if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
+			fastcgi_finish_request();
+		}
+
 		$checkout_start_time = microtime( true );
 
 		$buffer = $queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );


### PR DESCRIPTION
Based on the commit to core https://core.trac.wordpress.org/changeset/44488
That improves cron response. This PR tries to do the same but for Jetpack.

This works together with #7482
To improve the page load response time when sync is progress.

#### Testing instructions:

* Go to '..'

On an environment that support the function add the following to your code. 
```
diff --git a/sync/class.jetpack-sync-sender.php b/sync/class.jetpack-sync-sender.php
index 70cb4a09c..cd65e62bd 100644
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -205,6 +205,8 @@ class Jetpack_Sync_Sender {
                if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
                        fastcgi_finish_request();
                }
+               error_log( 'Does this show up' )?
+               sleep(10);

                $checkout_start_time = microtime( true );
```


Do something that should trigger a sync request. Such as triggering a full sync or doing updating a setting. 
Next try doing an api request to you site. 
Without the call to fastcgi_finish_request(); the api request should take at least 10 seconds to complete. 
With the call to `fastcgi_finish_request();` the request should be a lot faster. 


#### Proposed changelog entry for your changes:
* Improves sync performance on PHP 7.0.16 and higher with fastcgi_finish_request enabled. 
