### PR TITLE
Gutenberg: only load extra blocks if Gutenberg is available.

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -42,8 +42,14 @@ if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 	);
 }
 
-/* If Gutenberg blocks are enabled, register blocks that aren't associated with modules */
-if ( Jetpack_Gutenberg::should_load() ) {
+/**
+ * If Gutenberg blocks are enabled and if the block editor is supported,
+ * register blocks that aren't associated with modules
+ */
+if (
+	Jetpack_Gutenberg::is_gutenberg_available()
+	&& Jetpack_Gutenberg::should_load()
+) {
 	$tools[] = 'blocks.php';
 }
 


### PR DESCRIPTION
Follow-up from #11212

#### Changes proposed in this Pull Request:

* Fix Fatal Errors on sites that do not run WordPress 5.0 yet.

#### Testing instructions:

* Checkout this branch on a site connected to WordPress.com that does not run WP 5.0 yet.
* Do you get a Fatal?
* If you update to 5.0, and then go to the block editor, are all the blocks there?

#### Proposed changelog entry for your changes:

* None
