### PR TITLE
Related posts improve markup and add alt text

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -256,60 +256,55 @@ EOT;
 	public function render_block_item( $related_post, $block_attributes ) {
 		$instance_id = 'related-posts-item-' . uniqid();
 		$label_id    = $instance_id . '-label';
-		?>
-		<div
-			aria-labelledby="<?php echo esc_attr( $label_id ); ?>"
-			role="menuitem"
-			data-post-id="<?php echo esc_attr( $related_post['id'] ); ?>"
-			data-post-format="<?php echo esc_attr( ! empty( $related_post['format'] ) ? $related_post['format'] : 'false' ); ?>"
-			class="jp-related-posts-i2__post"
-			id="<?php echo esc_attr( $instance_id ); ?>"
-		>
-			<a
-				href="<?php echo esc_url( $related_post['url'] ); ?>"
-				title="<?php echo esc_attr( $related_post['title'] ); ?>"
-				rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
-				data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
-				data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
-				class="jp-related-posts-i2__post-link"
-				id="<?php echo esc_attr( $label_id ); ?>"
-			>
-				<?php echo esc_html( $related_post['title'] ); ?>
-			</a>
-			<?php if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ) : ?>
-			<a
-				href="<?php echo esc_url( $related_post['url'] ); ?>"
-				title="<?php echo esc_attr( $related_post['title'] ); ?>"
-				rel="<?php echo esc_attr( $related_post['rel'] ); ?>"
-				data-origin="<?php echo esc_attr( $related_post['url_meta']['origin'] ); ?>"
-				data-position="<?php echo esc_attr( $related_post['url_meta']['position'] ); ?>"
-				class="jp-related-posts-i2__post-img-link"
-			>
-				<img
-					class="jp-related-posts-i2__post-img"
-					src="<?php echo esc_url( $related_post['img']['src'] ); ?>"
-					width="<?php echo esc_attr( $related_post['img']['width'] ); ?>"
-					alt="<?php echo esc_attr( $related_post['title'] ); ?>"
-				/>
-			</a>
-			<?php endif; ?>
-			<?php if ( $block_attributes['show_date'] ) : ?>
-				<div class="jp-related-posts-i2__post-date has-small-font-size">
-					<?php echo esc_html( $related_post['date'] ); ?>
-				</div>
-			<?php endif; ?>
-			<?php
-			if (
-				( $block_attributes['show_context'] ) &&
-				! empty( $related_post['context'] )
-			) :
-				?>
-				<div class="jp-related-posts-i2__post-context has-small-font-size">
-					<?php echo esc_html( $related_post['context'] ); ?>
-				</div>
-			<?php endif; ?>
-		</div>
-		<?php
+
+		$item_markup = sprintf(
+			'<ul id="%1$s" aria-labelledby="%2$s" class="jp-related-posts-i2__post" role="menuitem">',
+			esc_attr( $instance_id ),
+			esc_attr( $label_id )
+		);
+
+		$item_markup .= sprintf(
+			'<li class="jp-related-posts-i2__post-link"><a id="%1$s" href="%2$s" rel="%4$s">%3$s</a></li>',
+			esc_attr( $label_id ),
+			esc_url( $related_post['url'] ),
+			esc_attr( $related_post['title'] ),
+			esc_attr( $related_post['rel'] )
+		);
+
+		if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ) {
+			$img_link = sprintf(
+				'<li class="jp-related-posts-i2__post-img-link"><a href="%1$s" rel="%2$s"><img src="%3$s" width="%4$s" alt="%5$s" /></a></li>',
+				esc_url( $related_post['url'] ),
+				esc_attr( $related_post['rel'] ),
+				esc_url( $related_post['img']['src'] ),
+				esc_attr( $related_post['img']['width'] ),
+				esc_attr( $related_post['img']['alt_text'] )
+			);
+
+			$item_markup .= $img_link;
+		}
+
+		if ( $block_attributes['show_date'] ) {
+			$date_tag = sprintf(
+				'<li class="jp-related-posts-i2__post-date">%1$s</li>',
+				esc_html( $related_post['date'] )
+			);
+
+			$item_markup .= $date_tag;
+		}
+
+		if ( ( $block_attributes['show_context'] ) && ! empty( $related_post['context'] ) ) {
+			$context_tag = sprintf(
+				'<li class="jp-related-posts-i2__post-context">%1$s</li>',
+				esc_html( $related_post['context'] )
+			);
+
+			$item_markup .= $context_tag;
+		}
+
+		$item_markup .= '</ul>';
+
+		return $item_markup;
 	}
 
 	/**
@@ -319,18 +314,15 @@ EOT;
 	 * @param array $block_attributes Block attributes.
 	 */
 	public function render_block_row( $posts, $block_attributes ) {
-		?>
-		<div
-			class="jp-related-posts-i2__row"
-			data-post-count="<?php echo count( $posts ); ?>"
-		>
-		<?php
+		$rows_markup = '';
 		foreach ( $posts as $post ) {
-			$this->render_block_item( $post, $block_attributes );
+			$rows_markup .= $this->render_block_item( $post, $block_attributes );
 		}
-		?>
-		</div>
-		<?php
+		return sprintf(
+			'<div class="jp-related-posts-i2__row" data-post-count="%1$s">%2$s</div>',
+			count( $posts ),
+			$rows_markup
+		);
 	}
 
 	/**
@@ -378,21 +370,10 @@ EOT;
 		$upper_row_posts = array_slice( $related_posts, 0, $top_row_end );
 		$lower_row_posts = array_slice( $related_posts, $top_row_end );
 
-		ob_start();
-		?>
-		<nav
-				class="jp-relatedposts-i2"
-				data-layout="<?php echo esc_attr( $block_attributes['layout'] ); ?>"
-		>
-			<?php
-			$this->render_block_row( $upper_row_posts, $block_attributes );
-			if ( $display_lower_row ) {
-				$this->render_block_row( $lower_row_posts, $block_attributes );
-			}
-			?>
-		</nav>
-		<?php
-		$html = ob_get_clean();
+		$rows_markup = $this->render_block_row( $upper_row_posts, $block_attributes );
+		if ( $display_lower_row ) {
+			$rows_markup .= $this->render_block_row( $lower_row_posts, $block_attributes );
+		}
 
 		$target_to_dom_priority = has_filter(
 			'the_content',
@@ -418,7 +399,11 @@ EOT;
 		remove_filter( 'the_content', 'wpautop', $priority );
 		add_filter( 'the_content', '_restore_wpautop_hook', $priority + 1 );
 
-		return $html;
+		return sprintf(
+			'<nav class="jp-relatedposts-i2" data-layout="%1$s">%2$s</nav>',
+			esc_attr( $block_attributes['layout'] ),
+			$rows_markup
+		);
 	}
 
 	/**
@@ -1288,9 +1273,10 @@ EOT;
 	protected function _generate_related_post_image_params( $post_id ) {
 		$options = $this->get_options();
 		$image_params = array(
-			'src' => '',
-			'width' => 0,
-			'height' => 0,
+			'alt_text' => '',
+			'src'      => '',
+			'width'    => 0,
+			'height'   => 0,
 		);
 
 		/**
@@ -1315,7 +1301,7 @@ EOT;
 
 		// Try to get post image
 		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			$img_url = '';
+			$img_url    = '';
 			$post_image = Jetpack_PostImages::get_image(
 				$post_id,
 				$thumbnail_size
@@ -1331,10 +1317,15 @@ EOT;
 				}
 			}
 
-			if ( !empty( $img_url ) ) {
-				$image_params['width'] = $thumbnail_size['width'];
+			if ( ! empty( $img_url ) ) {
+				if ( isset( $image_params['alt_text'] ) ) {
+					$image_params['alt_text'] = $post_image['alt_text'];
+				} else {
+					$image_params['alt_text'] = '';
+				}
+				$image_params['width']  = $thumbnail_size['width'];
 				$image_params['height'] = $thumbnail_size['height'];
-				$image_params['src'] = Jetpack_PostImages::fit_image_url(
+				$image_params['src']    = Jetpack_PostImages::fit_image_url(
 					$img_url,
 					$thumbnail_size['width'],
 					$thumbnail_size['height']

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1318,7 +1318,7 @@ EOT;
 			}
 
 			if ( ! empty( $img_url ) ) {
-				if ( isset( $image_params['alt_text'] ) ) {
+				if ( ! empty( $post_image['alt_text'] ) ) {
 					$image_params['alt_text'] = $post_image['alt_text'];
 				} else {
 					$image_params['alt_text'] = '';

--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -21,6 +21,7 @@
 	margin: 0 10px;
 	display: flex;
 	flex-direction: column;
+	padding-left: 0;
 }
 
 .jp-related-posts-i2__row[data-post-count="3"] .jp-related-posts-i2__post {
@@ -35,6 +36,7 @@
 .jp-related-posts-i2__post-heading, .jp-related-posts-i2__post-img-link,
 .jp-related-posts-i2__post-date, .jp-related-posts-i2__post-context {
 	flex-direction: row;
+	display: block;
 }
 
 .jp-related-posts-i2__post-heading {
@@ -46,14 +48,15 @@
 .jp-related-posts-i2__post-link {
 	display: block;
 	width: 100%;
-}
-
-.jp-related-posts-i2__post-img {
-	width: 100%;
+	line-height: 1.2em;
 }
 
 .jp-related-posts-i2__post-img-link {
 	order: -1;
+	line-height: 1em;
+	img {
+		width: 100%;
+	}
 }
 
 /* List view */
@@ -85,9 +88,9 @@
 	}
 	.jp-related-posts-i2__post-img-link {
 		margin-top: 1rem;
-	}
-	.jp-related-posts-i2__post-img {
-		width: 350px;
+		img {
+			width: 350px;
+		}
 	}
 }
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/Automattic/jetpack/pull/11220 and includes commits from there as well. Please merge that before this one.

Fixes #11175 

#### Changes proposed in this Pull Request:
- Adding support for alt text to Jetpack_PostImages
- Using alt text for images instead of a redundant article title
- Using sprintf to output HTML markup without newlines
- Properly using nav and ul elements to indicate related posts, increasing a11y
- Removes `has-small-font-size` classes from some HTML elements as this was causing a discrepancy between the editor (where this is defined) and the fronted, where is depends on the theme.

#### Testing instructions:

- See if the markup in the Related Posts block breaks in any way

#### Proposed changelog entry for your changes:
- Improved HTML markup for related posts, with emphasis on accessibility
