### PR TITLE
Tests: Jetpack_Post_Images, get urls from attachments

### DIFF
--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -75,27 +75,32 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 3.2
 	 */
 	public function test_from_attachment_is_correct_array() {
-		$img_name = 'image.jpg';
-		$alt_text = 'Alt Text.';
-		$img_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . $img_name;
-		$img_html = '<img src="' . $img_url . '" width="250" height="250" alt="' . $alt_text . '"/>';
+		$img_name       = 'image.jpg';
+		$alt_text       = 'Alt Text.';
 		$img_dimensions = array( 'width' => 250, 'height' => 250 );
 
-		$post_id = $this->factory->post->create( array(
-			'post_content' => $img_html,
-		) );
+		$post_id       = $this->factory->post->create();
 		$attachment_id = $this->factory->attachment->create_object( $img_name, $post_id, array(
 			'post_mime_type' => 'image/jpeg',
-			'post_type' => 'attachment',
+			'post_type'      => 'attachment',
 		) );
 		wp_update_attachment_metadata( $attachment_id, $img_dimensions );
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
 
+		$img_url  = wp_get_attachment_url( $attachment_id );
+		$img_html = '<img src="' . $img_url . '" width="250" height="250" alt="' . $alt_text . '"/>';
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $img_html
+			) );
+
 		$images = Jetpack_PostImages::from_attachment( $post_id );
 
-		$this->assertEquals( count( $images ), 1 );
-		$this->assertEquals( $images[ 0 ][ 'src' ], $img_url );
-		$this->assertEquals( $alt_text, $images[ 0 ][ 'alt_text' ] );
+		$this->assertEquals( 1, count( $images ) );
+		$this->assertEquals( $img_url, $images[0]['src'] );
+		$this->assertEquals( $alt_text, $images[0]['alt_text'] );
 	}
 
 	/**
@@ -110,18 +115,19 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * }
 	 */
 	protected function get_post_with_image_block() {
-		$img_name = 'image.jpg';
-		$alt_text = 'Alt Text.';
-		$img_url  = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . $img_name;
+		$img_name       = 'image.jpg';
+		$alt_text       = 'Alt Text.';
 		$img_dimensions = array( 'width' => 250, 'height' => 250 );
 
-		$post_id = $this->factory->post->create();
+		$post_id       = $this->factory->post->create();
 		$attachment_id = $this->factory->attachment->create_object( $img_name, $post_id, array(
 			'post_mime_type' => 'image/jpeg',
-			'post_type' => 'attachment'
+			'post_type'      => 'attachment'
 		) );
 		wp_update_attachment_metadata( $attachment_id, $img_dimensions );
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+		$img_url = wp_get_attachment_url( $attachment_id );
 
 		// Create another post with that picture.
 		$post_html = sprintf(
@@ -129,6 +135,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 			$img_url,
 			$attachment_id
 		);
+
 		$second_post_id = $this->factory->post->create( array(
 			'post_content' => $post_html,
 		) );
@@ -175,8 +182,8 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 
 		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
 
-		$this->assertEquals( $images[ 0 ][ 'src' ], $post_info['img_url'] );
-		$this->assertEquals( $images[ 0 ][ 'alt_text' ], $post_info['alt_text'] );
+		$this->assertEquals( $post_info['img_url'], $images[ 0 ][ 'src' ] );
+		$this->assertEquals( $post_info['alt_text'], $images[ 0 ][ 'alt_text' ] );
 	}
 
 	/**
@@ -227,7 +234,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 			wp_update_attachment_metadata( $attachment_id, $img_dimensions );
 
 			// Update our array to store attachment IDs. We'll need them later.
-			$img_urls[ $attachment_id ] = $img_url;
+			$img_urls[ $attachment_id ] = wp_get_attachment_url( $attachment_id );
 			unset( $img_urls[ $img_name ] );
 		}
 


### PR DESCRIPTION
Under some configurations attachment urls get changed on save.
We can't assume the url will be the given one on creation.


#### Testing instructions:
Do tests still pass?