### PR TITLE
Mailchimp: Hide Block If No Connection

### DIFF
--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -24,6 +24,9 @@ if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
  * @return string
  */
 function jetpack_mailchimp_block_load_assets( $attr ) {
+	if ( ! jetpack_mailchimp_verify_connection() ) {
+		return null;
+	}
 	$values  = array();
 	$blog_id = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ?
 		get_current_blog_id() : Jetpack_Options::get_option( 'id' );
@@ -85,4 +88,21 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	<?php
 	$html = ob_get_clean();
 	return $html;
+}
+
+/**
+ * Mailchimp connection/list selection verification.
+ *
+ * @return boolean
+ */
+function jetpack_mailchimp_verify_connection() {
+	$option = get_option( 'jetpack_mailchimp' );
+	if ( ! $option ) {
+		return false;
+	}
+	$data = json_decode( $option, true );
+	if ( ! $data ) {
+		return false;
+	}
+	return isset( $data['follower_list_id'], $data['keyring_id'] );
 }


### PR DESCRIPTION
This PR will not render the Mailchimp block if the site doesn't have a Mailchimp connection and list selected. 

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/Automattic/jetpack/issues/11290

#### Testing instructions:

- https://jurassic.ninja/create/?gutenpack&calypsobranch=master&branch=fix/mailchimp-hide-block-if-no-connection
- Connect Jetpack
- In `Settings->Jetpack Constants` enable `JETPACK_BETA_BLOCKS`
- Add Mailchimp block to a post
- Click through to WP.com Sharing page, link to Mailchimp account and select list
- Publish the post and view the published page. Mailchimp block should be visible.
- In WP.com sharing page, set list to `Do not save...`
- Refresh published page. Block should be hidden.
- In WP.com sharing page, choose a list again. Refresh published page and see Block visible again.
- In Wp.com sharing page, Disconnect Mailchimp.
- Refresh published page. Block should again be hidden.
