### PR TITLE
WPCOM API: Change switch_likes_status post meta to be 0 if likes are being disabled

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -262,11 +262,8 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'likes_enabled' :
 				/** This filter is documented in modules/likes.php */
 				$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
-				$post_likes_switched    = (bool) get_post_meta( $post->ID, 'switch_like_status', true );
-				$post_likes_enabled = $sitewide_likes_enabled;
-				if ( $post_likes_switched ) {
-					$post_likes_enabled = ! $post_likes_enabled;
-				}
+				$post_likes_switched    = get_post_meta( $post->ID, 'switch_like_status', true );
+				$post_likes_enabled = $post_likes_switched || ( $sitewide_likes_enabled && $post_likes_switched !== '0' );
 				$response[$key] = (bool) $post_likes_enabled;
 				break;
 			case 'sharing_enabled' :

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -537,7 +537,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 		if ( $new ) {
 			if ( $sitewide_likes_enabled ) {
 				if ( false === $likes ) {
-					update_post_meta( $post_id, 'switch_like_status', 1 );
+					update_post_meta( $post_id, 'switch_like_status', 0 );
 				} else {
 					delete_post_meta( $post_id, 'switch_like_status' );
 				}
@@ -552,7 +552,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			if ( isset( $likes ) ) {
 				if ( $sitewide_likes_enabled ) {
 					if ( false === $likes ) {
-						update_post_meta( $post_id, 'switch_like_status', 1 );
+						update_post_meta( $post_id, 'switch_like_status', 0 );
 					} else {
 						delete_post_meta( $post_id, 'switch_like_status' );
 					}

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -615,7 +615,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 		if ( $new ) {
 			if ( $sitewide_likes_enabled ) {
 				if ( false === $likes ) {
-					update_post_meta( $post_id, 'switch_like_status', 1 );
+					update_post_meta( $post_id, 'switch_like_status', 0 );
 				} else {
 					delete_post_meta( $post_id, 'switch_like_status' );
 				}
@@ -630,7 +630,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			if ( isset( $likes ) ) {
 				if ( $sitewide_likes_enabled ) {
 					if ( false === $likes ) {
-						update_post_meta( $post_id, 'switch_like_status', 1 );
+						update_post_meta( $post_id, 'switch_like_status', 0 );
 					} else {
 						delete_post_meta( $post_id, 'switch_like_status' );
 					}

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -586,7 +586,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		if ( $new ) {
 			if ( $sitewide_likes_enabled ) {
 				if ( false === $likes ) {
-					update_post_meta( $post_id, 'switch_like_status', 1 );
+					update_post_meta( $post_id, 'switch_like_status', 0 );
 				} else {
 					delete_post_meta( $post_id, 'switch_like_status' );
 				}
@@ -601,7 +601,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			if ( isset( $likes ) ) {
 				if ( $sitewide_likes_enabled ) {
 					if ( false === $likes ) {
-						update_post_meta( $post_id, 'switch_like_status', 1 );
+						update_post_meta( $post_id, 'switch_like_status', 0 );
 					} else {
 						delete_post_meta( $post_id, 'switch_like_status' );
 					}

--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -413,12 +413,9 @@ abstract class SAL_Post {
 	public function is_likes_enabled() {
 		/** This filter is documented in modules/likes.php */
 		$sitewide_likes_enabled = (bool) apply_filters( 'wpl_is_enabled_sitewide', ! get_option( 'disabled_likes' ) );
-		$post_likes_switched    = (bool) get_post_meta( $this->post->ID, 'switch_like_status', true );
-		$post_likes_enabled = $sitewide_likes_enabled;
-		if ( $post_likes_switched ) {
-			$post_likes_enabled = ! $post_likes_enabled;
-		}
-		return (bool) $post_likes_enabled;
+		$post_likes_switched    = get_post_meta( $this->post->ID, 'switch_like_status', true );
+
+		return $post_likes_switched || ( $sitewide_likes_enabled && $post_likes_switched !== '0' );
 	}
 
 	public function is_sharing_enabled() {


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/9076, the `switch_like_status` meta was changed to operate as a ternary: Unset means follow the global setting, 0 means disable likes regardless of global setting, and 1 means enable likes regardless of global setting.

This fixed a long-standing glitch where post likes that were set to override the global setting would be inverted if the site setting was toggled. So for example, if likes were disabled globally but enabled on a particular post, after enabling likes globally, likes would be disabled on that post.

This is all well and good but was never synced back to WPCOM or the v1.* API! So let's do that. Spinning this up here so Fusion can do its magic.

Likes module changes are on deck for WPCOM in D24273-code .

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Update the post API endpoints to both read and write `switch_like_status` as a ternary
* This logic is now the same as already exists in the Likes module

#### Testing instructions:

1. In the Calypso Editor (not Gutenberg), edit a post on a Jetpack site.
1. Enable and disable likes on a post and verify that they are correctly shown/hidden on the front-end.
1. Request the post info via the API console for versions 1.0, 1.1 and 1.2 of the API and verify that the likes_enabled key matches the post setting (it should be true or false).
1. Set the post's setting to override the global setting (e.g. disable likes if they are enabled globally)
1. Toggle the global setting in Sharing
1. Verify that likes are still correctly shown/hidden on the post and the API results are correct
1. Verify that the checkbox is set correctly in the editor


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* REST API: Fix a bug causing Likes settings on a post to sometimes be flipped
