### PR TITLE
Publicize: rely on ES to count words for posts.

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -341,10 +341,34 @@ class Jetpack_Media_Summary {
 	}
 
 	static function get_word_count( $post_content ) {
+		/**
+		 * es_api_word_count is useful to count words in all languages.
+		 * It uses our ES custom analyzers to handle language detection.
+		 */
+		if ( function_exists( 'es_api_word_count' ) ) {
+			$word_count = es_api_word_count( self::clean_text( $post_content ) );
+			if ( false !== $word_count ) {
+				return $word_count;
+			}
+		}
+
+		// Keep str_word_count as fallback, even though it has limitations. See https://github.com/Automattic/jetpack/issues/1656 for example.
 		return str_word_count( self::clean_text( $post_content ) );
 	}
 
 	static function get_word_remaining_count( $post_content, $excerpt_content ) {
+		/**
+		 * es_api_word_count is useful to count words in all languages.
+		 * It uses our ES custom analyzers to handle language detection.
+		 */
+		if ( function_exists( 'es_api_word_count' ) ) {
+			$word_remaining_count = es_api_word_count( self::clean_text( $post_content ) ) - es_api_word_count( self::clean_text( $excerpt_content ) );
+			if ( false !== $word_remaining_count ) {
+				return $word_remaining_count;
+			}
+		}
+
+		// Keep str_word_count as fallback.
 		return str_word_count( self::clean_text( $post_content ) ) - str_word_count( self::clean_text( $excerpt_content ) );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Summary:
Fixes 3551-gh-jpop-issues

Publicize counts the words in a full post, and compares that number with the number of words in an automatically generated excerpt, to decide how many words should be sent to each Social Network as a preview of the post.
Until now we've relied on `str_word_count` to count the number the words, and while that works well for latin languages, it is problematic with languages with special characters, like Japanese or Cyrillic.
See https://stackoverflow.com/q/23015600/1045686

`es_api_word_count` offers a good workaround on WordPress.com.

Tags: #touches_jetpack_files

Differential Revision: D25267-code

This commit syncs r188663-wpcom.

#### Testing instructions:

* Prepare your Jetpack site and your WordPress.com sandbox for testing:
    * Sandbox your JP site with the `JETPACK__SANDBOX_DOMAIN` constant.
    * Apply this patch.
    * Set up Publicize to work synchronously on your sandbox.
    * Link your site to a Facebook Page.
* Publish a new post with the content defined in the JPOP issue above.
* Make sure only the first part of the post is pushed to Facebook.

#### Proposed changelog entry for your changes:

* Publicize: ensure that we always count the number of words for each post correctly, regardless of the language used.
