### PR TITLE
Shortcodes: Deprecate Google+ Shortcode/Embed

### DIFF
--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -193,4 +193,12 @@ function wpcom_shortcodereverse_parseattr( $attrs ) {
 	return $attrs;
 }
 
+/**
+ * When an embed service goes away, we can use this handler
+ * to output a link for history's sake.
+ */
+function jetpack_deprecated_embed_handler( $matches, $attr, $url ) {
+	return sprintf( '<a href="%s">%s</a>', esc_url( $url ), esc_html( esc_url( $url ) ) );
+}
+
 jetpack_load_shortcodes();

--- a/modules/shortcodes/googleplus.php
+++ b/modules/shortcodes/googleplus.php
@@ -2,18 +2,15 @@
 
 /**
  * Google+ embeds
+ * Google+ has shut down. Output the link for history's sake.
+ * Other than that, there's not much we can do.
  */
 
 define( 'JETPACK_GOOGLEPLUS_EMBED_REGEX', '#^https?://plus\.(sandbox\.)?google\.com/(u/\d+/)?([^/]+)/posts/([^/]+)$#' );
 
 // Example URL: https://plus.google.com/114986219448604314131/posts/LgHkesWCmJo
 // Alternate example: https://plus.google.com/u/0/100004581596612508203/posts/2UKwN67MBQs  (note the /u/0/)
-wp_embed_register_handler( 'googleplus', JETPACK_GOOGLEPLUS_EMBED_REGEX, 'jetpack_googleplus_embed_handler' );
-
-function jetpack_googleplus_embed_handler( $matches, $attr, $url ) {
-	wp_enqueue_script( 'jetpack-gplus-api', 'https://apis.google.com/js/platform.js', array(), null, true );
-	return sprintf( '<div class="g-post" data-href="%s"></div>', esc_url( $url ) );
-}
+wp_embed_register_handler( 'googleplus', JETPACK_GOOGLEPLUS_EMBED_REGEX, 'jetpack_deprecated_embed_handler' );
 
 add_shortcode( 'googleplus', 'jetpack_googleplus_shortcode_handler' );
 
@@ -28,5 +25,5 @@ function jetpack_googleplus_shortcode_handler( $atts ) {
 		return;
 	}
 
-	return $wp_embed->shortcode( $atts, $atts['url'] );
+	return sprintf( '<p>%s</p>', $wp_embed->shortcode( $atts, $atts['url'] ) );
 }


### PR DESCRIPTION
See #10950.

#### Changes proposed in this Pull Request:
* Remove the auto-embed.
* Output the link to the old content.

#### Testing instructions:
In the Classic Editor:
1. Add `https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7` on its own line.
2. Add a `[googleplus url=https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7]` on its own line.
3. Preview the post. You should see two clickable URLs each in their own paragraph tag.

In the Block Editor:
1. Add a paragraph block with content `https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7`
2. Add a paragraph block with content `[googleplus url=https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7]`
3. Add a shortcode block with content `[googleplus url=https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7]`
4. Add a classic block with `[googleplus url=https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7]` on one line and `https://plus.google.com/106672383817838331060/posts/ddyLLrp2mw7` on another.
5. Preview the post. You should see five clickable URLs each in their own paragraph tag. 

#### Proposed changelog entry for your changes:
Deprecate Google+ Shortcode and Embed