### PR TITLE
Travis: Do not test building on a built branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ matrix:
     dist: precise
   - language: node_js
     env: WP_TRAVISCI="yarn lint"
-  - language: node_js
+  - if: branch !~ /(^branch-.*-built)/
+    language: node_js
     env: WP_TRAVISCI="yarn test-dangerci-and-adminpage"
   # We can't test PHP 7.3 with WP_BRANCH=previous just yet, as previous is currently 4.9.9.
   # Running PHP 7.3 tests on 4.9.9 will fail as it does not include https://core.trac.wordpress.org/changeset/44166#file6.


### PR DESCRIPTION
This helps us when doing release testing by avoiding false failures, which will allow us to keep failed builds as situations needing attention.

#### Changes proposed in this Pull Request:

* Add a conditional to the danger build that requires building.

#### Testing instructions:
* Did Travis run the danger build?

#### Proposed changelog entry for your changes:

* n/a
