### PR TITLE
Unit tests: Include geo-location tests in phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -105,6 +105,9 @@
 		<testsuite name="search">
 			<directory prefix="test_" suffix=".php">tests/php/modules/search</directory>
 		</testsuite>
+		<testsuite name="geo-location">
+			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -106,7 +106,7 @@
 			<directory prefix="test_" suffix=".php">tests/php/modules/search</directory>
 		</testsuite>
 		<testsuite name="geo-location">
-			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
+			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -37,7 +37,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 	public function test_location_display_filter_skipped_when_lacking_theme_support() {
 		$instance = $this->create_mock_instance(
-			[ 'current_theme_supports', 'the_content_location_display' ],
+			array( 'current_theme_supports', 'the_content_location_display' ),
 			self::ENABLE_CONSTRUCTOR
 		);
 
@@ -59,7 +59,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		}
 
 		$instance = $this->create_mock_instance(
-			[ 'the_content_location_display' ],
+			array( 'the_content_location_display' ),
 			self::ENABLE_CONSTRUCTOR
 		);
 
@@ -396,7 +396,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( WP_Query::class )
-			->setMethods( [ 'is_feed', 'is_single' ] )
+			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -409,7 +409,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( WP_Query::class )
-			->setMethods( [ 'is_feed', 'is_single' ] )
+			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -422,7 +422,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( WP_Query::class )
-			->setMethods( [ 'is_feed' ] )
+			->setMethods( array( 'is_feed' ) )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -435,7 +435,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( WP_Query::class )
-			->setMethods( [ 'is_feed' ] )
+			->setMethods( array( 'is_feed' ) )
 			->getMock();
 
 		$wp_query->expects( $this->any() )

--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -380,7 +380,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 			$additional_mock_methods
 		);
 
-		$klass = Jetpack_Geo_Location::class;
+		$klass = 'Jetpack_Geo_Location';
 		/* @var $instance Jetpack_Geo_Location|PHPUnit_Framework_MockObject_MockObject */
 		$builder = $this->getMockBuilder( $klass )->setMethods( $mock_methods );
 
@@ -394,7 +394,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_single() {
 		global $wp_query;
 
-		$klass = WP_Query::class;
+		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed', 'is_single' ) )
@@ -408,7 +408,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_single() {
 		global $wp_query;
 
-		$klass = WP_Query::class;
+		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed', 'is_single' ) )
@@ -422,7 +422,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_feed() {
 		global $wp_query;
 
-		$klass = WP_Query::class;
+		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed' ) )
@@ -436,7 +436,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_feed() {
 		global $wp_query;
 
-		$klass = WP_Query::class;
+		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
 		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed' ) )

--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -380,9 +380,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 			$additional_mock_methods
 		);
 
+		$klass = Jetpack_Geo_Location::class;
 		/* @var $instance Jetpack_Geo_Location|PHPUnit_Framework_MockObject_MockObject */
-		$builder = $this->getMockBuilder( Jetpack_Geo_Location::class )
-			->setMethods( $mock_methods );
+		$builder = $this->getMockBuilder( $klass )->setMethods( $mock_methods );
 
 		if ( $disable_constructor ) {
 			$builder->disableOriginalConstructor();
@@ -394,8 +394,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_single() {
 		global $wp_query;
 
+		$klass = WP_Query::class;
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( WP_Query::class )
+		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
@@ -407,8 +408,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_single() {
 		global $wp_query;
 
+		$klass = WP_Query::class;
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( WP_Query::class )
+		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
@@ -420,8 +422,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_feed() {
 		global $wp_query;
 
+		$klass = WP_Query::class;
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( WP_Query::class )
+		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed' ) )
 			->getMock();
 
@@ -433,8 +436,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_feed() {
 		global $wp_query;
 
+		$klass = WP_Query::class;
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( WP_Query::class )
+		$wp_query = $this->getMockBuilder( $klass )
 			->setMethods( array( 'is_feed' ) )
 			->getMock();
 

--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -41,7 +41,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 			self::ENABLE_CONSTRUCTOR
 		);
 
-		$instance->method( 'current_theme_supports' )->willReturn( false );
+		$instance->expects( $this->any() )->method( 'current_theme_supports' )->willReturn( false );
 
 		$instance->expects( $this->never() )
 			->method( 'the_content_location_display' );
@@ -380,9 +380,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 			$additional_mock_methods
 		);
 
-		$klass = 'Jetpack_Geo_Location';
 		/* @var $instance Jetpack_Geo_Location|PHPUnit_Framework_MockObject_MockObject */
-		$builder = $this->getMockBuilder( $klass )->setMethods( $mock_methods );
+		$builder = $this->getMockBuilder( 'Jetpack_Geo_Location' )->setMethods( $mock_methods );
 
 		if ( $disable_constructor ) {
 			$builder->disableOriginalConstructor();
@@ -394,9 +393,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_single() {
 		global $wp_query;
 
-		$klass = 'WP_Query';
+
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( $klass )
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
 			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
@@ -408,9 +407,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_single() {
 		global $wp_query;
 
-		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( $klass )
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
 			->setMethods( array( 'is_feed', 'is_single' ) )
 			->getMock();
 
@@ -422,9 +420,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_feed() {
 		global $wp_query;
 
-		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( $klass )
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
 			->setMethods( array( 'is_feed' ) )
 			->getMock();
 
@@ -436,9 +433,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_not_feed() {
 		global $wp_query;
 
-		$klass = 'WP_Query';
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( $klass )
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
 			->setMethods( array( 'is_feed' ) )
 			->getMock();
 

--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -37,11 +37,11 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 
 	public function test_location_display_filter_skipped_when_lacking_theme_support() {
 		$instance = $this->create_mock_instance(
-			array( 'current_theme_supports', 'the_content_location_display' ),
+			[ 'current_theme_supports', 'the_content_location_display' ],
 			self::ENABLE_CONSTRUCTOR
 		);
 
-		$instance->expects( $this->any() )->method( 'current_theme_supports' )->willReturn( false );
+		$instance->method( 'current_theme_supports' )->willReturn( false );
 
 		$instance->expects( $this->never() )
 			->method( 'the_content_location_display' );
@@ -59,7 +59,7 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		}
 
 		$instance = $this->create_mock_instance(
-			array( 'the_content_location_display' ),
+			[ 'the_content_location_display' ],
 			self::ENABLE_CONSTRUCTOR
 		);
 
@@ -381,7 +381,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		);
 
 		/* @var $instance Jetpack_Geo_Location|PHPUnit_Framework_MockObject_MockObject */
-		$builder = $this->getMockBuilder( 'Jetpack_Geo_Location' )->setMethods( $mock_methods );
+		$builder = $this->getMockBuilder( Jetpack_Geo_Location::class )
+			->setMethods( $mock_methods );
 
 		if ( $disable_constructor ) {
 			$builder->disableOriginalConstructor();
@@ -393,10 +394,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	private function mock_is_single() {
 		global $wp_query;
 
-
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'is_feed', 'is_single' ) )
+		$wp_query = $this->getMockBuilder( WP_Query::class )
+			->setMethods( [ 'is_feed', 'is_single' ] )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -408,8 +408,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		global $wp_query;
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'is_feed', 'is_single' ) )
+		$wp_query = $this->getMockBuilder( WP_Query::class )
+			->setMethods( [ 'is_feed', 'is_single' ] )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -421,8 +421,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		global $wp_query;
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'is_feed' ) )
+		$wp_query = $this->getMockBuilder( WP_Query::class )
+			->setMethods( [ 'is_feed' ] )
 			->getMock();
 
 		$wp_query->expects( $this->any() )
@@ -434,8 +434,8 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 		global $wp_query;
 
 		/* @var $wp_query WP_Query|PHPUnit_Framework_MockObject_MockObject */
-		$wp_query = $this->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'is_feed' ) )
+		$wp_query = $this->getMockBuilder( WP_Query::class )
+			->setMethods( [ 'is_feed' ] )
 			->getMock();
 
 		$wp_query->expects( $this->any() )


### PR DESCRIPTION
It seems like geo-location unit-tests was never added to phpunit config, which means we never run them as part of CI

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Include geo-location tests in `phpunit.xml.dist`

#### Testing instructions:

* Check the CI job. Are geo-location tests passing?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* nothing
