### PR TITLE
woocommerceanalytics: Add product type to events

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -97,6 +97,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 								'pc': '" . esc_js( $product_details['category'] ) . "',
 								'pp': '" . esc_js( $product_details['price'] ) . "',
 								'pq': '" . esc_js( $data_instance['quantity'] ) . "',
+								'pt': '" . esc_js( $product_details['type'] ) . "',
 								'ui': '" . esc_js( $this->get_user_id() ) . "',
 							} );"
 					);
@@ -193,6 +194,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pn': '" . esc_js( $product_details['name'] ) . "',
 				'pc': '" . esc_js( $product_details['category'] ) . "',
 				'pp': '" . esc_js( $product_details['price'] ) . "',
+				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
 			} );"
 		);
@@ -227,6 +229,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pc': '" . esc_js( $product_details['category'] ) . "',
 				'pp': '" . esc_js( $product_details['price'] ) . "',
 				'pq': '" . esc_js( $cart_item['quantity'] ) . "',
+				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
 			} );";
 		}
@@ -258,6 +261,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pc': '" . esc_js( $product_details['category'] ) . "',
 				'pp': '" . esc_js( $product_details['price'] ) . "',
 				'pq': '" . esc_js( $order_item->get_quantity() ) . "',
+				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'oi': '" . esc_js( $order->get_order_number() ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
 			} );";

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -172,6 +172,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			'name'     => $product->get_title(),
 			'category' => $this->get_product_categories_concatenated( $product ),
 			'price'    => $product->get_price(),
+			'type'     => $product->get_type(),
 		);
 	}
 


### PR DESCRIPTION
Add product type to Tracks events for `woocommerceanalytics`

#### Testing instructions:

1. Visit a product page in incognito mode (or logout).
2. See the network request for a Tracks pixel `t.gif`.
3. Make sure the product type, `pt` is included as a property.

![screen shot 2019-02-26 at 10 13 57 am](https://user-images.githubusercontent.com/1922453/53370403-87fd5800-39b2-11e9-9d6d-7582e4ce03bb.png)

#### Proposed changelog entry for your changes:

* Woocommerce Analytics: Include product type with analytics data