### PR TITLE
Ads: Add Gutenberg/Jetpack Ads Block

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -23,20 +23,20 @@ class WordAds {
 	 * @var array
 	 */
 	public static $ad_tag_ids = array(
-		'mrec'           => array(
+		'mrec' => array(
 			'tag'    => '300x250_mediumrectangle',
 			'height' => '250',
 			'width'  => '300',
 		),
-		'lrec'           => array(
-			'tag'    => '336x280_largerectangle',
-			'height' => '280',
-			'width'  => '336',
-		),
-		'leaderboard'    => array(
+		'leaderboard' => array(
 			'tag'    => '728x90_leaderboard',
 			'height' => '90',
 			'width'  => '728',
+		),
+		'mobile_leaderboard' => array(
+			'tag'    => '320x50_mobileleaderboard',
+			'height' => '50',
+			'width'  => '320',
 		),
 		'wideskyscraper' => array(
 			'tag'    => '160x600_wideskyscraper',
@@ -44,6 +44,8 @@ class WordAds {
 			'width'  => '160',
 		),
 	);
+
+	public static $SOLO_UNIT_CSS = 'float:left;margin-right:5px;margin-top:0px;';
 
 	/**
 	 * Convenience function for grabbing options from params->options
@@ -415,14 +417,14 @@ HTML;
 				$width      = 300;
 				$height     = 250;
 
-				$snippet = $this->get_ad_snippet( $section_id, $height, $width, $spot, 'float:left;margin-right:5px;margin-top:0px;' );
+				$snippet = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
 				if ( $this->option( 'wordads_second_belowpost', true ) ) {
 					$section_id2 = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID2 : $this->params->blog_id . '4';
 					$snippet    .= $this->get_ad_snippet( $section_id2, $height, $width, $spot, 'float:left;margin-top:0px;' );
 				}
 			} elseif ( 'inline' === $spot ) {
 				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '5';
-				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, 'mrec', 'float:left;margin-right:5px;margin-top:0px;' );
+				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, 'mrec', self::$SOLO_UNIT_CSS );
 			}
 		} elseif ( 'house' == $type ) {
 			$leaderboard = 'top' == $spot && ! $this->params->mobile_device;
@@ -432,18 +434,7 @@ HTML;
 			}
 		}
 
-		$header = 'top' == $spot ? 'wpcnt-header' : '';
-		$about  = __( 'Advertisements', 'jetpack' );
-		return <<<HTML
-		<div class="wpcnt $header">
-			<div class="wpa">
-				<span class="wpa-about">$about</span>
-				<div class="u $spot">
-					$snippet
-				</div>
-			</div>
-		</div>
-HTML;
+		return $this->get_ad_div( $spot, $snippet );
 	}
 
 
@@ -466,11 +457,9 @@ HTML;
 			'height'   => $height,
 		);
 		$ad_number   = count( $this->ads );
-		// Max 6 ads per page.
-		if ( $ad_number > 5 && 'top' !== $location ) {
-			return;
-		}
+
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
+		$css = esc_attr( $css );
 
 		return <<<HTML
 		<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
@@ -486,6 +475,41 @@ HTML;
 					});
 				});
 				</script>
+			</div>
+		</div>
+HTML;
+	}
+
+	/**
+	 * Returns the complete ad div with snippet to be inserted into the page
+	 *
+	 * @param  string  $spot top, side, inline, or belowpost
+	 * @param  string  $snippet The snippet to insert into the div
+	 * @param  array  $css_classes
+	 * @return string The supporting ad unit div
+	 *
+	 * @since 7.1
+	 */
+	function get_ad_div( $spot, $snippet, array $css_classes = array() ) {
+		if ( empty( $css_classes ) ) {
+			$css_classes = array();
+		}
+
+		$css_classes[] = 'wpcnt';
+		if ( 'top' == $spot ) {
+			$css_classes[] = 'wpcnt-header';
+		}
+
+		$spot = esc_attr( $spot );
+		$classes = esc_attr( implode( ' ', $css_classes ) );
+		$about  = esc_html__( 'Advertisements', 'jetpack' );
+		return <<<HTML
+		<div class="$classes">
+			<div class="wpa">
+				<span class="wpa-about">$about</span>
+				<div class="u $spot">
+					$snippet
+				</div>
 			</div>
 		</div>
 HTML;

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -23,12 +23,12 @@ class WordAds {
 	 * @var array
 	 */
 	public static $ad_tag_ids = array(
-		'mrec' => array(
+		'mrec'               => array(
 			'tag'    => '300x250_mediumrectangle',
 			'height' => '250',
 			'width'  => '300',
 		),
-		'leaderboard' => array(
+		'leaderboard'        => array(
 			'tag'    => '728x90_leaderboard',
 			'height' => '90',
 			'width'  => '728',
@@ -38,7 +38,7 @@ class WordAds {
 			'height' => '50',
 			'width'  => '320',
 		),
-		'wideskyscraper' => array(
+		'wideskyscraper'     => array(
 			'tag'    => '160x600_wideskyscraper',
 			'height' => '600',
 			'width'  => '160',


### PR DESCRIPTION
Adding a Jetpack Ads Gutenberg block per the Gutenpack Small Business Blocks initiative.

Fixes https://github.com/Automattic/wp-calypso/issues/30624

#### Changes proposed in this Pull Request:
* jetpack_register_block for wordads (`gutenblock_render`)
* Extracted/refactored `get_ad_div` into separate function to be used in `gutenblock_render`
* Added `mobile_leaderboard` to `$ad_tag_ids`, removed `lrec` (no longer supported)

#### Testing instructions

1. Compile Gutenblocks from https://github.com/Automattic/wp-calypso -- master
    1. e.g. `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir="../jetpack/_inc/blocks"`
1. Add `define( 'JETPACK_BETA_BLOCKS', true );` to your `wp-config.php`
1. Enable Ads module (Jetpack Settings -> Traffic)
1. Create new post and search for "WordAds" in the Gutenberg blocks (you should see `Ad`)
    <img width="387" alt="screen shot 2019-02-05 at 12 36 24 pm" src="https://user-images.githubusercontent.com/273708/52308924-b56e5d00-2942-11e9-805e-ca12791c6cb4.png">
1. Add some ads of various sizes and alignment, you should see them in your post 👍
<img width="714" alt="screen shot 2019-02-05 at 12 39 00 pm" src="https://user-images.githubusercontent.com/273708/52309070-1bf37b00-2943-11e9-8a29-b4cf2e90fee4.png">


#### Proposed changelog entry for your changes:
* Added Ads Gutenberg block