### PR TITLE
Fix vertical spacing for new posts loaded with Infinite Scroll

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -83,10 +83,6 @@
 	line-height: 1;
 }
 
-.entry .entry-content div.sharedaddy:last-of-type {
-	margin-bottom: 0;
-}
-
 .entry div.sharedaddy h3.sd-title,
 .entry h3.sd-title {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -64,6 +64,10 @@
 	outline-offset: -4px;
 }
 
+.site-main .infinite-wrap .entry:first-of-type {
+	margin-top: calc(6 * 1rem);
+}
+
 /**
  * Responsive Videos
  */
@@ -77,6 +81,10 @@
 
 .sd-block {
 	line-height: 1;
+}
+
+.entry .entry-content div.sharedaddy:last-of-type {
+	margin-bottom: 0;
 }
 
 .entry div.sharedaddy h3.sd-title,


### PR DESCRIPTION
Originally reported here: https://github.com/Automattic/themes/issues/470

## Changes proposed in this Pull Request:

* This change respects the top-margin spacing for post loaded within the `.infinite-wrap` wrapper.

## Testing instructions:

* Apply Twenty Nineteen to a WordPress.com site.
* Turn on infinite scroll, and set to click-to-load more.
* Load a few pages of posts.

## Before Fix

The very first post in each set of new posts loaded by Infinite Scroll sits closer to the one before it compared to spacing for all other posts.

In this screenshot, the spacing between Classic Editor Block and the post meta above it is normal; the Alignments post is the first in the next "page" of posts and is quite a bit closer. 

![image](https://user-images.githubusercontent.com/177561/50655609-8b8dd900-0f45-11e9-8475-9618c409f866.png)

## After Fix

The spacing is now consistent. 

![image](https://user-images.githubusercontent.com/709581/52363786-8e329100-2a11-11e9-90e4-33f4bf3e724e.png)

## Proposed changelog entry for your changes:

* Fix vertical spacing for new posts loaded with Infinite Scroll