### PR TITLE
Mobile Theme: do not redirect to referer

### DIFF
--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -117,7 +117,9 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
-	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. home_url( '?ak_action=accept_mobile' ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	global $wp;
+	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'accept_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
+	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. $current_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
 }
 
 function jetpack_mobile_request_handler() {

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -117,9 +117,7 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
-	global $wp;
-	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'accept_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
-	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. esc_url( $current_url ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. esc_url( home_url( add_query_arg('ak_action', 'accept_mobile') ) ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
 }
 
 function jetpack_mobile_request_handler() {

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -176,10 +176,7 @@ function jetpack_mobile_request_handler() {
 		if ($redirect) {
 			if ( isset( $_GET['redirect_to'] ) && $_GET['redirect_to'] ) {
 				$go = urldecode( $_GET['redirect_to'] );
-			} else if (!empty($_SERVER['HTTP_REFERER'])) {
-				$go = $_SERVER['HTTP_REFERER'];
-			}
-			else {
+			} else {
 				$go = remove_query_arg( array( 'ak_action' ) );
 			}
 			wp_safe_redirect( $go );

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -119,7 +119,7 @@ function jetpack_mobile_template( $theme ) {
 function jetpack_mobile_available() {
 	global $wp;
 	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'accept_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
-	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. $current_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. esc_url( $current_url ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
 }
 
 function jetpack_mobile_request_handler() {

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -32,7 +32,7 @@
 	global $wp;
 	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'reject_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
 ?>
-		<a href="<?php echo $current_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+		<a href="<?php echo esc_url( $current_url ); ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
 
 		<?php
 			/**

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -27,12 +27,7 @@
 
 <footer id="colophon" role="contentinfo">
 	<div id="site-generator">
-
-<?php
-	global $wp;
-	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'reject_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
-?>
-		<a href="<?php echo esc_url( $current_url ); ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+		<a href="<?php echo esc_url( home_url( add_query_arg('ak_action', 'reject_mobile') ) ); ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
 
 		<?php
 			/**

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -30,9 +30,9 @@
 
 <?php
 	global $wp;
-	$current_url =  trailingslashit( home_url( add_query_arg( array(), $wp->request ) ) );
+	$current_url =  home_url( add_query_arg( array( 'ak_action' => 'reject_mobile' ), add_query_arg( $_GET, $wp->request ) ) );
 ?>
-		<a href="<?php echo $current_url . '?ak_action=reject_mobile'; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+		<a href="<?php echo $current_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
 
 		<?php
 			/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11165 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Delete redirect to referer.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate the Mobile Theme feature on site A running the patch.
2. Have a site B that uses HTTPS, and add the following links to one of your posts on that site:
```
<a href="https://yoursite.com/a-post/?ak_action=reject_mobile">check out this link</a>
<a href="https://yoursite.com/?ak_action=reject_mobile">check out this link</a>
<a href="https://yoursite.com/a-post/?ak_action=force_mobile">check out this link</a>
<a href="https://yoursite.com/?ak_action=force_mobile">check out this link</a>
<a href="https://yoursite.com/a-post/?ak_action=accept_mobile">check out this link</a>
<a href="https://yoursite.com/?ak_action=accept_mobile">check out this link</a>
```
3. Have a site C that does not use HTTPS. Add the same links to that site.
4. Visit the posts on site B and site C from a mobile device and a desktop device, and make sure each link behaves properly. Remember to flush your cookies after clicking on each link.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix unexpected redirection when mobile theme is enabled.
