### PR TITLE
jshint: ignore folders 

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -8,5 +8,8 @@ modules/shortcodes/js/jquery.cycle.min.js
 modules/theme-tools/responsive-videos/responsive-videos.min.js
 modules/**/test-*.js
 
+_inc/client/**
+extensions/**
+
 todo:
 modules/infinite-scroll/infinity.js


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
It makes JSHint analyzer ignores for the `_inc/blocks` and `./extensions/blocks` folders, avoiding getting warnings for code written in ECMAScript 6.

#### Testing instructions:
Before to apply the patch confirm that code written in ECMAScript 6 gets some warnings. You can pick up a file either from `./extensions/blocks/` or `_inc/client folders`.

![image](https://user-images.githubusercontent.com/77539/55162134-e8b0b980-5145-11e9-8e76-ae2ef3292f7d.png)

After applying the patch those warnings should not be there anymore.
 
#### Proposed changelog entry for your changes:
?
