### PR TITLE
Update mailchimp texts

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -330,11 +330,11 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	$defaults = array(
 		'title'            => esc_html__( 'Join my email list', 'jetpack' ),
 		'emailPlaceholder' => esc_html__( 'Enter your email', 'jetpack' ),
-		'submitLabel'      => esc_html__( 'Join My Email List', 'jetpack' ),
+		'submitLabel'      => esc_html__( 'Join my email list', 'jetpack' ),
 		'consentText'      => esc_html__( 'By clicking submit, you agree to share your email address with the site owner and MailChimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.', 'jetpack' ),
 		'processingLabel'  => esc_html__( 'Processing…', 'jetpack' ),
-		'successLabel'     => esc_html__( 'Success! You\'ve been added to the list.', 'jetpack' ),
-		'errorLabel'       => esc_html__( 'Oh no! Unfortunately there was an error. Please try reloading this page and adding your email once more.', 'jetpack' ),
+		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
+		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
 	);
 	foreach ( $defaults as $id => $default ) {
 		$values[ $id ] = isset( $attr[ $id ] ) ? $attr[ $id ] : $default;

--- a/modules/shortcodes/email-subscribe.php
+++ b/modules/shortcodes/email-subscribe.php
@@ -119,13 +119,13 @@ class Jetpack_Email_Subscribe {
 		// We allow for overriding the presentation labels.
 		$data = shortcode_atts(
 			array(
-				'title'             => '',
+				'title'             => __( 'Join my email list', 'jetpack' ),
 				'email_placeholder' => __( 'Enter your email', 'jetpack' ),
-				'submit_label'      => __( 'Join My Email List', 'jetpack' ),
+				'submit_label'      => __( 'Join my email list', 'jetpack' ),
 				'consent_text'      => __( 'By clicking submit, you agree to share your email address with the site owner and MailChimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.', 'jetpack' ),
-				'processing_label'  => __( 'Processing...', 'jetpack' ),
-				'success_label'     => __( 'Success! You\'ve been added to the list.', 'jetpack' ),
-				'error_label'       => __( "Oh no! Unfortunately there was an error.\nPlease try reloading this page and adding your email once more.", 'jetpack' ),
+				'processing_label'  => __( 'Processing…', 'jetpack' ),
+				'success_label'     => __( 'Success! You\'re on the list.', 'jetpack' ),
+				'error_label'       => __( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
 			),
 			is_array( $attrs ) ? array_filter( $attrs ) : array()
 		);


### PR DESCRIPTION
Updates default texts for MailChimp block suggested in https://github.com/Automattic/jetpack/issues/11297#issuecomment-461391754

Calypso companion PR: https://github.com/Automattic/wp-calypso/pull/30650

## Testing instructions

1. Add the block. Do not change any of the default texts.
1. Publish
1. View on frontend
1. Texts should be updated as reflected in https://github.com/Automattic/jetpack/issues/11297#issuecomment-461391754
1. If https://github.com/Automattic/wp-calypso/pull/30650 is used for the editor or has landed, editor and frontend texts should match.