### PR TITLE
Bump Minimum Required WordPress Version to 5.0

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -70,9 +70,7 @@ class Jetpack_Provision { //phpcs:ignore
 			wp_set_current_user( $master_user_id );
 		}
 
-		$site_icon = ( function_exists( 'has_site_icon' ) && has_site_icon() )
-			? get_site_icon_url()
-			: false;
+		$site_icon = get_site_icon_url();
 
 		$auto_enable_sso = ( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) );
 

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -143,18 +143,6 @@ abstract class Jetpack_Admin_Page {
 	}
 
 	/**
-	 * Checks if WordPress version is too old to have REST API.
-	 *
-	 * @since 4.3
-	 *
-	 * @return bool
-	 */
-	function is_wp_version_too_old() {
-		global $wp_version;
-		return ( ! function_exists( 'rest_api_init' ) || version_compare( $wp_version, '4.4-z', '<=' ) );
-	}
-
-	/**
 	 * Checks if REST API is enabled.
 	 *
 	 * @since 4.4.2

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -172,24 +172,15 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need for scripts on a fallback page.
 		}
 
-		// Enqueue jp.js and localize it.
-		$dependencies = array();
-
-		// WordPress 5.0 and later supports the new client side i18n mechanism.
-		if ( version_compare( $GLOBALS['wp_version'], '5.0', '>' ) ) {
-			$dependencies = array( 'wp-i18n' );
-		}
 		wp_enqueue_script(
 			'react-plugin',
 			plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
-			$dependencies,
+			array( 'wp-i18n' ),
 			JETPACK__VERSION,
 			true
 		);
 
-		if ( function_exists( 'wp_set_script_translations' ) ) {
-			wp_set_script_translations( 'react-plugin', 'jetpack', JETPACK__PLUGIN_DIR . 'languages/json' );
-		}
+		wp_set_script_translations( 'react-plugin', 'jetpack', JETPACK__PLUGIN_DIR . 'languages/json' );
 
 		if ( ! Jetpack::is_development_mode() && Jetpack::is_active() ) {
 			// Required for Analytics.

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -25,8 +25,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need to handle the fallback redirection if we are not on the Jetpack page
 		}
 
-		// Adding a redirect meta tag for older WordPress versions or if the REST API is disabled
-		if ( $this->is_wp_version_too_old() || ! $this->is_rest_api_enabled() ) {
+		// Adding a redirect meta tag if the REST API is disabled
+		if ( ! $this->is_rest_api_enabled() ) {
 			$this->is_redirecting = true;
 			add_action( 'admin_head', array( $this, 'add_fallback_head_meta' ) );
 		}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -264,7 +264,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),
 			'currentVersion' => JETPACK__VERSION,
-			'is_gutenberg_available' => Jetpack_Gutenberg::is_gutenberg_available(),
+			'is_gutenberg_available' => true,
 			'getModules' => $modules,
 			'showJumpstart' => jetpack_show_jumpstart(),
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -29,7 +29,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		// We have static.html so let's continue trying to fetch the others
 		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
-		$version_notice = $rest_api_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
+		$rest_api_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
 		$ie_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
 
 		$noscript_notice = str_replace(
@@ -41,17 +41,6 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			'#TEXT#',
 			esc_html__( "Turn on JavaScript to unlock Jetpack's full potential!", 'jetpack' ),
 			$noscript_notice
-		);
-
-		$version_notice = str_replace(
-			'#HEADER_TEXT#',
-			esc_html__( 'You are using an outdated version of WordPress', 'jetpack' ),
-			$version_notice
-		);
-		$version_notice = str_replace(
-			'#TEXT#',
-			esc_html__( "Update WordPress to unlock Jetpack's full potential!", 'jetpack' ),
-			$version_notice
 		);
 
 		$rest_api_notice = str_replace(
@@ -76,9 +65,6 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$ie_notice
 		);
 
-		if ( $this->is_wp_version_too_old() ) {
-			echo $version_notice;
-		}
 		if ( ! $this->is_rest_api_enabled() ) {
 			echo $rest_api_notice;
 		}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -19,9 +19,6 @@
  * @return WP_Block_Type|false The registered block type on success, or false on failure.
  */
 function jetpack_register_block( $slug, $args = array() ) {
-	if ( ! function_exists( 'register_block_type' ) ) {
-		return false;
-	}
 	if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
 		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
 		$slug = 'jetpack/' . $slug;
@@ -205,10 +202,6 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! self::is_gutenberg_available() ) {
-			return;
-		}
-
 		if ( ! self::should_load() ) {
 			return;
 		}
@@ -333,10 +326,6 @@ class Jetpack_Gutenberg {
 	 * @return array A list of block and plugins and their availablity status
 	 */
 	public static function get_availability() {
-		if ( ! self::is_gutenberg_available() ) {
-			return array();
-		}
-
 		/**
 		 * Fires before Gutenberg extensions availability is computed.
 		 *
@@ -403,7 +392,7 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function is_gutenberg_available() {
-		return function_exists( 'register_block_type' );
+		return true;
 	}
 
 	/**
@@ -581,7 +570,7 @@ class Jetpack_Gutenberg {
 	 * @since 7.1.0
 	 */
 	public static function load_independent_blocks() {
-		if ( self::should_load() && self::is_gutenberg_available() ) {
+		if ( self::should_load() ) {
 			/**
 			 * Look for files that match our list of available Jetpack Gutenberg extensions (blocks and plugins).
 			 * If available, load them.

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -10,9 +10,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 
 		Jetpack::init();
 
-		// In WP 4.2 WP_List_Table will be sanitizing which values are __set()
-		global $wp_version;
-		if ( version_compare( $wp_version, '4.2-z', '>=' ) && $this->compat_fields && is_array( $this->compat_fields ) ) {
+		if ( $this->compat_fields && is_array( $this->compat_fields ) ) {
 			array_push( $this->compat_fields, 'all_items' );
 		}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -320,11 +320,6 @@ class Jetpack_PostImages {
 	public static function from_blocks( $html_or_id, $width = 200, $height = 200 ) {
 		$images = array();
 
-		// Bail early if the site does not support the block editor.
-		if ( ! function_exists( 'parse_blocks' ) ) {
-			return $images;
-		}
-
 		$html_info = self::get_post_html( $html_or_id );
 
 		if ( empty( $html_info['html'] ) ) {

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -482,10 +482,11 @@ class Jetpack_PostImages {
 			}
 
 			$url = blavatar_url( $domain, 'img', $size );
-		} elseif ( function_exists( 'has_site_icon' ) && has_site_icon() ) {
-			$url = get_site_icon_url( $size );
 		} else {
-			return array();
+			$url = get_site_icon_url( $size );
+			if ( ! $url ) {
+				return array();
+			}
 		}
 
 		return array( array(

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -235,10 +235,6 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
-		if ( ! function_exists( 'get_post_thumbnail_id' ) ) {
-			return $images;
-		}
-
 		if ( 'attachment' === get_post_type( $post ) && wp_attachment_is_image( $post ) ) {
 			$thumb = $post_id;
 		} else {

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -191,7 +191,7 @@ class Jetpack_Twitter_Cards {
 			}
 
 			// Third fall back, Site Icon
-			if ( empty( $og_tags['twitter:image'] ) && ( function_exists( 'has_site_icon' ) && has_site_icon() ) ) {
+			if ( empty( $og_tags['twitter:image'] ) && has_site_icon() ) {
 				$og_tags['twitter:image'] = get_site_icon_url( '240' );
 			}
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -236,9 +236,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( $user, 'jpc_remote_provision_fail' );
 		}
 
-		$site_icon = ( function_exists( 'has_site_icon' ) && has_site_icon() )
-			? get_site_icon_url()
-			: false;
+		$site_icon = get_site_icon_url();
 
 		$auto_enable_sso = ( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4773,10 +4773,6 @@ p {
 
 			$secrets = Jetpack::generate_secrets( 'authorize', false, 2 * HOUR_IN_SECONDS );
 
-			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
-				? get_site_icon_url()
-				: false;
-
 			/**
 			 * Filter the type of authorization.
 			 * 'calypso' completes authorization on wordpress.com/jetpack/connect
@@ -4814,7 +4810,7 @@ p {
 					'blogname'      => get_option( 'blogname' ),
 					'site_url'      => site_url(),
 					'home_url'      => home_url(),
-					'site_icon'     => $site_icon,
+					'site_icon'     => get_site_icon_url(),
 					'site_lang'     => get_locale(),
 					'_ui'           => $tracks_identity['_ui'],
 					'_ut'           => $tracks_identity['_ut'],

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -334,8 +334,8 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 		}
 	}
 
-	// Third fall back, Core Site Icon, if valid in size. Added in WP 4.3.
-	if ( empty( $image ) && ( function_exists( 'has_site_icon' ) && has_site_icon() ) ) {
+	// Third fall back, Core Site Icon, if valid in size.
+	if ( empty( $image ) && has_site_icon() ) {
 		$image_id = get_option( 'site_icon' );
 		$icon     = wp_get_attachment_image_src( $image_id, 'full' );
 		if (

--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '4.9' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.0' );
 
 define( 'JETPACK__VERSION',            '7.2-alpha' );
 define( 'JETPACK_MASTER_USER',         true );

--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '5.0' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '4.9' );
 
 define( 'JETPACK__VERSION',            '7.2-alpha' );
 define( 'JETPACK_MASTER_USER',         true );

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -245,18 +245,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	}
 
 	protected function current_user_can( $capability, $plugin = null ) {
-		global $wp_version;
-		if ( version_compare( $wp_version, '4.9-beta2' ) >= 0 ) {
-			if ( $plugin ) {
-				return current_user_can( $capability, $plugin );
-			}
-
-			return current_user_can( $capability );
+		if ( $plugin ) {
+			return current_user_can( $capability, $plugin );
 		}
 
-		// Assume that the user has the activate plugins capability.
-		return current_user_can( 'activate_plugins' );
-
+		return current_user_can( $capability );
 	}
 
 	protected function deactivate() {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -332,21 +332,10 @@ class Jetpack_Calypsoify {
 	 * @since 6.7.0
 	 */
 	public function is_post_type_gutenberg( $post_type ) {
-		// @TODO: Remove function check once 5.0 is the minimum supported WP version.
-		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
-			return use_block_editor_for_post_type( $post_type );
-		} else {
-			// We use the filter introduced in WordPress 5.0 to be backwards compatible.
-			/** This filter is already documented in core/wp-admin/includes/post.php */
-			return apply_filters( 'use_block_editor_for_post_type', true, $post_type );
-		}
+		return use_block_editor_for_post_type( $post_type );
 	}
 
 	public function is_page_gutenberg() {
-		if ( ! Jetpack_Gutenberg::is_gutenberg_available() ) {
-			return false;
-		}
-
 		$page = wp_basename( esc_url( $_SERVER['REQUEST_URI'] ) );
 
 		if ( false !== strpos( $page, 'post-new.php' ) && empty ( $_GET['post_type'] ) ) {

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -218,10 +218,7 @@ class Jetpack_Carousel {
 			return $content;
 		}
 
-		if (
-			function_exists( 'has_block' )
-			&& ( has_block( 'gallery', $content ) || has_block( 'jetpack/tiled-gallery', $content ) )
-		) {
+		if ( has_block( 'gallery', $content ) || has_block( 'jetpack/tiled-gallery', $content ) ) {
 			$this->enqueue_assets();
 			$content = $this->add_data_to_container( $content );
 		}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -239,9 +239,7 @@ class Grunion_Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
-		if ( Jetpack_Gutenberg::is_gutenberg_available() ) {
-			self::register_contact_form_blocks();
-		}
+		self::register_contact_form_blocks();
 	}
 
 	private static function register_contact_form_blocks() {

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -55,27 +55,13 @@ class Jetpack_Custom_CSS_Enhancements {
 		}
 
 		wp_register_style( 'jetpack-codemirror',      plugins_url( 'custom-css/css/codemirror.css', __FILE__ ), array(), '20120905' );
-		$deps = array();
-		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
-			// If Core < 4.9
-			$deps[] = 'jetpack-codemirror';
-		}
-		wp_register_style( 'jetpack-customizer-css',  plugins_url( 'custom-css/css/customizer-control.css', __FILE__ ), $deps, '20140728' );
+		wp_register_style( 'jetpack-customizer-css',  plugins_url( 'custom-css/css/customizer-control.css', __FILE__ ), array(), '20140728' );
 		wp_register_script( 'jetpack-codemirror',     plugins_url( 'custom-css/js/codemirror.min.js', __FILE__ ), array(), '3.16', true );
-		$deps = array( 'customize-controls', 'underscore' );
 		$src  = Jetpack::get_file_url_for_environment(
 			'_inc/build/custom-css/custom-css/js/core-customizer-css.core-4.9.min.js',
 			'modules/custom-css/custom-css/js/core-customizer-css.core-4.9.js'
 		);
-		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
-			// If Core < 4.9
-			$deps[] = 'jetpack-codemirror';
-			$src = Jetpack::get_file_url_for_environment(
-				'_inc/build/custom-css/custom-css/js/core-customizer-css.min.js',
-				'modules/custom-css/custom-css/js/core-customizer-css.js'
-			);
-		}
-		wp_register_script( 'jetpack-customizer-css', $src, $deps, JETPACK__VERSION, true );
+		wp_register_script( 'jetpack-customizer-css', $src, array( 'customize-controls', 'underscore' ), JETPACK__VERSION, true );
 
 		wp_register_script(
 			'jetpack-customizer-css-preview',

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1211,8 +1211,6 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function query() {
-		global $wp_customize;
-		global $wp_version;
 		if ( ! isset( $_REQUEST['page'] ) || ! current_theme_supports( 'infinite-scroll' ) )
 			die;
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1536,7 +1536,7 @@ class The_Neverending_Home_Page {
 	 *
 	 */
 	private function default_footer() {
-		if ( function_exists( 'get_privacy_policy_url' ) && ( '' !== get_privacy_policy_url() ) ) {
+		if ( '' !== get_privacy_policy_url() ) {
 			$credits = get_the_privacy_policy_link() . '<span role="separator" aria-hidden="true"> / </span>';
 		} else {
 			$credits = '';

--- a/modules/markdown/easy-markdown.php
+++ b/modules/markdown/easy-markdown.php
@@ -573,7 +573,7 @@ jQuery( function() {
 	 */
 	public function transform( $text, $args = array() ) {
 		// If this contains Gutenberg content, let's keep it intact.
-		if ( function_exists( 'has_blocks' ) && has_blocks( $text ) ) {
+		if ( has_blocks( $text ) ) {
 			return $text;
 		}
 

--- a/modules/pwa/class.jetpack-pwa-helpers.php
+++ b/modules/pwa/class.jetpack-pwa-helpers.php
@@ -10,9 +10,7 @@ class Jetpack_PWA_Helpers {
 	}
 
 	public static function site_icon_url( $size = 512 ) {
-		$url = function_exists( 'get_site_icon_url' )
-			? get_site_icon_url( $size )
-			: false;
+		$url = get_site_icon_url( $size );
 
 		// Fall back to built-in WordPress icon
 		if ( ! $url && in_array( $size, self::get_default_manifest_icon_sizes() ) ) {

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -178,10 +178,7 @@ class Jetpack_Related_Posts_Customize {
 	function get_options( $wp_customize ) {
 		$transport = isset( $wp_customize->selective_refresh ) ? 'postMessage' : 'refresh';
 
-		// Get the correct translated string for preview in WP 4.7 and later.
-		$switched_locale = function_exists( 'switch_to_locale' )
-			? switch_to_locale( get_user_locale() )
-			: false;
+		$switched_locale = switch_to_locale( get_user_locale() );
 		$headline = __( 'Related', 'jetpack' );
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -115,18 +115,12 @@ class Jetpack_Related_Posts_Customize {
 
 	/**
 	 * Check whether the current post contains a Related Posts block.
-	 * If we're on WP < 5.0, this automatically means it doesn't,
-	 * because block support is intrododuced in WP 5.0.
 	 *
 	 * @since 6.9.0
 	 *
 	 * @return bool
 	 */
 	public static function contains_related_posts_block() {
-		if ( ! function_exists( 'has_block' ) ) {
-			return false;
-		}
-
 		if ( has_block( 'jetpack/related-posts' ) ) {
 			return true;
 		}

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -65,9 +65,7 @@ class Jetpack_RelatedPosts {
 		}
 
 		// Add Related Posts to the REST API Post response.
-		if ( function_exists( 'register_rest_field' ) ) {
-			add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
-		}
+		add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 
 		jetpack_register_block(
 			'jetpack/related-posts',

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -165,7 +165,7 @@ class Jetpack_RelatedPosts {
 	 * @returns string
 	 */
 	public function filter_add_target_to_dom( $content ) {
-		if ( function_exists( 'has_block' ) && has_block( 'jetpack/related-posts', $content ) ) {
+		if ( has_block( 'jetpack/related-posts', $content ) ) {
 			return $content;
 		}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -41,7 +41,6 @@ class Sharing_Service {
 	 * Gets a list of all available service names and classes
 	 */
 	public function get_all_services( $include_custom = true ) {
-		global $wp_version;
 		// Default services
 		// if you update this list, please update the REST API tests
 		// in bin/tests/api/suites/SharingTest.php
@@ -76,7 +75,7 @@ class Sharing_Service {
 			$services['email'] = 'Share_Email';
 		}
 
-		if ( is_multisite() && ( version_compare( $wp_version, '4.9-RC1-42107', '<' ) || is_plugin_active( 'press-this/press-this-plugin.php' ) ) ) {
+		if ( is_multisite() && is_plugin_active( 'press-this/press-this-plugin.php' ) ) {
 			$services['press-this'] = 'Share_PressThis';
 		}
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1127,7 +1127,7 @@ class Share_PressThis extends Sharing_Source {
 	}
 
 	public function process_request( $post, array $post_data ) {
-		global $current_user, $wp_version;
+		global $current_user;
 
 		$primary_blog = (int) get_user_meta( $current_user->ID, 'primary_blog', true );
 		if ( $primary_blog ) {
@@ -1158,16 +1158,8 @@ class Share_PressThis extends Sharing_Source {
 			'u' => rawurlencode( $this->get_share_url( $post->ID ) ),
 			);
 
-		if ( version_compare( $wp_version, '4.9-RC1-42107', '>=' ) ) {
-			$args[ 'url-scan-submit' ] = 'Scan';
-			$args[ '_wpnonce' ]        = wp_create_nonce( 'scan-site' );
-
-		} else { // Remove once 4.9 is the minimum.
-			$args['t'] = rawurlencode( $this->get_share_title( $post->ID ) );
-			if ( isset( $_GET['sel'] ) ) {
-				$args['s'] = rawurlencode( $_GET['sel'] );
-			}
-		}
+		$args[ 'url-scan-submit' ] = 'Scan';
+		$args[ '_wpnonce' ]        = wp_create_nonce( 'scan-site' );
 
 		$url = $blog->siteurl . '/wp-admin/press-this.php';
 		$url = add_query_arg( $args, $url );

--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -84,10 +84,6 @@ function jetpack_load_shortcodes() {
  * @return string $content    Replaced post content.
  */
 function jetpack_preg_replace_outside_tags( $pattern, $replacement, $content, $search = null ) {
-	if ( ! function_exists( 'wp_html_split' ) ) {
-		return $content;
-	}
-
 	if ( $search && false === strpos( $content, $search ) ) {
 		return $content;
 	}
@@ -116,10 +112,6 @@ function jetpack_preg_replace_outside_tags( $pattern, $replacement, $content, $s
  * @return string $content Replaced post content.
  */
 function jetpack_preg_replace_callback_outside_tags( $pattern, $callback, $content, $search = null ) {
-	if ( ! function_exists( 'wp_html_split' ) ) {
-		return $content;
-	}
-
 	if ( $search && false === strpos( $content, $search ) ) {
 		return $content;
 	}

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -124,9 +124,7 @@ function wpme_rest_get_shortlink( $object ) {
 }
 
 // Add shortlinks to the REST API Post response.
-if ( function_exists( 'register_rest_field' ) ) {
-	add_action( 'rest_api_init', 'wpme_rest_register_shortlinks' );
-}
+add_action( 'rest_api_init', 'wpme_rest_register_shortlinks' );
 
 /**
  * Set the Shortlink Gutenberg extension as available.

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -931,7 +931,7 @@ function stats_admin_bar_head() {
 	if ( ! current_user_can( 'view_stats' ) )
 		return;
 
-	if ( function_exists( 'is_admin_bar_showing' ) && ! is_admin_bar_showing() ) {
+	if ( ! is_admin_bar_showing() ) {
 		return;
 	}
 

--- a/modules/theme-tools/compat/twentysixteen.php
+++ b/modules/theme-tools/compat/twentysixteen.php
@@ -56,10 +56,6 @@ function twentysixteen_remove_share() {
 add_action( 'loop_start', 'twentysixteen_remove_share' );
 
 function twentysixteen_jetpack_lazy_images_compat() {
-	if ( ! function_exists( 'wp_add_inline_script' ) ) {
-		return;
-	}
-
 	// Since TwentySixteen outdents when window is resized, let's trigger a window resize
 	// every time we lazy load an image on the TwentySixteen theme.
 	wp_add_inline_script(

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -772,7 +772,7 @@ class Jetpack_Widget_Conditions {
 			$taxonomy = 'post_tag';
 		}
 
-		if ( function_exists( 'wp_get_split_term' ) && $new_term_id = wp_get_split_term( $old_term_id, $taxonomy ) ) {
+		if ( $new_term_id = wp_get_split_term( $old_term_id, $taxonomy ) ) {
 			$term_id = $new_term_id;
 		}
 

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -144,7 +144,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 				'defaultFilterCount' => self::DEFAULT_FILTER_COUNT,
 				'tracksUserData'     => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 				'tracksEventData'    => array(
-					'is_customizer' => ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) ? 1 : 0,
+					'is_customizer' => (int) is_customize_preview(),
 				),
 				'i18n'               => array(
 					'month'        => Jetpack_Search_Helpers::get_date_filter_type_name( 'month', false ),

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -345,11 +345,8 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function site_icon_url( $size = 512 ) {
-		if ( ! function_exists( 'get_site_icon_url' ) || ! has_site_icon() ) {
-			return get_option( 'jetpack_site_icon_url' );
-		}
-
-		return get_site_icon_url( $size );
+		$site_icon = get_site_icon_url( $size );
+		return $site_icon ? $site_icon : get_option( 'jetpack_site_icon_url' );
 	}
 
 	public static function roles() {

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -151,11 +151,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	}
 
 	function jetpack_sync_core_icon() {
-		if ( function_exists( 'get_site_icon_url' ) ) {
-			$url = get_site_icon_url();
-		} else {
-			return;
-		}
+		$url = get_site_icon_url();
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/site-icon/site-icon-functions.php';
 		// If there's a core icon, maybe update the option.  If not, fall back to Jetpack's.

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -26,11 +26,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 		$this->action_handler = $callable;
 
-		// Core < 4.7 doesn't deal with nested wp_insert_post calls very well
-		global $wp_version;
-		$priority = version_compare( $wp_version, '4.7-alpha', '<' ) ? 0 : 11;
-
-		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), $priority, 3 );
+		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), 11, 3 );
 		add_action( 'jetpack_sync_save_post', $callable, 10, 4 );
 
 		add_action( 'deleted_post', $callable, 10 );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -297,8 +297,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			isset( $_POST['action'], $_GET['classic-editor'], $_GET['meta_box'] ) &&
 			'editpost' === $_POST['action'] &&
 			'1' === $_GET['classic-editor'] &&
-			'1' === $_GET['meta_box'] &&
-			Jetpack_Gutenberg::is_gutenberg_available()
+			'1' === $_GET['meta_box']
 		);
 	}
 

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -106,28 +106,15 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	}
 
 	public function expand_term_ids( $args ) {
-		global $wp_version;
 		$term_ids = $args[0];
 		$taxonomy = $args[1];
-		// version 4.5 or higher
-		if ( version_compare( $wp_version, 4.5, '>=' ) ) {
-			$terms = get_terms(
-				array(
-					'taxonomy'   => $taxonomy,
-					'hide_empty' => false,
-					'include'    => $term_ids,
-				)
-			);
-		} else {
-			$terms = get_terms(
-				$taxonomy,
-				array(
-					'hide_empty' => false,
-					'include'    => $term_ids,
-				)
-			);
-		}
 
-		return $terms;
+		return get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+				'include'    => $term_ids,
+			)
+		);
 	}
 }

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -358,11 +358,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_theme_support( $new_name, $new_theme = null, $old_theme = null ) {
-		// Previous theme support got added in WP 4.5
-		$previous_theme = false;
-		if ( $old_theme instanceof WP_Theme ) {
-			$previous_theme = $this->get_theme_support_info( $old_theme );
-		}
+		$previous_theme = $this->get_theme_support_info( $old_theme );
+
 		/**
 		 * Fires when the client needs to sync theme support info
 		 * Only sends theme support attributes whitelisted in Jetpack_Sync_Defaults::$default_theme_support_whitelist

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -216,14 +216,9 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function upsert_comment( $comment ) {
-		global $wpdb, $wp_version;
+		global $wpdb;
 
-		if ( version_compare( $wp_version, '4.4', '<' ) ) {
-			$comment = (array) $comment;
-		} else {
-			// WP 4.4 introduced the WP_Comment Class
-			$comment = $comment->to_array();
-		}
+		$comment = $comment->to_array();
 
 		// filter by fields on comment table
 		$comment_fields_whitelist = array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Bumps `JETPACK__MINIMUM_WP_VERSION` to 5.0
* Removes old `function_exists()` and `$wp_version` conditionals.

#### Testing instructions:
Completely untested. In fact, I suspect some automated tests will fail in this PR :)

#### Proposed changelog entry for your changes:
* Update the minimum WordPress version required to run Jetpack to WordPress 5.0.