### PR TITLE
Add repeat visitor polyfill

### DIFF
--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -23,7 +23,7 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_repeat_visitor_block_render( $attributes, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'repeat-visitor' );
+	Jetpack_Gutenberg::load_assets_as_required( 'repeat-visitor', array( 'wp-polyfill' ) );
 
 	$count     = isset( $_COOKIE['jp-visit-counter'] ) ? intval( $_COOKIE['jp-visit-counter'] ) : 0;
 	$criteria  = isset( $attributes['criteria'] ) ? $attributes['criteria'] : 'after-visits';


### PR DESCRIPTION
Similar to Tiled Gallery (#11487) and Mailchimp (#11498), Repeat Visitor requires a polyfill for its view script. It breaks when used with some browsers (ie11).

#### Testing instructions:
* Add the block
* View it in ie11
* Does the block work as expected?

#### Proposed changelog entry for your changes:

none