### PR TITLE
Top Posts: allow the use of negative integers when getting posts

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -542,7 +542,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			$days = 2;
 		}
 
-		$post_view_posts = stats_get_from_restapi( array(), 'top-posts?max=11&summarize=1&num=' . absint( $days ) );
+		$post_view_posts = stats_get_from_restapi( array(), 'top-posts?max=11&summarize=1&num=' . intval( $days ) );
 
 		if ( ! isset( $post_view_posts->summary ) || empty( $post_view_posts->summary->postviews ) ) {
 			return array();


### PR DESCRIPTION
See #11235

#### Changes proposed in this Pull Request:

When using the jetpack_top_posts_days filter, you can specify a negative integer, -1, to get results for an infinite number of days. Let's allow that number to be used in the API query.

#### Testing instructions:

* Add the Top Posts widget to your site.
* Add the following code snippet to a functionality plugin on your site:
```php
function jetpackme_top_posts_timeframe() {
    return -1;
}
add_filter( 'jetpack_top_posts_days', 'jetpackme_top_posts_timeframe' );
```
* Make sure the posts returned in the widget have changed, and return your most popular posts ever.

#### Proposed changelog entry for your changes:

* Top Posts: allow fetching posts from a long timeframe when using the `jetpack_top_posts_days` filter.
