### PR TITLE
Eliminate obsolete polyfill script in Subscriptions widget

### DIFF
--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -5,3 +5,21 @@
 .comment-subscription-form .subscribe-label {
 	display: inline !important;
 }
+
+/*
+Text meant only for screen readers.
+Provides support for themes that do not bundle this CSS yet.
+@see https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/
+***********************************/
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute ! important;
+	width: 1px;
+	word-wrap: normal ! important;
+}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -320,6 +320,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				if ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) { ?>
                     <p id="subscribe-email">
                         <label id="jetpack-subscribe-label"
+                               class="screen-reader-text"
                                for="<?php echo esc_attr( $subscribe_field_id ) . '-' . esc_attr( $widget_id ); ?>">
 							<?php echo ! empty( $subscribe_placeholder ) ? esc_html( $subscribe_placeholder ) : esc_html__( 'Email Address:', 'jetpack' ); ?>
                         </label>
@@ -344,44 +345,6 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     </p>
 				<?php } ?>
             </form>
-
-            <script>
-				/*
-				Custom functionality for safari and IE
-				 */
-				(function (d) {
-					// In case the placeholder functionality is available we remove labels
-					if (('placeholder' in d.createElement('input'))) {
-						var label = d.querySelector('label[for=subscribe-field-<?php echo $widget_id; ?>]');
-						label.style.clip = 'rect(1px, 1px, 1px, 1px)';
-						label.style.position = 'absolute';
-						label.style.height = '1px';
-						label.style.width = '1px';
-						label.style.overflow = 'hidden';
-					}
-
-					// Make sure the email value is filled in before allowing submit
-					var form = d.getElementById('subscribe-blog-<?php echo $widget_id; ?>'),
-						input = d.getElementById('<?php echo esc_attr( $subscribe_field_id ) . '-' . esc_attr( $widget_id ); ?>'),
-						handler = function (event) {
-							if ('' === input.value) {
-								input.focus();
-
-								if (event.preventDefault) {
-									event.preventDefault();
-								}
-
-								return false;
-							}
-						};
-
-					if (window.addEventListener) {
-						form.addEventListener('submit', handler, false);
-					} else {
-						form.attachEvent('onsubmit', handler);
-					}
-				})(document);
-            </script>
 		<?php }
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Subscriptions widget includes an inline `script` which adds a polyfill for the `input`'s `placeholder` attribute. It also adds a polyfill for HTML5 `required` attribute. Browsers have long supported these features natively and there is no need to include them. All modern browsers support them:

* `placeholder` is supported by 95% of all browsers: https://caniuse.com/#feat=input-placeholder
* `required` is supported by 92% of all browsers: https://caniuse.com/#feat=form-validation

The `label` is retained as `screen-reader-text`.

As an added bonus for doing so, the AMP compatibility increases. See #9730.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Subscriptions widget.
* Ensure the email address placeholder appears.
* Try submitting the form without providing an email, and ensure that the browser blocks the submission.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Eliminate obsolete polyfill JavaScript from subscriptions widget now that all browsers support the `placeholder` and `required` attributes on `input` elements. Improves AMP compatibility.
