### PR TITLE
Business Hours Block: adjust schema and remove current time

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -29,7 +29,6 @@ function jetpack_business_hours_render( $attributes, $content ) {
 
 	$start_of_week = (int) get_option( 'start_of_week', 0 );
 	$time_format   = get_option( 'time_format' );
-	$today         = current_time( 'D' );
 	$content       = sprintf(
 		'<dl class="jetpack-business-hours %s">',
 		! empty( $attributes['className'] ) ? esc_attr( $attributes['className'] ) : ''
@@ -38,9 +37,9 @@ function jetpack_business_hours_render( $attributes, $content ) {
 	$days = array( 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' );
 
 	if ( $start_of_week ) {
-		$chunk1              = array_slice( $attributes['hours'], 0, $start_of_week );
-		$chunk2              = array_slice( $attributes['hours'], $start_of_week );
-		$attributes['hours'] = array_merge( $chunk2, $chunk1 );
+		$chunk1              = array_slice( $attributes['days'], 0, $start_of_week );
+		$chunk2              = array_slice( $attributes['days'], $start_of_week );
+		$attributes['days'] = array_merge( $chunk2, $chunk1 );
 	}
 
 	foreach ( $attributes['days'] as $day ) {

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -62,29 +62,6 @@ function jetpack_business_hours_render( $attributes, $content ) {
 				date( $time_format, $opening ),
 				date( $time_format, $closing )
 			);
-
-			if ( $today === $day ) {
-				$now = strtotime( current_time( 'H:i' ) );
-				if ( $now < $opening ) {
-					$days_hours .= '<br />';
-					$days_hours .= esc_html(
-						sprintf(
-							/* Translators: Amount of time until business opens. */
-							_x( 'Opening in %s', 'Amount of time until business opens', 'jetpack' ),
-							human_time_diff( $now, $opening )
-						)
-					);
-				} elseif ( $now >= $opening && $now < $closing ) {
-					$days_hours .= '<br />';
-					$days_hours .= esc_html(
-						sprintf(
-							/* Translators: Amount of time until business closes. */
-							_x( 'Closing in %s', 'Amount of time until business closes', 'jetpack' ),
-							human_time_diff( $now, $closing )
-						)
-					);
-				}
-			}
 			$days_hours .= '<br />';
 		}
 

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -23,7 +23,7 @@ jetpack_register_block(
 function jetpack_business_hours_render( $attributes, $content ) {
 	global $wp_locale;
 
-	if ( empty( $attributes['hours'] ) || ! is_array( $attributes['hours'] ) ) {
+	if ( empty( $attributes['days'] ) || ! is_array( $attributes['days'] ) ) {
 		return $content;
 	}
 
@@ -43,14 +43,14 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		$attributes['hours'] = array_merge( $chunk2, $chunk1 );
 	}
 
-	foreach ( $attributes['hours'] as $day => $hours ) {
-		$content   .= '<dt class="' . esc_attr( $day ) . '">' .
-					ucfirst( $wp_locale->get_weekday( array_search( $day, $days, true ) ) ) .
+	foreach ( $attributes['days'] as $day ) {
+		$content   .= '<dt class="' . esc_attr( $day['name'] ) . '">' .
+					ucfirst( $wp_locale->get_weekday( array_search( $day['name'], $days, true ) ) ) .
 					'</dt>';
-		$content   .= '<dd class="' . esc_attr( $day ) . '">';
+		$content   .= '<dd class="' . esc_attr( $day['name'] ) . '">';
 		$days_hours = '';
 
-		foreach ( $hours as $hour ) {
+		foreach ( $day['hours'] as $hour ) {
 			if ( empty( $hour['opening'] ) || empty( $hour['closing'] ) ) {
 				continue;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11399

#### Changes proposed in this Pull Request:

* This PR adjusts the attribute schema for the business hours block after we merged: https://github.com/Automattic/wp-calypso/pull/30965

* This PR also fixes #11399 by removing any local time calculation. We'll need to handle local time calculation on the client side, and we can address that in a future PR. Props @enejb for reporting.

#### Testing instructions:
- When adding a Business Hours block, ensure it appears correctly on the front end, with no mention of 'opening in x hours' or 'closing in x hours'

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
