### PR TITLE
Publicize: Remove Google+

### DIFF
--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -49,11 +49,6 @@ div#tumblr:before {
 	content: '\f214';
 }
 
-div#google_plus:before {
-	color: #dd4b39;
-	content: '\f206';
-}
-
 div.publicize-service-left:before {
 	font: normal 30px/1 social-logos;
 	vertical-align: middle;

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -13,13 +13,11 @@ class Publicize extends Publicize_Base {
 		add_action( 'wp_ajax_publicize_facebook_options_page', array( $this, 'options_page_facebook' ) );
 		add_action( 'wp_ajax_publicize_twitter_options_page', array( $this, 'options_page_twitter' ) );
 		add_action( 'wp_ajax_publicize_linkedin_options_page', array( $this, 'options_page_linkedin' ) );
-		add_action( 'wp_ajax_publicize_google_plus_options_page', array( $this, 'options_page_google_plus' ) );
 
 		add_action( 'wp_ajax_publicize_tumblr_options_save', array( $this, 'options_save_tumblr' ) );
 		add_action( 'wp_ajax_publicize_facebook_options_save', array( $this, 'options_save_facebook' ) );
 		add_action( 'wp_ajax_publicize_twitter_options_save', array( $this, 'options_save_twitter' ) );
 		add_action( 'wp_ajax_publicize_linkedin_options_save', array( $this, 'options_save_linkedin' ) );
-		add_action( 'wp_ajax_publicize_google_plus_options_save', array( $this, 'options_save_google_plus' ) );
 
 		add_action( 'load-settings_page_sharing', array( $this, 'force_user_connection' ) );
 
@@ -117,7 +115,11 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_all_connections() {
-		return Jetpack_Options::get_option( 'publicize_connections' );
+		$connections = Jetpack_Options::get_option( 'publicize_connections' );
+		if ( isset( $connections['google_plus'] ) ) {
+			unset( $connections['google_plus'] );
+		}
+		return $connections;
 	}
 
 	function get_connections( $service_name, $_blog_id = false, $_user_id = false ) {
@@ -297,7 +299,6 @@ class Publicize extends Publicize_Base {
 			'twitter'     => array(),
 			'linkedin'    => array(),
 			'tumblr'      => array(),
-			'google_plus' => array(),
 		);
 
 		if ( 'all' == $filter ) {
@@ -673,20 +674,12 @@ class Publicize extends Publicize_Base {
 		Publicize_UI::options_page_other( 'linkedin' );
 	}
 
-	function options_page_google_plus() {
-		Publicize_UI::options_page_other( 'google_plus' );
-	}
-
 	function options_save_twitter() {
 		$this->options_save_other( 'twitter' );
 	}
 
 	function options_save_linkedin() {
 		$this->options_save_other( 'linkedin' );
-	}
-
-	function options_save_google_plus() {
-		$this->options_save_other( 'google_plus' );
 	}
 
 	function options_save_other( $service_name ) {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -141,7 +141,7 @@ abstract class Publicize_Base {
 	abstract function get_services( $filter = 'all', $_blog_id = false, $_user_id = false );
 
 	function can_connect_service( $service_name ) {
-		return 'google_plus' !== $service_name;
+		return true;
 	}
 
 	/**
@@ -207,9 +207,6 @@ abstract class Publicize_Base {
 		switch ( $service_name ) {
 			case 'linkedin':
 				return 'LinkedIn';
-				break;
-			case 'google_plus':
-				return  'Google+';
 				break;
 			case 'twitter':
 			case 'facebook':
@@ -335,10 +332,6 @@ abstract class Publicize_Base {
 			 return 'http://' . $cmeta['connection_data']['meta']['tumblr_base_hostname'];
 		} elseif ( 'twitter' == $service_name ) {
 			return 'https://twitter.com/' . substr( $cmeta['external_display'], 1 ); // Has a leading '@'
-		} elseif ( 'google_plus' == $service_name && isset( $cmeta['connection_data']['meta']['google_plus_page'] ) ) {
-			return 'https://plus.google.com/' . $cmeta['connection_data']['meta']['google_plus_page'];
-		} elseif ( 'google_plus' == $service_name ) {
-			return 'https://plus.google.com/' . $cmeta['external_id'];
 		} else if ( 'linkedin' == $service_name ) {
 			if ( !isset( $cmeta['connection_data']['meta']['profile_url'] ) ) {
 				return false;

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -131,12 +131,6 @@ class Publicize_UI {
 		$max_length = defined( 'JETPACK_PUBLICIZE_TWITTER_LENGTH' ) ? JETPACK_PUBLICIZE_TWITTER_LENGTH : 280;
 		$max_length = $max_length - 24; // t.co link, space
 
-		// for deprecation tooltip
-		wp_enqueue_style( 'wp-pointer' );
-		wp_enqueue_script( 'wp-pointer' );
-
-		$this->google_plus_shut_down_tooltip_script();
-
 		?>
 
 <script type="text/javascript">
@@ -507,14 +501,9 @@ jQuery( function($) {
 					}
 
 					$labels = array();
-					$has_google_plus = false;
 					foreach ( $connections_data as $connection_data ) {
 						if ( ! $connection_data['enabled'] ) {
 							continue;
-						}
-
-						if ( 'google_plus' === $connection_data['service_name'] ) {
-							$has_google_plus = true;
 						}
 
 						$labels[] = sprintf(
@@ -524,19 +513,6 @@ jQuery( function($) {
 					}
 
 				?>
-				<?php if ( $has_google_plus ) : ?>
-					<span class="notice-warning publicize__notice-warning">
-						<?php esc_html_e( 'Google+ support is being removed', 'jetpack' ); ?>
-						<a
-							href="javascript:void(0)"
-							id="jetpack-gplus-deprecated-notice"
-							class="publicize-external-link"
-						>
-							<span class="publicize-external-link__text"><?php esc_html_e( 'Why?', 'jetpack' ); ?></span>
-							<span class="dashicons dashicons-info"></span>
-						</a>
-					</span>
-				<?php endif; ?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
 					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
@@ -677,54 +653,5 @@ jQuery( function($) {
 			<a href="#" class="hide-if-no-js button" id="publicize-disconnected-form-hide"><?php esc_html_e( 'OK', 'jetpack' ); ?></a>
 		</div><?php // #publicize-form
 		return ob_get_clean();
-	}
-
-	private function google_plus_shut_down_notice() {
-		return wp_kses(
-			sprintf(
-				/* Translators: placeholder is a link to an announcement post on Google's blog. */
-				__(
-					'<h3>Google+ Support is being removed</h3><p>Google recently <a href="%1$s" target="_blank">announced</a> that Google+ is shutting down in April 2019, and access via third-party tools like Jetpack will cease in March 2019.</p><p>For now, you can still post to Google+ using existing connections, but you cannot add new connections. The ability to post will be removed in early 2019.</p>',
-					'jetpack'
-				),
-				esc_url( 'https://www.blog.google/technology/safety-security/expediting-changes-google-plus/' )
-			),
-			array(
-				'a'  => array(
-					'href' => true,
-					'target' => true,
-				),
-				'h3' => true,
-				'p'  => true,
-			)
-		);
-	}
-
-	private function google_plus_shut_down_tooltip_script() {
-		$google_plus_exp_msg = $this->google_plus_shut_down_notice();
-	?>
-		<script>
-		// deprecation tooltip
-		(function($){
-			var setup = function() {
-				$('#jetpack-gplus-deprecated-notice').first().pointer(
-					{
-						content: decodeURIComponent( "<?php echo rawurlencode( $google_plus_exp_msg ); ?>" ),
-						position: {
-							edge: "right",
-							align: "bottom"
-						},
-						pointerClass: "wp-pointer arrow-bottom",
-						pointerWidth: 420
-					}
-				).click( function( e ) {
-					e.preventDefault();
-					$( this ).pointer( 'open' );
-				} );
-			};
-			$(document).ready( setup );
-		})(jQuery);
-		</script>
-	<?php
 	}
 }


### PR DESCRIPTION
We deprecated Publicize: Google+ in 7.0. We need to remove it completely for 7.1.

See #10950

#### Changes proposed in this Pull Request:
* Remove Google+ from editor UI
* Remove Google+ from API responses

#### Testing instructions:

#### Editor UI

1. `git checkout master`
2. Remove all Publicize connections
3. Create a new post in the Classic Editor (don't publish it)
4. In the Classic Editor's Publicize UI, click "Edit"
5. See Google+ as an option.
6. Add a Google+ Connection (sneaky)
7. Save the post as a draft.
8. See the Google+ connection in Publicize UI.
9. Switch to Block Editor.
10. See the Google+ connection in Publicize UI.
11. `git checkout remove/publicize-google-plus`
12. Refresh the page (Block Editor).
13. See no Google+ connection in the Publicize UI.
14. Switch to the Classic Editor.
15. See no Google+ connection in the Publicize UI.
16. In the Classic Editor's Publicize UI, click "Edit"
17. See no Google+ as an option.

##### API Response
1. Query `https://jetpack.example.com/wpcom/v2/publicize/services/` (on your test site's domain).
2. See no Google+ in the response.

The simplest way to make that query is to edit any post in the Block Editor and paste the following into your browser's JS console:

```js
wp.apiFetch({path:'/wpcom/v2/publicize/services'}).then( console.log )
```


#### Proposed changelog entry for your changes:
Publicize: Remove Google+ since Google is shutting down the service.