### PR TITLE
Getty shortcode: fix all PHPCS warnings in preparation for Fusion

### DIFF
--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -94,14 +94,14 @@ function wpcom_shortcodereverse_getty( $content ) {
 	}
 
 	$regexp     = '!<iframe\s+src=[\'"](https?:)?//embed\.gettyimages\.com/embed(/|/?\?assets=)([a-z0-9_-]+(,[a-z0-9_-]+)*)[^\'"]*?[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)((?:[\s\w]*))></iframe>!i';
-	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) ); // phpcs:ignore
+	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	// Markup pattern for 2017 embed syntax with significant differences from the prior pattern.
 	$regexp_2017     = '!<a.+?class=\'gie-(single|slideshow)\'.+?gie\.widgets\.load\({([^}]+)}\).+?embed-cdn\.gettyimages\.com/widgets\.js.+?</script>!';
-	$regexp_2017_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp_2017, ENT_NOQUOTES ) ); // phpcs:ignore
+	$regexp_2017_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp_2017, ENT_NOQUOTES ) );
 
-	foreach ( array( 'regexp_2017', 'regexp_2017_ent', 'regexp', 'regexp_ent' ) as $reg ) {
-		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
+	foreach ( compact( 'regexp_2017', 'regexp_2017_ent', 'regexp', 'regexp_ent' ) as $reg => $regexp ) {
+		if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
 		}
 
@@ -169,8 +169,8 @@ function wpcom_shortcodereverse_getty( $content ) {
 	$regexp     = '%<div class="getty\s[^>]*+>.*?<div[^>]*+>(\[getty[^\]]*+\])\s*</div>.*?</div>%is';
 	$regexp_ent = str_replace( array( '&amp;#0*58;', '[^&gt;]' ), array( '&amp;#0*58;|&#0*58;', '[^&]' ), htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
-	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
-		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
+	foreach ( compact( 'regexp', 'regexp_ent' ) as $reg => $regexp ) {
+		if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
 		}
 

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -152,7 +152,7 @@ function wpcom_shortcodereverse_getty( $content ) {
 			if ( ! empty( $height ) ) {
 				$shortcode .= ' height="' . esc_attr( $height ) . '"';
 			}
-			/**
+			/*
 			 * While it does not appear to have any practical impact, Getty has
 			 * requested that we include TLD in the embed request
 			 */

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -4,6 +4,8 @@
  *
  * [getty src="82278805" width="$width" height="$height"]
  * <div class="getty embed image" style="background-color:#fff;display:inline-block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#a7a7a7;font-size:11px;width:100%;max-width:462px;"><div style="padding:0;margin:0;text-align:left;"><a href="http://www.gettyimages.com/detail/82278805" target="_blank" style="color:#a7a7a7;text-decoration:none;font-weight:normal !important;border:none;display:inline-block;">Embed from Getty Images</a></div><div style="overflow:hidden;position:relative;height:0;padding:80.086580% 0 0 0;width:100%;"><iframe src="//embed.gettyimages.com/embed/82278805?et=jGiu6FXXSpJDGf1SnwLV2g&sig=TFVNFtqghwNw5iJQ1MFWnI8f4Y40_sfogfZLhai6SfA=" width="462" height="370" scrolling="no" frameborder="0" style="display:inline-block;position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div><p style="margin:0;"></p></div>
+ *
+ * @package Jetpack
  */
 
 if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -20,14 +22,14 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
  */
 function jetpack_getty_enable_embeds() {
 
-	// Support their oEmbed Endpoint
+	// Support their oEmbed Endpoint.
 	wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', 'https://embed.gettyimages.com/oembed/', true );
 	wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i', 'https://embed.gettyimages.com/oembed/', true );
 
-	// Allow iframes to be filtered to short code (so direct copy+paste can be done)
+	// Allow iframes to be filtered to short code (so direct copy+paste can be done).
 	add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
 
-	// Actually display the Getty Embed
+	// Actually display the Getty Embed.
 	add_shortcode( 'getty', 'jetpack_getty_shortcode' );
 }
 
@@ -46,6 +48,11 @@ function jetpack_getty_enable_embeds() {
  */
 add_filter( 'oembed_fetch_url', 'getty_add_oembed_endpoint_caller' );
 
+/**
+ * Filter the embeds to add a caller parameter.
+ *
+ * @param string $provider URL of the oEmbed provider.
+ */
 function getty_add_oembed_endpoint_caller( $provider ) {
 	// By time filter is called, original provider URL has had url, maxwidth,
 	// maxheight query parameters added.
@@ -56,17 +63,17 @@ function getty_add_oembed_endpoint_caller( $provider ) {
 	// Set the caller argument to pass to Getty's oembed provider.
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 
-		// Only include caller for non-private sites
+		// Only include caller for non-private sites.
 		if ( ! function_exists( 'is_private_blog' ) || ! is_private_blog() ) {
-			$host = parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
+			$host = wp_parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
 		}
 
-		// Fall back to WordPress.com
+		// Fall back to WordPress.com.
 		if ( empty( $host ) ) {
 			$host = 'wordpress.com';
 		}
 	} else {
-		$host = parse_url( get_home_url(), PHP_URL_HOST );
+		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
 	}
 
 	return add_query_arg( 'caller', $host, $provider );
@@ -77,7 +84,7 @@ function getty_add_oembed_endpoint_caller( $provider ) {
  *
  * @since 4.5.0
  *
- * @param string $content
+ * @param string $content Post content.
  *
  * @return mixed
  */
@@ -87,12 +94,11 @@ function wpcom_shortcodereverse_getty( $content ) {
 	}
 
 	$regexp     = '!<iframe\s+src=[\'"](https?:)?//embed\.gettyimages\.com/embed(/|/?\?assets=)([a-z0-9_-]+(,[a-z0-9_-]+)*)[^\'"]*?[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)((?:[\s\w]*))></iframe>!i';
-	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) ); // phpcs:ignore
 
-	// Markup pattern for 2017 embed syntax with significant differences from
-	// the prior pattern:
+	// Markup pattern for 2017 embed syntax with significant differences from the prior pattern.
 	$regexp_2017     = '!<a.+?class=\'gie-(single|slideshow)\'.+?gie\.widgets\.load\({([^}]+)}\).+?embed-cdn\.gettyimages\.com/widgets\.js.+?</script>!';
-	$regexp_2017_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp_2017, ENT_NOQUOTES ) );
+	$regexp_2017_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp_2017, ENT_NOQUOTES ) ); // phpcs:ignore
 
 	foreach ( array( 'regexp_2017', 'regexp_2017_ent', 'regexp', 'regexp_ent' ) as $reg ) {
 		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
@@ -101,7 +107,7 @@ function wpcom_shortcodereverse_getty( $content ) {
 
 		foreach ( $matches as $match ) {
 			if ( 'regexp_2017' === $reg || 'regexp_2017_ent' === $reg ) {
-				// Extract individual keys from the matched JavaScript object
+				// Extract individual keys from the matched JavaScript object.
 				$params = $match[2];
 				if ( ! preg_match_all( '!(?P<key>\w+)\s*:\s*([\'"](?P<value>[^\'"]*?)(px)?[\'"])!', $params, $key_matches, PREG_SET_ORDER ) ) {
 					continue;
@@ -146,8 +152,10 @@ function wpcom_shortcodereverse_getty( $content ) {
 			if ( ! empty( $height ) ) {
 				$shortcode .= ' height="' . esc_attr( $height ) . '"';
 			}
-			// While it does not appear to have any practical impact, Getty has
-			// requested that we include TLD in the embed request
+			/**
+			 * While it does not appear to have any practical impact, Getty has
+			 * requested that we include TLD in the embed request
+			 */
 			if ( ! empty( $tld ) ) {
 				$shortcode .= ' tld="' . esc_attr( $tld ) . '"';
 			}
@@ -157,7 +165,7 @@ function wpcom_shortcodereverse_getty( $content ) {
 		}
 	}
 
-	// strip out enclosing div and any other markup
+	// strip out enclosing div and any other markup.
 	$regexp     = '%<div class="getty\s[^>]*+>.*?<div[^>]*+>(\[getty[^\]]*+\])\s*</div>.*?</div>%is';
 	$regexp_ent = str_replace( array( '&amp;#0*58;', '[^&gt;]' ), array( '&amp;#0*58;|&#0*58;', '[^&]' ), htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Fix all PHPCS warnings in preparation for Fusion

#### Testing instructions:

* Add the following content to a new post:
`[getty src="82278805"]`
`<div class="getty embed image" style="background-color:#fff;display:inline-block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#a7a7a7;font-size:11px;width:100%;max-width:462px;"><div style="padding:0;margin:0;text-align:left;"><a href="http://www.gettyimages.com/detail/82278805" target="_blank" style="color:#a7a7a7;text-decoration:none;font-weight:normal !important;border:none;display:inline-block;">Embed from Getty Images</a></div><div style="overflow:hidden;position:relative;height:0;padding:80.086580% 0 0 0;width:100%;"><iframe src="//embed.gettyimages.com/embed/82278805?et=jGiu6FXXSpJDGf1SnwLV2g&sig=TFVNFtqghwNw5iJQ1MFWnI8f4Y40_sfogfZLhai6SfA=" width="462" height="370" scrolling="no" frameborder="0" style="display:inline-block;position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div><p style="margin:0;"></p></div>`
* Make sure the embeds work well.

#### Proposed changelog entry for your changes:

* None
