### PR TITLE
Related Post Settings: Sync Copy with Proposed Copy in Calypso

### DIFF
--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -68,7 +68,7 @@ class RelatedPostsComponent extends React.Component {
 				>
 					<p className="jp-form-setting-explanation">
 						{ __(
-							'The following settings will impact all related posts on your site, except for those you created via the block editor:'
+							"These settings won't apply to related posts added using the block editor."
 						) }
 					</p>
 					<ModuleToggle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Companion PR to Automattic/wp-calypso#30713

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Update the Related Posts copy as stated [here](https://github.com/Automattic/wp-calypso/pull/30713#pullrequestreview-203081199) to the one suggested [here](https://github.com/Automattic/wp-calypso/pull/30713#discussion_r256001611). 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This change is visible at the `/wp-admin/admin.php?page=jetpack#/traffic` route. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None, it's only a minor copy change
