### PR TITLE
Contact Info block: register child blocks as so.

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -133,7 +133,19 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	return preg_replace( '/<div /', '<div data-api-key="'. esc_attr( $api_key ) .'" ', $content, 1 );
 }
 
+/**
+ * Register the Contact Info block and its child blocks.
+ */
 jetpack_register_block( 'contact-info' );
-jetpack_register_block( 'email' );
-jetpack_register_block( 'address' );
-jetpack_register_block( 'phone' );
+jetpack_register_block(
+	'email',
+	array( 'parent' => array( 'jetpack/contact-info' ) )
+);
+jetpack_register_block(
+	'address',
+	array( 'parent' => array( 'jetpack/contact-info' ) )
+);
+jetpack_register_block(
+	'phone',
+	array( 'parent' => array( 'jetpack/contact-info' ) )
+);


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/10988#pullrequestreview-196797063

#### Changes proposed in this Pull Request:

* Contact Info block: register child blocks as so.

#### Testing instructions:

* Using [this link](https://jurassic.ninja/create/?gutenberg&gutenpack&jetpack-beta&calypsobranch=add/contact-info&branch=fix/contact-info-child-blocks), start a new site
* In Settings > Jetpack constants, enable Beta blocks
* Make sure the block and its sub-blocks still work.

#### Proposed changelog entry for your changes:

* None
