### PR TITLE
Shorten publicize message about Facebook Page restrictions

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -498,7 +498,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Please select a Facebook page to publish updates.' );
+						$connection_test_message = __( 'Please select a Facebook Page to publish updates.' );
 					}
 				}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -502,7 +502,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Please select a Facebook Page to publish updates.' );
+						$connection_test_message = __( 'Please select a Facebook Page to publish updates.', 'jetpack' );
 					}
 				}
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -498,7 +498,7 @@ abstract class Publicize_Base {
 					if ( ! $this->is_valid_facebook_connection( $connection ) ) {
 						$connection_test_passed = false;
 						$user_can_refresh = false;
-						$connection_test_message = __( 'Facebook no longer supports Publicize connections to Facebook Profiles, but you can still connect Facebook Pages. Please select a Facebook Page to publish updates to.' );
+						$connection_test_message = __( 'Please select a Facebook page to publish updates.' );
 					}
 				}
 


### PR DESCRIPTION
Updates copy on Publicize Facebook Notice

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Changes copy for Facebook publicize for previously connected accounts.

#### Testing instructions:

Make 'modules/publicize/publicize.php' L423 ( is_valid_facebook_connection ) return false to simulate a invalid facebook connection

* Go to Gutenberg
* Click Jetpack logo
* Have Facebook connected
* Under "Share this post" observe the error block with correct copy

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Updates copy on Publicize Facebook Notice
