### PR TITLE
Configure dependencies as exact versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/.svnignore
+++ b/.svnignore
@@ -6,6 +6,7 @@
 .jshintrc
 .jshintignore
 .travis.yml
+.npmrc
 .nvmrc
 .eslines.json
 .eslintcache


### PR DESCRIPTION
When adding packages (`yarn add package-name`), it defaults to add them in `package.json` with `ˆ` semver range:

```
  "dependencies": {
    "package-bname": "^2.3.0",
  }
```

With this change, NPM and Yarn will always save strict versions and be consistent since all the versions seem to already be pinned in `package.json`:
```
  "dependencies": {
    "package-bname": "2.3.0",
  }
```

### Testing

Add a package (e.g. `yarn add @wordpress/browserslist-config`) with and without this change and note the difference.