### PR TITLE
Let all Pinterest TLDs Show the Social Menus Icon

### DIFF
--- a/modules/theme-tools/social-menu/icon-functions.php
+++ b/modules/theme-tools/social-menu/icon-functions.php
@@ -147,7 +147,7 @@ if ( ! function_exists( 'jetpack_social_menu_social_links_icons' ) ) :
 			'mailto:'         => 'mail',
 			'meetup.com'      => 'meetup',
 			'medium.com'      => 'medium',
-			'pinterest.com'   => 'pinterest',
+			'pinterest.'      => 'pinterest',
 			'getpocket.com'   => 'pocket',
 			'reddit.com'      => 'reddit',
 			'skype.com'       => 'skype',

--- a/modules/theme-tools/social-menu/social-menu.css
+++ b/modules/theme-tools/social-menu/social-menu.css
@@ -121,7 +121,7 @@ Genericons
 }
 
 /* Pinterest */
-.jetpack-social-navigation-genericons a[href*="pinterest.com"]:before {
+.jetpack-social-navigation-genericons a[href*="pinterest."]:before {
 	content: "\f210";
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11132

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Instead of relying on `pinterest.com` to be inputted to show an icon, just let `pinterest.` be inputted for one to show. It's much more ideal to show one irrespective of the TLD, because a quick search suggests there are around fifty: https://securitytrails.com/list/ns/ns1.pinterest.com

This essentially follows @cecilearkay's suggestion. 

> My suggestion would be that we make an exception for this service and show the Pinterest icon from the moment a user enters a valid pinterest.tld URL.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Customizer on a theme which supports social menus, such as Dara
* In Menus, add a social menu 
* Add any Pinterest URL as a menu, and notice that currently, it won't appear unless the TLD is `.com`. Try with this change

![gsdfsgfdgfsd](https://user-images.githubusercontent.com/43215253/52168022-54654000-271c-11e9-9adf-a51f422954ef.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such -->

Social menus: Let all Pinterest links show the intended logo
