### PR TITLE
Fix height of Contact Info map iframe in AMP

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -321,19 +321,42 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		/**
 		 * Builds map display HTML code from the supplied latitude and longitude.
 		 *
-		 * @param float $lat Map Latitude
-		 * @param float $lon Map Longitude
+		 * @param string $address Address.
+		 * @param string $api_key API Key.
 		 *
-		 * @return string HTML of the map
+		 * @return string HTML of the map.
 		 */
 		function build_map( $address, $api_key = null ) {
 			$this->enqueue_scripts();
-			$src = add_query_arg( 'q', urlencode( $address ), 'https://www.google.com/maps/embed/v1/place' );
+			$src = add_query_arg( 'q', rawurlencode( $address ), 'https://www.google.com/maps/embed/v1/place' );
 			if ( ! empty( $api_key ) ) {
 				$src = add_query_arg( 'key', $api_key, $src );
 			}
 
-			return '<iframe width="600" height="216" frameborder="0" src="' . esc_url( $src ) . '" class="contact-map"></iframe>';
+			$height = 216;
+
+			$iframe_attributes = sprintf(
+				' height="%d" frameborder="0" src="%s" class="contact-map"',
+				esc_attr( $height ),
+				esc_url( $src )
+			);
+
+			$iframe_html = sprintf( '<iframe width="600" %s></iframe>', $iframe_attributes );
+
+			if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+				return $iframe_html;
+			}
+
+			$amp_iframe_html = sprintf( '<amp-iframe layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" %s>', $iframe_attributes );
+
+			// Add placeholder to avoid AMP error: <amp-iframe> elements must be positioned outside the first 75% of the viewport or 600px from the top (whichever is smaller).
+			$amp_iframe_html .= sprintf( '<span placeholder>%s</span>', __( 'Loading map&hellip;', 'jetpack' ) );
+
+			// Add original iframe as fallback in case JavaScript is disabled.
+			$amp_iframe_html .= sprintf( '<noscript>%s</noscript>', $iframe_html );
+
+			$amp_iframe_html .= '</amp-iframe>';
+			return $amp_iframe_html;
 		}
 
 		/**

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -350,7 +350,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			$amp_iframe_html = sprintf( '<amp-iframe layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" %s>', $iframe_attributes );
 
 			// Add placeholder to avoid AMP error: <amp-iframe> elements must be positioned outside the first 75% of the viewport or 600px from the top (whichever is smaller).
-			$amp_iframe_html .= sprintf( '<span placeholder>%s</span>', __( 'Loading map&hellip;', 'jetpack' ) );
+			$amp_iframe_html .= sprintf( '<span placeholder>%s</span>', esc_html__( 'Loading map&hellip;', 'jetpack' ) );
 
 			// Add original iframe as fallback in case JavaScript is disabled.
 			$amp_iframe_html .= sprintf( '<noscript>%s</noscript>', $iframe_html );


### PR DESCRIPTION
See #9730.

#### Changes proposed in this Pull Request:

Since AMP has built-in responsiveness, the Contact Info widget's map iframe with 600⨉216 dimensions can the actual height to be much less. For example, in Twenty Seventeen the sidebar is 325px wide. This results in the iframe being 117px high, since 325:117 has the same aspect ratio as 600:216. To fix, this PR explicitly uses AMP's `fixed-height` layout for the `amp-iframe` so that the height will always be 216px with the width being responsive.

#### Testing instructions:

1. Activate Twenty Seventeen.
2. Install the AMP plugin and in the AMP settings switch to the paired mode. (You may also need to opt to hide the admin bar in AMP if there is too much CSS resulting.)
3. Add the Contact Info widget and click the checkbox to show the map (which requires a Google Maps API key).
4. Look at the frontend, and the non-AMP version should look like this:

> <img width="358" alt="screen shot 2019-02-28 at 11 17 01" src="https://user-images.githubusercontent.com/134745/53592773-d2660c80-3b4b-11e9-9c9a-2cfae4e434ae.png">

5. Switch to the AMP version (`?amp`) and in `master` it should look erroneously as this (with less vertical height):

> <img width="353" alt="screen shot 2019-02-28 at 11 17 12" src="https://user-images.githubusercontent.com/134745/53592873-148f4e00-3b4c-11e9-8935-50425af128e1.png">

6. Switch to this branch and in the AMP version it should look like the following, which is the same as the non-AMP version:

> <img width="356" alt="screen shot 2019-02-28 at 11 25 43" src="https://user-images.githubusercontent.com/134745/53592925-2a047800-3b4c-11e9-8e31-c98e2b32c49e.png">

The HTML markup for AMP should look like this (after https://github.com/ampproject/amp-wp/pull/1913, without which the `iframe` inside the `noscript` is also converted to `amp-iframe`):

```html
<amp-iframe layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" height="216" frameborder="0"
            src="https://www.google.com/maps/embed/v1/place?q=3999+Mission+Boulevard%2CSan+Diego+CA+92109&amp;key=..."
            class="contact-map">
    <span placeholder>Loading map…</span>
    <noscript>
        <iframe width="600" height="216" frameborder="0"
                src="https://www.google.com/maps/embed/v1/place?q=3999+Mission+Boulevard%2CSan+Diego+CA+92109&amp;key=..."
                class="contact-map"></iframe>
    </noscript>
</amp-iframe>
```

#### Proposed changelog entry for your changes:

* Improve rendering of Contact Info widget map in AMP.
