### PR TITLE
Build: Externalize React and Lodash

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -175,7 +175,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		wp_enqueue_script(
 			'react-plugin',
 			plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
-			array( 'wp-i18n' ),
+			array(
+				'lodash',
+				'react',
+				'react-dom',
+				'wp-i18n',
+			),
 			JETPACK__VERSION,
 			true
 		);

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -177,6 +177,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
 			array(
 				'lodash',
+				'moment',
 				'react',
 				'react-dom',
 				'wp-i18n',

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -172,6 +172,7 @@ function buildStatic( done ) {
 	global.React = require( 'react' );
 	global.ReactDOM = require( 'react-dom' );
 	global.lodash = require( 'lodash' );
+	global.moment = require( 'moment' );
 
 	window.Initial_State = {
 		dismissedNotices: [],

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -169,6 +169,9 @@ function buildStatic( done ) {
 	global.window = window;
 	global.document = document;
 	global.navigator = window.navigator;
+	global.React = require( 'react' );
+	global.ReactDOM = require( 'react-dom' );
+	global.lodash = require( 'lodash' );
 
 	window.Initial_State = {
 		dismissedNotices: [],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,6 +98,7 @@ const webpackConfig = {
 	],
 	externals: [
 		{
+			moment: 'moment',
 			lodash: 'lodash',
 			react: 'React',
 			'react-dom': 'ReactDOM',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,9 +72,6 @@ const webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '.js', '.jsx' ],
-		alias: {
-			react: path.join( __dirname, '/node_modules/react' )
-		},
 		modules: [
 			path.resolve( __dirname, 'node_modules' ),
 			path.resolve( __dirname, '_inc/client' ),
@@ -100,6 +97,9 @@ const webpackConfig = {
 		} )
 	],
 	externals: {
+		lodash: 'lodash',
+		react: 'React',
+		'react-dom': 'ReactDOM',
 		'react/addons': true,
 		'react/lib/ExecutionEnvironment': true,
 		'react/lib/ReactContext': true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,15 +96,25 @@ const webpackConfig = {
 			filename: '[name].dops-style.css',
 		} )
 	],
-	externals: {
-		lodash: 'lodash',
-		react: 'React',
-		'react-dom': 'ReactDOM',
-		'react/addons': true,
-		'react/lib/ExecutionEnvironment': true,
-		'react/lib/ReactContext': true,
-		jsdom: 'window'
-	},
+	externals: [
+		{
+			lodash: 'lodash',
+			react: 'React',
+			'react-dom': 'ReactDOM',
+			'react/addons': true,
+			'react/lib/ExecutionEnvironment': true,
+			'react/lib/ReactContext': true,
+			jsdom: 'window',
+		},
+		( _, request, callback ) => {
+			const match = request.match( /^lodash\/([a-zA-Z]+)$/ );
+			if ( match && match[ 1 ] ) {
+				const lodashFn = match[ 1 ];
+				return callback( null, `root lodash.${ lodashFn }` );
+			}
+			return callback();
+		},
+	],
 	devtool: devMode ? 'source-map' : false,
 };
 


### PR DESCRIPTION
Extern `React`, `ReactDOM`, `lodash` and `moment` from the Jetpack admin dashboard. They are all available as WordPress script dependencies.

Comparison `NODE_ENV=production yarn build-client`:

`master`
```
                Asset      Size  Chunks                    Chunk Names
             admin.js  2.34 MiB       0  [emitted]  [big]  admin
            static.js  1.49 MiB       1  [emitted]  [big]  static
Entrypoint admin [big] = admin.dops-style.css admin.js
Entrypoint static [big] = static.dops-style.css static.js
chunk    {0} admin.dops-style.css, admin.js (admin) 4.14 MiB [entry] [rendered]
chunk    {1} static.dops-style.css, static.js (static) 2.38 MiB [entry] [rendered]
```

Branch:
```
                Asset      Size  Chunks                    Chunk Names
             admin.js  1.97 MiB       0  [emitted]  [big]  admin
            static.js  1.24 MiB       1  [emitted]  [big]  static
Entrypoint admin [big] = admin.dops-style.css admin.js
Entrypoint static [big] = static.dops-style.css static.js
chunk    {0} admin.dops-style.css, admin.js (admin) 3.32 MiB [entry] [rendered]
chunk    {1} static.dops-style.css, static.js (static) 1.7 MiB [entry] [rendered]
```