### PR TITLE
Admin Page: move Carousel settings from Performance to Writing

### DIFF
--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -30,14 +30,9 @@ class Performance extends Component {
 			getModuleOverride: this.props.getModuleOverride,
 		};
 
-		const found = [
-			'photon',
-			'carousel',
-			'videopress',
-			'lazy-images',
-			'photon-cdn',
-			'search',
-		].some( this.props.isModuleFound );
+		const found = [ 'photon', 'videopress', 'lazy-images', 'photon-cdn', 'search' ].some(
+			this.props.isModuleFound
+		);
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;

--- a/_inc/client/performance/media.jsx
+++ b/_inc/client/performance/media.jsx
@@ -4,14 +4,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
 import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
 import { FEATURE_VIDEO_HOSTING_JETPACK, getPlanClass } from 'lib/plans/constants';
-import { FormFieldset, FormLegend, FormLabel, FormSelect } from 'components/forms';
+import { FormLegend } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -22,109 +21,15 @@ import { getSitePlan } from 'state/site';
 import { getModuleOverride } from 'state/modules';
 
 class Media extends React.Component {
-	/**
-	 * Get options for initial state.
-	 *
-	 * @returns {Object} {{carousel_display_exif: Boolean}}
-	 */
-	state = {
-		carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' ),
-	};
-
-	/**
-	 * Update state so toggles are updated.
-	 *
-	 * @param {string} optionName option slug
-	 */
-	updateOptions = optionName => {
-		this.setState(
-			{
-				[ optionName ]: ! this.state[ optionName ],
-			},
-			this.props.updateFormStateModuleOption( 'carousel', optionName )
-		);
-	};
-
-	handleCarouselDisplayExifChange = () => {
-		this.updateOptions( 'carousel_display_exif' );
-	};
-
 	render() {
-		const foundCarousel = this.props.isModuleFound( 'carousel' ),
-			foundVideoPress = this.props.isModuleFound( 'videopress' );
+		const foundVideoPress = this.props.isModuleFound( 'videopress' );
 
-		if ( ! foundCarousel && ! foundVideoPress ) {
+		if ( ! foundVideoPress ) {
 			return null;
 		}
 
-		const isCarouselActive = this.props.getOptionValue( 'carousel' ),
-			videoPress = this.props.module( 'videopress' ),
+		const videoPress = this.props.module( 'videopress' ),
 			planClass = getPlanClass( this.props.sitePlan.product_slug );
-
-		const carouselSettings = (
-			<SettingsGroup
-				hasChild
-				module={ { module: 'carousel' } }
-				support={ {
-					link: 'https://jetpack.com/support/carousel',
-				} }
-			>
-				<FormLegend className="jp-form-label-wide">{ __( 'Images' ) }</FormLegend>
-				<p>
-					{ __(
-						'Create full-screen carousel slideshows for the images in your ' +
-							'posts and pages. Carousel galleries are mobile-friendly and ' +
-							'encourage site visitors to interact with your photos.'
-					) }
-				</p>
-				<ModuleToggle
-					slug="carousel"
-					activated={ isCarouselActive }
-					toggling={ this.props.isSavingAnyOption( 'carousel' ) }
-					toggleModule={ this.props.toggleModuleNow }
-				>
-					<span className="jp-form-toggle-explanation">
-						{ __( 'Display images in a full-screen carousel gallery' ) }
-					</span>
-				</ModuleToggle>
-				<FormFieldset>
-					<CompactFormToggle
-						checked={ this.state.carousel_display_exif }
-						disabled={
-							! isCarouselActive ||
-							this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] )
-						}
-						onChange={ this.handleCarouselDisplayExifChange }
-					>
-						<span className="jp-form-toggle-explanation">
-							{ __( 'Show photo Exif metadata in carousel (when available)' ) }
-						</span>
-					</CompactFormToggle>
-					<FormFieldset>
-						<p className="jp-form-setting-explanation">
-							{ __(
-								'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
-							) }
-						</p>
-					</FormFieldset>
-					<FormLabel>
-						<FormLegend className="jp-form-label-wide">
-							{ __( 'Carousel color scheme' ) }
-						</FormLegend>
-						<FormSelect
-							name={ 'carousel_background_color' }
-							value={ this.props.getOptionValue( 'carousel_background_color' ) }
-							disabled={
-								! isCarouselActive ||
-								this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] )
-							}
-							{ ...this.props }
-							validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }
-						/>
-					</FormLabel>
-				</FormFieldset>
-			</SettingsGroup>
-		);
 
 		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
 			<SettingsGroup
@@ -164,11 +69,9 @@ class Media extends React.Component {
 			<SettingsCard
 				{ ...this.props }
 				header={ __( 'Media' ) }
-				hideButton={ ! foundCarousel }
 				feature={ ! videoPressForcedInactive && FEATURE_VIDEO_HOSTING_JETPACK }
-				saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
+				hideButton
 			>
-				{ foundCarousel && carouselSettings }
 				{ foundVideoPress && videoPressSettings }
 			</SettingsCard>
 		);

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -24,6 +24,7 @@ import ThemeEnhancements from './theme-enhancements';
 import PostByEmail from './post-by-email';
 import { Masterbar } from './masterbar';
 import { isAtomicSite } from 'state/initial-state';
+import WritingMedia from './writing-media';
 
 export class Writing extends React.Component {
 	static displayName = 'WritingSettings';
@@ -39,6 +40,7 @@ export class Writing extends React.Component {
 		};
 
 		const found = [
+			'carousel',
 			'copy-post',
 			'masterbar',
 			'markdown',
@@ -75,6 +77,7 @@ export class Writing extends React.Component {
 					className="jp-settings-description"
 				/>
 
+				{ this.props.isModuleFound( 'carousel' ) && <WritingMedia { ...commonProps } /> }
 				{ this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
 					<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
 				) }

--- a/_inc/client/writing/writing-media.jsx
+++ b/_inc/client/writing/writing-media.jsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldset, FormLegend, FormLabel, FormSelect } from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { getModule } from 'state/modules';
+import { isModuleFound as _isModuleFound } from 'state/search';
+
+class WritingMedia extends Component {
+	/**
+	 * Get options for initial state.
+	 *
+	 * @returns {Object} {{carousel_display_exif: Boolean}}
+	 */
+	state = {
+		carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' ),
+	};
+
+	/**
+	 * Update state so toggles are updated.
+	 *
+	 * @param {string} optionName option slug
+	 */
+	updateOptions = optionName => {
+		this.setState(
+			{
+				[ optionName ]: ! this.state[ optionName ],
+			},
+			this.props.updateFormStateModuleOption( 'carousel', optionName )
+		);
+	};
+
+	handleCarouselDisplayExifChange = () => {
+		this.updateOptions( 'carousel_display_exif' );
+	};
+
+	render() {
+		const foundCarousel = this.props.isModuleFound( 'carousel' );
+
+		if ( ! foundCarousel ) {
+			return null;
+		}
+
+		const isCarouselActive = this.props.getOptionValue( 'carousel' );
+
+		return (
+			<SettingsCard
+				{ ...this.props }
+				header={ __( 'Media' ) }
+				hideButton={ ! foundCarousel }
+				saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
+			>
+				<SettingsGroup
+					hasChild
+					module={ { module: 'carousel' } }
+					support={ {
+						link: 'https://jetpack.com/support/carousel',
+					} }
+				>
+					<p>
+						{ __(
+							'Create full-screen carousel slideshows for the images in your ' +
+								'posts and pages. Carousel galleries are mobile-friendly and ' +
+								'encourage site visitors to interact with your photos.'
+						) }
+					</p>
+					<ModuleToggle
+						slug="carousel"
+						activated={ isCarouselActive }
+						toggling={ this.props.isSavingAnyOption( 'carousel' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Display images in a full-screen carousel gallery' ) }
+						</span>
+					</ModuleToggle>
+					<FormFieldset>
+						<CompactFormToggle
+							checked={ this.state.carousel_display_exif }
+							disabled={
+								! isCarouselActive ||
+								this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] )
+							}
+							onChange={ this.handleCarouselDisplayExifChange }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Show photo Exif metadata in carousel (when available)' ) }
+							</span>
+						</CompactFormToggle>
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">
+								{ __(
+									'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
+								) }
+							</p>
+						</FormFieldset>
+						<FormLabel>
+							<FormLegend className="jp-form-label-wide">
+								{ __( 'Carousel color scheme' ) }
+							</FormLegend>
+							<FormSelect
+								name={ 'carousel_background_color' }
+								value={ this.props.getOptionValue( 'carousel_background_color' ) }
+								disabled={
+									! isCarouselActive ||
+									this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] )
+								}
+								{ ...this.props }
+								validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }
+							/>
+						</FormLabel>
+					</FormFieldset>
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		module: module_name => getModule( state, module_name ),
+		isModuleFound: module_name => _isModuleFound( state, module_name ),
+	};
+} )( withModuleSettingsFormHelpers( WritingMedia ) );


### PR DESCRIPTION
Fixes #11130

#### Changes proposed in this Pull Request:

* Move the Carousel settings from Jetpack > Settings > Performance to Jetpack > Settings > Writing, to match Calypso settings.

#### Testing instructions:

* Go to Jetpack > Settings, and switch between the Performance and Writing tabs.
* All settings should work as before; concentrate on the VideoPress and Carousel settings.

![image](https://user-images.githubusercontent.com/426388/53044678-f9f21080-348b-11e9-82ea-2f4d1933b45f.png)

#### Proposed changelog entry for your changes:

* Admin Page: move Carousel settings from Performance to Writing
