### PR TITLE
Gutenpack: Revert deprecating jetpack_register_block

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -16,17 +16,16 @@
  *
  * @since 6.7.0
  *
- * @return WP_Block_Type or false
+ * @return WP_Block_Type|false The registered block type on success, or false on failure.
  */
 function jetpack_register_block( $slug, $args = array() ) {
 	if ( ! function_exists( 'register_block_type' ) ) {
 		return false;
 	}
-	if ( ! 0 === strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
+	if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
 		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
 		$slug = 'jetpack/' . $slug;
 	}
-
 	return register_block_type( $slug, $args );
 }
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -7,8 +7,7 @@
  */
 
 /**
- * Helper function to register a Jetpack Gutenberg block
- *
+ * Wrapper function to safely register a gutenberg block type
  *
  * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
@@ -17,12 +16,16 @@
  *
  * @since 6.7.0
  *
- * @return void
+ * @return WP_Block_Type or false
  */
 function jetpack_register_block( $slug, $args = array() ) {
-	if( ! wp_startswith( 'jetpack/', $slug ) && ! strpos( $slug, '/' ) ) {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return false;
+	}
+	if ( ! wp_startswith( 'jetpack/', $slug ) && ! strpos( $slug, '/' ) ) {
 		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
 	}
+
 	return register_block_type( $slug, $args );
 }
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -7,28 +7,8 @@
  */
 
 /**
- * Wrapper function to safely register a Jetpack Gutenberg block
- *
- * @param string $slug Slug of the block.
- * @param array  $args Arguments that are passed into register_block_type.
- *
- * @see register_block_type
- *
- * @since 7.1.0
- *
- * @return WP_Block_Type|false The registered block type on success, or false on failure.
- */
-function jetpack_register_block_type( $slug, $args = array() ) {
-	if ( ! function_exists( 'register_block_type' ) ) {
-		return false;
-	}
-	return register_block_type( $slug, $args );
-}
-
-/**
  * Helper function to register a Jetpack Gutenberg block
  *
- * @deprecated 7.1.0 Use jetpack_register_block_type() instead
  *
  * @param string $slug Slug of the block.
  * @param array  $args Arguments that are passed into register_block_type.
@@ -40,9 +20,10 @@ function jetpack_register_block_type( $slug, $args = array() ) {
  * @return void
  */
 function jetpack_register_block( $slug, $args = array() ) {
-	_deprecated_function( __FUNCTION__, '7.1', 'jetpack_register_block_type' );
-
-	Jetpack_Gutenberg::register_block( $slug, $args );
+	if( ! wp_startswith( 'jetpack/', $slug ) && ! strpos( $slug, '/' ) ) {
+		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
+	}
+	return register_block_type( $slug, $args );
 }
 
 /**
@@ -139,15 +120,15 @@ class Jetpack_Gutenberg {
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.1.0 Use jetpack_register_block_type() instead
+	 * @deprecated 7.1.0 Use jetpack_register_block() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into register_block_type().
 	 */
 	public static function register_block( $slug, $args ) {
-		_deprecated_function( __METHOD__, '7.1', 'jetpack_register_block_type' );
+		_deprecated_function( __METHOD__, '7.1', 'jetpack_register_block' );
 
-		jetpack_register_block_type( 'jetpack/' . $slug, $args );
+		jetpack_register_block( 'jetpack/' . $slug, $args );
 	}
 
 	/**
@@ -166,14 +147,14 @@ class Jetpack_Gutenberg {
 	/**
 	 * Register a block
 	 *
-	 * @deprecated 7.0.0 Use jetpack_register_block_type() instead
+	 * @deprecated 7.0.0 Use jetpack_register_block() instead
 	 *
 	 * @param string $slug Slug of the block.
 	 * @param array  $args Arguments that are passed into the register_block_type.
 	 * @param array  $availability array containing if a block is available and the reason when it is not.
 	 */
 	public static function register( $slug, $args, $availability ) {
-		_deprecated_function( __METHOD__, '7.0', 'jetpack_register_block_type' );
+		_deprecated_function( __METHOD__, '7.0', 'jetpack_register_block' );
 
 		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
 			self::set_extension_unavailability_reason( $slug, $availability['unavailable_reason'] );
@@ -353,7 +334,7 @@ class Jetpack_Gutenberg {
 		/**
 		 * Fires before Gutenberg extensions availability is computed.
 		 *
-		 * In the function call you supply, use `jetpack_register_block_type()` to set a block as available.
+		 * In the function call you supply, use `jetpack_register_block()` to set a block as available.
 		 * Alternatively, use `Jetpack_Gutenberg::set_extension_available()` (for a non-block plugin), and
 		 * `Jetpack_Gutenberg::set_extension_unavailable()` (if the block or plugin should not be registered
 		 * but marked as unavailable).

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -22,8 +22,9 @@ function jetpack_register_block( $slug, $args = array() ) {
 	if ( ! function_exists( 'register_block_type' ) ) {
 		return false;
 	}
-	if ( ! wp_startswith( 'jetpack/', $slug ) && ! strpos( $slug, '/' ) ) {
+	if ( ! 0 === strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
 		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
+		$slug = 'jetpack/' . $slug;
 	}
 
 	return register_block_type( $slug, $args );

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/business-hours',
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -7,21 +7,21 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/contact-info',
 	array(
 		'render_callback' => 'jetpack_contact_info_block_load_assets',
 	)
 );
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/email',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/address',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/phone',
 	array( 'parent' => array( 'jetpack/contact-info' ) )
 );

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/gif',
 	array(
 		'render_callback' => 'jetpack_gif_block_render',

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -8,7 +8,7 @@
  */
 
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
-	jetpack_register_block_type(
+	jetpack_register_block(
 		'jetpack/mailchimp',
 		array(
 			'render_callback' => 'jetpack_mailchimp_block_load_assets',

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/map',
 	array(
 		'render_callback' => 'jetpack_map_block_load_assets',

--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -15,6 +15,6 @@ if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM )
 	|| ( method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'markdown' ) )
 ) {
-	jetpack_register_block_type( 'jetpack/markdown' );
+	jetpack_register_block( 'jetpack/markdown' );
 }
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type(
+jetpack_register_block(
 	'jetpack/slideshow',
 	array(
 		'render_callback' => 'jetpack_slideshow_block_load_assets',

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -11,7 +11,7 @@ if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
 ) {
-	jetpack_register_block_type(
+	jetpack_register_block(
 		'jetpack/tiled-gallery',
 		array(
 			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',

--- a/extensions/blocks/vr/vr.php
+++ b/extensions/blocks/vr/vr.php
@@ -7,4 +7,4 @@
  * @package Jetpack
  */
 
-jetpack_register_block_type( 'jetpack/vr' );
+jetpack_register_block( 'jetpack/vr' );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -245,52 +245,52 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		jetpack_register_block_type( 'jetpack/contact-form', array(
+		jetpack_register_block( 'jetpack/contact-form', array(
 			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 		) );
 
 		// Field render methods.
-		jetpack_register_block_type( 'jetpack/field-text', array(
+		jetpack_register_block( 'jetpack/field-text', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-name', array(
+		jetpack_register_block( 'jetpack/field-name', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-email', array(
+		jetpack_register_block( 'jetpack/field-email', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-url', array(
+		jetpack_register_block( 'jetpack/field-url', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-date', array(
+		jetpack_register_block( 'jetpack/field-date', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-telephone', array(
+		jetpack_register_block( 'jetpack/field-telephone', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-textarea', array(
+		jetpack_register_block( 'jetpack/field-textarea', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-checkbox', array(
+		jetpack_register_block( 'jetpack/field-checkbox', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-checkbox-multiple', array(
+		jetpack_register_block( 'jetpack/field-checkbox-multiple', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-radio', array(
+		jetpack_register_block( 'jetpack/field-radio', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
 		) );
-		jetpack_register_block_type( 'jetpack/field-select', array(
+		jetpack_register_block( 'jetpack/field-select', array(
 			'parent'          => array( 'jetpack/contact-form' ),
 			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
 		) );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -69,7 +69,7 @@ class Jetpack_RelatedPosts {
 			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 		}
 
-		jetpack_register_block_type(
+		jetpack_register_block(
 			'jetpack/related-posts',
 			array(
 				'render_callback' => array( $this, 'render_block' ),

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -62,7 +62,7 @@ class Jetpack_Simple_Payments {
 
 	function register_gutenberg_block() {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			jetpack_register_block_type( 'jetpack/simple-payments' );
+			jetpack_register_block( 'jetpack/simple-payments' );
 		} else {
 			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack/simple-payments', 'missing_plan' );
 		}

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -745,7 +745,7 @@ add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
 
 function jetpack_register_subscriptions_block() {
 	if ( class_exists( 'WP_Block_Type_Registry' ) && ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
-		jetpack_register_block_type( 'jetpack/subscriptions' );
+		jetpack_register_block( 'jetpack/subscriptions' );
 	}
 }
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -105,7 +105,7 @@ class VideoPress_Gutenberg {
 	 * It defines a server-side rendering that adds VideoPress support to the core video block.
 	 */
 	public function register_video_block_with_videopress() {
-		jetpack_register_block_type(
+		jetpack_register_block(
 			'core/video',
 			array(
 				'render_callback' => array( $this, 'render_video_block_with_videopress' ),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
 		Jetpack_Gutenberg::init();
-		jetpack_register_block_type( 'jetpack/test' );
+		jetpack_register_block( 'jetpack/test' );
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -61,7 +61,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_available() {
-		jetpack_register_block_type( 'jetpack/apple' );
+		jetpack_register_block( 'jetpack/apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['apple']['available'] );
 	}
@@ -74,7 +74,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_block_type( 'jetpack/durian' );
+		jetpack_register_block( 'jetpack/durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
 		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );


### PR DESCRIPTION

We introduced `jetpack_register_block_type` in #11310. But since we already have a wrapper function that we also deprecated. We end up with 2 functions `jetpack_register_block_type` and `jetpack_register_block` that do the same thing. 
This PR removed the new wrapper function in favour of the old one and ads a check that we don't call jetpack_register_block_type without `jetpack/` which is what we expect. 

#### Changes proposed in this Pull Request:
* remove the newly added jetpack_register_block_type in favour of the old jetpack_register_block_type. 


#### Testing instructions:
* Do the tests still pass? 
* Do the blocks still load in the editor? 
* Do you notice any php errors/notices? 

#### Proposed changelog entry
I don't think this needs a changelog entry
