### PR TITLE
Docker docs: include all relevant Ngrok regions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -238,11 +238,9 @@ If you are an Automattician, sign up on Ngrok.com using your a8c Google account;
 
 Once you’ve done that, follow [these steps](https://ngrok.com/download) to download and set up ngrok. However, instead of step four, edit your [config file](https://ngrok.com/docs#default-config-location) as explained below:
 
-
-
 ```
 authtoken: YOUR_AUTH_TOKEN # This should already be here
-region: eu # only needed for subdomains in Europe
+region: eu # only needed for subdomains in Europe (eu), Asia/Pacific (ap) or Australia (au)
 tunnels:
   jetpack:
     subdomain: YOUR_RESERVED_SUBDOMAIN # without the .ngrok.io


### PR DESCRIPTION
I set up a Docker instance for Jetpack today, including Ngrok.

During the Ngrok setup process, the docs included an example containing: 

```
region: eu # only needed for subdomains in Europe
```

Ngrok also offers subdomains in Asia/Pacific and Australia. My Ngrok domain is in Australia and `au` needs to be specified in that case.

#### Changes proposed in this Pull Request:

Adds Asia/Pacific and Australia to the example.
