### PR TITLE
Shortcode: Cache Twitter output 

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -32,6 +32,7 @@ class Jetpack_Tweet {
 	 * @return string
 	 */
 	public static function jetpack_tweet_shortcode( $atts ) {
+		global $wp_embed;
 		$default_atts = array(
 			'tweet'       => '',
 			'align'       => 'none',
@@ -68,7 +69,7 @@ class Jetpack_Tweet {
 		add_filter( 'oembed_fetch_url', array( 'Jetpack_Tweet', 'jetpack_tweet_url_extra_args' ), 10, 3 );
 
 		// Fetch tweet
-		$output = wp_oembed_get( $id, $atts );
+		$output = $wp_embed->shortcode( $atts, $id );
 
 		// Clean up filter
 		remove_filter( 'oembed_fetch_url', array( 'Jetpack_Tweet', 'jetpack_tweet_url_extra_args' ), 10 );


### PR DESCRIPTION
**Changes proposed in this Pull Request:**
Tweets embedded using the Jetpack shortcode `[tweet]` are not cached and create multiple HTTP API requests to Twitter every time they are displayed. The goal is to cache those requests to improve performance.

**Testing instructions:**
When multiple tweets are embedded in a post the time required to load this page tremendously increase. Looking at the trace, the [jetpack_tweet_shortcode](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/tweet.php#L34) method is used to generate the embed code.

![image](https://user-images.githubusercontent.com/4668242/51501956-02193c00-1d78-11e9-8459-a4b76442aae2.png)

In this very function `wp_oembed_get( $id, $atts );` is used to render the proper markup, however, it will **not** cache the result like default embedding feature in the editor in the `wp_postmeta` table.

This means that every time the page attempts to load, WordPress will make an HTTP API request to Twitter for each shortcode, which will prevent the page loading until the result is returned.

exemple:
![image](https://user-images.githubusercontent.com/4668242/51502219-304b4b80-1d79-11e9-91be-de652ded029f.png)


Looking at the [facebook](https://github.com/Automattic/jetpack/blob/150587591d8ce0eb05fa95e36dd9ba57ca581a28/modules/shortcodes/facebook.php#L73) or [instagram](https://github.com/Automattic/jetpack/blob/150587591d8ce0eb05fa95e36dd9ba57ca581a28/modules/shortcodes/instagram.php#L190) jetpack shortcode, a far better solution is used to generate the shortcode with the [$wp_embed->shortcode()](https://developer.wordpress.org/reference/classes/wp_embed/shortcode/) method.

I recommend using the same strategy to render the tweet shortcode. This way oEmbed will be stored in the wp_postmeta table and cached. No further HTTP API request will be done unless required.

**Proposed changelog entry:**

* Shortcodes: cache the output of the Twitter shortcode
