### PR TITLE
Search: Use consolidated posts count for found posts.

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -476,7 +476,7 @@ class Jetpack_Search {
 		$posts_query = new WP_Query( $args );
 
 		// WP Core doesn't call the set_found_posts and its filters when filtering posts_pre_query like we do, so need to do these manually.
-		$query->found_posts   = $this->found_posts;
+		$query->found_posts   = $posts_query->post_count;
 		$query->max_num_pages = ceil( $this->found_posts / $query->get( 'posts_per_page' ) );
 
 		return $posts_query->posts;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Once results are returned from the search index, we run a query to
ensure the posts actually exist within WP. However, we always use the
count from the search index, meaning there is a chance of a discrepancy
if the search index isn't completely synced (this happens more often
than you might expect in my experience).

This change uses the post_count from the query done for the post
consolidation to ensure you don't end up showing an inaccurate result
count.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unpublish a post on your site that you know exists in search index (not quite sure how you'd make sure this doesn't update the search index??)
* Search for something which should contain this post in the results
* Observe post doesn't show in search results due to (correct) consolidation
* Observe result count is wrong

With this fix the last step becomes...

* Observe result count is correct

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Search: Improve accuracy of search results count by using consolidated post_count.
