### PR TITLE
Add (beta) to beta extensions

### DIFF
--- a/extensions/utils/register-jetpack-block.js
+++ b/extensions/utils/register-jetpack-block.js
@@ -6,7 +6,10 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import extensionList from '../setup/index.json';
 import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
+
+const betaExtensions = extensionList.beta || [];
 
 /**
  * Registers a gutenberg block if the availability requirements are met.
@@ -18,9 +21,8 @@ import getJetpackExtensionAvailability from './get-jetpack-extension-availabilit
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
 	const { available, unavailableReason } = getJetpackExtensionAvailability( name );
-	const unavailable = ! available;
 
-	if ( unavailable ) {
+	if ( ! available ) {
 		if ( 'production' !== process.env.NODE_ENV ) {
 			// eslint-disable-next-line no-console
 			console.warn(
@@ -30,7 +32,12 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 		return false;
 	}
 
-	const result = registerBlockType( `jetpack/${ name }`, settings );
+	const result = registerBlockType(
+		`jetpack/${ name }`,
+		betaExtensions.includes( name )
+			? { ...settings, title: `${ settings.title } (beta)` }
+			: settings
+	);
 
 	// Register child blocks. Using `registerBlockType()` directly avoids availability checks -- if
 	// their parent is available, we register them all, without checking for their individual availability.


### PR DESCRIPTION
Appends ` (beta)` to beta block titles. The appended string is not localized.

We had this in Calypso and it was a nice addition.

## Screens

### Before

![Screen Shot 2019-03-28 at 14 02 44](https://user-images.githubusercontent.com/841763/55159817-2f141180-5162-11e9-97b8-354301ac7032.png)


### After

![Screen Shot 2019-03-28 at 13 59 19](https://user-images.githubusercontent.com/841763/55159705-f83dfb80-5161-11e9-8257-55a5edaf19ac.png)

#### Testing instructions:

* Open the block editor
* Open the inserter
* Scroll through blocks looking for beta (VR)
* Is ` (beta)` appended? all good?

#### Proposed changelog entry for your changes:

* None
