### PR TITLE
Sync: Add new core option to default sync, paused themes and plugins

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -138,6 +138,8 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
+		'paused_plugins',
+		'paused_themes'
 	);
 
 	public static function get_options_whitelist() {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -243,6 +243,8 @@ class Jetpack_Sync_Defaults {
 		'roles'                            => array( 'Jetpack_Sync_Functions', 'roles' ),
 		'timezone'                         => array( 'Jetpack_Sync_Functions', 'get_timezone' ),
 		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins
+		'paused_themes'                    => array( 'Jetpack_Sync_Functions', 'get_paused_themes' ),
+		'paused_plugins'                   => array( 'Jetpack_Sync_Functions', 'get_paused_plugins' ),
 	);
 
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -138,8 +138,6 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
-		'paused_plugins',
-		'paused_themes'
 	);
 
 	public static function get_options_whitelist() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -385,7 +385,7 @@ class Jetpack_Sync_Functions {
 		return sprintf( __( 'UTC%s', 'jetpack' ), $formatted_gmt_offset );
 	}
 	// New in WP 5.1
-	public function get_paused_themes() {
+	public static function get_paused_themes() {
 		if ( function_exists( 'wp_paused_themes' ) ) {
 			$paused_themes = wp_paused_themes();
 			return $paused_themes->get_all();
@@ -393,7 +393,7 @@ class Jetpack_Sync_Functions {
 		return false;
 	}
 	// New in WP 5.1
-	public function get_paused_plugins() {
+	public static function get_paused_plugins() {
 		if ( function_exists( 'wp_paused_plugins' ) ) {
 			$paused_plugins = wp_paused_plugins();
 			return $paused_plugins->get_all();

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -384,4 +384,20 @@ class Jetpack_Sync_Functions {
 		/* translators: %s is UTC offset, e.g. "+1" */
 		return sprintf( __( 'UTC%s', 'jetpack' ), $formatted_gmt_offset );
 	}
+	// New in WP 5.1
+	public function get_paused_themes() {
+		if ( function_exists( 'wp_paused_themes' ) ) {
+			$paused_themes = wp_paused_themes();
+			return $paused_themes->get_all();
+		}
+		return false;
+	}
+	// New in WP 5.1
+	public function get_paused_plugins() {
+		if ( function_exists( 'wp_paused_plugins' ) ) {
+			$paused_plugins = wp_paused_plugins();
+			return $paused_plugins->get_all();
+		}
+		return false;
+	}
 }

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -35,6 +35,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		);
 		foreach( $always_send_updates_to_these_options as $option ) {
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );
+			add_action( "delete_option_{$option}", array( $this, 'unlock_sync_callable' ) );
 		}
 
 		// Provide a hook so that hosts can send changes to certain callables right away.

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -30,6 +30,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			'home',
 			'siteurl',
 			'jetpack_sync_error_idc',
+			'paused_plugins',
+			'paused_themes',
 		);
 		foreach( $always_send_updates_to_these_options as $option ) {
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -88,6 +88,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'roles'                            => Jetpack_Sync_Functions::roles(),
 			'timezone'                         => Jetpack_Sync_Functions::get_timezone(),
 			'available_jetpack_blocks'         => Jetpack_Gutenberg::get_availability(),
+			'paused_themes'                    => Jetpack_Sync_Functions::get_paused_themes(),
+			'paused_plugins'                   => Jetpack_Sync_Functions::get_paused_plugins(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {
@@ -759,7 +761,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$plugins_action_links = $this->server_replica_storage->get_callable( 'get_plugins_action_links' );
-		
+
 		// Nothing should have changed since we cache the results.
 		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
 

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -197,8 +197,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
-			'paused_plugins'                       => array( 'slug'=> 'error' ),
-			'paused_themes'                        => array( 'slug'=> 'error' ),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -197,6 +197,8 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
+			'paused_plugins'                       => array( 'slug'=> 'error' ),
+			'paused_themes'                        => array( 'slug'=> 'error' ),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
This will enable us to track when a theme or a plugin experiences a fatal error and let our users know about it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add syncing of new in WP 5.1 paused themes and plugins options 

#### Testing instructions:
* Do the test pass? 
* Run WP beta 5.1 

* Trigger a fatal error in plugin. Does this result in the new data being synced? 
* Fix the plugin does that trigger a new sync event?

* Trigger a fatal error in theme. Does this result in the new data being synced? 
* Fix the theme does that trigger a new sync event?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Sync: Fatel events
