### PR TITLE
Jetpack blocks: Update version and build path

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -312,7 +312,7 @@ gulp.task( 'languages:phpize', function( done ) {
  */
 gulp.task( 'gutenberg:blocks', function() {
 	return gulp
-		.src( [ 'node_modules/@automattic/jetpack-blocks/build/**/*' ] )
+		.src( [ 'node_modules/@automattic/jetpack-blocks/dist/**/*' ] )
 		.pipe( gulp.dest( '_inc/blocks' ) );
 } );
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "14.0.0",
+    "@automattic/jetpack-blocks": "15.0.0",
     "@wordpress/browserslist-config": "2.3.0",
     "babel-core": "6.26.3",
     "babel-eslint": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
-    "@automattic/jetpack-blocks": "13.1.1",
+    "@automattic/jetpack-blocks": "14.0.0",
     "@wordpress/browserslist-config": "2.3.0",
     "babel-core": "6.26.3",
     "babel-eslint": "10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,46 @@
     loader-utils "^0.2.2"
     object-assign "^4.0.1"
 
-"@automattic/jetpack-blocks@13.1.1":
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-13.1.1.tgz#7a3eda493ea92ed4a3b4957a57b42fae5189a761"
+"@automattic/format-currency@1.0.0-alpha.0":
+  version "1.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@automattic/format-currency/-/format-currency-1.0.0-alpha.0.tgz#f7fb09b5e357b5c2ecb673e235e9a66bfc476b83"
+  integrity sha512-Y5An5nsNtskdLN3mbh5UWKvsS3C5PHbOcBU5D58dmjc96z5WAa99gSNYkN87FjqrJKGM4J2JhE5d1gIadYU++A==
+  dependencies:
+    i18n-calypso "^4.0.0-alpha.1"
+
+"@automattic/jetpack-blocks@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-14.0.0.tgz#80bb9091fae2935a35e479cf557ee2b4f635eb89"
+  integrity sha512-dJVqJa8+BXTA3Gm1uwew8fmlQycFwb8vaxG3Uld0Hviabedv1VcHivGN+deTnsANl3dtYe1b3yJBmCSta92U6A==
+  dependencies:
+    "@automattic/format-currency" "1.0.0-alpha.0"
+    "@wordpress/api-fetch" "2.2.8"
+    "@wordpress/blob" "2.1.0"
+    "@wordpress/blocks" "6.0.7"
+    "@wordpress/components" "7.0.8"
+    "@wordpress/compose" "3.0.1"
+    "@wordpress/data" "4.2.1"
+    "@wordpress/date" "3.0.1"
+    "@wordpress/edit-post" "3.1.11"
+    "@wordpress/editor" "9.0.11"
+    "@wordpress/element" "2.1.9"
+    "@wordpress/hooks" "2.0.5"
+    "@wordpress/i18n" "3.1.1"
+    "@wordpress/keycodes" "2.0.6"
+    "@wordpress/plugins" "2.0.11"
+    "@wordpress/token-list" "1.1.0"
+    "@wordpress/url" "2.3.3"
+    classnames "2.2.6"
+    cookie "0.3.1"
+    duplicate-package-checker-webpack-plugin "3.0.0"
+    email-validator "2.0.4"
+    gridicons "3.1.1"
+    lodash "4.17.11"
+    markdown-it "8.4.2"
+    photon "2.0.1"
+    refx "3.1.1"
+    resize-observer-polyfill "1.5.1"
+    swiper "4.4.6"
 
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
@@ -72,6 +109,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.0.0":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
+  integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.3.1":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
@@ -124,6 +168,19 @@
   dependencies:
     normalize-path "^2.0.1"
     through2 "^2.0.3"
+
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
+"@nodelib/fs.stat@^1.1.2":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
+  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@octokit/endpoint@^3.1.1":
   version "3.1.3"
@@ -215,6 +272,50 @@
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+
+"@tannin/compile@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tannin/compile/-/compile-1.0.3.tgz#812af915e2ac6ecc6d7518680b40ec275db7670d"
+  integrity sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==
+  dependencies:
+    "@tannin/evaluate" "^1.1.1"
+    "@tannin/postfix" "^1.0.2"
+
+"@tannin/evaluate@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@tannin/evaluate/-/evaluate-1.1.1.tgz#de25595d2c8cee5e5c654515bd1b789189048073"
+  integrity sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q==
+
+"@tannin/plural-forms@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tannin/plural-forms/-/plural-forms-1.0.3.tgz#fef0884452ba38dd67ecb35324d4812e88a1cb5e"
+  integrity sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==
+  dependencies:
+    "@tannin/compile" "^1.0.3"
+
+"@tannin/postfix@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tannin/postfix/-/postfix-1.0.2.tgz#fbb723e79603add30f5d8a08a626c2970d984857"
+  integrity sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g==
+
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
   version "10.12.12"
@@ -348,9 +449,724 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@wordpress/a11y@^2.0.2", "@wordpress/a11y@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-2.2.0.tgz#cb4fb88ba5aaf79aa1e8a2c2452f2eee10c80efa"
+  integrity sha512-cqVCKKGec+7++WTakp1KuK/s0aa054nycsEn9ZlB/kvKHpsveuR00qjeDRLbrXD3JifEusvGyx8GAHRPii+g3A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/dom-ready" "^2.2.0"
+
+"@wordpress/api-fetch@2.2.8", "@wordpress/api-fetch@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-2.2.8.tgz#be9a586ccb3f5c31201d75a76eabd4b7bc2a16b2"
+  integrity sha512-mbdP9GvDe8Ojv8cobk30mfg2btEZDQEe7IgO+rGSlvVlHC88U8cc2VgOLNX6c9/6/sCvkoGd4Tsy85VbdTlTXw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/hooks" "^2.0.5"
+    "@wordpress/i18n" "^3.1.1"
+    "@wordpress/url" "^2.3.3"
+
+"@wordpress/api-fetch@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.1.0.tgz#38db4c22c0de4eb8c77361bc41f6b49fbcfeade9"
+  integrity sha512-WCXWuSRzQwmjdS2RPM22ni3Teuu6JgE5EH7uKPO9KrvCUI+FVhvPZOIgb2q9QI6E63jbXOe/Uy8SnlNBFnlKBw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/url" "^2.5.0"
+
+"@wordpress/autop@^2.0.2", "@wordpress/autop@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-2.2.0.tgz#42daaab1e6af9671105575214768c931afea8054"
+  integrity sha512-jO7c2IQmMhaS57wxKfPRMWE/3r1Fwo2wBFUh0gsN4C7AtVHDMgsHfiR73zgnJ2MxslMoRX+uw4TM56lfxdByVw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/blob@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-2.1.0.tgz#b6fe503adb95b50e646913fa24f35c495255ddf6"
+  integrity sha512-2PBjKivnxVSFLn+askRHyYK61zTarNrpi3S8slC12xeFPXTecT+HBdYJVtk32GBFrQmyH7ZdpDrROhCmjXyiOw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@wordpress/blob@^2.1.0", "@wordpress/blob@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-2.3.0.tgz#aa74c8969fdf83d53cff5a41891531ac968030f3"
+  integrity sha512-WmzonzasFjz6S5mGqZrRuaYrIFRDULywPU4pLyz+CYvEvz9wgOC8DLi2/J5Qk6SSVMoTEoUVT5nuYftIpts84w==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/block-editor@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-editor/-/block-editor-1.1.0.tgz#3192861effe298d39319cd7f77e47371fa225939"
+  integrity sha512-51a9j7jFVAAMB2yicHIjiAGwMNgSExSJaKDTa8hbCi5ocIVxg5pt9XI+Lz3dYdElvdHWmZ7ymhVaf2r3xitp3Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/a11y" "^2.2.0"
+    "@wordpress/blob" "^2.3.0"
+    "@wordpress/blocks" "^6.2.0"
+    "@wordpress/components" "^7.2.0"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/core-data" "^2.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/dom" "^2.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/hooks" "^2.2.0"
+    "@wordpress/html-entities" "^2.2.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/is-shallow-equal" "^1.2.0"
+    "@wordpress/keycodes" "^2.2.0"
+    "@wordpress/rich-text" "^3.2.0"
+    "@wordpress/token-list" "^1.2.0"
+    "@wordpress/url" "^2.5.0"
+    "@wordpress/viewport" "^2.3.0"
+    "@wordpress/wordcount" "^2.2.0"
+    classnames "^2.2.5"
+    dom-scroll-into-view "^1.2.1"
+    lodash "^4.17.10"
+    redux-multi "^0.1.12"
+    refx "^3.0.0"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.1"
+
+"@wordpress/block-library@^2.2.16":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-library/-/block-library-2.4.0.tgz#4147992a562613ae1040ac67492a05004637eecc"
+  integrity sha512-vFI/G7FZt5H4tKwBqvwc47WppCuvaExo1QyDC1jOTiXHa1IatwrtMpFpG1iNA4q8+0MbpokP6Ftjm1IEyK+ATw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/autop" "^2.2.0"
+    "@wordpress/blob" "^2.3.0"
+    "@wordpress/block-editor" "^1.1.0"
+    "@wordpress/blocks" "^6.2.0"
+    "@wordpress/components" "^7.2.0"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/core-data" "^2.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/deprecated" "^2.2.0"
+    "@wordpress/editor" "^9.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/html-entities" "^2.2.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/keycodes" "^2.2.0"
+    "@wordpress/viewport" "^2.3.0"
+    classnames "^2.2.5"
+    fast-average-color "4.3.0"
+    lodash "^4.17.11"
+    memize "^1.0.5"
+    url "^0.11.0"
+
+"@wordpress/block-serialization-default-parser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-2.0.5.tgz#01c25e5abefb3352a5cd8f6df20c65494d7f9048"
+  integrity sha512-SzLHeqfz4G9bgugWQpqRKYZXWXJ87sJ67yiPB004Ev3SoPWiR7waqDmAPO//chCv7mBi+p0kWUnIw4feAq9x5w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@wordpress/block-serialization-default-parser@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.1.0.tgz#9b262fca83f524f06afc218be14b9f59d2588e56"
+  integrity sha512-SmxvnZ5N4L+H/lpq/orJetdK98Ij9BHWhcbBu5+NCfRho0RcErmVxj107VSpcP5s4METEvVRpmGcxG+Xr4aWtw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/block-serialization-spec-parser@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-2.0.3.tgz#147f5ea6d51ae68f56f258dac62bc1ae308e65a9"
+  integrity sha512-fLBKNRbnm5OZCseWYEuH2uHR2Sx6vWX9UY9wlu7ba1rQb4xjLEh547+yYs7985udB2pGmUG6JWdBcHAlTkkIqw==
+
+"@wordpress/block-serialization-spec-parser@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.0.0.tgz#5917f04e3dfc7256587fec979ef1958c0023bf42"
+  integrity sha512-G2rjbECdR5yMfWpezhT/5TzqnGbhkaCBeHrBC949ii+cH9RfljX+8HiiCWmc8uCTX/oT9ORxYI68FWmAVxS5vQ==
+  dependencies:
+    pegjs "^0.10.0"
+
+"@wordpress/blocks@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-6.0.7.tgz#237ed367e67b757886c3d3e98c3e140bf9e9db62"
+  integrity sha512-k1Hoq2PMTDWDJCPwF8d5RXxi2FZUkg0XvGdFoGT8os2l9PE3NWoZgzzSHnYZhkJhm/P+hKwHWxXk5xNqRBp9Mw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/autop" "^2.0.2"
+    "@wordpress/blob" "^2.1.0"
+    "@wordpress/block-serialization-default-parser" "^2.0.5"
+    "@wordpress/block-serialization-spec-parser" "^2.0.3"
+    "@wordpress/data" "^4.2.1"
+    "@wordpress/dom" "^2.0.8"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/hooks" "^2.0.5"
+    "@wordpress/html-entities" "^2.0.4"
+    "@wordpress/i18n" "^3.1.1"
+    "@wordpress/is-shallow-equal" "^1.1.5"
+    "@wordpress/shortcode" "^2.0.2"
+    hpq "^1.3.0"
+    lodash "^4.17.10"
+    rememo "^3.0.0"
+    showdown "^1.8.6"
+    simple-html-tokenizer "^0.4.1"
+    tinycolor2 "^1.4.1"
+    uuid "^3.3.2"
+
+"@wordpress/blocks@^6.0.7", "@wordpress/blocks@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-6.2.0.tgz#74414fc4620be4650c6063ddadb6ad8c0a2faf97"
+  integrity sha512-QA+mBWmMjSwJioJWR6vFc6cbdpX9QjgEXnzXOLngubZ2PmtqewSHSvqCR1zgvbgdpGid2jl3Ttb7p8d2n4rP8Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/autop" "^2.2.0"
+    "@wordpress/blob" "^2.3.0"
+    "@wordpress/block-serialization-default-parser" "^3.1.0"
+    "@wordpress/block-serialization-spec-parser" "^3.0.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/dom" "^2.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/hooks" "^2.2.0"
+    "@wordpress/html-entities" "^2.2.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/is-shallow-equal" "^1.2.0"
+    "@wordpress/shortcode" "^2.2.0"
+    hpq "^1.3.0"
+    lodash "^4.17.11"
+    rememo "^3.0.0"
+    showdown "^1.8.6"
+    simple-html-tokenizer "^0.4.1"
+    tinycolor2 "^1.4.1"
+    uuid "^3.3.2"
+
 "@wordpress/browserslist-config@2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.3.0.tgz#7a1b59e9fc81926522eb2cbd0ce603d866525b04"
+
+"@wordpress/components@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-7.0.8.tgz#da55a441261f4c56d665c306547ee586485b7ffe"
+  integrity sha512-6IKC+jod+VUiLpp/2Xh/a2VjvMW0mTT1C13ShFs5QJku/AkpcvETLb4gZmjrn3AnAW6N1NC4OILzx8XyLCfIkA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/a11y" "^2.0.2"
+    "@wordpress/api-fetch" "^2.2.8"
+    "@wordpress/compose" "^3.0.1"
+    "@wordpress/dom" "^2.0.8"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/hooks" "^2.0.5"
+    "@wordpress/i18n" "^3.1.1"
+    "@wordpress/is-shallow-equal" "^1.1.5"
+    "@wordpress/keycodes" "^2.0.6"
+    "@wordpress/rich-text" "^3.0.7"
+    "@wordpress/url" "^2.3.3"
+    classnames "^2.2.5"
+    clipboard "^2.0.1"
+    diff "^3.5.0"
+    dom-scroll-into-view "^1.2.1"
+    lodash "^4.17.10"
+    memize "^1.0.5"
+    moment "^2.22.1"
+    mousetrap "^1.6.2"
+    re-resizable "^4.7.1"
+    react-click-outside "^3.0.0"
+    react-dates "^17.1.1"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.1"
+    uuid "^3.3.2"
+
+"@wordpress/components@^7.0.8", "@wordpress/components@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-7.2.0.tgz#5bf6a7d1fcb7fa05ce5c23ff8a8372c129f092b1"
+  integrity sha512-30wh1evHn9QqoM9GixAlhpOFsAbaoGQ7xh2sJS6MscxY4x6SP7fsfvqoZATQZUIwKhG9CXxHpSEMQdUv7eeloQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/a11y" "^2.2.0"
+    "@wordpress/api-fetch" "^3.1.0"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/dom" "^2.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/hooks" "^2.2.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/is-shallow-equal" "^1.2.0"
+    "@wordpress/keycodes" "^2.2.0"
+    "@wordpress/rich-text" "^3.2.0"
+    "@wordpress/url" "^2.5.0"
+    classnames "^2.2.5"
+    clipboard "^2.0.1"
+    diff "^3.5.0"
+    dom-scroll-into-view "^1.2.1"
+    lodash "^4.17.11"
+    memize "^1.0.5"
+    moment "^2.22.1"
+    mousetrap "^1.6.2"
+    re-resizable "^4.7.1"
+    react-click-outside "^3.0.0"
+    react-dates "^17.1.1"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.1"
+    uuid "^3.3.2"
+
+"@wordpress/compose@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-3.0.1.tgz#e9ffa429d27366b1eefafc5ba99ab56dc3b0c522"
+  integrity sha512-A58zlkYzx4KJ8Z4mV8rIPMECZueWFmiV5VUbgfxxcU0SL8K9yJPuEcsO7pm/MfLPpw919BiGlxr5CMJwJEb70w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/is-shallow-equal" "^1.1.5"
+    lodash "^4.17.10"
+
+"@wordpress/compose@^3.0.1", "@wordpress/compose@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-3.2.0.tgz#c1873dab9a159030496ff82598b9e89442136eef"
+  integrity sha512-bwDSMABvTi3AXqsNNi29h3T4nCtiwuBm4XO4svp6nRTFnVgxrfZXjqHrnuv0qimg1UP35WSXKO6hrO/QqTkW8g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/is-shallow-equal" "^1.2.0"
+    lodash "^4.17.11"
+
+"@wordpress/core-data@^2.0.17", "@wordpress/core-data@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-2.2.0.tgz#08c5b26c84cfe64db441ea208f61519af009cd3f"
+  integrity sha512-1bdbBEa3Nn+NX3JFLTNOBNltHVk3FRWaZhIx7HpJc84nyzZbwj0r/dS7K0YvKd2GCdf1AsE7JBZuePVGE8henw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/api-fetch" "^3.1.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/deprecated" "^2.2.0"
+    "@wordpress/url" "^2.5.0"
+    equivalent-key-map "^0.2.2"
+    lodash "^4.17.11"
+    rememo "^3.0.0"
+
+"@wordpress/data@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-4.2.1.tgz#6b18a8e973fc9bd8bde141708376ff6066f0bac2"
+  integrity sha512-HI2kDDEnwb27c2JtkH7pgiVs5QHVmaqQ4fpb38TYiF+EGKAxEhXv+jOqJAGlumEUru3BAzxVXDvhZlhXLNaxVA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/compose" "^3.0.1"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/is-shallow-equal" "^1.1.5"
+    "@wordpress/redux-routine" "^3.0.4"
+    equivalent-key-map "^0.2.2"
+    is-promise "^2.1.0"
+    lodash "^4.17.10"
+    redux "^4.0.0"
+    turbo-combine-reducers "^1.0.2"
+
+"@wordpress/data@^4.2.1", "@wordpress/data@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-4.4.0.tgz#56202ce77da7c1bc81ba54c2d49a3234c4a8e939"
+  integrity sha512-2eWcjlkx0KoGDOsGnCa7XSoB4yDkFkm1UuwmFcGMn+1qnRzgAmZ07GGFJWgk7wKxgihj9tgwFcZ2a+dVJXQxuw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/is-shallow-equal" "^1.2.0"
+    "@wordpress/priority-queue" "^1.1.0"
+    "@wordpress/redux-routine" "^3.2.0"
+    equivalent-key-map "^0.2.2"
+    is-promise "^2.1.0"
+    lodash "^4.17.11"
+    redux "^4.0.0"
+    turbo-combine-reducers "^1.0.2"
+
+"@wordpress/date@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.0.1.tgz#3899ed528ffcd7e1befcfc35bc91ffdee40a1c77"
+  integrity sha512-LOOwZM0A5OeElWgdyuR3LJQ7sJJZ5oHdXnNTs3LEB5GH7FUoozF6B6KY5Qm13pizzWX018C8vggsHrsltuLo3A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    moment "^2.22.1"
+    moment-timezone "^0.5.16"
+
+"@wordpress/date@^3.0.1", "@wordpress/date@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.2.0.tgz#ad87a21cb400a795cd53f7bcad7b3a8d7f479ba0"
+  integrity sha512-dV9b2ObyX6I5Harl7tt3eN+yWSQu0DwLyj/hflVYUR6qlFVfg0fjDGuMa+ZxI0T1UhblP+EyGDXX8wS680JOsQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    moment "^2.22.1"
+    moment-timezone "^0.5.16"
+
+"@wordpress/deprecated@^2.0.5", "@wordpress/deprecated@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-2.2.0.tgz#7d0123209495b2310ab6c167b94f7574eef5174f"
+  integrity sha512-4B6ButV5dKPCiTbFl7cNHJTnaMN0crQhCFHhDYlZEBS/OUk/e07RUPpCMjpfk2ut7Hpfbkr8UHJT6yMpyegOuw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/hooks" "^2.2.0"
+
+"@wordpress/dom-ready@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-2.2.0.tgz#a60caf6d59609e153f6838dda65d13b08eba060d"
+  integrity sha512-tPmPcc7T+BGXS7WyIJ+hWzMR5YXBjQIWNWcFMcqMxjgm5MbTWnjvrv4o4FJ7evuWJlTa+4Rw2Tjc0iHAqr4aVA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/dom@^2.0.8", "@wordpress/dom@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-2.2.0.tgz#4372cca5cc34fff14f6b3d0b28648cb098534f05"
+  integrity sha512-1qTNAwzBOiBaO3u30HpZj6puGAozmRyvfHVw1dxQkeuTmZTttXkXtiiqyM4oqf555FDDDFWyoxgT0Ip20/Mh/Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    lodash "^4.17.11"
+
+"@wordpress/edit-post@3.1.11":
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/@wordpress/edit-post/-/edit-post-3.1.11.tgz#72aeaf2df29b4ebeb1260aeecac8f87483b7c679"
+  integrity sha512-NZucS6HHR7e6e1WQKQabAt2zGjo/TkjWHkg76wspLcnW8JdbRl+VFTIAe2BZOeomRbU03wTb1N6b1UJKs94nkQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/a11y" "^2.0.2"
+    "@wordpress/api-fetch" "^2.2.8"
+    "@wordpress/block-library" "^2.2.16"
+    "@wordpress/blocks" "^6.0.7"
+    "@wordpress/components" "^7.0.8"
+    "@wordpress/compose" "^3.0.1"
+    "@wordpress/core-data" "^2.0.17"
+    "@wordpress/data" "^4.2.1"
+    "@wordpress/editor" "^9.0.11"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/format-library" "^1.2.14"
+    "@wordpress/hooks" "^2.0.5"
+    "@wordpress/i18n" "^3.1.1"
+    "@wordpress/keycodes" "^2.0.6"
+    "@wordpress/nux" "^3.0.9"
+    "@wordpress/plugins" "^2.0.11"
+    "@wordpress/url" "^2.3.3"
+    "@wordpress/viewport" "^2.1.1"
+    classnames "^2.2.5"
+    lodash "^4.17.10"
+    refx "^3.0.0"
+
+"@wordpress/editor@9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-9.0.11.tgz#98807348d409a2e9b4fb7df8dcf5b2936afaf8c6"
+  integrity sha512-3kyua3fpQOJZYCWk+XfNtuUL8BCwKzmHWbm/5s6bv1so58q/4Ek1ZcEXo5B+KN+2crlg56zX1aNQ4LxiP+hnAA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/a11y" "^2.0.2"
+    "@wordpress/api-fetch" "^2.2.8"
+    "@wordpress/blob" "^2.1.0"
+    "@wordpress/blocks" "^6.0.7"
+    "@wordpress/components" "^7.0.8"
+    "@wordpress/compose" "^3.0.1"
+    "@wordpress/core-data" "^2.0.17"
+    "@wordpress/data" "^4.2.1"
+    "@wordpress/date" "^3.0.1"
+    "@wordpress/deprecated" "^2.0.5"
+    "@wordpress/dom" "^2.0.8"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/hooks" "^2.0.5"
+    "@wordpress/html-entities" "^2.0.4"
+    "@wordpress/i18n" "^3.1.1"
+    "@wordpress/is-shallow-equal" "^1.1.5"
+    "@wordpress/keycodes" "^2.0.6"
+    "@wordpress/notices" "^1.1.3"
+    "@wordpress/nux" "^3.0.9"
+    "@wordpress/token-list" "^1.1.0"
+    "@wordpress/url" "^2.3.3"
+    "@wordpress/viewport" "^2.1.1"
+    "@wordpress/wordcount" "^2.0.3"
+    classnames "^2.2.5"
+    dom-scroll-into-view "^1.2.1"
+    inherits "^2.0.3"
+    jquery "^3.3.1"
+    lodash "^4.17.10"
+    memize "^1.0.5"
+    react-autosize-textarea "^3.0.2"
+    redux-multi "^0.1.12"
+    redux-optimist "^1.0.0"
+    refx "^3.0.0"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.1"
+    tinymce "^4.7.2"
+    traverse "^0.6.6"
+
+"@wordpress/editor@^9.0.11", "@wordpress/editor@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-9.2.0.tgz#ef7606b4a628673fd8bb2507945a1f6b07f7d6ab"
+  integrity sha512-y/LvAAIfRNLH+EzZ/EnPPxvns5xQ2JGgK8q36WFpt1+r8aQHWC/JEq6/wzC6KwbyGCz61TvodqIOPXFGdYMQwg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/api-fetch" "^3.1.0"
+    "@wordpress/blob" "^2.3.0"
+    "@wordpress/block-editor" "^1.1.0"
+    "@wordpress/blocks" "^6.2.0"
+    "@wordpress/components" "^7.2.0"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/core-data" "^2.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/date" "^3.2.0"
+    "@wordpress/deprecated" "^2.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/hooks" "^2.2.0"
+    "@wordpress/html-entities" "^2.2.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/keycodes" "^2.2.0"
+    "@wordpress/notices" "^1.3.0"
+    "@wordpress/nux" "^3.2.0"
+    "@wordpress/url" "^2.5.0"
+    "@wordpress/viewport" "^2.3.0"
+    "@wordpress/wordcount" "^2.2.0"
+    classnames "^2.2.5"
+    inherits "^2.0.3"
+    lodash "^4.17.11"
+    memize "^1.0.5"
+    react-autosize-textarea "^3.0.2"
+    redux-multi "^0.1.12"
+    redux-optimist "^1.0.0"
+    refx "^3.0.0"
+    rememo "^3.0.0"
+    traverse "^0.6.6"
+
+"@wordpress/element@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.1.9.tgz#3c413ff9b60398a6139811b34255aac7c2331672"
+  integrity sha512-qKluF0oIajTYllZPG4XlopWHWs3VADT0sUW1oPprCCMMj2URkq4RQ9q2DvUwLr/UYZKUfyLtzyb3oD44SFgNsQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/escape-html" "^1.0.1"
+    lodash "^4.17.10"
+    react "^16.6.3"
+    react-dom "^16.6.3"
+
+"@wordpress/element@^2.1.9", "@wordpress/element@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.3.0.tgz#8173dd71770081c8987fb3800d366727f790632c"
+  integrity sha512-L/s1n6pqVUlo09uMdhnlarW7ZzTWlvKo6zQzoxZSLEMne/6Hr3sw2DbxE2AuijcJv/n9VzmV7/MNBQMEIPL7OA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/escape-html" "^1.2.0"
+    lodash "^4.17.11"
+    react "^16.8.4"
+    react-dom "^16.8.4"
+
+"@wordpress/escape-html@^1.0.1", "@wordpress/escape-html@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.2.0.tgz#551864c9003127a1157c538c86e234a3451989ff"
+  integrity sha512-IILebUBTFADag62cwxYcLFYoKeHRpDZiKwwhabiWd2sGoSdci1cqLxmLbE8iMcMQru7ALptQgQmhZcuX87DEwg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/format-library@^1.2.14":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/format-library/-/format-library-1.4.0.tgz#70559aec9f4f0a16437bae9575b9f61a587099cd"
+  integrity sha512-wz/l0B4jGEnwS8TIfqaL/u7wr3t8njctQTh3yf2TbvX7S6AokHmy2YrabWKJ5owJ4WmBc2NpTJVoxWZ5hhDZRg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/block-editor" "^1.1.0"
+    "@wordpress/components" "^7.2.0"
+    "@wordpress/editor" "^9.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/i18n" "^3.3.0"
+    "@wordpress/keycodes" "^2.2.0"
+    "@wordpress/rich-text" "^3.2.0"
+    "@wordpress/url" "^2.5.0"
+
+"@wordpress/hooks@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.0.5.tgz#fef43b4c2a107852303a1007cc1fa0f38f93250e"
+  integrity sha512-EcE7lm5p6f3qB6nJClY3LPejFpbjo66b6j4ihgLLgrWMKqs4lLPGS2OzK4KyP0O52cofKj+Tv/wBaAiYSufFcA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@wordpress/hooks@^2.0.5", "@wordpress/hooks@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.2.0.tgz#626cef9424ded5546333891fced140eab890fe34"
+  integrity sha512-pzLDgcQOPCU4xSN0yuGoPd9xeNW2MnB2o7O52qaFZ2DSmf9tN+OkPDg7lKsg7SEds0J7GngBS8tu+a4Lqywy/w==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/html-entities@^2.0.4", "@wordpress/html-entities@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-2.2.0.tgz#4eea4ac094eb554fae8c8b7327304b2584312fbf"
+  integrity sha512-z6baXTgiAKPKdGzHUrcy9Qa+kLPQnGhOK8b+T2xIVlpWgE5GQV235cRY3EBFJIy5S06pTRxQBf0TVr6mvrYxxQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/i18n@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.1.1.tgz#0bd0da86701c1be892e0df07f5c9016bdffe80d0"
+  integrity sha512-qZx3GcrIfPG5uOhYjb/Sz0XBT7OMkdFXYa966S8/gxWIkewD5TWV0ROQ9UX6+u7ScbblNdS87irJI0FDQ0lM3Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.10"
+    memize "^1.0.5"
+    sprintf-js "^1.1.1"
+    tannin "^1.0.1"
+
+"@wordpress/i18n@^3.1.1", "@wordpress/i18n@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.3.0.tgz#3b035399356cc06f8a51dc397a1e8a01bb74feb4"
+  integrity sha512-fQLltl+WKOesjNNmxVg0BBfRoDRpFgs2oxG/e9u+jjRq55vN591P05sOLlxqVolZ5r5aSZmuL593yAhUqJW09Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.11"
+    memize "^1.0.5"
+    sprintf-js "^1.1.1"
+    tannin "^1.0.1"
+
+"@wordpress/is-shallow-equal@^1.1.5", "@wordpress/is-shallow-equal@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.2.0.tgz#5835930dad01c76c6c1300b307a45077c017136d"
+  integrity sha512-WLB1sEz0xjtzJnorJTSuEpaYjo0E9zir0lJGwRjhYHlTjzngTakFPlifcvPVm7saA9KR9/t82jxOENAIWFzftQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/keycodes@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-2.0.6.tgz#35b5298bd0c4395a33a23426ef8d24fcfcd9e1cb"
+  integrity sha512-fWMf6aq1ymfqUVYS0RQF/5RtUl5ijZGC1add1HGMyquWd3Gtu0DV9VNfWU9B+LvcHVuG5ETK3Lc8wBNri9a/tg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/i18n" "^3.1.1"
+    lodash "^4.17.10"
+
+"@wordpress/keycodes@^2.0.6", "@wordpress/keycodes@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-2.2.0.tgz#6ad83e7b0e401247d4cb97e21673fe8b0dbab87b"
+  integrity sha512-UrsJuOlx4edjZMe37CdlaaAyZAiM/h4LE2UzQRdMp9e0nWU/pta6vQknqriTmyVIYyQT72dsKDAd97TbPhrMaA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/i18n" "^3.3.0"
+    lodash "^4.17.11"
+
+"@wordpress/notices@^1.1.3", "@wordpress/notices@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/notices/-/notices-1.3.0.tgz#b6490366a6742e48cee9d76a903daf6b709566ce"
+  integrity sha512-JqtPPs5rBnJq9FxkMbdammDEadZFk2CbPwLTGW5dGbXSyE3ZOtqUnbEKFVl6iAQwU/m4WQaBRbBTfVtC1bktqQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/a11y" "^2.2.0"
+    "@wordpress/data" "^4.4.0"
+    lodash "^4.17.11"
+
+"@wordpress/nux@^3.0.9", "@wordpress/nux@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/nux/-/nux-3.2.0.tgz#0b4ff3497f992c75e9bacbeb138ba10d67bfc581"
+  integrity sha512-qZ+49M2x54oKCTj6u7Cy/Tl/bixYx3ItOy3FwPeIeUGsGLoI9YGWmP0SyR7x/RmAuPbXqoPA7E0SbSlUJPHWUA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/components" "^7.2.0"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/i18n" "^3.3.0"
+    lodash "^4.17.11"
+    rememo "^3.0.0"
+
+"@wordpress/plugins@2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-2.0.11.tgz#e9eaed0c1ddd2f0cdc7611576bbebaf461c29899"
+  integrity sha512-Nd9gJ4HiOm5UYoNKyIIJO/1xmjeT1aOyWdS6ytRKSRS9UwUEm3E7I31NvFHUfe4old2HMXKToIzPxanugBIafg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@wordpress/compose" "^3.0.1"
+    "@wordpress/element" "^2.1.9"
+    "@wordpress/hooks" "^2.0.5"
+    lodash "^4.17.10"
+
+"@wordpress/plugins@^2.0.11":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-2.2.0.tgz#a62528f697316b9dc3d2af5d72ad06ae4d4ad7b2"
+  integrity sha512-XubGkWMjeSmex4evhZ/hwEsdapi9n4rOc8TWYfPK97KfIDaloKhN8O5Em87sApGhGMIyA29fuHbmLepeV+phnQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/element" "^2.3.0"
+    "@wordpress/hooks" "^2.2.0"
+    lodash "^4.17.11"
+
+"@wordpress/priority-queue@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-1.1.0.tgz#a034f4bfbf8eb9a53b0adc559a40d1e4f5b73113"
+  integrity sha512-WFdGqyb4PDvtQzrTFoONGTzGiwKvOaJ4bm2j5VSpR7Oz1vJWmZP7/5TXApDXNr+RKCo/ahmkRmtUilu4M9WKVg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@wordpress/redux-routine@^3.0.4", "@wordpress/redux-routine@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-3.2.0.tgz#ebdc077be8177164a351353622ee4ebbc64d89c4"
+  integrity sha512-t6FoEuLi0auIHcbjFuHC4GkW6XJFz+OaamcP4FurbbisLCbl6HlvEb7tXKnxbRh2bxOPo8w6IuNwI63WzR8rGw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    is-promise "^2.1.0"
+    rungen "^0.3.2"
+
+"@wordpress/rich-text@^3.0.7", "@wordpress/rich-text@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-3.2.0.tgz#86e6b9250fd0a869bf4a23f7e2ed09f43772cb2a"
+  integrity sha512-eo9hR9fk1FpBlTjDZQmeJtzUIut7vMN0uMjRrGv4EaBNqA5hJb3ajzt0cjq/uS4Fb74ubN1E3mi6Jd6Xm8+BFA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/escape-html" "^1.2.0"
+    lodash "^4.17.11"
+    rememo "^3.0.0"
+
+"@wordpress/shortcode@^2.0.2", "@wordpress/shortcode@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-2.2.0.tgz#a1ac4d5e4916c2f3c5dcb57c8554f3a0a262b8b3"
+  integrity sha512-GEa2CCU2hgmomd2e4xidVFLFawSj0jo6GWhEIQexB/s1GPAhbrLAHO6LQMTmZA7B50KF584UWr4hR+kARXLe2A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    lodash "^4.17.11"
+    memize "^1.0.5"
+
+"@wordpress/token-list@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-1.1.0.tgz#909a98d878e142296a3f102cedf3923fdf50c703"
+  integrity sha512-1InK0ic0syqUEyY3XkiDiZW9rJB/C/KZEzaOZjyzl/mwDR0npMiAouY3fTQ6qZSsMHjszhSl90yXz1I9M/DapA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    lodash "^4.17.10"
+
+"@wordpress/token-list@^1.1.0", "@wordpress/token-list@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-1.2.0.tgz#219c265cec5b3902868315ff8180ac125082de12"
+  integrity sha512-iL+EcpP0y8/IJV+zr5FT6/24GQByzi69ngv2vEebToMHfbedaC02REZip3PloVm6wsm8hHs5l9S8AbX77w/awA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    lodash "^4.17.11"
+
+"@wordpress/url@2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.3.3.tgz#7c3c4149d2360763ed59b17b5e8e1a17065ffbee"
+  integrity sha512-WGqQjOyu02E7bJ77G8385GGjUYpvF8vDqZXXHW06/WRSb4nW6fmMIM65UWdBaYY5XecAkpglCqwd8DNbquLucQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    qs "^6.5.2"
+
+"@wordpress/url@^2.3.3", "@wordpress/url@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.5.0.tgz#de171231fcc1bdd6cfc815d3bf2fbaf007389206"
+  integrity sha512-DADAoSMHHheeanC12KF3MhAJCqp0Y3ZQBqWVIEwW2VH9EmRUY4mIdfOHoCXhu+1SU7LmMjvWvzb0j778C0mwlw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    qs "^6.5.2"
+
+"@wordpress/viewport@^2.1.1", "@wordpress/viewport@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/viewport/-/viewport-2.3.0.tgz#4aafbb6e28d36cc3691dcf935c89d85f3d138eaa"
+  integrity sha512-AUFUX4E5kmtVZX6ELjCRKqlfrSS3uQ9u/jeIemxwp1fDq8EW76aAWScfN/fxVjiqYgI3z83C3fIRGde5rlMS4Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@wordpress/compose" "^3.2.0"
+    "@wordpress/data" "^4.4.0"
+    "@wordpress/element" "^2.3.0"
+    lodash "^4.17.11"
+
+"@wordpress/wordcount@^2.0.3", "@wordpress/wordcount@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/wordcount/-/wordcount-2.2.0.tgz#0b6f93867e704e2a93f651481bbcf43f5929d956"
+  integrity sha512-Z1s27db/xFOjo7Vu2sseMil+6WU2Gt27hRSMnLwXBx1ch+EA0ghz1N6beWeL/znfo7vsBZvk+Slasw7L8LHEcw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    lodash "^4.17.11"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -404,6 +1220,22 @@ agent-base@4, agent-base@^4.1.0:
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   dependencies:
     es6-promisify "^5.0.0"
+
+airbnb-prop-types@^2.10.0, airbnb-prop-types@^2.12.0, airbnb-prop-types@^2.8.1:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.12.0.tgz#67b30a5ba4dda9b9e70a480f85150a2ccd7fa132"
+  integrity sha512-EJLaLf0Rjg+AouOgIBlO1rerwgwu3Y0dwxp7BWzUemY9J1UPO9XOlMmOXzpaHW9O0RzpofiThVl0sIToHtLPAQ==
+  dependencies:
+    array.prototype.find "^2.0.4"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.1.0"
+    prop-types "^15.6.2"
+    prop-types-exact "^1.2.0"
+    react-is "^16.8.1"
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -641,9 +1473,10 @@ array-sort@^1.0.0:
     get-value "^2.0.6"
     kind-of "^5.0.2"
 
-array-union@^1.0.1:
+array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
 
@@ -654,6 +1487,14 @@ array-uniq@^1.0.1, array-uniq@^1.0.2:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+array.prototype.find@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
+  integrity sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array.prototype.flat@^1.2.1:
   version "1.2.1"
@@ -760,6 +1601,11 @@ autoprefixer@^9.1.3:
     num2fraction "^1.2.2"
     postcss "^7.0.6"
     postcss-value-parser "^3.3.1"
+
+autosize@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1605,6 +2451,11 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+brcast@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-2.0.2.tgz#2db16de44140e418dc37fab10beec0369e78dcef"
+  integrity sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -1763,6 +2614,11 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -1948,7 +2804,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6:
+classnames@2.2.6, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 
@@ -1983,9 +2839,10 @@ click-outside@2.0.2:
     component-event "^0.1.4"
     node-contains "^1.0.0"
 
-clipboard@2.0.4:
+clipboard@2.0.4, clipboard@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
+  integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"
@@ -2119,6 +2976,11 @@ component-uid@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/component-uid/-/component-uid-0.0.2.tgz#c9d7893d4b049ad30c6b8aa4c01d6d1afd569596"
 
+computed-style@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
+  integrity sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2148,6 +3010,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+"consolidated-events@^1.1.1 || ^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-2.0.2.tgz#da8d8f8c2b232831413d9e190dc11669c79f4a91"
+  integrity sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -2157,6 +3024,11 @@ convert-source-map@1.X, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -2200,6 +3072,11 @@ cosmiconfig@^5.0.7:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
+
+crc32@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/crc32/-/crc32-0.2.2.tgz#7ad220d6ffdcd119f9fc127a7772cacea390a4ba"
+  integrity sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -2437,9 +3314,10 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@3.X, debug@^3.1.0:
+debug@3.2.6, debug@3.X, debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -2490,6 +3368,11 @@ deep-is@~0.1.3:
 deepmerge@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
+
+deepmerge@^1.5.1, deepmerge@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+  integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
 default-compare@^1.0.0:
   version "1.0.0"
@@ -2586,6 +3469,18 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
+
+direction@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/direction/-/direction-1.0.2.tgz#ac49c4699edf1283fd82f34e701ca668ea4883b9"
+  integrity sha512-hSKoz5FBn+zhP9vWKkVQaaxnRDg3/MoPdcg2au54HIUDR8MrP8Ah1jXSJwCXel6SV3Afh5DSzc8Uqv2r1UoQwQ==
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -2596,12 +3491,31 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+document.contains@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/document.contains/-/document.contains-1.0.1.tgz#a18339ec8e74f407fa34709b65f45605b38a3e1f"
+  integrity sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==
+  dependencies:
+    define-properties "^1.1.3"
+
+dom-scroll-into-view@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
+  integrity sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom7@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/dom7/-/dom7-2.1.3.tgz#a736f9c3bfbc4ca039a81cd095f97d1d7f3de19c"
+  integrity sha512-QTxHHDox+M6ZFz1zHPAHZKI3JOHY5iY4i9BK2uctlggxKQwRhO3q3HHFq1BKsT25Bm/ySSj70K6Wk/G4bs9rMQ==
+  dependencies:
+    ssr-window "^1.0.1"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -2666,6 +3580,16 @@ duplexify@^3.4.2, duplexify@^3.5.0, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplicate-package-checker-webpack-plugin@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-3.0.0.tgz#78bb89e625fa7cf8c2a59c53f62b495fda9ba287"
+  integrity sha512-aO50/qPC7X2ChjRFniRiscxBLT/K01bALqfcDaf8Ih5OqQ1N4iT/Abx9Ofu3/ms446vHTm46FACIuJUmgUQcDQ==
+  dependencies:
+    chalk "^2.3.0"
+    find-root "^1.0.0"
+    lodash "^4.17.4"
+    semver "^5.4.1"
+
 each-props@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/each-props/-/each-props-1.3.2.tgz#ea45a414d16dd5cfa419b1a81720d5ca06892333"
@@ -2701,6 +3625,11 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+email-validator@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
+  integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
 
 emoji-regex@^6.5.1:
   version "6.5.1"
@@ -2785,6 +3714,11 @@ enzyme@3.9.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.1.2"
+
+equivalent-key-map@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz#be4d57049bb8d46a81d6e256c1628465620c2a13"
+  integrity sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3196,9 +4130,26 @@ fancy-log@1.3.3, fancy-log@^1.1.0, fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
+fast-average-color@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/fast-average-color/-/fast-average-color-4.3.0.tgz#baf08eb9c62955c40718a26c47d0b1501c62193e"
+  integrity sha512-k8FXd6+JeXoItmdNqB3hMwFgArryjdYBLuzEM8fRY/oztd/051yhSHU6GUrMOfIQU9dDHyFDcIAkGrQKlYtpDA==
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-glob@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
+  integrity sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==
+  dependencies:
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    "@nodelib/fs.stat" "^1.1.2"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.3"
+    micromatch "^3.1.10"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -3276,6 +4227,11 @@ find-cache-dir@^2.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3538,6 +4494,14 @@ gettext-parser@1.1.0:
   dependencies:
     encoding "^0.1.11"
 
+gettext-parser@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.4.0.tgz#f8baf34a292f03d5e42f02df099d301f167a7ace"
+  integrity sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==
+  dependencies:
+    encoding "^0.1.12"
+    safe-buffer "^5.1.1"
+
 gettext-parser@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-3.1.0.tgz#a92f4aa09cdaa944ce71832677749d84ac683649"
@@ -3576,6 +4540,11 @@ glob-stream@^6.1.0:
     to-absolute-glob "^2.0.0"
     unique-stream "^2.0.2"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
 glob-watcher@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.3.tgz#88a8abf1c4d131eb93928994bc4a593c2e5dd626"
@@ -3587,9 +4556,10 @@ glob-watcher@^5.0.0:
     just-debounce "^1.0.0"
     object.defaults "^1.1.0"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
+glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -3597,6 +4567,14 @@ glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glo
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-cache@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/global-cache/-/global-cache-1.2.1.tgz#39ca020d3dd7b3f0934c52b75363f8d53312c16d"
+  integrity sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==
+  dependencies:
+    define-properties "^1.1.2"
+    is-symbol "^1.0.1"
 
 global-modules@^1.0.0:
   version "1.0.0"
@@ -3634,6 +4612,20 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-9.1.0.tgz#e90f4d5134109e6d855abdd31bdb1b085428592e"
+  integrity sha512-VtYjhHr7ncls724Of5W6Kaahz0ag7dB4G62/2HsN+xEKG6SrPzM1AJMerGxQTwJGnN9reeyxdvXbuZYpfssCvg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^1.0.2"
+    dir-glob "^2.2.1"
+    fast-glob "^2.2.6"
+    glob "^7.1.3"
+    ignore "^4.0.3"
+    pify "^4.0.1"
+    slash "^2.0.0"
+
 globule@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.1.tgz#5dffb1b191f22d20797a9369b49eab4e9839696d"
@@ -3663,6 +4655,13 @@ graceful-fs@~3.0.2:
   resolved "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
   dependencies:
     natives "^1.1.0"
+
+gridicons@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/gridicons/-/gridicons-3.1.1.tgz#4bfdd3861d9db92d6e6473e94948bb151f4ef75d"
+  integrity sha512-Sec8WviTyXpsSQycju8RlmpN0o8KFSDZQJeVtHjaBT1GJxvS3g1OA9y1XsauNPwNEr9nk4DeLPI4TYnufTqMIg==
+  dependencies:
+    prop-types "^15.5.7"
 
 growl@1.10.5:
   version "1.10.5"
@@ -4037,9 +5036,10 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.0"
@@ -4063,6 +5063,11 @@ homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
 hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+
+hpq@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/hpq/-/hpq-1.3.0.tgz#fe73406927f6327ea66aa6055fbb130ac9a249c0"
+  integrity sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==
 
 html-element-map@^1.0.0:
   version "1.0.0"
@@ -4161,6 +5166,23 @@ i18n-calypso@3.0.0:
     react "0.14.8 || ^15.5.0 || ^16.0.0"
     xgettext-js "^2.0.0"
 
+i18n-calypso@^4.0.0-alpha.1:
+  version "4.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/i18n-calypso/-/i18n-calypso-4.0.0-alpha.1.tgz#e519d3679b755e497974e4f3dd823d3c743ab08e"
+  integrity sha512-iLxSlNNYddDyLlicN8mnpuOv8FH5MdEXNYar0UfpQJS29aQjXryNUui8Y6tkO5nRu5ZD6q7SocQKnVHuIKAdlQ==
+  dependencies:
+    commander "^2.9.0"
+    debug "^3.2.6"
+    globby "^9.0.0"
+    hash.js "^1.1.5"
+    interpolate-components "1.1.1"
+    jed "1.1.1"
+    lodash "^4.7.11"
+    lru "^3.1.0"
+    moment "^2.24.0"
+    react "^16.8.3"
+    xgettext-js "^2.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4191,9 +5213,10 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^4.0.6:
+ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -4501,11 +5524,16 @@ is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
-is-symbol@^1.0.2:
+is-symbol@^1.0.1, is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
   dependencies:
     has-symbols "^1.0.0"
+
+is-touch-device@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-touch-device/-/is-touch-device-1.0.1.tgz#9a2fd59f689e9a9bf6ae9a86924c4ba805a42eab"
+  integrity sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -4565,6 +5593,11 @@ isstream@~0.1.2:
 jed@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/jed/-/jed-1.1.1.tgz#7a549bbd9ffe1585b0cd0a191e203055bee574b4"
+
+jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 js-base64@^2.1.8:
   version "2.4.9"
@@ -4859,6 +5892,20 @@ liftoff@^2.5.0:
     object.map "^1.0.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
+
+line-height@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
+  integrity sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=
+  dependencies:
+    computed-style "~0.1.3"
+
+linkify-it@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.1.0.tgz#c4caf38a6cd7ac2212ef3c7d2bde30a91561f9db"
+  integrity sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==
+  dependencies:
+    uc.micro "^1.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -5196,7 +6243,7 @@ lodash.values@~2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@4.17.11, lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
+lodash@4.17.11, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.11, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -5296,6 +6343,17 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 "match-stream@>= 0.0.2 < 1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/match-stream/-/match-stream-0.0.2.tgz#99eb050093b34dffade421b9ac0b410a9cfa17cf"
@@ -5320,6 +6378,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -5337,6 +6400,11 @@ mem@^4.0.0:
 memfs-or-file-map-to-github-branch@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.1.2.tgz#9d46c02481b7eca8e5ee8a94f170b7e0138cad67"
+
+memize@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/memize/-/memize-1.0.5.tgz#51d89e8407643dbc8cab98c6d56b889f9a3954e3"
+  integrity sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg==
 
 memoizee@0.4.X:
   version "0.4.14"
@@ -5378,6 +6446,11 @@ merge-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
+
+merge2@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
+  integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
@@ -5546,9 +6619,19 @@ moment-timezone@^0.5.16:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
+moment@>=1.6.0, moment@^2.22.1, moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+
+mousetrap@^1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.3.tgz#80fee49665fd478bccf072c9d46bdf1bfed3558a"
+  integrity sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -5969,6 +7052,16 @@ object.entries@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+object.entries@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
 object.fromentries@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
@@ -6339,6 +7432,13 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
+
 pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
@@ -6359,9 +7459,23 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+  integrity sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
+photon@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/photon/-/photon-2.0.1.tgz#4044c1ad637ae4733744bb4643fb7b15a4429f97"
+  integrity sha512-9/a0UvjyNL1xQI3v416Ym0GIm9HyzM4kHjOj06WFqGYGKnaFIEFJ1uJtjkobmur4KHIoXsxhHydrVsq2tJ1N5g==
+  dependencies:
+    crc32 "0.2.2"
+    debug "3.1.0"
+    seed-random "2.2.0"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -6569,9 +7683,19 @@ promise@^8.0.1:
   dependencies:
     asap "~2.0.6"
 
-prop-types@15.7.2, prop-types@^15.7.2:
+prop-types-exact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
+
+prop-types@15.7.2, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
@@ -6658,6 +7782,11 @@ qs@^6.5.1:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
 
+qs@^6.5.2:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -6731,6 +7860,11 @@ rcloader@^0.2.2:
     lodash.merge "^4.6.0"
     rcfinder "^0.1.6"
 
+re-resizable@^4.7.1:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-4.11.0.tgz#d5df10bda445c4ec0945751a223bf195afb61890"
+  integrity sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q==
+
 "react-addons-create-fragment@^0.14.3 || ^15.1.0":
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
@@ -6738,6 +7872,49 @@ rcloader@^0.2.2:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
+
+react-addons-shallow-compare@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
+  integrity sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
+
+react-autosize-textarea@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz#30e8e081f35eb73b3667dc01cf4e8927c278466b"
+  integrity sha512-iOSZK7RUuJ+iEwkJ9rqYciqtjQgrG1CCRFL6h8Bk61kODnRyEq4tS74IgXpI1t4S6jBBZVm+6ugaU+tWTlVxXg==
+  dependencies:
+    autosize "^4.0.0"
+    line-height "^0.3.1"
+    prop-types "^15.5.6"
+
+react-click-outside@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  integrity sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
+
+react-dates@^17.1.1:
+  version "17.2.0"
+  resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-17.2.0.tgz#d8cfe29ceecb3fbe37abbaa385683504cc53cdf6"
+  integrity sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==
+  dependencies:
+    airbnb-prop-types "^2.10.0"
+    consolidated-events "^1.1.1 || ^2.0.0"
+    is-touch-device "^1.0.1"
+    lodash "^4.1.1"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.1"
+    react-addons-shallow-compare "^15.6.2"
+    react-moment-proptypes "^1.6.0"
+    react-outside-click-handler "^1.2.0"
+    react-portal "^4.1.5"
+    react-with-styles "^3.2.0"
+    react-with-styles-interface-css "^4.0.2"
 
 react-dom@16.8.4:
   version "16.8.4"
@@ -6757,6 +7934,16 @@ react-dom@16.8.4:
     prop-types "^15.6.2"
     scheduler "^0.11.2"
 
+react-dom@^16.6.3, react-dom@^16.8.4:
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.5.tgz#b3e37d152b49e07faaa8de41fdf562be3463335e"
+  integrity sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.5"
+
 react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
@@ -6772,6 +7959,31 @@ react-is@^16.8.1, react-is@^16.8.2:
 react-is@^16.8.4:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
+
+react-moment-proptypes@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz#8ec266ee392a08ba3412d2df2eebf833ab1046df"
+  integrity sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==
+  dependencies:
+    moment ">=1.6.0"
+
+react-outside-click-handler@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-outside-click-handler/-/react-outside-click-handler-1.2.3.tgz#911a8b91ca947882156d2483450d8638324f3399"
+  integrity sha512-4orkx59ais0mM/j1Ekc5ewyRu5xNLX4a6pMs7RT8U7JkbPOlRsucE+190kXzYUUHsGfZvyAmsdQkL7lpqzMGBg==
+  dependencies:
+    airbnb-prop-types "^2.12.0"
+    consolidated-events "^1.1.1 || ^2.0.0"
+    document.contains "^1.0.0"
+    object.values "^1.1.0"
+    prop-types "^15.7.2"
+
+react-portal@^4.1.5:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.0.tgz#5400831cdb0ae64dccb8128121cf076089ab1afd"
+  integrity sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-pure-render@1.0.2:
   version "1.0.2"
@@ -6826,6 +8038,38 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.6.3"
     scheduler "^0.11.2"
 
+react-with-direction@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.3.0.tgz#9885f5941aa986be753db95a41e8f3d8f8de97ff"
+  integrity sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==
+  dependencies:
+    airbnb-prop-types "^2.8.1"
+    brcast "^2.0.2"
+    deepmerge "^1.5.1"
+    direction "^1.0.1"
+    hoist-non-react-statics "^2.3.1"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+
+react-with-styles-interface-css@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz#c4a61277b2b8e4126b2cd25eca3ac4097bd2af09"
+  integrity sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==
+  dependencies:
+    array.prototype.flat "^1.2.1"
+    global-cache "^1.2.1"
+
+react-with-styles@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-with-styles/-/react-with-styles-3.2.1.tgz#57a313ae3dcd0b347193a5538d5061d3bb96bab4"
+  integrity sha512-L+x/EDgrKkqV6pTfDtLMShf7Xs+bVQ+HAT5rByX88QYX+ft9t5Gn4PWMmg36Ur21IVEBMGjjQQIJGJpBrzbsyg==
+  dependencies:
+    deepmerge "^1.5.2"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-with-direction "^1.3.0"
+
 "react@0.14.8 || ^15.5.0 || ^16.0.0", "react@^0.14.3 || ^15.1.0 || ^16.0.0":
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
@@ -6843,6 +8087,16 @@ react@16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.4"
+
+react@^16.6.3, react@^16.8.3, react@^16.8.4:
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
+  integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.5"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -6948,16 +8202,37 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redux-multi@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/redux-multi/-/redux-multi-0.1.12.tgz#28e1fe5e49672cbc5bd8a07f0b2aeaf0ef8355c2"
+  integrity sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI=
+
+redux-optimist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redux-optimist/-/redux-optimist-1.0.0.tgz#1f3d4ffbcd11573159bb90e96c68e35e3b875818"
+  integrity sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw==
+
 redux-thunk@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@4.0.1:
+redux@4.0.1, redux@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
+  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
+
+refx@3.1.1, refx@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/refx/-/refx-3.1.1.tgz#8ca1b4844ac81ff8e8b79523fdd082cac9b05517"
+  integrity sha512-lwN27W5iYyagpCxxYDYDl0IIiKh0Vgi3wvafqfthbzTfBgLOYAstcftp+G2X612xVaB8rhn5wDxd4er4KEeb8A==
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -6970,6 +8245,11 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -7007,6 +8287,11 @@ regjsparser@^0.1.4:
   resolved "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+rememo@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rememo/-/rememo-3.0.0.tgz#06e8e76e108865cc1e9b73329db49f844eaf8392"
+  integrity sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==
 
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
@@ -7112,6 +8397,11 @@ requireindex@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
 
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -7204,6 +8494,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rungen@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/rungen/-/rungen-0.3.2.tgz#400c09ebe914e7b17e0b6ef3263400fc2abc7cb3"
+  integrity sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM=
+
 rxjs@^6.1.0:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
@@ -7268,6 +8563,14 @@ scheduler@^0.13.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
+  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -7282,6 +8585,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seed-random@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
+  integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
 
 select@^1.1.2:
   version "1.1.2"
@@ -7364,9 +8672,21 @@ shelljs@0.3.x:
   version "0.3.0"
   resolved "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
 
+showdown@^1.8.6:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.0.tgz#d49d2a0b6db21b7c2e96ef855f7b3b2a28ef46f4"
+  integrity sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==
+  dependencies:
+    yargs "^10.0.3"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-html-tokenizer@^0.4.1:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz#9b00b766e30058b4bb377c0d4f97566a13ab1be1"
+  integrity sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw==
 
 sinon-chai@3.3.0:
   version "3.3.0"
@@ -7516,6 +8836,11 @@ split@0.2:
   dependencies:
     through "2"
 
+sprintf-js@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -7541,6 +8866,11 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+ssr-window@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-1.0.1.tgz#30752a6a4666e7767f0b7e6aa6fc2fdbd0d9b369"
+  integrity sha512-dgFqB+f00LJTEgb6UXhx0h+SrG50LJvti2yMKMqAgzfUmUXZrLSv2fjULF7AWGwK25EXu8+smLR3jYsJQChPsg==
 
 ssri@^6.0.0:
   version "6.0.1"
@@ -7763,6 +9093,14 @@ sver-compat@^1.5.0:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
+swiper@4.4.6:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-4.4.6.tgz#0dfa9d66e39811c73e96ea55cea61047a4091667"
+  integrity sha512-F9NDtijQt+etiOe6JAEH+Cb+QKzwwFpi08FlOIQv8ALdoQ8tvAX/38a/28E5XxalAkChsHCutwkBCzDxDXTGiA==
+  dependencies:
+    dom7 "^2.1.2"
+    ssr-window "^1.0.1"
+
 symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -7783,6 +9121,13 @@ table@^5.0.2:
     lodash "^4.17.11"
     slice-ansi "2.0.0"
     string-width "^2.1.1"
+
+tannin@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tannin/-/tannin-1.1.0.tgz#0cdc30bc81fafa63a0d6e9890e2bff56a64d27c7"
+  integrity sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==
+  dependencies:
+    "@tannin/plural-forms" "^1.0.3"
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.1"
@@ -7910,6 +9255,16 @@ tiny-emitter@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
+  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
+
+tinymce@^4.7.2:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.9.4.tgz#67c03d0c5a305b32f677e0680ed7909f3cfd457a"
+  integrity sha512-pht+jAPbVVEVaxGBAGqTwsVsdkI2+c/opuJ44KuD6pBJApMOQbfpGFt+XdxunyPLcxJsa7i28FIWe37W9zqeRA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -7987,6 +9342,11 @@ tr46@^1.0.1:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -8015,6 +9375,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbo-combine-reducers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz#aa3650b3c63daa6804d35a4042014f6d31df1e47"
+  integrity sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -8036,6 +9401,11 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.18:
   version "0.7.19"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-save-license@0.4.1:
   version "0.4.1"
@@ -8496,6 +9866,13 @@ yargs-parser@^5.0.0:
   dependencies:
     camelcase "^3.0.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -8526,6 +9903,24 @@ yargs@12.0.5, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^11.0.0:
   version "11.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   dependencies:
     i18n-calypso "^4.0.0-alpha.1"
 
-"@automattic/jetpack-blocks@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-14.0.0.tgz#80bb9091fae2935a35e479cf557ee2b4f635eb89"
-  integrity sha512-dJVqJa8+BXTA3Gm1uwew8fmlQycFwb8vaxG3Uld0Hviabedv1VcHivGN+deTnsANl3dtYe1b3yJBmCSta92U6A==
+"@automattic/jetpack-blocks@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@automattic/jetpack-blocks/-/jetpack-blocks-15.0.0.tgz#ac74ee8f883a9e6fab6a608893ce1a15cb075c82"
+  integrity sha512-Nx9Uzr/YNhSM96hxi6NWSOrrioxodjVCik1joVg8LpFl+/fdy4TAwJWlC14syjzGjdHoT+KEfLwj6374nCiyCQ==
   dependencies:
     "@automattic/format-currency" "1.0.0-alpha.0"
     "@wordpress/api-fetch" "2.2.8"


### PR DESCRIPTION
Companion to https://github.com/Automattic/wp-calypso/pull/31199 which changes the path to compiled blocks in the module.

This includes the updated path to the compiled source: `build` -> `dist`.
It also includes the theoretical major version change to `v14`. This is broken, the version has not been released.

## Testing
- `yarn`
- `npx gulp gutenberg:blocks`

Do the blocks work as expected? The repeat visitor block should be available as a normal (not beta) block.