### PR TITLE
Slideshow: Remove View-Side Dependencies

### DIFF
--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -23,12 +23,7 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
-	$dependencies = array(
-		'lodash',
-		'wp-element',
-		'wp-i18n',
-	);
-	Jetpack_Gutenberg::load_assets_as_required( 'slideshow', $dependencies );
+	Jetpack_Gutenberg::load_assets_as_required( 'slideshow' );
 
 	return $content;
 }

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -23,7 +23,11 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'slideshow' );
+	$dependencies = array(
+		'lodash',
+	);
+
+	Jetpack_Gutenberg::load_assets_as_required( 'slideshow', $dependencies );
 
 	return $content;
 }


### PR DESCRIPTION
This PR along with https://github.com/Automattic/wp-calypso/pull/30789 removes all view side dependencies for the Slideshow block. 

#### Testing instructions:

https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-dependencies&branch=fix/slideshow-dependencies