### PR TITLE
Imports: Record Tracks events for import actions

### DIFF
--- a/class.jetpack-import-stats.php
+++ b/class.jetpack-import-stats.php
@@ -6,6 +6,7 @@ class Jetpack_Import_Stats {
 		'LJ_API_Import' => 'livejournal',
 		'MT_Import' => 'mt',
 		'RSS_Import' => 'rss',
+		'WC_Tax_Rate_Importer' => 'woo-tax-rate',
 		'WP_Import' => 'wordpress',
 	);
 

--- a/class.jetpack-import-stats.php
+++ b/class.jetpack-import-stats.php
@@ -50,7 +50,7 @@ class Jetpack_Import_Stats {
 			return 'unknown';
 		}
 
-		// continue iterating the stack looking for a caller that extends WP_Import
+		// continue iterating the stack looking for a caller that extends WP_Importer
 		for ( $i = $do_action_pos + 1; $i < count( $backtrace ); $i++ ) {
 			// grab only class_name from the trace
 			list( $class_name ) = explode( '->', $backtrace[ $i ] );

--- a/class.jetpack-import-stats.php
+++ b/class.jetpack-import-stats.php
@@ -50,7 +50,7 @@ class Jetpack_Import_Stats {
 		}
 
 		// continue iterating the stack looking for a caller that extends WP_Import
-		for ( $i = $do_action_pos; $i < count( $backtrace ); $i++ ) {
+		for ( $i = $do_action_pos + 1; $i < count( $backtrace ); $i++ ) {
 			// grab only class_name from the trace
 			list( $class_name ) = explode( '->', $backtrace[ $i ] );
 

--- a/class.jetpack-import-stats.php
+++ b/class.jetpack-import-stats.php
@@ -1,7 +1,15 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/sync/class.jetpack-sync-functions.php';
+
 class Jetpack_Import_Stats {
-	static $known_importers = array(
+	/**
+	 * A mapping of known importers to friendly names.
+	 * Keys are the class name of the known importer.
+	 * Values are the friendly name.
+	 * @var array
+	 */
+	private static $known_importers = array(
 		'Blogger_Importer' => 'blogger',
 		'LJ_API_Import' => 'livejournal',
 		'MT_Import' => 'mt',
@@ -10,7 +18,13 @@ class Jetpack_Import_Stats {
 		'WP_Import' => 'wordpress',
 	);
 
-	static $action_event_name_map = array(
+	/**
+	 * A mapping of action types to event name.
+	 * Keys are the name of the action.
+	 * Values are the event name recorded for that action.
+	 * @var array
+	 */
+	private static $action_event_name_map = array(
 		'import_start' => 'jetpack_import_start',
 		'import_done'  => 'jetpack_import_done',
 		'import_end'   => 'jetpack_import_done',
@@ -25,54 +39,11 @@ class Jetpack_Import_Stats {
 		}
 	}
 
-	private static function get_calling_class() {
-		// If WP_Importer doesn't exist, neither will any importer that extends it
-		if ( ! class_exists( 'WP_Importer' ) ){
-			return 'unknown';
-		}
-
-		$action = current_filter();
-		$backtrace = wp_debug_backtrace_summary( null, 0, false );
-
-		$do_action_pos = -1;
-		for ( $i = 0; $i < count( $backtrace ); $i++ ) {
-			// Find the location in the stack of the calling action
-			if ( preg_match( "/^do_action\\(\'([^\']+)/", $backtrace[ $i ], $matches ) ) {
-				if ( $matches[1] === $action ) {
-					$do_action_pos = $i;
-					break;
-				}
-			}
-		}
-
-		// if the action wasn't called, the calling class is unknown
-		if ( -1 === $do_action_pos ) {
-			return 'unknown';
-		}
-
-		// continue iterating the stack looking for a caller that extends WP_Importer
-		for ( $i = $do_action_pos + 1; $i < count( $backtrace ); $i++ ) {
-			// grab only class_name from the trace
-			list( $class_name ) = explode( '->', $backtrace[ $i ] );
-
-			// check if the class extends WP_Importer
-			if ( class_exists( $class_name ) ) {
-				$parents = class_parents( $class_name );
-				if ( $parents && in_array( 'WP_Importer', $parents ) ) {
-					return $class_name;
-				}
-			}
-		}
-
-		// If we've exhausted the stack without a match, the calling class is unknown
-		return 'unknown';
-	}
-
 	public static function log_import_progress( $importer ) {
 		// prefer self-reported importer-names
 		if ( ! $importer ) {
 			// fall back to inferring by calling class name
-			$importer = self::get_calling_class();
+			$importer = Jetpack_Sync_Functions::get_calling_importer_class();
 		}
 		
 		// Give known importers a "friendly" name

--- a/class.jetpack-import-stats.php
+++ b/class.jetpack-import-stats.php
@@ -1,0 +1,76 @@
+<?php
+
+class Jetpack_Import_Stats {
+	static $known_importers = array(
+		'Blogger_Importer' => 'blogger',
+		'LJ_API_Import' => 'livejournal',
+		'MT_Import' => 'mt',
+		'RSS_Import' => 'rss',
+		'WP_Import' => 'wordpress',
+	);
+
+	static $action_event_name_map = array(
+		'import_start' => 'jetpack_import_start',
+		'import_done'  => 'jetpack_import_done',
+		'import_end'   => 'jetpack_import_done',
+	);
+
+	public static function init() {
+		// Only handle import actions for sites that have agreed to TOS 
+		if ( Jetpack::jetpack_tos_agreed() ) {
+			add_action( 'import_start', array( 'Jetpack_Import_Stats', 'log_import_progress' ) );
+			add_action( 'import_done',  array( 'Jetpack_Import_Stats', 'log_import_progress' ) );
+			add_action( 'import_end',   array( 'Jetpack_Import_Stats', 'log_import_progress' ) );
+		}
+	}
+
+	private static function get_calling_class() {
+		$action = current_filter();
+		$backtrace = wp_debug_backtrace_summary( null, 0, false );
+
+		$do_action_pos = -1;
+		for ( $i = 0; $i < count( $backtrace ); $i++ ) {
+			// Find the location in the stack of the calling action
+			if ( preg_match( "/^do_action\\(\'([^\']+)/", $backtrace[ $i ], $matches ) ) {
+				if ( $matches[1] === $action ) {
+					$do_action_pos = $i;
+					break;
+				}
+			}
+		}
+
+		// if the action wasn't called, the calling class is unknown
+		if ( -1 === $do_action_pos ) {
+			return 'unknown';
+		}
+
+		// The calling class is next in the stack, after $do_action_pos
+		list( $className ) = explode( '->', $backtrace[ $do_action_pos + 1 ] );
+		return $className;
+	}
+
+	public static function log_import_progress( $importer ) {
+		// prefer self-reported importer-names
+		if ( ! $importer ) {
+			// fall back to inferring by calling class name
+			$importer = self::get_calling_class();
+		}
+		
+		// Give known importers a "friendly" name
+		if ( isset( self::$known_importers[ $importer ] ) ) {
+			$importer = self::$known_importers[ $importer ];
+		}
+		$action = current_filter();
+		// map action to event name
+		$event_name = self::$action_event_name_map[ $action ];
+		
+		$current_user = wp_get_current_user();
+
+		// Record event to Tracks
+		jetpack_tracks_record_event( $current_user, $event_name, array(
+			'importer' => $importer,
+		) );
+	}
+}
+
+add_action( 'init', array( 'Jetpack_Import_Stats', 'init' ) );

--- a/jetpack.php
+++ b/jetpack.php
@@ -107,6 +107,7 @@ if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
+	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-import-stats.php' );
 }
 
 // Play nice with http://wp-cli.org/

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -403,4 +403,53 @@ class Jetpack_Sync_Functions {
 		}
 		return false;
 	}
+
+	/**
+	 * Determine the class that extends `WP_Importer` which is responsible for
+	 * the current action. Designed to be used within an action handler.
+	 *
+	 * @return string  The name of the calling class, or 'unknown'.
+	 */
+	public static function get_calling_importer_class() {
+		// If WP_Importer doesn't exist, neither will any importer that extends it
+		if ( ! class_exists( 'WP_Importer' ) ){
+			return 'unknown';
+		}
+
+		$action = current_filter();
+		$backtrace = wp_debug_backtrace_summary( null, 0, false );
+
+		$do_action_pos = -1;
+		for ( $i = 0; $i < count( $backtrace ); $i++ ) {
+			// Find the location in the stack of the calling action
+			if ( preg_match( "/^do_action\\(\'([^\']+)/", $backtrace[ $i ], $matches ) ) {
+				if ( $matches[1] === $action ) {
+					$do_action_pos = $i;
+					break;
+				}
+			}
+		}
+
+		// if the action wasn't called, the calling class is unknown
+		if ( -1 === $do_action_pos ) {
+			return 'unknown';
+		}
+
+		// continue iterating the stack looking for a caller that extends WP_Importer
+		for ( $i = $do_action_pos + 1; $i < count( $backtrace ); $i++ ) {
+			// grab only class_name from the trace
+			list( $class_name ) = explode( '->', $backtrace[ $i ] );
+
+			// check if the class extends WP_Importer
+			if ( class_exists( $class_name ) ) {
+				$parents = class_parents( $class_name );
+				if ( $parents && in_array( 'WP_Importer', $parents ) ) {
+					return $class_name;
+				}
+			}
+		}
+
+		// If we've exhausted the stack without a match, the calling class is unknown
+		return 'unknown';
+	}
 }

--- a/sync/class.jetpack-sync-module-import.php
+++ b/sync/class.jetpack-sync-module-import.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-functions.php';
+
 class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 
 	private $import_end = false;
@@ -49,19 +51,25 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 		}
 
 		$this->import_end = true;
-		$importer         = 'unknown';
-		$backtrace        = wp_debug_backtrace_summary( null, 0, false );
-		if ( $this->is_importer( $backtrace, 'Blogger_Importer' ) ) {
-			$importer = 'blogger';
-		}
+		$importer_class   = Jetpack_Sync_Functions::get_calling_importer_class();
 
-		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WC_Tax_Rate_Importer' ) ) {
-			$importer = 'woo-tax-rate';
-		}
+		switch( $importer_class ) {
+			case 'Blogger_Importer':
+				$importer = 'blogger';
+				break;
 
-		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WP_Import' ) ) {
-			// phpcs:ignore WordPress.WP.CapitalPDangit
-			$importer = 'wordpress';
+			case 'WC_Tax_Rate_Importer':
+				$importer = 'woo-tax-rate';
+				break;
+
+			case 'WP_Import':
+				// phpcs:ignore WordPress.WP.CapitalPDangit
+				$importer = 'wordpress';
+				break;
+
+			default:
+				$importer = 'unknown';
+				break;
 		}
 
 		$importer_name = $this->get_importer_name( $importer );
@@ -75,13 +83,4 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
 	}
 
-	private function is_importer( $backtrace, $class_name ) {
-		foreach ( $backtrace as $trace ) {
-			if ( strpos( $trace, $class_name ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Verifies that the user has agreed to the TOS and if so...
  * Hooks into `import_start`, `import_done`, and `import_end` actions
  * Uses the self-reported importer name from the action if it exists, if not:
    * Attempts to infer the importer name from the calling class determined by the call stack
  * Records that the action occurred to Tracks

#### Testing instructions:

* Go to `/wp-admin/admin.php?import=wordpress`
* Complete an import. If the import completes successfully, you should see two tracks events recorded:
  * `jetpack_import_start`
  * `jetpack_import_done`
* Both events should have an eventprop named `importer` with a value of `wordpress`
* Other types of imports that trigger the `import_done` or `import_end` actions should also record Tracks events named `jetpack_import_done`. Examples: (Blogger, LiveJournal, RSS). However, those importers don't currently trigger `import_start`, so it won't be recorded.

#### Proposed changelog entry for your changes:
No changelog entry required.
