### PR TITLE
Lint: Fix jshint === lint

### DIFF
--- a/modules/custom-css/custom-css/js/css-editor.js
+++ b/modules/custom-css/custom-css/js/css-editor.js
@@ -77,7 +77,7 @@ jQuery( function ( $ ) {
 		e.preventDefault();
 
 		$( '#css-mode-select' ).slideUp();
-		$( '#css-mode-display' ).text( $( 'input[name=add_to_existing_display]:checked' ).val() == 'true' ? 'Add-on' : 'Replacement' ); // jshint ignore:line
+		$( '#css-mode-display' ).text( $( 'input[name=add_to_existing_display]:checked' ).val() === 'true' ? 'Add-on' : 'Replacement' );
 		$( '#add_to_existing' ).val( $( 'input[name=add_to_existing_display]:checked' ).val() );
 		$( '.edit-css-mode' ).show();
 	} );


### PR DESCRIPTION
Removes a jshint disable comment and fixes the lint.
Surfaced in #11507 where prettier broke the line before the jshint disable-line.

Change a `==` jQuery `element.val()` comparison to `===` (strict equals):

Try this in your WP Admin console:

```js
jQuery( '<input type="checkbox" value="true" />' ).val() == 'true' // true
jQuery( '<input type="checkbox" value="true" />' ).val() === 'true' // true

jQuery( '<input type="checkbox" value="something-else" />' ).val() == 'true' // false
jQuery( '<input type="checkbox" value="something-else" />' ).val() === 'true' // false

jQuery( '<input type="checkbox" />' ).val() == 'true' // false
jQuery( '<input type="checkbox" />' ).val() === 'true' // false
```

My reasoning says this change should be safe.

## Testing
- Verify behavior is unchanged in the CSS editor? (I don't know anything about this feature)

## Changelog
none