### PR TITLE
REST API: Register Likes/Sharing fields for all post types

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -621,17 +621,20 @@ function jetpack_post_likes_update_value( $enable_post_likes, $post_object ) {
  * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
  */
 function jetpack_post_likes_register_rest_field() {
-	register_rest_field(
-		'post', 'jetpack_likes_enabled',
-		array(
-			'get_callback' => 'jetpack_post_likes_get_value',
-			'update_callback' => 'jetpack_post_likes_update_value',
-			'schema' => array(
-				'description' => __( 'Are Likes enabled?' ),
-				'type'        => 'boolean'
-			),
-		)
-	);
+	$post_types = get_post_types( array( 'public' => true ) );
+	foreach( $post_types as $post_type ) {
+		register_rest_field(
+			$post_type, 'jetpack_likes_enabled',
+			array(
+				'get_callback' => 'jetpack_post_likes_get_value',
+				'update_callback' => 'jetpack_post_likes_update_value',
+				'schema' => array(
+					'description' => __( 'Are Likes enabled?' ),
+					'type'        => 'boolean'
+				),
+			)
+		);
+	}
 }
 
 // Add Likes post_meta to the REST API Post response.

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -622,15 +622,16 @@ function jetpack_post_likes_update_value( $enable_post_likes, $post_object ) {
  */
 function jetpack_post_likes_register_rest_field() {
 	$post_types = get_post_types( array( 'public' => true ) );
-	foreach( $post_types as $post_type ) {
+	foreach ( $post_types as $post_type ) {
 		register_rest_field(
-			$post_type, 'jetpack_likes_enabled',
+			$post_type,
+			'jetpack_likes_enabled',
 			array(
-				'get_callback' => 'jetpack_post_likes_get_value',
+				'get_callback'    => 'jetpack_post_likes_get_value',
 				'update_callback' => 'jetpack_post_likes_update_value',
-				'schema' => array(
+				'schema'          => array(
 					'description' => __( 'Are Likes enabled?', 'jetpack' ),
-					'type'        => 'boolean'
+					'type'        => 'boolean',
 				),
 			)
 		);

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -629,7 +629,7 @@ function jetpack_post_likes_register_rest_field() {
 				'get_callback' => 'jetpack_post_likes_get_value',
 				'update_callback' => 'jetpack_post_likes_update_value',
 				'schema' => array(
-					'description' => __( 'Are Likes enabled?' ),
+					'description' => __( 'Are Likes enabled?', 'jetpack' ),
 					'type'        => 'boolean'
 				),
 			)

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -598,7 +598,7 @@ function jetpack_post_sharing_register_rest_field() {
 				'get_callback' => 'jetpack_post_sharing_get_value',
 				'update_callback' => 'jetpack_post_sharing_update_value',
 				'schema' => array(
-					'description' => __( 'Are sharing buttons enabled?' ),
+					'description' => __( 'Are sharing buttons enabled?', 'jetpack' ),
 					'type'        => 'boolean'
 				),
 			)

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -590,17 +590,20 @@ function jetpack_post_sharing_update_value( $enable_sharing, $post_object ) {
  * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
  */
 function jetpack_post_sharing_register_rest_field() {
-	register_rest_field(
-		'post', 'jetpack_sharing_enabled',
-		array(
-			'get_callback' => 'jetpack_post_sharing_get_value',
-			'update_callback' => 'jetpack_post_sharing_update_value',
-			'schema' => array(
-				'description' => __( 'Are sharing buttons enabled?' ),
-				'type'        => 'boolean'
-			),
-		)
-	);
+	$post_types = get_post_types( array( 'public' => true ) );
+	foreach( $post_types as $post_type ) {
+		register_rest_field(
+			$post_type, 'jetpack_sharing_enabled',
+			array(
+				'get_callback' => 'jetpack_post_sharing_get_value',
+				'update_callback' => 'jetpack_post_sharing_update_value',
+				'schema' => array(
+					'description' => __( 'Are sharing buttons enabled?' ),
+					'type'        => 'boolean'
+				),
+			)
+		);
+	}
 }
 
 // Add Sharing post_meta to the REST API Post response.

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -591,15 +591,16 @@ function jetpack_post_sharing_update_value( $enable_sharing, $post_object ) {
  */
 function jetpack_post_sharing_register_rest_field() {
 	$post_types = get_post_types( array( 'public' => true ) );
-	foreach( $post_types as $post_type ) {
+	foreach ( $post_types as $post_type ) {
 		register_rest_field(
-			$post_type, 'jetpack_sharing_enabled',
+			$post_type,
+			'jetpack_sharing_enabled',
 			array(
-				'get_callback' => 'jetpack_post_sharing_get_value',
+				'get_callback'    => 'jetpack_post_sharing_get_value',
 				'update_callback' => 'jetpack_post_sharing_update_value',
-				'schema' => array(
+				'schema'          => array(
 					'description' => __( 'Are sharing buttons enabled?', 'jetpack' ),
-					'type'        => 'boolean'
+					'type'        => 'boolean',
 				),
 			)
 		);


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
In #11298, metadata to check whether sharing and Like buttons are enabled was added to post endpoints. I thought at the time that hooking it to the "post" type meant "posts and pages", but it turns out it does not.

This PR follows the [pre-existing pattern](https://github.com/Automattic/jetpack/blob/efec7da79f99482da8935cac7a7d4bbb4e9678b6/modules/likes/jetpack-likes-settings.php#L34) of enabling this functionality for all public post types (this is the same logic used to add the metaboxes to the admin screen).

#### Testing instructions:
* Go through the following testing instructions for multiple post types: **pages**, another CPT that supports likes or sharing, and posts.
* In both Gutenberg and the Classic Editor, verify that the old (backwards-compatible) Likes and Sharing metabox still displays, and works as intended.
* In Jetpack Sharing settings, enable the toggles to show Likes and Sharing Buttons.
* Request the post (or page) endpoint via the REST API. Verify that `jetpack_likes_enabled` and `jetpack_sharing_enabled` show under the meta keys:

<img width="293" alt="screen shot 2019-02-07 at 12 48 47 am" src="https://user-images.githubusercontent.com/52152/52399804-2c564380-2a72-11e9-964a-fc22658d4585.png">

* Experiment with different combinations of sitewide like and sharing settings and post settings, and ensure the values returned by the API reflect reality

#### Proposed changelog entry for your changes:
* REST API: Enable Likes and Sharing meta field for all post types
