### PR TITLE
At a glance: improve Rewind messages in Scan and Backups cards

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -74,17 +74,18 @@ class AtAGlance extends Component {
 				<DashConnections />
 			</div>
 		);
-		const isRewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
+		// Status can be unavailable, active, provisioning, awaiting_credentials
+		const rewindStatus = get( this.props.rewindStatus, [ 'state' ], '' );
 		const securityCards = [
 			<DashScan
 				{ ...settingsProps }
 				siteRawUrl={ this.props.siteRawUrl }
-				isRewindActive={ isRewindActive }
+				rewindStatus={ rewindStatus }
 			/>,
 			<DashBackups
 				{ ...settingsProps }
 				siteRawUrl={ this.props.siteRawUrl }
-				isRewindActive={ isRewindActive }
+				rewindStatus={ rewindStatus }
 			/>,
 			<DashAkismet { ...urls } />,
 			<DashPluginUpdates { ...settingsProps } { ...urls } />,
@@ -98,7 +99,7 @@ class AtAGlance extends Component {
 		}
 
 		// Maybe add the rewind card
-		isRewindActive &&
+		'active' === rewindStatus &&
 			securityCards.unshift(
 				<DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
 			);

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -103,12 +103,23 @@
 	.dops-banner__icon-circle {
 		background: none !important;
 		padding: 0 0 0 3px;
-	}
 
-	svg.gridicon.gridicons-checkmark-circle {
-		width: 28px;
-		height: 28px;
-		color: #4ab866;
+		svg.gridicon {
+			width: 28px;
+			height: 28px;
+
+			&.gridicons-info {
+				color: $blue-wordpress;
+			}
+
+			&.gridicons-notice {
+				color: $alert-yellow;
+			}
+
+			&.gridicons-checkmark-circle {
+				color: $alert-green;
+			}
+		}
 	}
 
 	.dops-banner__description {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
@@ -28,6 +28,7 @@ import {
 	isFetchingAkismetData,
 } from 'state/at-a-glance';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
+import { getRewindStatus } from 'state/rewind';
 
 /**
  * Track click on Pro status badge.
@@ -58,12 +59,37 @@ class ProStatus extends React.Component {
 	static propTypes = {
 		isCompact: PropTypes.bool,
 		proFeature: PropTypes.string,
+
+		// Connected
+		rewindStatus: PropTypes.object.isRequired,
 	};
 
 	static defaultProps = {
 		isCompact: true,
 		proFeature: '',
 	};
+
+	getRewindMessage() {
+		switch ( this.props.rewindStatus.state ) {
+			case 'provisioning':
+				return {
+					status: 'is-info',
+					text: __( 'Setting up' ),
+				};
+			case 'awaiting_credentials':
+				return {
+					status: 'is-warning',
+					text: __( 'Action needed' ),
+				};
+			case 'active':
+				return {
+					status: 'is-success',
+					text: __( 'Connected' ),
+				};
+			default:
+				return { status: '', text: '' };
+		}
+	}
 
 	getProActions = ( type, feature ) => {
 		let status = '',
@@ -117,9 +143,10 @@ class ProStatus extends React.Component {
 				actionUrl = this.props.siteAdminUrl + 'admin.php?page=akismet-key-config';
 				break;
 			case 'rewind_connected':
+				const rewindMessage = this.getRewindMessage();
 				return (
-					<SimpleNotice showDismiss={ false } status="is-success" isCompact>
-						{ __( 'Connected' ) }
+					<SimpleNotice showDismiss={ false } status={ rewindMessage.status } isCompact>
+						{ rewindMessage.text }
 					</SimpleNotice>
 				);
 			case 'active':
@@ -284,5 +311,6 @@ export default connect( state => {
 		fetchingAkismetData: isFetchingAkismetData( state ),
 		paidFeatureUpgradeUrl: getUpgradeUrl( state, 'upgrade' ),
 		planProUpgradeUrl: getUpgradeUrl( state, 'plans-business' ),
+		rewindStatus: getRewindStatus( state ),
 	};
 } )( ProStatus );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
 import get from 'lodash/get';
+import includes from 'lodash/includes';
 import Banner from 'components/banner';
 
 /**
@@ -18,7 +20,6 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { getVaultPressData, getVaultPressScanThreatCount } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
-import includes from 'lodash/includes';
 import { isModuleActivated } from 'state/modules';
 import { showBackups } from 'state/initial-state';
 
@@ -49,21 +50,65 @@ class LoadingCard extends Component {
 }
 
 class BackupsScanRewind extends Component {
+	static propTypes = {
+		isDevMode: PropTypes.bool,
+		siteRawUrl: PropTypes.string,
+		rewindState: PropTypes.string,
+	};
+
+	static defaultProps = {
+		isDevMode: false,
+		siteRawUrl: '',
+		rewindState: '',
+	};
+
+	getRewindMessage() {
+		const { siteRawUrl, rewindState } = this.props;
+
+		switch ( rewindState ) {
+			case 'provisioning':
+				return {
+					title: __( 'Provisioning' ),
+					icon: 'info',
+					description: __( 'Backups and Scan are being configured for your site.' ),
+					url: '',
+				};
+			case 'awaiting_credentials':
+				return {
+					title: __( 'Action needed' ),
+					icon: 'notice',
+					description: __(
+						'You need to enter your server credentials to finish configuring Backups and Scan.'
+					),
+					url: 'https://wordpress.com/settings/security/' + siteRawUrl,
+				};
+			case 'active':
+				return {
+					title: __( 'Active' ),
+					icon: 'checkmark-circle',
+					description: __(
+						'Your site is being backed up in real time and regularly scanned for security threats.'
+					),
+					url: 'https://wordpress.com/activity-log/' + siteRawUrl,
+				};
+		}
+	}
+
 	getCardText = () => {
 		if ( this.props.isDevMode ) {
 			return __( 'Unavailable in Dev Mode.' );
 		}
 
+		const { title, icon, description, url } = this.getRewindMessage();
+
 		return (
 			<Banner
-				title={ __( 'Connected' ) }
-				icon="checkmark-circle"
+				title={ title }
+				icon={ icon }
 				feature={ 'rewind' }
-				description={ __(
-					'Your site is being backed up in real time and regularly scanned for security threats.'
-				) }
+				description={ description }
 				className="is-upgrade-premium jp-banner__no-border"
-				href={ 'https://wordpress.com/activity-log/' + this.props.siteRawUrl }
+				href={ url }
 			/>
 		);
 	};
@@ -171,8 +216,8 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				[ 'data', 'features', 'security' ],
 				false
 			);
-			const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false );
-			const hasRewindData = false !== get( this.props.rewindStatus, [ 'state' ], false );
+			const rewindState = get( this.props.rewindStatus, [ 'state' ], false );
+			const hasRewindData = false !== rewindState;
 			const hasVpData =
 				this.props.vaultPressData !== 'N/A' &&
 				false !== get( this.props.vaultPressData, [ 'data' ], false );
@@ -181,8 +226,9 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				return <LoadingCard />;
 			}
 
-			if ( rewindActive ) {
-				return <BackupsScanRewind { ...this.props } />;
+			// Rewind is working in this site.
+			if ( includes( [ 'provisioning', 'awaiting_credentials', 'active' ], rewindState ) ) {
+				return <BackupsScanRewind { ...this.props } rewindState={ rewindState } />;
 			}
 
 			return (

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -75,7 +75,7 @@ class BackupsScanRewind extends Component {
 				};
 			case 'awaiting_credentials':
 				return {
-					title: __( 'Action needed' ),
+					title: __( 'Awaiting credentials' ),
 					icon: 'notice',
 					description: __(
 						'You need to enter your server credentials to finish configuring Backups and Scan.'


### PR DESCRIPTION
This PR updates the Scan and Backup cards in At a Glance to provide more info about Rewind during its different states: `provisioning`, `awaiting_credentials`, `active`. In this cases the user will get a meaningful message and will be taken to either Activity Log or the Security area in Settings to enter their credentials.
When Rewind is `unavailable`, it's because VaultPress is working. In such case, the legacy VP content will be displayed.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #11727

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* refactor Scan and Backups cards in At a Glance in Jetpack dashboard.
* discard `isRewindActive` property since it was useless for this purpose
* introduce `rewindState` so we can have all the states in Backups and Scan cards
* create new methods to generate the proper content when Rewind is working

## provisioning
<img width="1081" alt="Captura de pantalla 2019-04-01 a la(s) 14 35 48" src="https://user-images.githubusercontent.com/1041600/55347707-c55e7500-548b-11e9-90a5-0425c1ea69de.png">

## awaiting_credentials
<img width="1069" alt="Captura de pantalla 2019-04-01 a la(s) 14 35 57" src="https://user-images.githubusercontent.com/1041600/55347710-c7283880-548b-11e9-8a5d-7f55cee9ae6b.png">

## active
<img width="1067" alt="Captura de pantalla 2019-04-01 a la(s) 14 35 31" src="https://user-images.githubusercontent.com/1041600/55347692-bc6da380-548b-11e9-8d0a-28a5338f0862.png">

# Security tab
_________________

<img width="1013" alt="Captura de pantalla 2019-04-01 a la(s) 18 00 42" src="https://user-images.githubusercontent.com/1041600/55360059-b4246100-54a9-11e9-9e0b-e751cd44f5d9.png">
<img width="1049" alt="Captura de pantalla 2019-04-01 a la(s) 18 28 42" src="https://user-images.githubusercontent.com/1041600/55360927-24cc7d00-54ac-11e9-9747-d92f5d9b795e.png">
<img width="1046" alt="Captura de pantalla 2019-04-01 a la(s) 18 29 09" src="https://user-images.githubusercontent.com/1041600/55360928-24cc7d00-54ac-11e9-8c2c-b964623bff03.png">


#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a new Jetpack site
* add a Professional plan
* activate Rewind for this site in VP dashboard
* verify that At a glance shows the correct messages depending on the Rewind states. For this, you can use the Dev Tools at the bottom

<img width="288" alt="Captura de pantalla 2019-03-29 a la(s) 16 05 01" src="https://user-images.githubusercontent.com/1041600/55256684-6f47c280-523c-11e9-9e22-6ab6ae01ef58.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Scan and Backups cards in Jetpack dashboard now show more meaningful messages concerning your security scans or backups.
