### PR TITLE
Contact Info: Make the block dynamic so that we can add the schema.

### DIFF
--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -23,10 +23,9 @@ class Jetpack_Contact_Info_Block {
 	 */
 	public static function render( $attr, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
-
 		return str_replace(
-			'class="wp-block-jetpack-contact-info"',
-			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
+			'class="wp-block-jetpack-contact-info', // Closing " intentionally ommited to that the user can also add the className as expected.
+			'itemprop="location" itemscope itemtype="http://schema.org/Organization" class="wp-block-jetpack-contact-info',
 			$content
 		);
 	}

--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Class Jetpack_Contact_Info_Block
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Helper class that lets us add schema attributes dynamically because they are not something that is store with the content.
+ * Due to the limitations of wp_kses.
+ *
+ * @since 7.1.0
+ */
+class Jetpack_Contact_Info_Block {
+
+	/**
+	 * Adds contact info schema attributes.
+	 *
+	 * @param array  $attr    Array containing the contact info block attributes.
+	 * @param string $content String containing the contact info block content.
+	 *
+	 * @return string
+	 */
+	public static function render( $attr, $content ) {
+		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
+
+		return str_replace(
+			'class="wp-block-jetpack-contact-info"',
+			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
+			$content
+		);
+	}
+
+	/**
+	 * Adds address schema attributes.
+	 *
+	 * @param array  $attr    Array containing the address block attributes.
+	 * @param string $content String containing the address block content.
+	 *
+	 * @return string
+	 */
+	public static function render_address( $attr, $content ) {
+		// Returns empty content if the only attribute set is linkToGoogleMaps.
+		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
+			return '';
+		}
+		$find    = array(
+			'class="wp-block-jetpack-address"',
+			'class="jetpack-address__address',
+			// Closing " left out on purpose - there are multiple address fields and they all need to be updated with the same itemprop.
+			'class="jetpack-address__region"',
+			'class="jetpack-address__city"',
+			'class="jetpack-address__postal"',
+			'class="jetpack-address__country"',
+		);
+		$replace = array(
+			'itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="wp-block-jetpack-address" ',
+			'itemprop="streetAddress" class="jetpack-address__address', // Closing " left out on purpose.
+			'itemprop="addressRegion" class="jetpack-address__region"',
+			'itemprop="addressLocality" class="jetpack-address__city"',
+			'itemprop="postalCode" class="jetpack-address__postal"',
+			'itemprop="addressCountry" class="jetpack-address__country"',
+		);
+
+		return str_replace( $find, $replace, $content );
+	}
+
+	/**
+	 * Helper function that lets us determine if a block has any valid attributes.
+	 *
+	 * @param array $attr Array containing the block attributes.
+	 * @param array $omit Array containing the block attributes that we ignore.
+	 *
+	 * @return string
+	 */
+	public static function has_attributes( $attr, $omit = array() ) {
+		foreach ( $attr as $attribute => $value ) {
+			if ( ! in_array( $attribute, $omit, true ) && ! empty( $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Adds email schema attributes.
+	 *
+	 * @param array  $attr    Array containing the email block attributes.
+	 * @param string $content String containing the email block content.
+	 *
+	 * @return string
+	 */
+	public static function render_email( $attr, $content ) {
+		if ( ! self::has_attributes( $attr ) ) {
+			return '';
+		}
+
+		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
+	}
+
+	/**
+	 * Adds phone schema attributes.
+	 *
+	 * @param array  $attr    Array containing the phone block attributes.
+	 * @param string $content String containing the phone block content.
+	 *
+	 * @return string
+	 */
+	public static function render_phone( $attr, $content ) {
+		if ( ! self::has_attributes( $attr ) ) {
+			return '';
+		}
+
+		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
+	}
+}

--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -40,7 +40,7 @@ class Jetpack_Contact_Info_Block {
 	 */
 	public static function render_address( $attr, $content ) {
 		// Returns empty content if the only attribute set is linkToGoogleMaps.
-		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
+		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps', 'className' ) ) ) {
 			return '';
 		}
 		$find    = array(
@@ -91,7 +91,7 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render_email( $attr, $content ) {
-		$content = self::has_attributes( $attr ) ?
+		$content = self::has_attributes( $attr, array( 'className' ) ) ?
 			str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content ) :
 			'';
 		return $content;
@@ -106,7 +106,7 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render_phone( $attr, $content ) {
-		$content = self::has_attributes( $attr ) ?
+		$content = self::has_attributes( $attr, array( 'className' ) ) ?
 			str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content ) :
 			'';
 		return $content;

--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -92,11 +92,10 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render_email( $attr, $content ) {
-		if ( ! self::has_attributes( $attr ) ) {
-			return '';
-		}
-
-		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
+		$content = self::has_attributes( $attr ) ?
+			str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content ) :
+			'';
+		return $content;
 	}
 
 	/**
@@ -108,10 +107,9 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render_phone( $attr, $content ) {
-		if ( ! self::has_attributes( $attr ) ) {
-			return '';
-		}
-
-		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
+		$content = self::has_attributes( $attr ) ?
+			str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content ) :
+			'';
+		return $content;
 	}
 }

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -39,18 +39,22 @@ jetpack_register_block(
 );
 
 /**
- * Contact info block registration/dependency declaration.
+ * Class Jetpack_Contact_Info_Block
  *
- * @param array  $attr    Array containing the contact info block attributes.
- * @param string $content String containing the contact info block content.
+ * Helper class that lets us add schema attributes dynamically because they are not something that we store in the post table.
  *
- * @return string
  */
-
 class Jetpack_Contact_Info_Block {
 
 	static $omit = array();
-
+	/**
+	 * Contact info block registration/dependency declaration.
+	 *
+	 * @param array  $attr    Array containing the contact info block attributes.
+	 * @param string $content String containing the contact info block content.
+	 *
+	 * @return string
+	 */
 	static function render( $attr, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
 		if( $content )
@@ -61,7 +65,7 @@ class Jetpack_Contact_Info_Block {
 	}
 
 	static function render_address( $attr, $content ) {
-		if ( ! self::has_some_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
+		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
 			return ''; // nothing to see here
 		}
 		$find = array(
@@ -83,7 +87,21 @@ class Jetpack_Contact_Info_Block {
 		return str_replace( $find, $replace, $content );
 	}
 
-	static function has_some_attributes( $attr, $omit = array() ) {
+	static function render_email( $attr, $content ) {
+		if ( ! self::has_attributes( $attr ) ) {
+			return ''; // nothing to see here
+		}
+		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
+	}
+
+	static function render_phone( $attr, $content ) {
+		if ( ! self::has_attributes( $attr ) ) {
+			return ''; // nothing to see here
+		}
+		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
+	}
+
+	static function has_attributes( $attr, $omit = array() ) {
 		foreach ( $attr as $attribute => $value ) {
 			if ( ! in_array( $attribute, $omit ) && ! empty( $value )  )  {
 				return true;
@@ -91,20 +109,4 @@ class Jetpack_Contact_Info_Block {
 		}
 		return false;
 	}
-
-	static function render_email( $attr, $content ) {
-		if ( ! self::has_some_attributes( $attr ) ) {
-			return ''; // nothing to see here
-		}
-		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
-	}
-
-	static function render_phone( $attr, $content ) {
-		if ( ! self::has_some_attributes( $attr ) ) {
-			return ''; // nothing to see here
-		}
-		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
-	}
-
-
 }

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -10,20 +10,32 @@
 jetpack_register_block(
 	'jetpack/contact-info',
 	array(
-		'render_callback' => 'jetpack_contact_info_block_load_assets',
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render' )
 	)
 );
-jetpack_register_block(
-	'jetpack/email',
-	array( 'parent' => array( 'jetpack/contact-info' ) )
-);
+
 jetpack_register_block(
 	'jetpack/address',
-	array( 'parent' => array( 'jetpack/contact-info' ) )
+	array(
+		'parent' => array( 'jetpack/contact-info' ),
+	    'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_address' )
+	)
 );
+
+jetpack_register_block(
+	'jetpack/email',
+	array(
+		'parent' => array( 'jetpack/contact-info' ),
+	    'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_email' )
+	)
+);
+
 jetpack_register_block(
 	'jetpack/phone',
-	array( 'parent' => array( 'jetpack/contact-info' ) )
+	array(
+		'parent' => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_phone' )
+	)
 );
 
 /**
@@ -34,7 +46,65 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_contact_info_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
-	return $content;
+
+class Jetpack_Contact_Info_Block {
+
+	static $omit = array();
+
+	static function render( $attr, $content ) {
+		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
+		if( $content )
+		return str_replace(
+			'class="wp-block-jetpack-contact-info"',
+			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
+			$content );
+	}
+
+	static function render_address( $attr, $content ) {
+		if ( ! self::has_some_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
+			return ''; // nothing to see here
+		}
+		$find = array(
+			'class="wp-block-jetpack-address"',
+			'class="jetpack-address__address',// Closing " left out on purpose
+			'class="jetpack-address__region"',
+			'class="jetpack-address__city"',
+			'class="jetpack-address__postal"',
+			'class="jetpack-address__country"',
+		);
+		$replace = array(
+			'itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="wp-block-jetpack-address" ',
+			'itemprop="streetAddress" class="jetpack-address__address', // Closing " left out on purpose
+			'itemprop="addressRegion" class="jetpack-address__region"',
+			'itemprop="addressLocality" class="jetpack-address__city"',
+			'itemprop="postalCode" class="jetpack-address__postal"',
+			'itemprop="addressCountry" class="jetpack-address__country"',
+		);
+		return str_replace( $find, $replace, $content );
+	}
+
+	static function has_some_attributes( $attr, $omit = array() ) {
+		foreach ( $attr as $attribute => $value ) {
+			if ( ! in_array( $attribute, $omit ) && ! empty( $value )  )  {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static function render_email( $attr, $content ) {
+		if ( ! self::has_some_attributes( $attr ) ) {
+			return ''; // nothing to see here
+		}
+		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
+	}
+
+	static function render_phone( $attr, $content ) {
+		if ( ! self::has_some_attributes( $attr ) ) {
+			return ''; // nothing to see here
+		}
+		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
+	}
+
+
 }

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -41,14 +41,13 @@ jetpack_register_block(
 /**
  * Class Jetpack_Contact_Info_Block
  *
- * Helper class that lets us add schema attributes dynamically because they are not something that we store in the post table.
+ * Helper class that lets us add schema attributes dynamically because they are not something that is store with the content
  *
  */
 class Jetpack_Contact_Info_Block {
 
-	static $omit = array();
 	/**
-	 * Contact info block registration/dependency declaration.
+	 * Adds contact info schema attributes
 	 *
 	 * @param array  $attr    Array containing the contact info block attributes.
 	 * @param string $content String containing the contact info block content.
@@ -64,6 +63,14 @@ class Jetpack_Contact_Info_Block {
 			$content );
 	}
 
+	/**
+	 * Adds address schema attributes
+	 *
+	 * @param array  $attr    Array containing the address block attributes.
+	 * @param string $content String containing the address block content.
+	 *
+	 * @return string
+	 */
 	static function render_address( $attr, $content ) {
 		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
 			return ''; // nothing to see here
@@ -87,6 +94,14 @@ class Jetpack_Contact_Info_Block {
 		return str_replace( $find, $replace, $content );
 	}
 
+	/**
+	 * Adds email schema attributes
+	 *
+	 * @param array  $attr    Array containing the email block attributes.
+	 * @param string $content String containing the email block content.
+	 *
+	 * @return string
+	 */
 	static function render_email( $attr, $content ) {
 		if ( ! self::has_attributes( $attr ) ) {
 			return ''; // nothing to see here
@@ -94,6 +109,14 @@ class Jetpack_Contact_Info_Block {
 		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
 	}
 
+	/**
+	 * Adds phone schema attributes
+	 *
+	 * @param array  $attr    Array containing the phone block attributes.
+	 * @param string $content String containing the phone block content.
+	 *
+	 * @return string
+	 */
 	static function render_phone( $attr, $content ) {
 		if ( ! self::has_attributes( $attr ) ) {
 			return ''; // nothing to see here
@@ -101,6 +124,14 @@ class Jetpack_Contact_Info_Block {
 		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
 	}
 
+	/**
+	 * Helper function that lets us determine if a block has any valid attributes.
+	 *
+	 * @param array  $attr Array containing the block attributes.
+	 * @param array $omit  Array containing the block attributes that we ignore.
+	 *
+	 * @return string
+	 */
 	static function has_attributes( $attr, $omit = array() ) {
 		foreach ( $attr as $attribute => $value ) {
 			if ( ! in_array( $attribute, $omit ) && ! empty( $value )  )  {

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -10,135 +10,31 @@
 jetpack_register_block(
 	'jetpack/contact-info',
 	array(
-		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render' )
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render' ),
 	)
 );
 
 jetpack_register_block(
 	'jetpack/address',
 	array(
-		'parent' => array( 'jetpack/contact-info' ),
-		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_address' )
+		'parent'          => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_address' ),
 	)
 );
 
 jetpack_register_block(
 	'jetpack/email',
 	array(
-		'parent' => array( 'jetpack/contact-info' ),
-		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_email' )
+		'parent'          => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_email' ),
 	)
 );
 
 jetpack_register_block(
 	'jetpack/phone',
 	array(
-		'parent' => array( 'jetpack/contact-info' ),
-		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_phone' )
+		'parent'          => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_phone' ),
 	)
 );
-
-/**
- * Class Jetpack_Contact_Info_Block
- *
- * Helper class that lets us add schema attributes dynamically because they are not something that is store with the content
- *
- */
-class Jetpack_Contact_Info_Block {
-
-	/**
-	 * Adds contact info schema attributes
-	 *
-	 * @param array  $attr    Array containing the contact info block attributes.
-	 * @param string $content String containing the contact info block content.
-	 *
-	 * @return string
-	 */
-	static function render( $attr, $content ) {
-		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
-
-		return str_replace(
-			'class="wp-block-jetpack-contact-info"',
-			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
-			$content );
-	}
-
-	/**
-	 * Adds address schema attributes
-	 *
-	 * @param array  $attr    Array containing the address block attributes.
-	 * @param string $content String containing the address block content.
-	 *
-	 * @return string
-	 */
-	static function render_address( $attr, $content ) {
-		// return empty content if the only attribute set is linkToGoogleMaps
-		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
-			return '';
-		}
-		$find = array(
-			'class="wp-block-jetpack-address"',
-			'class="jetpack-address__address', // Closing " left out on purpose - there are multiple address fields and they all need to be updated with the same itemprop
-			'class="jetpack-address__region"',
-			'class="jetpack-address__city"',
-			'class="jetpack-address__postal"',
-			'class="jetpack-address__country"',
-		);
-		$replace = array(
-			'itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="wp-block-jetpack-address" ',
-			'itemprop="streetAddress" class="jetpack-address__address', // Closing " left out on purpose
-			'itemprop="addressRegion" class="jetpack-address__region"',
-			'itemprop="addressLocality" class="jetpack-address__city"',
-			'itemprop="postalCode" class="jetpack-address__postal"',
-			'itemprop="addressCountry" class="jetpack-address__country"',
-		);
-		return str_replace( $find, $replace, $content );
-	}
-
-	/**
-	 * Adds email schema attributes
-	 *
-	 * @param array  $attr    Array containing the email block attributes.
-	 * @param string $content String containing the email block content.
-	 *
-	 * @return string
-	 */
-	static function render_email( $attr, $content ) {
-		if ( ! self::has_attributes( $attr ) ) {
-			return ''; // nothing to see here
-		}
-		return str_replace( 'href="mailto:', 'itemprop="email" href="mailto:', $content );
-	}
-
-	/**
-	 * Adds phone schema attributes
-	 *
-	 * @param array  $attr    Array containing the phone block attributes.
-	 * @param string $content String containing the phone block content.
-	 *
-	 * @return string
-	 */
-	static function render_phone( $attr, $content ) {
-		if ( ! self::has_attributes( $attr ) ) {
-			return ''; // nothing to see here
-		}
-		return str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content );
-	}
-
-	/**
-	 * Helper function that lets us determine if a block has any valid attributes.
-	 *
-	 * @param array  $attr Array containing the block attributes.
-	 * @param array $omit  Array containing the block attributes that we ignore.
-	 *
-	 * @return string
-	 */
-	static function has_attributes( $attr, $omit = array() ) {
-		foreach ( $attr as $attribute => $value ) {
-			if ( ! in_array( $attribute, $omit ) && ! empty( $value )  )  {
-				return true;
-			}
-		}
-		return false;
-	}
-}
+require_once 'class-jetpack-contact-info-block.php';

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -18,7 +18,7 @@ jetpack_register_block(
 	'jetpack/address',
 	array(
 		'parent' => array( 'jetpack/contact-info' ),
-	    'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_address' )
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_address' )
 	)
 );
 
@@ -26,7 +26,7 @@ jetpack_register_block(
 	'jetpack/email',
 	array(
 		'parent' => array( 'jetpack/contact-info' ),
-	    'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_email' )
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_email' )
 	)
 );
 
@@ -56,7 +56,7 @@ class Jetpack_Contact_Info_Block {
 	 */
 	static function render( $attr, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
-		if( $content )
+		
 		return str_replace(
 			'class="wp-block-jetpack-contact-info"',
 			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
@@ -77,7 +77,7 @@ class Jetpack_Contact_Info_Block {
 		}
 		$find = array(
 			'class="wp-block-jetpack-address"',
-			'class="jetpack-address__address',// Closing " left out on purpose
+			'class="jetpack-address__address', // Closing " left out on purpose - there are multiple address fields and they all need to be updated with the same itemprop
 			'class="jetpack-address__region"',
 			'class="jetpack-address__city"',
 			'class="jetpack-address__postal"',

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -56,7 +56,7 @@ class Jetpack_Contact_Info_Block {
 	 */
 	static function render( $attr, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
-		
+
 		return str_replace(
 			'class="wp-block-jetpack-contact-info"',
 			'class="wp-block-jetpack-contact-info" itemprop="location" itemscope itemtype="http://schema.org/Organization"',
@@ -72,8 +72,9 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	static function render_address( $attr, $content ) {
+		// return empty content if the only attribute set is linkToGoogleMaps
 		if ( ! self::has_attributes( $attr, array( 'linkToGoogleMaps' ) ) ) {
-			return ''; // nothing to see here
+			return '';
 		}
 		$find = array(
 			'class="wp-block-jetpack-address"',


### PR DESCRIPTION
This PR add the scheme to the block via the render_callback.

<!--- Provide a general summary of your changes in the Title above -->

Fixes [Automattic/wp-calypso#30608](https://github.com/Automattic/wp-calypso/issues/30608)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dynamically add the schema attributes to the contact info block.

#### Testing instructions:
Build the following Calypso PR with sdk
Use the PR created in https://github.com/Automattic/wp-calypso/pull/30815
Add a new contact info block. 
Use the https://search.google.com/structured-data/testing-tool/u/0/ to valida that it produced the expected schema.

#### Proposed change log entry for your changes:
Dynamically add the schema attributes.
