### PR TITLE
Plugin Search Tracks: Only track search terms with >= 3 chars

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -287,8 +287,10 @@ class Jetpack_Plugin_Search {
 			);
 			uasort( $jetpack_modules_list, array( $this, 'by_sorting_option' ) );
 
-			// Record event when user searches for a term
-			JetpackTracking::record_user_event( 'wpa_plugin_search_term', array( 'search_term' => $args->search ) );
+			// Record event when user searches for a term over 3 chars (less than 3 is not very useful.)
+			if ( strlen( $args->search ) >= 3 ) {
+				JetpackTracking::record_user_event( 'wpa_plugin_search_term', array( 'search_term' => $args->search ) );
+			}
 
 			// Lowercase, trim, remove punctuation/special chars, decode url, remove 'jetpack'
 			$normalized_term = $this->sanitize_search_term( $args->search );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We've been getting a lot of events that have only one or two chars, which are not very useful. Limit tracking to only terms with greater than or equal to 3 characters. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Search plugins with only a single char or two
- Verify it's not tracked anywhere
- Verify it's still tracking for 3 or greater chars. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

None needed
