### PR TITLE
Contact Form Submissions: Break Words

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -65,6 +65,7 @@
 
 .contact-form-submission p {
 	margin: 0 auto;
+	word-wrap: break-word;
 }
 
 .form-errors .form-error-message {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes Automattic/themes#506

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The Jetpack Contact Form currently assumes that a theme breaks submissions itself in the same way that it does with normal paragraphs. Most themes do, but not all themes do, including Karuna on WordPress.com. 

This PR proposes explicitly breaking submissions instead of relying on themes to do it. 

**Note:** I'm not actually sure if this is something which should be proposed to the Karuna theme only. I've submitted this PR because this might affect other themes currently and in the future, but won't cause any differences to other themes. Let me know if this should be closed in favour of a fix exclusive to Karuna, where this issue was originally reported! 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a contact form, using either the Classic Editor or the Form Block, publish and view
* Enter some long text or a long email
* Submit

Most themes will break this up. Some don't, such as Karuna, and it causes weird overlaps with the sidebar and overflows on mobile, which this aims to prevent. See below. 

**Current on some themes:**

![ezgif-2-c6e53ff6d8cd](https://user-images.githubusercontent.com/43215253/51566139-b657b700-1e8b-11e9-9f79-bb2f278b1477.gif)

**Proposed:**

![ezgif-2-bab52c7f1a64](https://user-images.githubusercontent.com/43215253/51566120-aa6bf500-1e8b-11e9-93e3-685d8de361f1.gif)

**Other themes - no difference (using Twenty Nineteen as an example):**

![gfdsfgdsfdgsgfd](https://user-images.githubusercontent.com/43215253/51566108-a049f680-1e8b-11e9-9d7a-b1b8020425bd.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

Ensure Contact Form submissions break words regardless of theme
