### PR TITLE
Stats: Ensure an error is returned if non-200

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1757,7 +1757,7 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 	// Do the dirty work.
 	$response = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, $api_version, $args );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		$data = $response;
+		$data = is_wp_error( $response ) ? $response : new WP_Error( 'stats_error' );
 	} else {
 		$data = json_decode( wp_remote_retrieve_body( $response ) );
 	}


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/11520/files#r263621970

#### Changes proposed in this Pull Request:
* If a non-successful API call is made, ensure an error is returned.

#### Testing instructions:
* I don't have a testing case off the top of my head.
*

#### Proposed changelog entry for your changes:
* n/a, previous log entry for the 7.2 api improvement applies.
