### PR TITLE
Add tracking to the legacy Publicize settings links to Calypso

### DIFF
--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -1,7 +1,7 @@
 /* global jpTracksAJAX, jQuery */
-
 (function( $, jpTracksAJAX ) {
 	window.jpTracksAJAX = window.jpTracksAJAX || {};
+	const debugSet = localStorage.getItem( 'debug' ) === 'dops:analytics';
 
 	window.jpTracksAJAX.record_ajax_event = function ( eventName, eventType, eventProp ) {
 		var data = {
@@ -15,11 +15,17 @@
 		return $.ajax( {
 			type: 'POST',
 			url: jpTracksAJAX.ajaxurl,
-			data: data
+			data: data,
+			success: function( response ) {
+				if ( debugSet ) {
+					// eslint-disable-next-line
+					console.log( 'AJAX tracks event recorded: ', data, response );
+				}
+			}
 		} );
 	};
 
-	$( document ).ready( function () {
+	$( document ).ready( function() {
 		$( 'body' ).on( 'click', '.jptracks a, a.jptracks', function( event ) {
 			// We know that the jptracks element is either this, or its ancestor
 			var $jptracks = $( this ).closest( '.jptracks' );

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -99,15 +99,15 @@ class Publicize_UI {
 		<h4><?php
 			printf(
 				wp_kses(
-					__( "We've made some updates to Publicize. Please visit the <a href='%s'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
-					array( 'a' => array( 'href' => array() ) )
+					__( "We've made some updates to Publicize. Please visit the <a href='%s' class='jptracks' data-jptracks-name='legacy_publicize_settings'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
+					array( 'a' => array( 'href' => array(), 'class' => array(), 'data-jptracks-name' => array() ) )
 				),
 				esc_url( publicize_calypso_url() )
 			);
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( publicize_calypso_url() ); ?>" class="button button-primary"><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
+		<a href="<?php echo esc_url( publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
 		<?php
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds tracking for both the button and text link on Publicize's new links in `/wp-admin/options-general.php?page=sharing`

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Enable Publicize 
2. In your browser console, submit `localStorage.setItem( 'debug', 'dops:analytics' );` to enable debugging tracks
3. Set your console to "preserve logs"
4. Click both the Publicize settings button, and the inline link in the text. 
5. You should see a successful response form the AJAX tracks handler.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*N/A
