### PR TITLE
Sync: Add new NUX options to whitelisted options

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -139,8 +139,8 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
-		'wpcom_site_type',
-		'wpcom_site_vertical',
+		'site_segment',
+		'site_vertical',
 	);
 
 	public static function get_options_whitelist() {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -139,6 +139,8 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
+		'wpcom_site_type',
+		'wpcom_site_vertical',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,6 +198,8 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
+			'wpcom_site_type'                      => 'pineapple',
+			'wpcom_site_vertical'                  => 'pineapple',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,8 +198,8 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
-			'wpcom_site_type'                      => 'pineapple',
-			'wpcom_site_vertical'                  => 'pineapple',
+			'site_segment'                         => 'pineapple',
+			'site_vertical'                        => 'pineapple',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
This adds a couple of new options we're going to be using for NUX to the list of sync whitelisted options.

Companion PR to D24416-code.

#### Changes proposed in this Pull Request:

* Whitelists the `site_segment` option.
* Whitelists the `site_vertical` option.

#### Testing instructions:

* Checkout this branch.
* Verify tests pass.
* More thorough testing instructions can be found in D24416-code.

#### Proposed changelog entry for your changes:

* Added several NUX options to the sync options whitelist.
