### PR TITLE
Related Posts: Revert "Removing enabled and published checks"

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -800,7 +800,6 @@ EOT;
 			! $options['enabled']
 			|| 0 === (int) $post_id
 			|| empty( $options['size'] )
-			|| get_post_status( $post_id ) !== 'publish'
 		) {
 			return array();
 		}

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -796,7 +796,7 @@ EOT;
 			$options['size'] = $args['size'];
 		}
 
-		if ( 0 === (int) $post_id || empty( $options['size'] ) ) {
+		if ( ! $options['enabled'] || 0 == (int)$post_id || empty( $options['size'] ) || get_post_status( $post_id) !== 'publish' ) {
 			return array();
 		}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -784,7 +784,7 @@ EOT;
 	/**
 	 * Gets an array of related posts that match the given post_id.
 	 *
-	 * @param int $post_id
+	 * @param int   $post_id Post which we want to find related posts for.
 	 * @param array $args - params to use when building Elasticsearch filters to narrow down the search domain.
 	 * @uses self::get_options, get_post_type, wp_parse_args, apply_filters
 	 * @return array
@@ -796,19 +796,24 @@ EOT;
 			$options['size'] = $args['size'];
 		}
 
-		if ( ! $options['enabled'] || 0 === (int)$post_id || empty( $options['size'] ) || get_post_status( $post_id) !== 'publish' ) {
+		if (
+			! $options['enabled']
+			|| 0 === (int) $post_id
+			|| empty( $options['size'] )
+			|| get_post_status( $post_id ) !== 'publish'
+		) {
 			return array();
 		}
 
 		$defaults = array(
-			'size' => (int)$options['size'],
-			'post_type' => get_post_type( $post_id ),
-			'post_formats' => array(),
-			'has_terms' => array(),
-			'date_range' => array(),
+			'size'             => (int) $options['size'],
+			'post_type'        => get_post_type( $post_id ),
+			'post_formats'     => array(),
+			'has_terms'        => array(),
+			'date_range'       => array(),
 			'exclude_post_ids' => array(),
 		);
-		$args = wp_parse_args( $args, $defaults );
+		$args     = wp_parse_args( $args, $defaults );
 		/**
 		 * Filter the arguments used to retrieve a list of Related Posts.
 		 *

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -796,7 +796,7 @@ EOT;
 			$options['size'] = $args['size'];
 		}
 
-		if ( ! $options['enabled'] || 0 == (int)$post_id || empty( $options['size'] ) || get_post_status( $post_id) !== 'publish' ) {
+		if ( ! $options['enabled'] || 0 === (int)$post_id || empty( $options['size'] ) || get_post_status( $post_id) !== 'publish' ) {
 			return array();
 		}
 


### PR DESCRIPTION
Fixes #11546 

This commit regressed the fix added in #9495 and breaks the jetpack_relatedposts_filter_options filter's use of "enabled".

This reverts commit 237c30f0a281e572b961cc9b057bd375ff479749.

#### Changes proposed in this Pull Request:
* Replace the enabled and publish post checks.

#### Testing instructions:
* On a Jetpack site with RPs enabled and RPs displaying as normal.
* Try the filter in 11546, except remove the conditional to return false always.
* Do RPs show? If not, good.

#### Proposed changelog entry for your changes:
* Related Posts: Restore use of the jetpack_relatedposts_filter_options filter and prevent HTTP errors when editing drafts in the Block Editor.

cc: @aldavigdis 
