### PR TITLE
SEO: Expose advanced_seo_description post meta in the REST API (Take Two)

### DIFF
--- a/modules/seo-tools/jetpack-seo-posts.php
+++ b/modules/seo-tools/jetpack-seo-posts.php
@@ -60,4 +60,32 @@ class Jetpack_SEO_Posts {
 
 		return $custom_description;
 	}
+
+	/**
+	 * Registers the self::DESCRIPTION_META_KEY post_meta for use in the REST API.
+	 */
+	public static function register_post_meta() {
+		$args = array(
+			'type' => 'string',
+			'description' => __( 'Custom post description to be used in HTML <meta /> tag.', 'jetpack' ),
+			'single' => true,
+			'default' => '',
+			'show_in_rest' => array(
+				'name' => self::DESCRIPTION_META_KEY
+			),
+		);
+
+		register_meta( 'post', self::DESCRIPTION_META_KEY, $args );
+	}
+
+	/**
+	 * Register the Advanced SEO Gutenberg extension
+	 */
+	public static function register_gutenberg_extension() {
+		if ( Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+			Jetpack_Gutenberg::set_extension_available( 'jetpack-seo' );
+		} else {
+			Jetpack_Gutenberg::set_extension_unavailable( 'jetpack-seo', 'jetpack_seo_disabled' );
+		}
+	}
 }


### PR DESCRIPTION
Take Two of #11323. Alternative to #11333.
Calypso counterpart: https://github.com/Automattic/wp-calypso/pull/30033 (merged)
Brings r197556-wpcom to Jetpack
Diff: D32268-code

#### Changes proposed in this Pull Request:

**Note: following the discussion below, and in D32268-code, this PR now does not bring any new feature to Jetpack.**

* SEO: Expose advanced_seo_description post meta in the (core) REST API

#### Testing instructions:

* This should not bring any changes to Jetpack. Nothing should change.

#### Proposed changelog entry for your changes:

* SEO: Expose advanced_seo_description post meta in the REST API