### PR TITLE
Settings: reorder Security tab

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -110,6 +110,24 @@ export const NavigationSettings = createReactClass( {
 		return 0 < intersection( moduleList, modules ).length;
 	},
 
+	hasAnyPerformanceFeature() {
+		return this.hasAnyOfThese( [
+			'carousel',
+			'lazy-images',
+			'photon',
+			'photon-cdn',
+			'search',
+			'videopress',
+		] );
+	},
+
+	hasAnySecurityFeature() {
+		return (
+			this.hasAnyOfThese( [ 'protect', 'sso', 'vaultpress' ] ) ||
+			this.props.isPluginActive( 'akismet/akismet.php' )
+		);
+	},
+
 	handleClickForTracking( target ) {
 		return () => this.trackNavClick( target );
 	},
@@ -119,8 +137,7 @@ export const NavigationSettings = createReactClass( {
 		if ( this.props.userCanManageModules ) {
 			navItems = (
 				<NavTabs selectedText={ this.props.route.name }>
-					{ ( this.hasAnyOfThese( [ 'protect', 'sso', 'vaultpress' ] ) ||
-						this.props.isPluginActive( 'akismet/akismet.php' ) ) && (
+					{ this.hasAnySecurityFeature() && (
 						<NavItem
 							path="#security"
 							onClick={ this.handleClickForTracking( 'security' ) }
@@ -131,14 +148,7 @@ export const NavigationSettings = createReactClass( {
 							{ __( 'Security', { context: 'Navigation item.' } ) }
 						</NavItem>
 					) }
-					{ this.hasAnyOfThese( [
-						'carousel',
-						'lazy-images',
-						'photon',
-						'photon-cdn',
-						'search',
-						'videopress',
-					] ) && (
+					{ this.hasAnyPerformanceFeature() && (
 						<NavItem
 							path="#performance"
 							onClick={ this.handleClickForTracking( 'performance' ) }

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -119,6 +119,16 @@ export const NavigationSettings = createReactClass( {
 		if ( this.props.userCanManageModules ) {
 			navItems = (
 				<NavTabs selectedText={ this.props.route.name }>
+					{ ( this.hasAnyOfThese( [ 'protect', 'sso', 'vaultpress' ] ) ||
+						this.props.isPluginActive( 'akismet/akismet.php' ) ) && (
+						<NavItem
+							path="#security"
+							onClick={ this.handleClickForTracking( 'security' ) }
+							selected={ this.props.route.path === '/security' }
+						>
+							{ __( 'Security', { context: 'Navigation item.' } ) }
+						</NavItem>
+					) }
 					{ this.hasAnyOfThese( [
 						'carousel',
 						'lazy-images',
@@ -193,16 +203,6 @@ export const NavigationSettings = createReactClass( {
 							selected={ this.props.route.path === '/traffic' }
 						>
 							{ __( 'Traffic', { context: 'Navigation item.' } ) }
-						</NavItem>
-					) }
-					{ ( this.hasAnyOfThese( [ 'protect', 'sso', 'vaultpress' ] ) ||
-						this.props.isPluginActive( 'akismet/akismet.php' ) ) && (
-						<NavItem
-							path="#security"
-							onClick={ this.handleClickForTracking( 'security' ) }
-							selected={ this.props.route.path === '/security' }
-						>
-							{ __( 'Security', { context: 'Navigation item.' } ) }
 						</NavItem>
 					) }
 				</NavTabs>

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -124,7 +124,9 @@ export const NavigationSettings = createReactClass( {
 						<NavItem
 							path="#security"
 							onClick={ this.handleClickForTracking( 'security' ) }
-							selected={ this.props.route.path === '/security' }
+							selected={
+								this.props.route.path === '/security' || this.props.route.path === '/settings'
+							}
 						>
 							{ __( 'Security', { context: 'Navigation item.' } ) }
 						</NavItem>
@@ -140,9 +142,7 @@ export const NavigationSettings = createReactClass( {
 						<NavItem
 							path="#performance"
 							onClick={ this.handleClickForTracking( 'performance' ) }
-							selected={
-								this.props.route.path === '/performance' || this.props.route.path === '/settings'
-							}
+							selected={ this.props.route.path === '/performance' }
 						>
 							{ __( 'Performance', { context: 'Navigation item.' } ) }
 						</NavItem>

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -40,23 +40,18 @@ export default class extends React.Component {
 						  } )
 						: __( 'Enter a search term to find settings or close search.' ) }
 				</div>
+				<Security
+					siteAdminUrl={ this.props.siteAdminUrl }
+					siteRawUrl={ this.props.siteRawUrl }
+					active={ '/security' === this.props.route.path || '/settings' === this.props.route.path }
+					{ ...commonProps }
+				/>
 				<Discussion
 					siteRawUrl={ this.props.siteRawUrl }
 					active={ '/discussion' === this.props.route.path }
 					{ ...commonProps }
 				/>
-				<Performance
-					active={
-						'/performance' === this.props.route.path || '/settings' === this.props.route.path
-					}
-					{ ...commonProps }
-				/>
-				<Security
-					siteAdminUrl={ this.props.siteAdminUrl }
-					siteRawUrl={ this.props.siteRawUrl }
-					active={ '/security' === this.props.route.path }
-					{ ...commonProps }
-				/>
+				<Performance active={ '/performance' === this.props.route.path } { ...commonProps } />
 				<Traffic
 					siteRawUrl={ this.props.siteRawUrl }
 					siteAdminUrl={ this.props.siteAdminUrl }


### PR DESCRIPTION
Twin PR for Calypso: https://github.com/Automattic/wp-calypso/pull/31355

#### Changes proposed in this Pull Request

* Reorder Security tab in Settings.
  * Moves the tab from the last place to first place, right before Performance.

**Notes**:
* Might need updated tests.

#### Testing instructions

* Fire up this PR.
* Visit your Jetpack site settings.
* Make sure the Security tab appears in the right spot.

#### Before

![mutelife com_wp-admin_admin php_page=jetpack(Calypso) (2)](https://user-images.githubusercontent.com/390760/54142654-1b597300-4420-11e9-8000-16358a8e60e6.png)

#### After

![mutelife com_wp-admin_admin php_page=jetpack(Calypso) (1)](https://user-images.githubusercontent.com/390760/54142662-1eecfa00-4420-11e9-9ce8-2c175893a51a.png)


#### Proposed changelog entry for your changes:

* Settings: reorder settings tabs, with more emphasis on Security and Performance.
