### PR TITLE
Jetpack_Gutenberg: Decouple extensions registration from availability

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -113,6 +113,20 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Remove the 'jetpack-' prefix from an extension name
+	 *
+	 * @param string $extension_name The extension name.
+	 *
+	 * @return string The prefixed block name.
+	 */
+	private static function remove_extension_prefix( $extension_name ) {
+		if ( wp_startswith( $extension_name, 'jetpack/' ) ) {
+			return substr( $extension_name, strlen( 'jetpack/' ) );
+		}
+		return $extension_name;
+	}
+
+	/**
 	 * Whether two arrays share at least one item
 	 *
 	 * @param array $a An array.
@@ -170,7 +184,7 @@ class Jetpack_Gutenberg {
 	 * @param string $slug Slug of the extension.
 	 */
 	public static function set_extension_available( $slug ) {
-		self::$availability[ $slug ] = true;
+		self::$availability[ self::remove_extension_prefix( $slug ) ] = true;
 	}
 
 	/**
@@ -180,7 +194,7 @@ class Jetpack_Gutenberg {
 	 * @param string $reason A string representation of why the extension is unavailable.
 	 */
 	public static function set_extension_unavailable( $slug, $reason ) {
-		self::$availability[ $slug ] = $reason;
+		self::$availability[ self::remove_extension_prefix( $slug ) ] = $reason;
 	}
 
 	/**
@@ -362,7 +376,7 @@ class Jetpack_Gutenberg {
 				continue;
 			}
 
-			$unprefixed_block_name = substr( $block_name, strlen( 'jetpack/' ) );
+			$unprefixed_block_name = self::remove_extension_prefix( $block_name );
 
 			if( in_array( $unprefixed_block_name, self::$extensions ) ) {
 				continue;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -9,7 +9,7 @@
 /**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @deprecated 7.0.0 Use (Gutenberg's) register_block_type() instead
+ * @deprecated 7.1.0 Use (Gutenberg's) register_block_type() instead
  *
  * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
@@ -106,7 +106,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.0.0 Use (Gutenberg's) register_block_type() instead
+	 * @deprecated 7.1.0 Use (Gutenberg's) register_block_type() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into register_block_type().

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -210,7 +210,7 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Set up a whitelist of allowed block editor extension cm[r[ryps
+	 * Set up a whitelist of allowed block editor extensions
 	 *
 	 * @return void
 	 */

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -27,7 +27,7 @@ function jetpack_register_block( $slug, $args = array() ) {
 /**
  * Helper function to register a Jetpack Gutenberg plugin
  *
- * @deprecated 7.1.0 Use jetpack_set_extension_available() instead
+ * @deprecated 7.1.0 Use Jetpack_Gutenberg::set_extension_available() instead
  *
  * @param string $slug Slug of the plugin.
  *
@@ -40,36 +40,9 @@ function jetpack_register_plugin( $slug ) {
 }
 
 /**
- * Set an (non-block) extension as available
- *
- * @param string $slug Slug of the block.
- *
- * @since 7.1.0
- *
- * @return void
- */
-function jetpack_set_extension_available( $slug ) {
-	Jetpack_Gutenberg::set_extension_available( $slug );
-}
-
-/**
  * Set the reason why an extension (block or plugin) is unavailable
  *
- * @param string $slug Slug of the block.
- * @param string $reason A string representation of why the extension is unavailable.
- *
- * @since 7.0.0
- *
- * @return void
- */
-function jetpack_set_extension_unavailable( $slug, $reason ) {
-	Jetpack_Gutenberg::set_extension_unavailable( $slug, $reason );
-}
-
-/**
- * Set the reason why an extension (block or plugin) is unavailable
- *
- * @deprecated 7.1.0 Use jetpack_set_extension_unavailable() instead
+ * @deprecated 7.1.0 Use Jetpack_Gutenberg::set_extension_unavailable() instead
  *
  * @param string $slug Slug of the block.
  * @param string $reason A string representation of why the extension is unavailable.
@@ -345,8 +318,8 @@ class Jetpack_Gutenberg {
 		 * Fires before Gutenberg extensions availability is computed.
 		 *
 		 * In the function call you supply, use `register_block_type()` to set a block as available.
-		 * Alternatively, use `jetpack_set_extension_available()` (for a non-block plugin), and
-		 * `jetpack_set_extension_unavailable()` (if the block or plugin should not be registered
+		 * Alternatively, use `Jetpack_Gutenberg::set_extension_available()` (for a non-block plugin), and
+		 * `Jetpack_Gutenberg::set_extension_unavailable()` (if the block or plugin should not be registered
 		 * but marked as unavailable.
 		 *
 		 * @since 7.0.0

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -96,10 +96,10 @@ class Jetpack_Gutenberg {
 	 *
 	 * @param string $extension_name The extension name.
 	 *
-	 * @return string The prefixed block name.
+	 * @return string The unprefixed extension name.
 	 */
 	private static function remove_extension_prefix( $extension_name ) {
-		if ( wp_startswith( $extension_name, 'jetpack/' ) ) {
+		if ( wp_startswith( $extension_name, 'jetpack/' ) || wp_startswith( $extension_name, 'jetpack-' ) ) {
 			return substr( $extension_name, strlen( 'jetpack/' ) );
 		}
 		return $extension_name;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -368,7 +368,7 @@ class Jetpack_Gutenberg {
 
 			$unprefixed_block_name = self::remove_extension_prefix( $block_name );
 
-			if( in_array( $unprefixed_block_name, self::$extensions ) ) {
+			if ( in_array( $unprefixed_block_name, self::$extensions ) ) {
 				continue;
 			}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -86,7 +86,7 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Remove the 'jetpack-' prefix from an extension name
+	 * Remove the 'jetpack/' or jetpack-' prefix from an extension name
 	 *
 	 * @param string $extension_name The extension name.
 	 *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -313,6 +313,9 @@ class Jetpack_Gutenberg {
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
+		if ( ! self::is_gutenberg_available() ) {
+			return array();
+		}
 
 		/**
 		 * Fires before Gutenberg extensions availability is computed.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -337,7 +337,7 @@ class Jetpack_Gutenberg {
 		 * In the function call you supply, use `register_block_type()` to set a block as available.
 		 * Alternatively, use `Jetpack_Gutenberg::set_extension_available()` (for a non-block plugin), and
 		 * `Jetpack_Gutenberg::set_extension_unavailable()` (if the block or plugin should not be registered
-		 * but marked as unavailable.
+		 * but marked as unavailable).
 		 *
 		 * @since 7.0.0
 		 */

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -21,6 +21,8 @@
  * @return void
  */
 function jetpack_register_block( $slug, $args = array() ) {
+	_deprecated_function( __FUNCTION__, '7.1', 'register_block_type' );
+
 	Jetpack_Gutenberg::register_block( $slug, $args );
 }
 
@@ -36,6 +38,8 @@ function jetpack_register_block( $slug, $args = array() ) {
  * @return void
  */
 function jetpack_register_plugin( $slug ) {
+	_deprecated_function( __FUNCTION__, '7.1', 'Jetpack_Gutenberg::set_extension_available' );
+
 	Jetpack_Gutenberg::register_plugin( $slug );
 }
 
@@ -52,6 +56,8 @@ function jetpack_register_plugin( $slug ) {
  * @return void
  */
 function jetpack_set_extension_unavailability_reason( $slug, $reason ) {
+	_deprecated_function( __FUNCTION__, '7.1', 'Jetpack_Gutenberg::set_extension_unavailable' );
+
 	Jetpack_Gutenberg::set_extension_unavailability_reason( $slug, $reason );
 }
 
@@ -120,30 +126,36 @@ class Jetpack_Gutenberg {
 	 * @param array  $args Arguments that are passed into register_block_type().
 	 */
 	public static function register_block( $slug, $args ) {
+		_deprecated_function( __METHOD__, '7.1', 'register_block_type' );
+
 		register_block_type( 'jetpack/' . $slug, $args );
 	}
 
 	/**
 	 * Register a plugin
 	 *
-	 * @deprecated 7.1.0 Use set_extension_available() instead
+	 * @deprecated 7.1.0 Use Jetpack_Gutenberg::set_extension_available() instead
 	 *
 	 * @param string $slug Slug of the plugin.
 	 */
 	public static function register_plugin( $slug ) {
+		_deprecated_function( __METHOD__, '7.1', 'Jetpack_Gutenberg::set_extension_available' );
+
 		self::set_extension_available( $slug );
 	}
 
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.0.0 Use register_block() instead
+	 * @deprecated 7.0.0 Use register_block_type() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into the register_block_type.
 	 * @param array  $availability array containing if a block is available and the reason when it is not.
 	 */
 	public static function register( $slug, $args, $availability ) {
+		_deprecated_function( __METHOD__, '7.0', 'register_block_type' );
+
 		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
 			self::set_extension_unavailability_reason( $slug, $availability['unavailable_reason'] );
 		} else {
@@ -179,6 +191,8 @@ class Jetpack_Gutenberg {
 	 * @param string $reason A string representation of why the extension is unavailable.
 	 */
 	public static function set_extension_unavailability_reason( $slug, $reason ) {
+		_deprecated_function( __METHOD__, '7.1', 'Jetpack_Gutenberg::set_extension_unavailable' );
+
 		self::set_extension_unavailable( $slug, $reason );
 	}
 

--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -10,8 +10,8 @@
  *
  * @since 6.8.0
  */
-jetpack_register_block(
-	'map',
+register_block_type(
+	'jetpack/map',
 	array(
 		'render_callback' => 'jetpack_map_block_load_assets',
 	)
@@ -49,8 +49,8 @@ if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
 ) {
-	jetpack_register_block(
-		'tiled-gallery',
+	register_block_type(
+		'jetpack/tiled-gallery',
 		array(
 			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
 		)
@@ -90,8 +90,8 @@ if (
  *
  * @since 7.0.0
  */
-jetpack_register_block(
-	'gif',
+register_block_type(
+	'jetpack/gif',
 	array(
 		'render_callback' => 'jetpack_gif_block_render',
 	)
@@ -152,22 +152,22 @@ function jetpack_gif_block_render( $attr ) {
 /**
  * Contact Info block and its child blocks.
  */
-jetpack_register_block(
-	'contact-info',
+register_block_type(
+	'jetpack/contact-info',
 	array(
 		'render_callback' => 'jetpack_contact_info_block_load_assets',
 	)
 );
-jetpack_register_block(
-	'email',
+register_block_type(
+	'jetpack/email',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-jetpack_register_block(
-	'address',
+register_block_type(
+	'jetpack/address',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-jetpack_register_block(
-	'phone',
+register_block_type(
+	'jetpack/phone',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
 
@@ -187,13 +187,13 @@ function jetpack_contact_info_block_load_assets( $attr, $content ) {
 /**
  * VR Block.
  */
-jetpack_register_block( 'vr' );
+register_block_type( 'jetpack/vr' );
 
 /**
  * Slideshow Block.
  */
-jetpack_register_block(
-	'slideshow',
+register_block_type(
+	'jetpack/slideshow',
 	array(
 		'render_callback' => 'jetpack_slideshow_block_load_assets',
 	)
@@ -221,8 +221,8 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 /**
  * Business Hours Block.
  */
-jetpack_register_block(
-	'business-hours',
+register_block_type(
+	'jetpack/business-hours',
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );
 
@@ -307,8 +307,8 @@ function jetpack_business_hours_render( $attributes, $content ) {
  * Mailchimp Block.
  */
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
-	jetpack_register_block(
-		'mailchimp',
+	register_block_type(
+		'jetpack/mailchimp',
 		array(
 			'render_callback' => 'jetpack_mailchimp_block_load_assets',
 		)

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -242,52 +242,52 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		jetpack_register_block( 'contact-form', array(
+		register_block_type( 'jetpack/contact-form', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 		) );
 
 		// Field render methods.
-		jetpack_register_block( 'field-text', array(
+		register_block_type( 'jetpack/field-text', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
 		) );
-		jetpack_register_block( 'field-name', array(
+		register_block_type( 'jetpack/field-name', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
 		) );
-		jetpack_register_block( 'field-email', array(
+		register_block_type( 'jetpack/field-email', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
 		) );
-		jetpack_register_block( 'field-url', array(
+		register_block_type( 'jetpack/field-url', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
 		) );
-		jetpack_register_block( 'field-date', array(
+		register_block_type( 'jetpack/field-date', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
 		) );
-		jetpack_register_block( 'field-telephone', array(
+		register_block_type( 'jetpack/field-telephone', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
 		) );
-		jetpack_register_block( 'field-textarea', array(
+		register_block_type( 'jetpack/field-textarea', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
 		) );
-		jetpack_register_block( 'field-checkbox', array(
+		register_block_type( 'jetpack/field-checkbox', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
 		) );
-		jetpack_register_block( 'field-checkbox-multiple', array(
+		register_block_type( 'jetpack/field-checkbox-multiple', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
 		) );
-		jetpack_register_block( 'field-radio', array(
+		register_block_type( 'jetpack/field-radio', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
 		) );
-		jetpack_register_block( 'field-select', array(
+		register_block_type( 'jetpack/field-select', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
 		) );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -120,7 +120,10 @@ class Grunion_Contact_Form_Plugin {
 		return $data_without_tags;
 	}
 
-	function __construct() {
+	/**
+	 * Class uses singleton pattern; use Grunion_Contact_Form_Plugin::init() to initialize.
+	 */
+	protected function __construct() {
 		$this->add_shortcode();
 
 		// While generating the output of a text widget with a contact-form shortcode, we need to know its widget ID.

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -72,7 +72,7 @@ class WPCom_Markdown {
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}
-		jetpack_register_block( 'markdown' );
+		register_block_type( 'jetpack/markdown' );
 	}
 
 	/**

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -72,7 +72,10 @@ class WPCom_Markdown {
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}
-		register_block_type( 'jetpack/markdown' );
+
+		if ( function_exists( 'register_block_type' ) ) {
+			register_block_type( 'jetpack/markdown' );
+		}
 	}
 
 	/**

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -788,7 +788,7 @@ abstract class Publicize_Base {
 		// so we cannot pass one to `$this->current_user_can_access_publicize_data()`.
 
 		if ( $this->current_user_can_access_publicize_data() ) {
-			jetpack_register_plugin( 'publicize' );
+			jetpack_set_extension_available( 'publicize' );
 		} else {
 			jetpack_set_extension_unavailable( 'publicize', 'unauthorized' );
 

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -788,9 +788,9 @@ abstract class Publicize_Base {
 		// so we cannot pass one to `$this->current_user_can_access_publicize_data()`.
 
 		if ( $this->current_user_can_access_publicize_data() ) {
-			jetpack_set_extension_available( 'publicize' );
+			jetpack_set_extension_available( 'jetpack/publicize' );
 		} else {
-			jetpack_set_extension_unavailable( 'publicize', 'unauthorized' );
+			jetpack_set_extension_unavailable( 'jetpack/publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -790,7 +790,7 @@ abstract class Publicize_Base {
 		if ( $this->current_user_can_access_publicize_data() ) {
 			jetpack_register_plugin( 'publicize' );
 		} else {
-			jetpack_set_extension_unavailability_reason( 'publicize', 'unauthorized' );
+			jetpack_set_extension_unavailable( 'publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -788,9 +788,9 @@ abstract class Publicize_Base {
 		// so we cannot pass one to `$this->current_user_can_access_publicize_data()`.
 
 		if ( $this->current_user_can_access_publicize_data() ) {
-			jetpack_set_extension_available( 'jetpack/publicize' );
+			Jetpack_Gutenberg::set_extension_available( 'jetpack/publicize' );
 		} else {
-			jetpack_set_extension_unavailable( 'jetpack/publicize', 'unauthorized' );
+			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/publicize', 'unauthorized' );
 
 		}
 	}

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -68,8 +68,8 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		jetpack_register_block(
-			'related-posts',
+		register_block_type(
+			'jetpack/related-posts',
 			array(
 				'render_callback' => array( $this, 'render_block' ),
 			)

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -68,12 +68,14 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		register_block_type(
-			'jetpack/related-posts',
-			array(
-				'render_callback' => array( $this, 'render_block' ),
-			)
-		);
+		if ( function_exists( 'register_block_type' ) ) {
+			register_block_type(
+				'jetpack/related-posts',
+				array(
+					'render_callback' => array( $this, 'render_block' ),
+				)
+			);
+		}
 	}
 
 	protected function get_blog_id() {

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -129,4 +129,4 @@ if ( function_exists( 'register_rest_field' ) ) {
 }
 
 // Register Gutenberg plugin
-jetpack_set_extension_available( 'shortlinks' );
+jetpack_set_extension_available( 'jetpack/shortlinks' );

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -129,4 +129,4 @@ if ( function_exists( 'register_rest_field' ) ) {
 }
 
 // Register Gutenberg plugin
-jetpack_register_plugin( 'shortlinks' );
+jetpack_set_extension_available( 'shortlinks' );

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -128,5 +128,11 @@ if ( function_exists( 'register_rest_field' ) ) {
 	add_action( 'rest_api_init', 'wpme_rest_register_shortlinks' );
 }
 
-// Register Gutenberg plugin
-Jetpack_Gutenberg::set_extension_available( 'jetpack/shortlinks' );
+/**
+ * Set the Shortlink Gutenberg extension as available.
+ */
+function wpme_set_extension_available() {
+	Jetpack_Gutenberg::set_extension_available( 'jetpack/shortlinks' );
+}
+
+add_action( 'init', 'wpme_set_extension_available' );

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -129,4 +129,4 @@ if ( function_exists( 'register_rest_field' ) ) {
 }
 
 // Register Gutenberg plugin
-jetpack_set_extension_available( 'jetpack/shortlinks' );
+Jetpack_Gutenberg::set_extension_available( 'jetpack/shortlinks' );

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			register_block_type( 'jetpack/simple-payments' );
 		} else {
-			jetpack_set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
+			jetpack_set_extension_unavailable( 'simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -62,7 +62,7 @@ class Jetpack_Simple_Payments {
 
 	function register_gutenberg_block() {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			jetpack_register_block( 'simple-payments' );
+			register_block_type( 'jetpack/simple-payments' );
 		} else {
 			jetpack_set_extension_unavailability_reason( 'simple-payments', 'missing_plan' );
 		}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			register_block_type( 'jetpack/simple-payments' );
 		} else {
-			jetpack_set_extension_unavailable( 'simple-payments', 'missing_plan' );
+			jetpack_set_extension_unavailable( 'jetpack/simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -64,7 +64,7 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			register_block_type( 'jetpack/simple-payments' );
 		} else {
-			jetpack_set_extension_unavailable( 'jetpack/simple-payments', 'missing_plan' );
+			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/simple-payments', 'missing_plan' );
 		}
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -61,6 +61,10 @@ class Jetpack_Simple_Payments {
 	}
 
 	function register_gutenberg_block() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			register_block_type( 'jetpack/simple-payments' );
 		} else {

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -727,7 +727,7 @@ function jetpack_blog_subscriptions_init() {
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
-	jetpack_register_block( 'subscriptions' );
+	register_block_type( 'jetpack/subscriptions' );
 }
 
 add_action( 'init', 'jetpack_register_subscriptions_block' );

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -727,7 +727,9 @@ function jetpack_blog_subscriptions_init() {
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
-	register_block_type( 'jetpack/subscriptions' );
+	if ( WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+		register_block_type( 'jetpack/subscriptions' );
+	}
 }
 
 add_action( 'init', 'jetpack_register_subscriptions_block' );

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -727,7 +727,7 @@ function jetpack_blog_subscriptions_init() {
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
-	if ( WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+	if ( class_exists( 'WP_Block_Type_Registry' ) && WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
 		register_block_type( 'jetpack/subscriptions' );
 	}
 }

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -727,7 +727,7 @@ function jetpack_blog_subscriptions_init() {
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
-	if ( class_exists( 'WP_Block_Type_Registry' ) && WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+	if ( class_exists( 'WP_Block_Type_Registry' ) && ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
 		register_block_type( 'jetpack/subscriptions' );
 	}
 }

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -30,10 +30,6 @@ class VideoPress_Gutenberg {
 	 * Register the Jetpack Gutenberg extension that adds VideoPress support to the core video block.
 	 */
 	public static function register_video_block_with_videopress() {
-		// We intentionally don't use `jetpack_register_block` because the current Jetpack extensions
-		// registration doesn't fit our needs. Right now, any extension registered with `jetpack_register_block`
-		// needs to have a name that is equal to the name of the registered block (our extension name would be
-		// "videopress" and the name of the block we need to register "core/video").
 		register_block_type(
 			'core/video',
 			array(

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -46,7 +46,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->post = $post;
 
 		// Initialize plugin
-		$this->plugin = new Grunion_Contact_Form_Plugin;
+		$this->plugin = Grunion_Contact_Form_Plugin::init();
 		// Call to add tokenization hook
 		$this->plugin->process_form_submission();
 	}
@@ -457,7 +457,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
 	 */
 	public function test_token_left_intact_when_no_matching_field() {
-		$plugin = new Grunion_Contact_Form_Plugin();
+		$plugin = Grunion_Contact_Form_Plugin::init();
 		$subject = 'Hello {name}!';
 		$field_values = array(
 			'City' => 'Chicago'
@@ -471,7 +471,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
 	 */
 	public function test_replaced_with_empty_string_when_no_value_in_field() {
-		$plugin = new Grunion_Contact_Form_Plugin();
+		$plugin = Grunion_Contact_Form_Plugin::init();
 		$subject = 'Hello {name}!';
 		$field_values = array(
 			'Name' => null
@@ -485,7 +485,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_whose_name_has_whitespace() {
-		$plugin = new Grunion_Contact_Form_Plugin();
+		$plugin = Grunion_Contact_Form_Plugin::init();
 		$subject = '{subject token}';
 		$field_values = array(
 			'Subject Token' => 'Chicago'
@@ -499,7 +499,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
 	 */
 	public function test_token_with_curly_brackets_can_be_replaced() {
-		$plugin = new Grunion_Contact_Form_Plugin();
+		$plugin = Grunion_Contact_Form_Plugin::init();
 		$subject = '{subject {token}}';
 		$field_values = array(
 			'Subject {Token}' => 'Chicago'
@@ -1294,7 +1294,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'another_field'          => 'thunderstruck'
 		);
 
-		$plugin = new Grunion_Contact_Form_Plugin();
+		$plugin = Grunion_Contact_Form_Plugin::init();
 
 		$result = $plugin->map_parsed_field_contents_of_post_to_field_names( $input_data );
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
 		Jetpack_Gutenberg::init();
-		jetpack_register_block( 'test' );
+		register_block_type( 'jetpack/test' );
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -52,9 +52,11 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function test_sync_callable_whitelist() {
 		// $this->setSyncClientDefaults();
 
-		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
-		Jetpack_Gutenberg::init();
-		register_block_type( 'jetpack/test' );
+		if ( function_exists( 'register_block_type' ) ) {
+			add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
+			Jetpack_Gutenberg::init();
+			register_block_type( 'jetpack/test' );
+		}
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),
@@ -128,8 +130,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$unique_whitelist = array_unique( $whitelist_keys );
 		$this->assertEquals( count( $unique_whitelist ), count( $whitelist_keys ), 'The duplicate keys are: ' . print_r( array_diff_key( $whitelist_keys, array_unique( $whitelist_keys ) ), 1 ) );
 
-		remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
-		Jetpack_Gutenberg::reset();
+		if ( function_exists( 'register_block_type' ) ) {
+			remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
+			Jetpack_Gutenberg::reset();
+		}
 	}
 
 	public function add_test_block() {

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
 		jetpack_register_plugin( 'parsnip' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertFalse( $availability['parsnip']['available'], 'durian is available!' );
+		$this->assertFalse( $availability['parsnip']['available'], 'parsnip is available!' );
 		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
 
 	}

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available() {
-		jetpack_set_extension_unavailable( 'banana', 'bar' );
+		jetpack_set_extension_unavailable( 'jetpack/banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
@@ -90,20 +90,20 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	// Plugins
 	function test_registered_plugin_is_available() {
-		jetpack_set_extension_available( 'onion' );
+		jetpack_set_extension_available( 'jetpack/onion' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['onion']['available'] );
 	}
 
 	function test_registered_plugin_is_not_available() {
-		jetpack_set_extension_unavailable( 'potato', 'bar' );
+		jetpack_set_extension_unavailable( 'jetpack/potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
 		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
 	}
 
 	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_set_extension_available( 'parsnip' );
+		jetpack_set_extension_available( 'jetpack/parsnip' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['parsnip']['available'], 'parsnip is available!' );
 		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available() {
-		jetpack_set_extension_unavailability_reason( 'banana', 'bar' );
+		jetpack_set_extension_unavailable( 'banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
@@ -96,7 +96,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_plugin_is_not_available() {
-		jetpack_set_extension_unavailability_reason( 'potato', 'bar' );
+		jetpack_set_extension_unavailable( 'potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
 		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	// Plugins
 	function test_registered_plugin_is_available() {
-		jetpack_register_plugin( 'onion' );
+		jetpack_set_extension_available( 'onion' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['onion']['available'] );
 	}
@@ -103,7 +103,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_plugin( 'parsnip' );
+		jetpack_set_extension_available( 'parsnip' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['parsnip']['available'], 'parsnip is available!' );
 		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -61,7 +61,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_available() {
-		jetpack_register_block( 'apple' );
+		register_block_type( 'jetpack/apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['apple']['available'] );
 	}
@@ -74,7 +74,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_block( 'durian' );
+		register_block_type( 'jetpack/durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
 		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -39,7 +39,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
 			$blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
 			foreach ( $blocks as $block_name => $block ) {
-				if ( strpos( $block_name, 'jetpack/' ) !== false ) {
+				if ( wp_startswith( $block_name, 'jetpack/' ) ) {
 					unregister_block_type( $block_name );
 				}
 			}

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available() {
-		jetpack_set_extension_unavailable( 'jetpack/banana', 'bar' );
+		Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/banana', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['banana']['available'], 'banana is available!' );
 		$this->assertEquals( $availability['banana']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
@@ -90,20 +90,20 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	// Plugins
 	function test_registered_plugin_is_available() {
-		jetpack_set_extension_available( 'jetpack/onion' );
+		Jetpack_Gutenberg::set_extension_available( 'jetpack/onion' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['onion']['available'] );
 	}
 
 	function test_registered_plugin_is_not_available() {
-		jetpack_set_extension_unavailable( 'jetpack/potato', 'bar' );
+		Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/potato', 'bar' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['potato']['available'], 'potato is available!' );
 		$this->assertEquals( $availability['potato']['unavailable_reason'], 'bar', 'unavailable_reason is not "bar"' );
 	}
 
 	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_set_extension_available( 'jetpack/parsnip' );
+		Jetpack_Gutenberg::set_extension_available( 'jetpack/parsnip' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['parsnip']['available'], 'parsnip is available!' );
 		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

`jetpack_register_block()` has been a pretty thin wrapper around (Gutenberg's) `register_block_type()`, and would alternatively call `jetpack_set_extension_unavailability_reason()` (with reason `not_whitelisted`) if a block wasn't whitelisted. However, we were already calling `jetpack_set_extension_unavailability_reason()` manually to specify different reasons.

This PR decouples extension registration and availability setting even further, to allow us to drop `jetpack_register_block()` altogether and directly use `register_block_type()` (with `jetpack/`-prefixed block names!) instead.

It also replaces `register_jetpack_plugin()` with the more generic `jetpack_set_extension_available()`, and `jetpack_set_extension_unavailability_reason` with `jetpack_set_extension_available()`. Note that both methods now require explicit use of the `jetpack-` prefix (or `jetpack-` for blocks).

It's still not quite as symmetric as I would like it to have ideally, since block availability is determined by block registration -- i.e. use `jetpack_set_extension_available` only for non-blocks, and `register_block_type` for blocks. However, use `jetpack_set_extension_unavailable` for both.

This is mostly because Gutenberg has the concept of a server-side block registration, but not for plugins. However, I think this should be a good enough compromise, since it should cater for the VideoPress situation, and it's untangling some concepts a bit better.

I think this also lays the groundwork for making `jetpack/` and `jetpack-` prefixes explicit everywhere.

The chief motivation for this PR is to provide VideoPress with the ability to set its availability, since it is going to be a bit of a special case (drop-in replacement for `core/video` block), so our previous abstraction didn't quite hold.

#### Testing instructions:

Same as #11091

#### Proposed changelog entry for your changes:

TBD

/cc @mmtr 