### PR TITLE
REST API: Change likes and sharing post meta to REST fields

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -563,6 +563,7 @@ class Jetpack_Likes {
 function jetpack_post_likes_get_value( array $post ) {
 	$post_likes_switched = get_post_meta( $post['id'], 'switch_like_status', true );
 
+	/** This filter is documented in modules/likes.php */
 	$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
 
 	return $post_likes_switched xor $sitewide_likes_enabled;
@@ -572,6 +573,7 @@ function jetpack_post_likes_get_value( array $post ) {
  * Callback to set switch_like_status post_meta when jetpack_likes_enabled is updated.
  */
 function jetpack_post_likes_update_value( $enable_post_likes, $post_object ) {
+	/** This filter is documented in modules/likes.php */
 	$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
 
 	$should_switch_status = $enable_post_likes xor $sitewide_likes_enabled;

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -566,6 +566,29 @@ function jetpack_post_likes_get_value( array $post ) {
 	/** This filter is documented in modules/likes.php */
 	$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
 
+	/** This filter is documented in class.json-api-endpoints.php */
+	$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+
+	if ( $is_jetpack ) {
+		// an empty string: post meta was not set, so go with the global setting
+		if ( "" === $post_likes_switched ) {
+			return $sitewide_likes_enabled;
+		}
+
+		// user overrode the global setting to disable likes
+		elseif ( "0" === $post_likes_switched ) {
+			return false;
+		}
+
+		// user overrode the global setting to enable likes
+		elseif ( "1" === $post_likes_switched ) {
+			return true;
+		}
+
+		// no default fallback, let's stay explicit
+	}
+
+	// WPCOM sites always set the meta to 1 if the user is flipping the global setting
 	return $post_likes_switched xor $sitewide_likes_enabled;
 }
 
@@ -578,7 +601,21 @@ function jetpack_post_likes_update_value( $enable_post_likes, $post_object ) {
 
 	$should_switch_status = $enable_post_likes xor $sitewide_likes_enabled;
 
-	update_post_meta( $post_object->ID, 'switch_like_status', $should_switch_status );
+	/** This filter is documented in class.json-api-endpoints.php */
+	$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+
+	if ( $should_switch_status ) {
+		// WPCOM sites set the meta to 1 if the user is flipping the global setting
+		$meta_value = 1;
+		if ( $is_jetpack ) {
+			// set the meta to 0 if the user wants to disable likes, 1 if user wants to enable
+			$meta_value = $enable_post_likes;
+		}
+		update_post_meta( $post_object->ID, 'switch_like_status', $meta_value );
+	} else {
+		// unset the meta otherwise
+		delete_post_meta( $post_object->ID, 'switch_like_status' );
+	}
 }
 
 /**

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -601,17 +601,15 @@ function jetpack_post_likes_update_value( $enable_post_likes, $post_object ) {
 	/** This filter is documented in modules/jetpack-likes-settings.php */
 	$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
 
-	$should_switch_status = $enable_post_likes xor $sitewide_likes_enabled;
-
-	/** This filter is documented in class.json-api-endpoints.php */
-	$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+	$should_switch_status = $enable_post_likes !== $sitewide_likes_enabled;
 
 	if ( $should_switch_status ) {
 		// set the meta to 0 if the user wants to disable likes, 1 if user wants to enable
-		update_post_meta( $post_object->ID, 'switch_like_status', $enable_post_likes );
+		$switch_like_status = ( $enable_post_likes ? 1 : 0 );
+		return update_post_meta( $post_object->ID, 'switch_like_status', $switch_like_status );
 	} else {
 		// unset the meta otherwise
-		delete_post_meta( $post_object->ID, 'switch_like_status' );
+		return delete_post_meta( $post_object->ID, 'switch_like_status' );
 	}
 }
 
@@ -628,6 +626,10 @@ function jetpack_post_likes_register_rest_field() {
 		array(
 			'get_callback' => 'jetpack_post_likes_get_value',
 			'update_callback' => 'jetpack_post_likes_update_value',
+			'schema' => array(
+				'description' => __( 'Are Likes enabled?' ),
+				'type'        => 'boolean'
+			),
 		)
 	);
 }

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -555,6 +555,9 @@ class Sharing_Admin {
 /**
  * Callback to get the value for the jetpack_sharing_enabled field.
  *
+ * When the sharing_disabled post_meta is unset, we follow the global setting in Sharing.
+ * When it is set to 1, we disable sharing on the post, regardless of the global setting.
+ * It is not possible to enable sharing on a post if it is disabled globally.
  */
 function jetpack_post_sharing_get_value( array $post ) {
 	// if sharing IS disabled on this post, enabled=false, so negate the meta
@@ -564,6 +567,10 @@ function jetpack_post_sharing_get_value( array $post ) {
 /**
  * Callback to set sharing_disabled post_meta when the
  * jetpack_sharing_enabled field is updated.
+ *
+ * When the sharing_disabled post_meta is unset, we follow the global setting in Sharing.
+ * When it is set to 1, we disable sharing on the post, regardless of the global setting.
+ * It is not possible to enable sharing on a post if it is disabled globally.
  *
  */
 function jetpack_post_sharing_update_value( $enable_sharing, $post_object ) {

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -576,9 +576,9 @@ function jetpack_post_sharing_get_value( array $post ) {
 function jetpack_post_sharing_update_value( $enable_sharing, $post_object ) {
 	if ( $enable_sharing ) {
 		// delete the override if we want to enable sharing
-		delete_post_meta( $post_object->ID, 'sharing_disabled' );
+		return delete_post_meta( $post_object->ID, 'sharing_disabled' );
 	} else {
-		update_post_meta( $post_object->ID, 'sharing_disabled', true );
+		return update_post_meta( $post_object->ID, 'sharing_disabled', true );
 	}
 }
 
@@ -595,6 +595,10 @@ function jetpack_post_sharing_register_rest_field() {
 		array(
 			'get_callback' => 'jetpack_post_sharing_get_value',
 			'update_callback' => 'jetpack_post_sharing_update_value',
+			'schema' => array(
+				'description' => __( 'Are sharing buttons enabled?' ),
+				'type'        => 'boolean'
+			),
 		)
 	);
 }

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -553,24 +553,53 @@ class Sharing_Admin {
 }
 
 /**
+ * Callback to get the value for the jetpack_sharing_enabled field.
+ *
+ */
+function jetpack_post_sharing_get_value( array $post ) {
+	// if sharing IS disabled on this post, enabled=false, so negate the meta
+	return (bool) ! get_post_meta( $post['id'], 'sharing_disabled', true );
+}
+
+/**
+ * Callback to set sharing_disabled post_meta when the
+ * jetpack_sharing_enabled field is updated.
+ *
+ */
+function jetpack_post_sharing_update_value( $enable_sharing, $post_object ) {
+	if ( $enable_sharing ) {
+		// delete the override if we want to enable sharing
+		delete_post_meta( $post_object->ID, 'sharing_disabled' );
+	} else {
+		update_post_meta( $post_object->ID, 'sharing_disabled', true );
+	}
+}
+
+/**
  * Add Sharing post_meta to the REST API Post response.
  *
  * @action rest_api_init
- * @uses register_meta
+ * @uses register_rest_field
+ * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
  */
-function jetpack_post_sharing_register_meta() {
-	register_meta(
-		'post', 'sharing_disabled',
+function jetpack_post_sharing_register_rest_field() {
+	register_rest_field(
+		'post', 'jetpack_sharing_enabled',
 		array(
-			'type'			=> 'boolean',
-			'single'		=> true,
-			'show_in_rest'	=> true,
+			'get_callback' => 'jetpack_post_sharing_get_value',
+			'update_callback' => 'jetpack_post_sharing_update_value',
 		)
 	);
 }
 
 // Add Sharing post_meta to the REST API Post response.
-add_action( 'rest_api_init', 'jetpack_post_sharing_register_meta' );
+add_action( 'rest_api_init', 'jetpack_post_sharing_register_rest_field' );
+
+function sharing_admin_init() {
+	global $sharing_admin;
+
+	$sharing_admin = new Sharing_Admin();
+}
 
 function sharing_admin_init() {
 	global $sharing_admin;

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -601,10 +601,4 @@ function sharing_admin_init() {
 	$sharing_admin = new Sharing_Admin();
 }
 
-function sharing_admin_init() {
-	global $sharing_admin;
-
-	$sharing_admin = new Sharing_Admin();
-}
-
 add_action( 'init', 'sharing_admin_init' );


### PR DESCRIPTION
This is an update to https://github.com/Automattic/jetpack/pull/11196, further groundwork to support migrating the Likes and Sharing metabox to Gutenberg. After working to implement this logic within Calypso, it became obvious that we should offload the complexity to the API instead.

See https://github.com/Automattic/wp-calypso/pull/29744 for the front-end block code and D23763-code for prior discussion on the WPCOM side.

#### Changes proposed in this Pull Request:
* Rather than using `register_meta`, we need to use `register_rest_field` so that we can add a response with custom callbacks for get and update
* Instead of simply passing along the existing (confusing) `post_meta` fields, this PR coerces them into booleans that make sense

#### Testing instructions:
* In both Gutenberg and the Classic Editor, verify that the old (backwards-compatible) Likes and Sharing metabox still displays, and works as intended.
* In Jetpack Sharing settings, enable the toggles to show Likes and Sharing Buttons.
* Request the post endpoint via the REST API. Verify that `jetpack_likes_enabled` and `jetpack_sharing_enabled` show under the meta keys:

<img width="293" alt="screen shot 2019-02-07 at 12 48 47 am" src="https://user-images.githubusercontent.com/52152/52399804-2c564380-2a72-11e9-964a-fc22658d4585.png">

* Experiment with different combinations of sitewide like and sharing settings and post settings, and ensure the values returned by the API reflect reality

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* REST API: Change likes and sharing post meta keys to jetpack_likes_enabled and jetpack_sharing_enabled keys