### PR TITLE
General: Add PHPCS/PHPCBF precommit hooks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
-	<config name="minimum_supported_wp_version" value="4.8" />
+	<config name="minimum_supported_wp_version" value="4.9" />
 	<config name="testVersion" value="5.2-"/>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -30,6 +30,7 @@ function phpcsFilesToFilter( file ) {
 		'_inc/lib/debugger/',
 		'extensions/',
 		'sync/',
+		'class.jetpack-gutenberg.php',
 	];
 
 	if ( -1 !== whitelist.findIndex( filePath => file.startsWith( filePath ) ) ) {

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -24,10 +24,26 @@ function parseGitDiffToPathArray( command ) {
 		.filter( name => name.startsWith( '_inc/client/' ) && /\.jsx?$/.test( name ) );
 }
 
+/**
+ * Provides filter to determine which PHP files to run through phpcs.
+ *
+ * @param {String} file File name of php file modified.
+ * @return {boolean}        If the file matches the whitelist.
+ */
+function phpcsFilesToFilter( file ){
+	if ( file.startsWith( '_inc/lib/debugger/' )
+//		|| file.startsWith( 'jetpack.php' ) // Example for future editions.
+		) {
+		return true;
+	}
+
+	return false;
+}
+
 const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
 const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
 const phpFiles = gitFiles.filter( name => name.endsWith( '.php' ) );
-const phpcsFiles = phpFiles.filter( name => name.startsWith( '_inc/lib/debugger/' ) );
+const phpcsFiles = phpFiles.filter( phpcsFilesToFilter );
 
 dirtyFiles.forEach( file =>
 	console.log(

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -5,6 +5,7 @@
 const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
+let exitCode = 0;
 
 /**
  * Parses the output of a git diff command into file paths.
@@ -103,7 +104,7 @@ if ( toLint.length ) {
 				'If you are aware of them and it is OK, ' +
 				'repeat the commit command with --no-verify to avoid this check.'
 		);
-		process.exit( 1 );
+		exitCode = 1;
 	}
 }
 
@@ -122,7 +123,7 @@ if ( phpLintResult && phpLintResult.status ) {
 			'If you are aware of them and it is OK, ' +
 			'repeat the commit command with --no-verify to avoid this check.'
 	);
-	process.exit( 1 );
+	exitCode = 1;
 }
 
 let phpcbfResult, phpcsResult;
@@ -155,5 +156,7 @@ if ( phpcsResult && phpcsResult.status ) {
 			'repeat the commit command with --no-verify to avoid this check.\n' +
 			"But please don't. Code is poetry."
 	);
-	process.exit( 1 );
+	exitCode = 1;
 }
+
+process.exit( exitCode );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -30,7 +30,6 @@ function phpcsFilesToFilter( file ) {
 	const whitelist = [
 		'_inc/lib/debugger/',
 		'extensions/',
-		'sync/',
 		'class.jetpack-gutenberg.php',
 	];
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -136,7 +136,7 @@ if ( phpcsFiles.length > 0 ) {
 		} );
 	}
 
-	phpcsResult = spawnSync( 'vendor/bin/phpcs', [ ...phpcsFiles ], {
+	phpcsResult = spawnSync( 'composer', [ 'php:lint:errors', ...phpcsFiles ], {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -44,7 +44,7 @@ function phpcsFilesToFilter( file ) {
 function jsFilesToFilter( file ) {
 	if (
 		file.startsWith( '_inc/client/' ) &&
-		/\.jsx?$/.test( name )
+		/\.jsx?$/.test( file )
 	) {
 		return true;
 	}

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,13 +6,8 @@ const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
 
-const gitFiles = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
-	.toString()
-	.split( '\n' )
-	.map( name => name.trim() );
-
 /**
- * Parses the output of a git diff command into javascript file paths.
+ * Parses the output of a git diff command into file paths.
  *
  * @param   {String} command Command to run. Expects output like `git diff --name-only […]`
  * @returns {Array}          Paths output from git command
@@ -20,8 +15,7 @@ const gitFiles = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
 function parseGitDiffToPathArray( command ) {
 	return execSync( command, { encoding: 'utf8' } )
 		.split( '\n' )
-		.map( name => name.trim() )
-		.filter( name => name.startsWith( '_inc/client/' ) && /\.jsx?$/.test( name ) );
+		.map( name => name.trim() );
 }
 
 /**
@@ -41,10 +35,38 @@ function phpcsFilesToFilter( file ) {
 	return false;
 }
 
-const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
-const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
+/**
+ * Provides filter to determine which JS files to run through Prettify and linting.
+ *
+ * @param {String} file File name of js file modified.
+ * @return {boolean}        If the file matches the whitelist.
+ */
+function jsFilesToFilter( file ) {
+	if (
+		file.startsWith( '_inc/client/' ) &&
+		/\.jsx?$/.test( name )
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+const gitFiles = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' ).filter( Boolean );
+const dirtyFiles = parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ).filter( Boolean );
+const jsFiles = gitFiles.filter( jsFilesToFilter );
 const phpFiles = gitFiles.filter( name => name.endsWith( '.php' ) );
 const phpcsFiles = phpFiles.filter( phpcsFilesToFilter );
+
+/**
+ * Filters out unstaged changes so we do not add an entire file without intention.
+ *
+ * @param {String} file File name to check against the dirty list.
+ * @return {boolean}    If the file should be checked.
+ */
+function checkFileAgainstDirtyList( file ) {
+	return -1 === dirtyFiles.indexOf( file );
+}
 
 dirtyFiles.forEach( file =>
 	console.log(
@@ -52,7 +74,7 @@ dirtyFiles.forEach( file =>
 	)
 );
 
-const toPrettify = files.filter( file => ! dirtyFiles.has( file ) );
+const toPrettify = jsFiles.filter( checkFileAgainstDirtyList );
 toPrettify.forEach( file => console.log( `Prettier formatting staged file: ${ file }` ) );
 
 if ( toPrettify.length ) {
@@ -63,7 +85,7 @@ if ( toPrettify.length ) {
 }
 
 // linting should happen after formatting
-const toLint = files;
+const toLint = jsFiles;
 if ( toLint.length ) {
 	const lintResult = spawnSync( './node_modules/.bin/eslint', [ '--quiet', ...toLint ], {
 		shell: true,
@@ -99,11 +121,14 @@ if ( phpLintResult && phpLintResult.status ) {
 }
 
 let phpcbfResult, phpcsResult;
+const toPhpcbf = phpcsFiles.filter( checkFileAgainstDirtyList );
 if ( phpcsFiles.length > 0 ) {
-	phpcbfResult = spawnSync( 'vendor/bin/phpcbf', [ ...phpcsFiles ], {
-		shell: true,
-		stdio: 'inherit',
-	} );
+	if ( toPhpcbf.length > 0 ) {
+		phpcbfResult = spawnSync( 'vendor/bin/phpcbf', [ ...toPhpcbf ], {
+			shell: true,
+			stdio: 'inherit',
+		} );
+	}
 
 	phpcsResult = spawnSync( 'vendor/bin/phpcs', [ ...phpcsFiles ], {
 		shell: true,
@@ -117,11 +142,12 @@ if ( phpcbfResult && phpcbfResult.status ) {
 }
 
 if ( phpcsResult && phpcsResult.status ) {
+	const phpcsStatus = ( 2 === phpcsResult.status ? 'PHPCS reported some problems and could not automatically fix them since there are unstaged changes in the file.\n' : 'PHPCS reported some problems and cannot automatically fix them.\n' );
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),
-		'PHPCS reported some problems and cannot automatically fix them. ' +
+			phpcsStatus +
 			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.' +
+			'repeat the commit command with --no-verify to avoid this check.\n' +
 			"But please don't. Code is poetry."
 	);
 	process.exit( 1 );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -29,6 +29,7 @@ function phpcsFilesToFilter( file ) {
 	const whitelist = [
 		'_inc/lib/debugger/',
 		'extensions/',
+		'sync/',
 	];
 
 	if ( -1 !== whitelist.findIndex( filePath => file.startsWith( filePath ) ) ) {

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -112,6 +112,7 @@ if ( phpcsFiles.length > 0 ) {
 }
 
 if ( phpcbfResult && phpcbfResult.status ) {
+	execSync( `git add ${ phpcsFiles.join( ' ' ) }` );
 	console.log( chalk.yellow( 'PHPCS issues detected and automatically fixed via PHPCBF.' ) );
 }
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -30,10 +30,11 @@ function parseGitDiffToPathArray( command ) {
  * @param {String} file File name of php file modified.
  * @return {boolean}        If the file matches the whitelist.
  */
-function phpcsFilesToFilter( file ){
-	if ( file.startsWith( '_inc/lib/debugger/' )
-//		|| file.startsWith( 'jetpack.php' ) // Example for future editions.
-		) {
+function phpcsFilesToFilter( file ) {
+	if (
+		file.startsWith( '_inc/lib/debugger/' )
+		// || file.startsWith( 'jetpack.php' ) // Example for future editions.
+	) {
 		return true;
 	}
 
@@ -99,29 +100,28 @@ if ( phpLintResult && phpLintResult.status ) {
 
 let phpcbfResult, phpcsResult;
 if ( phpcsFiles.length > 0 ) {
-	phpcbfResult = spawnSync( 'vendor/bin/phpcbf', [...phpcsFiles], {
+	phpcbfResult = spawnSync( 'vendor/bin/phpcbf', [ ...phpcsFiles ], {
 		shell: true,
 		stdio: 'inherit',
 	} );
 
-	phpcsResult = spawnSync( 'vendor/bin/phpcs', [...phpcsFiles], {
+	phpcsResult = spawnSync( 'vendor/bin/phpcs', [ ...phpcsFiles ], {
 		shell: true,
 		stdio: 'inherit',
 	} );
 }
 
 if ( phpcbfResult && phpcbfResult.status ) {
-	console.log(
-		chalk.yellow( 'PHPCS issues detected and automatically fixed via PHPCBF.' ) );
+	console.log( chalk.yellow( 'PHPCS issues detected and automatically fixed via PHPCBF.' ) );
 }
 
 if ( phpcsResult && phpcsResult.status ) {
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),
 		'PHPCS reported some problems and cannot automatically fix them. ' +
-		'If you are aware of them and it is OK, ' +
-		'repeat the commit command with --no-verify to avoid this check.' +
-		"But please don't. Code is poetry."
+			'If you are aware of them and it is OK, ' +
+			'repeat the commit command with --no-verify to avoid this check.' +
+			"But please don't. Code is poetry."
 	);
 	process.exit( 1 );
 }

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -25,10 +25,13 @@ function parseGitDiffToPathArray( command ) {
  * @return {boolean}        If the file matches the whitelist.
  */
 function phpcsFilesToFilter( file ) {
-	if (
-		file.startsWith( '_inc/lib/debugger/' )
-		// || file.startsWith( 'jetpack.php' ) // Example for future editions.
-	) {
+	// If the file path starts with anything like in the array below, it should be linted.
+	const whitelist = [
+		'_inc/lib/debugger/',
+		'extensions/',
+	];
+
+	if ( -1 !== whitelist.findIndex( filePath => file.startsWith( filePath ) ) ) {
 		return true;
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "scripts": {
       "php:compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
-      "php:lint": "composer install && vendor/bin/phpcs -p"
+      "php:lint": "composer install && vendor/bin/phpcs -p",
+      "php:lint:errors": "composer install && vendor/bin/phpcs -p --runtime-set ignore_warnings_on_exit 1"
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 7.0
-Requires at least: 4.8
+Requires at least: 4.9
 Tested up to: 5.0
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.


### PR DESCRIPTION
In an effort to ensure beautiful code and meet coding standards, this PR would run PHPCBF and enforce a clean PHPCS run from anything in the new debugger library (see #10554 )

#### Changes proposed in this Pull Request:
* Adds phpcbf testing.

#### Testing instructions:
* Create a _inc/lib/debugger folder and create some new php files. Have some automatically fixable phpcbf issues (e.g. spacing) and some manual fixes (output `__(` without escaping).
* Ensure you've ran `yarn install` 
* Attempt to commit.
* PHPCBF should fix the spacing and then fail on the manual fix.

#### Proposed changelog entry for your changes:
* None, internal tooling only.
