### PR TITLE
Sync: Add tests for Jetpack_Sync_Defaults::is_whitelisted_option

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-defaults.php
+++ b/tests/php/sync/test_class.jetpack-sync-defaults.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Testing WP_Test_Jetpack_Sync_Defaults class
+ */
+class WP_Test_Jetpack_Sync_Defaults extends WP_Test_Jetpack_Sync_Base {
+	private $jp_option = 'example_jp_option_name_here';
+
+	private $jp_sync_option = 'example_jp_sync_option_name_here';
+
+	public function setUp() {
+		parent::setUp();
+
+		add_filter( 'jetpack_options_whitelist', array( $this, 'add_to_options_whitelist' ) );
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_to_sync_options_whitelist' ) );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'jetpack_options_whitelist', array( $this, 'add_to_options_whitelist' ) );
+		remove_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_to_sync_options_whitelist' ) );
+	}
+
+	function test_is_whitelisted_option() {
+		// A default option.
+		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( 'blogname' ) );
+
+		// A custom JP option, registered with the `jetpack_options_whitelist` filter.
+		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( $this->jp_option ) );
+
+		// A custom JP sync option, registered with the `jetpack_sync_options_whitelist` filter.
+		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( $this->jp_sync_option ) );
+
+		// An unknown option.
+		$this->assertFalse( Jetpack_Sync_Defaults::is_whitelisted_option( 'some_unknown_option' ) );
+	}
+
+	public function add_to_options_whitelist( $whitelist ) {
+		$whitelist[] = $this->jp_option;
+		return $whitelist;
+	}
+
+	public function add_to_sync_options_whitelist( $whitelist ) {
+		$whitelist[] = $this->jp_sync_option;
+		return $whitelist;
+	}
+}
+


### PR DESCRIPTION
A follow-up to #11094 that adds tests to `Jetpack_Sync_Defaults::is_whitelisted_option()`. Recommended initially by @enejb here: https://github.com/Automattic/jetpack/pull/11094#issuecomment-457389289

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add tests for `Jetpack_Sync_Defaults::is_whitelisted_option()`.

#### Testing instructions:

* Checkout this branch.
* Verify tests pass.

#### Proposed changelog entry for your changes:

* Add tests for `Jetpack_Sync_Defaults::is_whitelisted_option()`.
