### PR TITLE
Dashboard: update inactive card styling

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -88,15 +88,12 @@
 
 // conditional styles for content when items are inactive
 .jp-dash-item__is-inactive {
-	.dops-card {
-		background-color: $gray-light;
-	}
 	.dops-section-header__label {
 		padding-right: rem( 8px );
 	}
 	.dops-section-header__label-text {
 		&:before {
-			@include long-content-fade( $size: 8px, $color : $gray-light );
+			@include long-content-fade( $size: 8px, $color : $white );
 		}
 	}
 	.jp-dash-item__description {


### PR DESCRIPTION
Partially addresses #11156

#### Changes proposed in this Pull Request:

* Updates inactive card styling in Jetpack Dashboard.

#### Testing instructions:

* 🔥 Fire up this PR.
* 🏠 Go to Jetpack Dashboard.
* 🔗 Connect Jetpack and select the free plan.
* 👁 Ensure all inactive cards on the Dashboard are not see-through.

#### Before

![image](https://user-images.githubusercontent.com/390760/53243184-013d3800-369f-11e9-9de2-120d97850a47.png)

#### After

<img width="1090" alt="screenshot 2019-02-22 at 12 39 01" src="https://user-images.githubusercontent.com/390760/53243146-e074e280-369e-11e9-8262-6724ec7ffd98.png">

#### Proposed changelog entry for your changes:

* Not worthy of changelog entry.
