### PR TITLE
Jetpack Blocks: update to a new version of the blocks for 7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "12.2.0",
+    "@automattic/jetpack-blocks": "13.0.0",
     "babel-core": "6.26.3",
     "babel-eslint": "6.1.2",
     "babel-loader": "7.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-12.2.0.tgz#f9a444ca3637de6bfbecbd3e88d982754d02e95d"
+"@automattic/jetpack-blocks@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-13.0.0.tgz#2b4a6c124ce06948ae6fb48e7efa3879fa951b3c"
 
 "@babel/code-frame@7.0.0-beta.46":
   version "7.0.0-beta.46"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Related PR: https://github.com/Automattic/wp-calypso/pull/31045
https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4013.0.0
https://www.npmjs.com/package/@automattic/jetpack-blocks/v/13.0.0

#### Testing instructions:

* Go to Posts > Add New
* Can you block?
* Be Happy

#### Proposed changelog entry for your changes:

* None
