### PR TITLE
Danger: Announce code freeze is the day before the beta day

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -63,7 +63,7 @@ function setReleaseDates() {
 			}
 			jetpackReleaseDate = firstTuesdayOfMonth.format( 'LL' );
 			// Calculate next code freeze date
-			codeFreezeDate = firstTuesdayOfMonth.subtract( 7, 'd' ).format( 'LL' );
+			codeFreezeDate = firstTuesdayOfMonth.subtract( 8, 'd' ).format( 'LL' );
 		}
 
 		markdown( `


### PR DESCRIPTION
Adjusts the math for when the code freeze should be advertised.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the code freeze to release-8d instead of -7

#### Testing instructions:
* Open a properly formed PR. See the date.
*

#### Proposed changelog entry for your changes:
* n/a
