### PR TITLE
Plugin search hints: introduce a master control 

### DIFF
--- a/_inc/jetpack-server-sandbox.php
+++ b/_inc/jetpack-server-sandbox.php
@@ -20,6 +20,7 @@ function jetpack_server_sandbox_request_parameters( $sandbox, $url, $headers ) {
 	switch ( $url_host ) {
 	case 'public-api.wordpress.com' :
 	case 'jetpack.wordpress.com' :
+	case 'jetpack.com' :
 	case 'dashboard.wordpress.com' :
 		$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
 		$url = preg_replace(

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -518,21 +518,52 @@ class Jetpack_Plugin_Search {
  * @return bool True if PSH is active.
  */
 function jetpack_is_psh_active() {
-	if ( false === ( $status = get_transient( 'jetpack_psh_status' ) ) ) {
-		$response = wp_remote_get( 'https://jetpack.com/psh-status/', array( 'sslverify' => false ) );
-		if ( is_wp_error( $response ) ) {
-			return true;
-		}
-		$body = wp_remote_retrieve_body( $response );
-		if ( empty( $body ) ) {
-			return true;
-		}
-		$json = json_decode( $body );
-		if ( ! isset( $json->active ) ) {
-			return true;
-		}
-		$status = (bool) $json->active;
-		set_transient( 'jetpack_psh_status', $status, 15 * MINUTE_IN_SECONDS );
+	// false means unset, 1 means active, 0 means inactive.
+	$status = get_transient( 'jetpack_psh_status' );
+
+	if ( false === $status ) {
+		$error = false;
+		$status = jetpack_get_remote_is_psh_active( $error );
+		set_transient(
+			'jetpack_psh_status',
+			// Cache as int
+			(int) $status,
+			// If there was an error, still cache but for a shorter time
+			( $error ? 5 : 15 ) * MINUTE_IN_SECONDS
+		);
 	}
-	return $status;
+
+	return (bool) $status;
+}
+
+/**
+ * Makes remote request to determine if Plugin search hints is active.
+ *
+ * @since 7.1.1
+ * @internal
+ *
+ * @param bool &$error Did the remote request result in an error?
+ * @return bool True if PSH is active.
+ */
+function jetpack_get_remote_is_psh_active( &$error ) {
+	$response = wp_remote_get( 'https://jetpack.com/psh-status/' );
+	if ( is_wp_error( $response ) ) {
+		$error = true;
+		return true;
+	}
+
+	$body = wp_remote_retrieve_body( $response );
+	if ( empty( $body ) ) {
+		$error = true;
+		return true;
+	}
+
+	$json = json_decode( $body );
+	if ( ! isset( $json->active ) ) {
+		$error = true;
+		return true;
+	}
+
+	$error = false;
+	return (bool) $json->active;
 }

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -339,12 +339,15 @@ class Jetpack_Plugin_Search {
 	/**
 	 * Remove cards for Akismet, Jetpack and VaultPress plugins since we don't want duplicates.
 	 *
-	 * @param array $plugin
+	 * @param array|object $plugin
 	 *
 	 * @return bool
 	 */
-	function filter_cards( $plugin = array() ) {
-		return ! in_array( $plugin['slug'], array( 'akismet', 'jetpack', 'vaultpress' ), true );
+	function filter_cards( $plugin ) {
+		// Take in account that before WordPress 5.1, the list of plugins is an array of objects.
+		// With WordPress 5.1 the list of plugins is an array of arrays.
+		$slug = is_array( $plugin ) ? $plugin['slug'] : $plugin->slug;
+		return ! in_array( $slug, array( 'akismet', 'jetpack', 'vaultpress' ), true );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes introduced by this PR

* A call to jetpack.com to verify that hints are active. It allows us to remotely deactivate hints. The status returned by `https://jetpack.com/psh-status/` will be saved in a transient for 15 minutes.
* Adds sandboxing capabilities for `jetpack.com`.
* Makes the plugin list filter function (`filter_cards`) compatible with WordPress < 5.1 

#### Testing instructions:

* ~Test with D25148-code~ (deployed now).
* Set it to return true and false and verify that the value changes. Remember that it's locally stored as a transient so you need to delete it `delete_transient( 'jetpack_psh_status' );`(or `wp transient delete jetpack_psh_status` or `yarn docker:wp transient delete jetpack_psh_status`)  after changing the status in jetpack.com.

#### Proposed changelog entry

Plugin search hints: these can now be remotely deactivated thanks to a master switch in jetpack.com
