### PR TITLE
Promo cards: update styling on Apps/Theme cards

### DIFF
--- a/_inc/client/components/apps-card/style.scss
+++ b/_inc/client/components/apps-card/style.scss
@@ -16,44 +16,20 @@
 }
 
 .jp-apps-card__top {
-	padding: rem( 40px ) 0 0;
+	padding: rem( 60px ) 0 0;
 	background: #ffffff;
 	text-align: center;
 
 	img {
-		max-width: 40%;
+		max-width: 26%;
 		padding-top: 10px;
-	}
-
-	svg {
-		position: relative;
-		display: block;
-		max-width: 40%;
-		margin: 0 auto rem( -42px );
-		z-index: 3;
-	}
-}
-
-.jp-apps-card__clouds {
-	position: relative;
-	overflow: hidden;
-	padding-top: rem( 44px );
-	z-index: 2;
-
-	img {
-		position: absolute;
-		bottom: -1px;
-		left: -2%;
-		right: -2%;
-		width: 104%;
-		height: auto;
 	}
 }
 
 .jp-apps-card__description {
 	max-width: 80%;
 	margin: 0 auto;
-	padding: rem( 24px );
+	padding: rem( 10px ) rem( 24px ) rem( 24px );
 	line-height: 1.65;
 	color: $black;
 	text-align: center;
@@ -69,30 +45,15 @@
 
 .jp-apps-card__header {
 	margin-top: 0;
+	margin-bottom: rem( 5px );
 	font-weight: 500;
 }
 
 .jp-apps-card__promo_subhead {
+	margin-top: 0;
 	font-style: italic;
 }
 
 .jp-themes-card {
 	margin-bottom: rem( 20px );
-
-	.jp-apps-card__top {
-		padding: rem( 60px ) 0 0;
-	}
-
-	.jp-apps-card__description {
-		max-width: 81%;
-		padding-top: rem( 10px );
-	}
-
-	.jp-apps-card__header {
-		margin-bottom: rem( 5px );
-	}
-
-	.jp-apps-card__promo_subhead {
-		margin-top: 0;
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update styling on Apps/Theme promo cards.
  * Unify styles between these two components.
  * Make the images take less space.

#### Testing instructions:

* Fire up this PR.
* Open `My Plan` and `Plans` page.
* Ensure the promo cards look good.

#### Before

![image](https://user-images.githubusercontent.com/390760/53427198-6c10ab00-39e0-11e9-8e5b-65cb05796b04.png)

![image](https://user-images.githubusercontent.com/390760/53427254-88ace300-39e0-11e9-95dd-b9b9855176c1.png)


#### After

![image](https://user-images.githubusercontent.com/390760/53426773-8c8c3580-39df-11e9-856f-e4626bd9d625.png)

![image](https://user-images.githubusercontent.com/390760/53427406-c873ca80-39e0-11e9-9491-f324f5734507.png)


#### Proposed changelog entry for your changes:

* Small changes not worthy of a changelog entry.
