### PR TITLE
Gutenberg: Keep using VideoPress videos after a downgrade

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -27,6 +27,10 @@ $tools = array(
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
 	'geo-location.php',
 	'calypsoify/class.jetpack-calypsoify.php',
+
+	// Keep working the VideoPress videos in existing posts/pages when the module is deactivated
+	'videopress/utility-functions.php',
+	'videopress/class.videopress-gutenberg.php',
 );
 
 // Not every tool needs to be included if Jetpack is inactive and not in development mode

--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -12,14 +12,12 @@
  * Plans: business, premium
  */
 
-include_once dirname( __FILE__ ) . '/videopress/utility-functions.php';
 include_once dirname( __FILE__ ) . '/videopress/shortcode.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-options.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-scheduler.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-xmlrpc.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-cli.php';
 include_once dirname( __FILE__ ) . '/videopress/class.jetpack-videopress.php';
-include_once dirname( __FILE__ ) . '/videopress/class.videopress-gutenberg.php';
 
 if ( is_admin() ) {
 	include_once dirname( __FILE__ ) . '/videopress/editor-media-view.php';

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -1,19 +1,25 @@
 <?php
+/**
+ * Block Editor functionality for VideoPress users.
+ *
+ * @package Jetpack
+ */
 
+/**
+ * Register a VideoPress extension to replace the default Core Video block.
+ */
 class VideoPress_Gutenberg {
 
 	/**
 	 * Initialize the VideoPress Gutenberg extension
 	 */
 	public static function init() {
-		// Should not initialize if Gutenberg is not available or if Jetpack is not active
+		// Should not initialize if Gutenberg is not available or if Jetpack is not active.
 		if (
 			( function_exists( 'register_block_type' ) )
-			&&
-			(
+			&& (
 				( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() )
-				||
-				( defined( 'IS_WPCOM' ) && IS_WPCOM )
+				|| ( defined( 'IS_WPCOM' ) && IS_WPCOM )
 			)
 		) {
 			add_action( 'init', array( __CLASS__, 'register_video_block_with_videopress' ) );
@@ -28,9 +34,12 @@ class VideoPress_Gutenberg {
 		// registration doesn't fit our needs. Right now, any extension registered with `jetpack_register_block`
 		// needs to have a name that is equal to the name of the registered block (our extension name would be
 		// "videopress" and the name of the block we need to register "core/video").
-		register_block_type( 'core/video', array(
-			'render_callback' => array( __CLASS__, 'render_video_block_with_videopress' ),
-		) );
+		register_block_type(
+			'core/video',
+			array(
+				'render_callback' => array( __CLASS__, 'render_video_block_with_videopress' ),
+			)
+		);
 	}
 
 	/**

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -6,8 +6,16 @@ class VideoPress_Gutenberg {
 	 * Initialize the VideoPress Gutenberg extension
 	 */
 	public static function init() {
-		// Should not initialize if Gutenberg is not available
-		if ( function_exists( 'register_block_type' ) ) {
+		// Should not initialize if Gutenberg is not available or if Jetpack is not active
+		if (
+			( function_exists( 'register_block_type' ) )
+			&&
+			(
+				( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() )
+				||
+				( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			)
+		) {
 			add_action( 'init', array( __CLASS__, 'register_video_block_with_videopress' ) );
 		}
 	}

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -34,7 +34,7 @@ class VideoPress_Gutenberg {
 	 * @return string
 	 */
 	public static function render_video_block_with_videopress( $attributes, $content ) {
-		if ( ! isset( $attributes['id'] ) ) {
+		if ( ! isset( $attributes['id'] ) || isset( $attributes['guid'] ) ) {
 			return $content;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up of #11193.

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

As @jeherve noted on https://github.com/Automattic/jetpack/pull/11193#issuecomment-459328914, we don't want to break videos embeds on a site, even if the VideoPress module is deactivated. 

This PR moves the `utility-functions.php` and `class.videopress-gutenberg.php` imports to `module-extras.php`, so they are always loaded if Jetpack is activated. These files are responsible for using the VideoPress URL as source of the core video blocks, so with this change we ensure that existing posts or pages containing core video blocks will still use the VideoPress videos after a plan downgrade.

There is also one additional change in this PR in order to don't modify the content of the video blocks if there is a `guid` attribute present. This is to prevent to change the block content when the saved post content already contains the needed markup for using VideoPress (done in https://github.com/Automattic/wp-calypso/pull/30546).

### Testing instructions:

**Jetpack**

In order to avoid issues with [Jetpack caching the VideoPress data](https://github.com/Automattic/jetpack/blob/9b323c5809e23492025cd0879c540243b75e894b/modules/videopress/utility-functions.php#L48), it's better if you test theses changes locally using [Docker and ngrok](https://github.com/Automattic/jetpack/tree/9b323c5809e23492025cd0879c540243b75e894b/docker), and override the `HOUR_IN_SECONDS` constant in the `docker/wordpress/wp-config.php` file, so the data is cached only 30 seconds:
```
define( 'HOUR_IN_SECONDS', 30 );
```

* Connect Jetpack to a WP.com site with a premium/business plan.
* Go to Jetpack → Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
* Add a new post.
* Insert a video block.
* Upload a video file using the Media Library in a format that is not supported by your browser (e.g. .mov in Chrome). 
  * VideoPress only converts videos uploaded with the Media Library, that's why we need to use that instead of the "Upload" button (bug already reported: https://github.com/Automattic/jetpack/issues/11194).
* Publish it the post.
* Wait until VideoPress finishes to convert the HD MP4 video.
  * You can check this on the Media section, by visualizing the attachment details and clicking on "Edit more details".
<img width="418" alt="screen shot 2019-02-05 at 15 31 15" src="https://user-images.githubusercontent.com/1233880/52280073-43eed880-295b-11e9-8f96-d84154e77047.png">
<img width="299" alt="screen shot 2019-02-05 at 15 31 34" src="https://user-images.githubusercontent.com/1233880/52280074-44876f00-295b-11e9-8ef8-c0d1cf1d1b99.png">

* Reload the published view of the post.
* Confirm the video is playable.
* Deactivate VideoPress or downgrade to a free plan.
* Reload the published view of the post.
* Make sure that the video is still playable.

**WordPress.com**

* Changes in WP.com (D23918-code) are only testable with https://github.com/Automattic/wp-calypso/pull/30546, so check the testing instructions on that PR.

### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Keep working the VideoPress videos in existing Gutenberg posts/pages when the module is deactivated.
