### PR TITLE
Notices: Update blacklisted notice copy

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -85,7 +85,9 @@ class JetpackStateNotices extends React.Component {
 				);
 				break;
 			case 'site_blacklisted':
-				message = __( "This site can't be connected to WordPress.com." );
+				message = __(
+					"This site can't be connected to WordPress.com because it violates our Terms of Service."
+				);
 				break;
 			case 'not_public':
 				message = __(

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -86,7 +86,12 @@ class JetpackStateNotices extends React.Component {
 				break;
 			case 'site_blacklisted':
 				message = __(
-					"This site can't be connected to WordPress.com because it violates our Terms of Service."
+					"This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.",
+					{
+						components: {
+							a: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank" />,
+						},
+					}
 				);
 				break;
 			case 'not_public':


### PR DESCRIPTION
This PR updates the blacklisted site notice copy for clarity, as suggested in p7pQDF-3XA-p2 and by @jeherve in https://github.com/Automattic/jetpack/pull/11168#pullrequestreview-194593406.

#### Changes proposed in this Pull Request:

* Update the copy of the notice that's displayed to the user when they try to connect a blacklisted site.

#### Testing instructions:
* Follow the instructions in https://github.com/Automattic/wp-calypso/pull/29983.

#### Proposed changelog entry for your changes:

* Improve the blacklisted site notice copy.
