### PR TITLE
FormToggle Test: Remove an obsolete require()

### DIFF
--- a/_inc/client/components/form/form-toggle/test/index.jsx
+++ b/_inc/client/components/form/form-toggle/test/index.jsx
@@ -3,15 +3,13 @@
  */
 import assert from 'assert';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM, { TestUtils } from 'react-dom';
 import unique from 'lodash/uniq';
 
 /**
  * Internal dependencies
  */
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-
-const TestUtils = ReactDOM.TestUtils;
 
 describe( 'CompactFormToggle', function() {
 	describe( 'rendering', function() {

--- a/_inc/client/components/form/form-toggle/test/index.jsx
+++ b/_inc/client/components/form/form-toggle/test/index.jsx
@@ -13,8 +13,6 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 const TestUtils = ReactDOM.TestUtils;
 
-require( 'lib/react-test-env-setup' )();
-
 describe( 'CompactFormToggle', function() {
 	describe( 'rendering', function() {
 		it( 'should have is-compact class', function() {


### PR DESCRIPTION
Carried over from https://github.com/Automattic/jetpack/pull/11677#discussion_r268968207

> We had a file like that in Calypso once. If it's not in JP, probably safe to remove.

#### Changes proposed in this Pull Request:

* FormToggle Test: Remove an obsolete require()
* FormToggle: Make an import prettier

#### Testing instructions:

`yarn test-client`
Also, `grep react-test-env-setup` to verify it's nowhere else referenced.

#### Proposed changelog entry for your changes:

* N/A
