### PR TITLE
Markdown: move block to its own file.

### DIFF
--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Markdown Block.
+ *
+ * @since 6.8.0
+ *
+ * @package Jetpack
+ */
+
+/**
+ * The block depends on the Markdown module to be active for now.
+ * Related discussion: https://github.com/Automattic/jetpack/issues/10294
+ */
+if (
+	( defined( 'IS_WPCOM' ) && IS_WPCOM )
+	|| ( method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'markdown' ) )
+) {
+	jetpack_register_block_type( 'jetpack/markdown' );
+}
+

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -72,8 +72,6 @@ class WPCom_Markdown {
 		if ( current_theme_supports( 'o2' ) || class_exists( 'P2' ) ) {
 			$this->add_o2_helpers();
 		}
-
-		jetpack_register_block_type( 'jetpack/markdown' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Following the changes we've made in #11312, I think it now makes sense to bring block registration
closer to where the block's code will eventually live, when possible.

See https://github.com/Automattic/jetpack/pull/11312#discussion_r255242725 (cc @simison)

#### Testing instructions:

* Go to Posts > Add New
* Can you use the Markdown block?
* Go to Jetpack > Settings > Writing
* Disable the Markdown feature
* Go to Posts > Add New
* The Markdown block should not be available (`"markdown":{"available":false,"unavailable_reason":"missing_module"}`)

#### Proposed changelog entry for your changes:

* None
