### PR TITLE
Mailchimp: update shortcode to bring in sync with WordPress.com

### DIFF
--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -188,6 +188,10 @@ class MailChimp_Subscriber_Popup {
 		// Split config & js vars
 		$config_vars = $js_vars = array();
 		foreach ( $attrs as $key => $value ) {
+			if ( 'baseUrl' == $key && ( ! preg_match( '#mc\.us\d+\.list-manage\d?\.com#', $value, $matches ) || $value !== $matches[0] ) ) {
+				return '<!-- Invalid MailChimp baseUrl -->';
+			}
+
 			if ( in_array( $key, self::$allowed_js_vars ) ) {
 				$js_vars[ $key ] = $value;
 			} else {

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -1,4 +1,4 @@
-<?php
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * MailChimp Subscriber Popup Form shortcode
  *
@@ -7,7 +7,6 @@
  *
  * Embed code example:
  * <script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">window.dojoRequire(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"1ca7856462585a934b8674c71","lid":"2d24f1898b","uniqueMethods":true}) })</script>
- *
  */
 
 /**
@@ -50,9 +49,9 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @var array
 	 */
-	static $reversal_regexes = array(
+	private static $reversal_regexes = array(
 		/* raw examplejs */
-		'/<script type="text\/javascript" src="(https?:)?\/\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/unique-methods\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">window.dojoRequire\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s',
+		'/<script type="text\/javascript" src="(https?:)?\/\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/unique-methods\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">window.dojoRequire\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s', //phpcs:ignore
 		/* visual editor */
 		'/&lt;script type="text\/javascript" src="(https?:)?\/\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/unique-methods\/embed\.js" data-dojo-config="([^"]*?)"&gt;&lt;\/script&gt;&lt;script type="text\/javascript"&gt;window.dojoRequire\(\["mojo\/signup-forms\/Loader"]\, function\(L\) { L\.start\({([^}]*?)}\) }\)&lt;\/script&gt;/s',
 	);
@@ -62,7 +61,7 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @var array
 	 */
-	static $allowed_config = array(
+	private static $allowed_config = array(
 		'usePlainJson' => 'true',
 		'isDebug'      => 'false',
 	);
@@ -72,7 +71,7 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @var array
 	 */
-	static $allowed_js_vars = array(
+	private static $allowed_js_vars = array(
 		'baseUrl',
 		'uuid',
 		'lid',
@@ -83,12 +82,12 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param string $content Post Content
+	 * @param string $content Post Content.
 	 *
 	 * @return string Content with embeds replaced
 	 */
-	static function reversal( $content ) {
-		// Bail without the js src
+	public static function reversal( $content ) {
+		// Bail without the js src.
 		if ( ! is_string( $content ) || false === stripos( $content, 'downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js' ) ) {
 			return $content;
 		}
@@ -96,7 +95,7 @@ class MailChimp_Subscriber_Popup {
 		require_once ABSPATH . WPINC . '/class-json.php';
 		$wp_json = new Services_JSON();
 
-		// loop through our rules and find valid embeds
+		// loop through our rules and find valid embeds.
 		foreach ( self::$reversal_regexes as $regex ) {
 
 			if ( ! preg_match_all( $regex, $content, $matches ) ) {
@@ -104,7 +103,7 @@ class MailChimp_Subscriber_Popup {
 			}
 
 			foreach ( $matches[3] as $index => $js_vars ) {
-				// the regex rule for a specific embed
+				// the regex rule for a specific embed.
 				$replace_regex = sprintf( '#\s*%s\s*#', preg_quote( $matches[0][ $index ], '#' ) );
 
 				$attrs = $wp_json->decode( '{' . $js_vars . '}' );
@@ -112,7 +111,7 @@ class MailChimp_Subscriber_Popup {
 				if ( $matches[2][ $index ] ) {
 					$config_attrs = $wp_json->decode( '{' . $matches[2][ $index ] . '}' );
 					foreach ( $config_attrs as $key => $value ) {
-						$attrs->$key = ( 1 == $value ) ? 'true' : 'false';
+						$attrs->$key = ( 1 === $value ) ? 'true' : 'false';
 					}
 				}
 
@@ -133,16 +132,19 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $attrs A valid list of attributes (gets matched against self::$allowed_config and self::$allowed_js_vars)
+	 * @param array $attrs A valid list of attributes (gets matched against self::$allowed_config and self::$allowed_js_vars).
 	 *
 	 * @return string
 	 */
-	static function build_shortcode_from_reversal_attrs( $attrs ) {
+	private static function build_shortcode_from_reversal_attrs( $attrs ) {
 		$shortcode = '[mailchimp_subscriber_popup ';
 
 		foreach ( $attrs as $key => $value ) {
-			// skip unsupported keys
-			if ( ! in_array( $key, array_keys( self::$allowed_config ) ) && ! in_array( $key, self::$allowed_js_vars ) ) {
+			// skip unsupported keys.
+			if (
+				! in_array( $key, array_keys( self::$allowed_config ), true )
+				&& ! in_array( $key, self::$allowed_js_vars, true )
+			) {
 				continue;
 			}
 
@@ -157,14 +159,14 @@ class MailChimp_Subscriber_Popup {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $lcase_attrs
+	 * @param array $lcase_attrs Lowercase shortcode attributes.
 	 *
 	 * @return string
 	 */
-	static function shortcode( $lcase_attrs ) {
+	public static function shortcode( $lcase_attrs ) {
 		static $displayed_once = false;
 
-		// Limit to one form per page load
+		// Limit to one form per page load.
 		if ( $displayed_once ) {
 			return '';
 		}
@@ -176,7 +178,7 @@ class MailChimp_Subscriber_Popup {
 		$defaults = array_fill_keys( self::$allowed_js_vars, '' );
 		$defaults = array_merge( $defaults, self::$allowed_config );
 
-		// Convert $attrs back to proper casing since they come through in all lowercase
+		// Convert $attrs back to proper casing since they come through in all lowercase.
 		$attrs = array();
 		foreach ( $defaults as $key => $value ) {
 			if ( array_key_exists( strtolower( $key ), $lcase_attrs ) ) {
@@ -185,14 +187,21 @@ class MailChimp_Subscriber_Popup {
 		}
 		$attrs = array_map( 'esc_js', array_filter( shortcode_atts( $defaults, $attrs ) ) );
 
-		// Split config & js vars
-		$config_vars = $js_vars = array();
+		// Split config & js vars.
+		$js_vars     = array();
+		$config_vars = array();
 		foreach ( $attrs as $key => $value ) {
-			if ( 'baseUrl' == $key && ( ! preg_match( '#mc\.us\d+\.list-manage\d?\.com#', $value, $matches ) || $value !== $matches[0] ) ) {
+			if (
+				'baseUrl' === $key
+				&& (
+					! preg_match( '#mc\.us\d+\.list-manage\d?\.com#', $value, $matches )
+					|| $value !== $matches[0]
+				)
+			) {
 				return '<!-- Invalid MailChimp baseUrl -->';
 			}
 
-			if ( in_array( $key, self::$allowed_js_vars ) ) {
+			if ( in_array( $key, self::$allowed_js_vars, true ) ) {
 				$js_vars[ $key ] = $value;
 			} else {
 				$config_vars[] = "$key: $value";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Mailchimp: update shortcode to bring in sync with WordPress.com and fix phpcs warnings.

Matching diff: D25301-code

#### Testing instructions:

The feature should continue to work properly. You can test it with a shortcode like this one:
`[mailchimp_subscriber_popup baseUrl="mc.us11.list-manage.com" uuid="1ca7856462585a934b8674c71" lid="2d24f1898b"]`

#### Proposed changelog entry for your changes:

* None
