### PR TITLE
Add workaround for subscriptions widget form submission failure in AMP pages

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -308,6 +308,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	                    );
 	                    ?>
                     </button>
+					<?php if ( Jetpack_AMP_Support::is_amp_request() ) : ?>
+						<!-- Add workaround for https://github.com/ampproject/amphtml/issues/21498 -->
+						<input type="hidden" name="jetpack_subscriptions_widget" value="">
+					<?php endif; ?>
                 </p>
             </form>
 			<?php


### PR DESCRIPTION
It was [discovered](https://wordpress.org/support/topic/amp-jetpack-subscribe-button-stopped-working/) that the subscription widget form submission fails on AMP pages. At issue is AMP form submissions appear to not include a field for the named button that sent the form. This field is used to initiate the subscription flow:

https://github.com/Automattic/jetpack/blob/e3986c699471dbb1dab42bdeac2041b8c979514c/modules/subscriptions.php#L84

Because this field is not included in the submission, the result is what appears to be a reload of the page.

For more information about the issue, see https://github.com/ampproject/amphtml/issues/21498 which I've reported as an apparent bug in the `amp-form` component.

See also this workaround plugin: https://gist.github.com/westonruter/3b61ffcfbc1b528b1135ac7cc065eaa2

Note: This workaround plugin also shows how the subscription widget UX could be greatly improved on AMP pages by not requiring a full page reload to submit the form. The form can instead be submitted via Ajax and the success/error message can instead be shown right in the existing form. The `AMP_Jetpack_Subscriptions_Form_Response_Container_Injector` in this plugin is a hack to inject the `div[submit-error]` and `div[submit-success]` elements into the `form`; this wouldn't be needed if the widget itself output the required elements. Also, the success/error messages could be refactored into a common helper method for use in Ajax responses as well as full page responses.

See #9730.
Fixes #11595.

#### Changes proposed in this Pull Request:

* Add a hidden `jetpack_subscriptions_widget` field to the subscriptions form in AMP pages to ensure the subscription flow is initiated.

#### Testing instructions:

* Active the AMP plugin and enable Paired mode.
* Add a Subscriptions widget to the sidebar.
* Navigate to an AMP page that has the subscriptions widget on it.
* Attempt to subscribe.

#### Proposed changelog entry for your changes:

* Fix subscriptions widget form submissions on AMP pages.
