### PR TITLE
SSO: Fix typo in SSO Discover JITM

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1130,7 +1130,7 @@ class Jetpack_SSO {
 				'message'     => esc_html__( "You've successfully signed in with WordPress.com Secure Sign On!", 'jetpack' ),
 				'icon'        => 'jetpack',
 				'list'        => array(),
-				'description' => esc_html__( 'Interested in learning more about how Secure Sign on keeps your site safer?', 'jetpack' ),
+				'description' => esc_html__( 'Interested in learning more about how Secure Sign On keeps your site safer?', 'jetpack' ),
 				'classes'     => '',
 			),
 			'CTA'             => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* "Secure Sign on" → "Secure Sign On"

#### Testing instructions:
1. Go to a site where you've never done an SSO
2. SSO :)
3. See the notice. See the correct casing of "On".

#### Proposed changelog entry for your changes:
None required.