### PR TITLE
Ustream: update shortcode to use Ustream's HTML5 player

### DIFF
--- a/modules/shortcodes/ustream.php
+++ b/modules/shortcodes/ustream.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * ustream.tv shortcode
+ * Ustream.tv shortcode
  *
  * Example:
  * [ustream id=1524 live=1]
@@ -9,6 +8,8 @@
  *
  * Embed code example, from http://www.ustream.tv/leolaporte
  * <iframe src="http://www.ustream.tv/embed/recorded/1524?v=3&#038;wmode=direct" width="480" height="296" scrolling="no" frameborder="0" style="border: 0 none transparent;"></iframe>
+ *
+ * @package Jetpack
  */
 
 add_shortcode( 'ustream', 'ustream_shortcode' );
@@ -19,7 +20,7 @@ add_shortcode( 'ustreamsocial', 'ustreamsocial_shortcode' );
  *
  * @since 4.5.0
  *
- * @param $atts array of user-supplied arguments.
+ * @param array $atts array of user-supplied arguments.
  *
  * @return string HTML output.
  */
@@ -37,52 +38,59 @@ function ustream_shortcode( $atts ) {
 		'version'   => 3,
 		'hwaccel'   => 1,
 	);
+	$atts     = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
 
-	$atts = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
-
-	$ustream_id = $atts['id'];
-	$width      = $atts['width'];
-	$height     = $atts['height'];
-	$live       = $atts['live'];
-	$highlight  = $atts['highlight'];
-	$version    = $atts['version'];
-	$hwaccel    = $atts['hwaccel'];
-
-	$version = 'v=' . esc_attr( $version );
-
-	if ( 0 >= $ustream_id ) {
+	if ( 0 >= $atts['id'] ) {
 		return '<!-- ustream error: bad video ID -->';
 	}
 
-	if ( 0 >= $height ) {
+	if ( 0 >= $atts['height'] ) {
 		return '<!-- ustream error: height invalid -->';
 	}
 
-	if ( 0 >= $width ) {
+	if ( 0 >= $atts['width'] ) {
 		return '<!-- ustream error: width invalid -->';
 	}
 
-	if ( $live ) {
+	if ( $atts['live'] ) {
 		$recorded = '';
 	} else {
 		$recorded = 'recorded/';
 	}
 
-	if ( ! $live && ( 0 < $highlight ) ) {
-		$highlight = "/highlight/$highlight";
+	if ( ! $atts['live'] && ( 0 < $atts['highlight'] ) ) {
+		$highlight = sprintf( '/highlight/%d', esc_attr( $atts['highlight'] ) );
 	} else {
 		$highlight = '';
 	}
 
-	if ( 0 < $hwaccel ) {
-		$wmode = '&amp;wmode=direct';
-	} else {
-		$wmode = '';
+	$url_base = sprintf(
+		'https://www.ustream.tv/embed/%s%d%s',
+		$recorded,
+		esc_attr( $atts['id'] ),
+		$highlight
+	);
+
+	$video_options = array(
+		'html5ui' => 1,
+		'v'       => absint( $atts['version'] ),
+	);
+
+	if ( 0 < $atts['hwaccel'] ) {
+		$video_options['wmode'] = 'direct';
 	}
 
-	$url    = 'http://www.ustream.tv/embed/' . $recorded . esc_attr( $ustream_id ) . $highlight . '?' . $version . $wmode;
-	$url    = set_url_scheme( $url );
-	$output = '<iframe src="' . esc_url( $url ) . '" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" scrolling="no" style="border: 0 none transparent;"></iframe>';
+	$url = add_query_arg(
+		$video_options,
+		$url_base
+	);
+
+	$output = sprintf(
+		'<iframe src="%1$s" width="%2$d" height="%3$d" scrolling="no" style="border: 0 none transparent;"></iframe>',
+		esc_url( $url ),
+		absint( $atts['width'] ),
+		absint( $atts['height'] )
+	);
 
 	return $output;
 }
@@ -92,7 +100,7 @@ function ustream_shortcode( $atts ) {
  *
  * @since 4.5.0
  *
- * @param $atts array of user-supplied arguments.
+ * @param array $atts array of user-supplied arguments.
  *
  * @return string HTML output.
  */
@@ -102,26 +110,26 @@ function ustreamsocial_shortcode( $atts ) {
 		'height' => 420,
 		'width'  => 320,
 	);
+	$atts     = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
 
-	$atts = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
-
-	$ustream_id = $atts['id'];
-	$width      = $atts['width'];
-	$height     = $atts['height'];
-
-	if ( 0 >= $ustream_id ) {
+	if ( 0 >= $atts['id'] ) {
 		return '<!-- ustreamsocial error: bad social stream ID -->';
 	}
 
-	if ( 0 >= $height ) {
+	if ( 0 >= $atts['height'] ) {
 		return '<!-- ustreamsocial error: height invalid -->';
 	}
 
-	if ( 0 >= $width ) {
+	if ( 0 >= $atts['width'] ) {
 		return '<!-- ustreamsocial error: width invalid -->';
 	}
 
-	$url = set_url_scheme( "http://www.ustream.tv/socialstream/$ustream_id" );
+	$url = 'https://www.ustream.tv/socialstream/' . esc_attr( $atts['id'] );
 
-	return '<iframe id="SocialStream" class="" name="SocialStream" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" scrolling="no" allowtransparency="true" src="' . esc_url( $url ) . '" style="visibility: visible; margin-top: 0; margin-bottom: 0; border: 0;"></iframe>';
+	return sprintf(
+		'<iframe id="SocialStream" src="%1$s" class="" name="SocialStream" width="%2$d" height="%3$d" scrolling="no" allowtransparency="true" style="visibility: visible; margin-top: 0; margin-bottom: 0; border: 0;"></iframe>',
+		esc_url( $url ),
+		absint( $atts['width'] ),
+		absint( $atts['height'] )
+	);
 }

--- a/tests/php/modules/shortcodes/test_class.ustream.php
+++ b/tests/php/modules/shortcodes/test_class.ustream.php
@@ -47,7 +47,7 @@ class WP_Test_Jetpack_Shortcodes_Ustream extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( '<iframe src="http://www.ustream.tv/embed/recorded/' . $id, $shortcode_content );
+		$this->assertContains( '<iframe src="https://www.ustream.tv/embed/recorded/' . $id, $shortcode_content );
 	}
 
 	/**
@@ -61,6 +61,6 @@ class WP_Test_Jetpack_Shortcodes_Ustream extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertContains( '<iframe id="SocialStream" class="" name="SocialStream" width="500" height="420" scrolling="no" allowtransparency="true" src="http://www.ustream.tv/socialstream/' . $id, $shortcode_content );
+		$this->assertContains( '<iframe id="SocialStream" src="https://www.ustream.tv/socialstream/' . $id, $shortcode_content );
 	}
 }


### PR DESCRIPTION
Fixes 8132-wpcom

#### Changes proposed in this Pull Request:

The old player does not appear to be supported anymore.

I took that opportunity to refactor the file a bit:
- No more phpcs errors.
- I simplified the URL creation from the different parameters.
- I set the URL to always use HTTPS.

#### Testing instructions:

* Add the following to a post:
```
[ustream id="12461849" live="1" width="600" height="480" hwaccel="1"]
[ustreamsocial id=12980237 width="500"]
<figure><iframe width="480" height="270" src="http://www.ustream.tv/embed/12461849?html5ui" allowfullscreen=""></iframe></figure>
```
* Make sure all embeds work.

#### Proposed changelog entry for your changes:

* Shortcodes: update the Ustream shortcode to use the HTML5 player
