### PR TITLE
Copy Post: update module description to not use a period.

### DIFF
--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Module Name: Copy Post
- * Module Description: Copy an existing post's content into a new draft post.
- * Jumpstart Description: Copy an existing post's content into a new post.
+ * Module Description: Copy an existing post's content into a new draft post
+ * Jumpstart Description: Copy an existing post's content into a new draft post
  * Sort Order: 15
  * First Introduced: 7.0
  * Requires Connection: No

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -41,8 +41,8 @@ function jetpack_get_module_i18n( $key ) {
 
 			'copy-post' => array(
 				'name' => _x( 'Copy Post', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Copy an existing post\'s content into a new draft post.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Copy an existing post\'s content into a new post.', 'Jumpstart Description', 'jetpack' ),
+				'description' => _x( 'Copy an existing post\'s content into a new draft post', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Copy an existing post\'s content into a new draft post', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'custom-content-types' => array(


### PR DESCRIPTION
Fixes #11272

#### Changes proposed in this Pull Request:

Copy Post: update module description to not use a period.

#### Testing instructions:

* Checkout this branch.
* Run `yarn build`
* Visit Jetpack > Settings > Writing 
* Do you see a period?
* No? 💥 	

#### Proposed changelog entry for your changes:

* None
