### PR TITLE
Fix empty term description update

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
@@ -182,7 +182,7 @@ class WPCOM_JSON_API_Update_Term_Endpoint extends WPCOM_JSON_API_Taxonomy_Endpoi
 			$update['parent'] = $input['parent'];
 		}
 
-		if ( ! empty( $input['description'] ) ) {
+		if ( isset( $input['description'] ) ) {
 			$update['description'] = addslashes( $input['description'] );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/26033

#### Changes proposed in this Pull Request:

Uses `isset()` instead of `! empty()` to detect term `description` update argument.

*

#### Testing instructions:

1. Starting at URL: https://wordpress.com/settings/taxonomies/category/
2. Click on a category.
3. Delete the description inside.
4. Click on Update.
5. Click on the category again to see if changes were saved. (they weren't)

#### Proposed changelog entry for your changes:

- Change term description to empty string.

*
