### PR TITLE
Copy Post: Fix content for non-standard post formats.

### DIFF
--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -64,10 +64,13 @@ class Jetpack_Copy_Post {
 			'update_post_type_terms' => $this->update_post_type_terms( $source_post, $target_post_id ),
 		);
 
-		// Required to satify get_default_post_to_edit(), which has these filters after post creation.
+		// Required to satisfy get_default_post_to_edit(), which has these filters after post creation.
 		add_filter( 'default_title', array( $this, 'filter_title' ), 10, 2 );
 		add_filter( 'default_content', array( $this, 'filter_content' ), 10, 2 );
 		add_filter( 'default_excerpt', array( $this, 'filter_excerpt' ), 10, 2 );
+
+		// Required to avoid the block editor from adding default blocks according to post format.
+		add_filter( 'block_editor_settings', array( $this, 'remove_post_format_template' ) );
 
 		/**
 		 * Fires after all updates have been performed, and default content filters have been added.
@@ -176,6 +179,17 @@ class Jetpack_Copy_Post {
 	protected function update_post_format( $source_post, $target_post_id ) {
 		$post_format = get_post_format( $source_post );
 		return set_post_format( $target_post_id, $post_format );
+	}
+
+	/**
+	 * Update the target post's post format.
+	 *
+	 * @param array $settings Settings to be passed into the block editor.
+	 * @return array Settings with any `template` key removed.
+	 */
+	public function remove_post_format_template( $settings ) {
+		unset( $settings['template'] );
+		return $settings;
 	}
 
 	/**

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -32,7 +32,7 @@ class Jetpack_Copy_Post {
 
 		if ( ! empty( $_GET['jetpack-copy'] ) && 'post-new.php' === $GLOBALS['pagenow'] ) {
 			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
-			add_filter( 'pre_option_default_post_format', array( $this, 'shortcircuit_default_post_format' ) );
+			add_filter( 'pre_option_default_post_format', '__return_empty_string' );
 		}
 	}
 
@@ -180,15 +180,6 @@ class Jetpack_Copy_Post {
 	protected function update_post_format( $source_post, $target_post_id ) {
 		$post_format = get_post_format( $source_post );
 		return set_post_format( $target_post_id, $post_format );
-	}
-
-	/**
-	 * Block core from assigning the default post format.
-	 *
-	 * @return string Empty string.
-	 */
-	public function shortcircuit_default_post_format() {
-		return '';
 	}
 
 	/**

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -170,7 +170,7 @@ class Jetpack_Copy_Post {
 	}
 
 	/**
-	 * Update the target post's post format.
+	 * Ensure the block editor doesn't modify the source post content for non-standard post formats.
 	 *
 	 * @param WP_Post $source_post Post object to be copied.
 	 * @param int     $target_post_id Target post ID.

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -32,6 +32,7 @@ class Jetpack_Copy_Post {
 
 		if ( ! empty( $_GET['jetpack-copy'] ) && 'post-new.php' === $GLOBALS['pagenow'] ) {
 			add_action( 'wp_insert_post', array( $this, 'update_post_data' ), 10, 3 );
+			add_filter( 'pre_option_default_post_format', array( $this, 'shortcircuit_default_post_format' ) );
 		}
 	}
 
@@ -179,6 +180,15 @@ class Jetpack_Copy_Post {
 	protected function update_post_format( $source_post, $target_post_id ) {
 		$post_format = get_post_format( $source_post );
 		return set_post_format( $target_post_id, $post_format );
+	}
+
+	/**
+	 * Block core from assigning the default post format.
+	 *
+	 * @return string Empty string.
+	 */
+	public function shortcircuit_default_post_format() {
+		return '';
 	}
 
 	/**

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -170,7 +170,7 @@ class Jetpack_Copy_Post {
 	}
 
 	/**
-	 * Ensure the block editor doesn't modify the source post content for non-standard post formats.
+	 * Update the target post's post format.
 	 *
 	 * @param WP_Post $source_post Post object to be copied.
 	 * @param int     $target_post_id Target post ID.
@@ -182,7 +182,7 @@ class Jetpack_Copy_Post {
 	}
 
 	/**
-	 * Update the target post's post format.
+	 * Ensure the block editor doesn't modify the source post content for non-standard post formats.
 	 *
 	 * @param array $settings Settings to be passed into the block editor.
 	 * @return array Settings with any `template` key removed.


### PR DESCRIPTION
When the new post screen is loading, it believes it is loading a newly-created post with default content, and attempts to set the post format to the default selected in `Settings > Writing`. Since Copy Post has already taken care of assigning the proper post format, we can take advantage of `set_post_format`'s shortcircuit to stop core from making any changes.

Fixes #11256 .

#### Testing instructions:
* Apply this PR.
* Set the default post format to something other than standard, in `Settings > Writing`.
* Set up a test post that has a post format other than standard, and different from the default.
* Copy the test post.
* Verify that content is correct, and that the post format of the source post is preserved in the newly-created post.

#### Proposed changelog entry for your changes:
* Fixed a bug with Copy Post and its handling of non-standard post formats.
