### PR TITLE
Calypsoify: Fix a typo in the top comment block

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * This is Calypso skin of the wp-admin interface that is conditionally triggered via the ?calypsoify=1 param.
- * Portted from an internal Automattic plugin.
+ * Ported from an internal Automattic plugin.
 */
 
 class Jetpack_Calypsoify {


### PR DESCRIPTION
Fix a super minor comment typo.

#### Changes proposed in this Pull Request:

* Use `Ported` instead of `Portted`

#### Testing instructions:

* n/a

#### Proposed changelog entry for your changes:

* None needed.
