### PR TITLE
GIF: Caption Styling Fixes

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -96,12 +96,14 @@ function jetpack_gif_block_render( $attr ) {
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( implode( $classes, ' ' ) ); ?>">
-		<figure style="<?php echo esc_attr( $style ); ?>">
-			<iframe src="<?php echo esc_url( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
+		<figure>
+			<div class="wp-block-jetpack-gif-wrapper" style="<?php echo esc_attr( $style ); ?>">
+				<iframe src="<?php echo esc_url( $giphy_url ); ?>" title="<?php echo esc_attr( $search_text ); ?>"></iframe>
+			</div>
+			<?php if ( $caption ) : ?>
+				<figcaption class="wp-block-jetpack-gif-caption gallery-caption"><?php echo wp_kses_post( $caption ); ?></figcaption>
+			<?php endif; ?>
 		</figure>
-		<?php if ( $caption ) : ?>
-			<p class="wp-block-jetpack-gif-caption"><?php echo wp_kses_post( $caption ); ?></p>
-		<?php endif; ?>
 	</div>
 	<?php
 	$html = ob_get_clean();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Resolves the CSS and Markup issues raised in https://github.com/Automattic/wp-calypso/issues/30411. GIF block caption is now a FIGCAPTION, placed inside the FIGURE element. The `padding-top` styling (which cause the block's dimensions to be set based on the dimensions of the selected GIF) are now applied to DIV that wraps the IFRAME, rather than the FIGURE. Also, the caption now has the `gallery-caption` class which brings in much of the CSS that the core Image block's caption has.  

The companion `wp-calypso` PR is here: https://github.com/Automattic/wp-calypso/pull/30441

#### Testing instructions:

JN: https://jurassic.ninja/create?gutenpack&calypsobranch=fix/gif-caption&branch=fix/gif-caption

- Verify that the caption is a FIGCAPTION, and that it is the final element in the containing FIGURE
- Verify that the appearance of the caption is similar to core Image block in both Editor and View environments. 
- Verify that the caption is fully editable (there is a block that intentionally blocks user interaction with the Giphy IFRAME in the editor, and we need to be sure that the caption is not also blocked)
- Verify that the sizing of the block in editor and view is equivalent to the sizing of the block on Master.