### PR TITLE
Gutenberg: Add and use jetpack_register_block_type() wrapper

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -7,9 +7,28 @@
  */
 
 /**
+ * Wrapper function to safely register a Jetpack Gutenberg block
+ *
+ * @param string $slug Slug of the block.
+ * @param array  $args Arguments that are passed into register_block_type.
+ *
+ * @see register_block_type
+ *
+ * @since 7.1.0
+ *
+ * @return WP_Block_Type|false The registered block type on success, or false on failure.
+ */
+function jetpack_register_block_type( $slug, $args = array() ) {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return false;
+	}
+	return register_block_type( $slug, $args );
+}
+
+/**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @deprecated 7.1.0 Use (Gutenberg's) register_block_type() instead
+ * @deprecated 7.1.0 Use jetpack_register_block_type() instead
  *
  * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
@@ -21,7 +40,7 @@
  * @return void
  */
 function jetpack_register_block( $slug, $args = array() ) {
-	_deprecated_function( __FUNCTION__, '7.1', 'register_block_type' );
+	_deprecated_function( __FUNCTION__, '7.1', 'jetpack_register_block_type' );
 
 	Jetpack_Gutenberg::register_block( $slug, $args );
 }
@@ -120,15 +139,15 @@ class Jetpack_Gutenberg {
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.1.0 Use (Gutenberg's) register_block_type() instead
+	 * @deprecated 7.1.0 Use jetpack_register_block_type() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into register_block_type().
 	 */
 	public static function register_block( $slug, $args ) {
-		_deprecated_function( __METHOD__, '7.1', 'register_block_type' );
+		_deprecated_function( __METHOD__, '7.1', 'jetpack_register_block_type' );
 
-		register_block_type( 'jetpack/' . $slug, $args );
+		jetpack_register_block_type( 'jetpack/' . $slug, $args );
 	}
 
 	/**
@@ -147,14 +166,14 @@ class Jetpack_Gutenberg {
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.0.0 Use register_block_type() instead
+	 * @deprecated 7.0.0 Use jetpack_register_block_type() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into the register_block_type.
 	 * @param array  $availability array containing if a block is available and the reason when it is not.
 	 */
 	public static function register( $slug, $args, $availability ) {
-		_deprecated_function( __METHOD__, '7.0', 'register_block_type' );
+		_deprecated_function( __METHOD__, '7.0', 'jetpack_register_block_type' );
 
 		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
 			self::set_extension_unavailability_reason( $slug, $availability['unavailable_reason'] );
@@ -334,7 +353,7 @@ class Jetpack_Gutenberg {
 		/**
 		 * Fires before Gutenberg extensions availability is computed.
 		 *
-		 * In the function call you supply, use `register_block_type()` to set a block as available.
+		 * In the function call you supply, use `jetpack_register_block_type()` to set a block as available.
 		 * Alternatively, use `Jetpack_Gutenberg::set_extension_available()` (for a non-block plugin), and
 		 * `Jetpack_Gutenberg::set_extension_unavailable()` (if the block or plugin should not be registered
 		 * but marked as unavailable).

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/business-hours',
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -7,21 +7,21 @@
  * @package Jetpack
  */
 
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/contact-info',
 	array(
 		'render_callback' => 'jetpack_contact_info_block_load_assets',
 	)
 );
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/email',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/address',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/phone',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/gif',
 	array(
 		'render_callback' => 'jetpack_gif_block_render',

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -8,7 +8,7 @@
  */
 
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
-	register_block_type(
+	jetpack_register_block_type(
 		'jetpack/mailchimp',
 		array(
 			'render_callback' => 'jetpack_mailchimp_block_load_assets',

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/map',
 	array(
 		'render_callback' => 'jetpack_map_block_load_assets',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-register_block_type(
+jetpack_register_block_type(
 	'jetpack/slideshow',
 	array(
 		'render_callback' => 'jetpack_slideshow_block_load_assets',

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -11,7 +11,7 @@ if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
 ) {
-	register_block_type(
+	jetpack_register_block_type(
 		'jetpack/tiled-gallery',
 		array(
 			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',

--- a/extensions/blocks/vr/vr.php
+++ b/extensions/blocks/vr/vr.php
@@ -7,4 +7,4 @@
  * @package Jetpack
  */
 
-register_block_type( 'jetpack/vr' );
+jetpack_register_block_type( 'jetpack/vr' );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -245,52 +245,52 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		register_block_type( 'jetpack/contact-form', array(
+		jetpack_register_block_type( 'jetpack/contact-form', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 		) );
 
 		// Field render methods.
-		register_block_type( 'jetpack/field-text', array(
+		jetpack_register_block_type( 'jetpack/field-text', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
 		) );
-		register_block_type( 'jetpack/field-name', array(
+		jetpack_register_block_type( 'jetpack/field-name', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
 		) );
-		register_block_type( 'jetpack/field-email', array(
+		jetpack_register_block_type( 'jetpack/field-email', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
 		) );
-		register_block_type( 'jetpack/field-url', array(
+		jetpack_register_block_type( 'jetpack/field-url', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
 		) );
-		register_block_type( 'jetpack/field-date', array(
+		jetpack_register_block_type( 'jetpack/field-date', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
 		) );
-		register_block_type( 'jetpack/field-telephone', array(
+		jetpack_register_block_type( 'jetpack/field-telephone', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
 		) );
-		register_block_type( 'jetpack/field-textarea', array(
+		jetpack_register_block_type( 'jetpack/field-textarea', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
 		) );
-		register_block_type( 'jetpack/field-checkbox', array(
+		jetpack_register_block_type( 'jetpack/field-checkbox', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
 		) );
-		register_block_type( 'jetpack/field-checkbox-multiple', array(
+		jetpack_register_block_type( 'jetpack/field-checkbox-multiple', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
 		) );
-		register_block_type( 'jetpack/field-radio', array(
+		jetpack_register_block_type( 'jetpack/field-radio', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
 		) );
-		register_block_type( 'jetpack/field-select', array(
+		jetpack_register_block_type( 'jetpack/field-select', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
 		) );
@@ -3232,8 +3232,8 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 		$type_class = $type ? ' ' .$type : '';
 		return
-			"<label 
-				for='" . esc_attr( $id ) . "' 
+			"<label
+				for='" . esc_attr( $id ) . "'
 				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'
 				>"
 				. esc_html( $label )
@@ -3243,13 +3243,13 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_input_field( $type, $id, $value, $class, $placeholder, $required ) {
-		return "<input 
-					type='". esc_attr( $type ) ."' 
-					name='" . esc_attr( $id ) . "' 
-					id='" . esc_attr( $id ) . "' 
-					value='" . esc_attr( $value ) . "' 
-					" . $class . $placeholder . ' 
-					' . ( $required ? "required aria-required='true'" : '' ) . " 
+		return "<input
+					type='". esc_attr( $type ) ."'
+					name='" . esc_attr( $id ) . "'
+					id='" . esc_attr( $id ) . "'
+					value='" . esc_attr( $value ) . "'
+					" . $class . $placeholder . '
+					' . ( $required ? "required aria-required='true'" : '' ) . "
 				/>\n";
 	}
 
@@ -3274,8 +3274,8 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 		$field = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
-		                name='" . esc_attr( $id ) . "' 
-		                id='contact-form-comment-" . esc_attr( $id ) . "' 
+		                name='" . esc_attr( $id ) . "'
+		                id='contact-form-comment-" . esc_attr( $id ) . "'
 		                rows='20' "
 		                . $class
 		                . $placeholder
@@ -3291,9 +3291,9 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 			$option = Grunion_Contact_Form_Plugin::strip_tags( $option );
 			if ( $option ) {
 				$field .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-				$field .= "<input 
-									type='radio' 
-									name='" . esc_attr( $id ) . "' 
+				$field .= "<input
+									type='radio'
+									name='" . esc_attr( $id ) . "'
 									value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $optionIndex, $option ) ) . "' "
 				                    . $class
 				                    . checked( $option, $value, false ) . ' '

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -73,9 +73,7 @@ class WPCom_Markdown {
 			$this->add_o2_helpers();
 		}
 
-		if ( function_exists( 'register_block_type' ) ) {
-			register_block_type( 'jetpack/markdown' );
-		}
+		jetpack_register_block_type( 'jetpack/markdown' );
 	}
 
 	/**

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -68,14 +68,12 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		if ( function_exists( 'register_block_type' ) ) {
-			register_block_type(
-				'jetpack/related-posts',
-				array(
-					'render_callback' => array( $this, 'render_block' ),
-				)
-			);
-		}
+		jetpack_register_block_type(
+			'jetpack/related-posts',
+			array(
+				'render_callback' => array( $this, 'render_block' ),
+			)
+		);
 	}
 
 	protected function get_blog_id() {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -61,12 +61,8 @@ class Jetpack_Simple_Payments {
 	}
 
 	function register_gutenberg_block() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			return;
-		}
-
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			register_block_type( 'jetpack/simple-payments' );
+			jetpack_register_block_type( 'jetpack/simple-payments' );
 		} else {
 			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/simple-payments', 'missing_plan' );
 		}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -745,7 +745,7 @@ add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
 	if ( class_exists( 'WP_Block_Type_Registry' ) && ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
-		register_block_type( 'jetpack/subscriptions' );
+		jetpack_register_block_type( 'jetpack/subscriptions' );
 	}
 }
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -30,7 +30,7 @@ class VideoPress_Gutenberg {
 	 * Register the Jetpack Gutenberg extension that adds VideoPress support to the core video block.
 	 */
 	public static function register_video_block_with_videopress() {
-		register_block_type(
+		jetpack_register_block_type(
 			'core/video',
 			array(
 				'render_callback' => array( __CLASS__, 'render_video_block_with_videopress' ),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -52,11 +52,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function test_sync_callable_whitelist() {
 		// $this->setSyncClientDefaults();
 
-		if ( function_exists( 'register_block_type' ) ) {
-			add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
-			Jetpack_Gutenberg::init();
-			register_block_type( 'jetpack/test' );
-		}
+		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
+		Jetpack_Gutenberg::init();
+		jetpack_register_block_type( 'jetpack/test' );
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),
@@ -130,10 +128,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$unique_whitelist = array_unique( $whitelist_keys );
 		$this->assertEquals( count( $unique_whitelist ), count( $whitelist_keys ), 'The duplicate keys are: ' . print_r( array_diff_key( $whitelist_keys, array_unique( $whitelist_keys ) ), 1 ) );
 
-		if ( function_exists( 'register_block_type' ) ) {
-			remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
-			Jetpack_Gutenberg::reset();
-		}
+		remove_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
+		Jetpack_Gutenberg::reset();
 	}
 
 	public function add_test_block() {

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -61,7 +61,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_available() {
-		register_block_type( 'jetpack/apple' );
+		jetpack_register_block_type( 'jetpack/apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['apple']['available'] );
 	}
@@ -74,7 +74,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
-		register_block_type( 'jetpack/durian' );
+		jetpack_register_block_type( 'jetpack/durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
 		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );


### PR DESCRIPTION
This includes a `function_exists()` check to avoid usage of `register_block_type` in older WordPress versions that don't yet have it, leading to fatals (which my recent #11212 caused -- very sorry!)

Some convo (with @dereksmart and @jeherve) at p1549647686423800-slack-jetpack-gutenberg

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add and use `jetpack_register_block_type()` wrapper instead of `register_block_type()`

#### Testing instructions:

- Verify that blocks are still registered and available
- On a test site running WP 4.9.9, verify that no fatals occur.
- Grep for `register_block_type` to make sure we're not calling it directly anymore.

#### Follow-up

As a follow-up, we should modify `tests/php/test_class.jetpack-gutenberg.php` (and `Jetpack_Gutenberg`) so it won't skip tests on a WP installation without `register_block_type` to make sure that `Jetpack_Gutenberg` doesn't fatal.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Add and use `jetpack_register_block_type()` wrapper instead of `register_block_type()`
