### PR TITLE
Publicize: fix counting words in posts, take 2.

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -340,12 +340,27 @@ class Jetpack_Media_Summary {
 		return '';
 	}
 
+	/**
+	 * Split a string into an array of words.
+	 *
+	 * @param string $text Post content or excerpt.
+	 */
+	static function split_content_in_words( $text ) {
+		$words = preg_split( '/[\s!?;,.]+/', $text, null, PREG_SPLIT_NO_EMPTY );
+
+		// Return an empty array if the split above fails. 
+		return $words ? $words : array();	
+	}
+
 	static function get_word_count( $post_content ) {
-		return str_word_count( self::clean_text( $post_content ) );
+		return (int) count( self::split_content_in_words( self::clean_text( $post_content ) ) );
 	}
 
 	static function get_word_remaining_count( $post_content, $excerpt_content ) {
-		return str_word_count( self::clean_text( $post_content ) ) - str_word_count( self::clean_text( $excerpt_content ) );
+		$content_word_count = count( self::split_content_in_words( self::clean_text( $post_content ) ) );
+		$excerpt_word_count = count( self::split_content_in_words( self::clean_text( $excerpt_content ) ) ); 
+
+		return (int) $content_word_count - $excerpt_word_count;
 	}
 
 	static function get_link_count( $post_content ) {


### PR DESCRIPTION
Differential Revision: D26167-code

This commit syncs r189761-wpcom.

#### Changes proposed in this Pull Request:

This is a follow-up to D25267-code, and D25799-code which reverted the first patch because of performance. We're now back to relying on str_word_count to count the number the words, and while that works well for latin languages, it is problematic with languages with special characters, like Japanese or Cyrillic.

This attempts to fix the issue detailed here, where all the content of a post ends up on Facebook, instead of just an excerpt: 3551-gh-jpop-issues

This time around let's try a simpler approach for counting words, by splitting words depending on common separators: space, !, ?, ;, , .
We can expand that regex in the future to support more / different separators.

#### Testing instructions:

- Prepare your Jetpack site and your WordPress.com sandbox for testing:
- Publish a new post with the content defined in the JPOP issue above.
- Make sure only the first part of the post is pushed to Facebook; at the end of the automatically generated excerpt you should see something like "[ 468 more words ]".

#### Proposed changelog entry for your changes:

* None
