### PR TITLE
Ad Gutenblock: Move code to blocks path & provide Fusion compatibility

### DIFF
--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -26,7 +26,7 @@ class Jetpack_WordAds_Gutenblock {
 	}
 
 	public static function register() {
-		if ( self::is_wpcom() || self::is_jetpack_module_active() ) {
+		if ( self::is_available() ) {
 			jetpack_register_block(
 				self::BLOCK_NAME,
 				array(

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -5,7 +5,7 @@
  * @since 7.1.0
  *
  * @package Jetpack
-*/
+ */
 class Jetpack_WordAds_Gutenblock {
 	const BLOCK_NAME = 'jetpack/wordads';
 
@@ -13,21 +13,27 @@ class Jetpack_WordAds_Gutenblock {
 		return defined( 'IS_WPCOM' ) && IS_WPCOM;
 	}
 
+	private static function is_jetpack_module_active() {
+		return method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'wordads' );
+	}
+
 	private static function is_available() {
 		if ( self::is_wpcom() ) {
 			return has_any_blog_stickers( array( 'wordads', 'wordads-approved', 'wordads-approved-misfits' ), get_current_blog_id() );
 		}
 
-		return Jetpack::is_module_active( 'wordads' );
+		return self::is_jetpack_module_active();
 	}
 
 	public static function register() {
-		jetpack_register_block(
-			self::BLOCK_NAME,
-			array(
-				'render_callback' => array( 'Jetpack_WordAds_Gutenblock', 'gutenblock_render' ),
-			)
-		);
+		if ( self::is_wpcom() || self::is_jetpack_module_active() ) {
+			jetpack_register_block(
+				self::BLOCK_NAME,
+				array(
+					'render_callback' => array( 'Jetpack_WordAds_Gutenblock', 'gutenblock_render' ),
+				)
+			);
+		}
 	}
 
 	public static function set_availability() {
@@ -38,7 +44,6 @@ class Jetpack_WordAds_Gutenblock {
 		// Make the block available. Just in case it wasn't registed before.
 		Jetpack_Gutenberg::set_extension_available( self::BLOCK_NAME );
 	}
-
 
 	public static function gutenblock_render( $attr ) {
 		global $wordads;
@@ -55,14 +60,14 @@ class Jetpack_WordAds_Gutenblock {
 		// section_id is mostly depricated at this point, but it helps us (devs) keep track of which ads end up where
 		// 6 is to keep track of gutenblock ads
 		$section_id = $wordads->params->blog_id . '6';
-		$align = 'center';
+		$align      = 'center';
 		if ( isset( $attr['align'] ) && in_array( $attr['align'], array( 'left', 'center', 'right' ) ) ) {
 			$align = $attr['align'];
 		}
 		$align = 'align' . $align;
 
 		$ad_tag_ids = $wordads->get_ad_tags();
-		$format = 'mrec';
+		$format     = 'mrec';
 		if ( isset( $attr['format'] ) && in_array( $attr['format'], array_keys( $ad_tag_ids ) ) ) {
 			$format = $attr['format'];
 		}
@@ -74,10 +79,12 @@ class Jetpack_WordAds_Gutenblock {
 	}
 }
 
-add_action( 'init',
+add_action(
+	'init',
 	array( 'Jetpack_WordAds_Gutenblock', 'register' )
 );
 
-add_action( 'jetpack_register_gutenberg_extensions',
+add_action(
+	'jetpack_register_gutenberg_extensions',
 	array( 'Jetpack_WordAds_Gutenblock', 'set_availability' )
 );

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Ads Block.
+ *
+ * @since 7.1.0
+ *
+ * @package Jetpack
+*/
+class Jetpack_WordAds_Gutenblock {
+	const BLOCK_NAME = 'jetpack/wordads';
+
+	private static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
+	}
+
+	private static function is_available() {
+		if ( self::is_wpcom() ) {
+			return has_any_blog_stickers( array( 'wordads', 'wordads-approved', 'wordads-approved-misfits' ), get_current_blog_id() );
+		}
+
+		return Jetpack::is_module_active( 'wordads' );
+	}
+
+	public static function register() {
+		jetpack_register_block(
+			self::BLOCK_NAME,
+			array(
+				'render_callback' => array( 'Jetpack_WordAds_Gutenblock', 'gutenblock_render' ),
+			)
+		);
+	}
+
+	public static function set_availability() {
+		if ( ! self::is_available() ) {
+			Jetpack_Gutenberg::set_extension_unavailable( self::BLOCK_NAME, 'WordAds unavailable' );
+			return;
+		}
+		// Make the block available. Just in case it wasn't registed before.
+		Jetpack_Gutenberg::set_extension_available( self::BLOCK_NAME );
+	}
+
+
+	public static function gutenblock_render( $attr ) {
+		global $wordads;
+
+		/** This filter is already documented in modules/wordads/wordads.php `insert_ad()` */
+		if ( empty( $wordads ) || is_feed() || apply_filters( 'wordads_inpost_disable', false ) ) {
+			return '';
+		}
+
+		if ( ! self::is_wpcom() && $wordads->option( 'wordads_house' ) ) {
+			return $wordads->get_ad( 'inline', 'house' );
+		}
+
+		// section_id is mostly depricated at this point, but it helps us (devs) keep track of which ads end up where
+		// 6 is to keep track of gutenblock ads
+		$section_id = $wordads->params->blog_id . '6';
+		$align = 'center';
+		if ( isset( $attr['align'] ) && in_array( $attr['align'], array( 'left', 'center', 'right' ) ) ) {
+			$align = $attr['align'];
+		}
+		$align = 'align' . $align;
+
+		$ad_tag_ids = $wordads->get_ad_tags();
+		$format = 'mrec';
+		if ( isset( $attr['format'] ) && in_array( $attr['format'], array_keys( $ad_tag_ids ) ) ) {
+			$format = $attr['format'];
+		}
+
+		$height  = $ad_tag_ids[ $format ]['height'];
+		$width   = $ad_tag_ids[ $format ]['width'];
+		$snippet = $wordads->get_ad_snippet( $section_id, $height, $width, 'inline', $wordads->get_solo_unit_css() );
+		return $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
+	}
+}
+
+add_action( 'init',
+	array( 'Jetpack_WordAds_Gutenblock', 'register' )
+);
+
+add_action( 'jetpack_register_gutenberg_extensions',
+	array( 'Jetpack_WordAds_Gutenblock', 'set_availability' )
+);

--- a/modules/shortcodes/wordads.php
+++ b/modules/shortcodes/wordads.php
@@ -20,11 +20,8 @@ class Jetpack_WordAds_Shortcode {
 		if ( empty( $wordads ) ) {
 			return null;
 		}
-		add_shortcode( 'wordads', array( $this, 'wordads_shortcode' ) );
 
-		jetpack_register_block( 'jetpack/wordads', array(
-			'render_callback' => array( $this, 'gutenblock_render' ),
-		) );
+		add_shortcode( 'wordads', array( $this, 'wordads_shortcode' ) );
 	}
 
 	/**
@@ -61,41 +58,6 @@ class Jetpack_WordAds_Shortcode {
 		$html = $wordads->insert_inline_ad( $html );
 
 		return $html;
-	}
-
-	public static function gutenblock_render( $attr ) {
-		global $wordads;
-
-		/** This filter is already documented in modules/wordads/wordads.php `insert_ad()` */
-		if ( is_feed() || apply_filters( 'wordads_inpost_disable', false ) ) {
-			return '';
-		}
-
-		if ( $wordads->option( 'wordads_house' ) ) {
-			return $wordads->get_ad( 'inline', 'house' );
-		}
-
-		// section_id is mostly depricated at this point, but it helps us (devs) keep track of which ads end up where
-		// 6 is to keep track of gutenblock ads
-		$section_id = 0 === $wordads->params->blog_id ?
-			WORDADS_API_TEST_ID :
-			$wordads->params->blog_id . '6';
-
-		$align = 'center';
-		if ( isset( $attr['align'] ) && in_array( $attr['align'], array( 'left', 'center', 'right' ) ) ) {
-			$align = $attr['align'];
-		}
-		$align = 'align' . $align;
-
-		$format = 'mrec';
-		if ( isset( $attr['format'] ) && in_array( $attr['format'], array_keys( WordAds::$ad_tag_ids ) ) ) {
-			$format = $attr['format'];
-		}
-
-		$height  = WordAds::$ad_tag_ids[ $format ]['height'];
-		$width   = WordAds::$ad_tag_ids[ $format ]['width'];
-		$snippet = $wordads->get_ad_snippet( $section_id, $height, $width, 'inline', WordAds::$SOLO_UNIT_CSS );
-		return $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
 	}
 }
 

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -65,6 +65,26 @@ class WordAds {
 	}
 
 	/**
+	 * Returns the ad tag property array for supported ad types.
+	 * @return array      array with ad tags
+	 *
+	 * @since 7.1.0
+	 */
+	function get_ad_tags() {
+		return self::$ad_tag_ids;
+	}
+
+	/**
+	 * Returns the solo css for unit
+	 * @return string the special css for solo units
+	 *
+	 * @since 7.1.0
+	 */
+	function get_solo_unit_css() {
+		return self::$SOLO_UNIT_CSS;
+	}
+
+	/**
 	 * Instantiate the plugin
 	 *
 	 * @since 4.5.0
@@ -87,12 +107,12 @@ class WordAds {
 		require_once WORDADS_ROOT . '/php/params.php';
 		$this->params = new WordAds_Params();
 
-		if ( is_admin() ) {
-			require_once WORDADS_ROOT . '/php/admin.php';
+		if ( $this->should_bail() ) {
 			return;
 		}
 
-		if ( $this->should_bail() ) {
+		if ( is_admin() ) {
+			require_once WORDADS_ROOT . '/php/admin.php';
 			return;
 		}
 


### PR DESCRIPTION
The current approach has two main issues:
- The Shortcodes module needs to be active for the block to be available.
- The file where the block lives is not synced with WordPress.com because ads are quite different on WordPress.com.

So we were thinking:
- We load a new file that registers and renders the block inside the WordAds module.
- This way the block is never registered if the module is off.
- We sync that new file with WordPress.com with Fusion.
- On the WordPress.com side, we load the file whenever we want it (basically after checking for a plan and other wpcom WordAds requirements)

#### Changes proposed in this Pull Request:
* Moved `jetpack_register_block` to separate class in `extensions/block` directory
* Added Fusion compatibility as WP.com and Jetpack implementations of WordAds differ in small, but significant ways

#### Testing instructions

1. Compile Gutenblocks from https://github.com/Automattic/wp-calypso -- master
    1. e.g. `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir="../jetpack/_inc/blocks"`
1. Add `define( 'JETPACK_BETA_BLOCKS', true );` to your `wp-config.php`
1. Enable Ads module (Jetpack Settings -> Traffic)
1. Create new post and search for "WordAds" in the Gutenberg blocks (you should see `Ad`)
    <img width="387" alt="screen shot 2019-02-05 at 12 36 24 pm" src="https://user-images.githubusercontent.com/273708/52308924-b56e5d00-2942-11e9-805e-ca12791c6cb4.png">
1. Add some ads of various sizes and alignment, you should see them in your post 👍
<img width="714" alt="screen shot 2019-02-05 at 12 39 00 pm" src="https://user-images.githubusercontent.com/273708/52309070-1bf37b00-2943-11e9-8a29-b4cf2e90fee4.png">


#### Proposed changelog entry for your changes:
* Added Ads Gutenberg block Fusion support