### PR TITLE
Repeat Visitor: Fix threshold reset bug

### DIFF
--- a/extensions/blocks/repeat-visitor/components/edit.js
+++ b/extensions/blocks/repeat-visitor/components/edit.js
@@ -34,7 +34,7 @@ class RepeatVisitorEdit extends Component {
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
 		if ( /^\d+$/.test( threshold ) && +threshold > 0 ) {
-			this.props.setAttributes( { threshold, isThresholdValid: true } );
+			this.props.setAttributes( { threshold: +threshold, isThresholdValid: true } );
 			return;
 		}
 		this.props.setAttributes( { isThresholdValid: false } );

--- a/extensions/blocks/repeat-visitor/components/edit.js
+++ b/extensions/blocks/repeat-visitor/components/edit.js
@@ -27,17 +27,18 @@ const RADIO_OPTIONS = [
 ];
 
 class RepeatVisitorEdit extends Component {
-	componentDidMount() {
-		this.props.setAttributes( { isThresholdValid: true } );
-	}
+	state = {
+		isThresholdValid: true,
+	};
 
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
 		if ( /^\d+$/.test( threshold ) && +threshold > 0 ) {
-			this.props.setAttributes( { threshold: +threshold, isThresholdValid: true } );
+			this.props.setAttributes( { threshold: +threshold } );
+			this.setState( { isThresholdValid: true } );
 			return;
 		}
-		this.props.setAttributes( { isThresholdValid: false } );
+		this.setState( { isThresholdValid: false } );
 	};
 
 	getNoticeLabel() {
@@ -77,9 +78,7 @@ class RepeatVisitorEdit extends Component {
 					<TextControl
 						className="wp-block-jetpack-repeat-visitor-threshold"
 						defaultValue={ this.props.attributes.threshold }
-						help={
-							this.props.attributes.isThresholdValid ? '' : __( 'Please enter a valid number.' )
-						}
+						help={ this.state.isThresholdValid ? '' : __( 'Please enter a valid number.' ) }
 						label={ __( 'Visit count threshold' ) }
 						min="1"
 						onChange={ this.setThreshold }

--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -37,6 +37,7 @@
 
 	.components-base-control__help {
 		color: $muriel-hot-red-500;
+		font-size: 13px;
 	}
 }
 

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -27,10 +27,6 @@ export const settings = {
 			type: 'number',
 			default: DEFAULT_THRESHOLD,
 		},
-		isThresholdValid: {
-			type: 'boolean',
-			default: true,
-		},
 	},
 	category: 'jetpack',
 	description: __( 'Control block visibility based on how often a visitor has viewed the page.' ),


### PR DESCRIPTION
Fixes #11718.

#### Changes proposed in this Pull Request:

This casts the threshold attribute value as a number before saving. Previously, it was erroneously being saved as a string.

#### Testing instructions:
0. Spin up a [JN instance](https://jurassic.ninja/create/?gutenpack&branch=fix/repeat-visitor-threshold-persistence).
1. Create a new post and the block.
2. Set the count to anything other than 3.
3. Publish and view the page.
4. Click the edit button on the page to return to the editor.
5. Ensure that your input from (2) has been persisted. 

#### Proposed changelog entry for your changes:

* No changelog necessary.
