### PR TITLE
Gutenberg: use 2 methods to get the site fragment.

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -529,6 +529,14 @@ class Jetpack_Gutenberg {
 			? filemtime( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.js' )
 			: JETPACK__VERSION;
 
+		if ( method_exists( 'Jetpack', 'build_raw_urls' ) ) {
+			$site_fragment = Jetpack::build_raw_urls( home_url() );
+		} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+			$site_fragment = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+		} else {
+			$site_fragment = '';
+		}
+
 		wp_enqueue_script(
 			'jetpack-blocks-editor',
 			$editor_script,
@@ -568,7 +576,7 @@ class Jetpack_Gutenberg {
 			array(
 				'available_blocks' => self::get_availability(),
 				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
-				'siteFragment'     => Jetpack::build_raw_urls( home_url() ),
+				'siteFragment'     => $site_fragment,
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #11314.

`build_raw_urls` is not available on WordPress.com, we consequently need an alternative solution on
WordPress.com.

#### Testing instructions:

* Ensure Jetpack is connected
* Go to Posts > Add New
* In your browser console, check for `Jetpack_Editor_Initial_State.siteFragment`
* You should get a value back (a site ID on WordPress.com, a sanitized site URL on Jetpack)

#### Proposed changelog entry for your changes:

* None
