### PR TITLE
Shortcodes: Clean up Crowdsignal oEmbed regex

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -562,8 +562,13 @@ if ( ! function_exists( 'crowdsignal_link' ) ) {
 	add_filter( 'the_content_rss', 'crowdsignal_link', 1 );
 }
 
-wp_oembed_add_provider( '#https?://(.+\.)?polldaddy\.com/.*#i', 'https://api.crowdsignal.com/oembed', true );
+	/**
+	 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
+	 * This should be removed after Core has the current regex is in our minimum version.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/46467
+	 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
+	 */
 wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
-wp_oembed_add_provider( '#https?://poll\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
 
 }


### PR DESCRIPTION
Jetpack is adding a couple of oEmbeds regexes that are already included by Core.

Note survey.fm is included in Core, but the regex doesn't include subdomains, so this needs to stay until https://core.trac.wordpress.org/ticket/46467 is in a minimum version of WP.

#### Changes proposed in this Pull Request:
* Clean up a couple of duplicate entries.

#### Testing instructions:
* Make sure previous polldaddy and poll.fm URLs still work, e.g. https://polldaddy.com/poll/7012505/
*

#### Proposed changelog entry for your changes:
* Update CrowdSignal regex.
