### PR TITLE
Jetpack_Gutenberg: Decrease abstraction when registering extensions

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -20,7 +20,7 @@ function jetpack_register_gutenberg_extension( $slug ) {
 /**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @deprecated 7.0.0 Use jetpack_activate_gutenberg_extension() + register_block_type() instead
+ * @deprecated 7.0.0 Use jetpack_register_gutenberg_extension() + register_block_type() instead
  *
  * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
@@ -36,7 +36,7 @@ function jetpack_register_block( $slug, $args = array() ) {
 /**
  * Helper function to register a Jetpack Gutenberg plugin
  *
- * @deprecated 7.0.0 Use jetpack_activate_gutenberg_extension() instead
+ * @deprecated 7.0.0 Use jetpack_register_gutenberg_extension() instead
  *
  * @param string $slug Slug of the plugin.
  *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -126,6 +126,11 @@ class Jetpack_Gutenberg {
 			return false;
 		}
 
+
+		if ( in_array( $slug, self::$registered_extensions, true ) ) {
+			return false;
+		}
+
 		self::$registered_extensions[] = $slug;
 		return true;
 	}

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -45,43 +45,46 @@ jetpack_register_gutenberg_extension( 'vr' );
  * @since 6.9.0
 */
 if (
-	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
+	(
+		( defined( 'IS_WPCOM' ) && IS_WPCOM )
+		||
+		( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) )
+	)
+	&&
+	( jetpack_register_gutenberg_extension( 'tiled-gallery' ) )
 ) {
-	if ( jetpack_register_gutenberg_extension( 'tiled-gallery' ) ) {
-		register_block_type(
-			'jetpack/tiled-gallery',
-			array(
-				'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
-			)
+	register_block_type(
+		'jetpack/tiled-gallery',
+		array(
+			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
+		)
+	);
+
+	/**
+	 * Tiled gallery block registration/dependency declaration.
+	 *
+	 * @param array  $attr - Array containing the block attributes.
+	 * @param string $content - String containing the block content.
+	 *
+	 * @return string
+	 */
+	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
+		$dependencies = array(
+			'lodash',
+			'wp-i18n',
+			'wp-token-list',
 		);
+		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
 
 		/**
-		 * Tiled gallery block registration/dependency declaration.
+		 * Filter the output of the Tiled Galleries content.
 		 *
-		 * @param array  $attr - Array containing the block attributes.
-		 * @param string $content - String containing the block content.
+		 * @module tiled-gallery
 		 *
-		 * @return string
+		 * @since 6.9.0
+		 *
+		 * @param string $content Tiled Gallery block content.
 		 */
-		function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-			$dependencies = array(
-				'lodash',
-				'wp-i18n',
-				'wp-token-list',
-			);
-			Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
-
-			/**
-			 * Filter the output of the Tiled Galleries content.
-			 *
-			 * @module tiled-gallery
-			 *
-			 * @since 6.9.0
-			 *
-			 * @param string $content Tiled Gallery block content.
-			 */
-			return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
-		}
+		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
 	}
 }

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -6,14 +6,38 @@
  *
  */
 
-jetpack_register_block(
-	'map',
-	array(
-		'render_callback' => 'jetpack_map_block_load_assets',
-	)
-);
 
-jetpack_register_block( 'vr' );
+if ( jetpack_register_gutenberg_extension( 'map' ) ) {
+	register_block_type(
+		'jetpack/map',
+		array(
+			'render_callback' => 'jetpack_map_block_load_assets',
+		)
+	);
+
+	/**
+	 * Map block registration/dependency declaration.
+	 *
+	 * @param array  $attr - Array containing the map block attributes.
+	 * @param string $content - String containing the map block content.
+	 *
+	 * @return string
+	 */
+	function jetpack_map_block_load_assets( $attr, $content ) {
+		$dependencies = array(
+			'lodash',
+			'wp-element',
+			'wp-i18n',
+		);
+
+		$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
+
+		Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
+		return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
+	}
+}
+
+jetpack_register_gutenberg_extension( 'vr' );
 
 /**
  * Tiled Gallery block. Depends on the Photon module.
@@ -24,59 +48,40 @@ if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
 ) {
-	jetpack_register_block(
-		'tiled-gallery',
-		array(
-			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
-		)
-	);
-
-	/**
-	 * Tiled gallery block registration/dependency declaration.
-	 *
-	 * @param array  $attr - Array containing the block attributes.
-	 * @param string $content - String containing the block content.
-	 *
-	 * @return string
-	 */
-	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		$dependencies = array(
-			'lodash',
-			'wp-i18n',
-			'wp-token-list',
+	if ( jetpack_register_gutenberg_extension( 'tiled-gallery' ) ) {
+		register_block_type(
+			'jetpack/tiled-gallery',
+			array(
+				'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
+			)
 		);
-		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
 
 		/**
-		 * Filter the output of the Tiled Galleries content.
+		 * Tiled gallery block registration/dependency declaration.
 		 *
-		 * @module tiled-gallery
+		 * @param array  $attr - Array containing the block attributes.
+		 * @param string $content - String containing the block content.
 		 *
-		 * @since 6.9.0
-		 *
-		 * @param string $content Tiled Gallery block content.
+		 * @return string
 		 */
-		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
+		function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
+			$dependencies = array(
+				'lodash',
+				'wp-i18n',
+				'wp-token-list',
+			);
+			Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
+
+			/**
+			 * Filter the output of the Tiled Galleries content.
+			 *
+			 * @module tiled-gallery
+			 *
+			 * @since 6.9.0
+			 *
+			 * @param string $content Tiled Gallery block content.
+			 */
+			return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
+		}
 	}
-}
-
-/**
- * Map block registration/dependency declaration.
- *
- * @param array  $attr - Array containing the map block attributes.
- * @param string $content - String containing the map block content.
- *
- * @return string
- */
-function jetpack_map_block_load_assets( $attr, $content ) {
-	$dependencies = array(
-		'lodash',
-		'wp-element',
-		'wp-i18n',
-	);
-
-	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
-
-	Jetpack_Gutenberg::load_assets_as_required( 'map', $dependencies );
-	return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
 }

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -242,55 +242,57 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		jetpack_register_block( 'contact-form', array(
-			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
-		) );
+		if ( jetpack_register_gutenberg_extension( 'contact-form' ) ) {
+			register_block_type( 'jetpack/contact-form', array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+			) );
 
-		// Field render methods.
-		jetpack_register_block( 'field-text', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
-		) );
-		jetpack_register_block( 'field-name', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
-		) );
-		jetpack_register_block( 'field-email', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
-		) );
-		jetpack_register_block( 'field-url', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
-		) );
-		jetpack_register_block( 'field-date', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
-		) );
-		jetpack_register_block( 'field-telephone', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
-		) );
-		jetpack_register_block( 'field-textarea', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
-		) );
-		jetpack_register_block( 'field-checkbox', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
-		) );
-		jetpack_register_block( 'field-checkbox-multiple', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
-		) );
-		jetpack_register_block( 'field-radio', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
-		) );
-		jetpack_register_block( 'field-select', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
-		) );
+			// Field render methods.
+			register_block_type( 'jetpack/field-text', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
+			) );
+			register_block_type( 'jetpack/field-name', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
+			) );
+			register_block_type( 'jetpack/field-email', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
+			) );
+			register_block_type( 'jetpack/field-url', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
+			) );
+			register_block_type( 'jetpack/field-date', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
+			) );
+			register_block_type( 'jetpack/field-telephone', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
+			) );
+			register_block_type( 'jetpack/field-textarea', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
+			) );
+			register_block_type( 'jetpack/field-checkbox', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
+			) );
+			register_block_type( 'jetpack/field-checkbox-multiple', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
+			) );
+			register_block_type( 'jetpack/field-radio', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
+			) );
+			register_block_type( 'jetpack/field-select', array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
+			) );
+		}
 	}
 
 	public static function gutenblock_render_form( $atts, $content ) {

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -72,7 +72,7 @@ class WPCom_Markdown {
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}
-		jetpack_register_block( 'markdown' );
+		jetpack_register_gutenberg_extension( 'markdown' );
 	}
 
 	/**

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -784,7 +784,7 @@ abstract class Publicize_Base {
 		// so we cannot pass one to `$this->current_user_can_access_publicize_data()`.
 
 		if ( $this->current_user_can_access_publicize_data() ) {
-			jetpack_register_plugin( 'publicize' );
+			jetpack_register_gutenberg_extension( 'publicize' );
 		} else {
 			jetpack_set_extension_unavailability_reason( 'publicize', 'unauthorized' );
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -68,12 +68,14 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		jetpack_register_block(
-			'related-posts',
-			array(
-				'render_callback' => array( $this, 'render_block' ),
-			)
-		);
+		if ( jetpack_register_gutenberg_extension( 'related-posts' ) ) {
+			register_block_type(
+				'jetpack/related-posts',
+				array(
+					'render_callback' => array( $this, 'render_block' ),
+				)
+			);
+		}
 	}
 
 	protected function get_blog_id() {

--- a/modules/shortcodes/email-subscribe.php
+++ b/modules/shortcodes/email-subscribe.php
@@ -64,36 +64,38 @@ class Jetpack_Email_Subscribe {
 	}
 
 	private function register_gutenberg_block() {
-		jetpack_register_block( self::$block_name, array(
-			'attributes' => array(
-				'title' => array(
-					'type' => 'string',
+		if ( jetpack_register_gutenberg_extension( self::$block_name ) ) {
+			register_block_type( 'jetpack/' . self::$block_name, array(
+				'attributes'      => array(
+					'title'             => array(
+						'type' => 'string',
+					),
+					'email_placeholder' => array(
+						'type' => 'string',
+					),
+					'submit_label'      => array(
+						'type' => 'string',
+					),
+					'consent_text'      => array(
+						'type' => 'string',
+					),
+					'processing_label'  => array(
+						'type' => 'string',
+					),
+					'success_label'     => array(
+						'type' => 'string',
+					),
+					'error_label'       => array(
+						'type' => 'string',
+					),
+					'className'         => array(
+						'type' => 'string',
+					),
 				),
-				'email_placeholder' => array(
-					'type' => 'string',
-				),
-				'submit_label' => array(
-					'type' => 'string',
-				),
-				'consent_text' => array(
-					'type' => 'string',
-				),
-				'processing_label' => array(
-					'type' => 'string',
-				),
-				'success_label' => array(
-					'type' => 'string',
-				),
-				'error_label' => array(
-					'type' => 'string',
-				),
-				'className' => array(
-					'type' => 'string',
-				),
-			),
-			'style' => 'jetpack-email-subscribe',
-			'render_callback' => array( $this, 'parse_shortcode' ),
-		) );
+				'style'           => 'jetpack-email-subscribe',
+				'render_callback' => array( $this, 'parse_shortcode' ),
+			) );
+		}
 	}
 
 	public function init_hook_action() {

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -129,4 +129,4 @@ if ( function_exists( 'register_rest_field' ) ) {
 }
 
 // Register Gutenberg plugin
-jetpack_register_plugin( 'shortlinks' );
+jetpack_register_gutenberg_extension( 'shortlinks' );

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -62,7 +62,7 @@ class Jetpack_Simple_Payments {
 
 	function register_gutenberg_block() {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			jetpack_register_block( 'simple-payments' );
+			jetpack_register_gutenberg_extension( 'simple-payments' );
 		} else {
 			jetpack_set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
 		}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -724,7 +724,7 @@ function jetpack_blog_subscriptions_init() {
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
-	jetpack_register_block( 'subscriptions' );
+	jetpack_register_gutenberg_extension( 'subscriptions' );
 }
 
 add_action( 'init', 'jetpack_register_subscriptions_block' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -6,15 +6,6 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'register_block_type not available' );
-			return;
-		}
-
-		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
-			$this->markTestSkipped( 'WP_Block_Type_Registry not available' );
-			return;
-		}
 		// Create a user and set it up as current.
 		$this->master_user_id = $this->factory->user->create( array( 'user_login' => 'current_master' ) );
 		// Mock a connection
@@ -35,86 +26,42 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 			Jetpack_Options::delete_option( array( 'master_user', 'user_tokens' ) );
 			wp_delete_user( $this->master_user_id );
 		}
-
-		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
-			$blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
-			foreach ( $blocks as $block_name => $block ) {
-				if ( strpos( $block_name, 'jetpack/' ) !== false ) {
-					unregister_block_type( $block_name );
-				}
-			}
-		}
 	}
 
 	public static function get_extensions_whitelist() {
 		return array(
-			// Our "Blocks" :)
 			'apple',
 			'banana',
 			'coconut',
 			'grape',
-			// Our "Plugins" :)
-			'onion',
-			'potato',
-			'tomato'
 		);
 	}
 
-	function test_registered_block_is_available() {
-		jetpack_register_block( 'apple' );
+	function test_registered_extension_is_available() {
+		jetpack_register_gutenberg_extension( 'apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['apple']['available'] );
 	}
 
-	function test_registered_block_is_not_available() {
+	function test_registered_extension_is_not_available() {
 		jetpack_set_extension_unavailability_reason( 'banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
 	}
 
-	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_block( 'durian' );
+	function test_registered_extension_is_not_available_when_not_defined_in_whitelist() {
+		jetpack_register_gutenberg_extension( 'durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
 		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
 	}
 
-	function test_block_is_not_available_when_not_registered_returns_missing_module() {
+	function test_extension_is_not_available_when_not_registered_returns_missing_module() {
 		$availability = Jetpack_Gutenberg::get_availability();
 
-		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
+		// 'unavailable_reason' should be 'missing_module' if the extension wasn't registered
 		$this->assertFalse( $availability['grape']['available'], 'Availability is not false exists' );
 		$this->assertEquals( $availability['grape']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
-	}
-
-	// Plugins
-	function test_registered_plugin_is_available() {
-		jetpack_register_plugin( 'onion' );
-		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertTrue( $availability['onion']['available'] );
-	}
-
-	function test_registered_plugin_is_not_available() {
-		jetpack_set_extension_unavailability_reason( 'potato', 'bar' );
-		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
-		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
-	}
-
-	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_plugin( 'parsnip' );
-		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertFalse( $availability['parsnip']['available'], 'durian is available!' );
-		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
-
-	}
-
-	function test_plugin_is_not_available_when_not_registered_returns_missing_module() {
-		$availability = Jetpack_Gutenberg::get_availability();
-
-		// 'unavailable_reason' should be 'missing_module' if the block wasn't registered
-		$this->assertFalse( $availability['tomato']['available'], 'Availability is not false exists' );
-		$this->assertEquals( $availability['tomato']['unavailable_reason'], 'missing_module', 'unavailable_reason is not "missing_module"'  );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Deprecates the `jetpack_register_block` and `jetpack_register_plugin` utilities in favor of the new `jetpack_register_gutenberg_extension`.

This new function doesn't actually register an extension, it just keeps track of the extensions that are registered if they are whitelisted.

This means that the blocks need to be now explicitly registered by the modules using `register_block_type`. Thanks to this, we remove some abstraction and allow to build more complex extensions (i.e.: overriding an existing block).

#### Testing instructions:

_Jetpack_

* Spin up a new Jurassic Ninja test site using this branch: https://jurassic.ninja/create?gutenpack&branch=try/refactor-jetpack-gutenberg-extensions
* Connect Jetpack to a WP.com site.
* Verify that [the production Jetpack extensions](https://github.com/Automattic/wp-calypso/blob/253016b428732a470c6c3e6c7452ca2018d0cd57/client/gutenberg/extensions/presets/jetpack/index.json#L3-L11) work as before:
  * Contact form
  * Map
  * Markdown
  * Publicize
  * Related posts
  * Shortlinks
  * Simple payments
  * Subscriptions
  * Tiled gallery
* Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to true.
* Confirm that [the beta extensions](https://github.com/Automattic/wp-calypso/blob/253016b428732a470c6c3e6c7452ca2018d0cd57/client/gutenberg/extensions/presets/jetpack/index.json#L14-L16) become now available:
  * Mailchimp
  * ~Giphy~ (not registered yet on Jetpack).
  * VR

_WordPress.com_

* Apply D23396-code in your sandbox.
* Verify that [the production Jetpack extensions](https://github.com/Automattic/wp-calypso/blob/253016b428732a470c6c3e6c7452ca2018d0cd57/client/gutenberg/extensions/presets/jetpack/index.json#L3-L11) work as before:
  * Contact form
  * Map
  * Markdown
  * Publicize
  * Related posts
  * Shortlinks
  * Simple payments
  * Subscriptions
  * Tiled gallery

#### Proposed changelog entry for your changes:

* Decrease abstraction when registering extensions on `Jetpack_Gutenberg` class
