### PR TITLE
Photon: add Dropbox to list of banned domains.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -285,6 +285,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/^graph\.facebook\.com$/',
 		'/\.fbcdn\.net$/',
 		'/\.paypalobjects\.com$/',
+		'/\.dropbox\.com$/',
 	);
 
 	$host = jetpack_photon_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
Fixes #11371

#### Changes proposed in this Pull Request:

Dropbox relies on its own image delivery system, and that creates a redirection when you try to access an image. That trips Photon.

Let's consequently add that domain to the list of domains Photon won't try to serve.

#### Testing instructions:

* Activate Photon on your site.
* Add the following HTML to a post:
```html
<img src="https://www.dropbox.com/s/b4ezvx00mm35y7l/step29A.png?raw=1">
```
* Publish
* Make sure the image is not served by Photon.

#### Proposed changelog entry for your changes:

* Photon: add dropbox.com to the list of banned domains.