### PR TITLE
Comments: remove Google+ data from the Comment module.

### DIFF
--- a/modules/comments.php
+++ b/modules/comments.php
@@ -2,14 +2,14 @@
 
 /**
  * Module Name: Comments
- * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
+ * Module Description: Let readers use WordPress.com, Twitter, or Facebook accounts to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
  * Feature: Engagement
- * Additional Search Queries: comments, comment, facebook, twitter, google+, social
+ * Additional Search Queries: comments, comment, facebook, twitter, social
  */
 
 require dirname( __FILE__ ) . '/comments/comments.php';

--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -190,7 +190,7 @@ class Highlander_Comments_Base {
 	 * @return If no
 	 */
 	function allow_logged_out_user_to_comment_as_external() {
-		if ( ! $this->is_highlander_comment_post( 'facebook', 'twitter', 'googleplus' ) ) {
+		if ( ! $this->is_highlander_comment_post( 'facebook', 'twitter' ) ) {
 			return;
 		}
 
@@ -218,7 +218,7 @@ class Highlander_Comments_Base {
 		}
 
 		// Bail if this is not a guest or external service credentialed request
-		if ( ! $this->is_highlander_comment_post( 'guest', 'facebook', 'twitter', 'googleplus' ) ) {
+		if ( ! $this->is_highlander_comment_post( 'guest', 'facebook', 'twitter' ) ) {
 			return $comment_data;
 		}
 


### PR DESCRIPTION
See #10950 

#### Changes proposed in this Pull Request:

Very little is done on the Jetpack side for the Comments module, but since Google+ is being sunset, once the option to comment via Google+ is removed from the form, we should remove this as well.

#### Testing instructions:

* Make sure you can still use the comment form like before.

#### Proposed changelog entry for your changes:

* None
