### PR TITLE
Calypsoify: Delay use of core admin functions until they are loaded.

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -20,39 +20,44 @@ class Jetpack_Calypsoify {
 	}
 
 	public function setup() {
-		add_action( 'admin_init', array( $this, 'check_param' ) );
+		add_action( 'admin_init', array( $this, 'check_param' ), 4 );
+
 		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
-
-			// Masterbar is currently required for this to work properly. Mock the instance of it
-			if ( ! Jetpack::is_module_active( 'masterbar' ) ) {
-				$this->mock_masterbar_activation();
-			}
-
-			if ( $this->is_page_gutenberg() ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_for_gutenberg' ), 100 );
-				return;
-			}
-			add_action( 'admin_init', array( $this, 'check_page' ) );
-			add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
-			add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ), 100 );
-			add_action( 'in_admin_header', array( $this, 'insert_sidebar_html' ) );
-			add_action( 'wp_before_admin_bar_render', array( $this, 'modify_masterbar' ), 100000 );
-
-
-			add_filter( 'get_user_option_admin_color', array( $this, 'admin_color_override' ) );
-
-			add_action( 'manage_plugins_columns', array( $this, 'manage_plugins_columns_header' ) );
-			add_action( 'manage_plugins_custom_column', array( $this, 'manage_plugins_custom_column' ), 10, 2 );
-			add_filter( 'bulk_actions-plugins', array( $this, 'bulk_actions_plugins' ) );
-
-			if ( 'plugins.php' === basename( $_SERVER['PHP_SELF'] ) ) {
-				add_action( 'admin_notices', array( $this, 'plugins_admin_notices' ) );
-			}
+			add_action( 'admin_init', array( $this, 'setup_admin' ), 6 );
 		}
+
 		// Make this always available -- in case calypsoify gets toggled off.
 		add_action( 'wp_ajax_jetpack_toggle_autoupdate', array( $this, 'jetpack_toggle_autoupdate' ) );
 		add_filter( 'handle_bulk_actions-plugins', array( $this, 'handle_bulk_actions_plugins' ), 10, 3 );
+	}
+
+	public function setup_admin() {
+		// Masterbar is currently required for this to work properly. Mock the instance of it
+		if ( ! Jetpack::is_module_active( 'masterbar' ) ) {
+			$this->mock_masterbar_activation();
+		}
+
+		if ( $this->is_page_gutenberg() ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_for_gutenberg' ), 100 );
+			return;
+		}
+
+		add_action( 'admin_init', array( $this, 'check_page' ) );
+		add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
+		add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ), 100 );
+		add_action( 'in_admin_header', array( $this, 'insert_sidebar_html' ) );
+		add_action( 'wp_before_admin_bar_render', array( $this, 'modify_masterbar' ), 100000 );
+
+		add_filter( 'get_user_option_admin_color', array( $this, 'admin_color_override' ) );
+
+		add_action( 'manage_plugins_columns', array( $this, 'manage_plugins_columns_header' ) );
+		add_action( 'manage_plugins_custom_column', array( $this, 'manage_plugins_custom_column' ), 10, 2 );
+		add_filter( 'bulk_actions-plugins', array( $this, 'bulk_actions_plugins' ) );
+
+		if ( 'plugins.php' === basename( $_SERVER['PHP_SELF'] ) ) {
+			add_action( 'admin_notices', array( $this, 'plugins_admin_notices' ) );
+		}
 	}
 
 	public function manage_plugins_columns_header( $columns ) {


### PR DESCRIPTION
Fixes #11650

#### Changes proposed in this Pull Request:
Calypsoify is loaded on `wp_loaded`, which is before core admin functions are loaded. It's only safe to use core admin functions during or after `admin_init`.

This PR keeps the current `get_user_meta()` checks where they are (in `wp_loaded`), but does the rest of the setup on `admin_init`. To do that, it juggles other `admin_init` priorities to ensure everything happens in the same order as before.

#### Testing instructions:
1. Go to /wp-admin/post-new.php?calypsoify=1.
2. Add a title and some content, then click "Preview".

Prior to this PR, the preview tab will spin forever, you'll see some errors in the JS console of the editor tab:

> POST …/wp-admin/post.php?post=660&action=edit&meta-box-loader=1&_wpnonce=4ca1d0cb7f&_locale=user 500
> Uncaught (in promise) Response {type: "basic", url: "…/wp-admin/post.php…", redirected: false, status: 500, ok: false, …}

and there will be a fatal error in your PHP error log:

> PHP Fatal error:  Uncaught Error: Call to undefined function use_block_editor_for_post_type() in /var/www/html/wp-content/plugins/jetpack/modules/calypsoify/class.jetpack-calypsoify.php:335

With this PR, the preview tab will eventually load, there will be fewer errors in the JS console of the editor tab, and there will be no PHP fatal errors.

#### Proposed changelog entry for your changes:
None needed.