### PR TITLE
Related posts: updates demo images for newer ones

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -69,18 +69,15 @@ export class RelatedPostsSettings extends React.Component {
 		const show_thumbnails = this.props.getOptionValue( 'show_thumbnails' );
 		const previews = [
 			{
-				url:
-					'https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&h=200&crop=1',
+				url: 'https://jetpackme.files.wordpress.com/2019/03/cat-blog.png',
 				text: __( 'Big iPhone/iPad Update Now Available' ),
 			},
 			{
-				url:
-					'https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&h=200&crop=1',
+				url: 'https://jetpackme.files.wordpress.com/2019/03/devices.jpg',
 				text: __( 'The WordPress for Android App Gets a Big Facelift' ),
 			},
 			{
-				url:
-					'https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&h=200&crop=1',
+				url: 'https://jetpackme.files.wordpress.com/2019/03/mobile-wedding.jpg',
 				text: __( 'Upgrade Focus: VideoPress For Weddings' ),
 			},
 		];

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -120,7 +120,7 @@ class RelatedPostsComponent extends React.Component {
 									) }
 									{ [
 										{
-											url: '1-wpios-ipad-3-1-viewsite.png',
+											url: 'cat-blog.png',
 											text: __( 'Big iPhone/iPad Update Now Available' ),
 											context: __( 'In "Mobile"', {
 												comment:
@@ -128,7 +128,7 @@ class RelatedPostsComponent extends React.Component {
 											} ),
 										},
 										{
-											url: 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
+											url: 'devices.jpg',
 											text: __( 'The WordPress for Android App Gets a Big Facelift' ),
 											context: __( 'In "Mobile"', {
 												comment:
@@ -136,7 +136,7 @@ class RelatedPostsComponent extends React.Component {
 											} ),
 										},
 										{
-											url: 'videopresswedding.jpg',
+											url: 'mobile-wedding.jpg',
 											text: __( 'Upgrade Focus: VideoPress For Weddings' ),
 											context: __( 'In "Upgrade"', {
 												comment:
@@ -147,9 +147,7 @@ class RelatedPostsComponent extends React.Component {
 										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
 											{ this.state.show_thumbnails && (
 												<img
-													src={ `https://jetpackme.files.wordpress.com/2014/08/${
-														item.url
-													}?w=350&h=200&crop=1` }
+													src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
 													alt={ item.text }
 												/>
 											) }

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -655,7 +655,7 @@ EOT;
 <div class="jp-relatedposts-items jp-relatedposts-items-visual">
 	<div class="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
 		<a $href_params>
-			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&amp;h=200&amp;crop=1" width="350" alt="Big iPhone/iPad Update Now Available" scale="0">
+			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2019/03/cat-blog.png" width="350" alt="Big iPhone/iPad Update Now Available" scale="0">
 		</a>
 		<h4 class="jp-relatedposts-post-title">
 			<a $href_params>Big iPhone/iPad Update Now Available</a>
@@ -665,7 +665,7 @@ EOT;
 	</div>
 	<div class="jp-relatedposts-post jp-relatedposts-post1 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
 		<a $href_params>
-			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&amp;h=200&amp;crop=1" width="350" alt="The WordPress for Android App Gets a Big Facelift" scale="0">
+			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2019/03/devices.jpg" width="350" alt="The WordPress for Android App Gets a Big Facelift" scale="0">
 		</a>
 		<h4 class="jp-relatedposts-post-title">
 			<a $href_params>The WordPress for Android App Gets a Big Facelift</a>
@@ -675,7 +675,7 @@ EOT;
 	</div>
 	<div class="jp-relatedposts-post jp-relatedposts-post2 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
 		<a $href_params>
-			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&amp;h=200&amp;crop=1" width="350" alt="Upgrade Focus: VideoPress For Weddings" scale="0">
+			<img class="jp-relatedposts-post-img" src="https://jetpackme.files.wordpress.com/2019/03/mobile-wedding.jpg" width="350" alt="Upgrade Focus: VideoPress For Weddings" scale="0">
 		</a>
 		<h4 class="jp-relatedposts-post-title">
 			<a $href_params>Upgrade Focus: VideoPress For Weddings</a>
@@ -1036,7 +1036,7 @@ EOT;
 			$related_posts = array(
 				array(
 					'id'       => - 1,
-					'url'      => 'https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&h=200&crop=1',
+					'url'      => 'https://jetpackme.files.wordpress.com/2019/03/cat-blog.png',
 					'url_meta' => array(
 						'origin'   => 0,
 						'position' => 0
@@ -1048,7 +1048,7 @@ EOT;
 					'rel'      => 'nofollow',
 					'context'  => esc_html__( 'In "Mobile"', 'jetpack' ),
 					'img'      => array(
-						'src'    => 'https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&h=200&crop=1',
+						'src'    => 'https://jetpackme.files.wordpress.com/2019/03/cat-blog.png',
 						'width'  => 350,
 						'height' => 200
 					),
@@ -1056,7 +1056,7 @@ EOT;
 				),
 				array(
 					'id'       => - 1,
-					'url'      => 'https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&h=200&crop=1',
+					'url'      => 'https://jetpackme.files.wordpress.com/2019/03/devices.jpg',
 					'url_meta' => array(
 						'origin'   => 0,
 						'position' => 0
@@ -1068,7 +1068,7 @@ EOT;
 					'rel'      => 'nofollow',
 					'context'  => esc_html__( 'In "Mobile"', 'jetpack' ),
 					'img'      => array(
-						'src'    => 'https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&h=200&crop=1',
+						'src'    => 'https://jetpackme.files.wordpress.com/2019/03/devices.jpg',
 						'width'  => 350,
 						'height' => 200
 					),
@@ -1076,7 +1076,7 @@ EOT;
 				),
 				array(
 					'id'       => - 1,
-					'url'      => 'https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&h=200&crop=1',
+					'url'      => 'https://jetpackme.files.wordpress.com/2019/03/mobile-wedding.jpg',
 					'url_meta' => array(
 						'origin'   => 0,
 						'position' => 0
@@ -1088,7 +1088,7 @@ EOT;
 					'rel'      => 'nofollow',
 					'context'  => esc_html__( 'In "Mobile"', 'jetpack' ),
 					'img'      => array(
-						'src'    => 'https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&h=200&crop=1',
+						'src'    => 'https://jetpackme.files.wordpress.com/2019/03/mobile-wedding.jpg',
 						'width'  => 350,
 						'height' => 200
 					),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Related posts: updates demo images for newer ones
* Calypso twin PR: https://github.com/Automattic/wp-calypso/pull/31518

#### Testing instructions:

* Spin up a [new Jetpack site using this link](https://jurassic.ninja/create?jetpack-beta&branch=update/related-posts-demo-images&wp-debug-log).
* Connect Jetpack.
* Go to `Settings > Traffic`.
* Make sure you see the new assets in the Related Posts module configuration.

#### Before

![image](https://user-images.githubusercontent.com/390760/54687362-51c77a00-4b13-11e9-851c-ca213b0a495f.png)

#### After

![image](https://user-images.githubusercontent.com/390760/54687442-7b80a100-4b13-11e9-8827-00773db4a102.png)

#### Proposed changelog entry for your changes:

* None; minor changes.
