### PR TITLE
Sharing: Updated WhatsApp url to track stats

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1703,7 +1703,15 @@ class Jetpack_Share_WhatsApp extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		return $this->get_link( 'https://api.whatsapp.com/send?text=' . rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) ), _x( 'WhatsApp', 'share to', 'jetpack' ), __( 'Click to share on WhatsApp', 'jetpack' ) );
+		return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'WhatsApp', 'share to', 'jetpack' ), __( 'Click to share on WhatsApp', 'jetpack' ), 'share=jetpack-whatsapp' );
+	}
+
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+		$url = 'https://api.whatsapp.com/send?text=' . rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
+		wp_redirect( $url );
+		exit;
 	}
 }
 


### PR DESCRIPTION
This PR brings Jetpack's code in sync with D25879-code

Just to note that we are not tracking anything stats here just bringing the code changes from the .com to the jetpack side.

#### Changes proposed in this Pull Request:
* Pass the url now though a redirect. This brings it easier to track stats. 

#### Testing instructions:
* Add the WhatsApp code sharing button to your page or post.
* Notice that it still works as expected.

#### Proposed changelog entry for your changes:
* Updated WhatsApp to be more constant with the other sharing buttons.
