### PR TITLE
Apply fixed position to carousel overlay

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -70,7 +70,7 @@ jQuery(document).ready(function($) {
 			overlay = $('<div></div>')
 				.addClass('jp-carousel-overlay')
 				.css({
-					'position' : 'absolute',
+					'position' : 'fixed',
 					'top'      : 0,
 					'right'    : 0,
 					'bottom'   : 0,


### PR DESCRIPTION
The overlay's container is fixed, which "sticks" to the top of the
viewport. If the overlay is absolute instead of fixed and the content
overflows, this may allow for scrolling where the overlay moves above
the viewport leading to the issue described in #11152.

By using fixed positioning on the container and the overlay, they are
positioned in the same way and the overlay covers the page content as
expected.

Fixes https://github.com/Automattic/jetpack/issues/11152

#### Testing instructions:

Follow the instructions from #11152 and verify that the problem is not present:

> 1. The conditions must be correct for carousels to display. Enabling suggested settings on a new Jetpack site is sufficient.
> 1. Add a gallery with a few images.
> 1. Add a very long caption to an image.
> 1. Click on the image to view it in the carousel.
> 1. When the carousel is displayed, scroll down to see the broken visual.

Check for any regressions across different browsers (ie) and devices (mobile).

#### Proposed changelog entry for your changes:

* Fix an issue in the Carousel display with large captions.

![fix](https://user-images.githubusercontent.com/841763/51272148-99be0980-19c9-11e9-830e-99a17abd12e2.gif)
