### PR TITLE
Copy Post: display toggle when searching for the feature.

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -39,6 +39,7 @@ export class Writing extends React.Component {
 		};
 
 		const found = [
+			'copy-post',
 			'masterbar',
 			'markdown',
 			'after-the-deadline',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Now that the feature has its own toggle inside the Writing Settings panel, we must allow that panel to be displayed when the Copy Post module is found.

#### Testing instructions:

* Go to Jetpack > Settings.
* Search for "copy".
* Make sure the Copy Post toggle appears.

#### Proposed changelog entry for your changes:

* None
