### PR TITLE
Tiled gallery: Remove unused view dependencies

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -27,11 +27,7 @@ if (
 	 * @return string
 	 */
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		$dependencies = array(
-			'lodash',
-			'wp-i18n',
-			'wp-token-list',
-		);
+		$dependencies = array();
 		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
 
 		/**

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -27,15 +27,7 @@ if (
 	 * @return string
 	 */
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		$dependencies = array(
-			// i18n isn't really needed for the view, but the current module structure
-			// requires it during evaluation of an imported module:
-			//
-			// https://github.com/Automattic/wp-calypso/blob/4b25daefec1425165086a0aaac8f10ac6c479463/client/gutenberg/extensions/tiled-gallery/constants.js#L6
-			//
-			// With some restructuring we can remove this view dependency.
-			'wp-i18n',
-		);
+		$dependencies = array();
 		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
 
 		/**

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -27,8 +27,7 @@ if (
 	 * @return string
 	 */
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		$dependencies = array();
-		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
+		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
 
 		/**
 		 * Filter the output of the Tiled Galleries content.

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -27,7 +27,15 @@ if (
 	 * @return string
 	 */
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		$dependencies = array();
+		$dependencies = array(
+			// i18n isn't really needed for the view, but the current module structure
+			// requires it during evaluation of an imported module:
+			//
+			// https://github.com/Automattic/wp-calypso/blob/4b25daefec1425165086a0aaac8f10ac6c479463/client/gutenberg/extensions/tiled-gallery/constants.js#L6
+			//
+			// With some restructuring we can remove this view dependency.
+			'wp-i18n',
+		);
 		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery', $dependencies );
 
 		/**


### PR DESCRIPTION
Remove unused view dependencies from the Tiled Gallery block.

Fixes https://github.com/Automattic/wp-calypso/issues/28933

#### Changes proposed in this Pull Request:

* Remove redundant Tiled Gallery frontend script dependencies.

#### Testing instructions:

Test with `calypsobranch=update/g7g-tg-restructure-drop-view-i18n-dep`

* Add a Tiled Gallery block. Use a mosaic or column layout
* View the block on the frontend
* Ensure that none of the removed scripts are enqueued
  - `lodash`
  - `wp-i18n` (depends on https://github.com/Automattic/wp-calypso/pull/30752)
  - `wp-token-list`
* Ensure view works correctly. Verify that resizing adjust the tile sizes correctly.

#### Proposed changelog entry for your changes:

* Remove redundant Tiled Gallery frontend script dependencies.
