### PR TITLE
Fusion: Sync likes settings with WPCOM

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -507,9 +507,25 @@ class Jetpack_Likes_Settings {
 							<input type="radio" class="code" name="jetpack_reblogs_enabled" value="off" <?php checked( $this->reblogs_enabled_sitewide(), false ); ?> />
 							<?php esc_html_e( 'Don\'t show the Reblog button on posts', 'jetpack' ); ?>
 						</label>
-						<div>
+					</div>
 				</td>
 			</tr>
+			<!-- WPCOM only: Comment Likes -->
+			<?php if ( ! $this->in_jetpack ) : ?>
+				<tr>
+					<th scope="row">
+						<label><?php esc_html_e( 'Comment Likes are', 'jetpack' ); ?></label>
+					</th>
+					<td>
+						<div>
+							<label>
+								<input type="checkbox" class="code" name="jetpack_comment_likes_enabled" value="1" <?php checked( $this->is_comments_enabled(), true ); ?> />
+								<?php esc_html_e( 'On for all comments', 'jetpack' ); ?>
+							</label>
+						</div>
+					</td>
+				</tr>
+			<?php endif; ?>
 		<?php endif; ?>
 		</tbody> <?php // closes the tbody attached to sharing_show_buttons_on_row_start... ?>
 	<?php
@@ -531,6 +547,25 @@ class Jetpack_Likes_Settings {
 		 * @param bool $option Are Reblogs enabled sitewide.
 		 */
 		return (bool) apply_filters( 'wpl_reblogging_enabled_sitewide', ! get_option( 'disabled_reblogs' ) );
+	}
+
+	/**
+	 * Used for WPCOM ONLY. Comment likes are in their own module in Jetpack.
+	 * Returns if comment likes are enabled. Defaults to 'off'
+	 * @return boolean true if we should show comment likes, false if not
+	 */
+	function is_comments_enabled() {
+		/**
+		 * Filters whether Comment Likes are enabled.
+		 * true if enabled, false if not.
+		 *
+		 * @module likes
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $option Are Comment Likes enabled sitewide.
+		 */
+		return (bool) apply_filters( 'jetpack_comment_likes_enabled', get_option( 'jetpack_comment_likes_enabled', false ) );
 	}
 
 	/**
@@ -578,6 +613,20 @@ class Jetpack_Likes_Settings {
 				delete_option( 'disabled_reblogs' );
 				break;
 		}
+
+		// WPCOM only: Comment Likes
+		if( ! $this->in_jetpack ) {
+			$new_comments_state = !empty( $_POST['jetpack_comment_likes_enabled'] ) ? $_POST['jetpack_comment_likes_enabled'] : false;
+			switch( (bool) $new_comments_state ) {
+				case true:
+					update_option( 'jetpack_comment_likes_enabled', 1 );
+				break;
+				case false:
+				default:
+					update_option( 'jetpack_comment_likes_enabled', 0 );
+				break;
+			}
+		}
 	}
 
 	/**
@@ -598,8 +647,6 @@ class Jetpack_Likes_Settings {
 	 * If sharedaddy is not loaded, we don't have the "Show buttons on" yet, so we need to add that since it affects likes too.
 	 */
 	function admin_settings_showbuttonon_init() {
-		?>
-		<?php
 		/** This action is documented in modules/sharedaddy/sharing.php */
 		echo apply_filters( 'sharing_show_buttons_on_row_start', '<tr valign="top">' );
 		?>

--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -395,7 +395,7 @@ class Jetpack_Likes_Settings {
 		}
 
 		// Ensure it's always an array (even if not previously empty or scalar)
-		$setting['show'] = !empty( $sharing['global']['show'] ) ? (array) $sharing['global']['show'] : array();
+		$setting['show'] = ! empty( $sharing['global']['show'] ) ? (array) $sharing['global']['show'] : array();
 
 		/**
 		 * Filters where the Likes are displayed.
@@ -559,7 +559,7 @@ class Jetpack_Likes_Settings {
 		 * Filters whether Comment Likes are enabled.
 		 * true if enabled, false if not.
 		 *
-		 * @module likes
+		 * @module comment-likes
 		 *
 		 * @since 2.2.0
 		 *
@@ -574,10 +574,10 @@ class Jetpack_Likes_Settings {
 	function admin_settings_callback() {
 		// We're looking for these, and doing a dance to set some stats and save
 		// them together in array option.
-		$new_state = !empty( $_POST['wpl_default'] ) ? $_POST['wpl_default'] : 'on';
+		$new_state = ! empty( $_POST['wpl_default'] ) ? $_POST['wpl_default'] : 'on';
 		$db_state  = $this->is_enabled_sitewide();
 
-		$reblogs_new_state = !empty( $_POST['jetpack_reblogs_enabled'] ) ? $_POST['jetpack_reblogs_enabled'] : 'on';
+		$reblogs_new_state = ! empty( $_POST['jetpack_reblogs_enabled'] ) ? $_POST['jetpack_reblogs_enabled'] : 'on';
 		$reblogs_db_state = $this->reblogs_enabled_sitewide();
 		/** Default State *********************************************************/
 
@@ -615,8 +615,8 @@ class Jetpack_Likes_Settings {
 		}
 
 		// WPCOM only: Comment Likes
-		if( ! $this->in_jetpack ) {
-			$new_comments_state = !empty( $_POST['jetpack_comment_likes_enabled'] ) ? $_POST['jetpack_comment_likes_enabled'] : false;
+		if ( ! $this->in_jetpack ) {
+			$new_comments_state = ! empty( $_POST['jetpack_comment_likes_enabled'] ) ? $_POST['jetpack_comment_likes_enabled'] : false;
 			switch( (bool) $new_comments_state ) {
 				case true:
 					update_option( 'jetpack_comment_likes_enabled', 1 );


### PR DESCRIPTION
A few minor updates needed to bring this file in sync with WPCOM (or, rather, to bring WPCOM in sync with Jetpack, as the corresponding WPCOM patch is much larger).

See D24273-code

#### Changes proposed in this Pull Request:
* This patch adds the WPCOM-specific comment likes functions and HTML to this file, gated behind a check to make sure we don't run them in Jetpack, where this functionality is provided by the Comment Likes module.
* Drive-by fix of a bad closing `<div>` and a vestigial close / open PHP tag.

#### Testing instructions:
* Smoke test post likes and comment likes, including the admin Sharing section, and make sure there are no errors or regressions.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog entry needed
