### PR TITLE
svnignore: Remove .babelrc*

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,4 +1,3 @@
-.babelrc*
 .eslintrc.js
 .eslintignore
 .git


### PR DESCRIPTION
Follow-up from https://github.com/Automattic/jetpack/pull/11640#discussion_r269295180

#### Changes proposed in this Pull Request:

Per #10810, there are no more `.babelrc*` files in this repo, so we don't need to `svnignore` them. (It's been replaced by `babel.config.*`, which has already been [added](https://github.com/Automattic/jetpack/blob/7b6c7495020716d3d89fd7b0b8d0f4f3093348bb/.svnignore#L16) to `.svnignore`.)

#### Testing instructions:

Verify that there are no more `.babelrc*` files in the repo.

#### Proposed changelog entry for your changes:

N/A
