### PR TITLE
i18n: blocks live in _inc, not _inc/build

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -234,7 +234,7 @@ gulp.task( 'languages:merge', function( done ) {
 	const paths = [];
 
 	gulp
-		.src( [ '_inc/build/blocks/*.pot', '_inc/build/jetpack-strings.pot' ] )
+		.src( [ '_inc/blocks/*.pot', '_inc/build/jetpack-strings.pot' ] )
 		.pipe(
 			tap( function( file ) {
 				paths.push( file.path );


### PR DESCRIPTION
Follow up from #11225

#### Changes proposed in this Pull Request:

* i18n: blocks live in _inc, not _inc/build

#### Testing instructions:

When running `yarn build-languages`, the gulp task should look for the pot file in the right folder.

#### Proposed changelog entry for your changes:

* None
