### PR TITLE
Use /regex/.test over "string".match( /regex/ )

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -993,7 +993,7 @@ jQuery(document).ready(function($) {
 			var imageLinkParser = document.createElement( 'a' );
 			imageLinkParser.href = args.large_file;
 
-			var isPhotonUrl = ( imageLinkParser.hostname.match( /^i[\d]{1}.wp.com$/i ) != null );
+			var isPhotonUrl = /^i[\d]{1}.wp.com$/i.test( imageLinkParser.hostname );
 
 			var medium_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.medium_file, args.orig_width, isPhotonUrl );
 			var large_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.large_file, args.orig_width, isPhotonUrl );

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -993,7 +993,7 @@ jQuery(document).ready(function($) {
 			var imageLinkParser = document.createElement( 'a' );
 			imageLinkParser.href = args.large_file;
 
-			var isPhotonUrl = /^i[\d]{1}.wp.com$/i.test( imageLinkParser.hostname );
+			var isPhotonUrl = /^i[0-2].wp.com$/i.test( imageLinkParser.hostname );
 
 			var medium_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.medium_file, args.orig_width, isPhotonUrl );
 			var large_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.large_file, args.orig_width, isPhotonUrl );


### PR DESCRIPTION
There was a lint error for a comparison `… != null`.
Rather than simply changing to `… !== null`, a more appropriate fix seem to be use the more adequate method of testing a regex which is effectively the same.

RegExp.prototype.test() is a better fit to check whether a string
matches a regular expression.

String.prototype.match() can be used an will return an Array of matches
or `null` if no matches are found.

Rather than matching and null checking, we can just test.

match: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
test: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test

From 926c482d7c8d233f7e43668249d350d7b6006136 / #11507 

#### Testing instructions:

I'm unfamiliar with carousel that is impacted. Test and ensure that carousels using photon and non-photon images continue to work well.

A Tiled Gallery block will allow you to test Carousel with photon images (photon and carousel should be enabled).

A core Gallery block with external image URLs will likely allow you to test non-photon images 🤷‍♂️ 

Alternatively, place console logging and check the results or trust in my logic:

```js
const regex = /^i[\d]{1}.wp.com$/i;
function before( input ) {
  return input.match( regex ) != null;
}
function after( input ) {
  return regex.test( input );
}

const candidates = [
   's0.wP.com',
   'I2.wp.COM',
   'example.wp.com',
   'jetpack.com',
   'I0.wp.COM',
   'I1.WP.COM',
   'i2.wp.com',
]

candidates.every( test => before( test ) === after( test ) );
```

#### Proposed changelog entry for your changes:
None
