### PR TITLE
Sync: Add/full sync terms previous end

### DIFF
--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -23,43 +23,70 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 
 	function init_before_send() {
 		// full sync
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_taxonomy_id' ) );
 	}
 
-	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
-
-		// TODO: process state
-		$taxonomies           = get_taxonomies();
-		$total_chunks_counter = 0;
-		foreach ( $taxonomies as $taxonomy ) {
-			// I hope this is never bigger than RAM...
-			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s ORDER BY ", $taxonomy ) ); // Should we set a limit here?
-			// Request posts in groups of N for efficiency
-			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
-
-			// Send each chunk as an array of objects
-			foreach ( $chunked_term_ids as $chunk ) {
-				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy,  );
-				$total_chunks_counter ++;
-			}
-		}
-
-		return array( $total_chunks_counter, true );
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_terms', $wpdb->term_taxonomy, 'term_taxonomy_id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
-	function estimate_full_sync_actions( $config ) {
-		// TODO - make this (and method above) more efficient for large numbers of terms or taxonomies
-		global $wpdb;
-
-		$taxonomies           = get_taxonomies();
-		$total_chunks_counter = 0;
-		foreach ( $taxonomies as $taxonomy ) {
-			$total_ids             = $wpdb->get_var( $wpdb->prepare( "SELECT count(term_id) FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) );
-			$total_chunks_counter += (int) ceil( $total_ids / self::ARRAY_CHUNK_SIZE );
+	private function get_where_sql( $config ) {
+		if ( is_array( $config ) ) {
+			return 'term_taxonomy_id IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 
-		return $total_chunks_counter;
+		return null;
+	}
+
+//	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+//		global $wpdb;
+//
+//		// TODO: process state
+//		$taxonomies           = get_taxonomies();
+//		$total_chunks_counter = 0;
+//		foreach ( $taxonomies as $taxonomy ) {
+//			// I hope this is never bigger than RAM...
+//			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s ORDER BY ", $taxonomy ) ); // Should we set a limit here?
+//			// Request posts in groups of N for efficiency
+//			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
+//
+//			// Send each chunk as an array of objects
+//			foreach ( $chunked_term_ids as $chunk ) {
+//				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy,  );
+//				$total_chunks_counter ++;
+//			}
+//		}
+//
+//		return array( $total_chunks_counter, true );
+//	}
+
+//	function estimate_full_sync_actions( $config ) {
+//		// TODO - make this (and method above) more efficient for large numbers of terms or taxonomies
+//		global $wpdb;
+//
+//		$taxonomies           = get_taxonomies();
+//		$total_chunks_counter = 0;
+//		foreach ( $taxonomies as $taxonomy ) {
+//			$total_ids             = $wpdb->get_var( $wpdb->prepare( "SELECT count(term_id) FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) );
+//			$total_chunks_counter += (int) ceil( $total_ids / self::ARRAY_CHUNK_SIZE );
+//		}
+//
+//		return $total_chunks_counter;
+//	}
+
+	public function estimate_full_sync_actions( $config ) {
+		global $wpdb;
+
+		$query = "SELECT count(*) FROM $wpdb->term_taxonomy";
+
+		if ( $where_sql = $this->get_where_sql( $config ) ) {
+			$query .= ' WHERE ' . $where_sql;
+		}
+
+		$count = $wpdb->get_var( $query );
+
+		return (int) ceil( $count / self::ARRAY_CHUNK_SIZE );
 	}
 
 	function get_full_sync_actions() {
@@ -105,17 +132,16 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		$this->taxonomy_whitelist = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
 	}
 
-	public function expand_term_ids( $args ) {
-		list( $term_ids, $taxonomy, $previous_end ) = $args;
+	public function expand_term_taxonomy_id( $args ) {
+		list( $term_taxonomy_ids,  $previous_end ) = $args;
 
 		return
 			array( 'terms' => get_terms(
 				array(
-					'taxonomy'   => $taxonomy,
-					'hide_empty' => false,
-					'include'    => $term_ids,
-					'orderby'    => 'id',
-					'order'      => 'DESC'
+					'hide_empty'       => false,
+					'term_taxonomy_id' => $term_taxonomy_ids,
+					'orderby'          => 'term_taxonomy_id',
+					'order'            => 'DESC'
 				)
 			),
 			'previous_end' => $previous_end

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -36,44 +36,8 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			return 'term_taxonomy_id IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 
-		return null;
+		return '';
 	}
-
-//	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
-//		global $wpdb;
-//
-//		// TODO: process state
-//		$taxonomies           = get_taxonomies();
-//		$total_chunks_counter = 0;
-//		foreach ( $taxonomies as $taxonomy ) {
-//			// I hope this is never bigger than RAM...
-//			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s ORDER BY ", $taxonomy ) ); // Should we set a limit here?
-//			// Request posts in groups of N for efficiency
-//			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
-//
-//			// Send each chunk as an array of objects
-//			foreach ( $chunked_term_ids as $chunk ) {
-//				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy,  );
-//				$total_chunks_counter ++;
-//			}
-//		}
-//
-//		return array( $total_chunks_counter, true );
-//	}
-
-//	function estimate_full_sync_actions( $config ) {
-//		// TODO - make this (and method above) more efficient for large numbers of terms or taxonomies
-//		global $wpdb;
-//
-//		$taxonomies           = get_taxonomies();
-//		$total_chunks_counter = 0;
-//		foreach ( $taxonomies as $taxonomy ) {
-//			$total_ids             = $wpdb->get_var( $wpdb->prepare( "SELECT count(term_id) FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) );
-//			$total_chunks_counter += (int) ceil( $total_ids / self::ARRAY_CHUNK_SIZE );
-//		}
-//
-//		return $total_chunks_counter;
-//	}
 
 	public function estimate_full_sync_actions( $config ) {
 		global $wpdb;

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -34,13 +34,13 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		$total_chunks_counter = 0;
 		foreach ( $taxonomies as $taxonomy ) {
 			// I hope this is never bigger than RAM...
-			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) ); // Should we set a limit here?
+			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s ORDER BY ", $taxonomy ) ); // Should we set a limit here?
 			// Request posts in groups of N for efficiency
 			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
 
 			// Send each chunk as an array of objects
 			foreach ( $chunked_term_ids as $chunk ) {
-				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy );
+				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy,  );
 				$total_chunks_counter ++;
 			}
 		}
@@ -106,15 +106,19 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	}
 
 	public function expand_term_ids( $args ) {
-		$term_ids = $args[0];
-		$taxonomy = $args[1];
+		list( $term_ids, $taxonomy, $previous_end ) = $args;
 
-		return get_terms(
-			array(
-				'taxonomy'   => $taxonomy,
-				'hide_empty' => false,
-				'include'    => $term_ids,
-			)
+		return
+			array( 'terms' => get_terms(
+				array(
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+					'include'    => $term_ids,
+					'orderby'    => 'id',
+					'order'      => 'DESC'
+				)
+			),
+			'previous_end' => $previous_end
 		);
 	}
 }

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -212,7 +212,7 @@ class Jetpack_Sync_Server_Replicator {
 				}
 				break;
 			case 'jetpack_full_sync_terms':
-				foreach ( $args as $term_object ) {
+				foreach ( $args['terms'] as $term_object ) {
 					$this->store->update_term( $term_object );
 				}
 				break;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -212,7 +212,6 @@ class Jetpack_Sync_Server_Replicator {
 				}
 				break;
 			case 'jetpack_full_sync_terms':
-				var_dump( $args );
 				foreach ( $args['terms'] as $term_object ) {
 					$this->store->update_term( $term_object );
 				}

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -212,6 +212,7 @@ class Jetpack_Sync_Server_Replicator {
 				}
 				break;
 			case 'jetpack_full_sync_terms':
+				var_dump( $args );
 				foreach ( $args['terms'] as $term_object ) {
 					$this->store->update_term( $term_object );
 				}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -156,8 +156,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_terms() {
 
 		for ( $i = 0; $i < 11; $i += 1 ) {
-			wp_insert_term( 'category' . $i, 'post_tag' );
-			wp_insert_term( 'term' . $i, 'post_tag' );
+			wp_insert_term( 'category ' . $i, 'category' );
+			wp_insert_term( 'term ' . $i, 'post_tag' );
 		}
 
 		// simulate emptying the server storage
@@ -168,7 +168,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
-		$this->assertEquals( 22, count( $terms ) );
+		$this->assertEquals( 22, count( $terms ) ); // 11 categories and 11 tags
 	}
 
 	function test_full_sync_sends_all_terms_with_previous_interval_end() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -156,6 +156,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_terms() {
 
 		for ( $i = 0; $i < 11; $i += 1 ) {
+			wp_insert_term( 'category' . $i, 'post_tag' );
 			wp_insert_term( 'term' . $i, 'post_tag' );
 		}
 
@@ -167,7 +168,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
-		$this->assertEquals( 11, count( $terms ) );
+		$this->assertEquals( 22, count( $terms ) );
 	}
 
 	function test_full_sync_sends_all_terms_with_previous_interval_end() {
@@ -201,7 +202,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_terms' );
 		$second_batch_terms = $event->args['terms'];
 		$previous_interval_end = $event->args['previous_end'];
-		$this->assertEquals( intval( $previous_interval_end ), $last_term->ID );
+		$this->assertEquals( intval( $previous_interval_end ), $last_term->term_taxonomy_id );
 
 		$last_term = end( $second_batch_terms );
 		$this->full_sync->continue_enqueuing();
@@ -209,7 +210,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_terms' );
 		$previous_interval_end = $event->args['previous_end'];
-		$this->assertEquals( intval( $previous_interval_end ), $last_term->ID );
+		$this->assertEquals( intval( $previous_interval_end ), $last_term->term_taxonomy_id );
 
 		$this->full_sync->reset_data();
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -156,8 +156,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_terms() {
 
 		for ( $i = 0; $i < 11; $i += 1 ) {
-			wp_insert_term( 'category ' . $i, 'category' );
-			wp_insert_term( 'term ' . $i, 'post_tag' );
+			wp_insert_term( 'category-' . $i, 'category' );
+			wp_insert_term( 'term-' . $i, 'post_tag' );
 		}
 
 		// simulate emptying the server storage

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -154,9 +154,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_terms() {
+		$NUMBER_OF_TERMS_TO_CREATE = 11;
 		$this->server_replica_storage->reset();
 		$this->sender->reset_data();
-		for ( $i = 0; $i < 11; $i += 1 ) {
+		for ( $i = 0; $i < $NUMBER_OF_TERMS_TO_CREATE; $i += 1 ) {
 			wp_insert_term( 'category ' . $i, 'category' );
 			wp_insert_term( 'term ' . $i, 'post_tag' );
 		}
@@ -169,10 +170,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
-		$this->assertEquals( 11, count( $terms ) );
+		$this->assertEquals( $NUMBER_OF_TERMS_TO_CREATE, count( $terms ) );
 
 		$terms = $this->server_replica_storage->get_terms( 'category' );
-		$this->assertEquals( 12, count( $terms ) ); // 11 + 1 (for uncategorized term)
+		$this->assertEquals( $NUMBER_OF_TERMS_TO_CREATE + 1, count( $terms ) ); // 11 + 1 (for uncategorized term)
 	}
 
 	function test_full_sync_sends_all_terms_with_previous_interval_end() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -154,10 +154,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_terms() {
-
+		$this->server_replica_storage->reset();
+		$this->sender->reset_data();
 		for ( $i = 0; $i < 11; $i += 1 ) {
-			wp_insert_term( 'category-' . $i, 'category' );
-			wp_insert_term( 'term-' . $i, 'post_tag' );
+			wp_insert_term( 'category ' . $i, 'category' );
+			wp_insert_term( 'term ' . $i, 'post_tag' );
 		}
 
 		// simulate emptying the server storage
@@ -168,7 +169,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
-		$this->assertEquals( 22, count( $terms ) ); // 11 categories and 11 tags
+		$this->assertEquals( 11, count( $terms ) );
+
+		$terms = $this->server_replica_storage->get_terms( 'category' );
+		$this->assertEquals( 12, count( $terms ) ); // 11 + 1 (for uncategorized term)
 	}
 
 	function test_full_sync_sends_all_terms_with_previous_interval_end() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -170,6 +170,50 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 11, count( $terms ) );
 	}
 
+	function test_full_sync_sends_all_terms_with_previous_interval_end() {
+		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+
+		for ( $i = 0; $i < 25; $i += 1 ) {
+			wp_insert_term( 'term' . $i, 'post_tag' );
+		}
+
+		// The first event is for full sync start.
+		$this->full_sync->start( array( 'terms' => true ) );
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_terms' );
+		$terms = $event->args['terms'];
+		$previous_interval_end = $event->args['previous_end'];
+		// The first batch has the previous_min_is not set.
+		// We user ~0 to denote that the previous min id unknown.
+		$this->assertEquals( $previous_interval_end, '~0' );
+
+		// Since posts are order by id and the ids are in decending order
+		// the very last post should be the id with the smallest ID. ( previous_interval_end )
+		$last_term = end( $terms );
+
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_terms' );
+		$second_batch_terms = $event->args['terms'];
+		$previous_interval_end = $event->args['previous_end'];
+		$this->assertEquals( intval( $previous_interval_end ), $last_term->ID );
+
+		$last_term = end( $second_batch_terms );
+		$this->full_sync->continue_enqueuing();
+		$this->sender->do_full_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_terms' );
+		$previous_interval_end = $event->args['previous_end'];
+		$this->assertEquals( intval( $previous_interval_end ), $last_term->ID );
+
+		$this->full_sync->reset_data();
+	}
+
 	function test_full_sync_sends_all_users() {
 		$first_user_id = $this->factory->user->create();
 		for ( $i = 0; $i < 9; $i += 1 ) {


### PR DESCRIPTION
This PR changes how we end term data on full sync.

We currently group terms by a taxonomy. Which will not work with the current strategy which implements the previous_end ranges. 

THe problem being that there is nothing that allows us to know what ranges of term_id we care about. 
This PR requires us to use the term_taxonomy_id which is an id that auto increments and has been available for a while now. 

This will allow us to be able to delete terms that fall in to a certain range of term_ids.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Rewrote how the we full sync terms.

#### Testing instructions:

Similar to 56760c2

* Do the tests pass?
* Does full sync for terms still work as expected?
* Related .com change D26281-code


#### Proposed changelog entry for your changes:
* Improvements to full terms full sync.
