### PR TITLE
First pass of ssh uploader cli command

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1166,6 +1166,72 @@ class Jetpack_CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Allows uploading SSH Credentials to the current site for backups, restores, and security scanning.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--host=<host>]
+	 * : The SSH server's address.
+	 *
+	 * [--user=<user>]
+	 * : The username to use to log in to the SSH server.
+	 *
+	 * [--pass=<pass>]
+	 * : The password used to log in, if using a password. (optional)
+	 * ---
+	 * default:
+	 * ---
+	 *
+	 * [--kpri=<kpri>]
+	 * : The private key used to log in, if using a private key. (optional)
+	 * ---
+	 * default:
+	 * ---
+	 *
+	 * [--pretty]
+	 * : Will pretty print the results of a successful API call.
+	 *
+	 * [--strip-success]
+	 * : Will remove the green success label from successful API calls.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp jetpack call_api --resource='/sites/%d'
+	 */
+	public function upload_ssh_creds( $args, $named_args ) {
+		if ( ! Jetpack::is_active() ) {
+			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
+		}
+
+		if ( empty( $named_args['pass'] ) && empty( $named_args['kpri'] ) ) {
+			WP_CLI::error( __( 'Both `pass` and `kpri` fields cannot be blank.', 'jetpack' ) );
+		}
+
+		$values = array(
+			'credentials' => array(
+				'site_url' => '',
+				'abspath'  => ABSPATH,
+				'protocol' => 'ssh',
+				'port'     => 22,
+				'role'     => 'main',
+				'host'     => $named_args['host'],
+				'user'     => $named_args['user'],
+				'pass'     => empty( $named_args['pass'] ) ? null : $named_args['pass'],
+				'kpri'     => empty( $named_args['kpri'] ) ? null : $named_args['kpri'],
+			),
+		);
+
+		$named_args = wp_parse_args( array(
+			'resource'    => '/activity-log/%d/update-credentials',
+			'method'      => 'POST',
+			'api_version' => '1.1',
+			'body'        => json_encode( $values ),
+		), $named_args );
+
+		self::call_api( $args, $named_args );
+	}
+
+	/**
 	 * API wrapper for getting stats from the WordPress.com API for the current site.
 	 *
 	 * ## OPTIONS

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1204,7 +1204,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		foreach ( $required_args as $arg ) {
-			if ( empty( $arg ) ) {
+			if ( empty( $args[ $arg ] ) ) {
 				WP_CLI::error(
 					sprintf(
 						/* translators: %s is a slug, such as 'host'. */

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1204,7 +1204,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		);
 
 		foreach ( $required_args as $arg ) {
-			if ( empty( $args[ $arg ] ) ) {
+			if ( empty( $named_args[ $arg ] ) ) {
 				WP_CLI::error(
 					sprintf(
 						/* translators: %s is a slug, such as 'host'. */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds CLI command to upload SSH key for current site to WordPress.com for Protect / Rewind / etc

#### Testing instructions:

On a test server, perhaps [JN](https://jurassic.ninja/create?jetpack-beta&branch=add/ssh-cli&wp-debug-log):

- Checkout `add/ssh-cli` of Jetpack
- With a disconnected site, in CLI, run `wp jetpack upload_ssh_creds` and ensure an error is returned
- Connect the site
- Run `wp jetpack upload_ssh_creds --host=example.com` and ensure an error is returned
- Run `wp jetpack upload_ssh_creds --ssh-user=example` and ensure an error is returned
- Run `wp jetpack upload_ssh_creds --host=example.com --ssh-user=example --pass=password` with an incorrect user and/or password and ensure an error is returned
- Run the above with correct credentials and ensure there is a successful response
- Run the above, adding `--strip-success` and ensure that the green `Success:` message from WP-CLI is not printed


#### Proposed changelog entry for your changes:

* Add SSH CLI command for hosting integration support.