### PR TITLE
Copy Post: add link to support doc.

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -703,6 +703,11 @@ add_action( 'jetpack_module_more_info_photon-cdn', 'jetpack_assetcdn_more_info' 
 /**
  * Copy Post
  */
+function jetpack_copy_post_more_link() {
+	echo 'https://jetpack.com/support/copy-post-2/';
+}
+add_action( 'jetpack_learn_more_button_copy-post', 'jetpack_copy_post_more_link' );
+
 function jetpack_more_info_copy_post() {
 	esc_html_e( 'Create a new post based on an existing post.', 'jetpack' );
 }


### PR DESCRIPTION
cc @kwight 

#### Changes proposed in this Pull Request:

* Add a link to the support doc for the Copy Post feature.

#### Testing instructions:

* Checkout that branch, run `yarn build` (alternatively, launch a quick site [here](https://jurassic.ninja/create?jetpack-beta&branch=add/copy-post-support-link&shortlived&wp-debug-log) once the Travis Tests for this branch have passed)
* Go to Jetpack > Settings
* Search for "Copy"
* You should now see a little info bubble on the right of the module info:

<img width="1085" alt="screenshot 2019-01-30 at 18 10 04" src="https://user-images.githubusercontent.com/426388/51999107-562fc900-24ba-11e9-8261-87ce4b886d40.png">

#### Proposed changelog entry for your changes:

* None
