### PR TITLE
Yarn: Add an php:autofix command that lets you phpcbf autofix specifiles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "scripts": {
       "php:compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
       "php:lint": "composer install && vendor/bin/phpcs -p",
+      "php:autofix": "composer install && vendor/bin/phpcbf",
       "php:lint:errors": "composer install && vendor/bin/phpcs -p --runtime-set ignore_warnings_on_exit 1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client -c .eslintrc.js",
     "php:compatibility": "composer php:compatibility",
     "php:lint": "composer php:lint",
+    "php:autofix": "composer php:autofix",
     "test-adminpage": "yarn test-client && yarn test-gui",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "wpi18n addtextdomain --textdomain=jetpack --glob-pattern='!(docker|node_modules|tests|tools|vendor){*.php,**/*.php}'",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Expose the already available phpcbf tool in composer and yarn.


#### Changes proposed in this Pull Request:
* Make the phpcbf tool available in yarn.

#### Testing instructions:
* Change so that it doesn't follow the php linting rules. 
* run `yarn php:autofix file-name.php`
* Notice that the autolinter works as expected. 

#### Proposed changelog entry for your changes:
* Make the phpcbf tool available in yarn.
