### PR TITLE
Sitemaps: Add thumbnails to video sitemaps

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1324,7 +1324,7 @@ class Jetpack_Sitemap_Builder {
 		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
 			$video_thumbnail_url = get_the_post_thumbnail_url( $post );
 		} else {
-			/*
+		       /**
 			* Filter the thumbnail image used in the video sitemap for non-VideoPress videos.
 			*
 			* @since 7.2.0

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1324,6 +1324,7 @@ class Jetpack_Sitemap_Builder {
 		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
 			$video_thumbnail_url = get_the_post_thumbnail_url( $post );
 		} else {
+			/*
 			* Filter the thumbnail image used in the video sitemap for non-VideoPress videos.
 			*
 			* @since 7.2.0

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1341,7 +1341,7 @@ class Jetpack_Sitemap_Builder {
 				'video:video' => array(
 					/** This filter is already documented in core/wp-includes/feed.php */
 					'video:title'         => apply_filters( 'the_title_rss', $post->post_title ),
-					'video:thumbnail_loc' => $video_thumbnail_url,
+					'video:thumbnail_loc' => esc_url( $video_thumbnail_url ),
 					'video:description'   => $content,
 					'video:content_loc'   => esc_url( wp_get_attachment_url( $post->ID ) ),
 				),

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1319,6 +1319,19 @@ class Jetpack_Sitemap_Builder {
 
 		/** This filter is already documented in core/wp-includes/feed.php */
 		$content = apply_filters( 'the_content_feed', $content, 'rss2' );
+		
+		// Include thumbnails for VideoPress videos, use blank image for others
+		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
+			$video_thumbnail_url = get_the_post_thumbnail_url( $post );
+		} else {
+			* Filter the thumbnail image used in the video sitemap for non-VideoPress videos.
+			*
+			* @since 7.2.0
+			*
+			* @param string $str Image URL.
+			*/
+			$video_thumbnail_url = apply_filters( 'jetpack_video_sitemap_default_thumbnail', 'https://s0.wp.com/i/blank.jpg' );
+		}
 
 		$item_array = array(
 			'url' => array(
@@ -1327,7 +1340,7 @@ class Jetpack_Sitemap_Builder {
 				'video:video' => array(
 					/** This filter is already documented in core/wp-includes/feed.php */
 					'video:title'         => apply_filters( 'the_title_rss', $post->post_title ),
-					'video:thumbnail_loc' => '',
+					'video:thumbnail_loc' => $video_thumbnail_url,
 					'video:description'   => $content,
 					'video:content_loc'   => esc_url( wp_get_attachment_url( $post->ID ) ),
 				),

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1324,13 +1324,13 @@ class Jetpack_Sitemap_Builder {
 		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
 			$video_thumbnail_url = get_the_post_thumbnail_url( $post );
 		} else {
-		       /**
-			* Filter the thumbnail image used in the video sitemap for non-VideoPress videos.
-			*
-			* @since 7.2.0
-			*
-			* @param string $str Image URL.
-			*/
+			/**
+			 * Filter the thumbnail image used in the video sitemap for non-VideoPress videos.
+			 *
+			 * @since 7.2.0
+			 *
+			 * @param string $str Image URL.
+			 */
 			$video_thumbnail_url = apply_filters( 'jetpack_video_sitemap_default_thumbnail', 'https://s0.wp.com/i/blank.jpg' );
 		}
 


### PR DESCRIPTION
Uses thumbnails from processed VideoPress videos where possible, otherwise falls back to a (filterable) blank image. This will avoid Google Search Console (fka Google Webmaster Tools) from complaining about invalid URLs in video sitemaps.

Fixes #9539.

#### Testing instructions:

1. Start with a properly connected, self-hosted site with a Premium or Professional plan.
2. Enable Jetpack's video hosting feature under Jetpack > Settings > Performance > Media section.
3. Upload a video to the site via `wordpress.com/media`.
4. Wait for VideoPress to finish processing the video.
5. Rebuild sitemaps with `wp jetpack sitemap rebuild --purge`.
6. View the view sitemap at `www.example.com/video-sitemap-1.xml`.

Videos processed with VideoPress will show an actual thumbnail. Videos not processed with VideoPress will have a blank image as the thumbnail, which is better than nothing.

<img width="1427" alt="screen shot 2019-03-01 at 7 04 58 am" src="https://user-images.githubusercontent.com/5512652/53637190-8325e780-3bf0-11e9-9d10-968b1d849ec9.png">

#### Proposed changelog entry for your changes:

Added thumbnails to video sitemaps as required by Google Search Console
