### PR TITLE
Simple Payments: pre-populate attributes when converting from classic block

### DIFF
--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -7,7 +7,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { dispatch, withSelect } from '@wordpress/data';
-import { get, isEqual, pick, trimEnd } from 'lodash';
+import { get, isEmpty, isEqual, pick, trimEnd } from 'lodash';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 import {
 	Disabled,
@@ -89,11 +89,13 @@ class SimplePaymentsEdit extends Component {
 		 * When subsequent saves occur, we should avoid injecting attributes so that we do not
 		 * overwrite changes that the user has made with stale state from the previous save.
 		 */
-		if ( ! this.shouldInjectPaymentAttributes ) {
+
+		const { simplePayment } = this.props;
+		if ( ! this.shouldInjectPaymentAttributes || isEmpty( simplePayment ) ) {
 			return;
 		}
 
-		const { attributes, setAttributes, simplePayment } = this.props;
+		const { attributes, setAttributes } = this.props;
 		const {
 			content,
 			currency,

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -412,7 +412,7 @@ class SimplePaymentsEdit extends Component {
 		 * The only disabled state that concerns us is when we expect a product but don't have it in
 		 * local state.
 		 */
-		const isDisabled = productId && ! simplePayment;
+		const isDisabled = productId && isEmpty( simplePayment );
 
 		if ( ! isSelected && isDisabled ) {
 			return (

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -96,29 +96,19 @@ class SimplePaymentsEdit extends Component {
 		}
 
 		const { attributes, setAttributes } = this.props;
-		const {
-			content,
-			currency,
-			email,
-			featuredMediaId,
-			multiple,
-			price,
-			productId,
-			title,
-		} = attributes;
+		const { content, currency, email, featuredMediaId, multiple, price, title } = attributes;
 
-		if ( productId && simplePayment ) {
-			setAttributes( {
-				content: get( simplePayment, [ 'content', 'raw' ], content ),
-				currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),
-				email: get( simplePayment, [ 'meta', 'spay_email' ], email ),
-				featuredMediaId: get( simplePayment, [ 'featured_media' ], featuredMediaId ),
-				multiple: Boolean( get( simplePayment, [ 'meta', 'spay_multiple' ], Boolean( multiple ) ) ),
-				price: get( simplePayment, [ 'meta', 'spay_price' ], price || undefined ),
-				title: get( simplePayment, [ 'title', 'raw' ], title ),
-			} );
-			this.shouldInjectPaymentAttributes = ! this.shouldInjectPaymentAttributes;
-		}
+		setAttributes( {
+			content: get( simplePayment, [ 'content', 'raw' ], content ),
+			currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),
+			email: get( simplePayment, [ 'meta', 'spay_email' ], email ),
+			featuredMediaId: get( simplePayment, [ 'featured_media' ], featuredMediaId ),
+			multiple: Boolean( get( simplePayment, [ 'meta', 'spay_multiple' ], Boolean( multiple ) ) ),
+			price: get( simplePayment, [ 'meta', 'spay_price' ], price || undefined ),
+			title: get( simplePayment, [ 'title', 'raw' ], title ),
+		} );
+
+		this.shouldInjectPaymentAttributes = ! this.shouldInjectPaymentAttributes;
 	}
 
 	toApi() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
It populates rightly the product properties gotten from the data/response when it comes from a shortcode transformation.

Fixes https://github.com/Automattic/wp-calypso/issues/29870

#### Testing instructions:
1. Get a post with a "Simple Payment Button". If it doesn't exist just create it:
a. Get the product ID (inspect the dom tree trying to find the ID, or inspect the XHR request from the network tab)
b. Once you get the product ID, create a new `Classic` block with the Simple Payments shortcode:
```
[simple-payment id="<product-id"]
```
![image](https://user-images.githubusercontent.com/77539/55110362-a2f8e000-50b6-11e9-9bfc-5b92a7db96cf.png)

2. Convert to Blocks
![image](https://user-images.githubusercontent.com/77539/55110540-fec36900-50b6-11e9-8138-aa263d6aa515.png)

3. Once it's converted it should populate the fields with the right data.
![populate-simple-payments](https://user-images.githubusercontent.com/77539/55112327-1e5c9080-50bb-11e9-8317-8b8f909b3bb8.gif)

#### Proposed changelog entry for your changes:

Simple Payments Button: Convert classic Blocks (shortcode) rightly.
