### PR TITLE
Docs: update link to Docker engine

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ _**All commands mentioned in this document should be run from the base Jetpack d
 
 ### Prerequisites
 
-* [Docker](https://www.docker.com/community-edition)
+* [Docker](https://hub.docker.com/search/?type=edition&offering=community)
 * [NodeJS](https://nodejs.org)
 * [Yarn](https://yarnpkg.com/) — please make sure your version is higher than v1.3: `yarn --version`
 * Optionally [Ngrok](https://ngrok.com) client and account or some other service for creating a local HTTP tunnel. It’s fine to stay on the free pricing tier with Ngrok.


### PR DESCRIPTION
Previous link https://www.docker.com/community-edition is redirected to a landing page with too mcuh text for users to figure out what they need, including a table comparing Enterprise and Community editions.

New link https://hub.docker.com/search/?type=edition&offering=community goes to the Docker Engine Community Edition with images to download for MacOS, Linux and Windows.