### PR TITLE
Sync: Full Sync users with previous_end

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -429,9 +429,18 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function expand_users( $args ) {
-		$user_ids = $args[0];
+		list( $user_ids, $previous_end ) = $args;
 
-		return array_map( array( $this, 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );
+		return array(
+			'users' => array_map( array( $this, 'sanitize_user_and_expand' ), get_users(
+				array(
+					'include' => $user_ids,
+					'orderby' => 'ID',
+					'order' => 'DESC'
+				)
+			) ),
+			'previous_end' => $previous_end
+		);
 	}
 
 	public function remove_user_from_blog_handler( $user_id, $blog_id ) {

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -207,7 +207,8 @@ class Jetpack_Sync_Server_Replicator {
 				}
 				break;
 			case 'jetpack_full_sync_users':
-				foreach ( $args as $user ) {
+
+				foreach ( $args['users'] as $user ) {
 					$this->store->upsert_user( $user );
 				}
 				break;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -971,8 +971,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$users = $synced_users_event->args['users'];
 
 		$this->assertEquals( 2, count( $users ) );
-		$this->assertEquals( $sync_user_id, $users[0]->ID );
-		$this->assertEquals( $sync_user_id_2, $users[1]->ID );
+		// The users are ordered in reverse order now.
+		$this->assertEquals( $sync_user_id_2, $users[0]->ID );
+		$this->assertEquals( $sync_user_id, $users[1]->ID );
 
 		$sync_status = $this->full_sync->get_status();
 		$this->assertEquals( array( $sync_user_id, $sync_user_id_2 ), $sync_status['config']['users'] );
@@ -1035,7 +1036,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$users = $synced_users_event->args['users'];
 
 		$this->assertEquals( $existing_user_count+1, count( $users ) );
-		$this->assertEquals( $keep_user_id, $users[ $existing_user_count ]->ID );
+		// the last created user should be the fist sent out.
+		$this->assertEquals( $keep_user_id, $users[ 0 ]->ID );
 	}
 
 	function test_full_sync_has_correct_sent_count_even_if_some_actions_unsent() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -242,6 +242,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		
 		$this->assertEquals( intval( $previous_interval_end ), $last_user->ID );
 
+		Jetpack_Sync_Settings::reset_data();
 		$this->full_sync->reset_data();
 
 	}
@@ -967,7 +968,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 
-		$users = $synced_users_event->args;
+		$users = $synced_users_event->args['users'];
 
 		$this->assertEquals( 2, count( $users ) );
 		$this->assertEquals( $sync_user_id, $users[0]->ID );
@@ -1031,7 +1032,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
-		$users = $synced_users_event->args;
+		$users = $synced_users_event->args['users'];
 
 		$this->assertEquals( $existing_user_count+1, count( $users ) );
 		$this->assertEquals( $keep_user_id, $users[ $existing_user_count ]->ID );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -196,6 +196,56 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( isset( $user->data->user_pass ) );
 	}
 
+	function test_full_sync_sends_previous_interval_end_for_users() {
+		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+
+		for ( $i = 0; $i < 45; $i += 1 ) {
+			$user_ids[] = $this->factory->user->create();
+		}
+
+		// The first event is for full sync start.
+		$this->full_sync->start( array( 'users' => true ) );
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
+
+		$users = $event->args['users'];
+		$previous_interval_end = $event->args['previous_end'];
+
+		// The first batch has the previous_min_is not set.
+		// We user ~0 to denote that the previous min id unknown.
+		$this->assertEquals( $previous_interval_end, '~0' );
+
+		// Since posts are order by id and the ids are in decending order
+		// the very last post should be the id with the smallest ID. ( previous_interval_end )
+		$last_user = end( $users );
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
+
+		$second_batch_users = $event->args['users'];
+		$previous_interval_end = $event->args['previous_end'];
+
+		$this->assertEquals( intval( $previous_interval_end ), $last_user->ID );
+
+		$last_user = end( $second_batch_users );
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
+		$previous_interval_end = $event->args['previous_end'];
+		
+		$this->assertEquals( intval( $previous_interval_end ), $last_user->ID );
+
+		$this->full_sync->reset_data();
+
+	}
+
 	// phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_only_current_blog_users_in_multisite
 	function test_full_sync_sends_only_current_blog_users_in_multisite() {
 		if ( ! is_multisite() ) {


### PR DESCRIPTION
Similar to https://github.com/Automattic/jetpack/commit/56760c2a27cc7716b82674e228d0d87b0b6a72b6

This PR adds a previous_end to the users full sync so that we can be more consistant with the rest of the full syncs. 

This will allows us to remove any users that do not get removed during the regular full sync.

* Adds tests.
* Makes sure that users are sent in a particular order (descending by user ID)

This change will require changes to .com as well.

<!--- Provide a general summary of your changes in the Title above -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* 

#### Testing instructions:
Similar to https://github.com/Automattic/jetpack/commit/56760c2a27cc7716b82674e228d0d87b0b6a72b6
* Do the tests pass?
* Does full sync for users work as expected?
- Related .com change D26268-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
