### PR TITLE
Business Hours Block: allow folks to filter the block's content

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -37,11 +37,18 @@ function jetpack_business_hours_should_use_schema() {
  */
 function jetpack_business_hours_opening_tag( $attributes ) {
 	if ( jetpack_business_hours_should_use_schema() ) {
-		$itemtype = apply_filters( 'jetpack_business_hours_item_type', 'https://schema.org/LocalBusiness' );
+		/**
+		 * Filters the type of item that the business hours are associated with.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $itemtype Defaults to https://schema.org/LocalBusiness
+		 */
+		$itemtype = apply_filters( 'jetpack_business_hours_itemtype', 'https://schema.org/LocalBusiness' );
 		return sprintf(
 			'<dl class="jetpack-business-hours %s" itemscope itemtype="%s">',
 			! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : '',
-			$itemtype
+			esc_url( $itemtype )
 		);
 	}
 	return sprintf(
@@ -89,7 +96,7 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$start_of_week = (int) get_option( 'start_of_week', 0 );
 	$time_format   = get_option( 'time_format' );
 	$today         = current_time( 'D' );
-	$content       = jetpack_business_hours_opening_tag();
+	$content       = jetpack_business_hours_opening_tag( $attributes );
 
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -13,6 +13,65 @@ jetpack_register_block_type(
 );
 
 /**
+ * Returns a filterable answer to the question: should we use a standardized schema in the business hours mark-up?
+ *
+ * @return bool
+ */
+function jetpack_business_hours_should_use_schema() {
+	/**
+	 * Filters if business hours html should use schema from https://schema.org/openingHours
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $should_use_schema Defaults to true
+	 */
+	return apply_filters( 'jetpack_business_hours_should_use_schema', true );
+}
+
+/**
+ * Returns the opening html tag for the business hours block.
+ *
+ * @param array $attributes Attributes for the business hours block established in the block editor.
+ *
+ * @return string The opening tag for the business hours markup.
+ */
+function jetpack_business_hours_opening_tag( $attributes ) {
+	if ( jetpack_business_hours_should_use_schema() ) {
+		$itemtype = apply_filters( 'jetpack_business_hours_item_type', 'https://schema.org/LocalBusiness' );
+		return sprintf(
+			'<dl class="jetpack-business-hours %s" itemscope itemtype="%s">',
+			! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : '',
+			$itemtype
+		);
+	}
+	return sprintf(
+		'<dl class="jetpack-business-hours %s">',
+		! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : ''
+	);
+}
+
+/**
+ * Returns the opening `<span>` tag for a set of opening - closing hours for a given day.
+ *
+ * @param string $day eg 'Mon'
+ * @param int $opens timestamp
+ * @param int $closes timestamp
+ *
+ * @return string The tag
+ */
+function jetpack_business_hours_opening_tag_for_days_hours( $day, $opens, $closes ) {
+	if ( jetpack_business_hours_should_use_schema() ) {
+		return sprintf(
+			'<span itemprop="openingHours" content="%s %s-%s">',
+			substr( $day, 0, 2 ),
+			date( 'H:i', $opens ),
+			date( 'H:i', $closes )
+		);
+	}
+	return '<span>';
+}
+
+/**
  * Dynamic rendering of the block.
  *
  * @param array  $attributes Array containing the business hours block attributes.
@@ -30,10 +89,7 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$start_of_week = (int) get_option( 'start_of_week', 0 );
 	$time_format   = get_option( 'time_format' );
 	$today         = current_time( 'D' );
-	$content       = sprintf(
-		'<dl class="jetpack-business-hours %s">',
-		! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : ''
-	);
+	$content       = jetpack_business_hours_opening_tag();
 
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 
@@ -51,11 +107,12 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		$days_hours = '';
 
 		foreach ( $hours as $hour ) {
-			if ( ! $hour['opening'] && $hour['closing'] ) {
+			if ( empty( $hour['opening'] ) || empty( $hour['closing'] ) ) {
 				continue;
 			}
 			$opening    = strtotime( $hour['opening'] );
 			$closing    = strtotime( $hour['closing'] );
+			$days_hours .= jetpack_business_hours_opening_tag_for_days_hours( $day, $opening, $closing );
 			$days_hours .= sprintf(
 			/* Translators: Business opening hours info. */
 				_x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),
@@ -81,11 +138,11 @@ function jetpack_business_hours_render( $attributes, $content ) {
 					) );
 				}
 			}
-			$days_hours .= '<br />';
+			$days_hours .= '</span><br />';
 		}
 
 		if ( empty( $days_hours ) ) {
-			$days_hours = esc_html__( 'CLOSED', 'jetpack' );
+			$days_hours = esc_html__( 'Closed', 'jetpack' );
 		}
 		$content .= $days_hours;
 		$content .= '</dd>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Provides a filter allowing folks to change the output of the business hours block
* We initially hoped provide schema data within the html, but that will require some more work
* I've updated https://github.com/Automattic/wp-calypso/issues/30594 with more details


#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get this branch going locally with docker, or try it out on Jurassic.ninja
* In your site's post editor, add a business hours block
* Ensure the block looks good on the front end
* Try filtering the content within your theme or in a helper plugin

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* none
