### PR TITLE
Mobile Theme: fix notice when trying to display gallery images.

### DIFF
--- a/modules/minileven/theme/pub/minileven/content-gallery.php
+++ b/modules/minileven/theme/pub/minileven/content-gallery.php
@@ -30,15 +30,15 @@
 					$images = minileven_get_gallery_images();
 					if ( $images ) :
 						$total_images = count( $images );
-						$large_image = array_shift( $images );
+						$large_image  = array_shift( $images );
 						$thumb1_image = array_shift( $images );
 						$thumb2_image = array_shift( $images );
 						$thumb3_image = array_shift( $images );
 
-						$image_img_tag = wp_get_attachment_image( $large_image->ID, 'large' );
-						$thumb1_img_tag = wp_get_attachment_image( $thumb1_image->ID, 'thumbnail' );
-						$thumb2_img_tag = wp_get_attachment_image( $thumb2_image->ID, 'thumbnail' );
-						$thumb3_img_tag = wp_get_attachment_image( $thumb3_image->ID, 'thumbnail' );
+						$image_img_tag  = wp_get_attachment_image( (int) $large_image, 'large' );
+						$thumb1_img_tag = wp_get_attachment_image( (int) $thumb1_image, 'thumbnail' );
+						$thumb2_img_tag = wp_get_attachment_image( (int) $thumb2_image, 'thumbnail' );
+						$thumb3_img_tag = wp_get_attachment_image( (int) $thumb3_image, 'thumbnail' );
 					?>
 					<div class="img-gallery">
 						<div class="gallery-large">


### PR DESCRIPTION
Fixes #11228

#### Changes proposed in this Pull Request:

`minileven_get_gallery_images` returns an array of IDs (not always integers, sometimes strings) instead of the array of objects we previously expected.

#### Testing instructions:

* Enable Jetpack's Mobile Theme on your site.
* Switch to a theme that supports the Gallery post format, like Twenty Fifteen.
* Create a new post; set the post format as gallery.
* Add a new gallery to the post, with less than 4 images.
* Publish your post.
* View your site's home page (not the post's page)
* You should see the gallery images (the first gallery is bigger) and no notices in your debug log.

#### Proposed changelog entry for your changes:

* Mobile Theme: fix PHP notices when trying to display gallery images.
