### PR TITLE
Contact Info Wiget: Bug fix url encoding 

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -348,9 +348,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			$address = strtolower( $address );
 			$address = preg_replace( '/\s+/', ' ', trim( $address ) ); // Get rid of any unwanted whitespace
 			$address = str_ireplace( ' ', '+', $address ); // Use + not %20
-			urlencode( $address );
-
-			return $address;
+			return urlencode( $address );
 		}
 
 		/**


### PR DESCRIPTION
Make sure that we url encode the address as expected and we don't return any errors.

Already deployed to .com via D25596-code

#### Changes proposed in this Pull Request:
* Fixes a bug with the address url encode function. 

#### Testing instructions:
To test. 
In the contact info block
add a google maps api key. 
- Enter an addressed that contains a # 
- Notice that the address can be mapped instead of returning an REQUEST_DENIED Error.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Bug Fix: Contact Info widget with addressed containing url characters works as expected. 
