### PR TITLE
Copy Post: Correct post status of new post.

### DIFF
--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -104,6 +104,7 @@ class Jetpack_Copy_Post {
 	protected function update_content( $source_post, $target_post_id ) {
 		$data = array(
 			'ID'             => $target_post_id,
+			'post_status'    => 'draft',
 			'post_title'     => $source_post->post_title,
 			'post_content'   => $source_post->post_content,
 			'post_excerpt'   => $source_post->post_excerpt,


### PR DESCRIPTION
If a new copied post has an `auto-draft` post status, it will be flagged as a new post requiring content – which is not required in our situation of copying a source post. If the source post also happens to be a `post` with a non-standard format, it will trigger the addition of [template information for the block editor](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/edit-form-blocks.php#L319), resulting in [incorrect content for the new post](https://github.com/Automattic/jetpack/issues/11256).

Since `auto-draft` is used as a flag for core to manipulate default content (something we do not need), setting the new copied post straight to `draft` status will bypass these issues. It also avoids needing to make later editor-specific adjustments; keeping all Copy Post operations at a single point in the codebase (the initial `wp_insert_post` [call](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/post.php#L662) by `get_default_post_to_edit`), we may avoid further complications down the road.

**Testing instructions**
* Switch to this branch.
* Make sure Copy Post is activated (it's under `Jetpack > Settings > Writing`).
* Prepare a test post that has a non-standard post format (eg. `image` or `quote`), and some content.
* Perform a Copy Post operation on the test file, in both the block and Classic editors.
* Verify the correct content is displayed.

**Proposed changelog entry**
* N/A

Fixes: #11256 
