### PR TITLE
Fixes Gutenberg i18n data loading.

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -557,9 +557,30 @@ class Jetpack_Gutenberg {
 			)
 		);
 
-		Jetpack::setup_wp_i18n_locale_data();
+		wp_set_script_translations( 'jetpack-blocks-editor', 'jetpack', plugins_url( 'languages/json', JETPACK__PLUGIN_FILE ) );
+
+		// Adding a filter late to allow every other filter to process the path, including the CDN.
+		add_filter( 'pre_load_script_translations', array( __CLASS__, 'filter_pre_load_script_translations' ), 1000, 3 );
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
+	}
+
+	/**
+	 * A workaround for setting i18n data for WordPress client-side i18n mechanism.
+	 * We are not yet using dotorg language packs for the editor file, so this short-circuits
+	 * the translation loading and feeds our JSON data directly into the translation getter.
+	 *
+	 * @param NULL   $null     not used.
+	 * @param String $file     the file path that is being loaded, ignored.
+	 * @param String $handle   the script handle.
+	 * @return NULL|String the translation data only if we're working with our handle.
+	 */
+	public static function filter_pre_load_script_translations( $null, $file, $handle ) {
+		if ( 'jetpack-blocks-editor' !== $handle ) {
+			return null;
+		}
+
+		return Jetpack::get_i18n_data_json();
 	}
 
 	/**


### PR DESCRIPTION
Fixes unavailable translation data in Gutenberg environment for Jetpack blocks.

#### Changes proposed in this Pull Request:
* Changed the way the translation JSON is loaded for Gutenberg.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* It's best to test with [the newest translations available](https://plugins.svn.wordpress.org/jetpack/tags/7.1.1/languages/json/), you can get a newest file from the latest tag and put it into your `languages/json` folder instead of the existing one.
* Load Gutenberg, see that Jetpack blocks are not translated, like, for example, the Ads block doesn't have translated sizes:
![Screenshot from 2019-03-19 14-25-25](https://user-images.githubusercontent.com/374293/54602511-f3d35d80-4a52-11e9-977c-320c66f3c3dd.png)
* Roll this PR on and with the newest translations you will see the difference:
![Screenshot from 2019-03-19 14-13-09](https://user-images.githubusercontent.com/374293/54602570-15344980-4a53-11e9-9db8-d5250c162750.png)

If you don't see translations with this PR, make sure the language you have selected has these strings translated, or use Russian.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed translations for Jetpack Gutenberg blocks.
