### PR TITLE
Jetpack Live Branches: Do not default to launching shortlived sites

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -18,14 +18,14 @@
 		const branchIsMerged = $( '.gh-header-meta .State' ).text().trim() === 'Merged';
 		const isGutenbergPr = $( ".discussion-sidebar .sidebar-labels .labels a[title='Gutenberg']" ).length;
 		const base = 'https://jurassic.ninja/create?';
-		const query = `jetpack-beta&branch=${ branch }&shortlived&wp-debug-log${ isGutenbergPr ? '&gutenpack' : '' }`;
+		const query = `jetpack-beta&branch=${ branch }&wp-debug-log${ isGutenbergPr ? '&gutenpack' : '' }`;
 		let link = base + query;
 		const canLiveTestText =
 			`<div id="jetpack-live-branches">
 			<h2>Jetpack Live Branches</h2>
 			<p style="height:3em;" ><a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="${ link }">${ link }</a></p>
 			<ul>
-			<li class="task-list-item enabled"><input type="checkbox" name="shortlived" checked class="task-list-item-checkbox">Launch a shortlived site</li>
+			<li class="task-list-item enabled"><input type="checkbox" name="shortlived" class="task-list-item-checkbox">Launch a shortlived site</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="wp-debug-log" checked class="task-list-item-checkbox">Launch sites with WP_DEBUG and WP_DEBUG_LOG set to true</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenberg" class="task-list-item-checkbox">Launch with Gutenberg installed</li>
 			<li class="task-list-item enabled"><input type="checkbox" name="gutenpack" ${ isGutenbergPr ? 'checked' : '' } class="task-list-item-checkbox">Launch with built blocks</li>

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.9.1
+// @version      1.10
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*


### PR DESCRIPTION

Launching shortlived sites is not quite the best option nowadays as they are launched with a random PHP version (mainly oriented to trigger backwards compatibility problems on end to end tests)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Removes the `shortlived` argument from generated URLs.

#### Testing instructions:

1. Check the version of the script in this branch.
2. Confirm that `shortlived` is no longer a default in the JN URL.

#### Proposed changelog entry for your changes:
None needed