### PR TITLE
AMP: move checks for AMP requests later, inside modules.

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -14,20 +14,8 @@ class Jetpack_AMP_Support {
 			add_action( 'amp_post_template_footer', array( 'Jetpack_AMP_Support', 'add_stats_pixel' ) );
 		}
 
-		// carousel
-		add_filter( 'jp_carousel_maybe_disable', array( __CLASS__, 'is_amp_request' ) );
-
-		// sharing
-		add_filter( 'sharing_enqueue_scripts', array( __CLASS__, 'is_not_amp_request' ) );
-		add_filter( 'jetpack_sharing_counts', array( __CLASS__, 'is_not_amp_request' ) );
-		add_filter( 'sharing_js', array( __CLASS__, 'is_not_amp_request' ) );
+		// Sharing.
 		add_filter( 'jetpack_sharing_display_markup', array( 'Jetpack_AMP_Support', 'render_sharing_html' ), 10, 2 );
-
-		// disable lazy images
-		add_filter( 'lazyload_is_enabled', array( __CLASS__, 'is_not_amp_request' ) );
-
-		// disable imploding CSS
-		add_filter( 'jetpack_implode_frontend_css', array( __CLASS__, 'is_not_amp_request' ) );
 
 		// enforce freedom mode for videopress
 		add_filter( 'videopress_shortcode_options', array( 'Jetpack_AMP_Support', 'videopress_enable_freedom_mode' ) );
@@ -62,16 +50,6 @@ class Jetpack_AMP_Support {
 		 * @param boolean $is_amp_request Is this request supposed to return valid AMP content?
 		 */
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
-	}
-
-	/**
-	 * Returns whether the request is not AMP.
-	 *
-	 * @see Jetpack_AMP_Support::is_amp_request()
-	 * @return bool Whether not AMP.
-	 */
-	static function is_not_amp_request() {
-		return ! self::is_amp_request();
 	}
 
 	static function amp_disable_the_content_filters() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6873,6 +6873,11 @@ p {
 			$do_implode = false;
 		}
 
+		// Do not implode CSS when the page loads via the AMP plugin.
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			$do_implode = false;
+		}
+
 		/**
 		 * Allow CSS to be concatenated into a single jetpack.css file.
 		 *

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -29,7 +29,7 @@ class Jetpack_Carousel {
 	public $single_image_gallery_enabled_media_file = false;
 
 	function __construct() {
-		add_action( 'wp', array( $this, 'init' ), 99 );
+		add_action( 'init', array( $this, 'init' ) );
 	}
 
 	function init() {
@@ -44,7 +44,7 @@ class Jetpack_Carousel {
 
 		if ( is_admin() ) {
 			// Register the Carousel-related related settings
-			$this->register_settings();
+			add_action( 'admin_init', array( $this, 'register_settings' ), 5 );
 			if ( ! $this->in_jetpack ) {
 				if ( 0 == $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) ) {
 					return; // Carousel disabled, abort early, but still register setting so user can switch it back on
@@ -217,7 +217,7 @@ class Jetpack_Carousel {
 		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return $content;
 		}
-    
+
 		if (
 			function_exists( 'has_block' )
 			&& ( has_block( 'gallery', $content ) || has_block( 'jetpack/tiled-gallery', $content ) )

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -40,6 +40,10 @@ class Jetpack_Lazy_Images {
 			return;
 		}
 
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		add_action( 'wp_head', array( $this, 'setup_filters' ), 9999 ); // we don't really want to modify anything in <head> since it's mostly all metadata
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
@@ -99,11 +103,6 @@ class Jetpack_Lazy_Images {
 
 		// Don't lazy-load if the content has already been run through previously
 		if ( false !== strpos( $content, 'data-lazy-src' ) ) {
-			return $content;
-		}
-
-		// Don't lazyload for amp-wp content
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return $content;
 		}
 
@@ -340,9 +339,6 @@ class Jetpack_Lazy_Images {
 	}
 
 	public function enqueue_assets() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
-			return;
-		}
 		wp_enqueue_script(
 			'jetpack-lazy-images',
 			Jetpack::get_file_url_for_environment(

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -577,6 +577,10 @@ function sharing_maybe_enqueue_scripts() {
 }
 
 function sharing_add_footer() {
+	if ( Jetpack_AMP_Support::is_amp_request() ) {
+		return;
+	}
+
 	global $jetpack_sharing_counts;
 
 	/**


### PR DESCRIPTION
Fixes #11151
Fixes #11148
Fixes #11123 
Fixes #11169

#### Changes proposed in this Pull Request:

Internal discussion: p1HpG7-6cV-p2

See https://github.com/Automattic/jetpack/issues/11169#issuecomment-456875877

> the AMP checks should be deferred to as late as possible.

#### Testing instructions:

* Install the AMP plugin.
* Switch AMP mode (AMP > General) to `Paired` or `Classic`.
* Activate the Carousel module, the sharing module, and ensure that `SCRIPT_DEBUG` is set to `false` on your install.
* Create a post with a gallery
* Add a Facebook sharing button to that post.
* Share that post on Facebook once.
* Comment on one of the images in the gallery.
* Load the post in a non-AMP view, and in the 3 modes available in the AMP options screen: Native, Paired, Classic. (`Native` mode -  all views are AMP views; `Paired` mode - add `?amp` to get to the AMP view; `Classic` mode - add `/amp` to get to the AMP view)
    -  **In non-AMP views:** Does the Carousel modal work? Do you see the comment in the Carousel modal? Do you see the sharing buttons? Do you see the counter next to the sharing button? Do you see the `jetpack.css` file when viewing source?
    - **In AMP views:** you should not see the Carousel. You should see a special styling of the sharing buttons. If you check the network tab in your browser tools, you should see a request to pixel.wp.com when logged out. You should not see a `jetpack.css` file in the source.

In all cases:
- You should not see any js errors in the browser console.
- You should not get any PHP notices in your debug log.

Now try adding the following to a functionality plugin on your site:

```php
add_filter( 'jetpack_implode_frontend_css', '__return_false' );
add_filter( 'jetpack_sharing_counts', '__return_false' );
```

Once you've done so, check the non-AMP view again: 
- you should not see the sharing counter on the Facebook button.
- you should not see the `jetpack.css` file in your source. 

#### Proposed changelog entry for your changes:

* Carousel: avoid errors when fetching comments in the Carousel modal.
* CSS: fix the behaviour of the CSS concatenation filter.
