### PR TITLE
Add wp-polyfill as a dependency for Slideshow block

### DIFF
--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -25,6 +25,7 @@ jetpack_register_block(
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	$dependencies = array(
 		'lodash',
+		'wp-polyfill',
 	);
 
 	Jetpack_Gutenberg::load_assets_as_required( 'slideshow', $dependencies );


### PR DESCRIPTION
Partly resolves https://github.com/Automattic/wp-calypso/issues/31689

Depends on https://github.com/Automattic/wp-calypso/pull/31690

#### Changes proposed in this Pull Request:

* add wp-polyfill as a dependency for Slideshow block

#### Testing instructions:
- Apply https://github.com/Automattic/wp-calypso/pull/31690 in Calypso
- Build blocks from Calypso repo root folder:
   ```
    npm ci
    npx lerna bootstrap --concurrency=2 --scope='@automattic/jetpack-blocks'
    npx lerna run build --stream --scope='@automattic/jetpack-blocks' -- -- --output-path /path/to/jetpack/_inc/blocks/ --watch
   ```
- Add Slideshow block in the editor (don't add any other blocks to mess up results)
- Open the page with the block
- Note from networks tab how wp-polyfill loads
- Block works in IE11

#### Proposed changelog entry for your changes:

This just moves code around and doesn't really change anything so this is an internal change....

