### PR TITLE
Publicize: add a section in Sharing settings pointing users to Calypso

### DIFF
--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -40,11 +40,12 @@ class Jetpack_Publicize {
 		$publicize_ui->in_jetpack = $this->in_jetpack;
 
 		// Jetpack specific checks / hooks
-		if ( $this->in_jetpack) {
+		if ( $this->in_jetpack ) {
 			// if sharedaddy isn't active, the sharing menu hasn't been added yet
 			$active = Jetpack::get_active_modules();
-			if ( in_array( 'publicize', $active ) && !in_array( 'sharedaddy', $active ) )
+			if ( in_array( 'publicize', $active ) && ! in_array( 'sharedaddy', $active ) ) {
 				add_action( 'admin_menu', array( &$publicize_ui, 'sharing_menu' ) );
+			}
 		}
 	}
 

--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -37,6 +37,15 @@ class Jetpack_Publicize {
 
 		require_once dirname( __FILE__ ) . '/publicize/ui.php';
 		$publicize_ui = new Publicize_UI();
+		$publicize_ui->in_jetpack = $this->in_jetpack;
+
+		// Jetpack specific checks / hooks
+		if ( $this->in_jetpack) {
+			// if sharedaddy isn't active, the sharing menu hasn't been added yet
+			$active = Jetpack::get_active_modules();
+			if ( in_array( 'publicize', $active ) && !in_array( 'sharedaddy', $active ) )
+				add_action( 'admin_menu', array( &$publicize_ui, 'sharing_menu' ) );
+		}
 	}
 
 	function jetpack_configuration_load() {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -81,6 +81,14 @@ class Publicize_UI {
 	}
 
 	/**
+	 * styling for the sharing screen and popups
+	 * JS for the options and switching
+	 */
+	function load_assets() {
+		Jetpack_Admin_Page::load_wrapper_styles();
+	}
+
+	/**
 	 * Lists the current user's publicized accounts for the blog
 	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
 	 */

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -61,7 +61,7 @@ class Publicize_UI {
 	}
 
 	function wrapper_admin_page() {
-		Jetpack_Admin_Page::wrap_ui( array( $this, 'management_page' ), array( 'is-wide' => true ) );
+		Jetpack_Admin_Page::wrap_ui( array( $this, 'management_page' ) );
 	}
 
 	/**

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -52,8 +52,8 @@ class Publicize_UI {
 	function sharing_menu() {
 		add_submenu_page(
 			'options-general.php',
-			__( 'Sharing Settings', 'jetpack' ),
-			__( 'Sharing', 'jetpack' ),
+			esc_html__( 'Sharing Settings', 'jetpack' ),
+			esc_html__( 'Sharing', 'jetpack' ),
 			'publish_posts',
 			'sharing',
 			array( $this, 'wrapper_admin_page' )
@@ -70,7 +70,7 @@ class Publicize_UI {
 	function management_page() { ?>
 		<div class="wrap">
 			<div class="icon32" id="icon-options-general"><br /></div>
-			<h1><?php _e( 'Sharing Settings', 'jetpack' ); ?></h1>
+			<h1><?php esc_html_e( 'Sharing Settings', 'jetpack' ); ?></h1>
 
 			<?php
 			/** This action is documented in modules/sharedaddy/sharing.php */
@@ -99,7 +99,7 @@ class Publicize_UI {
 		<h4><?php
 			printf(
 				wp_kses(
-					__( "We've recently made some updates to Publicize. Please visit the <a href='%s'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
+					__( "We've made some updates to Publicize. Please visit the <a href='%s'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
 					array( 'a' => array( 'href' => array() ) )
 				),
 				esc_url( publicize_calypso_url() )

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -34,10 +34,73 @@ class Publicize_UI {
 			return;
 		}
 
+		// assets (css, js)
+		if ( $this->in_jetpack ) {
+			add_action( 'load-settings_page_sharing', array( $this, 'load_assets' ) );
+		}
 		add_action( 'admin_head-post.php', array( $this, 'post_page_metabox_assets' ) );
 		add_action( 'admin_head-post-new.php', array( $this, 'post_page_metabox_assets' ) );
 
+		// management of publicize (sharing screen, ajax/lightbox popup, and metabox on post screen)
+		add_action( 'pre_admin_screen_sharing', array( $this, 'admin_page' ) );
 		add_action( 'post_submitbox_misc_actions', array( $this, 'post_page_metabox' ) );
+	}
+
+	/**
+	 * If the ShareDaddy plugin is not active we need to add the sharing settings page to the menu still
+	 */
+	function sharing_menu() {
+		add_submenu_page(
+			'options-general.php',
+			__( 'Sharing Settings', 'jetpack' ),
+			__( 'Sharing', 'jetpack' ),
+			'publish_posts',
+			'sharing',
+			array( $this, 'wrapper_admin_page' )
+		);
+	}
+
+	function wrapper_admin_page() {
+		Jetpack_Admin_Page::wrap_ui( array( $this, 'management_page' ), array( 'is-wide' => true ) );
+	}
+
+	/**
+	 * Management page to load if Sharedaddy is not active so the 'pre_admin_screen_sharing' action exists.
+	 */
+	function management_page() { ?>
+		<div class="wrap">
+			<div class="icon32" id="icon-options-general"><br /></div>
+			<h1><?php _e( 'Sharing Settings', 'jetpack' ); ?></h1>
+
+			<?php
+			/** This action is documented in modules/sharedaddy/sharing.php */
+			do_action( 'pre_admin_screen_sharing' );
+			?>
+
+		</div> <?php
+	}
+
+	/**
+	 * Lists the current user's publicized accounts for the blog
+	 * looks exactly like Publicize v1 for now, UI and functionality updates will come after the move to keyring
+	 */
+	function admin_page() {
+		?>
+		<h2 id="publicize"><?php esc_html_e( 'Publicize', 'jetpack' ) ?></h2>
+		<p><?php esc_html_e( 'Connect social media services to automatically share new posts.', 'jetpack' ) ?></p>
+		<h4><?php
+			printf(
+				wp_kses(
+					__( "We've recently made some updates to Publicize. Please visit the <a href='%s'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
+					array( 'a' => array( 'href' => array() ) )
+				),
+				esc_url( publicize_calypso_url() )
+			);
+			?>
+		</h4>
+
+		<a href="<?php echo esc_url( publicize_calypso_url() ); ?>" class="button button-primary"><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a small section for Publicize in WP Admin > Settings > Sharing with only text explaining that Publicize settings are now in Calypso plus a link to the Sharing settings page in Calypso

<img width="1047" alt="captura de pantalla 2019-02-14 a la s 17 25 37" src="https://user-images.githubusercontent.com/1041600/52815549-bce9e080-307d-11e9-933c-e037b5eb5a90.png">
