### PR TITLE
Plugin search hints: maintain array keys after sorting

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -283,7 +283,7 @@ class Jetpack_Plugin_Search {
 					'search',
 				) )
 			);
-			usort( $jetpack_modules_list, array( $this, 'by_sorting_option' ) );
+			uasort( $jetpack_modules_list, array( $this, 'by_sorting_option' ) );
 
 			// Record event when user searches for a term
 			JetpackTracking::record_user_event( 'wpa_plugin_search_term', array( 'search_term' => $args->search ) );
@@ -301,7 +301,7 @@ class Jetpack_Plugin_Search {
 				}
 			}
 
-			if ( isset( $matching_module ) && $this->is_not_dismissed( $jetpack_modules_list[ $matching_module ]['module'] ) ) {
+			if ( isset( $matching_module ) && $this->is_not_dismissed( $matching_module ) ) {
 				// Record event when a matching feature is found
 				JetpackTracking::record_user_event( 'wpa_plugin_search_match_found', array( 'feature' => $matching_module ) );
 


### PR DESCRIPTION
This PR solves an issue when tracking the matched module. Previously, the `usort` function was used and it didn't maintain the array keys that were supposed to be the module slugs. This PR changes it to `uasort` that maintains the index association so we can still use the key later.

To verify this, see the live view for the `jetpack_wpa_plugin_search_match_found` event in Tracks.