### PR TITLE
API: Add likes and sharing settings to the REST API Post response

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -557,4 +557,34 @@ class Jetpack_Likes {
 	}
 }
 
+/**
+ * Add likes and sharing settings to the REST API Post response.
+ *
+ * @action rest_api_init
+ * @uses register_meta
+ */
+function post_likes_register_meta() {
+	register_meta(
+		'post', 'switch_like_status',
+		array(
+			'type'			=> 'boolean',
+			'single'		=> true,
+			'show_in_rest'	=> true,
+		)
+	);
+	register_meta(
+		'post', 'sharing_disabled',
+		array(
+			'type'			=> 'boolean',
+			'single'		=> true,
+			'show_in_rest'	=> true,
+		)
+	);
+}
+
+// Add likes and sharing settings to the REST API Post response.
+if ( function_exists( 'register_meta' ) ) {
+	add_action( 'rest_api_init', 'post_likes_register_meta' );
+}
+
 Jetpack_Likes::init();

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -563,7 +563,7 @@ class Jetpack_Likes {
  * @action rest_api_init
  * @uses register_meta
  */
-function post_likes_register_meta() {
+function jetpack_post_likes_register_meta() {
 	register_meta(
 		'post', 'switch_like_status',
 		array(
@@ -575,8 +575,6 @@ function post_likes_register_meta() {
 }
 
 // Add Likes post_meta to the REST API Post response.
-if ( function_exists( 'register_meta' ) ) {
-	add_action( 'rest_api_init', 'post_likes_register_meta' );
-}
+add_action( 'rest_api_init', 'jetpack_post_likes_register_meta' );
 
 Jetpack_Likes::init();

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -558,7 +558,7 @@ class Jetpack_Likes {
 }
 
 /**
- * Add likes and sharing settings to the REST API Post response.
+ * Add Likes post_meta to the REST API Post response.
  *
  * @action rest_api_init
  * @uses register_meta
@@ -572,17 +572,9 @@ function post_likes_register_meta() {
 			'show_in_rest'	=> true,
 		)
 	);
-	register_meta(
-		'post', 'sharing_disabled',
-		array(
-			'type'			=> 'boolean',
-			'single'		=> true,
-			'show_in_rest'	=> true,
-		)
-	);
 }
 
-// Add likes and sharing settings to the REST API Post response.
+// Add Likes post_meta to the REST API Post response.
 if ( function_exists( 'register_meta' ) ) {
 	add_action( 'rest_api_init', 'post_likes_register_meta' );
 }

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -536,6 +536,28 @@ class Sharing_Admin {
 	}
 }
 
+/**
+ * Add Sharing post_meta to the REST API Post response.
+ *
+ * @action rest_api_init
+ * @uses register_meta
+ */
+function post_sharing_register_meta() {
+	register_meta(
+		'post', 'sharing_disabled',
+		array(
+			'type'			=> 'boolean',
+			'single'		=> true,
+			'show_in_rest'	=> true,
+		)
+	);
+}
+
+// Add Sharing post_meta to the REST API Post response.
+if ( function_exists( 'register_meta' ) ) {
+	add_action( 'rest_api_init', 'post_sharing_register_meta' );
+}
+
 function sharing_admin_init() {
 	global $sharing_admin;
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -542,7 +542,7 @@ class Sharing_Admin {
  * @action rest_api_init
  * @uses register_meta
  */
-function post_sharing_register_meta() {
+function jetpack_post_sharing_register_meta() {
 	register_meta(
 		'post', 'sharing_disabled',
 		array(
@@ -554,9 +554,7 @@ function post_sharing_register_meta() {
 }
 
 // Add Sharing post_meta to the REST API Post response.
-if ( function_exists( 'register_meta' ) ) {
-	add_action( 'rest_api_init', 'post_sharing_register_meta' );
-}
+add_action( 'rest_api_init', 'jetpack_post_sharing_register_meta' );
 
 function sharing_admin_init() {
 	global $sharing_admin;


### PR DESCRIPTION
This is necessary groundwork to support migrating the Likes and Sharing metabox to Gutenberg. See https://github.com/Automattic/wp-calypso/pull/29744 for context.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Calls `register_meta` with `show_in_rest=>true` for `switch_like_status` and `sharing_disabled`.

#### Testing instructions:
* In both Gutenberg and the Classic Editor, verify that the old (backwards-compatible) Likes and Sharing metabox still displays, and works as intended.
* In Jetpack Sharing settings, enable the toggles to show Likes and Sharing Buttons.
* Request the post endpoint via the REST API. Verify that `switch_like_status` and `sharing_disabled` show under the meta keys:

<img width="293" alt="screen shot 2019-01-24 at 1 56 13 pm" src="https://user-images.githubusercontent.com/52152/51701613-d5675d80-1fdf-11e9-9055-0c8ba92304be.png">

**Note:** These meta are confusingly named. A post with Likes disabled will have switch_like_status set to FALSE (assuming Likes are enabled on posts by default). A post with Sharing Buttons enabled will have sharing_disabled set to FALSE.

For the purposes of this PR, if these keys show up in the API, the values don't matter that much, as this simply exposes the meta saved on the post.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Add likes and sharing settings to the REST API Post response
