### PR TITLE
WordPress Importer: Enhanced Calypsoify support

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -19,9 +19,13 @@ class Jetpack_Calypsoify {
 		return self::$instance;
 	}
 
+	static function is_active() {
+		return 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true );
+	}
+
 	public function setup() {
 		add_action( 'admin_init', array( $this, 'check_param' ) );
-		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+		if ( self::is_active() ) {
 
 			// Masterbar is currently required for this to work properly. Mock the instance of it
 			if ( ! Jetpack::is_module_active( 'masterbar' ) ) {

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -22,6 +22,7 @@ $tools = array(
 	'seo-tools/jetpack-seo-utils.php',
 	'seo-tools/jetpack-seo-titles.php',
 	'seo-tools/jetpack-seo-posts.php',
+	'site-importer.php',
 	'simple-payments/simple-payments.php',
 	'verification-tools/verification-tools-utils.php',
 	'woocommerce-analytics/wp-woocommerce-analytics.php',

--- a/modules/site-importer.php
+++ b/modules/site-importer.php
@@ -1,0 +1,62 @@
+<?php
+
+class Jetpack_Site_Importer_Module {
+	static function admin_init() {
+		if ( ! ( class_exists( 'Jetpack_Calypsoify' ) && Jetpack_Calypsoify::is_active() ) ) {
+			// Don't do anything if we're not "calypsoified"
+			return;
+		}
+		add_action( 'current_screen', array( 'Jetpack_Site_Importer_Module', 'current_screen' ) );
+		add_filter( 'admin_url', array( 'Jetpack_Site_Importer_Module', 'admin_url_change_have_fun_link' ) );
+	}
+
+	static function is_import_screen() {
+		global $pagenow;
+
+		// $pagenow is probably enough for us
+		// We may want additional "screen" info at some point, so putting here for ref
+		// $screen = get_current_screen();
+		// error_log( print_r( $screen, 1 ) );
+
+		switch ( $pagenow ) {
+			case 'import.php':
+				return true;
+			case 'admin.php':
+				return isset( $_REQUEST['import'] ) && $_REQUEST['import'];
+		}
+	}
+
+	static function get_current_importer() {
+		if ( ! ( self::is_import_screen() && isset( $_REQUEST['import'] ) ) ) {
+			return '';
+		}
+		return strtolower( $_REQUEST['import'] );
+	}
+
+	static function is_wordpress_importer() {
+		return 'wordpress' === self::get_current_importer();
+	}
+
+	static function current_screen() {
+		if ( ! self::is_wordpress_importer() ) {
+			return;
+		}
+
+		error_log( "SUP WordPress Importer!!!!" );
+		// @TODO <img src="all-the-things.png" />
+	}
+
+	static function admin_url_change_have_fun_link( $admin_url ) {
+		if ( ! self::is_wordpress_importer() ) {
+			return $admin_url;
+		}
+
+		if ( isset( $_GET['step'] ) && 2 === (int) $_GET['step'] ) {
+			return 'https://wordpress.com/settings/'; // @TODO dynamic parts
+		}
+
+		return $admin_url;
+	}
+}
+
+add_action( 'admin_init', array( 'Jetpack_Site_Importer_Module', 'admin_init' ) );


### PR DESCRIPTION
In Progress.

#### Changes proposed in this Pull Request:
* New "extra" module: `Jetpack_Site_Importer_Module`
* Do nothing unless "calypsoify" is active & on the WordPress import screens
* New function `Jetpack_Calypsoify::is_active` to determine the above (check user meta)
* Use `Jetpack_Calypsoify::is_active` in its `setup` method
* Change the "have fun" link at the conclusion of the import flow to point to Calypso

#### Testing instructions:
* Go to `/wp-admin/import.php?calypsoify=1`
  * You should see the debug notice in the error_log
* Complete a flow
  * The "have fun" link should point to Calypso
* TBD

#### Proposed changelog entry for your changes:
* TBD
