### PR TITLE
Tiled Gallery block: Add server render srcset

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -7,27 +7,120 @@
  * @package Jetpack
  */
 
-if (
-	( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-	class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
-) {
-	jetpack_register_block(
-		'jetpack/tiled-gallery',
-		array(
-			'render_callback' => 'jetpack_tiled_gallery_load_block_assets',
-		)
-	);
+/**
+ * Jetpack Tiled Gallery Block class
+ *
+ * @since 7.1
+ */
+class Jetpack_Tiled_Gallery_Block {
+	/* Values for building srcsets */
+	const IMG_SRCSET_WIDTH_MAX  = 2000;
+	const IMG_SRCSET_WIDTH_MIN  = 600;
+	const IMG_SRCSET_WIDTH_STEP = 300;
 
 	/**
-	 * Tiled gallery block registration/dependency declaration.
+	 * Register the block
+	 */
+	public static function register() {
+		jetpack_register_block(
+			'jetpack/tiled-gallery',
+			array(
+				'render_callback' => array( __CLASS__, 'render' ),
+			)
+		);
+	}
+
+	/**
+	 * Tiled gallery block registration
 	 *
 	 * @param array  $attr    Array containing the block attributes.
 	 * @param string $content String containing the block content.
 	 *
 	 * @return string
 	 */
-	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
+	public static function render( $attr, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
+
+		$is_squareish_layout = self::is_squareish_layout( $attr );
+
+		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
+			/**
+			 * This block processes all of the images that are found and builds $find and $replace.
+			 *
+			 * The original img is added to the $find array and the replacement is made and added
+			 * to the $replace array. This is so that the same find and replace operations can be
+			 * made on the entire $content.
+			 */
+			$find    = array();
+			$replace = array();
+
+			foreach ( $images[0] as $image_html ) {
+				if (
+					preg_match( '/data-width="([0-9]+)"/', $image_html, $img_height )
+					&& preg_match( '/data-height="([0-9]+)"/', $image_html, $img_width )
+					&& preg_match( '/src="([^"]+)"/', $image_html, $img_src )
+				) {
+					// Drop img src query string so it can be used as a base toadd photon params
+					// for the srcset.
+					$src_parts   = explode( '?', $img_src[1], 2 );
+					$orig_src    = $src_parts[0];
+					$orig_height = absint( $img_height[1] );
+					$orig_width  = absint( $img_width[1] );
+
+					if ( ! $orig_width || ! $orig_height || ! $orig_src ) {
+						continue;
+					}
+
+					$srcset_parts = array();
+					if ( $is_squareish_layout ) {
+						$min_width = min( self::IMG_SRCSET_WIDTH_MIN, $orig_width, $orig_height );
+						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width, $orig_height );
+
+						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
+							$photonized_src = jetpack_photon_url(
+								$orig_src,
+								array(
+									'resize' => $w . ',' . $w,
+									'strip'  => 'all',
+								)
+							);
+							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';
+							if ( $w >= $max_width ) {
+								break;
+							}
+						}
+					} else {
+						$min_width = min( self::IMG_SRCSET_WIDTH_MIN, $orig_width );
+						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width );
+
+						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
+							$photonized_src = jetpack_photon_url(
+								$orig_src,
+								array(
+									'strip' => 'all',
+									'w'     => $w,
+								)
+							);
+							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';
+							if ( $w >= $max_width ) {
+								break;
+							}
+						}
+					}
+
+					if ( ! empty( $srcset_parts ) ) {
+						$srcset = 'srcset="' . esc_attr( implode( ',', $srcset_parts ) ) . '"';
+
+						$find[]    = $image_html;
+						$replace[] = str_replace( '<img ', '<img ' . $srcset, $image_html );
+					}
+				}
+			}
+
+			if ( ! empty( $find ) ) {
+				$content = str_replace( $find, $replace, $content );
+			}
+		}
 
 		/**
 		 * Filter the output of the Tiled Galleries content.
@@ -40,4 +133,28 @@ if (
 		 */
 		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
 	}
+
+	/**
+	 * Determines whether a Tiled Gallery block uses square or circle images (1:1 ratio)
+	 *
+	 * Layouts are block styles and will be available as `is-style-[LAYOUT]` in the className
+	 * attribute. The default (rectangular) will be omitted.
+	 *
+	 * @param  {Array} $attr Attributes key/value array.
+	 * @return {boolean} True if layout is squareish, otherwise false.
+	 */
+	private static function is_squareish_layout( $attr ) {
+		return isset( $attr['className'] )
+			&& (
+				'is-style-square' === $attr['className']
+				|| 'is-style-circle' === $attr['className']
+			);
+	}
+}
+
+if (
+	( defined( 'IS_WPCOM' ) && IS_WPCOM )
+	|| class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
+) {
+	Jetpack_Tiled_Gallery_Block::register();
 }

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -10,7 +10,7 @@
 /**
  * Jetpack Tiled Gallery Block class
  *
- * @since 7.4
+ * @since 7.3
  */
 class Jetpack_Tiled_Gallery_Block {
 	/* Values for building srcsets */

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -67,6 +67,10 @@ class Jetpack_Tiled_Gallery_Block {
 					$orig_height = absint( $img_height[1] );
 					$orig_width  = absint( $img_width[1] );
 
+					// Because URLs are already "photon", the photon function used short-circuits
+					// before ssl is added. Detect ssl and add is if necessary.
+					$is_ssl = false !== strpos( $src_parts[1], 'ssl=1' );
+
 					if ( ! $orig_width || ! $orig_height || ! $orig_src ) {
 						continue;
 					}
@@ -77,16 +81,17 @@ class Jetpack_Tiled_Gallery_Block {
 						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width, $orig_height );
 
 						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
-							$photonized_src = esc_url(
-								jetpack_photon_url(
-									$orig_src,
-									array(
-										'resize' => $w . ',' . $w,
-										'strip'  => 'all',
-									)
-								)
+							$srcset_src = add_query_arg(
+								array(
+									'resize' => $w . ',' . $w,
+									'strip'  => 'all',
+								),
+								$orig_src
 							);
-							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';
+							if ( $is_ssl ) {
+								$srcset_src = add_query_arg( 'ssl', '1', $srcset_src );
+							}
+							$srcset_parts[] = esc_url( $srcset_src ) . ' ' . $w . 'w';
 							if ( $w >= $max_width ) {
 								break;
 							}
@@ -96,16 +101,17 @@ class Jetpack_Tiled_Gallery_Block {
 						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width );
 
 						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
-							$photonized_src = esc_url(
-								jetpack_photon_url(
-									$orig_src,
-									array(
-										'strip' => 'all',
-										'w'     => $w,
-									)
-								)
+							$srcset_src = add_query_arg(
+								array(
+									'strip' => 'all',
+									'w'     => $w,
+								),
+								$orig_src
 							);
-							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';
+							if ( $is_ssl ) {
+								$srcset_src = add_query_arg( 'ssl', '1', $srcset_src );
+							}
+							$srcset_parts[] = esc_url( $srcset_src ) . ' ' . $w . 'w';
 							if ( $w >= $max_width ) {
 								break;
 							}

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -77,11 +77,13 @@ class Jetpack_Tiled_Gallery_Block {
 						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width, $orig_height );
 
 						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
-							$photonized_src = jetpack_photon_url(
-								$orig_src,
-								array(
-									'resize' => $w . ',' . $w,
-									'strip'  => 'all',
+							$photonized_src = esc_url(
+								jetpack_photon_url(
+									$orig_src,
+									array(
+										'resize' => $w . ',' . $w,
+										'strip'  => 'all',
+									)
 								)
 							);
 							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';
@@ -94,11 +96,13 @@ class Jetpack_Tiled_Gallery_Block {
 						$max_width = min( self::IMG_SRCSET_WIDTH_MAX, $orig_width );
 
 						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
-							$photonized_src = jetpack_photon_url(
-								$orig_src,
-								array(
-									'strip' => 'all',
-									'w'     => $w,
+							$photonized_src = esc_url(
+								jetpack_photon_url(
+									$orig_src,
+									array(
+										'strip' => 'all',
+										'w'     => $w,
+									)
 								)
 							);
 							$srcset_parts[] = $photonized_src . ' ' . $w . 'w';

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -60,7 +60,7 @@ class Jetpack_Tiled_Gallery_Block {
 					&& preg_match( '/data-height="([0-9]+)"/', $image_html, $img_width )
 					&& preg_match( '/src="([^"]+)"/', $image_html, $img_src )
 				) {
-					// Drop img src query string so it can be used as a base toadd photon params
+					// Drop img src query string so it can be used as a base to add photon params
 					// for the srcset.
 					$src_parts   = explode( '?', $img_src[1], 2 );
 					$orig_src    = $src_parts[0];
@@ -112,7 +112,7 @@ class Jetpack_Tiled_Gallery_Block {
 						$srcset = 'srcset="' . esc_attr( implode( ',', $srcset_parts ) ) . '"';
 
 						$find[]    = $image_html;
-						$replace[] = str_replace( '<img ', '<img ' . $srcset, $image_html );
+						$replace[] = str_replace( '<img', '<img ' . $srcset, $image_html );
 					}
 				}
 			}

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -10,7 +10,7 @@
 /**
  * Jetpack Tiled Gallery Block class
  *
- * @since 7.1
+ * @since 7.4
  */
 class Jetpack_Tiled_Gallery_Block {
 	/* Values for building srcsets */

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -1,4 +1,5 @@
-<?php
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
 /**
  * Tiled Gallery block. Depends on the Photon module.
  *
@@ -69,7 +70,7 @@ class Jetpack_Tiled_Gallery_Block {
 
 					// Because URLs are already "photon", the photon function used short-circuits
 					// before ssl is added. Detect ssl and add is if necessary.
-					$is_ssl = false !== strpos( $src_parts[1], 'ssl=1' );
+					$is_ssl = ! empty( $src_parts[1] ) && false !== strpos( $src_parts[1], 'ssl=1' );
 
 					if ( ! $orig_width || ! $orig_height || ! $orig_src ) {
 						continue;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/30118

Add `srcset` to Tiled Gallery blocks. This adds a `srcset` which will provide improved image sizes using photon.

Compainion to https://github.com/Automattic/jetpack/pull/12061

It provides a number of alternatives in the srcset, between a calculated minimum and maximum, with a step. 

Current values:

| Min | Max | Step |
| --- | --- | --- |
| `600px` | `2000px` | `300px` |

There were enough changes that it felt appropriate to rework the simple block registration as part of a class that serves to namespace some functions.

## Questions

Are the minimum and maximum values appropriate? The maximum `2000px` was found to be around the Photon threshold on the image size in bytes.

Is the step appropriate? Should we have more or less alternatives?

## Testing
- Add a tiled gallery
- Publish and view the post on the frontend
- Verify that the original `img[src]` is preserved and correct (should be the same as the `src` in the code editor)
- Verify that the `img[srcset]` looks good
- Verify that the `srcset` results in different image sizes loading at different viewport widths. Note that different browsers may exhibit slightly different behavior.
  - Start with a narrow viewport
  - Watch `img` requests in your network tab. Filter on `/(i[0-2]\.wp\.com)|(files\.wordpress\.com)/` to see only photon requests.
  - Scale the viewport up and watch larger images load.
- Test with lazy images enabled and disabled.

It's very important to test all the different layouts!

Also verify the same behavior in D24729-code for Simple sites.