### PR TITLE
Ensure invocation of parse_blocks doesn't result in fatal errors for older WordPress versions

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -327,11 +327,9 @@ class Jetpack_PostImages {
 		}
 
 		// Look for block information in the HTML.
-		/*
 		if ( ! function_exists( 'parse_blocks' ) ) {
 			return $images;
 		}
-		*/
 		$blocks = parse_blocks( $html_info['html'] );
 		if ( empty( $blocks ) ) {
 			return $images;

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -327,6 +327,11 @@ class Jetpack_PostImages {
 		}
 
 		// Look for block information in the HTML.
+		/*
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			return $images;
+		}
+		*/
 		$blocks = parse_blocks( $html_info['html'] );
 		if ( empty( $blocks ) ) {
 			return $images;


### PR DESCRIPTION
When testing https://github.com/Automattic/jetpack/pull/11569, I discovered that viewing any post threw a fatal error on WordPress version 4.9.10 because it was missing the `parse_blocks` function. 

This PR ensures that doesn't happen.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Ensure WordPress versions without `parse_blocks` don't throw fatal errors.

#### Testing instructions:

Use WordPress version `4.9.10`, install the Gutenberg plugin, see that you get a fatal error in your logs when viewing a newly pushed page.

Apply patch, see that you no longer get a fatal error in your logs when viewing published page.

#### Proposed changelog entry for your changes:
None needed
