### PR TITLE
Connection Banner: Address typo in connection banner

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -179,7 +179,7 @@ class Jetpack_Connection_Banner {
 							<p>
 								<?php
 								esc_html_e(
-									'Jetpack free protects your site against brute force attacks and unauthorized logins. Our premium security servives also include unlimited backups of your entire site, spam protection, malware scanning, and automated fixes.',
+									'Jetpack free protects your site against brute force attacks and unauthorized logins. Our premium security services also include unlimited backups of your entire site, spam protection, malware scanning, and automated fixes.',
 									'jetpack'
 								);
 								?>


### PR DESCRIPTION
Fixes typo in connection banner

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fixes `services` replacing it for `services.

#### Testing instructions:

* Check the file diff. Confirm it makes sense.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
