### PR TITLE
Change i18n fallback format

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2604,12 +2604,7 @@ class Jetpack {
 		}
 
 		// Return valid empty Jed locale
-		return json_encode( array(
-			'' => array(
-				'domain' => 'jetpack',
-				'lang'   => is_admin() ? get_user_locale() : get_locale(),
-			),
-		) );
+		return '{ "locale_data": { "messages": { "": {} } } }';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11722 

## Question?

Should we return something falsey and let the caller handle fallbacks? That should work well with core as @kwight mentioned: https://github.com/Automattic/jetpack/issues/11722#issuecomment-477348957.

Our [consuming functions](https://github.com/Automattic/jetpack/blob/bd4740e8f8c0c06247f6097d2258b6c16d7b4bbb/class.jetpack.php#L2630-L2639) could be adapted without much difficulty

#### Changes proposed in this Pull Request:

* Update the i18n fallback JSON format to align with WordPress core:

https://github.com/WordPress/WordPress/blob/ffc064d82d3f8bf7441aa7b1634ddaba9293857f/wp-includes/class.wp-scripts.php#L542-L547

#### Testing instructions:

* Verify that #11722 cannot be reproduced on this branch (with missing translation files).
* Verify that this will not break any current usage:

https://github.com/Automattic/jetpack/blob/bd4740e8f8c0c06247f6097d2258b6c16d7b4bbb/class.jetpack-gutenberg.php#L639

https://github.com/Automattic/jetpack/blob/bd4740e8f8c0c06247f6097d2258b6c16d7b4bbb/class.jetpack.php#L2630-L2639

https://github.com/Automattic/jetpack/blob/bd4740e8f8c0c06247f6097d2258b6c16d7b4bbb/_inc/lib/admin-pages/class.jetpack-react-page.php#L312

You can likely reproduce #11722 in any of these cases — WP Admin Jetpack dashboard, editor with Jetpack blocks, localized Jetpack blocks on the frontend (?)— and no longer reproduced them on this branch.

#### Proposed changelog entry for your changes:

* Not sure?
