### PR TITLE
Shortcopy: don't jumpstart Sitemaps since it's already auto activated

### DIFF
--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -7,7 +7,7 @@
  * Requires Connection: No
  * Auto Activate: Public
  * Module Tags: Recommended, Traffic
- * Feature: Recommended, Jumpstart
+ * Feature: Recommended
  * Additional Search Queries: sitemap, traffic, search, site map, seo
  *
  * @package Jetpack


### PR DESCRIPTION
This PR removes Sitemaps from the list of jumpstarted modules. The reason is that Sitemaps is already auto activated on public sites.

See #comment-654 in p9dueE-Au-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Don't jumpstart Sitemaps

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a new Jetpack site. Ensure it's public.
* Connect it
* Verify that Sitemaps is activated

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Not needed. Part of Shortcopy.
