### PR TITLE
Jetpack Blocks: update blocks for Jetpack 7.1.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "13.1.0",
+    "@automattic/jetpack-blocks": "13.1.1",
     "babel-core": "6.26.3",
     "babel-eslint": "6.1.2",
     "babel-loader": "7.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-13.1.0.tgz#b25da8b79611c61cc6e260863d2d1888cdc2d6ad"
+"@automattic/jetpack-blocks@13.1.1":
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-13.1.1.tgz#7a3eda493ea92ed4a3b4957a57b42fae5189a761"
 
 "@babel/code-frame@7.0.0-beta.46":
   version "7.0.0-beta.46"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

See https://www.npmjs.com/package/@automattic/jetpack-blocks

Blocks created from this tag:
https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4013.1.1

#### Testing instructions:

* Do the blocks work, are available in the editor?

#### Proposed changelog entry for your changes:

* None
