### PR TITLE
Ads Gutenblock: Add "Hide ad on mobile views" toggle

### DIFF
--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -80,6 +80,10 @@ class Jetpack_WordAds_Gutenblock {
 			return '';
 		}
 
+		if ( isset( $attr['hideMobile'] ) && $attr['hideMobile'] && $wordads->params->is_mobile() ) {
+			return '';
+		}
+
 		if ( ! self::is_wpcom() && $wordads->option( 'wordads_house' ) ) {
 			return $wordads->get_ad( 'inline', 'house' );
 		}

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -80,7 +80,7 @@ class Jetpack_WordAds_Gutenblock {
 			return '';
 		}
 
-		if ( isset( $attr['hideMobile'] ) && $attr['hideMobile'] && $wordads->params->is_mobile() ) {
+		if ( ! empty( $attr['hideMobile'] ) && $wordads->params->is_mobile() ) {
 			return '';
 		}
 


### PR DESCRIPTION
Sometimes a tall/wide ad unit makes sense on Desktop, but not a mobile impression. It makes sense to include an option to disable the ad on a mobile impression or replace it with one that's more mobile friendly.

Calypso PR: https://github.com/Automattic/wp-calypso/pull/31608
Addresses: https://github.com/Automattic/wp-calypso/issues/30870

<img width="741" alt="Screen Shot 2019-03-20 at 3 06 37 PM" src="https://user-images.githubusercontent.com/273708/54722457-cdc8be80-4b21-11e9-852e-526417c8f858.png">

#### Changes proposed in this Pull Request:
* Add "Hide ad on mobile views" toggle

#### Testing instructions:
* Before installing the update make a post containing some "old" Ads blocks.
* Download & build Jetpack branch: https://github.com/Automattic/jetpack/tree/update/ad-block-remove-on-mobile
* Open Calypso branch, install dependencies with (`npx lerna bootstrap --concurrency=2 --scope '@automattic/jetpack-blocks'`), and then compile blocks e.g. `npx lerna run build --stream --scope='@automattic/jetpack-blocks' && rsync -a --delete packages/jetpack-blocks/dist/ ../jetpack/_inc/blocks/`
* On WordAds approved site add a unit and toggle `Hide ad on mobile views`
* View page via favorite mobile impression tester, see ad is missing.
* Edit post with "old" blocks and verify the blocks have updated successfully.

#### Proposed changelog entry for your changes:

* Added toggle to remove ad blocks on mobile views