### PR TITLE
Photon: add paypalobjects.com to the list of banned domains.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -280,7 +280,8 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/^chart\.googleapis\.com$/',
 		'/^chart\.apis\.google\.com$/',
 		'/^graph\.facebook\.com$/',
-		'/\.fbcdn\.net$/'
+		'/\.fbcdn\.net$/',
+		'/\.paypalobjects\.com$/',
 	);
 
 	$host = jetpack_photon_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
Fixes #11371


#### Changes proposed in this Pull Request:

Paypalobjects.com (used to render Payment buttons by Paypal) relies on the Akamai CDN, and the CDN creates a redirection when you try to access an image. That trips Photon.

Let's consequently add that domain to the list of domains Photon won't try to serve.

#### Testing instructions:

* Activate Photon on your site.
* Add the following HTML to a post:
```html
<a href="https://wordpress.com">
<img src="https://www.paypalobjects.com/en_US/i/btn/btn_buynow_LG.gif" alt="Buy Now Button" />
</a>
```
* Publish
* Make sure the image is not served by Photon.

#### Proposed changelog entry for your changes:

* Photon: add paypalobjects.com to the list of banned domains.
