### PR TITLE
Stats: hide the Stats's widget title SVG in Screen Options.

### DIFF
--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -14,6 +14,10 @@
 			&:not(.js-toggle-stats_dashboard_widget_control) {
 				display: flex;
 				align-items:center;
+
+				span {
+					padding: 0 0.4em;
+				}
 			}
 		}
 
@@ -157,6 +161,15 @@
 			margin: 0;
 			padding: 0;
 			text-align: center;
+		}
+	}
+}
+
+/* Hide the widget title's SVG in the Screen Options tab */
+.metabox-prefs {
+	label[for="jetpack_summary_widget-hide"] {
+		span {
+ 			display: none;
 		}
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7116,7 +7116,10 @@ p {
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
 			$widget_title = sprintf(
-				esc_html__( 'Stats by %s', 'jetpack' ),
+				wp_kses(
+					__( 'Stats <span>by %s</span>', 'jetpack' ),
+					array( 'span' => array() )
+				),
 				Jetpack::get_jp_emblem( true )
 			);
 


### PR DESCRIPTION
Fixes #11265

#### Changes proposed in this Pull Request:

In #10958 I changed the widget title and included a SVG file in there, not thinking that the widget title was also displayed in the Screen Options tab.

WordPress does not currently offer a filter allowing you to change the widget title in Screen Options but not inside the widgets, so I opted to hide that extra part of the widget title with CSS in the Screen Options tab.

#### Testing instructions:

* Apply patch.
* Run `yarn build` (or use JN)
* Visit the main dashboard on a site connected to WordPress.com and with the Stats module active.
* The stats dashboard widget title should not have changed, but it should only say "stats" in the Screen Options tab.

![image](https://user-images.githubusercontent.com/426388/53259172-bf2bea80-36ce-11e9-9566-cd339e46dac9.png)
![image](https://user-images.githubusercontent.com/426388/53259192-c81cbc00-36ce-11e9-8373-f68382b127c1.png)

#### Proposed changelog entry for your changes:

* Stats: do not show the Jetpack logo in the Stats dashboard widget title in the Screen Options tab.