### PR TITLE
Module Extras: clearly separate features

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -35,6 +35,7 @@ function phpcsFilesToFilter( file ) {
 		'sync/class.jetpack-sync-module-auth.php',
 		'class.jetpack-gutenberg.php',
 		'class.jetpack-plan.php',
+		'modules/module-extras.php',
 		'modules/module-info.php',
 		'functions.opengraph.php',
 	];

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -4,8 +4,18 @@
  * For example, if a module shouldn't be activatable unless certain conditions are met, the code belongs in this file.
  */
 
-// Include extra tools that aren't modules, in a filterable way
+/**
+ * Features available all the time:
+ *    - When in development mode.
+ *    - When connected to WordPress.com.
+ */
 $tools = array(
+	// Always loaded, but only registered if theme supports it.
+	'custom-post-types/comics.php',
+	'custom-post-types/testimonial.php',
+	'custom-post-types/nova.php',
+	'geo-location.php',
+	'theme-tools.php',
 	'theme-tools/social-links.php',
 	'theme-tools/random-redirect.php',
 	'theme-tools/featured-content.php',
@@ -15,33 +25,27 @@ $tools = array(
 	'theme-tools/site-breadcrumbs.php',
 	'theme-tools/social-menu.php',
 	'theme-tools/content-options.php',
-	'custom-post-types/comics.php',
-	'custom-post-types/testimonial.php',
-	'custom-post-types/nova.php',
-	'theme-tools.php',
+	// Needed for SEO Tools.
 	'seo-tools/jetpack-seo-utils.php',
 	'seo-tools/jetpack-seo-titles.php',
 	'seo-tools/jetpack-seo-posts.php',
-	'simple-payments/simple-payments.php',
 	'verification-tools/verification-tools-utils.php',
-	'woocommerce-analytics/wp-woocommerce-analytics.php',
-	'geo-location.php',
-	'calypsoify/class.jetpack-calypsoify.php',
-
-	// Keep working the VideoPress videos in existing posts/pages when the module is deactivated
+	// Needed for VideoPress, so videos keep working in existing posts/pages when the module is deactivated.
 	'videopress/utility-functions.php',
 	'videopress/class.videopress-gutenberg.php',
-
-	'plugin-search.php',
 );
 
-// Not every tool needs to be included if Jetpack is inactive and not in development mode
-if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
-	$tools = array(
-		'seo-tools/jetpack-seo-utils.php',
-		'seo-tools/jetpack-seo-titles.php',
-		'seo-tools/jetpack-seo-posts.php',
-	);
+// Some features are only available when connected to WordPress.com.
+$connected_tools = array(
+	'calypsoify/class.jetpack-calypsoify.php',
+	'plugin-search.php',
+	'simple-payments/simple-payments.php',
+	'woocommerce-analytics/wp-woocommerce-analytics.php',
+);
+
+// Add connected features to our existing list if the site is currently connected.
+if ( Jetpack::is_active() ) {
+	$tools = array_merge( $tools, $connected_tools );
 }
 
 /**

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -1,7 +1,10 @@
 <?php
-/*
+/**
  * Load module code that is needed even when a module isn't active.
- * For example, if a module shouldn't be activatable unless certain conditions are met, the code belongs in this file.
+ * For example, if a module shouldn't be activatable unless certain conditions are met,
+ * the code belongs in this file.
+ *
+ * @package Jetpack
  */
 
 /**
@@ -61,15 +64,21 @@ $jetpack_tools_to_include = apply_filters( 'jetpack_tools_to_include', $tools );
 if ( ! empty( $jetpack_tools_to_include ) ) {
 	foreach ( $jetpack_tools_to_include as $tool ) {
 		if ( file_exists( JETPACK__PLUGIN_DIR . '/modules/' . $tool ) ) {
-			require_once( JETPACK__PLUGIN_DIR . '/modules/' . $tool );
+			require_once JETPACK__PLUGIN_DIR . '/modules/' . $tool;
 		}
 	}
 }
 
 /**
  * Add the "(Jetpack)" suffix to the widget names
+ *
+ * @param string $widget_name Widget name.
  */
 function jetpack_widgets_add_suffix( $widget_name ) {
-	return sprintf( __( '%s (Jetpack)', 'jetpack' ), $widget_name );
+	return sprintf(
+		/* Translators: Placeholder is the name of a widget. */
+		__( '%s (Jetpack)', 'jetpack' ),
+		$widget_name
+	);
 }
 add_filter( 'jetpack_widget_name', 'jetpack_widgets_add_suffix' );

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -5,41 +5,45 @@
  * This file will be included in module-extras.php.
  */
 
-function jetpack_verification_validate( $verification_services_codes ) {
-	foreach ( $verification_services_codes as $key => $code ) {
-		// Parse html meta tag if it does not look like a valid code
-		if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
-			$code = jetpack_verification_get_code( $code );
+if ( ! function_exists( 'jetpack_verification_validate' ) ) {
+	function jetpack_verification_validate( $verification_services_codes ) {
+		foreach ( $verification_services_codes as $key => $code ) {
+			// Parse html meta tag if it does not look like a valid code
+			if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
+				$code = jetpack_verification_get_code( $code );
+			}
+
+			$code = esc_attr( trim( $code ) );
+
+			// limit length to 100 chars.
+			$code = substr( $code, 0, 100 );
+
+			/**
+			 * Fire after each Verification code was validated.
+			 *
+			 * @module verification-tools
+			 *
+			 * @since 3.0.0
+			 *
+			 * @param string $key Verification service name.
+			 * @param string $code Verification service code provided in field in the Tools menu.
+			 */
+			do_action( 'jetpack_site_verification_validate', $key, $code );
+
+			$verification_services_codes[ $key ] = $code;
 		}
-
-		$code = esc_attr( trim( $code ) );
-
-		// limit length to 100 chars.
-		$code = substr( $code, 0, 100 );
-
-		/**
-		 * Fire after each Verification code was validated.
-		 *
-		 * @module verification-tools
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string $key Verification service name.
-		 * @param string $code Verification service code provided in field in the Tools menu.
-		 */
-		do_action( 'jetpack_site_verification_validate', $key, $code );
-
-		$verification_services_codes[ $key ] = $code;
+		return $verification_services_codes;
 	}
-	return $verification_services_codes;
 }
 
-function jetpack_verification_get_code( $code ) {
-	$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
-	preg_match( $pattern, $code, $match );
-	if ( $match ) {
-		return urldecode( $match[1] );
-	} else {
-		return false;
+if ( ! function_exists( 'jetpack_verification_get_code' ) ) {
+	function jetpack_verification_get_code( $code ) {
+		$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
+		preg_match( $pattern, $code, $match );
+		if ( $match ) {
+			return urldecode( $match[1] );
+		} else {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Features that need a WordPress.com connection should only be loaded then.
* I also fixed all PHPCS warnings and added the file to the pre-commit hook.

**Note**: I originally wanted to move the SEO features to the connected tools, but when testing I ran into Fatal Errors on Multisite, just as reported in #7898. Before to move those files, I think we should make changes to the different classes used by then SEO module and make sure we shortcircuit early when Jetpack is not connected to WordPress.com.

#### Testing instructions:

* On a site, try to access features:
    * Right after you activate the plugin, but before you do anything.
    * When development mode is active
    * When Jetpack is connected to WordPress.com.
* Nothing should change; the features should be accessed only in time.

#### Proposed changelog entry for your changes:

* None
