### PR TITLE
Quiz Shortcode: bring shortcode in sync with WordPress.com

### DIFF
--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -1,4 +1,4 @@
-<?php
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileNam
 /**
  * Quiz shortcode.
  *
@@ -78,12 +78,12 @@ class Quiz_Shortcode {
 	 * @since 4.5.0
 	 */
 	private static function enqueue_scripts() {
-		wp_enqueue_style( 'quiz', plugins_url( 'css/quiz.css', __FILE__ ) );
+		wp_enqueue_style( 'quiz', plugins_url( 'css/quiz.css', __FILE__ ), array(), JETPACK__VERSION );
 		wp_enqueue_script(
 			'quiz',
 			Jetpack::get_file_url_for_environment( '_inc/build/shortcodes/js/quiz.min.js', 'modules/shortcodes/js/quiz.js' ),
 			array( 'jquery' ),
-			null,
+			JETPACK__VERSION,
 			true
 		);
 	}
@@ -101,10 +101,12 @@ class Quiz_Shortcode {
 		}
 
 		if ( is_feed() ) {
-			return self::$javascript_unavailable = true;
+			self::$javascript_unavailable = true;
+			return self::$javascript_unavailable;
 		}
 
-		return self::$javascript_unavailable = false;
+		self::$javascript_unavailable = false;
+		return self::$javascript_unavailable;
 	}
 
 	/**
@@ -146,19 +148,19 @@ class Quiz_Shortcode {
 	public static function shortcode( $atts, $content = null ) {
 
 		// There's nothing to do if there's nothing enclosed.
-		if ( null == $content ) {
+		if ( null === $content ) {
 			return '';
 		}
 
 		$id = '';
 
 		if ( self::is_javascript_unavailable() ) {
-			// in an e-mail print the question and the info sentence once per question, too
+			// in an e-mail print the question and the info sentence once per question, too.
 			self::$noscript_info_printed = false;
 		} else {
 
 			if ( ! self::$scripts_enqueued ) {
-				// lazy enqueue cannot use the wp_enqueue_scripts action anymore
+				// lazy enqueue cannot use the wp_enqueue_scripts action anymore.
 				self::enqueue_scripts();
 				self::$scripts_enqueued = true;
 			}
@@ -194,15 +196,15 @@ class Quiz_Shortcode {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param string $content
+	 * @param string $content Post content.
 	 *
 	 * @return mixed|string
 	 */
 	private static function do_shortcode( $content ) {
-		// strip autoinserted line breaks
+		// strip autoinserted line breaks.
 		$content = preg_replace( '#(<(?:br /|/?p)>\n?)*(\[/?[a-z]+\])(<(?:br /|/?p)>\n?)*#', '$2', $content );
 
-		// Add internal parameter so it's only rendered when it has it
+		// Add internal parameter so it's only rendered when it has it.
 		$content = preg_replace( '/\[(question|answer|wrong|explanation)\]/i', '[$1 quiz_item="true"]', $content );
 		$content = do_shortcode( $content );
 		$content = wp_kses(
@@ -232,8 +234,8 @@ class Quiz_Shortcode {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $atts
-	 * @param null  $content
+	 * @param array $atts    Shortcode attributes.
+	 * @param null  $content Post content.
 	 *
 	 * @return string
 	 */
@@ -248,8 +250,8 @@ class Quiz_Shortcode {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $atts
-	 * @param null  $content
+	 * @param array $atts    Shortcode attributes.
+	 * @param null  $content Post content.
 	 *
 	 * @return string
 	 */
@@ -268,8 +270,8 @@ class Quiz_Shortcode {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $atts
-	 * @param null  $content
+	 * @param array $atts    Shortcode attributes.
+	 * @param null  $content Post content.
 	 *
 	 * @return string
 	 */
@@ -288,8 +290,8 @@ class Quiz_Shortcode {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param array $atts
-	 * @param null  $content
+	 * @param array $atts    Shortcode attributes.
+	 * @param null  $content Post content.
 	 *
 	 * @return string
 	 */

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -148,7 +148,7 @@ class Quiz_Shortcode {
 	public static function shortcode( $atts, $content = null ) {
 
 		// There's nothing to do if there's nothing enclosed.
-		if ( null === $content ) {
+		if ( empty( $content ) ) {
 			return '';
 		}
 

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -209,6 +209,7 @@ class Quiz_Shortcode {
 			$content,
 			array(
 				'tt'     => array(),
+				'a'      => array( 'href' => true ),
 				'pre'    => array(),
 				'strong' => array(),
 				'i'      => array(),


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This PR includes 2 main changes:
- allow links in explanations -- r159608-wpcom
- phpcs warnings

#### Testing instructions:

* Make sure the Quiz shortcode still works as expected
* https://en.support.wordpress.com/quiz-shortcode/

#### Proposed changelog entry for your changes:

* Quiz shortcode: allow links in explanations.
