### PR TITLE
Subscription form: fix missing subscriber count 

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -689,10 +689,13 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( empty( $instance ) || ! is_array( $instance ) ) {
 		$instance = array();
 	}
-	$instance['show_subscribers_total']     = false;
-	if ( ! empty( $instance['show_subscribers_total'] ) && 'false' !== $instance['show_subscribers_total'] ) {
+
+	if ( empty( $instance['show_subscribers_total'] ) || 'false' === $instance['show_subscribers_total'] ) {
+		$instance['show_subscribers_total'] = false;
+	} else {
 		$instance['show_subscribers_total'] = true;
 	}
+
 	$show_only_email_and_button             = isset( $instance['show_only_email_and_button'] ) ? $instance['show_only_email_and_button'] : false;
 	$submit_button_text                     = isset( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : '';
 


### PR DESCRIPTION
This PR seeks to solve an issue where the subscriber count is not displayed, even when the user chooses to do so. It was introduced in this refactor https://github.com/Automattic/jetpack/pull/11124/files#diff-99eaf41dd1a227df1293c796a7ee6f8bR712 

Fixes #11446

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* update logic

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use this branch and follow the steps in https://github.com/Automattic/jetpack/issues/11446

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Subscription form: fixed an issue that prevented displaying subscribers count.
