### PR TITLE
Add jsx highlighting to .js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-language=JSX


### PR DESCRIPTION
cc: @simison 

Details in https://github.com/Automattic/wp-calypso/pull/28459, although apparently has stopped working in the interim.