### PR TITLE
Repeat Visitor: Clarify visibility criteria

### DIFF
--- a/extensions/blocks/repeat-visitor/components/edit.js
+++ b/extensions/blocks/repeat-visitor/components/edit.js
@@ -44,8 +44,8 @@ class RepeatVisitorEdit extends Component {
 		if ( this.props.attributes.criteria === CRITERIA_AFTER ) {
 			return sprintf(
 				_n(
-					'This block will only appear to people who have visited this page at least once.',
-					'This block will only appear to people who have visited this page at least %d times.',
+					'This block will only appear to people who have visited this page more than once.',
+					'This block will only appear to people who have visited this page more than %d times.',
 					+this.props.attributes.threshold
 				),
 				this.props.attributes.threshold
@@ -54,8 +54,8 @@ class RepeatVisitorEdit extends Component {
 
 		return sprintf(
 			_n(
-				'This block will only appear to people who have never visited this page before.',
-				'This block will only appear to people who have visited this page less than %d times.',
+				'This block will only appear to people who are visiting this page for the first time.',
+				'This block will only appear to people who have visited this page at most %d times.',
 				+this.props.attributes.threshold
 			),
 			this.props.attributes.threshold

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -31,7 +31,7 @@ function jetpack_repeat_visitor_block_render( $attributes, $content ) {
 
 	if (
 		( 'after-visits' === $criteria && $count >= $threshold ) ||
-		( 'before-visits' === $criteria && $count <= $threshold )
+		( 'before-visits' === $criteria && $count < $threshold )
 	) {
 		return $content;
 	}


### PR DESCRIPTION
During testing, some users mentioned that the wording around thresholds in the Repeat Visitor block could be clearer:

>Issue 1: The text of the block indicates "more than X" and "less than X", but it seems the behavior is more or equal or less and equal.
> Could we clarify the language?

Partly addresses #11748.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Text changes only. Improve how we describe the number of visits required to show the content.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Create a new Repeat Visitor block in the editor.
Experiment with the threshold and ensure that the text in the notice box underneath makes sense.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

No changelog entry needed.
