### PR TITLE
Use VideoPress videos as source of the core video blocks

### DIFF
--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -19,6 +19,7 @@ include_once dirname( __FILE__ ) . '/videopress/class.videopress-scheduler.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-xmlrpc.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-cli.php';
 include_once dirname( __FILE__ ) . '/videopress/class.jetpack-videopress.php';
+include_once dirname( __FILE__ ) . '/videopress/class.videopress-gutenberg.php';
 
 if ( is_admin() ) {
 	include_once dirname( __FILE__ ) . '/videopress/editor-media-view.php';

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -73,11 +73,13 @@ class VideoPress_Gutenberg {
 
 		$videopress_url = $videopress_data->file_url_base->https . $videopress_data->files->hd->mp4;
 
+		$pattern = '/(\s)src=([\'"])(?:(?!\2).)+?\2/';
+
 		return preg_replace(
-			'/src="([^"]+)/',
+			$pattern,
 			sprintf(
-				'src="%1$s',
-				esc_attr( $videopress_url )
+				'\1src="%1$s"',
+				esc_url_raw( $videopress_url )
 			),
 			$content,
 			1

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -6,34 +6,10 @@ class VideoPress_Gutenberg {
 	 * Initialize the VideoPress Gutenberg extension
 	 */
 	public static function init() {
-		if ( self::should_initialize() ) {
+		// Should not initialize if Gutenberg is not available
+		if ( function_exists( 'register_block_type' ) ) {
 			add_action( 'init', array( __CLASS__, 'register_video_block_with_videopress' ) );
 		}
-	}
-
-	/**
-	 * Check whether conditions indicate the VideoPress Gutenberg extension should be initialized
-	 *
-	 * @return bool
-	 */
-	public static function should_initialize() {
-		// Should not initialize if Gutenberg is not available
-		if ( ! function_exists( 'register_block_type' ) ) {
-			return false;
-		}
-
-		// Should initialize if this is a WP.com site
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return true;
-		}
-
-		// Should not initialize if this is a Jetpack site but Jetpack is not active (unless the dev mode is enabled)
-		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
-			return false;
-		}
-
-		// Should initialize by default
-		return true;
 	}
 
 	/**

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -62,7 +62,12 @@ class VideoPress_Gutenberg {
 			return $content;
 		}
 
-		$blog_id = Jetpack_Options::get_option( 'id' );
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$blog_id = get_current_blog_id();
+		} else {
+			$blog_id = Jetpack_Options::get_option( 'id' );
+		}
+
 		$post_id = absint( $attributes['id'] );
 		$videopress_id = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
 		$videopress_data = videopress_get_video_details( $videopress_id );

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -68,8 +68,8 @@ class VideoPress_Gutenberg {
 			$blog_id = Jetpack_Options::get_option( 'id' );
 		}
 
-		$post_id = absint( $attributes['id'] );
-		$videopress_id = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
+		$post_id         = absint( $attributes['id'] );
+		$videopress_id   = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
 		$videopress_data = videopress_get_video_details( $videopress_id );
 
 		if ( empty( $videopress_data->file_url_base->https ) || empty( $videopress_data->files->hd->mp4 ) ) {

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -58,7 +58,7 @@ class VideoPress_Gutenberg {
 			return $content;
 		}
 
-		$blog_id = get_current_blog_id();
+		$blog_id = Jetpack_Options::get_option( 'id' );
 		$post_id = absint( $attributes['id'] );
 		$videopress_id = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
 		$videopress_data = videopress_get_video_details( $videopress_id );

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -1,0 +1,84 @@
+<?php
+
+class VideoPress_Gutenberg {
+
+	/**
+	 * Initialize the VideoPress Gutenberg extension
+	 */
+	public static function init() {
+		if ( self::should_initialize() ) {
+			add_action( 'init', array( __CLASS__, 'register_video_block_with_videopress' ) );
+		}
+	}
+
+	/**
+	 * Check whether conditions indicate the VideoPress Gutenberg extension should be initialized
+	 *
+	 * @return bool
+	 */
+	public static function should_initialize() {
+		// Should not initialize if Gutenberg is not available
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return false;
+		}
+
+		// Should initialize if this is a WP.com site
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return true;
+		}
+
+		// Should not initialize if this is a Jetpack site but Jetpack is not active (unless the dev mode is enabled)
+		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+			return false;
+		}
+
+		// Should initialize by default
+		return true;
+	}
+
+	/**
+	 * Register the Jetpack Gutenberg extension that adds VideoPress support to the core video block.
+	 */
+	public static function register_video_block_with_videopress() {
+		register_block_type( 'core/video', array(
+			'render_callback' => array( __CLASS__, 'render_video_block_with_videopress' ),
+		) );
+	}
+
+	/**
+	 * Render the core video block replacing the src attribute with the VideoPress URL
+	 *
+	 * @param array  $attributes Array containing the video block attributes.
+	 * @param string $content    String containing the video block content.
+	 *
+	 * @return string
+	 */
+	public function render_video_block_with_videopress( $attributes, $content ) {
+		if ( ! isset( $attributes['id'] ) ) {
+			return $content;
+		}
+
+		$blog_id = get_current_blog_id();
+		$post_id = absint( $attributes['id'] );
+		$videopress_id = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
+		$videopress_data = videopress_get_video_details( $videopress_id );
+
+		if ( empty( $videopress_data->files->hd->mp4 ) ) {
+			return $content;
+		}
+
+		$videopress_url = $videopress_data->file_url_base->https . $videopress_data->files->hd->mp4;
+
+		return preg_replace(
+			'/src="([^"]+)/',
+			sprintf(
+				'src="%1$s',
+				esc_attr( $videopress_url )
+			),
+			$content,
+			1
+		);
+	}
+}
+
+VideoPress_Gutenberg::init();

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -63,7 +63,7 @@ class VideoPress_Gutenberg {
 		$videopress_id = video_get_info_by_blogpostid( $blog_id, $post_id )->guid;
 		$videopress_data = videopress_get_video_details( $videopress_id );
 
-		if ( empty( $videopress_data->files->hd->mp4 ) ) {
+		if ( empty( $videopress_data->file_url_base->https ) || empty( $videopress_data->files->hd->mp4 ) ) {
 			return $content;
 		}
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -40,6 +40,10 @@ class VideoPress_Gutenberg {
 	 * Register the Jetpack Gutenberg extension that adds VideoPress support to the core video block.
 	 */
 	public static function register_video_block_with_videopress() {
+		// We intentionally don't use `jetpack_register_block` because the current Jetpack extensions
+		// registration doesn't fit our needs. Right now, any extension registered with `jetpack_register_block`
+		// needs to have a name that is equal to the name of the registered block (our extension name would be
+		// "videopress" and the name of the block we need to register "core/video").
 		register_block_type( 'core/video', array(
 			'render_callback' => array( __CLASS__, 'render_video_block_with_videopress' ),
 		) );

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -53,7 +53,7 @@ class VideoPress_Gutenberg {
 	 *
 	 * @return string
 	 */
-	public function render_video_block_with_videopress( $attributes, $content ) {
+	public static function render_video_block_with_videopress( $attributes, $content ) {
 		if ( ! isset( $attributes['id'] ) ) {
 			return $content;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR ensures that we are using the VideoPress videos on published posts containing video blocks.

* Add a new `VideoPress_Gutenberg` class to the VideoPress module that defines the server-side rendering of the `core/video` block.
* The server-side rendering returns the block content as defined by the client-side but replacing the `src` attribute used in the video player with the VideoPress URL if it is available.
* The logic has been created in a new file `class.videopress-gutenberg.php` so it can be reused in WP.com and synced with Fusion (D23482-code).

#### Testing instructions:

* Spin up a new Jurassic Ninja test site: https://jurassic.ninja/create/?jetpack-beta&branch=add/videopress-src-core-video-blocks&shortlived&wp-debug-log&gutenpack
* Connect Jetpack to a WP.com site with a premium/business plan.
* Go to Jetpack → Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
* Add a new post.
* Insert a video block.
* Upload a video file using the Media Library in a format that is not supported by your browser (e.g. .mov in Chrome). 
  * VideoPress only converts videos uploaded with the Media Library, that's why we need to use that instead of the "Upload" button (to be fixed in a follow-up PR/commit: https://github.com/Automattic/jetpack/issues/11194).
<img width="673" alt="screen shot 2019-01-15 at 17 11 12" src="https://user-images.githubusercontent.com/1233880/51193290-cd753280-18e8-11e9-8417-b69070f3109c.png">


* Publish it immediately.
* Check that a black placeholder is displayed on the published view. Note that this will only happen if VideoPress has not finished yet to convert the video.
<img width="333" alt="screen shot 2019-01-14 at 16 42 41" src="https://user-images.githubusercontent.com/1233880/51122999-6f2e4e00-181b-11e9-9583-05f3cb7583bb.png">

* Wait until VideoPress finishes to convert the video (you can check this on the Media section).
* Reload the published view of the post.
* Make sure that the video is now playable.
<img width="547" alt="screen shot 2019-01-14 at 16 48 22" src="https://user-images.githubusercontent.com/1233880/51123371-3b075d00-181c-11e9-900a-99940599b4ad.png">

* Inspect the video player with the browser devtools and confirm that the `src` attribute is pointing to the VideoPress video (`videos.files.wp.com`).
* Repeat the process downgrading the plan or disabling the VideoPress module and check that the video is not playable on the published view and the `src` attribute doesn't point to `videos.files.wp.com`. _Note that you need to upload a new video since the previous one is already converted)._

#### Proposed changelog entry for your changes:

* Use VideoPress videos as source of the core video blocks
