### PR TITLE
SEO: Expose advanced_seo_description post meta in the REST API

### DIFF
--- a/modules/seo-tools/jetpack-seo-posts.php
+++ b/modules/seo-tools/jetpack-seo-posts.php
@@ -60,4 +60,36 @@ class Jetpack_SEO_Posts {
 
 		return $custom_description;
 	}
+
+	/**
+	 * Registers the self::DESCRIPTION_META_KEY post_meta for use in the REST API.
+	 */
+	public static function register_post_meta() {
+		if ( ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+			return;
+		}
+
+		$args = array(
+			'type' => 'string',
+			'description' => __( 'Custom post description to be used in HTML <meta /> tag.', 'jetpack' ),
+			'single' => true,
+			'default' => '',
+			'show_in_rest' => array(
+				'name' => self::DESCRIPTION_META_KEY
+			),
+		);
+
+		register_meta( 'post', self::DESCRIPTION_META_KEY, $args );
+	}
+
+	/**
+	 * Register the Advanced SEO Gutenberg extension
+	 */
+	public static function register_gutenberg_extension() {
+		if ( Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+			Jetpack_Gutenberg::set_extension_available( 'jetpack-seo' );
+		} else {
+			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack-seo', 'missing_plan' );
+		}
+	}
 }

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -6,6 +6,8 @@
 class Jetpack_SEO {
 	public function __construct() {
 		add_action( 'init', array( $this, 'init' ) );
+		add_action( 'init', array( Jetpack_SEO_Posts, 'register_post_meta' ), 20 );
+		add_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_SEO_Posts, 'register_gutenberg_extension' ) );
 	}
 
 	public function init() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* SEO: Expose advanced_seo_description post meta in the (core) REST API
* Set SEO Gutenberg extension availability

#### TODO

* Decouple from plans check, make available for free. See p1HpG7-6a7-p2 #comment-30125 for more information.

#### Testing instructions:

* Apply this branch to your local environment or [create a new JN site using it](https://jurassic.ninja/create?jetpack-beta&branch=add/seo-meta&shortlived&wp-debug-log&gutenpack&calypsobranch=add/seo-gutenberg-extension).
* Start with a free plan.
* Make sure that your test site is not hidden from search engines (check `/wp-admin/options-reading.php` for the 'Search Engine Visibility' setting)
* Go to Posts > Add New.
* Open the browser console and type `Jetpack_Editor_Initial_State.available_blocks`.
* Check that the `seo` extension is marked as not available because we're missing a plan.
* Upgrade now to a premium subscription.
* Go to Posts > Add New and check again the `Jetpack_Editor_Initial_State.available_blocks` output.
* Make sure the extension is unavailable yet with `missing_module` as  `unavailable_reason`.
* Go to https://wordpress.com/settings/traffic/ and select the test site from the site picker. Scroll to the 'Search engine optimization' settings card, and activate the toggle that says 'Enable SEO Tools to optimize your site for search engines'
* Go to Posts > Add New and check again the `Jetpack_Editor_Initial_State.available_blocks` output.
* Confirm the extension is available now.

#### Proposed changelog entry for your changes:

* SEO: Expose advanced_seo_description post meta in the REST API

Required for https://github.com/Automattic/wp-calypso/pull/30033