### PR TITLE
Jetpack Plan: Updated cached plan via common method; fix issues with plan caching

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1343,19 +1343,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'site_data_fetch_failed' );
 		}
 
-		// Save plan details in the database for future use without API calls
-		$results = json_decode( $response['body'], true );
+		Jetpack_Plan::update_from_sites_response( $response );
 
-		if ( is_array( $results ) && isset( $results['plan'] ) ) {
-
-			// Set flag for newly purchased plan
-			$current_plan = Jetpack_Plan::get();
-			if ( $current_plan['product_slug'] !== $results['plan']['product_slug'] && 'jetpack_free' !== $results['plan']['product_slug'] ) {
-				update_option( 'show_welcome_for_new_plan', true ) ;
-			}
-
-			update_option( 'jetpack_active_plan', $results['plan'], true );
-		}
 		$body = wp_remote_retrieve_body( $response );
 
 		return json_decode( $body );

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -56,6 +56,12 @@ class Jetpack_Plan {
 
 		// Store the new plan in an option and return true if updated.
 		$result = update_option( 'jetpack_active_plan', $results['plan'], true );
+		if ( ! $result ) {
+			// If we got to this point, then we know we need to update. So, assume there is an issue
+			// with caching. To fix that issue, we can delete the current option and then update.
+			delete_option( 'jetpack_active_plan' );
+			$result = update_option( 'jetpack_active_plan', $results['plan'], true );
+		}
 
 		if ( $result ) {
 			// Reset the cache since we've just updated the plan.

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -16,6 +16,8 @@ class Jetpack_Plan {
 	 */
 	private static $active_plan_cache;
 
+	const PLAN_OPTION = 'jetpack_active_plan';
+
 	/**
 	 * Given a response to the `/sites/%d` endpoint, will parse the response and attempt to set the
 	 * plan from the response.
@@ -42,7 +44,7 @@ class Jetpack_Plan {
 			return false;
 		}
 
-		$current_plan = get_option( 'jetpack_active_plan', array() );
+		$current_plan = get_option( self::PLAN_OPTION, array() );
 
 		// If the plans don't differ, then there's nothing to do.
 		if ( ! empty( $current_plan ) && $current_plan['product_slug'] === $results['plan']['product_slug'] ) {
@@ -55,12 +57,12 @@ class Jetpack_Plan {
 		}
 
 		// Store the new plan in an option and return true if updated.
-		$result = update_option( 'jetpack_active_plan', $results['plan'], true );
+		$result = update_option( self::PLAN_OPTION, $results['plan'], true );
 		if ( ! $result ) {
 			// If we got to this point, then we know we need to update. So, assume there is an issue
 			// with caching. To fix that issue, we can delete the current option and then update.
-			delete_option( 'jetpack_active_plan' );
-			$result = update_option( 'jetpack_active_plan', $results['plan'], true );
+			delete_option( self::PLAN_OPTION );
+			$result = update_option( self::PLAN_OPTION, $results['plan'], true );
 		}
 
 		if ( $result ) {
@@ -107,7 +109,7 @@ class Jetpack_Plan {
 			return self::$active_plan_cache;
 		}
 
-		$plan = get_option( 'jetpack_active_plan', array() );
+		$plan = get_option( self::PLAN_OPTION, array() );
 
 		// Set the default options.
 		$plan = wp_parse_args(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
 			<file>tests/php/test_class.jetpack-constants.php</file>
 			<file>tests/php/test_class.jetpack-connection-banner.php</file>
 			<file>tests/php/test_class.jetpack-options.php</file>
+			<file>tests/php/test_class.jetpack-plan.php</file>
 		</testsuite>
 		<testsuite name="php-lint">
 			<file>tests/php/test_php-lint.php</file>

--- a/tests/php/test_class.jetpack-plan.php
+++ b/tests/php/test_class.jetpack-plan.php
@@ -11,12 +11,24 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 		delete_option( 'show_welcome_for_new_plan' );
 	}
 
+	public function test_update_from_sites_response_failure_to_update() {
+		update_option( 'jetpack_active_plan', $this->get_free_plan(), true );
+
+		$option = get_option( 'jetpack_active_plan' );
+		$this->assertSame( 'jetpack_free', $option['product_slug'] );
+
+		// Set up an issue where the value in cache does not match the DB, so the DB update fails.
+		Jetpack_Options::update_raw_option( 'jetpack_active_plan', $this->get_personal_plan(), true );
+
+		$this->assertTrue( Jetpack_Plan::update_from_sites_response( $this->get_response_personal_plan() ) );
+	}
+
 	/**
 	 * @dataProvider get_update_from_sites_response_data
 	 */
 	public function test_update_from_sites_response( $response, $expected_plan_slug_after, $expected_return, $initial_option = null ) {
 		if ( ! is_null( $initial_option ) ) {
-			update_option( 'jetpack_active_plan', $initial_option );
+			update_option( 'jetpack_active_plan', $initial_option, true );
 		}
 
 		$this->assertSame( $expected_return, Jetpack_Plan::update_from_sites_response( $response ) );

--- a/tests/php/test_class.jetpack-plan.php
+++ b/tests/php/test_class.jetpack-plan.php
@@ -104,153 +104,153 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 	}
 
 	private function get_free_plan() {
-		return [
+		return array(
 			'product_id' => 2002,
 			'product_slug' => 'jetpack_free',
 			'product_name_short' => 'Free',
 			'expired' => false,
 			'user_is_owner' => false,
 			'is_free' => true,
-			'features' => [
-				'active' => [
+			'features' => array(
+				'active' => array(
 					'akismet',
 					'support',
-				],
-				'available' => [
-					'akismet' => [
+				),
+				'available' => array(
+					'akismet' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-backups' => [
+					),
+					'vaultpress-backups' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-backup-archive' => [
+					),
+					'vaultpress-backup-archive' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-storage-space' => [
+					),
+					'vaultpress-storage-space' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-automated-restores' => [
+					),
+					'vaultpress-automated-restores' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'simple-payments' => [
+					),
+					'simple-payments' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'support' => [
+					),
+					'support' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_personal',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
 						'jetpack_personal_monthly',
-					],
-					'premium-themes' => [
+					),
+					'premium-themes' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-security-scanning' => [
+					),
+					'vaultpress-security-scanning' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-					'polldaddy' => [
+					),
+					'polldaddy' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-				],
-			],
-		];
+					),
+				),
+			),
+		);
 	}
 
 	private function get_personal_plan() {
-		return [
+		return array(
 			'product_id' => 2005,
 			'product_slug' => 'jetpack_personal',
 			'product_name_short' => 'Personal',
 			'expired' => false,
 			'user_is_owner' => false,
 			'is_free' => false,
-			'features' => [
-				'active' => [
+			'features' => array(
+				'active' => array(
 					'support',
-				],
-				'available' => [
-					'akismet' => [
+				),
+				'available' => array(
+					'akismet' => array(
 						'jetpack_free',
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'support' => [
+					),
+					'support' => array(
 						'jetpack_free',
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
 						'jetpack_personal_monthly',
-					],
-					'vaultpress-backups' => [
+					),
+					'vaultpress-backups' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-backup-archive' => [
+					),
+					'vaultpress-backup-archive' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-storage-space' => [
+					),
+					'vaultpress-storage-space' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-automated-restores' => [
+					),
+					'vaultpress-automated-restores' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'simple-payments' => [
+					),
+					'simple-payments' => array(
 						'jetpack_premium',
 						'jetpack_business',
 						'jetpack_premium_monthly',
 						'jetpack_business_monthly',
-					],
-					'premium-themes' => [
+					),
+					'premium-themes' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-					'vaultpress-security-scanning' => [
+					),
+					'vaultpress-security-scanning' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-					'polldaddy' => [
+					),
+					'polldaddy' => array(
 						'jetpack_business',
 						'jetpack_business_monthly',
-					],
-				],
-			],
-		];
+					),
+				),
+			),
+		);
 	}
 }
 

--- a/tests/php/test_class.jetpack-plan.php
+++ b/tests/php/test_class.jetpack-plan.php
@@ -1,0 +1,257 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+// phpcs:disable Squiz.Commenting, Generic.Commenting  -- Tests should be self documenting
+
+/**
+ * Contains the tests for the Jetpack_Plan class.
+ */
+class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
+	public function setUp() {
+		delete_option( 'jetpack_active_plan' );
+		delete_option( 'show_welcome_for_new_plan' );
+	}
+
+	/**
+	 * @dataProvider get_update_from_sites_response_data
+	 */
+	public function test_update_from_sites_response( $response, $expected_plan_slug_after, $expected_return, $initial_option = null ) {
+		if ( ! is_null( $initial_option ) ) {
+			update_option( 'jetpack_active_plan', $initial_option );
+		}
+
+		$this->assertSame( $expected_return, Jetpack_Plan::update_from_sites_response( $response ) );
+
+		$plan = Jetpack_Plan::get();
+		$this->assertSame( $expected_plan_slug_after, $plan['product_slug'] );
+	}
+
+	public function get_update_from_sites_response_data() {
+		return array(
+			'is_errored_response'            => array(
+				$this->get_errored_sites_response(),
+				'jetpack_free',
+				false,
+			),
+			'response_is_empty'              => array(
+				$this->get_mocked_response( 200, '' ),
+				'jetpack_free',
+				false,
+			),
+			'response_does_not_have_body'    => array(
+				array( 'code' => 400 ),
+				'jetpack_free',
+				false,
+			),
+			'response_does_not_have_plan'    => array(
+				array(
+					'code' => 200,
+					array(),
+				),
+				'jetpack_free',
+				false,
+			),
+			'initially_empty_option_to_free' => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				true,
+			),
+			'initially_empty_to_personal'    => array(
+				$this->get_response_personal_plan(),
+				'jetpack_personal',
+				true,
+			),
+			'initially_free_to_personal'     => array(
+				$this->get_response_personal_plan(),
+				'jetpack_personal',
+				true,
+				$this->get_free_plan(),
+			),
+			'initially_personal_to_free'     => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				true,
+				$this->get_personal_plan(),
+			),
+		);
+	}
+
+	private function get_response_free_plan() {
+		return $this->get_successful_plan_response( $this->get_free_plan() );
+	}
+
+	private function get_response_personal_plan() {
+		return $this->get_successful_plan_response( $this->get_personal_plan() );
+	}
+
+	private function get_successful_plan_response( $plan_response ) {
+		$body = wp_json_encode(
+			array(
+				'plan' => $plan_response,
+			)
+		);
+		return $this->get_mocked_response( 200, $body );
+	}
+
+	private function get_errored_sites_response() {
+		return $this->get_mocked_response( 400, new WP_Error() );
+	}
+
+	private function get_mocked_response( $code, $body ) {
+		return array(
+			'code' => $code,
+			'body' => $body,
+		);
+	}
+
+	private function get_free_plan() {
+		return [
+			'product_id' => 2002,
+			'product_slug' => 'jetpack_free',
+			'product_name_short' => 'Free',
+			'expired' => false,
+			'user_is_owner' => false,
+			'is_free' => true,
+			'features' => [
+				'active' => [
+					'akismet',
+					'support',
+				],
+				'available' => [
+					'akismet' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-backups' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-backup-archive' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-storage-space' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-automated-restores' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'simple-payments' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'support' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_personal',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					],
+					'premium-themes' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-security-scanning' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+					'polldaddy' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+				],
+			],
+		];
+	}
+
+	private function get_personal_plan() {
+		return [
+			'product_id' => 2005,
+			'product_slug' => 'jetpack_personal',
+			'product_name_short' => 'Personal',
+			'expired' => false,
+			'user_is_owner' => false,
+			'is_free' => false,
+			'features' => [
+				'active' => [
+					'support',
+				],
+				'available' => [
+					'akismet' => [
+						'jetpack_free',
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'support' => [
+						'jetpack_free',
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					],
+					'vaultpress-backups' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-backup-archive' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-storage-space' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-automated-restores' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'simple-payments' => [
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'premium-themes' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-security-scanning' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+					'polldaddy' => [
+						'jetpack_business',
+						'jetpack_business_monthly',
+					],
+				],
+			],
+		];
+	}
+}
+
+// phpcs:enable


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add tests for `Jetpack_Plan` class
* Refactor plans logic so that updates to the `jetpack_active_plan` option go through the `Jetpack_Plan` class
* Change how the active plan is cached so that it is a static variable on the `Jetpack_Plan` cache and add some functionality to clear that cache when the option is updated.
* Fix an issue where the active plan might not be updated if there was a mismatch in cache. See p1HpG7-5GG-p2 for backstory.

#### Testing instructions:

* Checkout branch
* For each of the plans, including free, check the following:
  * Load up the My Plan view (/wp-admin/admin.php?page=jetpack#/my-plan` and ensure the plan shows correctly
  * Ensure that there are no errors or warnings in logs
  * Run `wp option delete jetpack_active_plan` and then reload admin page. Ensure plan is reflected correctly
  * After waiting some seconds, ensure that you get a new plan welcome modal

#### Proposed changelog entry for your changes:

* Fix an issue where the Jetpack plan was not always reflected correctly.
