### PR TITLE
Add AMP support for GIF block

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -497,7 +497,7 @@ class Jetpack_Gutenberg {
 			: array();
 		$script_dependencies = array_merge( $script_dependencies, $dependencies, array( 'wp-polyfill' ) );
 
-		if ( self::block_has_asset( $script_relative_path ) ) {
+		if ( ! Jetpack_AMP_Support::is_amp_request() && self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -497,7 +497,7 @@ class Jetpack_Gutenberg {
 			: array();
 		$script_dependencies = array_merge( $script_dependencies, $dependencies, array( 'wp-polyfill' ) );
 
-		if ( ! Jetpack_AMP_Support::is_amp_request() && self::block_has_asset( $script_relative_path ) ) {
+		if ( ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) && self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1791,9 +1791,6 @@ class Jetpack {
 		wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
 		wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
 		wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
-
-		// For core, see <https://core.trac.wordpress.org/ticket/46067>.
-		wp_oembed_add_provider( '#^https?://giphy\.com/embed/(?:.+?-)?\w+#', 'https://giphy.com/services/oembed', true );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1791,6 +1791,9 @@ class Jetpack {
 		wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
 		wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
 		wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
+
+		// For core, see <https://core.trac.wordpress.org/ticket/46067>.
+		wp_oembed_add_provider( '#^https?://giphy\.com/embed/(?:.+?-)?\w+#', 'https://giphy.com/services/oembed', true );
 	}
 
 	/**

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -15,64 +15,6 @@ jetpack_register_block(
 );
 
 /**
- * Filter oEmbed HTML for Giphy to to replace GIF image with iframe/amp-iframe.
- *
- * @param mixed  $return The shortcode callback function to call.
- * @param string $url    The attempted embed URL.
- * @param array  $attr   An array of shortcode attributes.
- * @return string Embed.
- */
-function jetpack_filter_giphy_oembed_html( $return, $url, $attr ) {
-	unset( $attr ); // @todo Consider any width/height in $attr?
-	if ( 'giphy.com' !== wp_parse_url( $url, PHP_URL_HOST ) ) {
-		return $return;
-	}
-	if ( ! preg_match( '#^/gifs/(.*-)?(.+?)$#', wp_parse_url( $url, PHP_URL_PATH ), $matches ) ) {
-		return $return;
-	}
-
-	$id = $matches[2];
-
-	$width  = null;
-	$height = null;
-	$alt    = '';
-	if ( preg_match( '/width="(\d+)"/', $return, $matches ) ) {
-		$width = intval( $matches[1] );
-	}
-	if ( preg_match( '/height="(\d+)"/', $return, $matches ) ) {
-		$height = intval( $matches[1] );
-	}
-	if ( preg_match( '/alt="(.*?)"/', $return, $matches ) ) {
-		$alt = $matches[1];
-	}
-	if ( ! $width && ! $height ) {
-		return $return;
-	}
-
-	$iframe = sprintf(
-		'<iframe src="%s" width="%s" height="%s" title="%s"></iframe>',
-		esc_url( "https://giphy.com/embed/$id" ),
-		esc_attr( $width ),
-		esc_attr( $height ),
-		esc_attr( $alt )
-	);
-
-	if ( ! Jetpack_AMP_Support::is_amp_request() ) {
-		return $iframe;
-	}
-
-	return sprintf(
-		'<amp-iframe src="%s" width="%s" height="%s" sandbox="allow-scripts allow-same-origin" layout="responsive">%s<noscript>%s</noscript></amp-iframe>',
-		esc_url( "https://giphy.com/embed/$id" ),
-		esc_attr( $width ),
-		esc_attr( $height ),
-		sprintf( '<a href="%s" placeholder>%s</a>', esc_url( $url ), esc_html( $alt ) ),
-		$iframe
-	);
-}
-add_filter( 'embed_oembed_html', 'jetpack_filter_giphy_oembed_html', 10, 3 );
-
-/**
  * Gif block registration/dependency declaration.
  *
  * @param array $attr - Array containing the gif block attributes.
@@ -86,8 +28,7 @@ function jetpack_gif_block_render( $attr ) {
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 
-	$giphy_id = null;
-	if ( ! $giphy_url || ! preg_match( '#^' . preg_quote( 'https://giphy.com/embed/', '#' ) . '(\w+)#', $giphy_url, $matches ) ) {
+	if ( ! $giphy_url ) {
 		return null;
 	}
 
@@ -101,28 +42,15 @@ function jetpack_gif_block_render( $attr ) {
 	if ( isset( $attr['className'] ) ) {
 		array_push( $classes, $attr['className'] );
 	}
-	$classes = implode( $classes, ' ' );
-
-	global $wp_embed;
-	$embed_html = $wp_embed->shortcode( array(), $giphy_url );
-
-	$width = 250; // @todo Is this the right default?
-	if ( preg_match( '/width="(\d+)"/', $embed_html, $matches ) ) {
-		$width = (int) $matches[1];
-	}
-	$height = 250; // @todo Is this the right default?
-	if ( preg_match( '/height="(\d+)"/', $embed_html, $matches ) ) {
-		$height = (int) $matches[1];
-	}
-
-	$placeholder = preg_replace( '#<img.*?alt="(.*?)".*?>#', '$1', $embed_html );
+	$classes     = implode( $classes, ' ' );
+	$placeholder = sprintf( '<a href="%s">%s</a>', esc_url( $giphy_url ), esc_attr( $search_text ) );
 
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $classes ); ?>">
 		<figure>
 			<?php if ( Jetpack_AMP_Support::is_amp_request() ) : ?>
-				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="<?php echo esc_attr( $width ); ?>" height="<?php echo esc_attr( $height ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
+				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="100" height="<?php echo intval( $padding_top ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
 					<div placeholder>
 						<?php echo wp_kses_post( $placeholder ); ?>
 					</div>

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -49,8 +49,8 @@ function jetpack_gif_block_render( $attr ) {
 	?>
 	<div class="<?php echo esc_attr( $classes ); ?>">
 		<figure>
-			<?php if ( Jetpack_AMP_Support::is_amp_request() ) : ?>
-				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="100" height="<?php echo intval( $padding_top ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
+			<?php if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) : ?>
+				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="100" height="<?php echo absint( $padding_top ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
 					<div placeholder>
 						<?php echo wp_kses_post( $placeholder ); ?>
 					</div>

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -28,12 +28,8 @@ function jetpack_gif_block_render( $attr ) {
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 
-	if ( ! $giphy_url ) {
-		return null;
-	}
-
 	$giphy_id = null;
-	if ( ! preg_match( '#^' . preg_quote( 'https://giphy.com/embed/', '#' ) . '(\w+)#', $giphy_url, $matches ) ) {
+	if ( ! $giphy_url || ! preg_match( '#^' . preg_quote( 'https://giphy.com/embed/', '#' ) . '(\w+)#', $giphy_url, $matches ) ) {
 		return null;
 	}
 
@@ -52,13 +48,13 @@ function jetpack_gif_block_render( $attr ) {
 	global $wp_embed;
 	$embed_html = $wp_embed->shortcode( array(), $giphy_url );
 
-	$width = null;
+	$width = 250; // @todo Is this the right default?
 	if ( preg_match( '/width="(\d+)"/', $embed_html, $matches ) ) {
-		$width = $matches[1];
+		$width = (int) $matches[1];
 	}
-	$height = null;
+	$height = 250; // @todo Is this the right default?
 	if ( preg_match( '/height="(\d+)"/', $embed_html, $matches ) ) {
-		$height = $matches[1];
+		$height = (int) $matches[1];
 	}
 
 	$placeholder = preg_replace( '#<img.*?alt="(.*?)".*?>#', '$1', $embed_html );
@@ -67,7 +63,7 @@ function jetpack_gif_block_render( $attr ) {
 	?>
 	<div class="<?php echo esc_attr( $classes ); ?>">
 		<figure>
-			<?php if ( Jetpack_AMP_Support::is_amp_request() && $width && $height ) : ?>
+			<?php if ( Jetpack_AMP_Support::is_amp_request() ) : ?>
 				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="<?php echo esc_attr( $width ); ?>" height="<?php echo esc_attr( $height ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
 					<div placeholder>
 						<?php echo wp_kses_post( $placeholder ); ?>

--- a/extensions/blocks/gif/style.scss
+++ b/extensions/blocks/gif/style.scss
@@ -8,14 +8,6 @@
 		position: relative;
 		width: 100%;
 	}
-	iframe {
-		border: 0;
-		left: 0;
-		height: 100%;
-		position: absolute;
-		top: 0;
-		width: 100%;
-	}
 	&.aligncenter {
 		text-align: center;
 	}
@@ -36,5 +28,13 @@
 		padding: calc( 56.2% + 12px ) 0 0 0;
 		position: relative;
 		width: 100%;
+		iframe {
+			border: 0;
+			left: 0;
+			height: 100%;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 	}
 }


### PR DESCRIPTION
As noted by @jeherve in https://github.com/Automattic/jetpack/issues/9730#issuecomment-460310694:

> We should probably look at the output of our different blocks as well:
https://jetpack.com/support/jetpack-blocks/
>
> The upcoming GIF block (scheduled for release tomorrow), for example, is very broken right now.

This PR takes a stab at implementing the support.

Note that another change needed which is not included in this PR is modifying `jetpack/_inc/blocks/gif/view.css` to change the selector as follows:

```diff
- .wp-block-jetpack-gif iframe
+ .wp-block-jetpack-gif-wrapper iframe
```

This prevents the responsive code from applying in AMP where it is not needed.

#### Changes proposed in this Pull Request:

* Register oEmbed provider for Giphy.
* Output an `amp-iframe` for the Giphy embed without the unnecessary `wp-block-jetpack-gif-wrapper`, since AMP layout takes care of the responsive image. Obtain the `width` and `height` of the image for the `amp-iframe` via oEmbed. Use the `alt` text as the `placeholder` for when the `amp-iframe` has not been loaded yet.
* Skip enqueueing block script assets on frontend when in AMP, since they are not allowed in AMP.

#### Testing instructions:

* Activate the AMP plugin and enable paired mode.
* Add a GIF block to a post, for example:
```html
<!-- wp:jetpack/gif {"caption":"This is mars","giphyUrl":"https://giphy.com/embed/bJc1o7QdHRBHq","searchText":"mars","paddingTop":"100%"} /-->
```
* Compare the non-AMP version of the post with the AMP version. They should end up appearing similar.

#### Proposed changelog entry for your changes:

* Improve AMP compatibility for GIF block.

# Todo

- [ ] Upstream changes to block CSS.
- [ ] Remove extra margin under `amp-iframe` before the caption.
- [ ] Double-check if there is not a better way of obtaining the raw oEmbed data to avoid using regex on HTML. For example, this request has what is needed directly: https://giphy.com/services/oembed?url=https://giphy.com/embed/bJc1o7QdHRBHq

# Screenshots

## Non-AMP Reference

> <img width="568" alt="not-amp" src="https://user-images.githubusercontent.com/134745/52530954-dfb57700-2cc2-11e9-9a3f-634e5aa9829a.png">

## AMP While Loading

> <img width="581" alt="amp-while-loading" src="https://user-images.githubusercontent.com/134745/52530957-e8a64880-2cc2-11e9-832d-d30e13a63e37.png">

## AMP After Loading

> <img width="571" alt="amp-after-loading" src="https://user-images.githubusercontent.com/134745/52530958-ee9c2980-2cc2-11e9-86c6-3ac5a3fbeb9d.png">