### PR TITLE
Business Hours: Ensure we have a valid time before rendering interval

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -50,11 +50,11 @@ function jetpack_business_hours_render( $attributes, $content ) {
 		$days_hours = '';
 
 		foreach ( $day['hours'] as $hour ) {
-			if ( empty( $hour['opening'] ) || empty( $hour['closing'] ) ) {
-				continue;
-			}
 			$opening     = strtotime( $hour['opening'] );
 			$closing     = strtotime( $hour['closing'] );
+			if ( ! $opening || ! $closing ) {
+				continue;
+			}
 			$days_hours .= sprintf(
 				/* Translators: Business opening hours info. */
 				_x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The business hours block should bail on rendering an interval if any of the times are invalid
* Safari, for example, allows you to enter any thing for a time, like "foo"

#### Testing instructions:

* [Try out this Jurassic.ninja link](https://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&branch=fix/business-hours-time-validation&calypsobranch=fix/31027-missing-business-hours)
* Enable beta blocks in Settings -> Jetpack Constants
* In the post editor, using Safari preferably, add a Business Hours block
* Enter in some invalid times, and preview or publish the post
* On the front end, invalid times should not be displayed
* If the day has only invalid times, it will appear as closed


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None
