### PR TITLE
 Instagram: update embed to support new TV URLs

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -74,14 +74,24 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	$min_width = 320;
 
 	if ( is_feed() ) {
-		$media_url = sprintf( 'http://instagr.am/%1$s/%2$s/media/?size=l', $matches[4], $matches[5] );
-		return sprintf(
-			'<a href="%1$s" title="%2$s" target="_blank"><img src="%3$s" alt="%4$s" /></a>',
-			esc_url( $url ),
-			esc_attr__( 'View on Instagram', 'jetpack' ),
-			esc_url( $media_url ),
-			( 'tv' === $matches[4] ? esc_html__( 'Instagram video', 'jetpack' ) : esc_html__( 'Instagram Photo', 'jetpack' ) )
-		);
+		// Instagram offers direct links to images, but not to videos.
+		if ( 'p' === $matches[4] ) {
+			$media_url = sprintf( 'http://instagr.am/p/%1$s/media/?size=l', $matches[5] );
+			return sprintf(
+				'<a href="%1$s" title="%2$s" target="_blank"><img src="%3$s" alt="%4$s" /></a>',
+				esc_url( $url ),
+				esc_attr__( 'View on Instagram', 'jetpack' ),
+				esc_url( $media_url ),
+				esc_html__( 'Instagram Photo', 'jetpack' )
+			);
+		} elseif ( 'tv' === $matches[4] ) {
+			return sprintf(
+				'<a href="%1$s" title="%2$s" target="_blank">%3$s</a>',
+				esc_url( $url ),
+				esc_attr__( 'View on Instagram', 'jetpack' ),
+				esc_html__( 'Instagram Video', 'jetpack' )
+			);
+		}
 	}
 
 	$atts = shortcode_atts(

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -59,9 +59,16 @@ function jetpack_instagram_embed_reversal( $content ) {
 add_filter( 'pre_kses', 'jetpack_instagram_embed_reversal' );
 
 /**
- * Instagram
+ * Instagram's custom Embed provider.
+ * We first remove 2 different embed providers, both registered by Core.
+ * - The first is the original provider,that only supports images.
+ * - The second is tne new provider that replaced the first one in Core when Core added support for videos. https://core.trac.wordpress.org/changeset/44486
+ *
+ * Once the core embed provider is removed (one or the other, depending on your version of Core), we declare our own.
  */
-wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' ); // remove core's oEmbed support so we can override
+wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' );
+wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' );
+
 wp_embed_register_handler( 'jetpack_instagram', '#http(s?)://(www\.)?instagr(\.am|am\.com)/(p|tv)/([^/]*)#i', 'jetpack_instagram_handler' );
 
 function jetpack_instagram_handler( $matches, $atts, $url ) {

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -21,17 +21,17 @@ function jetpack_instagram_embed_reversal( $content ) {
 
 	$regexes = array();
 
-	// new style js
-	$regexes[] = '#<blockquote[^>]+?class="instagram-media"[^>](.+?)>(.+?)</blockquote><script[^>]+?src="(https?:)?//platform\.instagram\.com/(.+?)/embeds\.js"></script>#ix';
+	// new style js.
+	$regexes[] = '#<blockquote[^>]+?class="instagram-media"[^>].+?>(.+?)</blockquote><script[^>]+?src="(https?:)?//platform\.instagram\.com/(.+?)/embeds\.js"></script>#ix';
 
 	// Let's play nice with the visual editor too.
-	$regexes[] = '#&lt;blockquote(?:[^&]|&(?!gt;))+?class="instagram-media"(?:[^&]|&(?!gt;))(.+?)&gt;(.+?)&lt;/blockquote&gt;&lt;script(?:[^&]|&(?!gt;))+?src="(https?:)?//platform\.instagram\.com/(.+?)/embeds\.js"(?:[^&]|&(?!gt;))*+&gt;&lt;/script&gt;#ix';
+	$regexes[] = '#&lt;blockquote(?:[^&]|&(?!gt;))+?class="instagram-media"(?:[^&]|&(?!gt;)).+?&gt;(.+?)&lt;/blockquote&gt;&lt;script(?:[^&]|&(?!gt;))+?src="(https?:)?//platform\.instagram\.com/(.+?)/embeds\.js"(?:[^&]|&(?!gt;))*+&gt;&lt;/script&gt;#ix';
 
-	// old style iframe
-	$regexes[] = '#<iframe[^>]+?src="(?:https?:)?//instagram\.com/(p|tv)/([^"\'/]++)[^"\']*?"[^>]*+>\s*?</iframe>#i';
+	// old style iframe.
+	$regexes[] = '#<iframe[^>]+?src="((?:https?:)?//(?:www\.)?instagram\.com/p/([^"\'/]++)[^"\']*?)"[^>]*+>\s*?</iframe>#i';
 
 	// Let's play nice with the visual editor too.
-	$regexes[] = '#&lt;iframe(?:[^&]|&(?!gt;))+?src="(?:https?:)?//instagram\.com/(p|tv)/([^"\'/]++)[^"\']*?"(?:[^&]|&(?!gt;))*+&gt;\s*?&lt;/iframe&gt;#i';
+	$regexes[] = '#&lt;iframe(?:[^&]|&(?!gt;))+?src="((?:https?:)?//(?:www\.)instagram\.com/p/([^"\'/]++)[^"\']*?)"(?:[^&]|&(?!gt;))*+&gt;\s*?&lt;/iframe&gt;#i';
 
 	foreach ( $regexes as $regex ) {
 		if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
@@ -39,7 +39,7 @@ function jetpack_instagram_embed_reversal( $content ) {
 		}
 
 		foreach ( $matches as $match ) {
-			if ( ! preg_match( '#(https?:)?//instagr(\.am|am\.com)/(p|tv)/([^/]*)#i', $match[2], $url_matches ) ) {
+			if ( ! preg_match( '#(https?:)?//(?:www\.)?instagr(\.am|am\.com)/p/([^/]*)#i', $match[1], $url_matches ) ) {
 				continue;
 			}
 

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -69,7 +69,11 @@ add_filter( 'pre_kses', 'jetpack_instagram_embed_reversal' );
 wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' );
 wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' );
 
-wp_embed_register_handler( 'jetpack_instagram', '#http(s?)://(www\.)?instagr(\.am|am\.com)/(p|tv)/([^/]*)#i', 'jetpack_instagram_handler' );
+wp_embed_register_handler(
+	'jetpack_instagram',
+	'#http(s?)://(www\.)?instagr(\.am|am\.com)/(p|tv)/([^\/]*)#i',
+	'jetpack_instagram_handler'
+);
 
 function jetpack_instagram_handler( $matches, $atts, $url ) {
 	global $content_width;
@@ -190,7 +194,11 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 }
 
 // filters instagram's username format to the expected format that matches the embed handler
-wp_embed_register_handler( 'jetpack_instagram_alternate_format', '#http(s?)://(www\.)?instagr(\.am|am\.com)/([^/]*)/(p|tv)/([^/]*)#i', 'jetpack_instagram_alternate_format_handler' );
+wp_embed_register_handler(
+	'jetpack_instagram_alternate_format',
+	'#http(s?)://(www\.)?instagr(\.am|am\.com)/([^/]*)/(p|tv)/([^\/]*)#i',
+	'jetpack_instagram_alternate_format_handler'
+);
 function jetpack_instagram_alternate_format_handler( $matches, $atts, $url ) {
 	$url        = esc_url_raw(
 		sprintf(

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -190,7 +190,7 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 }
 
 // filters instagram's username format to the expected format that matches the embed handler
-wp_embed_register_handler( 'jetpack_instagram_alternate_format', '#http(s?)://(www\.)instagr(\.am|am\.com)/([^/]*)/(p|tv)/([^/]*)#i', 'jetpack_instagram_alternate_format_handler' );
+wp_embed_register_handler( 'jetpack_instagram_alternate_format', '#http(s?)://(www\.)?instagr(\.am|am\.com)/([^/]*)/(p|tv)/([^/]*)#i', 'jetpack_instagram_alternate_format_handler' );
 function jetpack_instagram_alternate_format_handler( $matches, $atts, $url ) {
 	$url        = esc_url_raw(
 		sprintf(

--- a/tests/php/modules/shortcodes/test_class.instagram.php
+++ b/tests/php/modules/shortcodes/test_class.instagram.php
@@ -66,8 +66,11 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 	public function test_instagram_replace_profile_image_url_with_embed() {
 		global $post;
 
-		$instagram_url = 'https://www.instagram.com/jeherve/p/BnMO9vRleEx/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+		$instagram_username      = 'jeherve';
+		$instagram_id            = 'BnMO9vRleEx';
+		$instagram_original_url  = 'https://www.instagram.com/' . $instagram_username . '/p/' . $instagram_id . '/';
+		$instagram_canonical_url = 'https://www.instagram.com/p/' . $instagram_id . '/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_original_url ) );
 
 		do_action( 'init' );
 		setup_postdata( $post );
@@ -77,7 +80,7 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 		wp_reset_postdata();
 
 		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_canonical_url,
 			$actual
 		);
 	}
@@ -88,8 +91,11 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 	public function test_instagram_replace_profile_video_url_with_embed() {
 		global $post;
 
-		$instagram_url = 'https://www.instagram.com/instagram/tv/BkQjCfsBIzi/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+		$instagram_username      = 'instagram';
+		$instagram_id            = 'BkQjCfsBIzi';
+		$instagram_original_url  = 'https://www.instagram.com/' . $instagram_username . '/tv/' . $instagram_id . '/';
+		$instagram_canonical_url = 'https://www.instagram.com/tv/' . $instagram_id . '/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_original_url ) );
 
 		do_action( 'init' );
 		setup_postdata( $post );
@@ -99,7 +105,7 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 		wp_reset_postdata();
 
 		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_canonical_url,
 			$actual
 		);
 	}

--- a/tests/php/modules/shortcodes/test_class.instagram.php
+++ b/tests/php/modules/shortcodes/test_class.instagram.php
@@ -1,0 +1,106 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
+	/**
+	 * @covers ::jetpack_shortcode_instagram
+	 */
+	public function test_shortcode_instagram() {
+		$instagram_url = 'https://www.instagram.com/p/BnMO9vRleEx/';
+		$content       = '[instagram url="' . $instagram_url . '"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains(
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * @covers ::jetpack_instagram_handler
+	 */
+	public function test_instagram_replace_image_url_with_embed() {
+		global $post;
+
+		$instagram_url = 'https://www.instagram.com/p/BnMO9vRleEx/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+
+		$this->assertContains(
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			$actual
+		);
+	}
+
+	/**
+	 * @covers ::jetpack_instagram_handler
+	 */
+	public function test_instagram_replace_video_url_with_embed() {
+		global $post;
+
+		$instagram_url = 'https://www.instagram.com/tv/BkQjCfsBIzi/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+
+		$this->assertContains(
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			$actual
+		);
+	}
+
+	/**
+	 * @covers ::jetpack_instagram_handler
+	 */
+	public function test_instagram_replace_profile_image_url_with_embed() {
+		global $post;
+
+		$instagram_url = 'https://www.instagram.com/jeherve/p/BnMO9vRleEx/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+
+		$this->assertContains(
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			$actual
+		);
+	}
+
+	/**
+	 * @covers ::jetpack_instagram_handler
+	 */
+	public function test_instagram_replace_profile_video_url_with_embed() {
+		global $post;
+
+		$instagram_url = 'https://www.instagram.com/instagram/tv/BkQjCfsBIzi/';
+		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+
+		$this->assertContains(
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			$actual
+		);
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This updates our custom embed provider to support Instagram TV URLs, just like Core will soon: https://core.trac.wordpress.org/changeset/44486

I also took the opportunity to add some Unit Tests for Instagram, we did not have any before.

#### Testing instructions:

* Try adding the following URLs to a brand new post, and see that they all get transformed into embeds on publish:
```
A classic IG embed

https://www.instagram.com/p/BnMOk_FFsxg/

A TV IG embed

https://www.instagram.com/tv/BkQjCfsBIzi/

A profile alternative picture IG embed

https://www.instagram.com/jeherve/p/BnMO9vRleEx/

A profile alternative video IG embed

https://www.instagram.com/instagram/tv/BkQjCfsBIzi/

An Instagram shortcode

[instagram url="http://instagram.com/p/BnMO9vRleEx/"]
```
* I would recommend testing this with the Classic Editor, because Instagram Embeds are currently broken in the block editor (see #9331)

#### Proposed changelog entry for your changes:

*  Instagram: update embed to support Instagram TV URLs
