### PR TITLE
Linter: Update jshint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,6 +6,7 @@
 	"eqnull": true,
 	"expr": true,
 	"immed": true,
+	"laxbreak": true,
 	"noarg": true,
 	"onevar": true,
 	"quotmark": "single",

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,6 @@
 	"noarg": true,
 	"onevar": true,
 	"quotmark": "single",
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,9 +1,9 @@
 {
 	"boss": true,
 	"curly": true,
+	"esversion": 5,
 	"eqeqeq": true,
 	"eqnull": true,
-	"es3": true,
 	"expr": true,
 	"immed": true,
 	"noarg": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
 	"laxbreak": true,
 	"noarg": true,
 	"onevar": true,
-	"quotmark": "single",
+	"quotmark": false,
 	"undef": true,
 	"unused": true,
 


### PR DESCRIPTION
Update jshint config

https://jshint.com/docs/options/#trailingcomma

es3 becomes esversion:5 — our supported browsers are all es5 compatible, correct?
trailing is removed (outdated)
remove quotmark (deprecated - conflicts with prettier)
add laxbreak (conflicts with prettier)

required for #11507 

## Testing
- `npx gulp js:hint`