### PR TITLE
Masterbar: Hide for WordPress mobile apps

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -32,7 +32,8 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		// Don't show the masterbar on WordPress mobile apps.
-		if ( preg_match( '/wp-(android|iphone)/', $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
+			add_filter( 'show_admin_bar', '__return_false' );
 			return;
 		}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -31,6 +31,11 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
+		// Don't show the masterbar on WordPress mobile apps.
+		if ( preg_match( '/wp-(android|iphone)/', $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return;
+		}
+
 		Jetpack::dns_prefetch( array(
 			'//s0.wp.com',
 			'//s1.wp.com',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/31157

#### Changes proposed in this Pull Request:

Prevents the Masterbar from showing up on mobile apps. The aim of this change is to prevent users from navigating to pages they can access through the app.

This implementation relies on the fact that we can identify requests coming from the WP mobile apps by checking that the user agent contains `wp-iphone` ([iOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/4ac54edd8c4db2978a0122f97e137c755e627d4a/WordPress/Classes/Utility/WPUserAgent.m#L33-L43)) or `wp-android` ([Android](https://github.com/wordpress-mobile/WordPress-iOS/blob/4ac54edd8c4db2978a0122f97e137c755e627d4a/WordPress/Classes/Utility/WPUserAgent.m#L33-L43)).

#### Testing instructions:

* Spin up a new JN site using this branch: https://jurassic.ninja/create/?jetpack-beta&branch=update/masterbar-hide-mobile-app&shortlived
* Connect the site to WordPress.com
* Go to Jetpack → Settings → Writing and activate the "WordPress.com toolbar" module.
* Note how the Masterbar shows up.
<img width="552" alt="Screen Shot 2019-03-29 at 12 56 03" src="https://user-images.githubusercontent.com/1233880/55208619-2a169700-5222-11e9-83ff-51b6f0f48b82.png">

* Use a fake user agent that contains either `wp-iphone` or `wp-android`:
  * iOS example: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wp-iphone/12.1`.
  * Android example: `Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/4.7`.
  * On Chrome you can do this using the Network conditions on the browser devtools:
<img width="404" alt="Screen Shot 2019-03-28 at 13 01 49" src="https://user-images.githubusercontent.com/1233880/55129228-ab562700-5159-11e9-9a75-d05cfe97b65e.png">
<img width="900" alt="Screen Shot 2019-03-28 at 13 02 45" src="https://user-images.githubusercontent.com/1233880/55129288-df314c80-5159-11e9-8278-f14471c9eb2f.png">

* Reload the page.
* Make sure the Masterbar doesn't show up now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Masterbar: Hide for WordPress mobile apps
