### PR TITLE
Sharing: Remove Google+ from deprecated list

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -56,9 +56,6 @@ class Sharing_Service {
 			'telegram'         => 'Share_Telegram',
 			'jetpack-whatsapp' => 'Jetpack_Share_WhatsApp',
 			'skype'            => 'Share_Skype',
-
-			// Deprecated
-			'google-plus-1'    => 'Share_GooglePlus1',
 		);
 
 		/**

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1177,14 +1177,6 @@ class Share_PressThis extends Sharing_Source {
 	}
 }
 
-class Share_GooglePlus1 extends Deprecated_Sharing_Source {
-	public $shortname = 'googleplus1';
-
-	public function get_name() {
-		return __( 'Google+', 'jetpack' );
-	}
-}
-
 class Share_Custom extends Sharing_Advanced_Source {
 	private $name;
 	private $icon;


### PR DESCRIPTION
With Google+ for consumers reaching EOL and being shut down on April 2nd, we can close out the Google+ saga by removing it completely vs showing the deprecation notice during the transition.

#### Changes proposed in this Pull Request:
* Remove Google+ from the Sharing module.

#### Testing instructions:
* On a site with a Google+ sharing button, upgrade to this branch.
* Any errors on the front-end (logged out or not) or the sharing settings page?

#### Proposed changelog entry for your changes:
* Sharing: Remove the deprecation notice for Google+ and remove the button completely.
