### PR TITLE
SEO: Register Post Meta, Enable Gutenberg Plugin

### DIFF
--- a/extensions/plugins/seo/seo.php
+++ b/extensions/plugins/seo/seo.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * SEO Plugin.
+ *
+ * @since 7.1.0
+ *
+ * @package Jetpack
+ */
+
+Jetpack_Gutenberg::set_extension_available( 'jetpack-seo' );
+
+/**
+ * Registers the `advanced_seo_description` post_meta for use in the REST API.
+ */
+function jetpack_register_seo_post_meta() {
+    $args = array(
+        'type' => 'string',
+        'description' => __( 'Custom post description to be used in HTML <meta /> tag.', 'jetpack' ),
+        'single' => true,
+        'default' => '',
+        'show_in_rest' => array(
+            'name' => 'advanced_seo_description'
+        ),
+    );
+
+    register_meta( 'post', 'advanced_seo_description', $args );
+}
+
+add_action( 'init', 'jetpack_register_seo_post_meta', 20 );

--- a/extensions/plugins/seo/seo.php
+++ b/extensions/plugins/seo/seo.php
@@ -13,17 +13,17 @@ Jetpack_Gutenberg::set_extension_available( 'jetpack-seo' );
  * Registers the `advanced_seo_description` post_meta for use in the REST API.
  */
 function jetpack_register_seo_post_meta() {
-    $args = array(
-        'type' => 'string',
-        'description' => __( 'Custom post description to be used in HTML <meta /> tag.', 'jetpack' ),
-        'single' => true,
-        'default' => '',
-        'show_in_rest' => array(
-            'name' => 'advanced_seo_description'
-        ),
-    );
+		$args = array(
+			'type'         => 'string',
+			'description'  => __( 'Custom post description to be used in HTML <meta /> tag.', 'jetpack' ),
+			'single'       => true,
+			'default'      => '',
+			'show_in_rest' => array(
+				'name' => 'advanced_seo_description',
+			),
+		);
 
-    register_meta( 'post', 'advanced_seo_description', $args );
+		register_meta( 'post', 'advanced_seo_description', $args );
 }
 
 add_action( 'init', 'jetpack_register_seo_post_meta', 20 );

--- a/extensions/plugins/seo/seo.php
+++ b/extensions/plugins/seo/seo.php
@@ -2,7 +2,7 @@
 /**
  * SEO Plugin.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @package Jetpack
  */


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/27692

Per discussion at p1HpG7-6a7-p2 #comment-30125, we're making this available for free.

Adding this logic to a newly created file `extensions/plugins/seo/seo.php` which is loaded unconditionally, instead of any of the files in `modules/seo-tools/jetpack-seo-posts.php` which are only loaded if a plan that includes the SEO feature is active (>= Premium).

#### Changes proposed in this Pull Request:

* SEO: Expose advanced_seo_description post meta in the (core) REST API
* Set SEO Gutenberg plugin as available

#### Testing instructions:

- Apply this branch to your local environment
- Build blocks from Calypso using steps from https://github.com/Automattic/wp-calypso/pull/30033
- The usual setup steps: Connect to WP.com and start writing a new post.
- Open the browser console and type `Jetpack_Editor_Initial_State.available_blocks`.
- Check that the `seo` extension is marked as available.
- Check that SEO textfield is visible at Jetpack sidebar and post publish-sidebar

Back in wp-admin:

- Go back to the site's wp-admin Gutenberg editor.
- Expand the 'Post Meta Inspector' panel at the bottom. Verify that it contains a field `advanced_seo_description` with the string that you previously entered.

#### Proposed changelog entry for your changes:

* SEO: Expose advanced_seo_description post meta in the REST API, and enable Gutenberg plugin.

~Required for https://github.com/Automattic/wp-calypso/pull/30033~ (merged)
Supersedes #11323