### PR TITLE
Publicize: shortcircuit API when Publicize isn't available anymore

### DIFF
--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -115,7 +115,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	function permission_check( $post_id ) {
 		global $publicize;
 
-		if ( null === $publicize ) {
+		if ( ! $publicize ) {
 			return new WP_Error(
 				'publicize_not_available',
 				__( 'Sorry, Publicize is not available on your site right now.', 'jetpack' ),
@@ -167,6 +167,10 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	 */
 	public function get( $post_array, $request ) {
 		global $publicize;
+
+		if ( ! $publicize ) {
+			return array();
+		}
 
 		$schema     = $this->post_connection_schema();
 		$properties = array_keys( $schema['properties'] );
@@ -245,6 +249,10 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 
 	protected function get_meta_to_update( $requested_connections, $post_id = 0 ) {
 		global $publicize;
+
+		if ( ! $publicize ) {
+			return array();
+		}
 
 		if ( isset( $this->memoized_updates[$post_id] ) ) {
 			return $this->memoized_updates[$post_id];

--- a/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -115,6 +115,14 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	function permission_check( $post_id ) {
 		global $publicize;
 
+		if ( null === $publicize ) {
+			return new WP_Error(
+				'publicize_not_available',
+				__( 'Sorry, Publicize is not available on your site right now.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
 		if ( $publicize->current_user_can_access_publicize_data( $post_id ) ) {
 			return true;
 		}


### PR DESCRIPTION
Fixes #10727

#### Changes proposed in this Pull Request:

In some cases (like site previously connected but put in dev mode), Publicize can be active but not available.
In such cases, let's shortcircuit the API.

#### Testing instructions:

* On your local docker install connected via ngrok using WP 5.0.3, connect your site to WordPress.com.
* Activate Publicize, and connect one of your Social networks.
* Activate the Custom Content Types module.
* Go to Portfolios > Add New, and create a new post. Publish it, it is pushed to Social Media, all works well.
* Now access your dashboard using the localhost site address, not your ngrok address.
* Go to Portfolios > Add New and notice the Fatal Error:
```
PHP Fatal error:  Uncaught Error: Call to a member function current_user_can_access_publicize_data() on null in /var/www/html/wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php:120
```
* Apply this patch.
* Reload the page, the error should be gone.
* Now access your site using the ngrok address again; you should be able to publish a new post without any errors, and that post will be shared to Social Media.

#### Proposed changelog entry for your changes:

* Publicize: avoid Fatal Errors on site using Development Mode.
