### PR TITLE
PSH: Restore Akismit and VaultPress cards

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -340,7 +340,10 @@ class Jetpack_Plugin_Search {
 	}
 
 	/**
-	 * Remove cards for Akismet, Jetpack and VaultPress plugins since we don't want duplicates.
+	 * Remove cards for Jetpack plugins since we don't want duplicates.
+	 *
+	 * @since 7.1.0
+	 * @since 7.2.0 Only remove Jetpack.
 	 *
 	 * @param array|object $plugin
 	 *
@@ -350,7 +353,7 @@ class Jetpack_Plugin_Search {
 		// Take in account that before WordPress 5.1, the list of plugins is an array of objects.
 		// With WordPress 5.1 the list of plugins is an array of arrays.
 		$slug = is_array( $plugin ) ? $plugin['slug'] : $plugin->slug;
-		return ! in_array( $slug, array( 'akismet', 'jetpack', 'vaultpress' ), true );
+		return ! in_array( $slug, array( 'jetpack' ), true );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11504

#### Changes proposed in this Pull Request:
Restores native functionality wrt VP and Akismet plugin info cards.

#### Testing instructions:
* Go to Plugins-Add New
* Search for "VaultPress"
* Before patch: See the Jetpack PSH, but no card for VaultPress.
* After patch: See the Jetpack PSH AND the VaultPress card.

#### Proposed changelog entry for your changes:
* Plugin Search Hints: Display Akismet and VaultPress as normal when returned by Core search.
