### PR TITLE
Tiled gallery block: switch "masonry" keyword to "pictures"

### DIFF
--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -133,7 +133,7 @@ export const settings = {
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),
-		_x( 'masonry', 'block search term', 'jetpack' ),
+		_x( 'pictures', 'block search term', 'jetpack' ),
 	],
 	styles: layoutStylesWithLabels,
 	supports: {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/29780

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* switch "masonry" keyword to "pictures"

#### Testing instructions:
- Tiled gallery block should show up when typing "pictures" in block picker.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
