### PR TITLE
Social Icons Widget: Handle Alternative Pinterest TLDs

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -563,7 +563,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Medium',
 			),
 			array(
-				'url'   => 'pinterest.com',
+				'url'   => 'pinterest.',
 				'icon'  => 'pinterest',
 				'label' => 'Pinterest',
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #8422

Applies the same logic as #11252 to the Social Icons Widget, so therefore the description is almost identical. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Instead of relying on `pinterest.com` to be inputted to show an icon, just let `pinterest.` be inputted for one to show. It's much more ideal to show one irrespective of the TLD, because a quick search suggests there are around fifty: https://securitytrails.com/list/ns/ns1.pinterest.com

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Customizer on a theme which supports social menus, such as Dara
* In Widgets, add a Social Icons Widget
* Add any Pinterest URL as a menu, and notice that currently, it won't appear unless the TLD is `.com`. Try with this change, and notice the following 

![sgdfsfdgsdfgsdgf](https://user-images.githubusercontent.com/43215253/52396596-62171e80-2aaa-11e9-9cfd-d9e647629348.png)
![sgdfdsfgsfdgfgsd](https://user-images.githubusercontent.com/43215253/52396599-65120f00-2aaa-11e9-8a15-13825f71d98e.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

If there really needs to be a changelog, it's probably best just to merge #11252 and this into one 
