### PR TITLE
Likes/Fusion: Sync jetpack-likes-settings file to wpcom again

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -249,8 +249,7 @@ class Jetpack_Likes_Settings {
 		// see: p7DVsv-64H-p2
 		$last_modified_time = strtotime( $post->post_modified_gmt );
 
-		// TODO set this to the current date/time immediately before committing
-		$behavior_was_changed_at = strtotime( "2019-02-20 00:00:00" );
+		$behavior_was_changed_at = strtotime( "2019-02-22 00:40:42" );
 
 		if ( $this->in_jetpack || $last_modified_time > $behavior_was_changed_at ) {
 			// the new and improved behavior on Jetpack and recent WPCOM posts:


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/jetpack/pull/11336 as we found we need a few additional changes on the WPCOM side.

See D24273-code

#### Changes proposed in this Pull Request:

* To avoid regressions on WPCOM, we need to check the post modification date and only use the new behavior for posts modified since the code was changed
* This doesn't affect the existing behavior on Jetpack
* Note that this will need one final update when I deploy this on the WPCOM side, to make the timestamps match. The existing timestamp is a placeholder.

#### Testing instructions:
* Smoke test post likes and comment likes, including the admin Sharing section, and make sure there are no errors or regressions.

#### Proposed changelog entry for your changes:

* No changelog needed