### PR TITLE
Docker: Add docker based yarn build

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -130,7 +130,7 @@ Will stop all of the containers created by this docker-compose configuration and
 ### Rebuild images
 
 ```sh
-yarn docker:build
+yarn docker:build-image
 ```
 
 You need to rebuild the WordPress image with this command if you modified `Dockerfile`, `docker-composer.yml` or the provisioned files we use for configuring Apache and PHP.

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -5,7 +5,7 @@ set -e
 # These commands will be run each time the container is run.
 #
 # If you modify anything here, remember to build the image again by running:
-# yarn docker:build
+# yarn docker:build-image
 
 user="${APACHE_RUN_USER:-www-data}"
 group="${APACHE_RUN_GROUP:-www-data}"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "docker:up": "yarn docker:compose up",
     "docker:stop": "yarn docker:compose stop",
     "docker:down": "yarn docker:compose down",
-    "docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node yarn",
+    "docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node yarn build",
     "docker:build-image": "yarn docker:compose build",
     "docker:wp": "yarn docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
     "docker:install": "yarn docker:compose exec wordpress bash -c \"/var/scripts/install.sh\"",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "docker:up": "yarn docker:compose up",
     "docker:stop": "yarn docker:compose stop",
     "docker:down": "yarn docker:compose down",
-    "docker:build": "yarn docker:compose build",
+    "docker:build-image": "yarn docker:compose build",
     "docker:wp": "yarn docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
     "docker:install": "yarn docker:compose exec wordpress bash -c \"/var/scripts/install.sh\"",
     "docker:uninstall": "yarn docker:compose exec wordpress bash -c \"/var/scripts/uninstall.sh\"",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docker:up": "yarn docker:compose up",
     "docker:stop": "yarn docker:compose stop",
     "docker:down": "yarn docker:compose down",
+    "docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node yarn",
     "docker:build-image": "yarn docker:compose build",
     "docker:wp": "yarn docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
     "docker:install": "yarn docker:compose exec wordpress bash -c \"/var/scripts/install.sh\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:


* Attempts to introduce a `yarn docker:build` command that runs `yarn build` inside a docker container (official node image).
* Renames current `yarn docker:build` to `yarn docker:build-image` and updates reference to this command.

#### Current concerns

1. Using the current directory mapped intot the container will make `${PWD}/node_modules` contain Linux versions of the packages.
  2. We not only use `node_modules` content for building. We use it for the precommit hook for example.
2. This solution won't just box as is right now, cause one of the build steps depends on php existing in the environment. 

#### Ideas

* Maybe don't use PWD for the build node_modules.

#### Testing instructions:

1. checkout to this branch.
2. clean your node_modules.
3. Run `yarn docker:build`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
