### PR TITLE
Publicize: Sync Classic Editor Notices with WP.com

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -372,7 +372,7 @@ jQuery( function($) {
 	padding-left: 1em;
 }
 .publicize__notice-warning {
-	display: inline-block;
+	display: block;
 	padding: 7px 10px;
 	margin: 5px 0;
 	border-left-width: 4px;
@@ -380,17 +380,13 @@ jQuery( function($) {
 	font-size: 12px;
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
 }
-.publicize__sharing-settings {
+.publicize-external-link {
 	display: block;
 	text-decoration: none;
 	margin-top: 8px;
 }
-.publicize__sharing-settings:after {
-	content: "\f504";
-	font: normal 18px/.5em dashicons;
-	speak: none;
-	margin-left: 5px;
-	vertical-align: middle;
+.publicize-external-link__text {
+	text-decoration: underline;
 }
 #publicize-title:before {
 	content: "\f237";
@@ -414,7 +410,7 @@ jQuery( function($) {
 .wpas-twitter-length-limit {
 	color: red;
 }
-.publicize-disabled-service-message .dashicons {
+.publicize__notice-warning .dashicons {
 	font-size: 16px;
 	text-decoration: none;
 }
@@ -488,16 +484,21 @@ jQuery( function($) {
 						foreach ( $must_reauth as $connection_name ) {
 							?>
 							<span class="notice-warning publicize__notice-warning">
-				                <?php
-				                printf( esc_html__(
-					                'Your %s connection needs to be reauthenticated to continue working – head to Sharing to take care of it.',
-							'jetpack'
-				                ), $connection_name );
-				                ?>
+								<?php
+									/* translators: %s is the name of a Pubilicize service like "LinkedIn" */
+									printf( esc_html__(
+										'Your %s connection needs to be reauthenticated to continue working – head to Sharing to take care of it.',
+										'jetpack'
+									), $connection_name );
+								?>
 								<a
-										class="publicize__sharing-settings"
-										href="<?php echo publicize_calypso_url() ?>"
-								><?php esc_html_e( 'Go to Sharing settings', 'jetpack' ) ?></a>
+									class="publicize-external-link"
+									href="<?php echo publicize_calypso_url() ?>"
+									target="_blank"
+								>
+									<span class="publicize-external-link__text"><?php esc_html_e( 'Go to Sharing settings', 'jetpack' ); ?></span>
+									<span class="dashicons dashicons-external"></span>
+								</a>
 							</span>
 							<?php
 						}
@@ -523,18 +524,20 @@ jQuery( function($) {
 					}
 
 				?>
-					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
 				<?php if ( $has_google_plus ) : ?>
-					<div class="notice inline notice-warning publicize-disabled-service-message">
-						<p>
-							<strong><?php esc_html_e( 'Google+ support is being removed', 'jetpack' ); ?></strong>
-							<a href="javascript:void(0)" id="jetpack-gplus-deprecated-notice">
-								<?php esc_html_e( 'Why?', 'jetpack' ); ?>
-								<span class="dashicons dashicons-info"></span>
-							</a>
-						</p>
-					</div>
+					<span class="notice-warning publicize__notice-warning">
+						<?php esc_html_e( 'Google+ support is being removed', 'jetpack' ); ?>
+						<a
+							href="javascript:void(0)"
+							id="jetpack-gplus-deprecated-notice"
+							class="publicize-external-link"
+						>
+							<span class="publicize-external-link__text"><?php esc_html_e( 'Why?', 'jetpack' ); ?></span>
+							<span class="dashicons dashicons-info"></span>
+						</a>
+					</span>
 				<?php endif; ?>
+					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
 					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Moves Google+ notice next to LinkedIn notice.
* Style tweaks, consistency.

Syncs code with WordPress.com.

##### Before

<img width="285" alt="screen shot 2019-02-15 at 12 29 00 pm" src="https://user-images.githubusercontent.com/125994/52882681-55836d80-311d-11e9-9102-98f03144eb9a.png">

##### After

<img width="286" alt="screen shot 2019-02-15 at 12 29 19 pm" src="https://user-images.githubusercontent.com/125994/52882682-57e5c780-311d-11e9-9c81-cbd3932b3fe9.png">

#### Testing instructions:
(Only works for Automatticians)

1. Use `JETPACK__SANDBOX_DOMAIN` to configure your test site to talk to your sandbox.
2. Remove all Publicize connections
3. Create a new post in the Classic Editor (don't publish it)
4. In the Classic Editor's Publicize UI, click "Edit"
5. Add a Google+ Connection (sneaky)
6. Save the post as a draft.
7. `git checkout 7.0` ← important
8. On your sandbox, revert `187529`.
9. On your test site, go to Settings → Sharing.
10. Add a LinkedIn Connection.
11. `git checkout sync/publicize-notices-ui`
12. `yarn build` (not sure if this is strictly required)
13. Go to your saved draft post (refresh tab if necessary).
14. You should see the cleaned up notices as shown above.

#### Proposed changelog entry for your changes:
* Publicize notice styling consistency tweaks.