### PR TITLE
Business Hours block: provide defaults

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -12,6 +12,49 @@ jetpack_register_block(
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );
 
+function jetpack_business_hours_get_default_days() {
+	return array(
+		array(
+			'name' => 'Sun',
+			'hours' => array(),
+		),
+		array(
+			'name' => 'Mon',
+			'hours' => array(
+				array( 'opening' => '09:00', 'closing' => '17:00' )
+			),
+		),
+		array(
+			'name' => 'Tue',
+			'hours' => array(
+				array( 'opening' => '09:00', 'closing' => '17:00' )
+			),
+		),
+		array(
+			'name' => 'Wed',
+			'hours' => array(
+				array( 'opening' => '09:00', 'closing' => '17:00' )
+			),
+		),
+		array(
+			'name' => 'Thu',
+			'hours' => array(
+				array( 'opening' => '09:00', 'closing' => '17:00' )
+			),
+		),
+		array(
+			'name' => 'Fri',
+			'hours' => array(
+				array( 'opening' => '09:00', 'closing' => '17:00' )
+			),
+		),
+		array(
+			'name' => 'Sat',
+			'hours' => array(),
+		),
+	);
+}
+
 /**
  * Dynamic rendering of the block.
  *
@@ -20,11 +63,11 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_business_hours_render( $attributes, $content ) {
+function jetpack_business_hours_render( $attributes ) {
 	global $wp_locale;
 
 	if ( empty( $attributes['days'] ) || ! is_array( $attributes['days'] ) ) {
-		return $content;
+		$attributes['days'] = jetpack_business_hours_get_default_days();
 	}
 
 	$start_of_week = (int) get_option( 'start_of_week', 0 );

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -64,7 +64,6 @@ function jetpack_business_hours_get_default_days() {
  * Dynamic rendering of the block.
  *
  * @param array  $attributes Array containing the business hours block attributes.
- * @param string $content    String containing the business hours block content.
  *
  * @return string
  */

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -12,6 +12,11 @@ jetpack_register_block(
 	array( 'render_callback' => 'jetpack_business_hours_render' )
 );
 
+/**
+ * Get's default days / hours to render a business hour block with no data provided.
+ *
+ * @return array
+ */
 function jetpack_business_hours_get_default_days() {
 	return array(
 		array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/31533

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The editor portion of the Business Hours block provides defaults to make the editor experience work before any attributes are set.  If folks try to preview the block before configuring them, the front end is blank, because the front end doesn't have any default attributes.

This PR remedies that by using the same defaults that the editor uses.

#### Testing instructions:

- Spin up a Jurassic.ninja site using [this link](https://jurassic.ninja/create/?jetpack-beta&branch=fix/business-hours-block-defaults)
- Set-up Jetpack
- Start a new post, and add a business hours block
- Before making any changes to the block, click "Preview"
- Ensure the preview looks like you'd expect

#### Proposed changelog entry for your changes:

* Fixes a bug in the Business Hours block when blocks with the default attributes failed to appear on the front end
