### PR TITLE
Blocks: allow multi-line submit buttons

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1799,6 +1799,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 */
 	static $style = false;
 
+	/**
+	 * @var array When printing the submit button, what tags are allowed
+	 */
+	static $allowed_html_tags_for_submit_button = array( 'br' => array() );
+
 	function __construct( $attributes, $content = null ) {
 		global $post;
 
@@ -2057,14 +2062,15 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$submit_button_text = $form->get_attribute( 'submit_button_text' );
 			}
 
-			$allowed_html_tags_for_submit_button = array( 'br' => array() );
-
 			$r .= "\t\t<button type='submit' class='" . esc_attr( $submit_button_class ) . "'";
 			if ( ! empty( $submit_button_styles ) ) {
 				$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
 			}
 			$r .= ">";
-			$r .= wp_kses( $submit_button_text, $allowed_html_tags_for_submit_button ) . "</button>";
+			$r .= wp_kses(
+				      $submit_button_text,
+				      self::$allowed_html_tags_for_submit_button
+			      ) . "</button>";
 
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -136,7 +136,7 @@ class Grunion_Contact_Form_Plugin {
 		) {
 			add_filter( 'widget_text', array( $this, 'widget_shortcode_hack' ), 5 );
 		}
-		
+
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'is_spam_blacklist' ), 10, 2 );
 
 		// Akismet to the rescue
@@ -631,7 +631,7 @@ class Grunion_Contact_Form_Plugin {
 
 		return $text;
 	}
-	
+
 	/**
 	 * Check if a submission matches the Comment Blacklist.
 	 * The Comment Blacklist is a means to moderate discussion, and contact
@@ -647,11 +647,11 @@ class Grunion_Contact_Form_Plugin {
 		if ( $is_spam ) {
 			return $is_spam;
 		}
-		
+
 		if ( wp_blacklist_check( $form['comment_author'], $form['comment_author_email'], $form['comment_author_url'], $form['comment_content'], $form['user_ip'], $form['user_agent'] ) ) {
 			return true;
 		}
-		
+
 		return false;
 	}
 
@@ -2057,12 +2057,15 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				$submit_button_text = $form->get_attribute( 'submit_button_text' );
 			}
 
-			$r .= "\t\t<input type='submit' value='" . esc_attr( $submit_button_text ) . "' class='" . esc_attr( $submit_button_class ) . "'";
+			$allowed_html_tags_for_submit_button = array( 'br' => array() );
+
+			$r .= "\t\t<button type='submit' class='" . esc_attr( $submit_button_class ) . "'";
 			if ( ! empty( $submit_button_styles ) ) {
 				$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
 			}
-			$r .= "/>\n";
-			
+			$r .= ">";
+			$r .= wp_kses( $submit_button_text, $allowed_html_tags_for_submit_button ) . "</button>";
+
 			if ( is_user_logged_in() ) {
 				$r .= "\t\t" . wp_nonce_field( 'contact-form_' . $id, '_wpnonce', true, false ) . "\n"; // nonce and referer
 			}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -2,6 +2,10 @@
 
 class Jetpack_Subscriptions_Widget extends WP_Widget {
 	static $instance_count = 0;
+	/**
+	 * @var array When printing the submit button, what tags are allowed
+	 */
+	static $allowed_html_tags_for_submit_button = array( 'br' => array() );
 
 	function __construct() {
 		$widget_ops = array(
@@ -297,7 +301,12 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			                style="<?php echo esc_attr( $submit_button_styles ); ?>"
 		                <?php }; ?>
 	                >
-                        <?php echo wp_kses( $subscribe_button, array( 'br' => array() ) ); ?>
+	                    <?php
+	                    echo wp_kses(
+		                    $subscribe_button,
+		                    self::$allowed_html_tags_for_submit_button
+	                    );
+	                    ?>
                     </button>
                 </p>
             </form>
@@ -360,7 +369,11 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		                    <?php }; ?>
 	                        name="jetpack_subscriptions_widget"
 	                    >
-                            <?php echo wp_kses( $subscribe_button, array( 'br' => array() ) ); ?>
+	                        <?php
+	                        echo wp_kses(
+		                        $subscribe_button,
+		                        self::$allowed_html_tags_for_submit_button
+	                        ); ?>
                         </button>
                     </p>
 				<?php } ?>

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -289,14 +289,17 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
                     <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-                    <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"
+                    <b
+                    <button type="submit"
 	                    <?php if ( ! empty( $submit_button_classes ) ) { ?>
 	                        class="<?php echo esc_attr( $submit_button_classes ); ?>"
 	                    <?php }; ?>
 		                <?php if ( ! empty( $submit_button_styles ) ) { ?>
 			                style="<?php echo esc_attr( $submit_button_styles ); ?>"
 		                <?php }; ?>
-	                />
+	                >
+                        <?php echo wp_kses( $subscribe_button, array( 'br' => array() ) ); ?>
+                    </button>
                 </p>
             </form>
 			<?php
@@ -349,7 +352,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
 						}
 						?>
-                        <input type="submit" value="<?php echo esc_attr( $subscribe_button ); ?>"
+                        <button type="submit"
 	                        <?php if ( ! empty( $submit_button_classes ) ) { ?>
 	                            class="<?php echo esc_attr( $submit_button_classes ); ?>"
                             <?php }; ?>
@@ -357,7 +360,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			                    style="<?php echo esc_attr( $submit_button_styles ); ?>"
 		                    <?php }; ?>
 	                        name="jetpack_subscriptions_widget"
-	                    />
+	                    >
+                            <?php echo wp_kses( $subscribe_button, array( 'br' => array() ) ); ?>
+                        </button>
                     </p>
 				<?php } ?>
             </form>

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -289,7 +289,6 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
                     <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-                    <b
                     <button type="submit"
 	                    <?php if ( ! empty( $submit_button_classes ) ) { ?>
 	                        class="<?php echo esc_attr( $submit_button_classes ); ?>"


### PR DESCRIPTION
The Contact Form and Subscription form use a submit button component that allows for multiple lines. However, on the front-end, we use an `<input>` tag which does not support new lines within its `value` attribute.

This PR fixes this issue by using a `<button>` component instead

Fixes n/a

#### Changes proposed in this Pull Request:

* This PR changes the way the subscription form and contact form are displayed on the front end.

#### Testing instructions:
- Try running this PR on Jurassic.ninja
- Try creating a subscription form block in the post editor. Create a multi-line submit button and ensure:
   - The multi-lines appear when you preview the post
   - You can still use the form to subscribe to the blog

![screen shot 2019-01-29 at 4 13 59 pm](https://user-images.githubusercontent.com/2694219/51940777-eb5e8f00-23e0-11e9-980d-b9a9a7485f9f.png)



- Try creating a contact form block in the post editor. Create a multi-line submit button and ensure:
   - The multi-lines appear when you preview the post
   - You can still use the form to contact the blog owner

![screen shot 2019-01-29 at 4 17 13 pm](https://user-images.githubusercontent.com/2694219/51940960-5f009c00-23e1-11e9-8700-c3b91f2b7b02.png)




#### Proposed changelog entry for your changes:

* Fixes an issue with the submit button in the contact form and subscription form blocks.
