### PR TITLE
PHPCS: Clean up a few warnings and use strict compare on array_search

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -45,8 +45,8 @@ function jetpack_business_hours_render( $attributes, $content ) {
 
 	foreach ( $attributes['hours'] as $day => $hours ) {
 		$content   .= '<dt class="' . esc_attr( $day ) . '">' .
-					   ucfirst( $wp_locale->get_weekday( array_search( $day, $days ) ) ) .
-					   '</dt>';
+					ucfirst( $wp_locale->get_weekday( array_search( $day, $days, true ) ) ) .
+					'</dt>';
 		$content   .= '<dd class="' . esc_attr( $day ) . '">';
 		$days_hours = '';
 


### PR DESCRIPTION
```
FILE: /Users/kraft/code/jetpack/extensions/blocks/business-hours/business-hours.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 48 | WARNING | Found precision alignment of 3 spaces. (WordPress.WhiteSpace.PrecisionAlignment.Found)
 48 | WARNING | Not using strict comparison for array_search; supply true for third argument.
    |         | (WordPress.PHP.StrictInArray.MissingTrueStrict)
 49 | WARNING | Found precision alignment of 3 spaces. (WordPress.WhiteSpace.PrecisionAlignment.Found)
----------------------------------------------------------------------------------------------------------------------------------------------
```

See #11379 for starting to auto-fix/check PHPCS for `extensions` directory. This would make that directory "clean" as a starting point.

#### Changes proposed in this Pull Request:

* Spacing + strict compare on `array_search`

#### Testing instructions:
* Comfirm block displays hours properly.

#### Proposed changelog entry for your changes:
* n/a
