### PR TITLE
AtD: Use `admin_url()` correctly

### DIFF
--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -223,7 +223,7 @@ function AtD_load_javascripts() {
 			array('jquery'),
 			ATD_VERSION
 		);
-		wp_enqueue_script( 'AtD_settings', admin_url() . 'admin-ajax.php?action=atd_settings', array('AtD_jquery'), ATD_VERSION );
+		wp_enqueue_script( 'AtD_settings', admin_url( 'admin-ajax.php?action=atd_settings' ), array('AtD_jquery'), ATD_VERSION );
 		wp_enqueue_script(
 			'AtD_autoproofread',
 			Jetpack::get_file_url_for_environment(

--- a/modules/after-the-deadline/tinymce/plugin.js
+++ b/modules/after-the-deadline/tinymce/plugin.js
@@ -85,7 +85,7 @@ tinymce.PluginManager.add( 'AtD', function( editor ) {
 	function checkIfFinished() {
 		if ( ! editor.dom.select('span.hiddenSpellError, span.hiddenGrammarError, span.hiddenSuggestion').length ) {
 			if ( suggestionsMenu ) {
-				suggestionsMenu.hideMenu();
+				suggestionsMenu.hide();
 			}
 
 			finish();


### PR DESCRIPTION
Use `admin_url( "admin-ajax.php…" )` instead of `admin_url() . "admin-ajax.php…"`. When filters are attached to `admin_url`, the concatenation pattern may no longer work.

Syncs file with WP.com: D23473-code.

To test that things still work:
1. Turn on AtD (Jetpack -> Settings -> Writing -> Composing -> "Check your spelling, style, and grammar").
2. Under "Ignored Phrases", add a nonsense word: `yaay`.
3. Click the Composing block's "Save Settings" button.
4. Create a new post in the Classic Editor.
5. Type the nonsense word in the content. (You'll probably see your browser highlight it as a misspelling.)
6. Click "proofread" in the Text editor or "ABC✔️" in the Visual editor.
7. See that the nonsense word is *not* highlighted as a misspelling by AtD.