### PR TITLE
Plans: Refactor so that logic is in own Jetpack_Plans class

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -185,7 +185,7 @@ abstract class Jetpack_Admin_Page {
 			return false;
 		}
 
-		$current = Jetpack::get_active_plan();
+		$current = Jetpack_Plan::get_active_plan();
 
 		$to_deactivate = array();
 		if ( isset( $current['product_slug'] ) ) {
@@ -207,7 +207,7 @@ abstract class Jetpack_Admin_Page {
 
 			$to_leave_enabled = array();
 			foreach ( $to_deactivate as $feature ) {
-				if ( Jetpack::active_plan_supports( $feature ) ) {
+				if ( Jetpack_Plan::active_plan_supports( $feature ) ) {
 					$to_leave_enabled []= $feature;
 				}
 			}

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -185,7 +185,7 @@ abstract class Jetpack_Admin_Page {
 			return false;
 		}
 
-		$current = Jetpack_Plan::get_active_plan();
+		$current = Jetpack_Plan::get();
 
 		$to_deactivate = array();
 		if ( isset( $current['product_slug'] ) ) {
@@ -207,7 +207,7 @@ abstract class Jetpack_Admin_Page {
 
 			$to_leave_enabled = array();
 			foreach ( $to_deactivate as $feature ) {
-				if ( Jetpack_Plan::active_plan_supports( $feature ) ) {
+				if ( Jetpack_Plan::supports( $feature ) ) {
 					$to_leave_enabled []= $feature;
 				}
 			}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -299,7 +299,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 				'isAtomicSite' => jetpack_is_atomic_site(),
-				'plan' => Jetpack::get_active_plan(),
+				'plan' => Jetpack_Plan::get_active_plan(),
 				'showBackups' => Jetpack::show_backups_ui(),
 			),
 			'themeData' => array(

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -299,7 +299,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 				'isAtomicSite' => jetpack_is_atomic_site(),
-				'plan' => Jetpack_Plan::get_active_plan(),
+				'plan' => Jetpack_Plan::get(),
 				'showBackups' => Jetpack::show_backups_ui(),
 			),
 			'themeData' => array(

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1349,7 +1349,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( is_array( $results ) && isset( $results['plan'] ) ) {
 
 			// Set flag for newly purchased plan
-			$current_plan = Jetpack::get_active_plan();
+			$current_plan = Jetpack_Plan::get_active_plan();
 			if ( $current_plan['product_slug'] !== $results['plan']['product_slug'] && 'jetpack_free' !== $results['plan']['product_slug'] ) {
 				update_option( 'show_welcome_for_new_plan', true ) ;
 			}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1349,7 +1349,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( is_array( $results ) && isset( $results['plan'] ) ) {
 
 			// Set flag for newly purchased plan
-			$current_plan = Jetpack_Plan::get_active_plan();
+			$current_plan = Jetpack_Plan::get();
 			if ( $current_plan['product_slug'] !== $results['plan']['product_slug'] && 'jetpack_free' !== $results['plan']['product_slug'] ) {
 				update_option( 'show_welcome_for_new_plan', true ) ;
 			}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -67,7 +67,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! Jetpack::active_plan_supports( $module_slug ) ) {
+		if ( ! Jetpack_Plan::active_plan_supports( $module_slug ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -67,7 +67,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! Jetpack_Plan::active_plan_supports( $module_slug ) ) {
+		if ( ! Jetpack_Plan::supports( $module_slug ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -18,7 +18,7 @@ class Jetpack_Debugger {
 	 * @return string The plan slug prepended with "JetpackPlan"
 	 */
 	private static function what_jetpack_plan() {
-		$plan = Jetpack::get_active_plan();
+		$plan = Jetpack_Plan::get_active_plan();
 		$plan = ! empty( $plan['class'] ) ? $plan['class'] : 'undefined';
 		return 'JetpackPlan' . $plan;
 	}
@@ -277,7 +277,7 @@ class Jetpack_Debugger {
 						?>
 						<?php esc_html_e( "If this solves the problem, something in your theme is probably broken – let the theme's author know.", 'jetpack' ); ?>
 					</li>
-					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>  
+					<li><b><em><?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?></em></b>
 						<?php
 						echo sprintf(
 							wp_kses(
@@ -326,7 +326,7 @@ class Jetpack_Debugger {
 					<?php endif; ?>
 				</ol>
 				<h4><?php esc_html_e( 'Still having trouble?', 'jetpack' ); ?></h4>
-				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>  
+				<p><b><em><?php esc_html_e( 'Ask us for help!', 'jetpack' ); ?></em></b>
 				<?php
 				echo sprintf(
 					wp_kses(

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -18,7 +18,7 @@ class Jetpack_Debugger {
 	 * @return string The plan slug prepended with "JetpackPlan"
 	 */
 	private static function what_jetpack_plan() {
-		$plan = Jetpack_Plan::get_active_plan();
+		$plan = Jetpack_Plan::get();
 		$plan = ! empty( $plan['class'] ) ? $plan['class'] : 'undefined';
 		return 'JetpackPlan' . $plan;
 	}

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -31,6 +31,7 @@ function phpcsFilesToFilter( file ) {
 		'_inc/lib/debugger/',
 		'extensions/',
 		'class.jetpack-gutenberg.php',
+		'class.jetpack-plan.php',
 	];
 
 	if ( -1 !== whitelist.findIndex( filePath => file.startsWith( filePath ) ) ) {

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -199,7 +199,7 @@ class Jetpack_Admin {
 				return false;
 			}
 
-			return Jetpack::active_plan_supports( $module['module'] );
+			return Jetpack_Plan::active_plan_supports( $module['module'] );
 		}
 	}
 

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -199,7 +199,7 @@ class Jetpack_Admin {
 				return false;
 			}
 
-			return Jetpack_Plan::active_plan_supports( $module['module'] );
+			return Jetpack_Plan::supports( $module['module'] );
 		}
 	}
 

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -21,9 +21,9 @@ class Jetpack_Plan {
 	 *
 	 * @return bool True if plan is updated, false if no update
 	 */
-	public static function refresh_active_plan_from_wpcom() {
+	public static function refresh_from_wpcom() {
 		// Make the API request.
-		$request = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
+		$request  = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1' );
 
 		// Bail if there was an error or malformed response.
@@ -44,7 +44,7 @@ class Jetpack_Plan {
 	}
 
 	/**
-	 * Get the plan that this Jetpack site is currently using
+	 * Get the plan that this Jetpack site is currently using.
 	 *
 	 * @uses get_option()
 	 *
@@ -53,7 +53,7 @@ class Jetpack_Plan {
 	 *
 	 * @return array Active Jetpack plan details
 	 */
-	public static function get_active_plan() {
+	public static function get() {
 		global $active_plan_cache;
 
 		// this can be expensive to compute so we cache for the duration of a request.
@@ -87,7 +87,7 @@ class Jetpack_Plan {
 
 		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
 			// special support value, not a module but a separate plugin.
-			$supports[] = 'akismet';
+			$supports[]    = 'akismet';
 			$plan['class'] = 'personal';
 		}
 
@@ -100,10 +100,10 @@ class Jetpack_Plan {
 		);
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
-			$supports[] = 'akismet';
-			$supports[] = 'simple-payments';
-			$supports[] = 'vaultpress';
-			$supports[] = 'videopress';
+			$supports[]    = 'akismet';
+			$supports[]    = 'simple-payments';
+			$supports[]    = 'vaultpress';
+			$supports[]    = 'videopress';
 			$plan['class'] = 'premium';
 		}
 
@@ -119,10 +119,10 @@ class Jetpack_Plan {
 		);
 
 		if ( in_array( $plan['product_slug'], $business_plans ) ) {
-			$supports[] = 'akismet';
-			$supports[] = 'simple-payments';
-			$supports[] = 'vaultpress';
-			$supports[] = 'videopress';
+			$supports[]    = 'akismet';
+			$supports[]    = 'simple-payments';
+			$supports[]    = 'vaultpress';
+			$supports[]    = 'videopress';
 			$plan['class'] = 'business';
 		}
 
@@ -147,7 +147,7 @@ class Jetpack_Plan {
 	/**
 	 * Determine whether the active plan supports a particular feature
 	 *
-	 * @uses Jetpack_Plan::get_active_plan()
+	 * @uses Jetpack_Plan::get()
 	 *
 	 * @access public
 	 * @static
@@ -156,8 +156,8 @@ class Jetpack_Plan {
 	 *
 	 * @return bool True if plan supports feature, false if not
 	 */
-	public static function active_plan_supports( $feature ) {
-		$plan = self::get_active_plan();
+	public static function supports( $feature ) {
+		$plan = self::get();
 
 		// Manually mapping WordPress.com features to Jetpack module slugs.
 		foreach ( $plan['features']['active'] as $wpcom_feature ) {

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -1,0 +1,183 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Handles fetching of the site's plan from WordPress.com and caching the value locally.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Provides methods methods for fetching the plan from WordPress.com.
+ */
+class Jetpack_Plan {
+	/**
+	 * Make an API call to WordPress.com for plan status
+	 *
+	 * @uses Jetpack_Options::get_option()
+	 * @uses Jetpack_Client::wpcom_json_api_request_as_blog()
+	 * @uses update_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool True if plan is updated, false if no update
+	 */
+	public static function refresh_active_plan_from_wpcom() {
+		// Make the API request.
+		$request = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
+		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+
+		// Bail if there was an error or malformed response.
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return false;
+		}
+
+		// Decode the results.
+		$results = json_decode( $response['body'], true );
+
+		// Bail if there were no results or plan details returned.
+		if ( ! is_array( $results ) || ! isset( $results['plan'] ) ) {
+			return false;
+		}
+
+		// Store the option and return true if updated.
+		return update_option( 'jetpack_active_plan', $results['plan'], true );
+	}
+
+	/**
+	 * Get the plan that this Jetpack site is currently using
+	 *
+	 * @uses get_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return array Active Jetpack plan details
+	 */
+	public static function get_active_plan() {
+		global $active_plan_cache;
+
+		// this can be expensive to compute so we cache for the duration of a request.
+		if ( is_array( $active_plan_cache ) && ! empty( $active_plan_cache ) ) {
+			return $active_plan_cache;
+		}
+
+		$plan = get_option( 'jetpack_active_plan', array() );
+
+		// Set the default options.
+		$plan = wp_parse_args(
+			$plan,
+			array(
+				'product_slug' => 'jetpack_free',
+				'class'        => 'free',
+				'features'     => array(
+					'active' => array(),
+				),
+			)
+		);
+
+		$supports = array();
+
+		// Define what paid modules are supported by personal plans.
+		$personal_plans = array(
+			'jetpack_personal',
+			'jetpack_personal_monthly',
+			'personal-bundle',
+			'personal-bundle-2y',
+		);
+
+		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
+			// special support value, not a module but a separate plugin.
+			$supports[] = 'akismet';
+			$plan['class'] = 'personal';
+		}
+
+		// Define what paid modules are supported by premium plans.
+		$premium_plans = array(
+			'jetpack_premium',
+			'jetpack_premium_monthly',
+			'value_bundle',
+			'value_bundle-2y',
+		);
+
+		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
+			$supports[] = 'akismet';
+			$supports[] = 'simple-payments';
+			$supports[] = 'vaultpress';
+			$supports[] = 'videopress';
+			$plan['class'] = 'premium';
+		}
+
+		// Define what paid modules are supported by professional plans.
+		$business_plans = array(
+			'jetpack_business',
+			'jetpack_business_monthly',
+			'business-bundle',
+			'business-bundle-2y',
+			'ecommerce-bundle',
+			'ecommerce-bundle-2y',
+			'vip',
+		);
+
+		if ( in_array( $plan['product_slug'], $business_plans ) ) {
+			$supports[] = 'akismet';
+			$supports[] = 'simple-payments';
+			$supports[] = 'vaultpress';
+			$supports[] = 'videopress';
+			$plan['class'] = 'business';
+		}
+
+		// get available features.
+		foreach ( Jetpack::get_available_modules() as $module_slug ) {
+			$module = Jetpack::get_module( $module_slug );
+			if ( ! isset( $module ) || ! is_array( $module ) ) {
+				continue;
+			}
+			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
+				$supports[] = $module_slug;
+			}
+		}
+
+		$plan['supports'] = $supports;
+
+		$active_plan_cache = $plan;
+
+		return $plan;
+	}
+
+	/**
+	 * Determine whether the active plan supports a particular feature
+	 *
+	 * @uses Jetpack_Plan::get_active_plan()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $feature The module or feature to check.
+	 *
+	 * @return bool True if plan supports feature, false if not
+	 */
+	public static function active_plan_supports( $feature ) {
+		$plan = self::get_active_plan();
+
+		// Manually mapping WordPress.com features to Jetpack module slugs.
+		foreach ( $plan['features']['active'] as $wpcom_feature ) {
+			switch ( $wpcom_feature ) {
+				case 'wordads-jetpack':
+					// WordAds are supported for this site.
+					if ( 'wordads' === $feature ) {
+						return true;
+					}
+					break;
+			}
+		}
+
+		if (
+			in_array( $feature, $plan['supports'] )
+			|| in_array( $feature, $plan['features']['active'] )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -85,7 +85,7 @@ class Jetpack_Plan {
 			'personal-bundle-2y',
 		);
 
-		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
+		if ( in_array( $plan['product_slug'], $personal_plans, true ) ) {
 			// special support value, not a module but a separate plugin.
 			$supports[]    = 'akismet';
 			$plan['class'] = 'personal';
@@ -99,7 +99,7 @@ class Jetpack_Plan {
 			'value_bundle-2y',
 		);
 
-		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
+		if ( in_array( $plan['product_slug'], $premium_plans, true ) ) {
 			$supports[]    = 'akismet';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
@@ -118,7 +118,7 @@ class Jetpack_Plan {
 			'vip',
 		);
 
-		if ( in_array( $plan['product_slug'], $business_plans ) ) {
+		if ( in_array( $plan['product_slug'], $business_plans, true ) ) {
 			$supports[]    = 'akismet';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
@@ -132,7 +132,7 @@ class Jetpack_Plan {
 			if ( ! isset( $module ) || ! is_array( $module ) ) {
 				continue;
 			}
-			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
+			if ( in_array( 'free', $module['plan_classes'], true ) || in_array( $plan['class'], $module['plan_classes'], true ) ) {
 				$supports[] = $module_slug;
 			}
 		}
@@ -172,8 +172,8 @@ class Jetpack_Plan {
 		}
 
 		if (
-			in_array( $feature, $plan['supports'] )
-			|| in_array( $feature, $plan['features']['active'] )
+			in_array( $feature, $plan['supports'], true )
+			|| in_array( $feature, $plan['features']['active'], true )
 		) {
 			return true;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -689,7 +689,7 @@ class Jetpack {
 		}
 
 		// Update the Jetpack plan from API on heartbeats
-		add_action( 'jetpack_heartbeat', array( $this, 'refresh_active_plan_from_wpcom' ) );
+		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_active_plan_from_wpcom' ) );
 
 		/**
 		 * This is the hack to concatenate all css files into one.
@@ -1516,174 +1516,6 @@ class Jetpack {
 	 */
 	public static function is_active() {
 		return (bool) Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-	}
-
-	/**
-	 * Make an API call to WordPress.com for plan status
-	 *
-	 * @uses Jetpack_Options::get_option()
-	 * @uses Jetpack_Client::wpcom_json_api_request_as_blog()
-	 * @uses update_option()
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @return bool True if plan is updated, false if no update
-	 */
-	public static function refresh_active_plan_from_wpcom() {
-		// Make the API request
-		$request = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
-		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1' );
-
-		// Bail if there was an error or malformed response
-		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
-			return false;
-		}
-
-		// Decode the results
-		$results = json_decode( $response['body'], true );
-
-		// Bail if there were no results or plan details returned
-		if ( ! is_array( $results ) || ! isset( $results['plan'] ) ) {
-			return false;
-		}
-
-		// Store the option and return true if updated
-		return update_option( 'jetpack_active_plan', $results['plan'], true );
-	}
-
-	/**
-	 * Get the plan that this Jetpack site is currently using
-	 *
-	 * @uses get_option()
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @return array Active Jetpack plan details
-	 */
-	public static function get_active_plan() {
-		global $active_plan_cache;
-
-		// this can be expensive to compute so we cache for the duration of a request
-		if ( is_array( $active_plan_cache ) && ! empty( $active_plan_cache ) ) {
-			return $active_plan_cache;
-		}
-
-		$plan = get_option( 'jetpack_active_plan', array() );
-
-		// Set the default options
-		$plan = wp_parse_args( $plan, array(
-			'product_slug' => 'jetpack_free',
-			'class'        => 'free',
-			'features'     => array(
-				'active' => array()
-			),
-		) );
-
-		$supports = array();
-
-		// Define what paid modules are supported by personal plans
-		$personal_plans = array(
-			'jetpack_personal',
-			'jetpack_personal_monthly',
-			'personal-bundle',
-			'personal-bundle-2y',
-		);
-
-		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
-			// special support value, not a module but a separate plugin
-			$supports[] = 'akismet';
-			$plan['class'] = 'personal';
-		}
-
-		// Define what paid modules are supported by premium plans
-		$premium_plans = array(
-			'jetpack_premium',
-			'jetpack_premium_monthly',
-			'value_bundle',
-			'value_bundle-2y',
-		);
-
-		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
-			$supports[] = 'akismet';
-			$supports[] = 'simple-payments';
-			$supports[] = 'vaultpress';
-			$supports[] = 'videopress';
-			$plan['class'] = 'premium';
-		}
-
-		// Define what paid modules are supported by professional plans
-		$business_plans = array(
-			'jetpack_business',
-			'jetpack_business_monthly',
-			'business-bundle',
-			'business-bundle-2y',
-			'ecommerce-bundle',
-			'ecommerce-bundle-2y',
-			'vip',
-		);
-
-		if ( in_array( $plan['product_slug'], $business_plans ) ) {
-			$supports[] = 'akismet';
-			$supports[] = 'simple-payments';
-			$supports[] = 'vaultpress';
-			$supports[] = 'videopress';
-			$plan['class'] = 'business';
-		}
-
-		// get available features
-		foreach ( self::get_available_modules() as $module_slug ) {
-			$module = self::get_module( $module_slug );
-			if ( ! isset( $module ) || ! is_array( $module ) ) {
-				continue;
-			}
-			if ( in_array( 'free', $module['plan_classes'] ) || in_array( $plan['class'], $module['plan_classes'] ) ) {
-				$supports[] = $module_slug;
-			}
-		}
-
-		$plan['supports'] = $supports;
-
-		$active_plan_cache = $plan;
-
-		return $plan;
-	}
-
-	/**
-	 * Determine whether the active plan supports a particular feature
-	 *
-	 * @uses Jetpack::get_active_plan()
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @return bool True if plan supports feature, false if not
-	 */
-	public static function active_plan_supports( $feature ) {
-		$plan = Jetpack::get_active_plan();
-
-		// Manually mapping WordPress.com features to Jetpack module slugs
-		foreach ( $plan['features']['active'] as $wpcom_feature ) {
-			switch ( $wpcom_feature ) {
-				case 'wordads-jetpack';
-
-				// WordAds are supported for this site
-				if ( 'wordads' === $feature ) {
-					return true;
-				}
-				break;
-			}
-		}
-
-		if (
-			in_array( $feature, $plan['supports'] )
-			|| in_array( $feature, $plan['features']['active'] )
-		) {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**
@@ -3091,7 +2923,7 @@ class Jetpack {
 			}
 		}
 
-		if ( ! Jetpack::active_plan_supports( $module ) ) {
+		if ( ! Jetpack_Plan::active_plan_supports( $module ) ) {
 			return false;
 		}
 
@@ -4875,7 +4707,7 @@ p {
 		} else {
 			$earliest_post_date = PHP_INT_MAX;
 		}
-		
+
 		return min( $earliest_registration_date, $earliest_post_date );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1519,6 +1519,40 @@ class Jetpack {
 	}
 
 	/**
+	 * Make an API call to WordPress.com for plan status
+	 *
+	 * @deprecated 7.2.0 Use Jetpack_Plan::refresh_from_wpcom.
+	 *
+	 * @return bool True if plan is updated, false if no update
+	 */
+	public static function refresh_active_plan_from_wpcom() {
+		_deprecated_function( __METHOD__, 'jetpack-7.2.0', 'Jetpack_Plan::refresh_from_wpcom' );
+		return Jetpack_Plan::refresh_from_wpcom();
+	}
+
+	/**
+	 * Get the plan that this Jetpack site is currently using
+	 *
+	 * @deprecated 7.2.0 Use Jetpack_Plan::get.
+	 * @return array Active Jetpack plan details.
+	 */
+	public static function get_active_plan() {
+		_deprecated_function( __METHOD__, 'jetpack-7.2.0', 'Jetpack_Plan::get' );
+		return Jetpack_Plan::get();
+	}
+
+	/**
+	 * Determine whether the active plan supports a particular feature
+	 *
+	 * @deprecated 7.2.0 Use Jetpack_Plan::supports.
+	 * @return bool True if plan supports feature, false if not.
+	 */
+	public static function active_plan_supports( $feature ) {
+		_deprecated_function( __METHOD__, 'jetpack-7.2.0', 'Jetpack_Plan::supports' );
+		return Jetpack_Plan::supports( $feature );
+	}
+
+	/**
 	 * Is Jetpack in development (offline) mode?
 	 */
 	public static function is_development_mode() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -689,7 +689,7 @@ class Jetpack {
 		}
 
 		// Update the Jetpack plan from API on heartbeats
-		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_active_plan_from_wpcom' ) );
+		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_from_wpcom' ) );
 
 		/**
 		 * This is the hack to concatenate all css files into one.
@@ -2923,7 +2923,7 @@ class Jetpack {
 			}
 		}
 
-		if ( ! Jetpack_Plan::active_plan_supports( $module ) ) {
+		if ( ! Jetpack_Plan::supports( $module ) ) {
 			return false;
 		}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -102,6 +102,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-constants.php');
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php'          );
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -509,7 +509,7 @@ class A8C_WPCOM_Masterbar {
 				'class' => 'mb-icon user-info-item',
 			),
 		) );
-		
+
 		$help_link = 'https://jetpack.com/support/';
 
 		if ( jetpack_is_atomic_site() ) {
@@ -660,7 +660,7 @@ class A8C_WPCOM_Masterbar {
 		if ( is_user_member_of_blog( $current_user->ID ) ) {
 			$plans_url = 'https://wordpress.com/plans/' . esc_attr( $this->primary_site_slug );
 			$label = esc_html__( 'Plan', 'jetpack' );
-			$plan = Jetpack::get_active_plan();
+			$plan = Jetpack_Plan::get_active_plan();
 
 			$plan_title = $this->create_menu_item_pair(
 				array(

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -660,7 +660,7 @@ class A8C_WPCOM_Masterbar {
 		if ( is_user_member_of_blog( $current_user->ID ) ) {
 			$plans_url = 'https://wordpress.com/plans/' . esc_attr( $this->primary_site_slug );
 			$label = esc_html__( 'Plan', 'jetpack' );
-			$plan = Jetpack_Plan::get_active_plan();
+			$plan = Jetpack_Plan::get();
 
 			$plan_title = $this->create_menu_item_pair(
 				array(

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -454,7 +454,7 @@ class Jetpack_Plugin_Search {
 			current_user_can( 'jetpack_activate_modules' ) &&
 			! Jetpack::is_module_active( $plugin['module'] )
 		) {
-			$links[] = Jetpack::active_plan_supports( $plugin['module'] )
+			$links[] = Jetpack_Plan::active_plan_supports( $plugin['module'] )
 				? '<button
 					id="plugin-select-activate"
 					class="jetpack-plugin-search__primary button"

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -454,7 +454,7 @@ class Jetpack_Plugin_Search {
 			current_user_can( 'jetpack_activate_modules' ) &&
 			! Jetpack::is_module_active( $plugin['module'] )
 		) {
-			$links[] = Jetpack_Plan::active_plan_supports( $plugin['module'] )
+			$links[] = Jetpack_Plan::supports( $plugin['module'] )
 				? '<button
 					id="plugin-select-activate"
 					class="jetpack-plugin-search__primary button"

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -150,7 +150,7 @@ class Jetpack_Search {
 	 * @since 5.0.0
 	 */
 	public function setup() {
-		if ( ! Jetpack::is_active() || ! Jetpack::active_plan_supports( 'search' ) ) {
+		if ( ! Jetpack::is_active() || ! Jetpack_Plan::active_plan_supports( 'search' ) ) {
 			return;
 		}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -150,7 +150,7 @@ class Jetpack_Search {
 	 * @since 5.0.0
 	 */
 	public function setup() {
-		if ( ! Jetpack::is_active() || ! Jetpack_Plan::active_plan_supports( 'search' ) ) {
+		if ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'search' ) ) {
 			return;
 		}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -108,7 +108,7 @@ class Jetpack_Simple_Payments {
 		}
 
 		// For all Jetpack sites
-		return Jetpack::is_active() && Jetpack::active_plan_supports( 'simple-payments');
+		return Jetpack::is_active() && Jetpack_Plan::active_plan_supports( 'simple-payments');
 	}
 
 	function parse_shortcode( $attrs, $content = false ) {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -108,7 +108,7 @@ class Jetpack_Simple_Payments {
 		}
 
 		// For all Jetpack sites
-		return Jetpack::is_active() && Jetpack_Plan::active_plan_supports( 'simple-payments');
+		return Jetpack::is_active() && Jetpack_Plan::supports( 'simple-payments');
 	}
 
 	function parse_shortcode( $attrs, $content = false ) {

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -42,7 +42,7 @@ class Jetpack_VideoPress {
 		add_filter( 'plupload_default_settings', array( $this, 'videopress_pluploder_config' ) );
 		add_filter( 'wp_get_attachment_url', array( $this, 'update_attachment_url_for_videopress' ), 10, 2 );
 
-		if ( Jetpack::active_plan_supports( 'videopress' ) ) {
+		if ( Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
 			add_filter( 'upload_mimes', array( $this, 'add_video_upload_mimes' ), 999 );
 		}
 

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -42,7 +42,7 @@ class Jetpack_VideoPress {
 		add_filter( 'plupload_default_settings', array( $this, 'videopress_pluploder_config' ) );
 		add_filter( 'wp_get_attachment_url', array( $this, 'update_attachment_url_for_videopress' ), 10, 2 );
 
-		if ( Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
+		if ( Jetpack_Plan::supports( 'videopress' ) ) {
 			add_filter( 'upload_mimes', array( $this, 'add_video_upload_mimes' ), 999 );
 		}
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -64,11 +64,11 @@ class VideoPress_Gutenberg {
 		if (
 			method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active()
 			&& method_exists( 'Jetpack', 'is_module_active' )
-			&& method_exists( 'Jetpack', 'active_plan_supports' )
+			&& method_exists( 'Jetpack_Plan', 'active_plan_supports' )
 		) {
 			if ( Jetpack::is_module_active( 'videopress' ) ) {
 				return array( 'available' => true );
-			} elseif ( ! Jetpack::active_plan_supports( 'videopress' ) ) {
+			} elseif ( ! Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
 				return array(
 					'available'          => false,
 					'unavailable_reason' => 'missing_plan',

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -64,11 +64,11 @@ class VideoPress_Gutenberg {
 		if (
 			method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active()
 			&& method_exists( 'Jetpack', 'is_module_active' )
-			&& method_exists( 'Jetpack_Plan', 'active_plan_supports' )
+			&& method_exists( 'Jetpack_Plan', 'supports' )
 		) {
 			if ( Jetpack::is_module_active( 'videopress' ) ) {
 				return array( 'available' => true );
-			} elseif ( ! Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
+			} elseif ( ! Jetpack_Plan::supports( 'videopress' ) ) {
 				return array(
 					'available'          => false,
 					'unavailable_reason' => 'missing_plan',

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -31,7 +31,7 @@ class VideoPress_Options {
 		self::$options['shadow_blog_id'] = 0;
 
 		// Use the Jetpack ID for the shadow blog ID if we have a plan that supports VideoPress
-		if ( Jetpack::active_plan_supports( 'videopress' ) ) {
+		if ( Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
 			self::$options['shadow_blog_id'] = Jetpack_Options::get_option( 'id' );
 		}
 

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -31,7 +31,7 @@ class VideoPress_Options {
 		self::$options['shadow_blog_id'] = 0;
 
 		// Use the Jetpack ID for the shadow blog ID if we have a plan that supports VideoPress
-		if ( Jetpack_Plan::active_plan_supports( 'videopress' ) ) {
+		if ( Jetpack_Plan::supports( 'videopress' ) ) {
 			self::$options['shadow_blog_id'] = Jetpack_Options::get_option( 'id' );
 		}
 

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -10,7 +10,7 @@
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 
 function jetpack_search_widget_init() {
-	if ( ! Jetpack::is_active() || ! Jetpack::active_plan_supports( 'search' ) ) {
+	if ( ! Jetpack::is_active() || ! Jetpack_Plan::active_plan_supports( 'search' ) ) {
 		return;
 	}
 

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -10,7 +10,7 @@
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 
 function jetpack_search_widget_init() {
-	if ( ! Jetpack::is_active() || ! Jetpack_Plan::active_plan_supports( 'search' ) ) {
+	if ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'search' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Refactor logic for managing the site's plan information into its own class so that we can remove some logic from the large `Jetpack` class as well as simplify future testing in a follow-up PR.

#### Testing instructions:

* Checkout branch
* For each of the plans, including free, check the following:
  * Load up the My Plan view (/wp-admin/admin.php?page=jetpack#/my-plan` and ensure the plan shows correctly
  * Ensure that there are no errors or warnings in logs
  * Run `wp option delete jetpack_active_plan` and then reload admin page. Ensure plan is reflected correctly

#### Proposed changelog entry for your changes:

Refactors logic for managing the Jetpack plan into its own class.
