### PR TITLE
Add Gutenpack squad as codeowners for Gutenberg files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@
 # Jetpack CLI is used heavily by our partners
 /class.jetpack-cli.php @automattic/catalyst
 
+# Gutenberg editor integrations
+/class.jetpack-gutenberg.php @automattic/gutenpack
+/extensions/ @automattic/gutenpack
+
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list
 * @automattic/jetpack-crew


### PR DESCRIPTION
Adds Gutenpack squad as code-owners for Jetpack Gutenberg integrations.

This doesn't mean we "own" the code, but we'd like to get notified for changes in these files for the time being. GitHub will add team as a reviewer automatically for PRs touching these files.

We'll need to proactively inform in PRs if they're something we're not looking into; that just sets expectations clear that might be there otherwise anyway.

We might take this out after the project is over and practically "everyone" becomes code-owners for these files.

@Automattic/gutenpack any objections?