### PR TITLE
Stats: Return error for API requests

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1503,7 +1503,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 *     @type string $date Date range to restrict results to.
 	 * }
 	 *
-	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response Stats information relayed from WordPress.com
+	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
 	 */
 	public function get_stats_data( WP_REST_Request $request ) {
 		// Get parameters to fetch Stats data.

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1503,7 +1503,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 *     @type string $date Date range to restrict results to.
 	 * }
 	 *
-	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
+	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response Stats information relayed from WordPress.com
 	 */
 	public function get_stats_data( WP_REST_Request $request ) {
 		// Get parameters to fetch Stats data.

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1745,6 +1745,9 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 		$time = key( $stats_cache[ $cache_key ] );
 		if ( time() - $time < ( 5 * MINUTE_IN_SECONDS ) ) {
 			$cached_stats = $stats_cache[ $cache_key ][ $time ];
+			if ( is_wp_error( $cached_stats ) ) {
+				return $cached_stats;
+			}
 			$cached_stats = (object) array_merge( array( 'cached_at' => $time ), (array) $cached_stats );
 			return $cached_stats;
 		}
@@ -1754,7 +1757,7 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 	// Do the dirty work.
 	$response = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, $api_version, $args );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		$data = array();
+		$data = $response;
 	} else {
 		$data = json_decode( wp_remote_retrieve_body( $response ) );
 	}


### PR DESCRIPTION
Fixes #11513

Handles cases where the WP.com API fails when loading the JP dashboard after #11489

#### Changes proposed in this Pull Request:
* Passes through error message.

#### Testing instructions:
* Set up your site's hosts file to blackhole `JETPACK__WPCOM_JSON_API_HOST` or set it to your sandbox and intentionally 500 any response.
* Open the Jetpack dashboard.
* Confirm the error is handled gracefully like so:
![2019-03-07 at 11 17](https://user-images.githubusercontent.com/88897/53975857-66475380-40cb-11e9-94b3-b0b04eca7f8e.jpg)


#### Proposed changelog entry for your changes:
* Stats Dashboard: Properly handle an error from the REST API
