### PR TITLE
Dashboard: Migrate CommonJS require()s to ESM imports

### DIFF
--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -16,7 +16,7 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import PlanIcon from 'components/plans/plan-icon';
 
-require( './style.scss' );
+import './style.scss';
 
 class Banner extends Component {
 	static propTypes = {

--- a/_inc/client/components/button-group/docs/example.jsx
+++ b/_inc/client/components/button-group/docs/example.jsx
@@ -3,18 +3,19 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const ButtonGroup = require( 'components/button-group' ),
-	Button = require( 'components/button' ),
-	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' );
+import ButtonGroup from 'components/button-group';
+
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
 
 const Buttons = createReactClass( {
 	displayName: 'ButtonGroup',

--- a/_inc/client/components/button-group/index.jsx
+++ b/_inc/client/components/button-group/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class ButtonGroup extends React.Component {
 	static displayName = 'ButtonGroup';

--- a/_inc/client/components/button/index.jsx
+++ b/_inc/client/components/button/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class Button extends React.Component {
 	static displayName = 'Button';

--- a/_inc/client/components/card/compact.jsx
+++ b/_inc/client/components/card/compact.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	assign = require( 'lodash/assign' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+
+import assign from 'lodash/assign';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-const Card = require( 'components/card' );
+import Card from 'components/card';
 
 export default class CompactCard extends React.Component {
 	static displayName = 'CompactCard';

--- a/_inc/client/components/card/index.jsx
+++ b/_inc/client/components/card/index.jsx
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' );
-const classnames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classnames from 'classnames';
 import assign from 'lodash/assign';
 import omit from 'lodash/omit';
+
 /**
  * Internal dependencies
  */
-const Gridicon = require( '../gridicon' );
+import Gridicon from '../gridicon';
 
-require( './style.scss' );
+import './style.scss';
 
 class CardSection extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/chart/bar-container.jsx
+++ b/_inc/client/components/chart/bar-container.jsx
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const Bar = require( './bar' ),
-	XAxis = require( './x-axis' );
+import Bar from './bar';
+
+import XAxis from './x-axis';
 
 export default class ModuleChartBarContainer extends React.Component {
 	static displayName = 'ModuleChartBarContainer';

--- a/_inc/client/components/chart/bar.jsx
+++ b/_inc/client/components/chart/bar.jsx
@@ -3,15 +3,17 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-const Tooltip = require( 'components/tooltip' ),
-	Gridicon = require( 'components/gridicon' );
+import Tooltip from 'components/tooltip';
+
+import Gridicon from 'components/gridicon';
 
 export default class ModuleChartBar extends React.Component {
 	static displayName = 'ModuleChartBar';

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PropTypes = require( 'prop-types' ),
-	noop = require( 'lodash/noop' ),
-	throttle = require( 'lodash/throttle' );
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import noop from 'lodash/noop';
+import throttle from 'lodash/throttle';
 
 /**
  * Internal dependencies
  */
-const BarContainer = require( './bar-container' ),
-	touchDetect = require( 'lib/touch-detect' );
+import BarContainer from './bar-container';
 
-require( './style.scss' );
+import touchDetect from 'lib/touch-detect';
+import './style.scss';
 
 export default class ModuleChart extends React.Component {
 	static displayName = 'ModuleChart';

--- a/_inc/client/components/chart/label.jsx
+++ b/_inc/client/components/chart/label.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 export default class ModuleChartLabel extends React.Component {
 	static displayName = 'ModuleChartLabel';

--- a/_inc/client/components/chart/legend.jsx
+++ b/_inc/client/components/chart/legend.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies

--- a/_inc/client/components/chart/x-axis.jsx
+++ b/_inc/client/components/chart/x-axis.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PropTypes = require( 'prop-types' ),
-	throttle = require( 'lodash/throttle' );
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import throttle from 'lodash/throttle';
 
 /**
  * Internal dependencies
  */
-const Label = require( './label' );
+import Label from './label';
 
 export default class ModuleChartXAxis extends React.Component {
 	static displayName = 'ModuleChartXAxis';

--- a/_inc/client/components/clipboard-button-input/index.jsx
+++ b/_inc/client/components/clipboard-button-input/index.jsx
@@ -12,7 +12,7 @@ import omit from 'lodash/omit';
 import ClipboardButton from 'components/form/clipboard-button';
 import TextInput from 'components/text-input';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class ClipboardButtonInput extends React.Component {
 	static displayName = 'ClipboardButtonInput';

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -25,7 +25,7 @@ import { getSiteRawUrl } from 'state/initial-state';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 import JetpackDisconnectDialog from 'components/jetpack-disconnect-dialog';
 
-require( './style.scss' );
+import './style.scss';
 
 export class ConnectButton extends React.Component {
 	static displayName = 'ConnectButton';

--- a/_inc/client/components/count/docs/example.jsx
+++ b/_inc/client/components/count/docs/example.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const Count = require( 'components/count' );
+import Count from 'components/count';
 
 module.exports = createReactClass( {
 	displayName: 'Count',

--- a/_inc/client/components/count/index.jsx
+++ b/_inc/client/components/count/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-pure-render/mixin';
 
-require( './style.scss' );
+import './style.scss';
 
 export default createReactClass( {
 	displayName: 'Count',

--- a/_inc/client/components/count/test/index.jsx
+++ b/_inc/client/components/count/test/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-const expect = require( 'chai' ).expect,
-	useMockery = require( 'test/helpers/use-mockery' );
+import { expect } from 'chai';
+
+import useMockery from 'test/helpers/use-mockery';
 
 /**
  * Internal dependencies

--- a/_inc/client/components/external-link/index.jsx
+++ b/_inc/client/components/external-link/index.jsx
@@ -14,7 +14,7 @@ import omit from 'lodash/omit';
  */
 import Gridicon from 'components/gridicon';
 
-require( './style.scss' );
+import './style.scss';
 
 export default createReactClass( {
 	displayName: 'ExternalLink',

--- a/_inc/client/components/foldable-card/index.jsx
+++ b/_inc/client/components/foldable-card/index.jsx
@@ -1,20 +1,21 @@
 /**
  * External Dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	noop = require( 'lodash/noop' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 /**
  * Internal Dependencies
  */
-const Card = require( 'components/card' ),
-	CompactCard = require( 'components/card/compact' ),
-	Gridicon = require( 'components/gridicon' ),
-	onKeyDownCallback = require( 'utils/onkeydown-callback' );
+import Card from 'components/card';
 
-require( './style.scss' );
+import CompactCard from 'components/card/compact';
+import Gridicon from 'components/gridicon';
+import onKeyDownCallback from 'utils/onkeydown-callback';
+import './style.scss';
 
 class FoldableCard extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/form-input-validation/index.jsx
+++ b/_inc/client/components/form-input-validation/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	Gridicon = require( 'components/gridicon' );
+import PropTypes from 'prop-types';
 
-require( './style.scss' );
+import React from 'react';
+import classNames from 'classnames';
+import Gridicon from 'components/gridicon';
+import './style.scss';
 
 export default class FormInputValidation extends React.Component {
 	static displayName = 'FormInputValidation';

--- a/_inc/client/components/form/action-bar.jsx
+++ b/_inc/client/components/form/action-bar.jsx
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 
 export default class ActionBar extends React.Component {

--- a/_inc/client/components/form/action-bar.jsx
+++ b/_inc/client/components/form/action-bar.jsx
@@ -1,6 +1,7 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 export default class ActionBar extends React.Component {
 	static displayName = 'ActionBar';

--- a/_inc/client/components/form/clipboard-button/index.jsx
+++ b/_inc/client/components/form/clipboard-button/index.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	Clipboard = require( 'clipboard' ),
-	omit = require( 'lodash/omit' ),
-	noop = require( 'lodash/noop' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import ReactDom from 'react-dom';
+import React from 'react';
+import Clipboard from 'clipboard';
+import omit from 'lodash/omit';
+import noop from 'lodash/noop';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies

--- a/_inc/client/components/form/form-toggle/compact.jsx
+++ b/_inc/client/components/form/form-toggle/compact.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
+import React from 'react';
+
+import classNames from 'classnames';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
  */
-const Toggle = require( 'components/form/form-toggle' );
+import Toggle from 'components/form/form-toggle';
 
 export default class CompactFormToggle extends React.Component {
 	static displayName = 'CompactFormToggle';

--- a/_inc/client/components/form/form-toggle/index.jsx
+++ b/_inc/client/components/form/form-toggle/index.jsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
  */
 import Popover from 'components/popover';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class FormToggle extends Component {
 	static propTypes = {

--- a/_inc/client/components/form/form-toggle/test/index.jsx
+++ b/_inc/client/components/form/form-toggle/test/index.jsx
@@ -2,19 +2,16 @@
  * External dependencies
  */
 import assert from 'assert';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import unique from 'lodash/uniq';
-/**
- * External dependencies
- */
-const TestUtils = ReactDOM.TestUtils;
 
 /**
  * Internal dependencies
  */
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+
+const TestUtils = ReactDOM.TestUtils;
 
 require( 'lib/react-test-env-setup' )();
 

--- a/_inc/client/components/form/form-toggle/test/index.jsx
+++ b/_inc/client/components/form/form-toggle/test/index.jsx
@@ -1,16 +1,20 @@
 /**
  * External dependencies
  */
-const assert = require( 'assert' ),
-	React = require( 'react' ),
-	ReactDOM = require( 'react-dom' ),
-	TestUtils = ReactDOM.TestUtils,
-	unique = require( 'lodash/uniq' );
+import assert from 'assert';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import unique from 'lodash/uniq';
+/**
+ * External dependencies
+ */
+const TestUtils = ReactDOM.TestUtils;
 
 /**
  * Internal dependencies
  */
-const CompactFormToggle = require( 'components/forms/form-toggle/compact' );
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 require( 'lib/react-test-env-setup' )();
 

--- a/_inc/client/components/form/index.jsx
+++ b/_inc/client/components/form/index.jsx
@@ -1,24 +1,25 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	isArray = require( 'lodash/isArray' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import isArray from 'lodash/isArray';
+import Formsy from 'formsy-react';
 
 /** Internal Dependencies **/
-const ActionBar = require( './action-bar' ),
-	Section = require( './section' ),
-	Row = require( './row' ),
-	Label = require( './label' ),
-	TextInput = require( './input-text' ),
-	RadioInput = require( './input-radio' ),
-	CheckboxInput = require( './input-checkbox' ),
-	MultiCheckboxInput = require( './input-checkbox-multiple' ),
-	SelectInput = require( './input-select' ),
-	CountrySelect = require( './input-select-country' ),
-	HiddenInput = require( './input-hidden' ),
-	Submit = require( './submit' );
+import ActionBar from './action-bar';
 
-require( './style.scss' );
+import Section from './section';
+import Row from './row';
+import Label from './label';
+import TextInput from './input-text';
+import RadioInput from './input-radio';
+import CheckboxInput from './input-checkbox';
+import MultiCheckboxInput from './input-checkbox-multiple';
+import SelectInput from './input-select';
+import CountrySelect from './input-select-country';
+import HiddenInput from './input-hidden';
+import Submit from './submit';
+import './style.scss';
 
 // very thin wrapper for Formsy.Form
 class Form extends React.Component {

--- a/_inc/client/components/form/index.jsx
+++ b/_inc/client/components/form/index.jsx
@@ -1,13 +1,15 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import isArray from 'lodash/isArray';
 import Formsy from 'formsy-react';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import ActionBar from './action-bar';
-
 import Section from './section';
 import Row from './row';
 import Label from './label';

--- a/_inc/client/components/form/input-checkbox-multiple.jsx
+++ b/_inc/client/components/form/input-checkbox-multiple.jsx
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import isArray from 'lodash/isArray';
@@ -8,9 +9,10 @@ import map from 'lodash/map';
 import Formsy from 'formsy-react';
 import createReactClass from 'create-react-class';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Label from './label';
-
 import getUniqueId from './counter';
 import FormInputValidation from '../form-input-validation';
 import requiredFieldErrorFormatter from './required-error-label';

--- a/_inc/client/components/form/input-checkbox-multiple.jsx
+++ b/_inc/client/components/form/input-checkbox-multiple.jsx
@@ -1,18 +1,19 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	ReactDOM = require( 'react-dom' ),
-	isArray = require( 'lodash/isArray' ),
-	map = require( 'lodash/map' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import ReactDOM from 'react-dom';
+import isArray from 'lodash/isArray';
+import map from 'lodash/map';
+import Formsy from 'formsy-react';
+import createReactClass from 'create-react-class';
 
 /** Internal Dependencies **/
-const Label = require( './label' ),
-	getUniqueId = require( './counter' ),
-	FormInputValidation = require( '../form-input-validation' ),
-	requiredFieldErrorFormatter = require( './required-error-label' );
+import Label from './label';
+
+import getUniqueId from './counter';
+import FormInputValidation from '../form-input-validation';
+import requiredFieldErrorFormatter from './required-error-label';
 
 module.exports = createReactClass( {
 	displayName: 'MultiCheckboxInput',

--- a/_inc/client/components/form/input-checkbox.jsx
+++ b/_inc/client/components/form/input-checkbox.jsx
@@ -1,14 +1,16 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 import createReactClass from 'create-react-class';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Label from './label';
-
 import getUniqueId from './counter';
 import FormInputValidation from '../form-input-validation';
 import requiredFieldErrorFormatter from './required-error-label';

--- a/_inc/client/components/form/input-checkbox.jsx
+++ b/_inc/client/components/form/input-checkbox.jsx
@@ -1,16 +1,17 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import classNames from 'classnames';
+import Formsy from 'formsy-react';
+import createReactClass from 'create-react-class';
 
 /** Internal Dependencies **/
-const Label = require( './label' ),
-	getUniqueId = require( './counter' ),
-	FormInputValidation = require( '../form-input-validation' ),
-	requiredFieldErrorFormatter = require( './required-error-label' );
+import Label from './label';
+
+import getUniqueId from './counter';
+import FormInputValidation from '../form-input-validation';
+import requiredFieldErrorFormatter from './required-error-label';
 
 module.exports = createReactClass( {
 	displayName: 'CheckboxInput',

--- a/_inc/client/components/form/input-hidden.jsx
+++ b/_inc/client/components/form/input-hidden.jsx
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import Formsy from 'formsy-react';
 import createReactClass from 'create-react-class';

--- a/_inc/client/components/form/input-hidden.jsx
+++ b/_inc/client/components/form/input-hidden.jsx
@@ -1,9 +1,9 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import Formsy from 'formsy-react';
+import createReactClass from 'create-react-class';
 
 module.exports = createReactClass( {
 	displayName: 'HiddenInput',

--- a/_inc/client/components/form/input-radio.jsx
+++ b/_inc/client/components/form/input-radio.jsx
@@ -1,16 +1,17 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import classNames from 'classnames';
+import Formsy from 'formsy-react';
+import createReactClass from 'create-react-class';
 
 /** Internal Dependencies **/
-const Label = require( './label' ),
-	getUniqueId = require( './counter' ),
-	FormInputValidation = require( '../form-input-validation' ),
-	requiredFieldErrorFormatter = require( './required-error-label' );
+import Label from './label';
+
+import getUniqueId from './counter';
+import FormInputValidation from '../form-input-validation';
+import requiredFieldErrorFormatter from './required-error-label';
 
 class Radios extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/form/input-radio.jsx
+++ b/_inc/client/components/form/input-radio.jsx
@@ -1,14 +1,16 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 import createReactClass from 'create-react-class';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Label from './label';
-
 import getUniqueId from './counter';
 import FormInputValidation from '../form-input-validation';
 import requiredFieldErrorFormatter from './required-error-label';

--- a/_inc/client/components/form/input-select-country-2.jsx
+++ b/_inc/client/components/form/input-select-country-2.jsx
@@ -1,8 +1,8 @@
 /** External Dependencies **/
-const React = require( 'react' );
+import React from 'react';
 
 /** Internal Dependencies **/
-const SelectInput = require( './input-select' );
+import SelectInput from './input-select';
 
 export default class CountrySelectInput2 extends React.Component {
 	static displayName = 'CountrySelectInput2';

--- a/_inc/client/components/form/input-select-country-2.jsx
+++ b/_inc/client/components/form/input-select-country-2.jsx
@@ -1,7 +1,11 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import React from 'react';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import SelectInput from './input-select';
 
 export default class CountrySelectInput2 extends React.Component {

--- a/_inc/client/components/form/input-select-country.jsx
+++ b/_inc/client/components/form/input-select-country.jsx
@@ -1,8 +1,8 @@
 /** External Dependencies **/
-const React = require( 'react' );
+import React from 'react';
 
 /** Internal Dependencies **/
-const SelectInput = require( './input-select' );
+import SelectInput from './input-select';
 
 export default class CountrySelectInput extends React.Component {
 	static displayName = 'CountrySelectInput';

--- a/_inc/client/components/form/input-select-country.jsx
+++ b/_inc/client/components/form/input-select-country.jsx
@@ -1,7 +1,11 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import React from 'react';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import SelectInput from './input-select';
 
 export default class CountrySelectInput extends React.Component {

--- a/_inc/client/components/form/input-select.jsx
+++ b/_inc/client/components/form/input-select.jsx
@@ -1,18 +1,19 @@
 /* eslint-disable jsx-a11y/no-onchange */
 
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	Formsy = require( 'formsy-react' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import classNames from 'classnames';
+import Formsy from 'formsy-react';
+import createReactClass from 'create-react-class';
 
 /** Internal Dependencies **/
-const Label = require( './label' ),
-	getUniqueId = require( './counter' ),
-	FormInputValidation = require( '../form-input-validation' ),
-	requiredFieldErrorFormatter = require( './required-error-label' );
+import Label from './label';
+
+import getUniqueId from './counter';
+import FormInputValidation from '../form-input-validation';
+import requiredFieldErrorFormatter from './required-error-label';
 
 module.exports = createReactClass( {
 	displayName: 'SelectInput',

--- a/_inc/client/components/form/input-select.jsx
+++ b/_inc/client/components/form/input-select.jsx
@@ -1,16 +1,18 @@
 /* eslint-disable jsx-a11y/no-onchange */
 
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 import createReactClass from 'create-react-class';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Label from './label';
-
 import getUniqueId from './counter';
 import FormInputValidation from '../form-input-validation';
 import requiredFieldErrorFormatter from './required-error-label';

--- a/_inc/client/components/form/input-text.js
+++ b/_inc/client/components/form/input-text.js
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import React from 'react';
-
 import ReactDOM from 'react-dom';
 import Formsy from 'formsy-react';
 import classNames from 'classnames';
@@ -8,9 +9,10 @@ import Payment from 'payment';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Label from './label';
-
 import getUniqueId from './counter';
 import FormInputValidation from '../form-input-validation';
 import requiredFieldErrorFormatter from './required-error-label';

--- a/_inc/client/components/form/input-text.js
+++ b/_inc/client/components/form/input-text.js
@@ -1,16 +1,19 @@
 /** External Dependencies **/
-const React = require( 'react' ),
-	ReactDOM = require( 'react-dom' ),
-	Formsy = require( 'formsy-react' ),
-	classNames = require( 'classnames' ),
-	Payment = require( 'payment' ),
-	createReactClass = require( 'create-react-class' ),
-	PropTypes = require( 'prop-types' );
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import Formsy from 'formsy-react';
+import classNames from 'classnames';
+import Payment from 'payment';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+
 /** Internal Dependencies **/
-const Label = require( './label' ),
-	getUniqueId = require( './counter' ),
-	FormInputValidation = require( '../form-input-validation' ),
-	requiredFieldErrorFormatter = require( './required-error-label' );
+import Label from './label';
+
+import getUniqueId from './counter';
+import FormInputValidation from '../form-input-validation';
+import requiredFieldErrorFormatter from './required-error-label';
 
 module.exports = createReactClass( {
 	displayName: 'TextInput',

--- a/_inc/client/components/form/label.jsx
+++ b/_inc/client/components/form/label.jsx
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 

--- a/_inc/client/components/form/label.jsx
+++ b/_inc/client/components/form/label.jsx
@@ -1,7 +1,8 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classNames from 'classnames';
 
 export default class Label extends React.Component {
 	static displayName = 'Label';

--- a/_inc/client/components/form/row.jsx
+++ b/_inc/client/components/form/row.jsx
@@ -1,5 +1,5 @@
 /** External Dependencies **/
-const React = require( 'react' );
+import React from 'react';
 
 export default class Row extends React.Component {
 	static displayName = 'Row';

--- a/_inc/client/components/form/row.jsx
+++ b/_inc/client/components/form/row.jsx
@@ -1,4 +1,6 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import React from 'react';
 
 export default class Row extends React.Component {

--- a/_inc/client/components/form/section.jsx
+++ b/_inc/client/components/form/section.jsx
@@ -1,6 +1,7 @@
 /** External Dependencies **/
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 export default class Section extends React.Component {
 	static displayName = 'Section';

--- a/_inc/client/components/form/section.jsx
+++ b/_inc/client/components/form/section.jsx
@@ -1,6 +1,7 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 
 export default class Section extends React.Component {

--- a/_inc/client/components/form/submit.jsx
+++ b/_inc/client/components/form/submit.jsx
@@ -1,7 +1,11 @@
-/** External Dependencies **/
+/**
+ * External Dependencies
+ */
 import React from 'react';
 
-/** Internal Dependencies **/
+/**
+ * Internal Dependencies
+ */
 import Button from '../button';
 
 export default class Submit extends React.Component {

--- a/_inc/client/components/form/submit.jsx
+++ b/_inc/client/components/form/submit.jsx
@@ -1,8 +1,8 @@
 /** External Dependencies **/
-const React = require( 'react' );
+import React from 'react';
 
 /** Internal Dependencies **/
-const Button = require( '../button' );
+import Button from '../button';
 
 export default class Submit extends React.Component {
 	static displayName = 'Submit';

--- a/_inc/client/components/global-notices/index.jsx
+++ b/_inc/client/components/global-notices/index.jsx
@@ -17,7 +17,7 @@ import { removeNotice } from './state/notices/actions';
 
 const debug = debugModule( 'calypso:notices' );
 
-require( './style.scss' );
+import './style.scss';
 
 class NoticesList extends React.Component {
 	static displayName = 'NoticesList';

--- a/_inc/client/components/gridicon/index.jsx
+++ b/_inc/client/components/gridicon/index.jsx
@@ -10,14 +10,13 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
-
-require( './style.scss' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classNames from 'classnames';
+import createReactClass from 'create-react-class';
+import './style.scss';
 
 const Gridicon = createReactClass( {
 	displayName: 'Gridicon',

--- a/_inc/client/components/info-popover/docs/example.jsx
+++ b/_inc/client/components/info-popover/docs/example.jsx
@@ -2,15 +2,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const InfoPopover = require( 'components/info-popover' );
+import InfoPopover from 'components/info-popover';
 
 const InfoPopoverExample = createReactClass( {
 	displayName: 'InfoPopover',

--- a/_inc/client/components/info-popover/index.jsx
+++ b/_inc/client/components/info-popover/index.jsx
@@ -14,7 +14,7 @@ import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import analytics from 'lib/analytics';
 
-require( './style.scss' );
+import './style.scss';
 
 export default createReactClass( {
 	displayName: 'InfoPopover',

--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -3,8 +3,10 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
+/**
+ * External Dependencies
+ */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';

--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -3,14 +3,14 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	ReactDOM = require( 'react-dom' ),
-	classNames = require( 'classnames' ),
-	assign = require( 'lodash/assign' ),
-	omit = require( 'lodash/omit' );
+import PropTypes from 'prop-types';
 
-const focusTrap = require( 'focus-trap' );
+import React from 'react';
+import ReactDOM from 'react-dom';
+import classNames from 'classnames';
+import assign from 'lodash/assign';
+import omit from 'lodash/omit';
+import focusTrap from 'focus-trap';
 
 // this flag will prevent ANY modals from closing.
 // use with caution!
@@ -19,7 +19,7 @@ const focusTrap = require( 'focus-trap' );
 // this is for important processes that must not be interrupted, e.g. payments
 let preventCloseFlag = false;
 
-require( './style.scss' );
+import './style.scss';
 
 function preventClose() {
 	preventCloseFlag = true;

--- a/_inc/client/components/module-overridden-banner/index.jsx
+++ b/_inc/client/components/module-overridden-banner/index.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  */
 import JetpackBanner from 'components/jetpack-banner';
 
-require( './style.scss' );
+import './style.scss';
 
 class ModuleOverridenBanner extends JetpackBanner {
 	static propTypes = {

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -12,7 +12,7 @@ import onKeyDownCallback from 'utils/onkeydown-callback';
  */
 import Gridicon from 'components/gridicon';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class SimpleNotice extends React.Component {
 	static displayName = 'SimpleNotice';

--- a/_inc/client/components/notice/notice-action.jsx
+++ b/_inc/client/components/notice/notice-action.jsx
@@ -9,7 +9,7 @@ import React from 'react';
  */
 import Gridicon from 'components/gridicon';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class NoticeAction extends React.Component {
 	static displayName = 'NoticeAction';

--- a/_inc/client/components/plans/plan-icon/index.jsx
+++ b/_inc/client/components/plans/plan-icon/index.jsx
@@ -27,7 +27,7 @@ import {
 	getPlanClass,
 } from 'lib/plans/constants';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class PlanIcon extends Component {
 	getIconClassNames( iconClass = '' ) {

--- a/_inc/client/components/popover/index.jsx
+++ b/_inc/client/components/popover/index.jsx
@@ -23,7 +23,7 @@ import {
 	offset,
 } from './util';
 
-require( './style.scss' );
+import './style.scss';
 
 /**
  * Module variables

--- a/_inc/client/components/popover/menu-item.jsx
+++ b/_inc/client/components/popover/menu-item.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	noop = require( 'lodash/noop' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+
+import noop from 'lodash/noop';
+import classnames from 'classnames';
 
 class MenuItem extends React.Component {
 	static defaultProps = {

--- a/_inc/client/components/popover/menu.jsx
+++ b/_inc/client/components/popover/menu.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+import PropTypes from 'prop-types';
+
+import ReactDom from 'react-dom';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const Popover = require( 'components/popover' );
+import Popover from 'components/popover';
 
 class PopoverMenu extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/search/docs/example.jsx
+++ b/_inc/client/components/search/docs/example.jsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const Search = require( 'components/search' ),
-	SearchCard = require( 'components/search-card' );
+import Search from 'components/search';
+
+import SearchCard from 'components/search-card';
 
 /**
  * Globals

--- a/_inc/client/components/search/index.jsx
+++ b/_inc/client/components/search/index.jsx
@@ -17,7 +17,7 @@ import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
 import { isMobile } from 'lib/viewport';
 
-require( './style.scss' );
+import './style.scss';
 
 /**
  * Internal variables

--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
  */
 import Card from 'components/card';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class SectionHeader extends React.Component {
 	static displayName = 'SectionHeader';

--- a/_inc/client/components/section-nav/docs/example.jsx
+++ b/_inc/client/components/section-nav/docs/example.jsx
@@ -1,20 +1,21 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	forEach = require( 'lodash/forEach' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import forEach from 'lodash/forEach';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavSegmented = require( 'components/section-nav/segmented' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' );
+import SectionNav from 'components/section-nav';
+
+import NavTabs from 'components/section-nav/tabs';
+import NavSegmented from 'components/section-nav/segmented';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
 
 /**
  * Main

--- a/_inc/client/components/section-nav/index.jsx
+++ b/_inc/client/components/section-nav/index.jsx
@@ -3,21 +3,21 @@
 /**
  * External Dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	isEqual = require( 'lodash/isEqual' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import isEqual from 'lodash/isEqual';
+import classNames from 'classnames';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal Dependencies
  */
-const NavTabs = require( './tabs' ),
-	NavItem = require( './item' ),
-	Search = require( 'components/search' );
+import NavTabs from './tabs';
 
-require( './style.scss' );
+import NavItem from './item';
+import Search from 'components/search';
+import './style.scss';
 
 /**
  * Main

--- a/_inc/client/components/section-nav/item.jsx
+++ b/_inc/client/components/section-nav/item.jsx
@@ -3,17 +3,17 @@
 /**
  * External Dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
 
-const createReactClass = require( 'create-react-class' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classNames from 'classnames';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal Dependencies
  */
-const Count = require( 'components/count' );
+import Count from 'components/count';
 
 /**
  * Main

--- a/_inc/client/components/section-nav/segmented.jsx
+++ b/_inc/client/components/section-nav/segmented.jsx
@@ -1,15 +1,17 @@
 /**
  * External Dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
  */
-const SegmentedControl = require( 'components/segmented-control' ),
-	ControlItem = require( 'components/segmented-control/item' );
+import SegmentedControl from 'components/segmented-control';
+
+import ControlItem from 'components/segmented-control/item';
 
 /**
  * Internal variables

--- a/_inc/client/components/section-nav/tabs.jsx
+++ b/_inc/client/components/section-nav/tabs.jsx
@@ -12,9 +12,10 @@ import classNames from 'classnames';
 /**
  * Internal Dependencies
  */
-const SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' ),
-	viewport = require( 'lib/viewport' );
+import SelectDropdown from 'components/select-dropdown';
+
+import DropdownItem from 'components/select-dropdown/item';
+import viewport from 'lib/viewport';
 
 /**
  * Internal Variables

--- a/_inc/client/components/section-nav/test/index.jsx
+++ b/_inc/client/components/section-nav/test/index.jsx
@@ -1,7 +1,7 @@
-const assert = require( 'chai' ).assert,
-	sinon = require( 'sinon' ),
-	useMockery = require( 'test/helpers/use-mockery' ),
-	useFakeDom = require( 'test/helpers/use-fake-dom' );
+import { assert } from 'chai';
+import sinon from 'sinon';
+import useMockery from 'test/helpers/use-mockery';
+import useFakeDom from 'test/helpers/use-fake-dom';
 let ReactDom, React, TestUtils, SectionNav;
 
 function createComponent( component, props, children ) {

--- a/_inc/client/components/section-nav/test/index.jsx
+++ b/_inc/client/components/section-nav/test/index.jsx
@@ -1,3 +1,6 @@
+/**
+ * External Dependencies
+ */
 import { assert } from 'chai';
 import sinon from 'sinon';
 import useMockery from 'test/helpers/use-mockery';

--- a/_inc/client/components/select-dropdown/docs/example.jsx
+++ b/_inc/client/components/select-dropdown/docs/example.jsx
@@ -3,18 +3,19 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' ),
-	DropdownLabel = require( 'components/select-dropdown/label' ),
-	DropdownSeparator = require( 'components/select-dropdown/separator' );
+import SelectDropdown from 'components/select-dropdown';
+
+import DropdownItem from 'components/select-dropdown/item';
+import DropdownLabel from 'components/select-dropdown/label';
+import DropdownSeparator from 'components/select-dropdown/separator';
 
 const SelectDropdownDemo = createReactClass( {
 	displayName: 'SelectDropdown',

--- a/_inc/client/components/select-dropdown/index.jsx
+++ b/_inc/client/components/select-dropdown/index.jsx
@@ -21,7 +21,7 @@ import DropdownSeparator from 'components/select-dropdown/separator';
 import DropdownLabel from 'components/select-dropdown/label';
 import Count from 'components/count';
 
-require( './style.scss' );
+import './style.scss';
 
 /**
  * Module variables

--- a/_inc/client/components/select-dropdown/item.jsx
+++ b/_inc/client/components/select-dropdown/item.jsx
@@ -3,14 +3,15 @@
 /**
  * External Dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-const Count = require( 'components/count' );
+import Count from 'components/count';
 
 class SelectDropdownItem extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/select-dropdown/separator.jsx
+++ b/_inc/client/components/select-dropdown/separator.jsx
@@ -3,7 +3,7 @@
 /**
  * External Dependencies
  */
-const React = require( 'react' );
+import React from 'react';
 
 class SelectDropdownSeparator extends React.Component {
 	render() {

--- a/_inc/client/components/spinner/docs/example.jsx
+++ b/_inc/client/components/spinner/docs/example.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
-const createReactClass = require( 'create-react-class' );
+import PureRenderMixin from 'react-pure-render/mixin';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
-const Spinner = require( 'components/spinner' );
+import Spinner from 'components/spinner';
 
 module.exports = createReactClass( {
 	displayName: 'Spinner',

--- a/_inc/client/components/spinner/index.jsx
+++ b/_inc/client/components/spinner/index.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+import PropTypes from 'prop-types';
 
-require( './style.scss' );
+import React from 'react';
+import classNames from 'classnames';
+import './style.scss';
 
 class Spinner extends React.Component {
 	static propTypes = {

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -12,7 +12,7 @@ import analytics from 'lib/analytics';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class SupportInfo extends Component {
 	static propTypes = {

--- a/_inc/client/components/text-input/index.jsx
+++ b/_inc/client/components/text-input/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 
-require( './style.scss' );
+import './style.scss';
 
 export default class TextInput extends React.Component {
 	static displayName = 'TextInput';

--- a/_inc/client/components/textarea/index.jsx
+++ b/_inc/client/components/textarea/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
+import React from 'react';
 
-require( './style.scss' );
+import classnames from 'classnames';
+import omit from 'lodash/omit';
+import './style.scss';
 
 export default class Textarea extends React.Component {
 	static displayName = 'Textarea';

--- a/_inc/client/components/tooltip/index.jsx
+++ b/_inc/client/components/tooltip/index.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import Popover from 'components/popover';
 import viewport from 'lib/viewport';
 
-require( './style.scss' );
+import './style.scss';
 
 /**
  * Module variables

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-
-const debug = debugFactory( 'dops:analytics' );
 import assign from 'lodash/assign';
 
 /**
@@ -11,6 +9,7 @@ import assign from 'lodash/assign';
  */
 import config from 'config';
 
+const debug = debugFactory( 'dops:analytics' );
 let _superProps, _user;
 
 // Load tracking scripts

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 
-const debug = debugFactory('dops:analytics');
+const debug = debugFactory( 'dops:analytics' );
 import assign from 'lodash/assign';
 
 /**

--- a/_inc/client/lib/analytics/index.js
+++ b/_inc/client/lib/analytics/index.js
@@ -1,13 +1,16 @@
 /**
  * External dependencies
  */
-const debug = require( 'debug' )( 'dops:analytics' ),
-	assign = require( 'lodash/assign' );
+import debugFactory from 'debug';
+
+const debug = debugFactory('dops:analytics');
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
  */
-const config = require( 'config' );
+import config from 'config';
+
 let _superProps, _user;
 
 // Load tracking scripts

--- a/_inc/client/mixins/emitter/index.js
+++ b/_inc/client/mixins/emitter/index.js
@@ -6,8 +6,9 @@
 // load the module from `node_modules/` instead of the core’s `events.js`
 // file. Webpack uses the same module on the client side, too, which
 // makes for a nice consistency.
-const EventEmitter = require( 'events/' ).EventEmitter,
-	assign = require( 'lodash/assign' );
+import { EventEmitter } from 'events/';
+
+import assign from 'lodash/assign';
 
 module.exports = function( prototype ) {
 	assign( prototype, EventEmitter.prototype );

--- a/_inc/client/mixins/emitter/index.js
+++ b/_inc/client/mixins/emitter/index.js
@@ -10,8 +10,8 @@
 /**
  * External Dependencies
  */
-import { EventEmitter } from 'events/';
 import assign from 'lodash/assign';
+import { EventEmitter } from 'events';
 
 module.exports = function( prototype ) {
 	assign( prototype, EventEmitter.prototype );

--- a/_inc/client/mixins/emitter/index.js
+++ b/_inc/client/mixins/emitter/index.js
@@ -6,8 +6,11 @@
 // load the module from `node_modules/` instead of the core’s `events.js`
 // file. Webpack uses the same module on the client side, too, which
 // makes for a nice consistency.
-import { EventEmitter } from 'events/';
 
+/**
+ * External Dependencies
+ */
+import { EventEmitter } from 'events/';
 import assign from 'lodash/assign';
 
 module.exports = function( prototype ) {

--- a/_inc/client/mixins/url-search/build-url.js
+++ b/_inc/client/mixins/url-search/build-url.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-const url = require( 'url' ),
-	pick = require( 'lodash/pick' );
+import url from 'url';
+
+import pick from 'lodash/pick';
 
 /**
  * Given a URL or path and search terms, returns a path including the search

--- a/_inc/client/mixins/url-search/index.js
+++ b/_inc/client/mixins/url-search/index.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 
-const debug = debugFactory('calypso:url-search');
+const debug = debugFactory( 'calypso:url-search' );
 import page from 'page';
 
 /**

--- a/_inc/client/mixins/url-search/index.js
+++ b/_inc/client/mixins/url-search/index.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-const debug = require( 'debug' )( 'calypso:url-search' ),
-	page = require( 'page' );
+import debugFactory from 'debug';
+
+const debug = debugFactory('calypso:url-search');
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-const buildUrl = require( './build-url' );
+import buildUrl from './build-url';
 
 module.exports = {
 	getInitialState: function() {

--- a/_inc/client/mixins/url-search/index.js
+++ b/_inc/client/mixins/url-search/index.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:url-search' );
 import page from 'page';
 
 /**
  * Internal dependencies
  */
 import buildUrl from './build-url';
+
+const debug = debugFactory( 'calypso:url-search' );
 
 module.exports = {
 	getInitialState: function() {

--- a/_inc/client/notices/index.js
+++ b/_inc/client/notices/index.js
@@ -1,9 +1,10 @@
 /**
  * External Dependencies
  */
-const debug = require( 'debug' )( 'calypso:notices' );
+import debugFactory from 'debug';
 
-const Emitter = require( 'mixins/emitter' );
+const debug = debugFactory('calypso:notices');
+import Emitter from 'mixins/emitter';
 
 debug( 'initializing notices' );
 
@@ -11,7 +12,7 @@ const list = { containerNames: {} };
 Emitter( list );
 let delayedNotices = [];
 
-require( './style.scss' );
+import './style.scss';
 
 const notices = {
 	/**

--- a/_inc/client/notices/index.js
+++ b/_inc/client/notices/index.js
@@ -2,17 +2,19 @@
  * External Dependencies
  */
 import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:notices' );
 import Emitter from 'mixins/emitter';
 
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+
+const debug = debugFactory( 'calypso:notices' );
 debug( 'initializing notices' );
 
 const list = { containerNames: {} };
 Emitter( list );
 let delayedNotices = [];
-
-import './style.scss';
 
 const notices = {
 	/**

--- a/_inc/client/notices/index.js
+++ b/_inc/client/notices/index.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 
-const debug = debugFactory('calypso:notices');
+const debug = debugFactory( 'calypso:notices' );
 import Emitter from 'mixins/emitter';
 
 debug( 'initializing notices' );

--- a/_inc/client/notices/validation-error-list.jsx
+++ b/_inc/client/notices/validation-error-list.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-const PropTypes = require( 'prop-types' );
-const React = require( 'react' ),
-	map = require( 'lodash/map' );
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import map from 'lodash/map';
 import { translate as __ } from 'i18n-calypso';
 
 export default class ValidationErrorList extends React.Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Migrate CommonJS require()s to ESM imports. Produced by running `calypso-codemods commonjs-imports _inc/client/` ([see](https://github.com/Automattic/calypso-codemods#getting-started)). This seems to work surprisingly well.

This might be needed for #10810 to not break the React dashboard.

At some point in the future, we might want to re-use Calypso's (or core's) components here, but for now, I really just wanna unblock #10810 :sweat_smile: 

#### Testing instructions:

Smoke-test the heck out of Jetpack's React dashboard.

#### Proposed changelog entry for your changes:

Dashboard: Migrate CommonJS require()s to ESM imports
