### PR TITLE
Only process the home domain in Photon noresize mode.

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -146,6 +146,13 @@ class Jetpack_Photon {
 	 * @return String an URL to be used for the media file.
 	 */
 	public static function filter_photon_norezise_domain( $photon_url, $image_url ) {
+		$home_url = home_url();
+
+		// If the URL does not begin with the site's home URL, we do not process it - it's hosted elsewhere.
+		if ( ! wp_startswith( $image_url, $home_url ) ) {
+			return $image_url;
+		}
+
 		return $photon_url;
 	}
 
@@ -161,7 +168,7 @@ class Jetpack_Photon {
 
 	public static function filter_photon_noresize_thumbnail_urls( $sizes ) {
 		foreach ( $sizes as $size => $url ) {
-			$parts = explode( '?', $url );
+			$parts     = explode( '?', $url );
 			$arguments = isset( $parts[1] ) ? $parts[1] : array();
 
 			$sizes[ $size ] = jetpack_photon_url( $url, wp_parse_args( $arguments ) );


### PR DESCRIPTION
This is needed to leave images hosted on other sites the way they were before.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a condition to the domain filter that short-circuit processing of foreign URLs.

#### Testing instructions:
* Enable Photon noresize mode with the filter: `add_filter( 'jetpack_photon_noresize_mode', '__return_true' );`
* Create a new post with images embedded from services like Imgur or Giphy.
* See that the images attached are processed with Photon and are given URLs starting with `https://i*.wp.com`.
* Patch Jetpack with this PR, see that the URLs are no longer processed, and have the domain of the actual service.
* See that all other URLs that you embed in the posts do get processed and are served from `wp.com`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed the logic problem in the Image CDN's noresize mode.
