### PR TITLE
Sync: Add the NUX site user type option to the whitelisted options.

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -139,8 +139,8 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
-		'site_ownership',
 		'site_segment',
+		'site_user_type',
 		'site_vertical',
 	);
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -139,6 +139,7 @@ class Jetpack_Sync_Defaults {
 		'wordads_display_page',
 		'wordads_display_archive',
 		'wordads_custom_adstxt',
+		'site_ownership',
 		'site_segment',
 		'site_vertical',
 	);

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,7 +198,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
-			'site_ownership'                       =>  array( 'user_id' => 0, 'is_owner' => true ),
+			'site_user_type'                       =>  json_encode( array( 0 => 'pineapple' ) ),
 			'site_segment'                         => 'pineapple',
 			'site_vertical'                        => 'pineapple',
 		);

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,6 +198,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
+			'site_ownership'                       =>  array( 'user_id' => 0, 'is_owner' => true ),
 			'site_segment'                         => 'pineapple',
 			'site_vertical'                        => 'pineapple',
 		);

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,7 +198,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wordads_display_page'                 => '1',
 			'wordads_display_archive'              => '1',
 			'wordads_custom_adstxt'                => 'pineapple',
-			'site_user_type'                       =>  json_encode( array( 0 => 'pineapple' ) ),
+			'site_user_type'                       => wp_json_encode( array( 1 => 'pineapple' ) ),
 			'site_segment'                         => 'pineapple',
 			'site_vertical'                        => 'pineapple',
 		);


### PR DESCRIPTION
Adding `site_user_type` option to the sync whitelisted options.

<!--- Provide a general summary of your changes in the Title above -->

Companion to D25062-code .

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Whitelists the `site_user_type` option, which is part of the Jetpack NUX flow.


#### Testing instructions:
- tests passing
- thorough testing at D25062-code .

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Adds NUX option to the sync options whitelist.
