### PR TITLE
Dev domains: remove and replace by .test tld.

### DIFF
--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -74,17 +74,17 @@ class Jetpack_Data {
 			'localhost',
 			'localhost.localdomain',
 			'127.0.0.1',
-			'local.wordpress.dev',         // VVV
-			'local.wordpress-trunk.dev',   // VVV
-			'src.wordpress-develop.dev',   // VVV
-			'build.wordpress-develop.dev', // VVV
+			'local.wordpress.test',         // VVV
+			'local.wordpress-trunk.test',   // VVV
+			'src.wordpress-develop.test',   // VVV
+			'build.wordpress-develop.test', // VVV
 		);
 		if ( in_array( $domain, $forbidden_domains ) ) {
 			return new WP_Error( 'fail_domain_forbidden', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', 'jetpack' ), $domain ) );
 		}
 
-		// No .dev or .local domains
-		if ( preg_match( '#\.(dev|local)$#i', $domain ) ) {
+		// No .test or .local domains
+		if ( preg_match( '#\.(test|local)$#i', $domain ) ) {
 			return new WP_Error( 'fail_domain_tld', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', 'jetpack' ), $domain ) );
 		}
 

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -115,10 +115,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_http
 	 */
 	public function test_photon_url_filter_http_http() {
-		$this->apply_custom_domain( 'http://photon.dev' );
+		$this->apply_custom_domain( 'http://photon.test' );
 		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
 
-		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'http://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -128,10 +128,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_http
 	 */
 	public function test_photon_url_filter_http_http_to_http() {
-		$this->apply_custom_domain( 'http://photon.dev' );
+		$this->apply_custom_domain( 'http://photon.test' );
 		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
 
-		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'http://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -141,10 +141,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_http
 	 */
 	public function test_photon_url_filter_http_photonized_http() {
-		$this->apply_custom_domain( 'http://photon.dev' );
-		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg' );
+		$this->apply_custom_domain( 'http://photon.test' );
+		$url = jetpack_photon_url( 'http://photon.test/example.com/img.jpg' );
 
-		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'http://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -154,10 +154,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_http
 	 */
 	public function test_photon_url_filter_http_photonized_https() {
-		$this->apply_custom_domain( 'http://photon.dev' );
-		$url = jetpack_photon_url( 'https://photon.dev/example.com/img.jpg' );
+		$this->apply_custom_domain( 'http://photon.test' );
+		$url = jetpack_photon_url( 'https://photon.test/example.com/img.jpg' );
 
-		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'https://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -167,10 +167,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_http
 	 */
 	public function test_photon_url_filter_http_photonized_http_to_https() {
-		$this->apply_custom_domain( 'http://photon.dev' );
-		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg', array(), 'https' );
+		$this->apply_custom_domain( 'http://photon.test' );
+		$url = jetpack_photon_url( 'http://photon.test/example.com/img.jpg', array(), 'https' );
 
-		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'https://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -180,10 +180,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_network_path
 	 */
 	public function test_photon_url_filter_network_path_http() {
-		$this->apply_custom_domain( '//photon.dev' );
+		$this->apply_custom_domain( '//photon.test' );
 		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
 
-		$this->assertEquals( '//photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( '//photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -193,10 +193,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_network_path
 	 */
 	public function test_photon_url_filter_network_path_http_to_http() {
-		$this->apply_custom_domain( '//photon.dev' );
+		$this->apply_custom_domain( '//photon.test' );
 		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
 
-		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'http://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -206,10 +206,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_network_path
 	 */
 	public function test_photon_url_filter_network_path_photonized_http() {
-		$this->apply_custom_domain( '//photon.dev' );
-		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg' );
+		$this->apply_custom_domain( '//photon.test' );
+		$url = jetpack_photon_url( 'http://photon.test/example.com/img.jpg' );
 
-		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'http://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -219,10 +219,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_network_path
 	 */
 	public function test_photon_url_filter_network_path_photonized_https() {
-		$this->apply_custom_domain( '//photon.dev' );
-		$url = jetpack_photon_url( 'https://photon.dev/example.com/img.jpg' );
+		$this->apply_custom_domain( '//photon.test' );
+		$url = jetpack_photon_url( 'https://photon.test/example.com/img.jpg' );
 
-		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'https://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**
@@ -232,10 +232,10 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 * @group  jetpack_photon_filter_network_path
 	 */
 	public function test_photon_url_filter_network_path_photonized_to_https() {
-		$this->apply_custom_domain( '//photon.dev' );
-		$url = jetpack_photon_url( '//photon.dev/example.com/img.jpg', array(), 'https' );
+		$this->apply_custom_domain( '//photon.test' );
+		$url = jetpack_photon_url( '//photon.test/example.com/img.jpg', array(), 'https' );
 
-		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+		$this->assertEquals( 'https://photon.test/example.com/img.jpg', $url );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The .dev TLD will soon become available to everyone, and we consequently cannot continue to consider it a local test TLD anymore. This commit replaces all .dev references by .test ones.

References:
- https://varyingvagrantvagrants.org/docs/en-US/troubleshooting/dev-tld/
- p3btAN-137-p2
- https://www.blog.google/technology/developers/hello-dev/

#### Testing instructions:

* Do tests pass?
* Can you use Jetpack with a .dev domain? (This may be a bit harder to test)

#### Proposed changelog entry for your changes:

* General: replace all .dev TLD references by .test.
