### PR TITLE
Set the availability of the VideoPress extension for Gutenberg

### DIFF
--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -99,12 +99,7 @@ class VideoPress_Gutenberg {
 	 * It defines a server-side rendering that adds VideoPress support to the core video block.
 	 */
 	public function register_video_block_with_videopress() {
-		// Early return if Gutenberg is not available.
-		if ( function_exists( 'register_block_type' ) ) {
-			return;
-		}
-
-		register_block_type(
+		jetpack_register_block_type(
 			'core/video',
 			array(
 				'render_callback' => array( $this, 'render_video_block_with_videopress' ),

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -29,8 +29,8 @@ class VideoPress_Gutenberg {
 	 * Initialize the VideoPress Gutenberg extension
 	 */
 	private function __construct() {
-		add_action( 'init', array( $this, 'set_extension_availability' ) );
 		add_action( 'init', array( $this, 'register_video_block_with_videopress' ) );
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'set_extension_availability' ) );
 	}
 
 	/**
@@ -47,18 +47,10 @@ class VideoPress_Gutenberg {
 		// It is available on Simple Sites having the appropriate a plan.
 		if (
 			defined( 'IS_WPCOM' ) && IS_WPCOM
-			&& method_exists( 'WPCOM_Store', 'get_bundle_subscription' )
-			&& method_exists( 'Store_Product_List', 'get_feature_list' )
+			&& method_exists( 'Store_Product_List', 'get_site_specific_features_data' )
 		) {
-			$current_plan = WPCOM_Store::get_bundle_subscription( get_current_blog_id() );
-			$features     = Store_Product_List::get_feature_list();
-			foreach ( $features as $feature ) {
-				if ( 'videopress' === $feature['product_slug'] ) {
-					$has_feature = array_key_exists( $current_plan->product_id, $feature['plans'] );
-					break;
-				}
-			}
-			if ( isset( $has_feature ) && $has_feature ) {
+			$features = Store_Product_List::get_site_specific_features_data();
+			if ( in_array( 'videopress', $features['active'], true ) ) {
 				return array( 'available' => true );
 			} else {
 				return array(

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -44,9 +44,26 @@ class VideoPress_Gutenberg {
 	 * unavailable (key `unavailable_reason)`
 	 */
 	public function check_videopress_availability() {
+		// It is available on Simple Sites having the appropriate a plan.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$features = Store_Product_List::get_site_specific_features_data();
+			$has_feature = in_array( 'videopress', $features['active'] );
+			if ( $has_feature ) {
+				return array( 'available' => true );
+			} else {
+				return array(
+					'available'          => false,
+					'unavailable_reason' => 'missing_plan',
+				);
+			}
+		}
+
 		// It is available on Jetpack Sites having the module active.
 		if ( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() ) {
-			if ( Jetpack::is_module_active( 'videopress' ) ) {
+			if (
+				method_exists( 'Jetpack', 'is_module_active' )
+				&& Jetpack::is_module_active( 'videopress' )
+			) {
 				return array( 'available' => true );
 			} elseif ( ! Jetpack::active_plan_supports( 'videopress' ) ) {
 				return array(
@@ -61,19 +78,7 @@ class VideoPress_Gutenberg {
 			}
 		}
 
-		// It is available on Simple Sites having the appropriate a plan.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$features = Store_Product_List::get_site_specific_features_data();
-			$has_feature = in_array( 'videopress', $features['active'] );
-			if ( $has_feature ) {
-				return array( 'available' => true );
-			} else {
-				return array(
-					'available'          => false,
-					'unavailable_reason' => 'missing_plan',
-				);
-			}
-		}
+
 
 		return array(
 			'available'          => false,

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -128,6 +128,12 @@ class VideoPress_Gutenberg {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$blog_id = get_current_blog_id();
 		} elseif ( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() ) {
+			/**
+			 * We're intentionally not using `get_current_blog_id` because it was returning unexpected values.
+			 *
+			 * @see https://github.com/Automattic/jetpack/pull/11193#issuecomment-457883886
+			 * @see https://github.com/Automattic/jetpack/pull/11193/commits/215cf789f3d8bd03ff9eb1bbdb693acb8831d273
+			 */
 			$blog_id = Jetpack_Options::get_option( 'id' );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR sets the `jetpack/videopress` extension availability, so we can check it on the editor when deciding if we need to enhance the core video block with VideoPress support ([#](https://github.com/Automattic/wp-calypso/pull/30546/files#diff-e436b8d5ae66471d9bff239c6c650f68R61)). This will also allow us in the future to display upgrade nudges if we detect we're missing a plan.

The extension is set available:
* On Jetpack sites having the VideoPress module activated (included in Premium and above subscriptions).
* On WordPress.com sites having the video upgrade (included in Premium and above plans).

### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
**Jetpack**

* Apply this branch to your local environment or [create a new JN site using it](https://jurassic.ninja/create?jetpack-beta&branch=update/set-videopress-extension-availability&shortlived&wp-debug-log&gutenpack).
* Start with a free subscription.
* Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to true.
* Go to Posts > Add New.
* Open the browser console and type `Jetpack_Editor_Initial_State.available_blocks`.
* Check that the `videopress` extension is marked as not available because we're missing a plan:

<img width="606" alt="screen shot 2019-02-11 at 12 31 46" src="https://user-images.githubusercontent.com/1233880/52560584-1097c800-2df9-11e9-9407-96be01389d84.png">

* Upgrade now to a premium subscription.
* Go to Posts > Add New and check again the `Jetpack_Editor_Initial_State.available_blocks` output.
* Make sure the extension is unavailable yet with `missing_module` as  `unavailable_reason`.
* Go to Jetpack > Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
* Go to Posts > Add New and check again the `Jetpack_Editor_Initial_State.available_blocks` output.
* Confirm the extension is available now.
* Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to false.
* Make sure the extension is not available because it is not whitelisted.

**WordPress.com**

* Apply the diff D24180-code to your sandbox site.
* Start with a free plan.
* Go to Posts > Add New.
* Open the browser console and type `Jetpack_Editor_Initial_State.available_blocks`.
* Check that the `videopress` extension is marked as not available because we're missing a plan.
* Upgrade now to a premium subscription.
* Go to Posts > Add New and check again the `Jetpack_Editor_Initial_State.available_blocks` output.
* Confirm the extension is available now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* VideoPress: Set the Block editor extension availability
