### PR TITLE
Ads Gutenblock: Fix for loading blocks on infinite scroll

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -99,15 +99,10 @@ class WordAds {
 	 * @since 4.5.0
 	 */
 	function init() {
-		// bail on infinite scroll
-		if ( self::is_infinite_scroll() ) {
-			return;
-		}
-
 		require_once WORDADS_ROOT . '/php/params.php';
 		$this->params = new WordAds_Params();
 
-		if ( $this->should_bail() ) {
+		if ( $this->should_bail() || self::is_infinite_scroll() ) {
 			return;
 		}
 
@@ -476,7 +471,7 @@ HTML;
 			'width'    => $width,
 			'height'   => $height,
 		);
-		$ad_number   = count( $this->ads );
+		$ad_number   = count( $this->ads ) . '-' . uniqid();
 
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
 		$css = esc_attr( $css );


### PR DESCRIPTION
Turns out the ad blocks have a potential to have bad interactions w/ infinite scroll (e.g. preventing new posts from being loaded). This will ensure the blocks don't prevent infinite scrolling and will also allow the new ad units to populate after being added.

#### Changes proposed in this Pull Request:
* Fix for loading ad blocks via infinite scroll

#### Testing instructions:
* Activate Ads module
* Turn on infinite scroll and change to a theme that supports it (e.g. Twenty*)
* Create a few posts with Ads blocks such that they will appear after the infinite scroller grabs new posts.
* See the ad units appear and there are no problem loading the new posts.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No entry needed
