### PR TITLE
Using remove_filter to remove Related Posts if block is visible

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -394,6 +394,16 @@ EOT;
 		<?php
 		$html = ob_get_clean();
 
+		$target_to_dom_priority = has_filter(
+			'the_content',
+			array( $this, 'filter_add_target_to_dom' )
+		);
+		remove_filter(
+			'the_content',
+			array( $this, 'filter_add_target_to_dom' ),
+			$target_to_dom_priority
+		);
+
 		/*
 		Below is a hack to get the block content to render correctly.
 


### PR DESCRIPTION
Removes the Related Posts section that is added below the_content if a Related Posts block is already a part of the content. The current solution seems to be a CSS hack that does not work properly.

#### Testing instructions:
* Create a post using the Gutenberg editor and add the Related Posts block to it. Do you see the Related Posts section below the post or not? (They should not.)
* Does the Related Posts section below the post appear if you don't include the Related Posts block? (They should.)
* Create a post using the Classic editor. Do Related Posts appear below the post? (They should.)

#### Proposed changelog entry for your changes:
If the Related Post block is a part of a post's content, the Related Posts section below it will now be removed for that post.