### PR TITLE
Repeat Visitor: swap 'traffic' for 'return' in block keywords

### DIFF
--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -32,7 +32,7 @@ export const settings = {
 	description: __( 'Control block visibility based on how often a visitor has viewed the page.' ),
 	icon,
 	keywords: [
-		_x( 'traffic', 'block search term' ),
+		_x( 'return', 'block search term' ),
 		_x( 'visitors', 'block search term' ),
 		_x( 'visibility', 'block search term' ),
 	],


### PR DESCRIPTION
During beta testing, we received feedback that "return" was a good keyword for the block.

Fixes #11749.

#### Changes proposed in this Pull Request:

This PR replaces "traffic" with "return" in the block keywords.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add a new block to a post. 
Search using the keyword 'return'. 
Repeat Visitor should be presented as an option.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

No changelog entry required.