### PR TITLE
Plugin search hints: fix issue where the first result was replaced

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -328,7 +328,8 @@ class Jetpack_Plugin_Search {
 				$inject = array_merge( $inject, $jetpack_modules_list[ $matching_module ], $overrides );
 
 				// Add it to the top of the list
-				$result->plugins = array( $inject ) + array_filter( $result->plugins, array( $this, 'filter_cards' ) );
+				$result->plugins = array_filter( $result->plugins, array( $this, 'filter_cards' ) );
+				array_unshift( $result->plugins, $inject );
 			}
 		}
 		return $result;


### PR DESCRIPTION
This PR fixes an issue reported at

https://wordpress.org/support/topic/incompatibility-with-jetpack-3/
https://wordpress.org/support/topic/jetpack-over-writing-plugin-search-results/

where the first result was replaced by a hint.

