### PR TITLE
Testimonials shortcode: order by menu_order

### DIFF
--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -531,7 +531,7 @@ class Jetpack_Testimonial {
 			'columns'         => 1,
 			'showposts'       => -1,
 			'order'           => 'asc',
-			'orderby'         => 'date',
+			'orderby'         => 'menu_order,date',
 		), $atts, 'testimonial' );
 
 		// A little sanitization
@@ -558,7 +558,7 @@ class Jetpack_Testimonial {
 		if ( $atts['orderby'] ) {
 			$atts['orderby'] = urldecode( $atts['orderby'] );
 			$atts['orderby'] = strtolower( $atts['orderby'] );
-			$allowed_keys = array('author', 'date', 'title', 'rand');
+			$allowed_keys = array( 'author', 'date', 'title', 'menu_order', 'rand' );
 
 			$parsed = array();
 			foreach ( explode( ',', $atts['orderby'] ) as $testimonial_index_number => $orderby ) {


### PR DESCRIPTION
Testimonials CPT supports `page-attributes` but `[testimonials]` shortcode doesn't allow `menu_order` as a `orderby` possible value nor uses it by default. This PR aims to fix this.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #11118

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Order testimonials by `menu_order` by default (keeping `date` as a second criteria) and add `menu_order` in `$allowed_keys`.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to Dashboard -> Testimonials
1. Click on Add new (create at least 3 different testimonials)
1. In attributes set order 1 to 3
1. Go to the page with `[testimonials]` shortcode


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Testimonials shortcode now orders by `Post Attributes -> Order`
