### PR TITLE
Post Images: Return attachment info when using from_thumbnail

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -239,7 +239,7 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
-		if ( 'attachment' === get_post_type( $post ) ) {
+		if ( 'attachment' === get_post_type( $post ) && wp_attachment_is_image( $post )) {
 			$thumb = $post_id;
 		} else {
 			$thumb = get_post_thumbnail_id( $post );

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -239,7 +239,11 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
-		$thumb = get_post_thumbnail_id( $post_id );
+		if ( 'attachment' === get_post_type( $post ) ) {
+			$thumb = $post_id;
+		} else {
+			$thumb = get_post_thumbnail_id( $post );
+		}
 
 		if ( $thumb ) {
 			$meta = wp_get_attachment_metadata( $thumb );

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -239,7 +239,7 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
-		if ( 'attachment' === get_post_type( $post ) && wp_attachment_is_image( $post )) {
+		if ( 'attachment' === get_post_type( $post ) && wp_attachment_is_image( $post ) ) {
 			$thumb = $post_id;
 		} else {
 			$thumb = get_post_thumbnail_id( $post );


### PR DESCRIPTION
The `Jetpack_PostImages` class returns no post image for an `attachment` post type. We should return the image.

I attached it onto the `from_thumbnail` group since the attachment's "featured image" is itself, which made more sense to me than the other groups, not to mention matches the intent (the `from_html` and `from_attachment` is kinda weird and, personally, something I would often opt out of using).

Fixes #11413 

#### Changes proposed in this Pull Request:
* If the post we're requesting is an attachment, return the attachment's src instead of an empty string.

#### Testing instructions:
* Upload an image and note the post_id.
* Run `Jetpack_PostImages::get_image( [the id] )`; via `wp shell`
* See empty string returned.
* Apply patch.
* Run command again and see an array containing image information.

#### Proposed changelog entry for your changes:
* Jetpack Post Images: Provide the image itself when requesting an attachment's post image.
