### PR TITLE
Contact Info: Only load styles for this block.

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -464,7 +464,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Only enqueue block scripts when needed.
 	 *
-	 * @param string $type slug of the block.
+	 * @param string $type Slug of the block.
 	 * @param array  $script_dependencies An array of view-side Javascript dependencies to be enqueued.
 	 *
 	 * @return void

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -435,12 +435,44 @@ class Jetpack_Gutenberg {
 		}
 
 		$type = sanitize_title_with_dashes( $type );
+		self::load_styles_as_required( $type );
+		self::load_scripts_as_required( $type, $script_dependencies );
+	}
+
+	/**
+	 * Only enqueue block sytles when needed.
+	 *
+	 * @param string $type slug of the block.
+	 *
+	 * @return void
+	 */
+	public static function load_styles_as_required( $type ) {
+		if ( is_admin() ) {
+			// A block's view assets will not be required in wp-admin.
+			return;
+		}
+
 		// Enqueue styles.
 		$style_relative_path = self::get_blocks_directory() . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( self::block_has_asset( $style_relative_path ) ) {
 			$style_version = self::get_asset_version( $style_relative_path );
 			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
+		}
+
+	}
+	/**
+	 * Only enqueue block scripts when needed.
+	 *
+	 * @param string $type slug of the block.
+	 * @param array  $script_dependencies An array of view-side Javascript dependencies to be enqueued.
+	 *
+	 * @return void
+	 */
+	public static function load_scripts_as_required( $type, $script_dependencies = array() ) {
+		if ( is_admin() ) {
+			// A block's view assets will not be required in wp-admin.
+			return;
 		}
 
 		// Enqueue script.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -423,7 +423,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Only enqueue block assets when needed.
 	 *
-	 * @param string $type slug of the block.
+	 * @param string $type Slug of the block.
 	 * @param array  $script_dependencies An array of view-side Javascript dependencies to be enqueued.
 	 *
 	 * @return void
@@ -442,7 +442,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Only enqueue block sytles when needed.
 	 *
-	 * @param string $type slug of the block.
+	 * @param string $type Slug of the block.
 	 *
 	 * @return void
 	 */

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -444,6 +444,8 @@ class Jetpack_Gutenberg {
 	 *
 	 * @param string $type Slug of the block.
 	 *
+	 * @since 7.2.0
+	 *
 	 * @return void
 	 */
 	public static function load_styles_as_required( $type ) {
@@ -466,6 +468,8 @@ class Jetpack_Gutenberg {
 	 *
 	 * @param string $type Slug of the block.
 	 * @param array  $script_dependencies An array of view-side Javascript dependencies to be enqueued.
+	 *
+	 * @since 7.2.0
 	 *
 	 * @return void
 	 */

--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -22,7 +22,7 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render( $attr, $content ) {
-		Jetpack_Gutenberg::load_assets_as_required( 'contact-info' );
+		Jetpack_Gutenberg::load_styles_as_required( 'contact-info' );
 		return str_replace(
 			'class="wp-block-jetpack-contact-info', // Closing " intentionally ommited to that the user can also add the className as expected.
 			'itemprop="location" itemscope itemtype="http://schema.org/Organization" class="wp-block-jetpack-contact-info',


### PR DESCRIPTION
Currently we also load the js files that don't do anything on the front end of the contact info block. This PR removes them. This should ideally be fixed by the block building part. 

<!--- Provide a general summary of your changes in the Title above -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add helper methods for only including js or css files required by a block. 

#### Testing instructions:
1. Add a contact info block. 
2. Notice that we don't build include the the js files for the contact info block.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Improvement: Remove any js loaded due to the contact info block.
