### PR TITLE
Use amp-mathml for beautiful math in AMP responses

### DIFF
--- a/modules/latex.php
+++ b/modules/latex.php
@@ -84,11 +84,27 @@ function latex_entity_decode( $latex ) {
 }
 
 function latex_render( $latex, $fg, $bg, $s = 0 ) {
-	$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
-	$url = esc_url( $url );
-	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
+	if ( Jetpack_AMP_Support::is_amp_request() ) {
+		$markup = sprintf(
+			'<amp-mathml data-formula="%s" inline></amp-mathml>',
+			esc_attr( "$$ $latex $$" )
+		);
+	} else {
+		$url = add_query_arg(
+			array_merge(
+				array( 'latex' => rawurlencode( $latex ) ),
+				compact( 'fg', 'bg', 's' )
+			),
+			'//s0.wp.com/latex.php'
+		);
 
-	return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
+		$markup = sprintf(
+			'<img src="%1$s" alt="%2$s" title="%2$s" class="latex">',
+			esc_url( $url ),
+			str_replace( '\\', '&#92;', esc_attr( $latex ) )
+		);
+	}
+	return $markup;
 }
 
 /**


### PR DESCRIPTION
There is an AMP component specifically for MathML: [`amp-mathml`](https://www.ampproject.org/docs/reference/components/amp-mathml). In AMP responses, the Beautiful Math module should re-use this.

Given a post with the following markup:

```
A mathematical formula is $latex i\hbar\frac{\partial}{\partial t}\left|\Psi(t)\right>=H\left|\Psi(t)\right>$ and it is something that should be rendered properly.
```

In a non-AMP response the result looks like:

> ![image](https://user-images.githubusercontent.com/134745/52905744-d1c1a200-323e-11e9-802e-5fcfe3edcc29.png)

With the changes in this PR, an AMP response now renders as:

> ![image](https://user-images.githubusercontent.com/134745/52905754-fe75b980-323e-11e9-89ff-cd203e6916ca.png)

Notice the superior quality of the mathematical formula due to vector-based rendering in AMP. This works in paired AMP and native AMP modes, as well as in classic mode:

> ![image](https://user-images.githubusercontent.com/134745/52905760-177e6a80-323f-11e9-9441-13c75b5d8083.png)

See #9730 for master issue on AMP compatibility.

#### Changes proposed in this Pull Request:

* Use `amp-mathml` in Beautiful Math module to render mathematical formulas in AMP responses.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate AMP plugin.
* Create a post with the content shown above.
* View a post in AMP (either native, paired, or classic mode).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Use `amp-mathml` in Beautiful Math module to render mathematical formulas in AMP responses.
