### PR TITLE
Enable seo-tools for the WPCOM Ecommerce bundle

### DIFF
--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -6,6 +6,8 @@ import includes from 'lodash/includes';
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
 export const PLAN_BUSINESS_2_YEARS = 'business-bundle-2y';
+export const PLAN_ECOMMERCE = 'ecommerce-bundle';
+export const PLAN_ECOMMERCE_2_YEARS = 'ecommerce-bundle-2y';
 export const PLAN_PREMIUM = 'value_bundle';
 export const PLAN_PREMIUM_2_YEARS = 'value_bundle-2y';
 export const PLAN_PERSONAL = 'personal-bundle';
@@ -129,6 +131,8 @@ export function getPlanClass( plan ) {
 		case PLAN_JETPACK_BUSINESS:
 		case PLAN_JETPACK_BUSINESS_MONTHLY:
 		case PLAN_VIP:
+		case PLAN_ECOMMERCE:
+		case PLAN_ECOMMERCE_2_YEARS:
 			return 'is-business-plan';
 		default:
 			return '';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1619,6 +1619,8 @@ class Jetpack {
 			'jetpack_business_monthly',
 			'business-bundle',
 			'business-bundle-2y',
+			'ecommerce-bundle',
+			'ecommerce-bundle-2y',
 			'vip',
 		);
 


### PR DESCRIPTION
For more context see: https://trello.com/b/vhozj5K2

TLDR: The wpcom ecommerce plan should be included in the business level of plans so that things like seo-tools are available.

#### Testing instructions:
* On a site that has the ecommerce plan goto the jetpack settings eg:
https://YOUR-ECOM-PLAN.wpcomstaging.com/wp-admin/admin.php?page=jetpack#/traffic
* Make sure that the seo tools section is not asking you to upgrade.

#### Proposed changelog entry for your changes:
* No changelog needed
