### PR TITLE
Blacklist `vip-legacy-redirect` post type

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -320,6 +320,7 @@ class Jetpack_Sync_Defaults {
 		'jp_img_sitemap_index',
 		'jp_vid_sitemap',
 		'jp_vid_sitemap_index',
+		'vip-legacy-redirect',
 	);
 
 	static $default_post_checksum_columns = array(


### PR DESCRIPTION
`vip-legacy-redirect` comes from the redirect plugin here: https://github.com/Automattic/WPCOM-Legacy-Redirector/blob/master/wpcom-legacy-redirector.php#L31

Sites can have several thousand redirects and we don’t need to sync these to WordPress.com.