### PR TITLE
Ads: Add search pages to archive toggle

### DIFF
--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -208,7 +208,7 @@ class WordAds_Params {
 			return false;
 		}
 
-		if ( is_archive() && ! $this->options['wordads_display_archive'] ) {
+		if ( ( is_archive() || is_search() ) && ! $this->options['wordads_display_archive'] ) {
 			return false;
 		}
 


### PR DESCRIPTION
Right now search pages are excluded from control via toggles. Since search is essentially a special type of archive page let's roll that into the archive toggle (which is consistent with user expectations).

#### Changes proposed in this Pull Request:

* Adds `is_search()` check into the archive disable belowpost ads toggle.

<img width="459" alt="screen shot 2019-02-14 at 12 04 04 pm" src="https://user-images.githubusercontent.com/273708/52814324-b5601280-3050-11e9-8113-ea46bffc7392.png">

#### Testing instructions:

* With Premium+ Jetpack plan enable Ads module under Jetpack Settings -> Traffic
* Disable `Archive` toggle
* Do a search, e.g. `foo.com/?s=bar`, no ads should appear below post.

**Pre-PR**
<img width="880" alt="screen shot 2019-02-14 at 12 07 23 pm" src="https://user-images.githubusercontent.com/273708/52814487-243d6b80-3051-11e9-9b7e-304a0780d332.png">

**With PR**
<img width="917" alt="screen shot 2019-02-14 at 12 07 36 pm" src="https://user-images.githubusercontent.com/273708/52814494-27385c00-3051-11e9-8e8b-f31983b20966.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Ads: Included search result pages under `Archive` toggle.
