### PR TITLE
My Plan: remove upgrade prompts from cards describing current plan.

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -413,67 +413,6 @@ class MyPlanBody extends React.Component {
 									) }
 								</div>
 							) }
-
-						{ this.props.showBackups &&
-							'is-personal-plan' === planClass && (
-								<div className="jp-landing__plan-features-card">
-									<h3 className="jp-landing__plan-features-title">
-										{ __( 'Three great reasons to go Pro' ) }
-									</h3>
-									<p>
-										{ __(
-											'Design the perfect site with unlimited access to hundreds of themes and unlimited, high-speed, and ad-free video hosting.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'Always-on security including real-time backups, malware scanning, and automatic threat resolution.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'Grow your traffic and revenue with social media scheduling, enhanced site search, SEO tools, PayPal payments, and an ad program.'
-										) }
-									</p>
-									<p>
-										<Button
-											onClick={ this.handleButtonClickForTracking( 'compare_plans' ) }
-											href={ this.props.comparePlansUpgradeUrl }
-											className="is-primary"
-										>
-											{ __( 'Compare plans' ) }
-										</Button>
-									</p>
-								</div>
-							) }
-
-						{ ( ! this.props.showBackups && 'is-personal-plan' === planClass ) ||
-							( 'is-premium-plan' === planClass && (
-								<div className="jp-landing__plan-features-card">
-									<h3 className="jp-landing__plan-features-title">
-										{ __( 'Two great reasons to go Pro' ) }
-									</h3>
-									<p>
-										{ __(
-											'Unlimited access to hundreds of premium WordPress themes with dedicated support directly from the theme authors.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'A superior search experience powered by Elasticsearch providing your users with faster and more relevant search results. Previously only available to WordPress.com VIP customers and trusted by industry-leading brands.'
-										) }
-									</p>
-									<p>
-										<Button
-											onClick={ this.handleButtonClickForTracking( 'compare_plans' ) }
-											href={ this.props.plansComparePremiumUpgradeUrl }
-											className="is-primary"
-										>
-											{ __( 'Explore Jetpack Professional' ) }
-										</Button>
-									</p>
-								</div>
-							) ) }
 					</div>
 				);
 				break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11110

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Remove `Two/Three great reasons to go Pro` upgrade nudge from the `My Plan` section

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
BEFORE
<img width="670" alt="screenshot 2019-02-04 at 23 30 14" src="https://user-images.githubusercontent.com/13561163/52241766-da2beb80-28d4-11e9-890b-f238b5ce8807.png">
AFTER
<img width="982" alt="screenshot 2019-02-04 at 22 53 25" src="https://user-images.githubusercontent.com/13561163/52241521-3b9f8a80-28d4-11e9-887a-5280fb7fda6a.png">

* Go to 'wp-admin/admin.php?page=jetpack#/my-plan' in wp-admin of a site on a Personal or Premium plans, and verify that the nudge to upgrade is not present among the cards under My Plan.

