### PR TITLE
Twenty Nineteen: Fix Top Posts and Pages Widget image list margins

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -352,7 +352,9 @@
 
 /* Top Posts & Pages Widget */
 .widget_top-posts .widgets-list-layout-links {
+	float: inherit;
     margin-left: calc(40px + 1rem);
+	width: inherit;
 }
 
 /* Search widget override */

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -350,6 +350,11 @@
 	content: "\2014\00a0";
 }
 
+/* Top Posts & Pages Widget */
+.widget_top-posts .widgets-list-layout-links {
+    margin-left: calc(40px + 1rem);
+}
+
 /* Search widget override */
 @media only screen and (min-width: 600px) {
 	.widget.widget_search .search-field {

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -353,7 +353,7 @@
 /* Top Posts & Pages Widget */
 .widget_top-posts .widgets-list-layout-links {
 	float: inherit;
-    margin-left: calc(40px + 1rem);
+	margin-left: calc(40px + 1rem);
 	width: inherit;
 }
 


### PR DESCRIPTION
This PR adds proper spacing to the Top Posts & Pages Widget when using the Image List option.

Originally reported here: https://github.com/Automattic/themes/issues/441

## Testing instructions

- Add Top Posts & Pages widget to footer with the Image List option

## Before Fix

<img width="1093" alt="screen shot 2018-12-18 at 6 49 16 pm" src="https://user-images.githubusercontent.com/42454301/50190133-fd371780-02f5-11e9-9a3f-b341ebc40d5a.png">

## After Fix

![image](https://user-images.githubusercontent.com/709581/52313462-9a204380-297c-11e9-8eeb-f6c9117676c2.png)

## Proposed changelog entry

* Twenty Nineteen: Fix Top Posts and Pages Widget image list margins