### PR TITLE
Multisite: fix the display of the main connection banner.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -255,6 +255,9 @@ abstract class Jetpack_Admin_Page {
 			#jp-plugin-container.is-wide .wrap {
 				max-width: 1040px;
 			}
+			#jp-plugin-container .wrap .jetpack-wrap-container {
+				margin-top: 1em;
+			}
 			.wp-admin #dolly {
 			    float: none;
 			    position: relative;

--- a/views/admin/must-connect-main-blog.php
+++ b/views/admin/must-connect-main-blog.php
@@ -1,18 +1,16 @@
 <div class="wrap">
-	<div id="message" class="updated jetpack-message jp-connect" style="display:block !important;">
-		<div class="jetpack-wrap-container">
-			<div class="jetpack-text-container">
-				<h1><?php _e( 'Get started with Jetpack Multisite', 'jetpack' ); ?></h1>
-				<p>
-					<?php _e( 'Get started managing your Multisite install of Jetpack by connecting.', 'jetpack' ) ?>
-				</p>
-			</div>
-			<div class="jetpack-install-container">
-				<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector" id="wpcom-connect"><?php _e( 'Connect to WordPress.com', 'jetpack' ); ?></a></p>
-				<p class="jetpack-install-blurb">
-					<?php jetpack_render_tos_blurb(); ?>
-				</p>
-			</div>
+	<div class="jetpack-wrap-container dops-card">
+		<div class="jetpack-text-container">
+			<h1><?php _e( 'Get started with Jetpack Multisite', 'jetpack' ); ?></h1>
+			<p>
+				<?php _e( 'Get started managing your Multisite install of Jetpack by connecting.', 'jetpack' ) ?>
+			</p>
+		</div>
+		<div class="jetpack-install-container">
+			<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector" id="wpcom-connect"><?php _e( 'Connect to WordPress.com', 'jetpack' ); ?></a></p>
+			<p class="jetpack-install-blurb">
+				<?php jetpack_render_tos_blurb(); ?>
+			</p>
 		</div>
 	</div>
 </div>

--- a/views/admin/must-connect-main-blog.php
+++ b/views/admin/must-connect-main-blog.php
@@ -1,13 +1,13 @@
 <div class="wrap">
 	<div class="jetpack-wrap-container dops-card">
 		<div class="jetpack-text-container">
-			<h1><?php _e( 'Get started with Jetpack Multisite', 'jetpack' ); ?></h1>
+			<h1><?php esc_html_e( 'Get started with Jetpack Multisite', 'jetpack' ); ?></h1>
 			<p>
-				<?php _e( 'Get started managing your Multisite install of Jetpack by connecting.', 'jetpack' ) ?>
+				<?php esc_html_e( 'Get started managing your Multisite install of Jetpack by connecting.', 'jetpack' ); ?>
 			</p>
 		</div>
 		<div class="jetpack-install-container">
-			<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector" id="wpcom-connect"><?php _e( 'Connect to WordPress.com', 'jetpack' ); ?></a></p>
+			<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector dops-button is-primary" id="wpcom-connect"><?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?></a></p>
 			<p class="jetpack-install-blurb">
 				<?php jetpack_render_tos_blurb(); ?>
 			</p>


### PR DESCRIPTION
Fixes #11186

#### Changes proposed in this Pull Request:

* Changes the structure of the main Connection banner in the multisite screen.

**Before 6.6:**

<img width="1268" alt="screenshot 2019-01-24 at 10 51 39" src="https://user-images.githubusercontent.com/426388/51673235-c7a8dc80-1fcd-11e9-8d9a-8d53b9e32cb9.png">

**After 6.6:**

![](https://user-images.githubusercontent.com/7129409/51636512-77773f00-1f27-11e9-8bf0-b543e5c9bdb1.png)

**With this PR:**

<img width="1115" alt="screenshot 2019-01-24 at 11 41 50" src="https://user-images.githubusercontent.com/426388/51673281-e7d89b80-1fcd-11e9-8aac-60741064d564.png">


#### Testing instructions:

1. Launch [New Jurassic Ninja multisite on subdir](https://jurassic.ninja/create?jetpack-beta&branch=fix/network-activation-notice&shortlived&wp-debug-log&subdir_multisite) 
2. Do not connect Jetpack yet
3. Add a new site to your multisite 
4. Navigate to Jetpack > Sites `/wp-admin/network/admin.php?page=jetpack`


#### Proposed changelog entry for your changes:

* Multisite: fix the display of the main connection banner.
