### PR TITLE
Short-circuit Asset CDN in AMP responses

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -39,6 +39,17 @@ class Jetpack_Photon_Static_Assets_CDN {
 	public static function cdnize_assets() {
 		global $wp_scripts, $wp_styles, $wp_version;
 
+		/*
+		 * Short-circuit if AMP since not relevant as custom JS is not allowed and CSS is inlined.
+		 * Note that it is not suitable to use the jetpack_force_disable_site_accelerator filter for this
+		 * because it will be applied before the wp action, which is the point at which the queried object
+		 * is available and we know whether the response will be AMP or not. This is particularly important
+		 * for AMP-first (native AMP) pages where there are no AMP-specific URLs.
+		 */
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		/**
 		 * Filters Jetpack CDN's Core version number and locale. Can be used to override the values
 		 * that Jetpack uses to retrieve assets. Expects the values to be returned in an array.
@@ -92,6 +103,12 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return string The expected relative path for the CDN-ed URL.
 	 */
 	public static function fix_script_relative_path( $relative, $src ) {
+
+		// Note relevant in AMP responses. See note above.
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return $relative;
+		}
+
 		$strpos = strpos( $src, '/wp-includes/' );
 
 		// We only treat URLs that have wp-includes in them. Cases like language textdomains


### PR DESCRIPTION
I noticed that when turning on the Asset CDN module that styles were broken in AMP responses. In looking at the AMP plugin's CSS manifest comment I saw that that the Dashicons were were way larger than expected:

```
 35249 B (90%): link#dashicons-css[rel=stylesheet][id=dashicons-css][href=https://c0.wp.com/c/5.0.3/wp-includes/css/dashicons.min.css][type=text/css][media=all]
```

This is due to the fact that the AMP plugin was loading the CSS from the remote URL as opposed to using the local copy. Recall that AMP requires all CSS to be inlined (except for CDN stylesheets). Also, AMP allows a max of 50KB. Since the `data:` URL for the Dashicons font is very large, the AMP plugin will instead try to reference the font file with `https:` instead of the `data:` URL. See previously in #9513. All of this to say, the Asset CDN is breaking this since it fetches the CSS from a remote location. And in the `style[amp-custom]` element I see unexpectedly:

```css
@font-face{font-family:dashicons;src:url("data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAGYMAA4AAAAAowAAAQ..."
```

When there should instead be:

```css
@font-face{font-family:dashicons;src:url("https://example.com/wp-includes/fonts/dashicons.woff") format("woff");
```

The `data:` URL is causing the theme's stylesheet to be excluded:

```
The following stylesheets are too large to be included in style[amp-custom]:
 23967 B (64%): link#twentyseventeen-parent-style-css[rel=stylesheet][id=twentyseventeen-parent-style-css][href=https://amp-jetpack-westonruter.pantheonsite.io/wp-content/themes/twentyseventeen/style.css?ver=1.1][type=text/css][media=all]
Total excluded size: 23,967 bytes (64% of 37,093 total after tree shaking)
```

So the fix is simply to short-circuit the Asset CDN from doing its thing when the response will be an AMP page. As noted in the comments, the Asset CDN is not relevant in AMP because custom JS is not allowed and CSS is inlined. Note also that it is not suitable to use the `jetpack_force_disable_site_accelerator` filter for this because it will be applied before the `wp` action, which is the point at which the queried object is available and we know whether the response will be AMP or not. This is particularly important for AMP-first (native AMP) pages where there are no AMP-specific URLs. For more on that, see #11195.

See #9730 which is the master issue for AMP compatibility.

#### Changes proposed in this Pull Request:

* Short-circuit Asset CDN module in AMP responses.

#### Testing instructions:

0. Activate the Twenty Seventeen theme.
1. Activate the [AMP plugin](https://github.com/ampproject/amp-wp).
2. On the AMP settings screen, turn on Native mode.
3. Enable the Asset CDN module.
4. View the frontend and notice that the page looks broken in terms of styling, and the AMP CSS unexpectedly includes a `data:` URL for the font.  
5. Switch to this branch and notice the styling is no longer broken and the AMP CSS no longer uses the `data:` URL for the Dashicons font.

#### Proposed changelog entry for your changes:

* Add AMP compatibility for the Asset CDN module.