### PR TITLE
Remove version from `package.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack",
-	"version": "7.2.0-alpha",
+	"version": "7.3.0-alpha",
 	"description": "Jetpack supercharges your self‑hosted WordPress site with the awesome cloud power of WordPress.com",
 	"homepage": "https://jetpack.com/",
 	"type": "wordpress-plugin",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"name": "automattic/jetpack",
+	"version": "7.2.0-alpha",
 	"description": "Jetpack supercharges your self‑hosted WordPress site with the awesome cloud power of WordPress.com",
 	"homepage": "https://jetpack.com/",
 	"type": "wordpress-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "Jetpack",
-	"version": "7.3.0-alpha",
 	"description": "[Jetpack](http://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",
 	"author": "Automattic",


### PR DESCRIPTION
If we sync `package.json` to wpcom, we might want to have less changes applied to this file if possible.

Version is one that doesn't have to technically be in `package.json`, unless I'm missing something?

> _If you don’t plan to publish your package, the name and version fields are optional._

via [docs](https://docs.npmjs.com/files/package.json#version)

Adding version to `composer.json` instead. [docs](https://getcomposer.org/doc/04-schema.md#version)

Composer file is shipped with the plugin, while package.json [is ignored](https://github.com/Automattic/jetpack/blob/858b174e510ebcb59904cbeb0a89a072870d33e1/.svnignore#L24).


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Remove `version` from `package.json`
* Add `version` to `composer.json`

#### Testing instructions:
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
