### PR TITLE
API: Endpoint to allow setting WooCommerce access token and secret via secure endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-jps-woocommerce-connect-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-jps-woocommerce-connect-endpoint.php
@@ -1,0 +1,58 @@
+<?php
+
+class Jetpack_JSON_API_JPS_WooCommerce_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
+
+	protected $needed_capabilities = 'manage_options';
+
+	function result() {
+		$input       = $this->input();
+		$helper_data = get_option( 'woocommerce_helper_data', array() );
+
+		if ( ! empty( $helper_data['auth'] ) ) {
+			return new WP_Error(
+				'already_configured',
+				__( 'WooCommerce auth data is already set.', 'jetpack' )
+			);
+		}
+
+		// Only update the auth field for `woocommerce_helper_data` instead of blowing out the entire option.
+		$helper_data['auth'] = array(
+			'user_id'             => $input['user_id'],
+			'site_id'             => $input['site_id'],
+			'updated'             => time(),
+			'access_token'        => $input['access_token'],
+			'access_token_secret' => $input['access_token_secret'],
+		);
+
+		$updated = update_option(
+			'woocommerce_helper_data',
+			$helper_data
+		);
+
+		return array(
+			'success' => $updated,
+		);
+	}
+
+	function validate_input( $object ) {
+		$input = $this->input();
+
+		if ( empty( $input['access_token'] ) ) {
+			return new WP_Error( 'input_error', __( 'access_token is required', 'jetpack' ) );
+		}
+
+		if ( empty( $input['access_token_secret'] ) ) {
+			return new WP_Error( 'input_error', __( 'access_token_secret is required', 'jetpack' ) );
+		}
+
+		if ( empty( $input['user_id'] ) ) {
+			return new WP_Error( 'input_error', __( 'user_id is required', 'jetpack' ) );
+		}
+
+		if ( empty( $input['site_id'] ) ) {
+			return new WP_Error( 'input_error', __( 'site_id is required', 'jetpack' ) );
+		}
+
+		return parent::validate_input( $object );
+	}
+}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1193,3 +1193,40 @@ new Jetpack_JSON_API_User_Create_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/users/create'
 
 ) );
+
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-jps-woocommerce-connect-endpoint.php' );
+
+// POST /sites/%s/jps/woo-connect
+new Jetpack_JSON_API_JPS_WooCommerce_Connect_Endpoint( array(
+	'description'    => 'Attempts to connect the WooCommerce plugin for this site to WooCommerce.com.',
+	'group'          => '__do_not_document',
+	'method'         => 'POST',
+	'path'           => '/sites/%s/jps/woo-connect',
+	'stat'           => 'jps:woo-connect',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+	),
+	'request_format'  => array(
+		'access_token'        => '(string) The access token for WooCommerce to connect to WooCommerce.com',
+		'access_token_secret' => '(string) The access token secret for WooCommerce to connect to WooCommerce.com',
+		'user_id'             => '(int) The user\'s ID after registering for a host plan',
+		'site_id'             => '(int) The site\'s ID after registering for a host plan',
+	),
+	'response_format' => array(
+		'success' => '(bool) Setting access token and access token secret successful?',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN',
+		),
+		'body' => array(
+			'access_token'        => '123456789',
+			'access_token_secret' => 'abcdefghiklmnop',
+			'user_id'             => 1,
+			'site_id'             => 2,
+		),
+	),
+	'example_response' => '{ "success": true }',
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/jps/woo-connect'
+) );


### PR DESCRIPTION
This adds an endpoint so that we can remotely set the values necessary to connect a new Jetpack site with WooCommerce installed. cc Poseidon for some eyes on the secure endpoint. cc @mattyza to verify that we're setting `access_token` and `access_token_secret` correctly here.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* As part of provisioning a WooCommerce package, we need the ability to set the `access_token` and `access_token_secret` that WooComerce.com returns from their `host-plan` endpoint. This patch adds the Jetpack side of a new `/sites/%site/jps/woo-connect` endpoint that will be used to handle this logic.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout D23397 on WP.com
* Sandbox API by setting JETPACK__SANDBOX_DOMAIN constant on your Jetpack site
  * Something like`define( 'JETPACK__SANDBOX_DOMAIN', '*.wordpress.com' );` on your sandbox
* Ensure that Jetpack site host is sandboxing `public-api.wordpress.com`
  * I do this by setting a value in `/etc/hosts`
* Checkout `update/jetpack-start-woocommerce-connect` on remote Jetpack site
* Manually make a POST request to site using the REST API console by querying like this:
  * URL: `/sites/$site/jps/woo-connect?force=secure` 
  * Body: `access_token=123456&access_token_secret=abcdef&user_id=1&site_id=2`
* Ensure that WooCommerce option value is set correctly when the API call is made with something like `wp option get woocommerce_helper_data`
* See D23397 for more testing instructions

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Adds endpoint to support setting up WooCommerce connection via Jetpack API.
