### PR TITLE
Ensuring extensions/blocks do not inadvertently register twice

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -25,7 +25,11 @@ function jetpack_register_block( $slug, $args = array() ) {
 	}
 
 	// Checking whether block is registered to ensure it isn't registered twice.
-	return Jetpack_Gutenberg::is_registered( $slug ) ? false : register_block_type( $slug, $args );
+	if ( Jetpack_Gutenberg::is_registered( $slug ) ) {
+		return false;
+	}
+
+	return register_block_type( $slug, $args );
 }
 
 /**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -395,12 +395,12 @@ class Jetpack_Gutenberg {
 	 *
 	 * @since 7.2
 	 *
-	 * @param string $extension Name of extension to check.
+	 * @param string $slug Name of extension/block to check.
 	 *
 	 * @return bool
 	 */
-	public static function is_registered( $extension ) {
-		return WP_Block_Type_Registry::get_instance()->is_registered( $extension );
+	public static function is_registered( $slug ) {
+		return WP_Block_Type_Registry::get_instance()->is_registered( $slug );
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -23,7 +23,9 @@ function jetpack_register_block( $slug, $args = array() ) {
 		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
 		$slug = 'jetpack/' . $slug;
 	}
-	return register_block_type( $slug, $args );
+
+	// Checking whether block is registered to ensure it isn't registered twice.
+	return Jetpack_Gutenberg::is_registered( $slug ) ? false : register_block_type( $slug, $args );
 }
 
 /**
@@ -341,7 +343,7 @@ class Jetpack_Gutenberg {
 		$available_extensions = array();
 
 		foreach ( self::$extensions as $extension ) {
-			$is_available = WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/' . $extension ) ||
+			$is_available = self::is_registered( 'jetpack/' . $extension ) ||
 			( isset( self::$availability[ $extension ] ) && true === self::$availability[ $extension ] );
 
 			$available_extensions[ $extension ] = array(
@@ -382,6 +384,19 @@ class Jetpack_Gutenberg {
 			)
 		);
 		return array_merge( $available_extensions, $unwhitelisted_blocks, $unwhitelisted_extensions );
+	}
+
+	/**
+	 * Check if an extension/block is already registered
+	 *
+	 * @since 7.2
+	 *
+	 * @param string $extension Name of extension to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_registered( $extension ) {
+		return WP_Block_Type_Registry::get_instance()->is_registered( $extension );
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -217,7 +217,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 
 			if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
-				//return;
+				return;
 			}
 		}
 

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -217,7 +217,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 
 			if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
-				return;
+				//return;
 			}
 		}
 

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -195,7 +195,6 @@ class Jetpack_Sync_Sender {
 	}
 
 	public function do_sync_for_queue( $queue ) {
-return;
 		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
 		if ( $queue->size() === 0 ) {
 			return new WP_Error( 'empty_queue_' . $queue->id );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -195,7 +195,7 @@ class Jetpack_Sync_Sender {
 	}
 
 	public function do_sync_for_queue( $queue ) {
-
+return;
 		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
 		if ( $queue->size() === 0 ) {
 			return new WP_Error( 'empty_queue_' . $queue->id );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -123,7 +123,7 @@ if ( file_exists( $test_root . '/includes/listener-loader.php' ) ) {
 	require $test_root . '/includes/listener-loader.php';
 } else {
 	if ( file_exists( require $test_root . '/includes/speed-trap-listener.php' ) ) {
-		echo'UPDATE YOUR WP CORE TESTS HELPERS!';
+		echo 'UPDATE YOUR WP CORE TESTS HELPERS!';
 		require $test_root . '/includes/speed-trap-listener.php';
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -118,8 +118,12 @@ function in_running_uninstall_group() {
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist
 // @todo Remove version check when 5.1 is the minimum WP version.
-if ( version_compare( $wp_version, '5.1', '>=' ) ) {
+if ( file_exists( $test_root . '/includes/listener-loader.php' ) ) {
+	// version 5.1 and higher could have this set.
 	require $test_root . '/includes/listener-loader.php';
 } else {
-	require $test_root . '/includes/speed-trap-listener.php';
+	if ( file_exists( require $test_root . '/includes/speed-trap-listener.php' ) ) {
+		echo'UPDATE YOUR WP CORE TESTS HELPERS!';
+		require $test_root . '/includes/speed-trap-listener.php';
+	}
 }

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -60,6 +60,20 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * This test will throw an exception/fail if blocks register twice upon repeat calls to get_availability()
+	 */
+	function test_does_calling_get_availability_twice_result_in_notice() {
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block') );
+		Jetpack_Gutenberg::get_availability();
+		Jetpack_Gutenberg::get_availability();
+		remove_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block') );
+	}
+
+	function register_block() {
+		jetpack_register_block( 'jetpack/apple' );
+	}
+
 	function test_registered_block_is_available() {
 		jetpack_register_block( 'jetpack/apple' );
 		$availability = Jetpack_Gutenberg::get_availability();


### PR DESCRIPTION
This PR ensures extensions/blocks cannot be registered more than once.

Fixes #11590 
Fixes #11506

#### Changes proposed in this Pull Request:

Will not register an extension/block if it's already registered.

#### Testing instructions:

See https://github.com/Automattic/jetpack/issues/11590#issue-422334893
Also, an additional phpunit test checks this functionality

#### Proposed changelog entry for your changes:
No changelog entry needed
