### PR TITLE
Revert "Sync: add fastcgi finish request to sync (#11146)"

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -201,11 +201,6 @@ class Jetpack_Sync_Sender {
 			ignore_user_abort( true );
 		}
 
-		/* Don't make the request block till we finish, if possible. */
-		if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
-			fastcgi_finish_request();
-		}
-
 		$checkout_start_time = microtime( true );
 
 		$buffer = $queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This reverts commit f899f22d3914ca004c2a37c5f66fa9d5c116df45, as this is causing issues with the code editor in wp-admin (under Appearance > Editor or Plugins > Editor).

See 3518-gh-jpop-issues for more info.

#### Testing instructions:

* Start with this branch in an environment that supports `fastcgi_finish_request` (e.g. an Atomic site)
* Go to Appearance > Editor.
* Try to edit any of the files and save your changes.
* The file should get changed with no error.

#### Proposed changelog entry for your changes:

* Sync: fix bug in WordPress' code editor, for sites using PHP 7 with `fastcgi_finish_request` enabled.
