### PR TITLE
Docker: install Gutenberg and Gutenberg debugger by default

### DIFF
--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -22,6 +22,11 @@ wp --allow-root core install \
 # https://wordpress.org/plugins/query-monitor/
 wp --allow-root plugin install query-monitor --activate
 
+# Install Gutenberg and Gutenberg debugger
+# https://wordpress.org/plugins/gutenberg/
+# https://wordpress.org/plugins/g-debugger/
+wp --allow-root plugin install g-debugger gutenberg
+
 # Activate Jetpack
 wp --allow-root plugin activate jetpack
 

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -39,7 +39,6 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	wp --allow-root config set WP_DEBUG true --raw --type=constant
 	wp --allow-root config set WP_DEBUG_LOG true --raw --type=constant
 	wp --allow-root config set WP_DEBUG_DISPLAY false --raw --type=constant
-	wp --allow-root config set GUTENBERG_DEVELOPMENT_MODE true --raw --type=constant
 
 	# Respecting Dockerfile-forwarded environment variables
 	# Allow to be reverse-proxied from https

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -39,6 +39,7 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	wp --allow-root config set WP_DEBUG true --raw --type=constant
 	wp --allow-root config set WP_DEBUG_LOG true --raw --type=constant
 	wp --allow-root config set WP_DEBUG_DISPLAY false --raw --type=constant
+	wp --allow-root config set GUTENBERG_DEVELOPMENT_MODE true --raw --type=constant
 
 	# Respecting Dockerfile-forwarded environment variables
 	# Allow to be reverse-proxied from https


### PR DESCRIPTION
When running `yarn docker:install` (quick WordPress installer helper), install also Gutenberg and Gutenberg debugger plugins.

While WP 5 has Gutenberg, it's pretty important to test with latest Gutenberg changes while developing. Latest Gutenberg also contains features for the next phases (e.g. right now Widgets and 

G Debugger, on the other hand, integrates with the Gutenberg block editor to add useful visual debugging tools to assist in block development.

## Testing

If you have WP installed, just run `yarn docker:uninstall` and then `yarn docker:install` again to test this script. You should end up with these plugins installed, but not activated.

`./bin:/var/scripts` is mounted as volume, so changes to it should be visible in Docker container without restart or rebuild.

Ensure you don't have `gutenberg` or `g-debugger` plugins in your folder before testing, unless you just want to see _"Plugins already installed"_ -messages :-)