### PR TITLE
Display notice for LinkedIn connection so they can reauthenticate

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -105,6 +105,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 			}
 		}
 
+		if ( 'linkedin' === $item['id'] && 'must_reauth' === $test_result['connectionTestPassed'] ) {
+			$item['test_success'] = 'must_reauth';
+		}
+
 		$response = rest_ensure_response( $items );
 
 		$response->header( 'X-WP-Total', count( $items ) );

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -523,7 +523,7 @@ abstract class Publicize_Base {
 				if ( 'linkedin' === $service_name && $this->is_invalid_linkedin_connection( $connection ) ) {
 					$connection_test_passed = 'must_reauth';
 					$user_can_refresh = false;
-					$connection_test_message = esc_html__( 'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.' );
+					$connection_test_message = esc_html__( 'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.', 'jetpack' );
 				}
 
 				$unique_id = null;

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -434,6 +434,19 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * LinkedIn needs to be reauthenticated to use v2 of their API.
+	 * If it's using LinkedIn old API, it's an 'invalid' connection
+	 *
+	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
+	 * @return bool
+	 */
+	function is_invalid_linkedin_connection( $connection ) {
+		// LinkedIn API v1 included the profile link in the connection data.
+		$connection_meta = $this->get_connection_meta( $connection );
+		return isset( $connection_meta['connection_data']['meta']['profile_url'] );
+	}
+
+	/**
 	 * Whether the Connection currently being connected
 	 *
 	 * @param object|array The Connection object (WordPress.com) or array (Jetpack)
@@ -504,6 +517,13 @@ abstract class Publicize_Base {
 						$user_can_refresh = false;
 						$connection_test_message = __( 'Please select a Facebook Page to publish updates.', 'jetpack' );
 					}
+				}
+
+				// LinkedIn needs reauthentication to be compatible with v2 of their API
+				if ( 'linkedin' === $service_name && $this->is_invalid_linkedin_connection( $connection ) ) {
+					$connection_test_passed = 'must_reauth';
+					$user_can_refresh = false;
+					$connection_test_message = esc_html__( 'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.' );
 				}
 
 				$unique_id = null;

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -747,13 +747,14 @@ jQuery( function($) {
 							<span class="notice-warning publicize__notice-warning">
 				                <?php
 				                printf( esc_html__(
-					                'Your %s connection needs to be reauthenticated to continue working – head to Sharing to take care of it.'
+					                'Your %s connection needs to be reauthenticated to continue working – head to Sharing to take care of it.',
+							'jetpack'
 				                ), $connection_name );
 				                ?>
 								<a
 										class="publicize__sharing-settings"
 										href="<?php echo publicize_calypso_url() ?>"
-								><?php esc_html_e( 'Go to Sharing settings' ) ?></a>
+								><?php esc_html_e( 'Go to Sharing settings', 'jetpack' ) ?></a>
 							</span>
 							<?php
 						}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -628,6 +628,27 @@ jQuery( function($) {
 	list-style: square;
 	padding-left: 1em;
 }
+.publicize__notice-warning {
+	display: inline-block;
+	padding: 7px 10px;
+	margin: 5px 0;
+	border-left-width: 4px;
+	border-left-style: solid;
+	font-size: 12px;
+	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+.publicize__sharing-settings {
+	display: block;
+	text-decoration: none;
+	margin-top: 8px;
+}
+.publicize__sharing-settings:after {
+	content: "\f504";
+	font: normal 18px/.5em dashicons;
+	speak: none;
+	margin-left: 5px;
+	vertical-align: middle;
+}
 #publicize-title:before {
 	content: "\f237";
 	font: normal 20px/1 dashicons;
@@ -672,6 +693,24 @@ jQuery( function($) {
 	}
 
 	/**
+	 * Extracts the connections that require reauthentication, for example, LinkedIn, when it switched v1 to v2 of its API.
+	 *
+	 * @return array Connections that must be reauthenticated
+	 */
+	function get_must_reauth_connections() {
+		$must_reauth = array();
+		$connections = $this->publicize->get_connections( 'linkedin' );
+		if ( is_array( $connections ) ) {
+			foreach ( $connections as $index => $connection ) {
+				if ( $this->publicize->is_invalid_linkedin_connection( $connection ) ) {
+					$must_reauth[ $index ] = 'LinkedIn';
+				}
+			}
+		}
+		return $must_reauth;
+	}
+
+	/**
 	* Controls the metabox that is displayed on the post page
 	* Allows the user to customize the message that will be sent out to the social network, as well as pick which
 	* networks to publish to. Also displays the character counter and some other information.
@@ -700,6 +739,27 @@ jQuery( function($) {
 
 				if ( 0 < count( $connections_data ) ) :
 					$publicize_form = $this->get_metabox_form_connected( $connections_data );
+
+					$must_reauth = $this->get_must_reauth_connections();
+					if ( ! empty( $must_reauth ) ) {
+						foreach ( $must_reauth as $connection_name ) {
+							?>
+							<span class="notice-warning publicize__notice-warning">
+				                <?php
+				                printf( esc_html__(
+					                'Your %s connection needs to be reauthenticated to continue working – head to Sharing to take care of it.'
+				                ), $connection_name );
+				                ?>
+								<a
+										class="publicize__sharing-settings"
+										href="<?php echo publicize_calypso_url() ?>"
+								><?php esc_html_e( 'Go to Sharing settings' ) ?></a>
+							</span>
+							<?php
+						}
+						?>
+						<?php
+					}
 
 					$labels = array();
 					$has_google_plus = false;


### PR DESCRIPTION
```
======================================================
  _____          _   _       _   
 |  __ \        | \ | |     | |  
 | |  | | ___   |  \| | ___ | |_ 
 | |  | |/ _ \  | . ` |/ _ \| __|
 | |__| | (_) | | |\  | (_) | |_ 
 |_____/ \___/  |_| \_|\___/ \__|
 |  \/  |                        
 | \  / | ___ _ __ __ _  ___     
 | |\/| |/ _ \ '__/ _` |/ _ \    
 | |  | |  __/ | | (_| |  __/    
 |_|  |_|\___|_|  \__, |\___|    
                   __/ |         
                  |___/          
======================================================
```

<!--- Provide a general summary of your changes in the Title above -->

Fixes #11145

Requires https://github.com/Automattic/wp-calypso/pull/30504 for changes in Publicize for Gutenberg in WP Admin in the Jetpack site

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In Classic editor

<img width="294" alt="captura de pantalla 2019-02-06 a la s 16 57 08" src="https://user-images.githubusercontent.com/1041600/52371675-f34bae00-2a34-11e9-8465-4026764eac1d.png">

Gutenberg in Calypso

<img width="288" alt="captura de pantalla 2019-02-11 a la s 13 03 23" src="https://user-images.githubusercontent.com/1041600/52304668-00539900-2972-11e9-9f00-ecec4aafa9f2.png">

Gutenberg in WP Admin in JP site

<img width="288" alt="captura de pantalla 2019-02-11 a la s 13 03 23" src="https://user-images.githubusercontent.com/1041600/52575785-93228680-2dfd-11e9-8d30-9eeb7d9daa6b.png">

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure you have an old LinkedIn connection
* Apply D23810-code to your sandbox and use this branch, remember to sandbox your Jetpack site
* Go to Publicize panel in post editing, both in Gutenberg and classic editor
* They should display a notice alerting user that the LinkedIn connection needs reauthentication
* It should display a link to Calypso Sharing settings

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* LinkedIn is deprecating its API v1 on March 1st so we've moved to API v2. We're showing a message to users that lets them know that they need to reauthenticate.
