### PR TITLE
Photon: update module name to use the new naming convention

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -135,7 +135,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'photon' => array(
-				'name' => _x( 'Photon', 'Module Name', 'jetpack' ),
+				'name' => _x( 'Image CDN', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.', 'Jumpstart Description', 'jetpack' ),
 			),
@@ -221,8 +221,8 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'vaultpress' => array(
-				'name' => _x( 'Data Backups', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Every bit and byte of your site is backed up safely - daily or in real-time - to an off-site location.', 'Module Description', 'jetpack' ),
+				'name' => _x( 'Backups and Scanning', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Protect your site with daily or real-time backups and automated virus scanning and threat detection.', 'Module Description', 'jetpack' ),
 			),
 
 			'verification-tools' => array(

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Photon
+ * Module Name: Image CDN
  * Module Description:  Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.
  * Jumpstart Description: Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.
  * Sort Order: 25


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is more important now that we rely on the module's headers for plugin hints.

Reported in p8oabR-kb-p2 #comment-2620

#### Testing instructions:

* Start from a site connected to WordPress.com and where Photon is active.
* Apply this patch.
* Make sure the Photon module remains active.
* Go to Plugins > Add New, and search for CDN.
* You should see the plugin hint card, but it should not mention Photon anymore.

![image](https://user-images.githubusercontent.com/426388/53595876-b63f8b00-3b9e-11e9-85bb-1ab0c3a27087.png)

I'm trying to think of anything important that may be impacted by this change, but I can't think of anything right now. I know the module name will appear differently in the old module list, but I believe that's it?

#### Proposed changelog entry for your changes:

* None
