### PR TITLE
Net Neutrality: Remove

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -101,7 +101,6 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'site_icon'                    => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                    => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'               => '(int) Number of posts to show on blog pages',
-		'net_neutrality'               => '(bool) Whether to show the net neutrality modal for a site',
 		'posts_per_rss'                => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'              => '(bool) Whether the RSS feed will use post excerpts',
 	),
@@ -327,11 +326,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
-				$net_neutrality_options = get_option( 'net_neutrality_options_2017' );
-				$net_neutrality = ( $net_neutrality_options && ! empty( $net_neutrality_options['enabled'] ) )
-					? true
-					: false;
-
 				$response[ $key ] = array(
 
 					// also exists as "options"
@@ -399,7 +393,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'amp_is_enabled'          => (bool) function_exists( 'wpcom_is_amp_enabled' ) && wpcom_is_amp_enabled( $blog_id ),
 					'api_cache'               => $api_cache,
 					'posts_per_page'          => (int) get_option( 'posts_per_page' ),
-					'net_neutrality'          => $net_neutrality,
 					'posts_per_rss'           => (int) get_option( 'posts_per_rss' ),
 					'rss_use_excerpt'         => (bool) get_option( 'rss_use_excerpt' ),
 				);
@@ -791,15 +784,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 							$updated[ $key ] = (bool) $value;
 						}
 					}
-					break;
-
-				case 'net_neutrality':
-					$original_value = $value;
-					$value = array( 'enabled' => (bool) $value );
-					if ( update_option( 'net_neutrality_options_2017', $value ) ) {
-						$updated[ $key ] = $original_value;
-					}
-
 					break;
 
 				case 'rss_use_excerpt':

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -98,7 +98,6 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
-		'net_neutrality'                       => '(bool) Whether the net neutrality modal is enabled for this site',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -98,7 +98,6 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
-		'net_neutrality'                       => '(bool) Whether the net neutrality modal is enabled for this site',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -98,7 +98,6 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
-		'net_neutrality'                       => '(bool) Whether the net neutrality modal is enabled for this site',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
 	),


### PR DESCRIPTION
JP counterpart to D23671-code, prompted by https://github.com/Automattic/wp-calypso/pull/30489

#### Changes proposed in this Pull Request:

Remove Net Neutrality campaign feature.

#### Testing instructions:

Verify that nothing is broken :grimacing: 
Grep `net_neutrality` to verify that there are no remaining occurrences.

#### Proposed changelog entry for your changes:

Remove Net Neutrality campaign feature.
