### PR TITLE
Fix content option settings to allow for both excerpts and full content

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -30,7 +30,7 @@ function twentynineteen_jetpack_setup() {
 	 * Add theme support for Content Options.
 	 */
 	add_theme_support( 'jetpack-content-options', array(
-		'blog-display' => 'content', // the default setting of the theme: 'content', 'excerpt' or array( 'content', 'excerpt' ) for themes mixing both display.
+		'blog-display' => array( 'content', 'excerpt' ),
     	'post-details' => array(
 			'stylesheet' => 'twentynineteen-style',
 			'date'       => '.posted-on',


### PR DESCRIPTION
Originally reported on Trac https://core.trac.wordpress.org/ticket/46178 and later on the themes repo here: https://github.com/Automattic/themes/issues/528

## Changes proposed in this Pull Request: 
<!--- Explain what functional changes your PR includes -->

* Adds support for “mixed” content options on archives and the main blog index feed.

## Steps to replicate

1. In the customizer set the Blog Display to “full posts” for blog and archive' pages.
2. View archive pages on site and you’ll see only excerpts are shown

## Result

* On the blog page the full post shows as expected.
* Going to an archive page though shows excerpts on the first page 
* However, it works properly, showing full posts in subsequent archive pages -when you click on the 'Older posts' button. 

## Expected 

* Full posts should be displayed on archives.

## Proposed changelog entry for your changes:

* Add support for “mixed” content options on archives and the main blog index feed.
