### PR TITLE
Sharing: add alt text to OG tags and Twitter Cards

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -13,6 +13,13 @@ class Jetpack_Twitter_Cards {
 	static function twitter_cards_tags( $og_tags ) {
 		global $post;
 
+		/**
+		 * Maximum alt text length.
+		 *
+		 * @see https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html
+		 */
+		$alt_length = 420;
+
 		if ( post_password_required() ) {
 			return $og_tags;
 		}
@@ -83,6 +90,16 @@ class Jetpack_Twitter_Cards {
 					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $featured[0]['src'] ) );
 				} else {
 					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $featured[0]['src'] ) );
+				}
+
+				// Add the alt tag if we have one.
+				if ( ! empty( $featured[0]['alt_text'] ) ) {
+					// Shorten it if it is too long.
+					if ( strlen( $featured['alt_text'] ) > $alt_length ) {
+						$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $featured[0]['alt_text'], 0, $alt_length ) . '…' );
+					} else {
+						$og_tags['twitter:image:alt'] = esc_attr( $featured[0]['alt_text'] );
+					}
 				}
 			}
 		}

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -95,7 +95,7 @@ class Jetpack_Twitter_Cards {
 				// Add the alt tag if we have one.
 				if ( ! empty( $featured[0]['alt_text'] ) ) {
 					// Shorten it if it is too long.
-					if ( strlen( $featured['alt_text'] ) > $alt_length ) {
+					if ( strlen( $featured[0]['alt_text'] ) > $alt_length ) {
 						$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $featured[0]['alt_text'], 0, $alt_length ) . '…' );
 					} else {
 						$og_tags['twitter:image:alt'] = esc_attr( $featured[0]['alt_text'] );

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -175,6 +175,9 @@ function jetpack_og_tags() {
 		if ( ! empty( $image_info['height'] ) ) {
 			$tags['og:image:height'] = (int) $image_info['height'];
 		}
+		if ( ! empty( $image_info['alt_text'] ) ) {
+			$tags['og:image:alt'] = esc_attr( $image_info['alt_text'] );
+		}
 	}
 
 	// Facebook whines if you give it an empty title
@@ -293,6 +296,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 					if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
 						$image['width']  = $post_image['src_width'];
 						$image['height'] = $post_image['src_height'];
+					}
+					if ( ! empty( $post_image['alt_text'] ) ) {
+						$image['alt_text'] = $post_image['alt_text'];
 					}
 				}
 			}


### PR DESCRIPTION
Follow-up from #11339

Fixes #10593

#### Changes proposed in this Pull Request:

When we get an alt text when inspecting images for a post, we display it in OG tags and Twitter Meta cards, allowing Social Networks and third-parties to build proper previews on their sites using that information.

It's worth noting that we only add that meta information when there is only one image that will be returned in the post; we can't add multiple alt texts in OG or Twitter meta cards as third-parties would not be able to know which alt belongs to which image.

Note: the block editor currently does not always save alt meta data properly, as described here:
https://github.com/WordPress/gutenberg/issues/12913

As such, when testing, you may find that in some cases (like when using the Image block), even though you specify an alt tag it will not appear in Open Graph Meta tags.

#### Testing instructions:

* Apply this branch.
* Make sure that either the Sharing or the Publicize feature is active on your site. 
* Make sure you do not use another plugin that may stop Jetpack from outputting Open Graph Meta tags and / or Twitter Cards.
* Go to Posts > Add New
* In that new draft, add some text and a featured image. When creating the featured image, specify some alt text. Make it long (more than 420 chars).
* Publish your post.
* View source and make sure you see both a `twitter:image:alt` tag (it should be truncated) and a `og:image:alt` tag.
* Edit the post, remove the featured image, and add a new classic block. Insert an image in that classic block and ensure that it includes an alt tag.
* Repeat the steps above with galleries, slideshows. If more than one image appears in the Meta Tags, no alt meta tag should be added.

#### Proposed changelog entry for your changes:
* Sharing: add alt text to Open Graph Meta tags and Twitter Cards
