### PR TITLE
Jetpack Sync: Add the previous interval end to full sync posts, comments

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -125,7 +125,7 @@ class Jetpack_Sync_Listener {
 	 * @param $args_array Array of Ids
 	 * @param $previous_interval_endpoint String
 	 */
-	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_interval_endpoint = null ) {
+	function bulk_enqueue_full_sync_actions( $action_name, $args_array ) {
 		$queue = $this->get_full_sync_queue();
 
 		// periodically check the size of the queue, and disable adding to it if
@@ -156,15 +156,11 @@ class Jetpack_Sync_Listener {
 			 *
 			 * @param array The action parameters
 			 */
-			$args = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
+			$action_data = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
 
 			// allow listeners to abort
-			if ( $args === false ) {
+			if ( $action_data === false ) {
 				continue;
-			}
-			$action_data = array( $args );
-			if ( ! is_null( $previous_interval_endpoint ) ) {
-				$action_data[] = $previous_interval_endpoint;
 			}
 
 			$data_to_enqueue[] = array(

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -117,7 +117,7 @@ class Jetpack_Sync_Listener {
 	}
 
 	// add many actions to the queue directly, without invoking them
-	function bulk_enqueue_full_sync_actions( $action_name, $args_array ) {
+	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_max_id ) {
 		$queue = $this->get_full_sync_queue();
 
 		// periodically check the size of the queue, and disable adding to it if
@@ -157,7 +157,7 @@ class Jetpack_Sync_Listener {
 
 			$data_to_enqueue[] = array(
 				$action_name,
-				array( $args ),
+				array( $args, $previous_max_id ),
 				$user_id,
 				$currtime,
 				$is_importing,

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -145,8 +145,8 @@ class Jetpack_Sync_Listener {
 		$is_importing    = Jetpack_Sync_Settings::is_importing();
 
 		foreach ( $args_array as $args ) {
-			$previous_endpoint = isset( $args['previous_endpoint'] ) ? $args['previous_endpoint'] : null;
-			$args = isset( $args['ids'] )? $args['ids']: $args;
+			$previous_end = isset( $args['previous_end'] ) ? $args['previous_end'] : null;
+			$args = isset( $args['ids'] ) ? $args['ids']: $args;
 
 
 			/**
@@ -160,8 +160,8 @@ class Jetpack_Sync_Listener {
 			 */
 			$args = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
 			$action_data = array( $args );
-			if ( ! is_null( $previous_endpoint ) ) {
-				$action_data[] = $previous_endpoint;
+			if ( ! is_null( $previous_end ) ) {
+				$action_data[] = $previous_end;
 			}
 			// allow listeners to abort
 			if ( $args === false ) {

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -125,7 +125,7 @@ class Jetpack_Sync_Listener {
 	 * @param $args_array Array of Ids
 	 * @param $previous_interval_endpoint String
 	 */
-	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_interval_endpoint = null ) {
+	function bulk_enqueue_full_sync_actions( $action_name, $args_array ) {
 		$queue = $this->get_full_sync_queue();
 
 		// periodically check the size of the queue, and disable adding to it if
@@ -146,6 +146,9 @@ class Jetpack_Sync_Listener {
 		$is_importing    = Jetpack_Sync_Settings::is_importing();
 
 		foreach ( $args_array as $args ) {
+			$previous_endpoint = isset( $args['previous_endpoint'] ) ? $args['previous_endpoint'] : null;
+			$args = isset( $args['ids'] )? $args['ids']: $args;
+
 
 			/**
 			 * Modify or reject the data within an action before it is enqueued locally.
@@ -157,14 +160,13 @@ class Jetpack_Sync_Listener {
 			 * @param array The action parameters
 			 */
 			$args = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
-
+			$action_data = array( $args );
+			if ( ! is_null( $previous_endpoint ) ) {
+				$action_data[] = $previous_endpoint;
+			}
 			// allow listeners to abort
 			if ( $args === false ) {
 				continue;
-			}
-			$action_data = array( $args );
-			if ( ! is_null( $previous_interval_endpoint ) ) {
-				$action_data[] = $previous_interval_endpoint;
 			}
 
 			$data_to_enqueue[] = array(

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -117,7 +117,15 @@ class Jetpack_Sync_Listener {
 	}
 
 	// add many actions to the queue directly, without invoking them
-	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_max_id ) {
+
+	/**
+	 * Bulk add action to the queue.
+	 *
+	 * @param $action_name String the name the full sync action.
+	 * @param $args_array Array of Ids
+	 * @param $previous_interval_endpoint String
+	 */
+	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_interval_endpoint = null ) {
 		$queue = $this->get_full_sync_queue();
 
 		// periodically check the size of the queue, and disable adding to it if
@@ -154,10 +162,14 @@ class Jetpack_Sync_Listener {
 			if ( $args === false ) {
 				continue;
 			}
+			$action_data = array( $args );
+			if ( ! is_null( $previous_interval_endpoint ) ) {
+				$action_data[] = $previous_interval_endpoint;
+			}
 
 			$data_to_enqueue[] = array(
 				$action_name,
-				array( $args, $previous_max_id ),
+				$action_data,
 				$user_id,
 				$currtime,
 				$is_importing,

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -122,8 +122,7 @@ class Jetpack_Sync_Listener {
 	 * Bulk add action to the queue.
 	 *
 	 * @param $action_name String the name the full sync action.
-	 * @param $args_array Array of Ids
-	 * @param $previous_interval_endpoint String
+	 * @param $args_array Array of chunked arguments
 	 */
 	function bulk_enqueue_full_sync_actions( $action_name, $args_array ) {
 		$queue = $this->get_full_sync_queue();

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -125,7 +125,7 @@ class Jetpack_Sync_Listener {
 	 * @param $args_array Array of Ids
 	 * @param $previous_interval_endpoint String
 	 */
-	function bulk_enqueue_full_sync_actions( $action_name, $args_array ) {
+	function bulk_enqueue_full_sync_actions( $action_name, $args_array, $previous_interval_endpoint = null ) {
 		$queue = $this->get_full_sync_queue();
 
 		// periodically check the size of the queue, and disable adding to it if
@@ -156,11 +156,15 @@ class Jetpack_Sync_Listener {
 			 *
 			 * @param array The action parameters
 			 */
-			$action_data = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
+			$args = apply_filters( "jetpack_sync_before_enqueue_$action_name", $args );
 
 			// allow listeners to abort
-			if ( $action_data === false ) {
+			if ( $args === false ) {
 				continue;
+			}
+			$action_data = array( $args );
+			if ( ! is_null( $previous_interval_endpoint ) ) {
+				$action_data[] = $previous_interval_endpoint;
 			}
 
 			$data_to_enqueue[] = array(

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -146,7 +146,7 @@ class Jetpack_Sync_Listener {
 
 		foreach ( $args_array as $args ) {
 			$previous_end = isset( $args['previous_end'] ) ? $args['previous_end'] : null;
-			$args = isset( $args['ids'] ) ? $args['ids']: $args;
+			$args = isset( $args['ids'] ) ? $args['ids'] : $args;
 
 
 			/**

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -177,7 +177,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	}
 
 	public function expand_comment_ids( $args ) {
-		list( $comment_ids, $previous_interval_endpoint ) = $args;
+		list( $comment_ids, $previous_interval_end ) = $args;
 		$comments    = get_comments(
 			array(
 				'include_unapproved' => true,
@@ -190,7 +190,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		return array(
 			$comments,
 			$this->get_metadata( $comment_ids, 'comment', Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) ),
-			$previous_interval_endpoint,
+			$previous_interval_end,
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -161,7 +161,6 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 			$blocked_comment->comment_date     = $comment->comment_date;
 			$blocked_comment->comment_date_gmt = $comment->comment_date_gmt;
 			$blocked_comment->comment_approved = 'jetpack_sync_blocked';
-
 			return $blocked_comment;
 		}
 
@@ -178,17 +177,20 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	}
 
 	public function expand_comment_ids( $args ) {
-		$comment_ids = $args[0];
+		list( $comment_ids, $previous_interval_endpoint ) = $args;
 		$comments    = get_comments(
 			array(
 				'include_unapproved' => true,
 				'comment__in'        => $comment_ids,
+				'orderby'            => 'comment_ID',
+				'order'              => 'DESC',
 			)
 		);
 
 		return array(
 			$comments,
 			$this->get_metadata( $comment_ids, 'comment', Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) ),
+			$previous_interval_endpoint,
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -178,7 +178,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	}
 
 	public function expand_comment_ids( $args ) {
-		$comment_ids = $args[0];
+		list( $comment_ids, $previous_min_id ) = $args;
 		$comments    = get_comments(
 			array(
 				'include_unapproved' => true,
@@ -189,6 +189,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		return array(
 			$comments,
 			$this->get_metadata( $comment_ids, 'comment', Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) ),
+			$previous_min_id,
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -178,7 +178,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	}
 
 	public function expand_comment_ids( $args ) {
-		list( $comment_ids, $previous_min_id ) = $args;
+		$comment_ids = $args[0];
 		$comments    = get_comments(
 			array(
 				'include_unapproved' => true,
@@ -189,7 +189,6 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		return array(
 			$comments,
 			$this->get_metadata( $comment_ids, 'comment', Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) ),
-			$previous_min_id,
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -73,7 +73,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_post', array( $this, 'expand_jetpack_sync_save_post' ) );
 
 		// full sync
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ), 10, 2 );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -413,7 +413,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function expand_post_ids( $args ) {
-		$post_ids = $args[0];
+		list( $post_ids, $previous_min_id ) = $args;
 
 		$posts = array_filter( array_map( array( 'WP_Post', 'get_instance' ), $post_ids ) );
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
@@ -423,6 +423,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$posts,
 			$this->get_metadata( $post_ids, 'post', Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' ) ),
 			$this->get_term_relationships( $post_ids ),
+			$previous_min_id
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -413,7 +413,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function expand_post_ids( $args ) {
-		list( $post_ids, $previous_min_id ) = $args;
+		list( $post_ids, $previous_interval_endpoint ) = $args;
 
 		$posts = array_filter( array_map( array( 'WP_Post', 'get_instance' ), $post_ids ) );
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
@@ -423,7 +423,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$posts,
 			$this->get_metadata( $post_ids, 'post', Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' ) ),
 			$this->get_term_relationships( $post_ids ),
-			$previous_min_id
+			$previous_interval_endpoint
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -413,7 +413,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function expand_post_ids( $args ) {
-		list( $post_ids, $previous_interval_endpoint ) = $args;
+		list( $post_ids, $previous_interval_end) = $args;
 
 		$posts = array_filter( array_map( array( 'WP_Post', 'get_instance' ), $post_ids ) );
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
@@ -423,7 +423,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$posts,
 			$this->get_metadata( $post_ids, 'post', Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' ) ),
 			$this->get_term_relationships( $post_ids ),
-			$previous_interval_endpoint
+			$previous_interval_end
 		);
 	}
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -73,7 +73,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_post', array( $this, 'expand_jetpack_sync_save_post' ) );
 
 		// full sync
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ), 10, 2 );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -80,13 +80,13 @@ abstract class Jetpack_Sync_Module {
 			if ( $chunk_count + count( $chunked_ids ) >= $max_items_to_enqueue ) {
 				$remaining_items_count = $max_items_to_enqueue - $chunk_count;
 				$remaining_items       = array_slice( $chunked_ids, 0, $remaining_items_count );
-				$remaining_items_with_previous_interval_end = $this->get_chunks_with_preceding_endpoint( $remaining_items, $previous_interval_end );
+				$remaining_items_with_previous_interval_end = $this->get_chunks_with_preceding_end( $remaining_items, $previous_interval_end );
 				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items_with_previous_interval_end );
 
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
-			$chunked_ids_with_previous_end = $this->get_chunks_with_preceding_endpoints( $chunked_ids, $previous_interval_end );
+			$chunked_ids_with_previous_end = $this->get_chunks_with_preceding_end( $chunked_ids, $previous_interval_end );
 
 			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids_with_previous_end );
 
@@ -99,7 +99,7 @@ abstract class Jetpack_Sync_Module {
 		return array( $chunk_count, true );
 	}
 
-	private function get_chunks_with_preceding_endpoints( $chunks, $previous_interval_end ) {
+	private function get_chunks_with_preceding_end( $chunks, $previous_interval_end ) {
 		foreach( $chunks as $chunk ) {
 			$chunks_with_endpoints[] = array(
 				'ids' => $chunk,

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -68,11 +68,11 @@ abstract class Jetpack_Sync_Module {
 		$items_per_page  = 1000;
 		$page            = 1;
 		$chunk_count     = 0;
-		$previous_max_id = $state ? $state : '~0';
+		$previous_interval_endpoint = $state ? $state : '~0';
 		$listener        = Jetpack_Sync_Listener::get_instance();
 
 		// count down from max_id to min_id so we get newest posts/comments/etc first
-		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} < {$previous_max_id} ORDER BY {$id_field} DESC LIMIT {$items_per_page}" ) ) {
+		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} < {$previous_interval_endpoint} ORDER BY {$id_field} DESC LIMIT {$items_per_page}" ) ) {
 			// Request posts in groups of N for efficiency
 			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
 
@@ -81,17 +81,17 @@ abstract class Jetpack_Sync_Module {
 				$remaining_items_count = $max_items_to_enqueue - $chunk_count;
 				$remaining_items       = array_slice( $chunked_ids, 0, $remaining_items_count );
 
-				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items, $previous_max_id );
+				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items, $previous_interval_endpoint );
 
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
 
-			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids, $previous_max_id );
+			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids, $previous_interval_endpoint );
 
 			$chunk_count    += count( $chunked_ids );
 			$page           += 1;
-			$previous_max_id = end( $ids );
+			$previous_interval_endpoint = end( $ids );
 		}
 
 		return array( $chunk_count, true );

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -81,13 +81,13 @@ abstract class Jetpack_Sync_Module {
 				$remaining_items_count = $max_items_to_enqueue - $chunk_count;
 				$remaining_items       = array_slice( $chunked_ids, 0, $remaining_items_count );
 
-				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items, $previous_interval_endpoint );
+				$listener->bulk_enqueue_full_sync_actions( $action_name, array( $remaining_items, $previous_interval_endpoint ) );
 
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
 
-			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids, $previous_interval_endpoint );
+			$listener->bulk_enqueue_full_sync_actions( $action_name, array( $chunked_ids, $previous_interval_endpoint ) );
 
 			$chunk_count    += count( $chunked_ids );
 			$page           += 1;

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -101,14 +101,14 @@ abstract class Jetpack_Sync_Module {
 
 	private function get_chunks_with_preceding_end( $chunks, $previous_interval_end ) {
 		foreach( $chunks as $chunk ) {
-			$chunks_with_endpoints[] = array(
+			$chunks_with_ends[] = array(
 				'ids' => $chunk,
 				'previous_end' => $previous_interval_end
 			);
 			// Chunks are ordered in descending order
 			$previous_interval_end = end( $chunk );
 		}
-		return $chunks_with_endpoints;
+		return $chunks_with_ends;
 	}
 
 	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist ) {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -81,13 +81,13 @@ abstract class Jetpack_Sync_Module {
 				$remaining_items_count = $max_items_to_enqueue - $chunk_count;
 				$remaining_items       = array_slice( $chunked_ids, 0, $remaining_items_count );
 
-				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items );
+				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items, $previous_max_id );
 
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
 
-			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids );
+			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids, $previous_max_id );
 
 			$chunk_count    += count( $chunked_ids );
 			$page           += 1;

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -86,9 +86,9 @@ abstract class Jetpack_Sync_Module {
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
-			$chunked_ids_with_previous_endpoints = $this->get_chunks_with_preceding_endpoints( $chunked_ids, $previous_interval_end );
+			$chunked_ids_with_previous_end = $this->get_chunks_with_preceding_endpoints( $chunked_ids, $previous_interval_end );
 
-			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids_with_previous_endpoints );
+			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids_with_previous_end );
 
 			$chunk_count    += count( $chunked_ids );
 			$page           += 1;

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -81,13 +81,13 @@ abstract class Jetpack_Sync_Module {
 				$remaining_items_count = $max_items_to_enqueue - $chunk_count;
 				$remaining_items       = array_slice( $chunked_ids, 0, $remaining_items_count );
 
-				$listener->bulk_enqueue_full_sync_actions( $action_name, array( $remaining_items, $previous_interval_endpoint ) );
+				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items, $previous_interval_endpoint );
 
 				$last_chunk = end( $remaining_items );
 				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
 
-			$listener->bulk_enqueue_full_sync_actions( $action_name, array( $chunked_ids, $previous_interval_endpoint ) );
+			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids, $previous_interval_endpoint );
 
 			$chunk_count    += count( $chunked_ids );
 			$page           += 1;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1082,10 +1082,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );
 		$this->assertEquals( $full_sync_status['sent'], $should_be_status['sent'] );
 		$this->assertEquals( $full_sync_status['total'], $should_be_status['total'] );
-		$this->assertInternalType( 'int', $full_sync_status['started'] );
-		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertInternalType( 'int', $full_sync_status['send_started'] );
-		$this->assertInternalType( 'int', $full_sync_status['finished'] );
+		$this->assertInternalType( 'int', $full_sync_status['started'], 'Started is not an integer' );
+		$this->assertInternalType( 'int', $full_sync_status['queue_finished'], 'Queue finished is not an integer' );
+		$this->assertInternalType( 'int', $full_sync_status['send_started'], 'Send started is not an integer' );
+		$this->assertInternalType( 'int', $full_sync_status['finished'], 'Finished is not an integer' );
 
 		// Reset all the defaults
 		$this->setSyncClientDefaults();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1242,8 +1242,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
+		list( $posts, $meta, $taxonomy, $previous_min_id) = $event->args;
+		$this->assertEquals( $previous_min_id, '~0' );
+		$last_post = end( $posts );
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
 
-		$this->assetEquals( $event->args[3], '~0');
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
+		list( $second_batch_posts, $meta, $taxonomy, $previous_min_id) = $event->args;
+
+		$this->assertEquals( intval( $previous_min_id ), $last_post->ID );
 	}
 
 	function test_full_sync_sends_previous_min_id_on_comments() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1266,6 +1266,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 		list( $third_batch_posts, $meta, $taxonomy, $previous_interval_endpoint ) = $event->args;
 		$this->assertEquals( intval( $previous_interval_endpoint ), $last_post->ID );
+
+		$this->full_sync->reset_data();
 	}
 
 	function test_full_sync_sends_previous_min_id_on_comments() {
@@ -1302,6 +1304,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
 		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
 
+		$this->full_sync->reset_data(); 
 	}
 
 	function _do_cron() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1232,7 +1232,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 0, $this->sender->get_full_sync_queue()->size() );
 	}
 
-	function test_full_sync_sends_previous_interval_endpoint_on_posts() {
+	function test_full_sync_sends_previous_interval_end_on_posts() {
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		$this->factory->post->create_many( 25 );
@@ -1245,35 +1245,35 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
-		list( $posts, $meta, $taxonomy, $previous_interval_endpoint ) = $event->args;
+		list( $posts, $meta, $taxonomy, $previous_interval_end ) = $event->args;
 
 		// The first batch has the previous_min_is not set.
 		// We user ~0 to denote that the previous min id unknown.
-		$this->assertEquals( $previous_interval_endpoint, '~0' );
+		$this->assertEquals( $previous_interval_end, '~0' );
 
 		// Since posts are order by id and the ids are in decending order
-		// the very last post should be the id with the smallest ID. ( previous_interval_endpoint )
+		// the very last post should be the id with the smallest ID. ( previous_interval_end )
 		$last_post = end( $posts );
 
 		$this->full_sync->continue_enqueuing();
 		$this->sender->do_full_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
-		list( $second_batch_posts, $meta, $taxonomy, $previous_interval_endpoint ) = $event->args;
-		$this->assertEquals( intval( $previous_interval_endpoint ), $last_post->ID );
+		list( $second_batch_posts, $meta, $taxonomy, $previous_interval_end ) = $event->args;
+		$this->assertEquals( intval( $previous_interval_end ), $last_post->ID );
 
 		$last_post = end( $second_batch_posts );
 		$this->full_sync->continue_enqueuing();
 		$this->sender->do_full_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
-		list( $third_batch_posts, $meta, $taxonomy, $previous_interval_endpoint ) = $event->args;
-		$this->assertEquals( intval( $previous_interval_endpoint ), $last_post->ID );
+		list( $third_batch_posts, $meta, $taxonomy, $previous_interval_end ) = $event->args;
+		$this->assertEquals( intval( $previous_interval_end ), $last_post->ID );
 
 		$this->full_sync->reset_data();
 	}
 
-	function test_full_sync_sends_previous_interval_endpoint_on_comments() {
+	function test_full_sync_sends_previous_interval_end_on_comments() {
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 		$this->post_id = $this->factory->post->create();
 		for( $i = 0; $i < 25; $i++ ) {
@@ -1287,25 +1287,25 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
-		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
+		list( $comments, $meta,  $previous_interval_end ) = $event->args;
 		$last_comment = end( $comments );
 
 		// The first batch has the previous_min_is not set.
 		// We user ~0 to denote that the previous min id unknown.
-		$this->assertEquals( $previous_interval_endpoint, '~0' );
+		$this->assertEquals( $previous_interval_end, '~0' );
 
 		$this->full_sync->continue_enqueuing();
 		$this->sender->do_full_sync();
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
-		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
-		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
+		list( $comments, $meta,  $previous_interval_end ) = $event->args;
+		$this->assertEquals( $previous_interval_end, $last_comment->comment_ID );
 		$last_comment = end( $comments );
 
 		$this->full_sync->continue_enqueuing();
 		$this->sender->do_full_sync();
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
-		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
-		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
+		list( $comments, $meta,  $previous_interval_end ) = $event->args;
+		$this->assertEquals( $previous_interval_end, $last_comment->comment_ID );
 
 		$this->full_sync->reset_data();
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1268,6 +1268,42 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( intval( $previous_interval_endpoint ), $last_post->ID );
 	}
 
+	function test_full_sync_sends_previous_min_id_on_comments() {
+		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+		$this->post_id = $this->factory->post->create();
+		for( $i = 0; $i < 25; $i++ ) {
+			$this->factory->comment->create_post_comments( $this->post_id );
+		}
+		// The first event is for sync start...
+		$this->full_sync->start( array( 'comments' => true ) );
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
+		$last_comment = end( $comments );
+
+		// The first batch has the previous_min_is not set.
+		// We user ~0 to denote that the previous min id unknown.
+		$this->assertEquals( $previous_interval_endpoint, '~0' );
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
+		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
+		$last_comment = end( $comments );
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
+		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
+
+	}
+
 	function _do_cron() {
 		$_GET['check'] = wp_hash( '187425' );
 		require( ABSPATH . '/wp-cron.php' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1034,6 +1034,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertSame( null, $full_sync_status['finished'] );
 
 		$this->sender->do_full_sync();
+		$this->sender->do_full_sync(); // juuuust in case
 		$this->sender->do_full_sync(); // juuuust in case - otherwise we use too many bytes for multisite
 
 		$full_sync_status = $this->full_sync->get_status();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1232,7 +1232,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 0, $this->sender->get_full_sync_queue()->size() );
 	}
 
-	function test_full_sync_sends_previous_min_id_on_posts() {
+	function test_full_sync_sends_previous_interval_endpoint_on_posts() {
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		$this->factory->post->create_many( 25 );
@@ -1252,7 +1252,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $previous_interval_endpoint, '~0' );
 
 		// Since posts are order by id and the ids are in decending order
-		// the very last post should be the id with the smallest ID. (Previous_Min_ID)
+		// the very last post should be the id with the smallest ID. ( previous_interval_endpoint )
 		$last_post = end( $posts );
 
 		$this->full_sync->continue_enqueuing();
@@ -1273,7 +1273,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->reset_data();
 	}
 
-	function test_full_sync_sends_previous_min_id_on_comments() {
+	function test_full_sync_sends_previous_interval_endpoint_on_comments() {
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 		$this->post_id = $this->factory->post->create();
 		for( $i = 0; $i < 25; $i++ ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1235,6 +1235,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		$this->factory->post->create_many( 25 );
+
+		// The first event is for full sync start.
 		$this->full_sync->start( array( 'posts' => true ) );
 		$this->sender->do_full_sync();
 
@@ -1276,7 +1278,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		for( $i = 0; $i < 25; $i++ ) {
 			$this->factory->comment->create_post_comments( $this->post_id );
 		}
-		// The first event is for sync start...
+		// The first event is for full sync start.
 		$this->full_sync->start( array( 'comments' => true ) );
 		$this->sender->do_full_sync();
 
@@ -1304,7 +1306,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		list( $comments, $meta,  $previous_interval_endpoint ) = $event->args;
 		$this->assertEquals( $previous_interval_endpoint, $last_comment->comment_ID );
 
-		$this->full_sync->reset_data(); 
+		$this->full_sync->reset_data();
 	}
 
 	function _do_cron() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1254,22 +1254,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( intval( $previous_min_id ), $last_post->ID );
 	}
 
-	function test_full_sync_sends_previous_min_id_on_comments() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 2, 'max_enqueue_full_sync' => 10 ) );
-		$this->post_id = $this->factory->post->create();
-
-		for( $i = 0; $i < 25; $i++ ) {
-			$this->factory->comment->create_post_comments( $this->post_id );
-		}
-
-		$this->full_sync->start( array( 'comments' => true ) );
-
-		$this->sender->do_full_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
-		$this->assetEquals( $event->args[2], '~0');
-	}
-
 	function _do_cron() {
 		$_GET['check'] = wp_hash( '187425' );
 		require( ABSPATH . '/wp-cron.php' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

For clarification purposes note that "posts and commented" include all the different `post_types` (post, pages, revisions, attachments, we actually have a blacklist for this) and `comment types` (comments, ping, trackbacks) that we care about. 

* Adds the previous interval end will allow us to know what the range is in between sync batches allowing us to safely delete the posts during a full sync that do not fall under the full range.

Previously we were sending batch posts and comments during full sync like this. 
`$post_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];`

When we did a full sync we would send the ids in the following order. 

`[12, 11, 10, 9, 8, 7, 6, 5, 4, 3] , [ 2, 1 ] `

Which then would be expanded to the whole post object. 

`[ [ {ID:12, post_title:...}, {ID:12, post_title:...}, ...], [post_meta], [taxonomies] ]`

This PR changes things so that now we also send the previous interval end

`[ [ {ID:12, post_title:...}, {ID:11 post_title:...}, ..., {ID:3, post_title:...}], [post_meta], [taxonomies], *~0* ]`
and then on the next full sync of posts. we would send 
`[ [ {ID:2, post_title:...}, {ID:1, post_title:...} ], [post_meta], [taxonomies], *3* ]`

The same applies to comments. 
Knowing the previous interval end will allows us to determine the full range that we can use to potentially remove deleted posts, comments, and users. 


#### Testing instructions:
- Do the test pass?
- Do a full sync, do full sync post events send the previous interval end as expected?
 - Point your jetpack site to your dotcom sandbox. `define( 'JETPACK__API_BASE', 'https://somethingsomething.wordpress.com/jetpack.' );`
 -  Add the following in your `0-sandbox.php` 
```
// Remote action
add_action( 'jetpack_sync_remote_action', 'testing_sync_log_sync', 10, 9 );

function testing_sync_log_sync( $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id, $token, $actor ) {
	l( $action_name .  ' - blog_id: ' .$token->blog_id )
        l(  $args );
}
```


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
