### PR TITLE
Plugin search hints: fix console warning when loading the plugin thickbox

### DIFF
--- a/modules/plugin-search/plugin-search.js
+++ b/modules/plugin-search/plugin-search.js
@@ -159,6 +159,10 @@ var JetpackPSH = {};
 		 * Start suggesting.
 		 */
 		init: function() {
+			if ( JetpackPSH.$pluginFilter.length < 1 ) {
+				return;
+			}
+
 			// Replace PSH bottom row on page load
 			JetpackPSH.replaceCardBottom();
 


### PR DESCRIPTION
This PR fixes an issue when the title of a plugin–not the hint card title–is clicked and the Thickbox with more info is loaded. Previously it was throwing an error on console and it's been fixed now.

![error](https://user-images.githubusercontent.com/1041600/53754636-52b1a800-3e93-11e9-835b-518f5d987f84.png)


#### Testing instructions:
Keep the JS console open
WP Admin > Plugins > Add New 
Do a plugin search that triggers a hint, like `publicize`
Click the title of other plugins returned by search
The error above shouldn't be displayed in console