### PR TITLE
Contact Info: Add schema attributes to the allowed attributes 

### DIFF
--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -49,8 +49,7 @@ function jetpack_contact_info_add_schema_attributes( $tags, $context_type ) {
 	if ( $context_type !== 'post' ) {
 		return $tags;
 	}
-	l( 'jetpack_contact_info_add_schema_attributes' );
-	l( $tags );
+
 	$scheme_attribues = array(
 		'itemscope' => true,
 		'itemtype' => true,

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -38,3 +38,34 @@ function jetpack_contact_info_block_load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
 	return $content;
 }
+
+add_filter( 'wp_kses_allowed_html', 'jetpack_contact_info_add_schema_attributes', 10, 2 );
+/**
+ * Add the schema attributes to post data. So that it can be saved as expected.
+ * @param array  $tags      Allowed tags by.
+ * @param string $context_type Context type (explicit).
+ */
+function jetpack_contact_info_add_schema_attributes( $tags, $context_type ) {
+	if ( $context_type !== 'post' ) {
+		return $tags;
+	}
+	l( 'jetpack_contact_info_add_schema_attributes' );
+	l( $tags );
+	$scheme_attribues = array(
+		'itemscope' => true,
+		'itemtype' => true,
+		'itemprop' => true,
+		'content' => true
+	);
+	if ( ! is_array( $tags['div'] ) ) {
+		$tags['div'] = array();
+	}
+	$tags['div'] = array_merge( $tags['div'], $scheme_attribues );
+
+	if ( ! is_array( $tags['a'] ) ) {
+		$tags['a'] = array();
+	}
+	$tags['a'] = array_merge( $tags['a'], $scheme_attribues );
+
+	return $tags;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently in only when the user has unfiltered_html permissions are they able to save and contact info block.
Other wise we end up with block that doesn't have all the schema permissions.

This PR fixes this by making sure the new schema attributes are able to be saved when the data passes though wp_kses function.

Fixes https://github.com/Automattic/wp-calypso/issues/30608

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* 

#### Testing instructions:
* Enable the jetpack beta blocks and build the PR
* Login as user that has the role of author or any other user that doesn't have `unfiltered_html` capabilities. https://codex.wordpress.org/Roles_and_Capabilities#unfiltered_html 
* Add the contact info block. Populate it. Save the block. 
* Notice when you refresh the page that the post saves as expected and you are able to edit the block. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bug fix: Allows authors to edit the contact info block.
