### PR TITLE
Bump minimum version to 5.0

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '4.9' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.0' );
 
 define( 'JETPACK__VERSION',            '7.2-alpha' );
 define( 'JETPACK_MASTER_USER',         true );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, sdquirk, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 7.0.1
-Requires at least: 4.9
+Requires at least: 5.0
 Tested up to: 5.1
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.


### PR DESCRIPTION
The bare minimum to proclaim boldly that 5.0 is our minimum supported version. The rest of the clean-up is happening in #11460

#### Changes proposed in this Pull Request:
* Bump version.

#### Testing instructions:
* Read the diff.
* Commit.

#### Proposed changelog entry for your changes:
* Nope.
