### PR TITLE
Notices: Add a site blacklisted notice

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -84,6 +84,9 @@ class JetpackStateNotices extends React.Component {
 					}
 				);
 				break;
+			case 'site_blacklisted':
+				message = __( "This site can't be connected to WordPress.com." );
+				break;
 			case 'not_public':
 				message = __(
 					'{{s}}Your Jetpack has a glitch.{{/s}} Connecting this site with WordPress.com is not possible. ' +


### PR DESCRIPTION
Work in progress. Part of 3155-gh-jpop-issues.

#### Changes proposed in this Pull Request:

* Add a notice for `site_blacklisted`.

#### Preview
![](https://cldup.com/O3pbxDFU-J.png)

#### Testing instructions:
* Follow the instructions in https://github.com/Automattic/wp-calypso/pull/29983 (note both it and its corresponding diff have been merged already)
* Apply D23346-code to your sandbox.
* ~Set the `JETPACK__SANDBOX_DOMAIN` to point the test WP.com site that points to your sandbox.~ Sandbox `jetpack.wordpress.com`.
* After blacklisting the site, when starting connection from Jetpack, verify you can see the new notice.

#### Proposed changelog entry for your changes:

* Display a notice upon connection when the site is blacklisted.
