### PR TITLE
Adding filter for Sharedaddy ajax_action.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -759,7 +759,12 @@ function sharing_display( $text = '', $echo = false ) {
 	$ajax_action = apply_filters( 'sharing_ajax_action', 'get_latest_posts' );
 
 	// Allow to be used in ajax requests for latest posts.
-	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['action'] ) && $ajax_action == $_REQUEST['action'] ) {
+	if (
+		defined( 'DOING_AJAX' )
+		&& DOING_AJAX
+		&& isset( $_REQUEST['action'] )
+		&& $ajax_action === $_REQUEST['action']
+	) {
 		$show = true;
 	}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -749,7 +749,7 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	/**
-	 * Filter the default ajax action name
+	 * Filter the Sharing buttons' Ajax action name Jetpack checks for, to allow the use of the buttons with your own Ajax implementation.
 	 *
 	 * @module sharedaddy
 	 *

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -749,11 +749,13 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	/**
-	 * Filter the Sharing buttons' Ajax action name Jetpack checks for, to allow the use of the buttons with your own Ajax implementation.
+	 * Filter the Sharing buttons' Ajax action name Jetpack checks for.
+	 * This allows the use of the buttons with your own Ajax implementation.
 	 *
 	 * @module sharedaddy
 	 *
-	 * @since 7.2.0
+	 * @since 7.3.0
+	 *
 	 * @param string $sharing_ajax_action_name Name of the Sharing buttons' Ajax action.
 	 */
 	$ajax_action = apply_filters( 'sharing_ajax_action', 'get_latest_posts' );

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -753,7 +753,7 @@ function sharing_display( $text = '', $echo = false ) {
 	 *
 	 * @module sharedaddy
 	 *
-	 * @since 5.1.1
+	 * @since 7.2.0
 	 * @param string $sharing_ajax_action_name Name of the Sharing buttons' Ajax action.
 	 */
 	$ajax_action = apply_filters( 'sharing_ajax_action', 'get_latest_posts' );

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -748,8 +748,17 @@ function sharing_display( $text = '', $echo = false ) {
 		$show = false;
 	}
 
-	// Allow to be used on P2 ajax requests for latest posts.
-	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['action'] ) && apply_filters('sharing_ajax_action', 'get_latest_posts') == $_REQUEST['action'] ) {
+	/**
+	 * Filter the default ajax action name
+	 *
+	 * @module sharedaddy
+	 *
+	 * @since 5.1.1
+	 */
+	$ajax_action = apply_filters( 'sharing_ajax_action', 'get_latest_posts' );
+
+	// Allow to be used in ajax requests for latest posts.
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['action'] ) && $ajax_action == $_REQUEST['action'] ) {
 		$show = true;
 	}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -749,7 +749,7 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	// Allow to be used on P2 ajax requests for latest posts.
-	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['action'] ) && 'get_latest_posts' == $_REQUEST['action'] ) {
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['action'] ) && apply_filters('sharing_ajax_action', 'get_latest_posts') == $_REQUEST['action'] ) {
 		$show = true;
 	}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -754,6 +754,7 @@ function sharing_display( $text = '', $echo = false ) {
 	 * @module sharedaddy
 	 *
 	 * @since 5.1.1
+	 * @param string $sharing_ajax_action_name Name of the Sharing buttons' Ajax action.
 	 */
 	$ajax_action = apply_filters( 'sharing_ajax_action', 'get_latest_posts' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11565 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* This PR simply makes the ajax action name (`get_latest_posts`) filterable to allow other plugins and scripts to renders ShareDaddy in Ajax. 

#### Testing instructions:
I tested the new filter on my local build and a customers site running Jetpack and the Ajax Load More plugin.
![image](https://user-images.githubusercontent.com/428624/54618003-acd86e80-4a38-11e9-8c41-0d7e0f7228dc.png)


#### Proposed changelog entry for your changes:
Adding `sharing_ajax_action` filter to allow for the rendering of ShareDaddy in other Ajax requests.
