### PR TITLE
Stats Widget: Update language when no hits or no response from API server

### DIFF
--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -150,7 +150,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 				isset( $instance['hits'] ) ? esc_html( $instance['hits'] ) : ''
 			);
 		} else {
-			esc_html_e( 'No hits.', 'jetpack' );
+			esc_html_e( 'There was an issue retrieving stats. Please try again later.', 'jetpack' );
 		}
 
 		echo $args['after_widget'];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Updates the "no hits" text.

#### Testing instructions:
* On a brand new site, add the blog stats widget and see "no hits" returned.
* Apply patch, repeat.
* Alternatively, ensure the Jetpack site is not able to contact public-api.wordpress.com and try again.

Note: There is five minutes of caching for successful API requests.

#### Proposed changelog entry for your changes:
* None needed.
