### PR TITLE
Cron endpoint: change expected return from wp_schedule_single_event

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
@@ -200,6 +200,11 @@ class Jetpack_JSON_API_Cron_Schedule_Endpoint extends Jetpack_JSON_API_Cron_Endp
 		$lock = $this->lock_cron();
 		$next = wp_schedule_single_event( $args['timestamp'], $hook, $arguments );
 		$this->maybe_unlock_cron( $lock );
+		/**
+		 * Note: Before WP 5.1, the return value was either `false` or `null`.
+		 *  With 5.1 and later, the return value is now `false` or `true`.
+		 * We need to account for both.
+		 */
 		return array( 'success' => false !== $next );
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
@@ -200,7 +200,7 @@ class Jetpack_JSON_API_Cron_Schedule_Endpoint extends Jetpack_JSON_API_Cron_Endp
 		$lock = $this->lock_cron();
 		$next = wp_schedule_single_event( $args['timestamp'], $hook, $arguments );
 		$this->maybe_unlock_cron( $lock );
-		return array( 'success' => is_null( $next  ) ? true : false );
+		return array( 'success' => is_null( $next ) || true === $next ? true : false );
 	}
 }
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
@@ -200,7 +200,7 @@ class Jetpack_JSON_API_Cron_Schedule_Endpoint extends Jetpack_JSON_API_Cron_Endp
 		$lock = $this->lock_cron();
 		$next = wp_schedule_single_event( $args['timestamp'], $hook, $arguments );
 		$this->maybe_unlock_cron( $lock );
-		return array( 'success' => is_null( $next ) || true === $next ? true : false );
+		return array( 'success' => false !== $next );
 	}
 }
 


### PR DESCRIPTION
Fixes #11392

#### Changes proposed in this Pull Request:

Starting in WordPress 5.1, `wp_schedule_single_event` will return either true or false, and not null.
Let's update our check to take that into account, while still checking for null, for the folks who may not be running WordPress 5.1 yet.

For reference: https://make.wordpress.org/core/2019/01/23/cron-api-changes-in-wordpress-5-1/

#### Testing instructions:

* Apply the patch on a site connected to WordPress.com.
* Make changes to your site and make sure sync events appear in audit log
* In the Jetpack.com Debug, examine the sync section, trigger a new sync, and ensure it works well.

@enejb Is there a better way we could be testing to make sure the endpoint works well?

#### Proposed changelog entry for your changes:

* WordPress 5.1 Compatibility: update usage of `wp_schedule_single_event` to match changes in WordPress.
