### PR TITLE
Blocks: Remove Availability Fallback for Beta Blocks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -360,34 +360,7 @@ class Jetpack_Gutenberg {
 			}
 		}
 
-		$unwhitelisted_blocks  = array();
-		$all_registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
-		foreach ( $all_registered_blocks as $block_name => $block_type ) {
-			if ( ! wp_startswith( $block_name, 'jetpack/' ) || isset( $block_type->parent ) ) {
-				continue;
-			}
-
-			$unprefixed_block_name = self::remove_extension_prefix( $block_name );
-
-			if ( in_array( $unprefixed_block_name, self::$extensions, true ) ) {
-				continue;
-			}
-
-			$unwhitelisted_blocks[ $unprefixed_block_name ] = array(
-				'available'          => false,
-				'unavailable_reason' => 'not_whitelisted',
-			);
-		}
-
-		// Finally: Unwhitelisted non-block extensions. These are in $availability.
-		$unwhitelisted_extensions = array_fill_keys(
-			array_diff( array_keys( self::$availability ), self::$extensions ),
-			array(
-				'available'          => false,
-				'unavailable_reason' => 'not_whitelisted',
-			)
-		);
-		return array_merge( $available_extensions, $unwhitelisted_blocks, $unwhitelisted_extensions );
+		return $available_extensions;
 	}
 
 	/**

--- a/extensions/utils/get-jetpack-extension-availability.js
+++ b/extensions/utils/get-jetpack-extension-availability.js
@@ -1,20 +1,15 @@
 /**
  * External dependencies
  */
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import extensionSlugsJson from '../setup/index.json';
 import getJetpackData from './get-jetpack-data';
 
 /**
  * Return whether a Jetpack Gutenberg extension is available or not.
- *
- * Defaults to `false` for production blocks, and to `true` for beta blocks.
- * This is to make it easier for folks to write their first block without needing
- * to touch the server side.
  *
  * @param {string} name The extension's name (without the `jetpack/` prefix)
  * @returns {object} Object indicating if the extension is available (property `available`) and the reason why it is
@@ -22,8 +17,7 @@ import getJetpackData from './get-jetpack-data';
  */
 export default function getJetpackExtensionAvailability( name ) {
 	const data = getJetpackData();
-	const defaultAvailability = includes( extensionSlugsJson.beta, name );
-	const available = get( data, [ 'available_blocks', name, 'available' ], defaultAvailability );
+	const available = get( data, [ 'available_blocks', name, 'available' ], false );
 	const unavailableReason = get(
 		data,
 		[ 'available_blocks', name, 'unavailable_reason' ],

--- a/tests/php/test_class.jetpack-gutenberg.php
+++ b/tests/php/test_class.jetpack-gutenberg.php
@@ -90,8 +90,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
 		jetpack_register_block( 'jetpack/durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertFalse( $availability['durian']['available'], 'durian is available!' );
-		$this->assertEquals( $availability['durian']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
+		$this->assertArrayNotHasKey( 'durian', $availability, 'durian is available!' );
 	}
 
 	function test_block_is_not_available_when_not_registered_returns_missing_module() {
@@ -119,8 +118,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	function test_registered_plugin_is_not_available_when_not_defined_in_whitelist() {
 		Jetpack_Gutenberg::set_extension_available( 'jetpack/parsnip' );
 		$availability = Jetpack_Gutenberg::get_availability();
-		$this->assertFalse( $availability['parsnip']['available'], 'parsnip is available!' );
-		$this->assertEquals( $availability['parsnip']['unavailable_reason'], 'not_whitelisted', 'unavailable_reason is not "not_whitelisted"' );
+		$this->assertArrayNotHasKey( 'parsnip', $availability, 'parsnip is available!' );
 
 	}
 


### PR DESCRIPTION
Fixes #11738

#### Changes proposed in this Pull Request:

Blocks: Remove Availability Fallback for Beta Blocks

Remove logic that added unwhitelisted blocks (and plugins) to the availability endpoint (with reason `not_whitelisted`).
The rationale for this was to enable developers to more quickly write blocks in Calypso without needing to set that block's availability on the server side (in the Jetpack repo) -- by enabling beta blocks by default, as long as they're not explicitly set as unavailable in the availability endpoint's response.

Now that we can simply add a new block's availability in the same PR as we add the client-side code, this mechanism is obsolete, and we can remove it.

#### Testing instructions:

- Verify that when beta blocks are turned off, they really don't show up in the block picker (same for plugins in the Jetpack sidebar)
- Verify that they do show up when switched on.

#### Proposed changelog entry for your changes:

Blocks: Remove availability fallback for beta blocks, and no longer include non-whitelisted blocks in the availability endpoint's response.