### PR TITLE
Tiled gallery: add wp-polyfill as a dependency

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -543,6 +543,7 @@ class Jetpack_Gutenberg {
 				'wp-i18n',
 				'wp-keycodes',
 				'wp-plugins',
+				'wp-polyfill',
 				'wp-rich-text',
 				'wp-token-list',
 				'wp-url',

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -27,7 +27,10 @@ if (
 	 * @return string
 	 */
 	function jetpack_tiled_gallery_load_block_assets( $attr, $content ) {
-		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
+		Jetpack_Gutenberg::load_assets_as_required(
+			'tiled-gallery',
+			array( 'wp-polyfill' )
+		);
 
 		/**
 		 * Filter the output of the Tiled Galleries content.


### PR DESCRIPTION
The previous version of Tiled gallery had `wp-i18n` as a dependency which depends on `wp-polyfill` (https://github.com/WordPress/WordPress/blob/029fcf7791e425303d14328471ed61e9f0ecc1e1/wp-includes/script-loader.php#L424).

We removed view side deps in https://github.com/Automattic/jetpack/pull/11326

By adding `wp-polyfill`, we ensure that `isNaN`, `Array.from` and other methods that need polyfilling to work in IE11.

Editor side dependency isn't _really_ needed here since many other dependencies pull in wp-polyfill as well, but seems like it's good to be explicit?

This fix is an alternative to https://github.com/Automattic/wp-calypso/pull/31228 because of size considerations: https://github.com/Automattic/wp-calypso/pull/31228#discussion_r262689258:
>wp-polyfill (v7.0.0) 30.7 KB minified
>
>view.js when building minified production versions from https://github.com/Automattic/wp-calypso/pull/31228:
>- without polyfill 7.96 KiB
>- with polyfill 87.6 KiB


#### Changes proposed in this Pull Request:
- Add `wp-polyfill` as a dependency for tiled gallery block view side and editor side.

#### Testing instructions:

- Spin up jurassic ninja with this branch gutenpack-jn
- Add Tiled gallery to a page where no other blocks are not present (to ensure you're not loading `wp-polyfill` via other sources)
- open the saved page in IE11 and observe no more  fatal errors in debugger

Fixes https://github.com/Automattic/wp-calypso/issues/31224

#### Proposed changelog entry for your changes:
Fix regression that caused Tiled Gallery not function in Internet Explorer 11 browsers anymore.
