### PR TITLE
Shortcopy: update event name for Tracks

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -73,16 +73,20 @@ class Jetpack_Connection_Banner {
 	 * a URL for, this function returns a connection URL with a from parameter that will
 	 * support split testing.
 	 *
+	 * @since 7.2   Event key format is now banner-connect-banner-72-dashboard or connect-banner-72-plugins.
+	 *              The param $slide_num was removed since we removed all slides but the first one.
+	 * @since 4.4.0
+	 *
 	 * @param string     $jp_version_banner_added A short version of when the banner was added. Ex. 44
-	 * @param string|int $slide_num               The index of the slide, 1-indexed.
+	 *
 	 * @return string
 	 */
-	function build_connect_url_for_slide( $jp_version_banner_added, $slide_num ) {
+	function build_connect_url_for_slide( $jp_version_banner_added ) {
 		global $current_screen;
 		$url = Jetpack::init()->build_connect_url(
 			true,
 			false,
-			sprintf( 'banner-%s-slide-%s-%s', $jp_version_banner_added, $slide_num, $current_screen->base )
+			sprintf( 'connect-banner-%s-%s', $jp_version_banner_added, $current_screen->base )
 		);
 		return add_query_arg( 'auth_approved', 'true', $url );
 	}
@@ -182,6 +186,7 @@ class Jetpack_Connection_Banner {
 	/**
 	 * Renders the new connection banner as of 4.4.0.
 	 *
+	 * @since 7.2   Copy and visual elements reduced to show the new focus of Jetpack on Security and Performance.
 	 * @since 4.4.0
 	 */
 	function render_banner() { ?>
@@ -240,7 +245,7 @@ class Jetpack_Connection_Banner {
 							<div class="jp-banner__button-container">
 								<span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
 								<a
-									href="<?php echo esc_url( $this->build_connect_url_for_slide( '44', 1 ) ); ?>"
+									href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
 									class="dops-button is-primary">
 									<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
 								</a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11580

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Update event key for Tracks updating version and removing the slide reference since we now have only one.
* Update contents of function that creates a B version of the connect dialog.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the connect banner in Plugins or Dashboard screens in WP Admin
* The URL for the Setup up Jetpack button should have the parameter `from` with the value `banner-connect-72-plugins` or `banner-connect-72-dashboard` depending on where the banner is displayed.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Not neded. Part of Shortcopy.
