### PR TITLE
Sync: Re-adds the fastcgi_finish_request()

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -188,6 +188,12 @@ class Jetpack_Sync_Sender {
 		return array( $items_to_send, $skipped_items_ids, $items, microtime( true ) - $start_time );
 	}
 
+	private function fastcgi_finish_request() {
+		if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
+			fastcgi_finish_request();
+		}
+	}
+
 	public function do_sync_for_queue( $queue ) {
 
 		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
@@ -199,6 +205,11 @@ class Jetpack_Sync_Sender {
 		// bad state
 		if ( function_exists( 'ignore_user_abort' ) ) {
 			ignore_user_abort( true );
+		}
+
+		/* Don't make the request block till we finish, if possible. */
+		if ( Jetpack_Constants::is_true( 'REST_REQUEST' ) || Jetpack_Constants::is_true('XMLRPC_REQUEST' ) ) {
+			$this->fastcgi_finish_request();
 		}
 
 		$checkout_start_time = microtime( true );


### PR DESCRIPTION
It was reverted in https://github.com/Automattic/jetpack/pull/11338


#### Changes proposed in this Pull Request:
* This PR adds the fastcgi_finish_request when it is available but only for REST and XMLRPC requests.
* This makes the api responses still fast. 

#### Testing instructions:
- Doe sit cause a regression? When editing files in the wp-admin interface?
- Does it speed up the rest api responses ? both .com and the regular rest requests? 

#### Proposed changelog entry for your changes:
* Sync: Re-adds the fastcgi_finish_request()
