### PR TITLE
Slideshow: Fix Javascript Error After Adding Block

### DIFF
--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -68,10 +68,14 @@ class Slideshow extends Component {
 			delay !== prevProps.delay ||
 			images !== prevProps.images
 		) {
-			const realIndex =
-				images.length === prevProps.images.length
-					? this.swiperInstance.realIndex
-					: prevProps.images.length;
+			let realIndex;
+			if ( ! this.swiperIndex ) {
+				realIndex = 0;
+			} else if ( images.length === prevProps.images.length ) {
+				realIndex = this.swiperInstance.realIndex;
+			} else {
+				realIndex = prevProps.images.length;
+			}
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
 			this.buildSwiper( realIndex )
 				.then( swiper => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Fixes a Javascript error that occurs when Slideshow block is first added. 

#### Testing instructions:

- On local instance install Gutenberg plugin (v.5.3 or higher). The issue won't occur without the plugin.
- Check out `master`, then run `yarn && yarn build-extensions`
- Create a new Post, add Slideshow block, choose an image and create a gallery.
- The block should fail with a JS error, as described in https://github.com/Automattic/jetpack/issues/11702
- Check out `fix/slideshow-realindex-error` and repeat the steps above. This time there should be no error.

Fixes https://github.com/Automattic/jetpack/issues/11702