### PR TITLE
Simple payments block: document why block isn't reusable

### DIFF
--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -119,6 +119,8 @@ export const settings = {
 		className: false,
 		customClassName: false,
 		html: false,
+		// Disabled due several problems because the block uses custom post type to store information
+		// https://github.com/Automattic/jetpack/issues/11789
 		reusable: false,
 	},
 };


### PR DESCRIPTION
Link to issues that explain why simple payments block isn't reusable.

This is important especially because we've been moving the code around between repositories, so tracking the `git blame` might be challenging.

#### Changes proposed in this Pull Request:
—

#### Testing instructions:
—

#### Proposed changelog entry for your changes:
—
