### PR TITLE
Search: new URL param to display search query results in page source

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -243,6 +243,13 @@ class Jetpack_Search {
 				intval( $this->last_query_info['elapsed_time'] ),
 				esc_html( $this->last_query_info['es_time'] )
 			);
+
+			if ( isset( $_GET['searchdebug'] ) ) {
+				printf(
+					'<!-- Query response data: %s -->',
+					esc_html( print_r( $this->last_query_info, 1 ) )
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR provides an easy way to see what Jetpack search is returning for results. It can be useful if we are not sure whether the issue is with the theme, conflicting plugin, etc. It can be useful for HEs or users. 

It adds the results to the page source only. 

There very well may be a better way to do this, or a reason we're not doing it already. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Purchase a plan 
- Enable Jetpack Search 
- Search for something
- On the search results URL, manually add `&searchdebug=1` to the url and load 
- Look in the page source. `cmd+f` for `Query response data`
- You should see the response data. 
- It should not affect any default searches. You should not see this if the query param is not present. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Jetpack Search: An easy way to see the raw Jetpack Search query results. 
