### PR TITLE
Carousel: Don't enable for Slideshow Block

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -390,7 +390,8 @@ class Jetpack_Carousel {
 		}
 		$selected_images = array();
 		foreach ( $matches[0] as $image_html ) {
-			if ( preg_match( '/(wp-image-|data-id=)\"?([0-9]+)\"?/i', $image_html, $class_id ) ) {
+			if ( preg_match( '/(wp-image-|data-id=)\"?([0-9]+)\"?/i', $image_html, $class_id ) &&
+				! preg_match( '/wp-block-jetpack-slideshow_image/', $image_html ) ) {
 				$attachment_id = absint( $class_id[2] );
 				/**
 				 * If exactly the same image tag is used more than once, overwrite it.


### PR DESCRIPTION
The Slideshow block [adds a `data-id`](https://github.com/Automattic/wp-calypso/blob/c782ff5da13931490700a218be88f8c6df43bffb/client/gutenberg/extensions/slideshow/slideshow.js#L112) to each of its images (and will [soon also add a `wp-image-${ id }` class](https://github.com/Automattic/wp-calypso/pull/30878)). Jetpack's Carousel module looks for those; if it finds them, it adds meta data to the corresponding `<img />` tag for the Carousel, and enqueues Carousel relevant CSS and JS. We don't want any of that for the Slideshow block.

Via https://github.com/Automattic/wp-calypso/pull/30878#issuecomment-465557443 -- h/t @sirreal and @jeherve for finding this, and suggesting a solution.

#### Changes proposed in this Pull Request:

Don't enable Carousel for `<img />` tags that have a `wp-block-jetpack-slideshow_image` class set.

#### Testing instructions:

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&branch=update/no-carousel-for-slideshow-block
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`
- Start writing a new post, add a Slideshow, publish and view the post
- Inspect any slideshow image in the element inspector and verify that there are no Carousel meta data (e.g.: `data-permalink`, `data-orig-file`, `data-orig-size`, `data-comments-opened`, `data-image-meta`, `data-image-title`, `data-image-description`, `data-medium-file`, `data-large-file`)
- View the page source, and search for the word `carousel`. Verify that it doesn't appear there (unless you added it to your post :roll_eyes: )
- (For bonus points: Compare that to current `master` and verify that both Carousel meta data is present, as is `carousel/jetpack-carousel.min.js` in the page source.)
- (Extra bonus points if you switch back to this branch, create a post that (also) includes a plain ol' gallery, and verify that that _does_ enable Carousel.)

#### Proposed changelog entry for your changes:

(N/A since we're only introducing the Slideshow block with this release.)
