### PR TITLE
Twenty Nineteen: Prevent Sharing Button Overlap

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.css
+++ b/modules/theme-tools/compat/twentynineteen.css
@@ -112,12 +112,9 @@
 	margin-bottom: -0.3125em !important;
 }
 
-.sd-social-icon .sd-content ul {
-	margin-bottom: 0 !important;
-}
-
+.sd-social-icon .sd-content ul,
 .sd-social-official .sd-content ul {
-	margin-bottom: -0.625em !important;
+	margin-bottom: 0 !important;
 }
 
 .entry #sharing_email .sharing_send,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This removes some of the additional CSS added in the initial commit of this file with the sharing buttons. It's from the Twenty Sixteen file, where it makes sense to include due to the unique styling, but in the Twenty Nineteen theme, it causes an overlap. Instead, it feels better adding a margin-bottom of zero, otherwise there's an obscure gap just by completely removing it. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to https://wordpress.com/sharing/buttons
* Add a social button, selecting the Official Buttons, and turn likes on 
* Activate Twenty Nineteen 
* Check the bottom of your posts 
* Do they overlap? 
* Try the other button styles, can you produce an issue? 

**Before:**

![fsdsdfdsf](https://user-images.githubusercontent.com/43215253/54068917-9e74a080-4249-11e9-8e64-7c03d947aee3.png)


**After:**

![dfgfdggd](https://user-images.githubusercontent.com/43215253/54068916-93217500-4249-11e9-92f9-c21dece864f4.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Twenty Nineteen: Prevent sharing buttons overlapping with the Like button. 
