### PR TITLE
Docker: Don't show a warning for unset PORT_WORDPRESS variable.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,4 +83,4 @@ services:
       - default.env
       - .env
     environment:
-      - HOST_PORT=${PORT_WORDPRESS}
+      - HOST_PORT=${PORT_WORDPRESS:-80}


### PR DESCRIPTION
Fixes #11583.
Bug goes back to #10049.
#### Changes proposed in this Pull Request:
* We default to `80` elsewhere. Default to `80` everywhere.

#### Testing instructions:
* Remove any `/.env` file in the root of your checkout (back it up if you need it).
* `yarn docker:wp nope` (a WPCLI command that does not exist)
* In `master`, see:
  > WARNING: The PORT_WORDPRESS variable is not set. Defaulting to a blank string.
* In this branch, see that the warning is gone.

#### Proposed changelog entry for your changes:
None required.