### PR TITLE
Contact Info block: do not use a relative path to require file.

### DIFF
--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -37,4 +37,4 @@ jetpack_register_block(
 		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_phone' ),
 	)
 );
-require_once 'class-jetpack-contact-info-block.php';
+require_once dirname( __FILE__ ) . '/class-jetpack-contact-info-block.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #11367 

This avoids errors on WordPress.com (relative paths not allowed).

#### Testing instructions:

* Make sure Beta blocks are enabled on your site.
* Go to Posts > Add New
* Insert a new contact info block
* Make sure it works well and no errors appear in your log.

#### Proposed changelog entry for your changes:

* None
