### PR TITLE
Fix: Removal of widget DOM element following acceptance of cookie policy

### DIFF
--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -58,6 +58,8 @@
 
 		overlay.fadeOut( 400, function() {
 			overlay.remove();
+			var widgetSection = document.querySelector(".widget.widget_eu_cookie_law_widget");
+			widgetSection.parentNode.removeChild(elem);
 		} );
 	}
 } )( jQuery );

--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -59,7 +59,7 @@
 		overlay.fadeOut( 400, function() {
 			overlay.remove();
 			var widgetSection = document.querySelector(".widget.widget_eu_cookie_law_widget");
-			widgetSection.parentNode.removeChild(elem);
+			widgetSection.parentNode.removeChild(widgetSection);
 		} );
 	}
 } )( jQuery );


### PR DESCRIPTION
Fixes #11311

#### Changes proposed in this Pull Request:
* The described expected behavior is the removal of the invisible element from the DOM that stays behind after the users click on the accept button. To achieve this, I have added code responsible for removing this element in the accept function of the widget. I've placed it under the function that is responsible to fade out the element gradually to keep the smooth transition.

#### Testing instructions:

* Add the Cookies & Consents Banner (Jetpack) widget to the site.
* Click on the Accept button and observe the gradual disappearance of the widget wrapper.
* Check that the site functions as expected and inspect the DOM to verify that the invisible wrapper (.widget_eu_cookie_law_widget) is removed.

![eucookie1](https://user-images.githubusercontent.com/31791243/54496211-92fb3680-4927-11e9-8a36-fb9097ac6747.png)
![eucookie2](https://user-images.githubusercontent.com/31791243/54496216-9d1d3500-4927-11e9-8671-4c59b923d87e.png)

#### Proposed changelog entry for your changes:
* None required
