### PR TITLE
Mailchimp: whitelist the option

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -56,6 +56,7 @@ class Jetpack_Options {
 				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 				'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
 				'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
+				'mailchimp',				   // (string) Mailchimp keyring data, for mailchimp block.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -56,7 +56,7 @@ class Jetpack_Options {
 				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 				'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
 				'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
-				'mailchimp',				   // (string) Mailchimp keyring data, for mailchimp block.
+				'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 			);
 
 		case 'private' :

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -100,6 +100,7 @@ class Jetpack_Sync_Defaults {
 		'wp_mobile_app_promos',
 		'monitor_receive_notifications',
 		'post_by_email_address',
+		'jetpack_mailchimp',
 		'jetpack_protect_key',
 		'jetpack_protect_global_whitelist',
 		'jetpack_sso_require_two_step',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -158,6 +158,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wp_mobile_app_promos'                 => 'pineapple',
 			'monitor_receive_notifications'        => 'pineapple',
 			'post_by_email_address'                => 'pineapple',
+			'jetpack_mailchimp'                    => '{}',
 			'jetpack_protect_key'                  => 'pineapple',
 			'jetpack_protect_global_whitelist'     => 'pineapple',
 			'jetpack_sso_require_two_step'         => '1',


### PR DESCRIPTION
# The bug

Block always shows as not connected

# Details

I understand the rationale for removing the shortcode, but that line was pretty critical for it to work:
https://github.com/Automattic/jetpack/pull/11322/files#diff-33c60b45474dc43cc068c0d86e333d21L58

See, block / shortcode is a small part of this feature. The bulk of work is keeping the Oauth connection and the proper options. and actually connectiong with mailchimp API.
These are set remotely via WPCOM.
So wpcom is reaching out to the site to change this option.
Now, be removing this whitelisting, the option cannot be set remotely anymore.

This whitelists the shortcode in the other place.

## Testing instructions

1. get a fresh site
2. Connect mailchimp in /me/sharing
3. Select a list
4. Go to your site and try to use the block



