### PR TITLE
Syntax fixes in contact form CSS and builder JS

### DIFF
--- a/modules/contact-form/css/editor-inline-editing-style.css
+++ b/modules/contact-form/css/editor-inline-editing-style.css
@@ -476,7 +476,8 @@ select {
 	vertical-align: top;
 	white-space: nowrap;
 	box-sizing: border-box;
-	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	/* Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow. */
+	padding: 7px 32px 9px 14px;
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;

--- a/modules/contact-form/css/editor-style.css
+++ b/modules/contact-form/css/editor-style.css
@@ -405,7 +405,8 @@ select {
 	vertical-align: top;
 	white-space: nowrap;
 	box-sizing: border-box;
-	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	/* Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow. */
+	padding: 7px 32px 9px 14px;
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -138,7 +138,7 @@ function onBuild( done, err, stats ) {
 	// Don't process minified JS in _inc or modules directories
 	const sourceNegations = [ '!_inc/*.min.js', '!modules/**/*.min.js' ];
 	gulp
-		.src( Array.concat( sources, sourceNegations ) )
+		.src( sources.concat( sourceNegations ) )
 		.pipe( banner( '/* Do not modify this file directly. It is compiled from other files. */\n' ) )
 		.pipe( gulpif( ! is_prod, sourcemaps.init() ) )
 		.pipe(

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -138,7 +138,7 @@ function onBuild( done, err, stats ) {
 	// Don't process minified JS in _inc or modules directories
 	const sourceNegations = [ '!_inc/*.min.js', '!modules/**/*.min.js' ];
 	gulp
-		.src( sources.concat( sourceNegations ) )
+		.src( [ ...sources, ...sourceNegations ] )
 		.pipe( banner( '/* Do not modify this file directly. It is compiled from other files. */\n' ) )
 		.pipe( gulpif( ! is_prod, sourcemaps.init() ) )
 		.pipe(


### PR DESCRIPTION
- Fix syntax in two CSS files (`//` comments are not valid in CSS https://developer.mozilla.org/en-US/docs/Web/CSS/Comments)

- Fix syntax in tools/builder/react.js (`TypeError: Array.concat is not a function` with Babel 7 upgrade https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat)

Noticed these in Babel 7 upgrade PR and thought it's better to PR separately: https://github.com/Automattic/jetpack/pull/10810

#### Testing instructions:
`yarn build` still works?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* —
