### PR TITLE
Fixes the CDN asset path filter breaking i18n.

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -92,7 +92,14 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return string The expected relative path for the CDN-ed URL.
 	 */
 	public static function fix_script_relative_path( $relative, $src ) {
-		return substr( $src, 1 + strpos( $src, '/wp-includes/' ) );
+		$strpos = strpos( $src, '/wp-includes/' );
+
+		// We only treat URLs that have wp-includes in them. Cases like language textdomains
+		// can also use this filter, they don't need to be touched because they are local paths.
+		if ( false === $strpos ) {
+			return $relative;
+		}
+		return substr( $src, 1 + $strpos );
 	}
 
 	/**


### PR DESCRIPTION
Before we would use a certain filter to allow the CDN to properly load files from the wp-includes folder, and the i18n to properly use the path for loading translations. But this fails when loading textdomain for JavaScript because the process uses the same filter. This change fixes that by only applying the filter for URLs that actually contain wp-includes.

<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Narrows down the CDN filter usage to only files that it's intended to be used with.

#### Testing instructions:
Testing is hard for now because you need a plugin that requires a textdomain that's different than `default`. Jetpack does it, but you won't be seeing any difference because we are requiring the file anyway for legacy support.
The easiest way to test is to apply a filter after Jetpack to see what actual path WordPress tries to use for enqueueing the JSON file:
```
add_filter( 'load_script_textdomain_relative_path', function( $relative, $src ) {
	error_log( $relative );
	return $relative;
}, 99999, 2 );

```
Without this PR when opening Jetpack's settings page you will see that the file that WordPress is trying to include is a malformed URL instead of a local path, like this:
`ttps://dev71.lousy.site/wp-content/plugins/jetpack/_inc/build/admin.js`
Which throws off the md5 hash and nothing gets loaded.

With the PR enabled you should see the regular relative path:
`_inc/build/admin.js`

It makes sense to also test all Gutenberg blocks that have translations - they should be loading fine. Just switch your site to a language of choice and open Gutenberg.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed a minor problem affecting translations in the new Gutenberg editor.