### PR TITLE
Photon: add Instagram CDN to list of banned domains.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -286,6 +286,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/\.fbcdn\.net$/',
 		'/\.paypalobjects\.com$/',
 		'/\.dropbox\.com$/',
+		'/\.cdninstagram\.com$/',
 	);
 
 	$host = jetpack_photon_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
Fixes 3609-gh-jpop-issues

#### Changes proposed in this Pull Request:

Instagram relies on its own image delivery system, and that creates a redirection when you try to access
an image. That trips Photon.

Let's consequently add that domain to the list of domains Photon won't try to serve.

#### Testing instructions:

* Activate Photon on your site.
* Add the following HTML to a post:
```html
<img src="https://scontent.cdninstagram.com/vp/4fca0efd4a4ec5e40808eb8fb55595f7/5CC1C546/t51.2885-15/sh0.08/e35/s640x640/47690656_347606795967500_58425116800623747_n.jpg?_nc_ht=scontent.cdninstagram.com">
```
* Publish
* Make sure the image is not served by Photon.

#### Proposed changelog entry for your changes:

* Photon: add Instagram CDN to list of banned domains.
