### PR TITLE
Copy Post: Activate under Writing settings, rather than just being a searchable module.

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -145,6 +145,7 @@ export const NavigationSettings = createReactClass( {
 						'post-by-email',
 						'infinite-scroll',
 						'minileven',
+						'copy-post',
 					] ) && (
 						<NavItem
 							path="#writing"

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -42,7 +42,6 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 			// Only should be features that don't already have a UI, and we want to reveal in search.
 			const whitelist = [
 				'contact-form',
-				'copy-post',
 				'custom-css',
 				'enhanced-distribution',
 				'json-api',

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -197,16 +197,41 @@ export class Composing extends React.Component {
 	};
 
 	render() {
-		const foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
+		const foundCopyPost = this.props.isModuleFound( 'copy-post' ),
+			foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
 			foundMarkdown = this.props.isModuleFound( 'markdown' );
 
-		if ( ! foundMarkdown && ! foundAtD ) {
+		if ( ! foundCopyPost && ! foundMarkdown && ! foundAtD ) {
 			return null;
 		}
 
 		const markdown = this.props.module( 'markdown' ),
 			atd = this.props.module( 'after-the-deadline' ),
+			copyPost = this.props.module( 'copy-post' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
+			copyPostSettings = (
+				<SettingsGroup
+					module={ copyPost }
+					support={ {
+						text: __(
+							'Copy data (such as content, featured images, Sharing settings, and more) from existing posts, pages, Testimonials, and Portfolios.'
+						),
+						link: 'https://jetpack.com/support/copy-post-2/',
+					} }
+				>
+					<FormFieldset>
+						<ModuleToggle
+							slug="copy-post"
+							activated={ !! this.props.getOptionValue( 'copy-post' ) }
+							toggling={ this.props.isSavingAnyOption( 'copy-post' ) }
+							disabled={ this.props.isSavingAnyOption( 'copy-post' ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">{ copyPost.description }</span>
+						</ModuleToggle>
+					</FormFieldset>
+				</SettingsGroup>
+			),
 			markdownSettings = (
 				<SettingsGroup
 					module={ markdown }
@@ -273,6 +298,7 @@ export class Composing extends React.Component {
 				module="composing"
 				saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 			>
+				{ foundCopyPost && copyPostSettings }
 				{ foundMarkdown && markdownSettings }
 				{ foundAtD && atdSettings }
 			</SettingsCard>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -214,7 +214,8 @@ export class Composing extends React.Component {
 					module={ copyPost }
 					support={ {
 						text: __(
-							'Copy data (such as content, featured images, Sharing settings, and more) from existing posts, pages, Testimonials, and Portfolios.'
+							'Duplicate existing posts, pages, Testimonials, and Portfolios. ' +
+								'All the content will be copied including text, featured images, sharing settings, and more.'
 						),
 						link: 'https://jetpack.com/support/copy-post-2/',
 					} }

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Copy Post
- * Module Description: Copy an existing post's content into a new post.
+ * Module Description: Copy an existing post's content into a new draft post.
  * Jumpstart Description: Copy an existing post's content into a new post.
  * Sort Order: 15
  * First Introduced: 7.0

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -41,7 +41,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'copy-post' => array(
 				'name' => _x( 'Copy Post', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Copy an existing post\'s content into a new post.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Copy an existing post\'s content into a new draft post.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Copy an existing post\'s content into a new post.', 'Jumpstart Description', 'jetpack' ),
 			),
 
@@ -179,7 +179,7 @@ function jetpack_get_module_i18n( $key ) {
 			'sharedaddy' => array(
 				'name' => _x( 'Sharing', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Allow visitors to share your content.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Twitter, Facebook and Google+ buttons at the bottom of each post, making it easy for visitors to share your content.', 'Jumpstart Description', 'jetpack' ),
+				'recommended description' => _x( 'Twitter, Facebook and many other buttons at the bottom of each post, making it easy for visitors to share your content.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'shortcodes' => array(


### PR DESCRIPTION
This PR adds activation for Copy Post under `Settings > Writing > Composing`, rather than it being a module that must be searched.

See: https://github.com/Automattic/jetpack/pull/11106#issuecomment-452680056
See: p8oabR-jJ-p2

<img width="1291" alt="screen shot 2019-01-31 at 2 24 27 pm" src="https://user-images.githubusercontent.com/349751/52089719-18877a80-2564-11e9-8363-9045d9a3e421.png">

#### Testing instructions:
* Fire up this branch.
* Go to https://:domain/wp-admin/admin.php?page=jetpack#/writing, and verify the Copy Post content is there (like the screenshot above).
* Toggle it on and off, making sure it saves, and that it's activated/deactivated as intended (check for the "Copy" row action in `wp-admin/edit.php`).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* N/A
