### PR TITLE
Jetpack_Gutenberg: Use new jetpack_register_gutenberg_extensions action for availability

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -293,6 +293,18 @@ class Jetpack_Gutenberg {
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
+
+		/**
+		 * Fires before Gutenberg extensions availability is computed.
+		 *
+		 * In the function call you supply, use `jetpack_register_block()` and `jetpack_register_plugin()`, respectively.
+		 * Alternatively, use `jetpack_set_extension_unavailability_reason()` if the block or plugin should not be registered but
+		 * marked as unavailable.
+		 *
+		 * @since 7.0.0
+		 */
+		do_action( 'jetpack_register_gutenberg_extensions' );
+
 		$available_extensions = array();
 
 		foreach ( self::$extensions as $extension ) {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -119,7 +119,7 @@ abstract class Publicize_Base {
 
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
-		add_action( 'init', array( $this, 'register_gutenberg_extension' ), 30 );
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_extension' ) );
 	}
 
 /*

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -40,7 +40,7 @@ class Jetpack_Simple_Payments {
 
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
-		add_action( 'init', array( $this, 'register_gutenberg_block' ), 40 );
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_block' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
 	}
 


### PR DESCRIPTION
I recently merged #11091, which refactored `Jetpack_Gutenberg`.

I have not yet merged the WP.com counterpart, D22852-code, since I discovered a (WP.com specific) bug: 

> When unproxied, and called from Calypso, the availability endpoint return `unauthorized` for `publicize` for a user with admin role :-/
> 
> The reason is, once again, that we're currently hooking `publicize`'s `register_gutenberg_extension()` to `init`, which is too early -- the current blog ID is still set to public-api.wordpress.com's at that point.
> [...]
> The previous code seems to have worked, but it's difficult to track down _when_ exactly registration/availability setting occurred. It might have been at [`rest_request_before_callbacks`](https://github.com/Automattic/jetpack/pull/11091/files#diff-d24019d250171c53680546ef0b1164e2L122). 

(For more information on the bug, see that phab diff, D22852-code #463643)

As for the solution (D22852-code #469428):

> [H]ere's the thing -- that hook is really called for all REST API requests. So if we only want to call block registration/availability setting for the `/gutenberg/available-extensions` endpoint, our best option is to connect those actions to that endpoint's callback.
> Currently, that callback is set to invoke `Jetpack_Gutenberg::get_availability()`, which makes sense. So I think one solution would be to add `do_action( 'jetpack_register_gutenberg_extensions' );` on top of that method, and hook Publicize's and Simple Payments' block registration methods to that.
>
> Finally, we'll also need to add that `do_action` call to the frontend rendering, to make sure that e.g. Simple Payments buttons are properly rendered.

So I ended up pushing code to that phab diff which seems to have fixed the issue, and plan to merge tomorrow. However, this means that D22852-code no longer faithfully mirrors #11091. Thus, I've filed this PR to sync the changes back to JP (and to some extent, for increased visibility of this change).

#### Changes proposed in this Pull Request:

Add a new `jetpack_register_gutenberg_extensions` hook which is called in `Jetpack_Gutenberg::get_availability()`, and use it to conditionally register the Simple Payments block and Publicize pluging (or set their unavailability reason, respectively).

#### Testing instructions:

Verify that extension availability works as before. In particular:

- Create a user on a site which has only Contributor privileges, and verify that the endpoint returns `unavailable` for `publicize`.
- Verify that `publicize` is available for a user with Author privileges (or higher).
- Verify that on a site with a lesser Plan than Premium, the endpoint returns `missing_plan` for `simple-payments`.
- Verify the Simple Payments block is available on a site with a Premium Plan (or higher tier).

#### Proposed changelog entry for your changes:

Add a new `jetpack_register_gutenberg_extensions` hook which is called in `Jetpack_Gutenberg::get_availability()`, and use it to conditionally register the Simple Payments block and Publicize pluging (or set their unavailability reason, respectively).
