### PR TITLE
Mailchimp: Add view polyfill

### DIFF
--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -31,7 +31,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	$values  = array();
 	$blog_id = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ?
 		get_current_blog_id() : Jetpack_Options::get_option( 'id' );
-	Jetpack_Gutenberg::load_assets_as_required( 'mailchimp', null );
+	Jetpack_Gutenberg::load_assets_as_required( 'mailchimp', array( 'wp-polyfill' ) );
 	$defaults = array(
 		'emailPlaceholder' => esc_html__( 'Enter your email', 'jetpack' ),
 		'submitButtonText' => esc_html__( 'Join my email list', 'jetpack' ),


### PR DESCRIPTION
Mailchimp was breaking view side in ie11, similar to Tiled Gallery.

Add wp-polyfill as a view dependency

#### Testing instructions:
* Add the mailchimp block
* View the block in an isolated post with no other blocks
* Does the block work as expected when viewed in ie11?

#### Proposed changelog entry for your changes:

* Fix Mailchimp block behavior in ie11
