### PR TITLE
Sync: Plugin and Theme updates should only be sent once

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -7,6 +7,10 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	private $old_wp_version = null;
 	private $updates = array();
 
+	public function set_defaults() {
+		$this->updates = array();
+	}
+
 	function name() {
 		return 'updates';
 	}

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -211,13 +211,13 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			do_action( "jetpack_update_core_change", $value );
 			return;
 		}
-		if ( empty( $this->updates ) ) {
+		if ( ! empty( $this->updates ) ) {
 			add_action( 'shutdown', array( $this, 'sync_last_event' ), 9 );
 		}
 		if ( ! isset( $this->updates[ $transient ] ) ) {
-			$this->updates[$transient] = array();
+			$this->updates[ $transient ] = array();
 		}
-		$this->updates[$transient][] = $value;
+		$this->updates[ $transient ][] = $value;
 	}
 
 	public function sync_last_event() {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -211,13 +211,13 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			do_action( "jetpack_update_core_change", $value );
 			return;
 		}
-		if ( ! empty( $this->updates ) ) {
+		if ( empty( $this->updates ) ) {
 			add_action( 'shutdown', array( $this, 'sync_last_event' ), 9 );
 		}
 		if ( ! isset( $this->updates[ $transient ] ) ) {
-			$this->updates[ $transient ] = array();
+			$this->updates[$transient] = array();
 		}
-		$this->updates[ $transient ][] = $value;
+		$this->updates[$transient][] = $value;
 	}
 
 	public function sync_last_event() {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -212,6 +212,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			return;
 		}
 		if ( empty( $this->updates ) ) {
+			// lets add the shutdown method once and only when the updates move from empty to filled with something
 			add_action( 'shutdown', array( $this, 'sync_last_event' ), 9 );
 		}
 		if ( ! isset( $this->updates[ $transient ] ) ) {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -208,7 +208,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			 * @param array containing info that tells us what needs updating
 			 *
 			 */
-			do_action( "jetpack_update_core_change", $value );
+			do_action( 'jetpack_update_core_change', $value );
 			return;
 		}
 		if ( empty( $this->updates ) ) {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -215,9 +215,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			add_action( 'shutdown', array( $this, 'sync_last_event' ), 9 );
 		}
 		if ( ! isset( $this->updates[ $transient ] ) ) {
-			$this->updates[$transient] = array();
+			$this->updates[ $transient ] = array();
 		}
-		$this->updates[$transient][] = $value;
+		$this->updates[ $transient ][] = $value;
 	}
 
 	public function sync_last_event() {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -120,7 +120,6 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 	}
 
-
 	public function get_update_checksum( $update, $transient ) {
 		$updates = array();
 		$no_updated = array();
@@ -185,8 +184,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	}
 
 	public function validate_update_change( $value, $expiration, $transient ) {
-
 		$new_checksum = $this->get_update_checksum( $value, $transient );
+
 		if ( false === $new_checksum  ) {
 			return;
 		}
@@ -200,7 +199,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		$checksums[ $transient ] = $new_checksum;
 
 		update_option( self::UPDATES_CHECKSUM_OPTION_NAME, $checksums );
-		if ( $transient === 'update_core' ) {
+		if ( 'update_core' === $transient ) {
 			/**
 			 * jetpack_update_core_change
 			 *
@@ -209,7 +208,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			 * @param array containing info that tells us what needs updating
 			 *
 			 */
-			do_action( "jetpack_{$transient}_change", $value );
+			do_action( "jetpack_update_core_change", $value );
 			return;
 		}
 		if ( empty( $this->updates ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -572,6 +572,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $this->server_replica_storage->current_theme_supports( 'post-thumbnails' ) );
 	}
 
+	function check_for_updates_to_sync() {
+		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module->sync_last_event();
+	}
+
 	function test_full_sync_sends_plugin_updates() {
 
 		if ( is_multisite() ) {
@@ -579,7 +584,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		}
 
 		wp_update_plugins();
-
+		$this->check_for_updates_to_sync();
 		$this->sender->do_sync();
 
 		// check that an update just finished
@@ -606,7 +611,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		}
 
 		wp_update_themes();
-
+		$this->check_for_updates_to_sync();
 		$this->sender->do_sync();
 
 		// check that an update just finished

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -13,12 +13,18 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 	}
 
+	function check_for_updates_to_sync() {
+		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module->sync_last_event();
+	}
+
 	public function test_update_plugins_is_synced() {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}
 
 		wp_update_plugins();
+		$this->check_for_updates_to_sync();
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
 
@@ -32,6 +38,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}
+		$this->server_event_storage->reset();
 		$current = get_site_transient( 'update_plugins' );
 
 		$response = $this->new_plugin_response( '1' );
@@ -46,9 +53,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		//
 		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
 		$updates_module->sync_last_event();
-
 		$has_action = has_action( 'shutdown', array( $updates_module, 'sync_last_event' ) );
-
 		$this->sender->do_sync();
 
 		$events = $this->server_event_storage->get_all_events( 'jetpack_update_plugins_change' );
@@ -80,6 +85,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		}
 
 		wp_update_themes();
+		$this->check_for_updates_to_sync();
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
 		$theme = reset( $updates->response );
@@ -92,6 +98,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}
+		$this->server_event_storage->reset();
 		$current = get_site_transient( 'update_themes' );
 
 		$response = $this->new_theme_response( '1' );

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -151,7 +151,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		_maybe_update_core();
 		$core_transiant = get_site_transient( 'update_core' );
-		if( sizeof( $core_transiant->updates )  === 1 && $core_transiant->updates[0]->response === 'latest' ) {
+		if ( sizeof( $core_transiant->updates ) === 1 && $core_transiant->updates[0]->response === 'latest' ) {
 			$this->markTestSkipped( 'No new updates!' );
 		}
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -150,6 +150,10 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->server_event_storage->reset();
 
 		_maybe_update_core();
+		$core_transiant = get_site_transient( 'update_core' );
+		if( sizeof( $core_transiant->updates )  === 1 && $core_transiant->updates[0]->response === 'latest' ) {
+			$this->markTestSkipped( 'No new updates!' );
+		}
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertTrue( is_int( $updates->last_checked ) );


### PR DESCRIPTION
This PR modifies Jetpack syncing of updates so that we only send one update per page load.

This helps with custom plugins from only sending the update since wp_update_plugins and wp_update_themes can trigger multiple writes to the transient. This make sure that we only send the last one (the one that gets stored in the DB).

Alternative to https://github.com/Automattic/jetpack/pull/8611/

#### Changes proposed in this Pull Request:
* We listen for changes as before and then on shutdown we record only the last change for themes and plugins.

#### Testing instructions:
* Do the test pass?
* Set a plugin to update, by modifying wp-includes/version.php file
* Set a theme to update by modifying style.css file
* Do events show up in the activity log? 

#### Proposed changelog entry for your changes:
* Improvements to syncing plugin updates
