### PR TITLE
Admin Page: avoid console errors when saving changes in a form

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -316,7 +316,7 @@ export const SettingsCard = props => {
 
 	return (
 		getModuleOverridenBanner() || (
-			<form className="jp-form-settings-card" onSubmit={ ! isSaving && props.onSubmit }>
+			<form className="jp-form-settings-card" onSubmit={ ! isSaving ? props.onSubmit : undefined }>
 				<SectionHeader label={ header }>
 					{ ! props.hideButton && (
 						<Button primary compact type="submit" disabled={ isSaving || ! props.isDirty() }>


### PR DESCRIPTION
Fixes #11678

#### Changes proposed in this Pull Request:

* Avoid console errors when saving changes in any form in the Admin Page.

#### Testing instructions:

* Go to Jetpack > Settings > Writing
* Enable Carousel
* Try changing the carousel color from black to white.
* Save your changes, and make sure you get no errors on saving, or in the JS console.
* Repeat with other forms on the page, like the Protect form under the Security tab.

#### Proposed changelog entry for your changes:

* Admin Page: avoid console errors when saving changes in a form
