### PR TITLE
Crowdsignal: updates to get ready for Fusion

### DIFF
--- a/_inc/crowdsignal-shortcode.js
+++ b/_inc/crowdsignal-shortcode.js
@@ -1,0 +1,18 @@
+( function( d, c, j ) {
+	var crowdsignal_shortcode_options;
+	if (
+		crowdsignal_shortcode_options &&
+		crowdsignal_shortcode_options.script_url &&
+		! d.getElementById( j )
+	) {
+		var pd = d.createElement( c ),
+			s;
+		pd.id = j;
+		pd.async = true;
+		pd.src = crowdsignal_shortcode_options.script_url;
+		s = d.getElementsByTagName( c )[ 0 ];
+		s.parentNode.insertBefore( pd, s );
+	} else if ( typeof jQuery !== 'undefined' ) {
+		jQuery( d.body ).trigger( 'pd-script-load' );
+	}
+} )( document, 'script', 'pd-polldaddy-loader' );

--- a/_inc/crowdsignal-survey.js
+++ b/_inc/crowdsignal-survey.js
@@ -1,0 +1,10 @@
+( function( d, c, j ) {
+	if ( ! d.getElementById( j ) ) {
+		var pd = d.createElement( c ),
+			s;
+		pd.id = j;
+		pd.src = 'https://polldaddy.com/survey.js';
+		s = d.getElementsByTagName( c )[ 0 ];
+		s.parentNode.insertBefore( pd, s );
+	}
+} )( document, 'script', 'pd-embed' );

--- a/_inc/polldaddy-shortcode.js
+++ b/_inc/polldaddy-shortcode.js
@@ -1,0 +1,76 @@
+/* jshint ignore:start */
+( function( $ ) {
+	window.polldaddyshortcode = {
+		render: function() {
+			var ratings = $( 'div.pd-rating[data-settings]' );
+			var polls = $( 'div.PDS_Poll[data-settings]' );
+
+			if ( polls ) {
+				$.each( polls, function() {
+					var poll = $( this ).data( 'settings' );
+
+					if ( poll ) {
+						var poll_url = document.createElement( 'a' );
+						poll_url.href = poll[ 'url' ];
+						if (
+							poll_url.hostname != 'secure.polldaddy.com' &&
+							poll_url.hostname != 'static.polldaddy.com'
+						) {
+							return false;
+						}
+						var pathname = poll_url.pathname;
+						if ( ! /\/?p\/\d+\.js/.test( pathname ) ) {
+							return false;
+						}
+						var wp_pd_js = document.createElement( 'script' );
+						wp_pd_js.type = 'text/javascript';
+						wp_pd_js.src = poll[ 'url' ];
+						wp_pd_js.charset = 'utf-8';
+						wp_pd_js.async = true;
+						document.getElementsByTagName( 'head' )[ 0 ].appendChild( wp_pd_js );
+					}
+				} );
+			}
+
+			if ( ratings ) {
+				var script = '';
+
+				$.each( ratings, function() {
+					var rating = $( this ).data( 'settings' );
+
+					if ( rating ) {
+						script +=
+							'PDRTJS_settings_' +
+							rating[ 'id' ] +
+							rating[ 'item_id' ] +
+							'=' +
+							rating[ 'settings' ] +
+							"; if ( typeof PDRTJS_RATING !== 'undefined' ){ if ( typeof PDRTJS_" +
+							rating[ 'id' ] +
+							rating[ 'item_id' ] +
+							"=='undefined' ){PDRTJS_" +
+							rating[ 'id' ] +
+							rating[ 'item_id' ] +
+							'= new PDRTJS_RATING( PDRTJS_settings_' +
+							rating[ 'id' ] +
+							rating[ 'item_id' ] +
+							' );}}';
+					}
+				} );
+
+				if ( script.length > 0 )
+					$( '#polldaddyRatings' ).after(
+						"<script type='text/javascript' charset='utf-8' id='polldaddyDynamicRatings'>" +
+							script +
+							'</script>'
+					);
+			}
+		},
+	};
+
+	$( 'body' ).on( 'post-load pd-script-load', function() {
+		window.polldaddyshortcode.render();
+	} );
+	$( 'body' ).trigger( 'pd-script-load' );
+} )( jQuery );
+/* jshint ignore:end */

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Crowosignal (ne PollDaddy) shortcode.
+ * Crowdsignal (PollDaddy) shortcode.
  *
  * Formats:
  * [polldaddy type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -246,7 +246,10 @@ if (
 
 				$item_id = esc_js( $item_id );
 
-				if ( Jetpack_AMP_Support::is_amp_request() ) {
+				if (
+					class_exists( 'Jetpack_AMP_Support' )
+					&& Jetpack_AMP_Support::is_amp_request()
+				) {
 					return sprintf(
 						'<a href="%s" target="_blank">%s</a>',
 						esc_url( $attributes['permalink'] ),
@@ -314,7 +317,10 @@ if (
 					esc_html( $attributes['title'] )
 				);
 
-				if ( $no_script || Jetpack_AMP_Support::is_amp_request() ) {
+				if (
+					$no_script
+					|| ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() )
+				) {
 					return $poll_link;
 				} else {
 					if (
@@ -455,7 +461,12 @@ if (
 					$settings = array();
 
 					// Do we want a full embed code or a link?
-					if ( $no_script || $inline || $infinite_scroll || Jetpack_AMP_Support::is_amp_request() ) {
+					if (
+						$no_script
+						|| $inline
+						|| $infinite_scroll
+						|| ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() )
+					) {
 						return $survey_link;
 					}
 
@@ -663,7 +674,10 @@ if (
 		 * @param string $content Post content.
 		 */
 		function crowdsignal_link( $content ) {
-			if ( Jetpack_AMP_Support::is_amp_request() ) {
+			if (
+				class_exists( 'Jetpack_AMP_Support' )
+				&& Jetpack_AMP_Support::is_amp_request()
+			) {
 				return $content;
 			}
 

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -161,32 +161,6 @@ CONTAINER;
 			global $post;
 			global $content_width;
 
-			/**
-			 * Variables extracted from $atts.
-			 *
-			 * @var string $survey
-			 * @var string $link_text
-			 * @var string $poll
-			 * @var string $rating
-			 * @var string $unique_id
-			 * @var string $item_id
-			 * @var string $title
-			 * @var string $permalink
-			 * @var int $cb
-			 * @var string $type
-			 * @var string $body
-			 * @var string $button
-			 * @var string $text_color
-			 * @var string $back_color
-			 * @var string $align
-			 * @var string $style
-			 * @var int $width
-			 * @var int $height
-			 * @var int $delay
-			 * @var string $visit
-			 * @var string $domain
-			 * @var string $id
-			 */
 			$attributes = shortcode_atts(
 				array(
 					'survey'     => null,

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -202,10 +202,6 @@ CONTAINER;
 				$infinite_scroll = true;
 			}
 
-			if ( defined( 'PADPRESS_LOADED' ) ) {
-				$inline = true;
-			}
-
 			if ( function_exists( 'get_option' ) && get_option( 'polldaddy_load_poll_inline' ) ) {
 				$inline = true;
 			}

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -41,12 +41,10 @@ if (
 		 * Add all the actions & resgister the shortcode.
 		 */
 		public function __construct() {
-			if ( false === defined( 'GLOBAL_TAGS' ) ) {
-				add_shortcode( 'crowdsignal', array( $this, 'crowdsignal_shortcode' ) );
-				add_shortcode( 'polldaddy', array( $this, 'crowdsignal_shortcode' ) );
+			add_shortcode( 'crowdsignal', array( $this, 'crowdsignal_shortcode' ) );
+			add_shortcode( 'polldaddy', array( $this, 'crowdsignal_shortcode' ) );
 
-				add_filter( 'pre_kses', array( $this, 'crowdsignal_embed_to_shortcode' ) );
-			}
+			add_filter( 'pre_kses', array( $this, 'crowdsignal_embed_to_shortcode' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'check_infinite' ) );
 			add_action( 'infinite_scroll_render', array( $this, 'crowdsignal_shortcode_infinite' ), 11 );
 		}

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -298,7 +298,11 @@ CONTAINER;
 				$poll      = intval( $attributes['poll'] );
 				$poll_url  = sprintf( 'https://poll.fm/%d', $poll );
 				$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
-				$poll_link = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $poll_url ), esc_html( $attributes['title'] ) );
+				$poll_link = sprintf(
+					'<a href="%s" target="_blank">%s</a>',
+					esc_url( $poll_url ),
+					esc_html( $attributes['title'] )
+				);
 
 				if ( $no_script || Jetpack_AMP_Support::is_amp_request() ) {
 					return $poll_link;
@@ -435,7 +439,11 @@ CONTAINER;
 
 					$survey      = preg_replace( '/[^a-f0-9]/i', '', $attributes['survey'] );
 					$survey_url  = esc_url( "https://survey.fm/{$survey}" );
-					$survey_link = sprintf( '<a href="%s" target="_blank">%s</a>', $survey_url, esc_html( $attributes['title'] ) );
+					$survey_link = sprintf(
+						'<a href="%s" target="_blank">%s</a>',
+						$survey_url,
+						esc_html( $attributes['title'] )
+					);
 
 					$settings = array();
 
@@ -667,12 +675,12 @@ SCRIPT;
 		add_filter( 'the_content_rss', 'crowdsignal_link', 1 );
 	}
 
-		/**
-		 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
-		 * This should be removed after Core has the current regex is in our minimum version.
-		 *
-		 * @see https://core.trac.wordpress.org/ticket/46467
-		 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
-		 */
+	/**
+	 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
+	 * This should be removed after Core has the current regex is in our minimum version.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/46467
+	 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
+	 */
 	wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
 }

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -1,343 +1,416 @@
-<?php
-
-// Keep compatibility with polldaddy-plugin
-if ( ! class_exists( 'CrowdsignalShortcode' ) && ! class_exists( 'PolldaddyShortcode' ) ) {
-
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
-* Class wrapper for Crowdsignal shortcodes
-*/
+ * Crowosignal (ne PollDaddy) shortcode.
+ *
+ * Formats:
+ * [polldaddy type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]
+ * https://polldaddy.com/poll/7910844/
+ * https://jeherve.survey.fm/a-survey
+ * https://jeherve.survey.fm/a-survey-with-branches
+ * [crowdsignal type="iframe" survey="7676FB1FF2B56CE9" height="auto" domain="jeherve" id="a-survey"]
+ * [crowdsignal poll=9541291]
+ *
+ * @package Jetpack
+ */
 
-class CrowdsignalShortcode {
-
-	static $add_script = false;
-	static $scripts = false;
-
+// Keep compatibility with the PollDaddy plugin.
+if (
+	! class_exists( 'CrowdsignalShortcode' )
+	&& ! class_exists( 'PolldaddyShortcode' )
+) {
 	/**
-	 * Add all the actions & resgister the shortcode
+	 * Class wrapper for Crowdsignal shortcodes
 	 */
-	function __construct() {
-		if ( defined( 'GLOBAL_TAGS' ) == false ) {
-			add_shortcode( 'crowdsignal', array( $this, 'crowdsignal_shortcode' ) );
-			add_shortcode( 'polldaddy', array( $this, 'crowdsignal_shortcode' ) );
+	class CrowdsignalShortcode {
 
-			add_filter( 'pre_kses', array( $this, 'crowdsignal_embed_to_shortcode' ) );
+		/**
+		 * Should the Crowdsignal JavaScript be added to the page?
+		 *
+		 * @var bool
+		 */
+		private static $add_script = false;
+
+		/**
+		 * Array of Polls / Surveys present on the page, and that need to be added.
+		 *
+		 * @var bool|array
+		 */
+		private static $scripts = false;
+
+		/**
+		 * Add all the actions & resgister the shortcode.
+		 */
+		public function __construct() {
+			if ( false === defined( 'GLOBAL_TAGS' ) ) {
+				add_shortcode( 'crowdsignal', array( $this, 'crowdsignal_shortcode' ) );
+				add_shortcode( 'polldaddy', array( $this, 'crowdsignal_shortcode' ) );
+
+				add_filter( 'pre_kses', array( $this, 'crowdsignal_embed_to_shortcode' ) );
+			}
+			add_action( 'wp_enqueue_scripts', array( $this, 'check_infinite' ) );
+			add_action( 'infinite_scroll_render', array( $this, 'crowdsignal_shortcode_infinite' ), 11 );
 		}
-		add_action( 'wp_enqueue_scripts', array( $this, 'check_infinite' ) );
-		add_action( 'infinite_scroll_render', array( $this, 'crowdsignal_shortcode_infinite' ), 11 );
-	}
 
-	private function get_async_code( array $settings, $survey_link ) {
-		$include = <<<CONTAINER
+		/**
+		 * JavaScript code for a specific survey / poll.
+		 *
+		 * @param array  $settings Array of information about a survey / poll.
+		 * @param string $survey_link HTML link tag for a specific survey or poll.
+		 */
+		private function get_async_code( array $settings, $survey_link ) {
+			$include = <<<CONTAINER
 ( function( d, c, j ) {
-  if ( !d.getElementById( j ) ) {
-    var pd = d.createElement( c ), s;
-    pd.id = j;
-    pd.src = 'https://polldaddy.com/survey.js';
-    s = d.getElementsByTagName( c )[0];
-    s.parentNode.insertBefore( pd, s );
-  }
+	if ( !d.getElementById( j ) ) {
+		var pd = d.createElement( c ), s;
+		pd.id = j;
+		pd.src = 'https://polldaddy.com/survey.js';
+		s = d.getElementsByTagName( c )[0];
+		s.parentNode.insertBefore( pd, s );
+	}
 }( document, 'script', 'pd-embed' ) );
 CONTAINER;
 
-		// Compress it a bit
-		$include = $this->compress_it( $include );
+			// Compress it a bit.
+			$include = $this->compress_it( $include );
 
-		$placeholder =
-			'<div class="cs-embed pd-embed" data-settings="'
-			. esc_attr( json_encode( $settings ) )
-			. '"></div>';
-		if ( 'button' === $settings['type'] ) {
-			$placeholder =
-				'<a class="cs-embed pd-embed" href="'
-				. esc_attr( $survey_link )
-				. '" data-settings="'
-				. esc_attr( json_encode( $settings ) )
-				. '">'
-				. esc_html( $settings['title'] )
-				. '</a>';
-		}
+			$placeholder = sprintf(
+				'<div class="cs-embed pd-embed" data-settings="%s"></div>',
+				esc_attr( wp_json_encode( $settings ) )
+			);
 
-		$js_include = $placeholder . "\n";
-		$js_include .= '<script type="text/javascript"><!--//--><![CDATA[//><!--' . "\n";
-		$js_include .= $include . "\n";
-		$js_include .= "//--><!]]></script>\n";
-
-		if ( 'button' !== $settings['type'] ) {
-			$js_include .= '<noscript>' . $survey_link . "</noscript>\n";
-		}
-
-		return $js_include;
-	}
-
-	private function compress_it( $js ) {
-		$js = str_replace( array( "\n", "\t", "\r" ), '', $js );
-		$js = preg_replace( '/\s*([,:\?\{;\-=\(\)])\s*/', '$1', $js );
-		return $js;
-	}
-
-	/*
-	 * Crowdsignal Poll Embed script - transforms code that looks like that:
-	 * <script type="text/javascript" charset="utf-8" async src="http://static.polldaddy.com/p/123456.js"></script>
-	 * <noscript><a href="http://polldaddy.com/poll/123456/">What is your favourite color?</a></noscript>
-	 * into the [crowdsignal poll=...] shortcode format
-	 */
-	function crowdsignal_embed_to_shortcode( $content ) {
-
-		if ( ! is_string( $content ) || false === strpos( $content, 'polldaddy.com/p/' ) ) {
-			return $content;
-		}
-
-		$regexes = array();
-
-		$regexes[] = '#<script[^>]+?src="https?://(secure|static)\.polldaddy\.com/p/([0-9]+)\.js"[^>]*+>\s*?</script>\r?\n?(<noscript>.*?</noscript>)?#i';
-
-		$regexes[] = '#&lt;script(?:[^&]|&(?!gt;))+?src="https?://(secure|static)\.polldaddy\.com/p/([0-9]+)\.js"(?:[^&]|&(?!gt;))*+&gt;\s*?&lt;/script&gt;\r?\n?(&lt;noscript&gt;.*?&lt;/noscript&gt;)?#i';
-
-		foreach ( $regexes as $regex ) {
-			if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
-				continue;
+			if ( 'button' === $settings['type'] ) {
+				$placeholder = sprintf(
+					'<a class="cs-embed pd-embed" href="%1$s" data-settings="%2$s">%3$s</a>',
+					esc_attr( $survey_link ),
+					esc_attr( wp_json_encode( $settings ) ),
+					esc_html( $settings['title'] )
+				);
 			}
 
-			foreach ( $matches as $match ) {
-				if ( ! isset( $match[2] ) ) {
+			$js_include  = $placeholder . "\n";
+			$js_include .= '<script type="text/javascript"><!--//--><![CDATA[//><!--' . "\n";
+			$js_include .= $include . "\n";
+			$js_include .= "//--><!]]></script>\n";
+
+			if ( 'button' !== $settings['type'] ) {
+				$js_include .= '<noscript>' . $survey_link . "</noscript>\n";
+			}
+
+			return $js_include;
+		}
+
+		/**
+		 * Compress a JavaScript snippet before it's added to the page.
+		 *
+		 * @param string $js JavaScript snippet.
+		 */
+		private function compress_it( $js ) {
+			$js = str_replace( array( "\n", "\t", "\r" ), '', $js );
+			$js = preg_replace( '/\s*([,:\?\{;\-=\(\)])\s*/', '$1', $js );
+			return $js;
+		}
+
+		/**
+		 * Crowdsignal Poll Embed script - transforms code that looks like that:
+		 * <script type="text/javascript" charset="utf-8" async src="http://static.polldaddy.com/p/123456.js"></script>
+		 * <noscript><a href="http://polldaddy.com/poll/123456/">What is your favourite color?</a></noscript>
+		 * into the [crowdsignal poll=...] shortcode format
+		 *
+		 * @param string $content Post content.
+		 */
+		public function crowdsignal_embed_to_shortcode( $content ) {
+
+			if ( ! is_string( $content ) || false === strpos( $content, 'polldaddy.com/p/' ) ) {
+				return $content;
+			}
+
+			$regexes = array();
+
+			$regexes[] = '#<script[^>]+?src="https?://(secure|static)\.polldaddy\.com/p/([0-9]+)\.js"[^>]*+>\s*?</script>\r?\n?(<noscript>.*?</noscript>)?#i';
+
+			$regexes[] = '#&lt;script(?:[^&]|&(?!gt;))+?src="https?://(secure|static)\.polldaddy\.com/p/([0-9]+)\.js"(?:[^&]|&(?!gt;))*+&gt;\s*?&lt;/script&gt;\r?\n?(&lt;noscript&gt;.*?&lt;/noscript&gt;)?#i';
+
+			foreach ( $regexes as $regex ) {
+				if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
 					continue;
 				}
 
-				$id = (int) $match[2];
+				foreach ( $matches as $match ) {
+					if ( ! isset( $match[2] ) ) {
+						continue;
+					}
 
-				if ( $id > 0 ) {
-					$content = str_replace( $match[0], " [crowdsignal poll=$id]", $content );
-					/** This action is documented in modules/shortcodes/youtube.php */
-					do_action( 'jetpack_embed_to_shortcode', 'crowdsignal', $id );
+					$id = (int) $match[2];
+
+					if ( $id > 0 ) {
+						$content = str_replace( $match[0], " [crowdsignal poll=$id]", $content );
+						/** This action is documented in modules/shortcodes/youtube.php */
+						do_action( 'jetpack_embed_to_shortcode', 'crowdsignal', $id );
+					}
 				}
 			}
+
+			return $content;
 		}
-
-		return $content;
-	}
-
-	/**
-	 * Shortcode for polldadddy
-	 * [crowdsignal poll|survey|rating="123456"]
-	 */
-	function crowdsignal_shortcode( $atts ) {
-		global $post;
-		global $content_width;
 
 		/**
-		 * Variables extracted from $atts.
+		 * Shortcode for polldadddy
+		 * [crowdsignal poll|survey|rating="123456"]
 		 *
-		 * @var string $survey
-		 * @var string $link_text
-		 * @var string $poll
-		 * @var string $rating
-		 * @var string $unique_id
-		 * @var string $item_id
-		 * @var string $title
-		 * @var string $permalink
-		 * @var int $cb
-		 * @var string $type
-		 * @var string $body
-		 * @var string $button
-		 * @var string $text_color
-		 * @var string $back_color
-		 * @var string $align
-		 * @var string $style
-		 * @var int $width
-		 * @var int $height
-		 * @var int $delay
-		 * @var string $visit
-		 * @var string $domain
-		 * @var string $id
+		 * @param array $atts Shortcode attributes.
 		 */
-		extract( shortcode_atts( array(
-			'survey'     => null,
-			'link_text'  => 'Take Our Survey',
-			'poll'       => 'empty',
-			'rating'     => 'empty',
-			'unique_id'  => null,
-			'item_id'    => null,
-			'title'      => null,
-			'permalink'  => null,
-			'cb'         => 0,
-			'type'       => 'button',
-			'body'       => '',
-			'button'     => '',
-			'text_color' => '000000',
-			'back_color' => 'FFFFFF',
-			'align'      => '',
-			'style'      => '',
-			'width'      => $content_width,
-			'height'     => floor( $content_width * 3 / 4 ),
-			'delay'      => 100,
-			'visit'      => 'single',
-			'domain'     => '',
-			'id'         => '',
-		), $atts, 'crowdsignal' ) );
+		public function crowdsignal_shortcode( $atts ) {
+			global $post;
+			global $content_width;
 
-		if ( ! is_array( $atts ) ) {
-			return '<!-- Crowdsignal shortcode passed invalid attributes -->';
-		}
+			/**
+			 * Variables extracted from $atts.
+			 *
+			 * @var string $survey
+			 * @var string $link_text
+			 * @var string $poll
+			 * @var string $rating
+			 * @var string $unique_id
+			 * @var string $item_id
+			 * @var string $title
+			 * @var string $permalink
+			 * @var int $cb
+			 * @var string $type
+			 * @var string $body
+			 * @var string $button
+			 * @var string $text_color
+			 * @var string $back_color
+			 * @var string $align
+			 * @var string $style
+			 * @var int $width
+			 * @var int $height
+			 * @var int $delay
+			 * @var string $visit
+			 * @var string $domain
+			 * @var string $id
+			 */
+			$attributes = shortcode_atts(
+				array(
+					'survey'     => null,
+					'link_text'  => esc_html__( 'Take Our Survey', 'jetpack' ),
+					'poll'       => 'empty',
+					'rating'     => 'empty',
+					'unique_id'  => null,
+					'item_id'    => null,
+					'title'      => null,
+					'permalink'  => null,
+					'cb'         => 0,
+					'type'       => 'button',
+					'body'       => '',
+					'button'     => '',
+					'text_color' => '000000',
+					'back_color' => 'FFFFFF',
+					'align'      => '',
+					'style'      => '',
+					'width'      => $content_width,
+					'height'     => floor( $content_width * 3 / 4 ),
+					'delay'      => 100,
+					'visit'      => 'single',
+					'domain'     => '',
+					'id'         => '',
+				),
+				$atts,
+				'crowdsignal'
+			);
 
-		$inline          = ! in_the_loop();
-		$no_script       = false;
-		$infinite_scroll = false;
-
-		if ( is_home() && current_theme_supports( 'infinite-scroll' ) ) {
-			$infinite_scroll = true;
-		}
-
-		if ( defined( 'PADPRESS_LOADED' ) ) {
-			$inline = true;
-		}
-
-		if ( function_exists( 'get_option' ) && get_option( 'polldaddy_load_poll_inline' ) ) {
-			$inline = true;
-		}
-
-		if ( is_feed() || ( defined( 'DOING_AJAX' ) && ! $infinite_scroll ) ) {
-			$no_script = false;
-		}
-
-		self::$add_script = $infinite_scroll;
-
-		if ( intval( $rating ) > 0 && ! $no_script ) { //rating embed
-
-			if ( empty( $unique_id ) ) {
-				$unique_id = is_page() ? 'wp-page-' . $post->ID : 'wp-post-' . $post->ID;
+			if ( ! is_array( $atts ) ) {
+				return '<!-- Crowdsignal shortcode passed invalid attributes -->';
 			}
 
-			if ( empty( $item_id ) ) {
-				$item_id = is_page() ? '_page_' . $post->ID : '_post_' . $post->ID;
+			$inline          = ! in_the_loop();
+			$no_script       = false;
+			$infinite_scroll = false;
+
+			if ( is_home() && current_theme_supports( 'infinite-scroll' ) ) {
+				$infinite_scroll = true;
 			}
 
-			if ( empty( $title ) ) {
-				/** This filter is documented in core/src/wp-includes/general-template.php */
-				$title = apply_filters( 'wp_title', $post->post_title, '', '' );
+			if ( defined( 'PADPRESS_LOADED' ) ) {
+				$inline = true;
 			}
 
-			if ( empty( $permalink ) ) {
-				$permalink = get_permalink( $post->ID );
+			if ( function_exists( 'get_option' ) && get_option( 'polldaddy_load_poll_inline' ) ) {
+				$inline = true;
 			}
 
-			$rating    = intval( $rating );
-			$unique_id = preg_replace( '/[^\-_a-z0-9]/i', '', wp_strip_all_tags( $unique_id ) );
-			$item_id   = wp_strip_all_tags( $item_id );
-			$item_id   = preg_replace( '/[^_a-z0-9]/i', '', $item_id );
+			if ( is_feed() || ( defined( 'DOING_AJAX' ) && ! $infinite_scroll ) ) {
+				$no_script = false;
+			}
 
-			$settings = json_encode( array(
-				'id'        => $rating,
-				'unique_id' => $unique_id,
-				'title'     => rawurlencode( trim( $title ) ),
-				'permalink' => esc_url( $permalink ),
-				'item_id'   => $item_id,
-			) );
+			self::$add_script = $infinite_scroll;
 
-			$item_id = esc_js( $item_id );
+			if ( intval( $attributes['rating'] ) > 0 && ! $no_script ) { // rating embed.
 
-			if ( Jetpack_AMP_Support::is_amp_request() ) {
-				return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $permalink ), esc_html( trim( $title ) ) );
-			} elseif ( $inline ) {
-				return <<<SCRIPT
+				if ( empty( $attributes['unique_id'] ) ) {
+					$attributes['unique_id'] = is_page() ? 'wp-page-' . $post->ID : 'wp-post-' . $post->ID;
+				}
+
+				if ( empty( $attributes['item_id'] ) ) {
+					$attributes['item_id'] = is_page() ? '_page_' . $post->ID : '_post_' . $post->ID;
+				}
+
+				if ( empty( $attributes['title'] ) ) {
+					/** This filter is documented in core/src/wp-includes/general-template.php */
+					$attributes['title'] = apply_filters( 'wp_title', $post->post_title, '', '' );
+				}
+
+				if ( empty( $attributes['permalink'] ) ) {
+					$attributes['permalink'] = get_permalink( $post->ID );
+				}
+
+				$rating    = intval( $attributes['rating'] );
+				$unique_id = preg_replace( '/[^\-_a-z0-9]/i', '', wp_strip_all_tags( $attributes['unique_id'] ) );
+				$item_id   = wp_strip_all_tags( $attributes['item_id'] );
+				$item_id   = preg_replace( '/[^_a-z0-9]/i', '', $item_id );
+
+				$settings = wp_json_encode(
+					array(
+						'id'        => $rating,
+						'unique_id' => $unique_id,
+						'title'     => rawurlencode( trim( $attributes['title'] ) ),
+						'permalink' => esc_url( $attributes['permalink'] ),
+						'item_id'   => $item_id,
+					)
+				);
+
+				$item_id = esc_js( $item_id );
+
+				if ( Jetpack_AMP_Support::is_amp_request() ) {
+					return sprintf(
+						'<a href="%s" target="_blank">%s</a>',
+						esc_url( $attributes['permalink'] ),
+						esc_html( trim( $attributes['title'] ) )
+					);
+				} elseif ( $inline ) {
+					return <<<SCRIPT
 <div class="cs-rating pd-rating" id="pd_rating_holder_{$rating}{$item_id}"></div>
 <script type="text/javascript" charset="UTF-8"><!--//--><![CDATA[//><!--
 PDRTJS_settings_{$rating}{$item_id}={$settings};
 //--><!]]></script>
 <script type="text/javascript" charset="UTF-8" async src="https://polldaddy.com/js/rating/rating.js"></script>
 SCRIPT;
-			} else {
-				if ( false === self::$scripts ) {
-					self::$scripts = array();
-				}
-
-				$data = array( 'id' => $rating, 'item_id' => $item_id, 'settings' => $settings );
-
-				self::$scripts['rating'][] = $data;
-
-				add_action( 'wp_footer', array( $this, 'generate_scripts' ) );
-
-				$data = esc_attr( json_encode( $data ) );
-
-				if ( $infinite_scroll ) {
-					return <<<CONTAINER
-<div class="cs-rating pd-rating" id="pd_rating_holder_{$rating}{$item_id}" data-settings="{$data}"></div>
-CONTAINER;
 				} else {
-					return <<<CONTAINER
-<div class="cs-rating pd-rating" id="pd_rating_holder_{$rating}{$item_id}"></div>
-CONTAINER;
-				}
-			}
-		} elseif ( intval( $poll ) > 0 ) { //poll embed
-
-			if ( empty( $title ) ) {
-				$title = __( 'Take Our Poll', 'jetpack' );
-			}
-
-			$poll      = intval( $poll );
-			$poll_url  = sprintf( 'https://poll.fm/%d', $poll );
-			$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
-			$poll_link = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $poll_url ), esc_html( $title ) );
-
-			if ( $no_script || Jetpack_AMP_Support::is_amp_request() ) {
-				return $poll_link;
-			} else {
-				if ( $type == 'slider' && !$inline ) {
-
-					if ( ! in_array( $visit, array( 'single', 'multiple' ) ) ) {
-						$visit = 'single';
+					if ( false === self::$scripts ) {
+						self::$scripts = array();
 					}
 
-					$settings = array(
-						'type'  => 'slider',
-						'embed' => 'poll',
-						'delay' => intval( $delay ),
-						'visit' => $visit,
-						'id'    => intval( $poll )
+					$data = array(
+						'id'       => $rating,
+						'item_id'  => $item_id,
+						'settings' => $settings,
 					);
 
-					return $this->get_async_code( $settings, $poll_link );
+					self::$scripts['rating'][] = $data;
+
+					add_action( 'wp_footer', array( $this, 'generate_scripts' ) );
+
+					$data = esc_attr( wp_json_encode( $data ) );
+
+					if ( $infinite_scroll ) {
+						return <<<CONTAINER
+<div class="cs-rating pd-rating" id="pd_rating_holder_{$rating}{$item_id}" data-settings="{$data}"></div>
+CONTAINER;
+					} else {
+						return <<<CONTAINER
+<div class="cs-rating pd-rating" id="pd_rating_holder_{$rating}{$item_id}"></div>
+CONTAINER;
+					}
+				}
+			} elseif ( intval( $attributes['poll'] ) > 0 ) { // poll embed.
+
+				if ( empty( $attributes['title'] ) ) {
+					$attributes['title'] = esc_html__( 'Take Our Poll', 'jetpack' );
+				}
+
+				$poll      = intval( $attributes['poll'] );
+				$poll_url  = sprintf( 'https://poll.fm/%d', $poll );
+				$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
+				$poll_link = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $poll_url ), esc_html( $attributes['title'] ) );
+
+				if ( $no_script || Jetpack_AMP_Support::is_amp_request() ) {
+					return $poll_link;
 				} else {
-					$cb      = ( $cb == 1 ? '?cb='.mktime() : false );
-					$margins = '';
-					$float   = '';
+					if (
+						'slider' === $attributes['type']
+						&& ! $inline
+					) {
 
-					if ( in_array( $align, array( 'right', 'left' ) ) ) {
-						$float = sprintf( 'float: %s;', $align );
-
-						if ( $align == 'left')
-							$margins = 'margin: 0px 10px 0px 0px;';
-						elseif ( $align == 'right' )
-							$margins = 'margin: 0px 0px 0px 10px';
-					}
-
-					// Force the normal style embed on single posts/pages otherwise it's not rendered on infinite scroll themed blogs ('infinite_scroll_render' isn't fired)
-					if ( is_singular() ) {
-						$inline = true;
-					}
-
-					if ( false === $cb && ! $inline ) {
-						if ( false === self::$scripts ) {
-							self::$scripts = array();
+						if ( ! in_array(
+							$attributes['visit'],
+							array( 'single', 'multiple' ),
+							true
+						) ) {
+							$attributes['visit'] = 'single';
 						}
 
-						$data = array( 'url' => $poll_js );
+						$settings = array(
+							'type'  => 'slider',
+							'embed' => 'poll',
+							'delay' => intval( $attributes['delay'] ),
+							'visit' => $attributes['visit'],
+							'id'    => intval( $poll ),
+						);
 
-						self::$scripts['poll'][intval( $poll )] = $data;
+						return $this->get_async_code( $settings, $poll_link );
+					} else {
+						if ( 1 === $attributes['cb'] ) {
+							$attributes['cb'] = '?cb=' . mktime();
+						} else {
+							$attributes['cb'] = false;
+						}
+						$margins = '';
+						$float   = '';
 
-						add_action( 'wp_footer', array( $this, 'generate_scripts' ) );
+						if ( in_array(
+							$attributes['align'],
+							array( 'right', 'left' ),
+							true
+						) ) {
+							$float = sprintf( 'float: %s;', $attributes['align'] );
 
-						$data = esc_attr( json_encode( $data ) );
+							if ( 'left' === $attributes['align'] ) {
+								$margins = 'margin: 0px 10px 0px 0px;';
+							} elseif ( 'right' === $attributes['align'] ) {
+								$margins = 'margin: 0px 0px 0px 10px';
+							}
+						}
 
-						$script_url = esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) );
-						$str = <<<CONTAINER
+						/*
+						 * Force the normal style embed on single posts/pages
+						 * otherwise it's not rendered on infinite scroll themed blogs
+						 * ('infinite_scroll_render' isn't fired)
+						 */
+						if ( is_singular() ) {
+							$inline = true;
+						}
+
+						if ( false === $attributes['cb'] && ! $inline ) {
+							if ( false === self::$scripts ) {
+								self::$scripts = array();
+							}
+
+							$data = array( 'url' => $poll_js );
+
+							self::$scripts['poll'][ intval( $poll ) ] = $data;
+
+							add_action( 'wp_footer', array( $this, 'generate_scripts' ) );
+
+							$data = esc_attr( wp_json_encode( $data ) );
+
+							$script_url = esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) );
+							$str        = <<<CONTAINER
 <a name="pd_a_{$poll}"></a>
 <div class="CSS_Poll PDS_Poll" id="PDI_container{$poll}" data-settings="{$data}" style="display:inline-block;{$float}{$margins}"></div>
 <div id="PD_superContainer"></div>
 <noscript>{$poll_link}</noscript>
 CONTAINER;
 
-$loader = <<<SCRIPT
+							$loader = <<<SCRIPT
 ( function( d, c, j ) {
 	if ( ! d.getElementById( j ) ) {
 		var pd = d.createElement( c ), s;
@@ -351,260 +424,287 @@ $loader = <<<SCRIPT
 } ( document, 'script', 'pd-polldaddy-loader' ) );
 SCRIPT;
 
-						$loader = $this->compress_it( $loader );
-						$loader = "<script type='text/javascript'>\n" . $loader . "\n</script>";
+							$loader = $this->compress_it( $loader );
+							$loader = "<script type='text/javascript'>\n" . $loader . "\n</script>";
 
-						return $str . $loader;
-					} else {
-						if ( $inline ) {
-							$cb = '';
-						}
+							return $str . $loader;
+						} else {
+							if ( $inline ) {
+								$attributes['cb'] = '';
+							}
 
-						return <<<CONTAINER
+							return <<<CONTAINER
 <a id="pd_a_{$poll}"></a>
 <div class="CSS_Poll PDS_Poll" id="PDI_container{$poll}" style="display:inline-block;{$float}{$margins}"></div>
 <div id="PD_superContainer"></div>
-<script type="text/javascript" charset="UTF-8" async src="{$poll_js}{$cb}"></script>
+<script type="text/javascript" charset="UTF-8" async src="{$poll_js}{$attributes['cb']}"></script>
 <noscript>{$poll_link}</noscript>
 CONTAINER;
+						}
 					}
 				}
-			}
-		} elseif ( ! empty( $survey ) ) { //survey embed
+			} elseif ( ! empty( $attributes['survey'] ) ) { // survey embed.
 
-			if ( in_array( $type, array( 'iframe', 'button', 'banner', 'slider' ) ) ) {
+				if ( in_array(
+					$attributes['type'],
+					array( 'iframe', 'button', 'banner', 'slider' ),
+					true
+				) ) {
 
-				if ( empty( $title ) ) {
-					$title = __( 'Take Our Survey', 'jetpack' );
-					if( ! empty( $link_text ) ) {
-						$title = $link_text;
+					if ( empty( $attributes['title'] ) ) {
+						$attributes['title'] = esc_html__( 'Take Our Survey', 'jetpack' );
+						if ( ! empty( $attributes['link_text'] ) ) {
+							$attributes['title'] = $attributes['link_text'];
+						}
 					}
-				}
 
-				if ( $type == 'banner' || $type == 'slider' )
-					$inline = false;
+					if (
+						'banner' === $attributes['type']
+						|| 'slider' === $attributes['type']
+					) {
+						$inline = false;
+					}
 
-				$survey      = preg_replace( '/[^a-f0-9]/i', '', $survey );
-				$survey_url  = esc_url( "https://survey.fm/{$survey}" );
-				$survey_link = sprintf( '<a href="%s" target="_blank">%s</a>', $survey_url, esc_html( $title ) );
+					$survey      = preg_replace( '/[^a-f0-9]/i', '', $attributes['survey'] );
+					$survey_url  = esc_url( "https://survey.fm/{$survey}" );
+					$survey_link = sprintf( '<a href="%s" target="_blank">%s</a>', $survey_url, esc_html( $attributes['title'] ) );
 
-				$settings = array();
+					$settings = array();
 
-				// Do we want a full embed code or a link?
-				if ( $no_script || $inline || $infinite_scroll || Jetpack_AMP_Support::is_amp_request() ) {
-					return $survey_link;
-				}
+					// Do we want a full embed code or a link?
+					if ( $no_script || $inline || $infinite_scroll || Jetpack_AMP_Support::is_amp_request() ) {
+						return $survey_link;
+					}
 
-				if ( $type == 'iframe' ) {
-					if ( $height != 'auto' ) {
-						if ( isset( $content_width ) && is_numeric( $width ) && $width > $content_width ) {
-							$width = $content_width;
-						}
+					if ( 'iframe' === $attributes['type'] ) {
+						if ( 'auto' !== $attributes['height'] ) {
+							if (
+								isset( $content_width )
+								&& is_numeric( $attributes['width'] )
+								&& $attributes['width'] > $content_width
+							) {
+								$attributes['width'] = $content_width;
+							}
 
-						if ( ! $width ) {
-							$width = '100%';
-						} else {
-							$width = (int) $width;
-						}
+							if ( ! $attributes['width'] ) {
+								$attributes['width'] = '100%';
+							} else {
+								$attributes['width'] = (int) $attributes['width'];
+							}
 
-						if ( ! $height ) {
-							$height = '600';
-						} else {
-							$height = (int) $height;
-						}
+							if ( ! $attributes['height'] ) {
+								$attributes['height'] = '600';
+							} else {
+								$attributes['height'] = (int) $attributes['height'];
+							}
 
-						return <<<CONTAINER
-<iframe src="{$survey_url}?iframe=1" frameborder="0" width="{$width}" height="{$height}" scrolling="auto" allowtransparency="true" marginheight="0" marginwidth="0">{$survey_link}</iframe>
+							return <<<CONTAINER
+<iframe src="{$survey_url}?iframe=1" frameborder="0" width="{$attributes['width']}" height="{$attributes['height']}" scrolling="auto" allowtransparency="true" marginheight="0" marginwidth="0">{$survey_link}</iframe>
 CONTAINER;
-					} elseif ( ! empty( $domain ) && ! empty( $id ) ) {
+						} elseif (
+							! empty( $attributes['domain'] )
+							&& ! empty( $attributes['id'] )
+						) {
 
-						$domain = preg_replace( '/[^a-z0-9\-]/i', '', $domain );
-						$id = preg_replace( '/[\/\?&\{\}]/', '', $id );
+							$domain = preg_replace( '/[^a-z0-9\-]/i', '', $attributes['domain'] );
+							$id     = preg_replace( '/[\/\?&\{\}]/', '', $attributes['id'] );
 
-						$auto_src = esc_url( "https://{$domain}.survey.fm/{$id}" );
-						$auto_src = parse_url( $auto_src );
+							$auto_src = esc_url( "https://{$domain}.survey.fm/{$id}" );
+							$auto_src = wp_parse_url( $auto_src );
 
-						if ( ! is_array( $auto_src ) || count( $auto_src ) == 0 ) {
-							return '<!-- no crowdsignal output -->';
+							if ( ! is_array( $auto_src ) || 0 === count( $auto_src ) ) {
+								return '<!-- no crowdsignal output -->';
+							}
+
+							if ( ! isset( $auto_src['host'] ) || ! isset( $auto_src['path'] ) ) {
+								return '<!-- no crowdsignal output -->';
+							}
+
+							$domain = $auto_src['host'] . '/';
+							$id     = ltrim( $auto_src['path'], '/' );
+
+							$settings = array(
+								'type'   => $attributes['type'],
+								'auto'   => true,
+								'domain' => $domain,
+								'id'     => $id,
+							);
+						}
+					} else {
+						$text_color = preg_replace( '/[^a-f0-9]/i', '', $attributes['text_color'] );
+						$back_color = preg_replace( '/[^a-f0-9]/i', '', $attributes['back_color'] );
+
+						if (
+							! in_array(
+								$attributes['align'],
+								array(
+									'right',
+									'left',
+									'top-left',
+									'top-right',
+									'middle-left',
+									'middle-right',
+									'bottom-left',
+									'bottom-right',
+								),
+								true
+							)
+						) {
+							$attributes['align'] = '';
 						}
 
-						if ( ! isset( $auto_src['host'] ) || ! isset( $auto_src['path'] ) ) {
-							return '<!-- no crowdsignal output -->';
+						if (
+							! in_array(
+								$attributes['style'],
+								array(
+									'inline',
+									'side',
+									'corner',
+									'rounded',
+									'square',
+								),
+								true
+							)
+						) {
+							$attributes['style'] = '';
 						}
 
-						$domain   = $auto_src['host'] . '/';
-						$id       = ltrim( $auto_src['path'], '/' );
-
-						$settings = array(
-							'type'       => $type,
-							'auto'       => true,
-							'domain'     => $domain,
-							'id'         => $id
+						$settings = array_filter(
+							array(
+								'title'      => wp_strip_all_tags( $attributes['title'] ),
+								'type'       => $attributes['type'],
+								'body'       => wp_strip_all_tags( $attributes['body'] ),
+								'button'     => wp_strip_all_tags( $attributes['button'] ),
+								'text_color' => $text_color,
+								'back_color' => $back_color,
+								'align'      => $attributes['align'],
+								'style'      => $attributes['style'],
+								'id'         => $survey,
+							)
 						);
 					}
-				} else {
-					$text_color = preg_replace( '/[^a-f0-9]/i', '', $text_color );
-					$back_color = preg_replace( '/[^a-f0-9]/i', '', $back_color );
 
-					if (
-						! in_array(
-							$align,
-							array(
-								'right',
-								'left',
-								'top-left',
-								'top-right',
-								'middle-left',
-								'middle-right',
-								'bottom-left',
-								'bottom-right'
-							)
-						)
-					) {
-						$align = '';
+					if ( empty( $settings ) ) {
+						return '<!-- no crowdsignal output -->';
 					}
 
-					if (
-						! in_array(
-							$style,
-							array(
-								'inline',
-								'side',
-								'corner',
-								'rounded',
-								'square'
-							)
-						)
-					) {
-						$style = '';
-					}
-
-					$title  = wp_strip_all_tags( $title );
-					$body   = wp_strip_all_tags( $body );
-					$button = wp_strip_all_tags( $button );
-
-					$settings = array_filter( array(
-						'title'      => $title,
-						'type'       => $type,
-						'body'       => $body,
-						'button'     => $button,
-						'text_color' => $text_color,
-						'back_color' => $back_color,
-						'align'      => $align,
-						'style'      => $style,
-						'id'         => $survey,
-					) );
+					return $this->get_async_code( $settings, $survey_link );
 				}
-
-				if ( empty( $settings ) ) {
-					return '<!-- no crowdsignal output -->';
-				}
-
-				return $this->get_async_code( $settings, $survey_link );
-			}
-		} else {
-			return '<!-- no crowdsignal output -->';
-		}
-	}
-
-	function generate_scripts() {
-		$script = '';
-
-		if ( is_array( self::$scripts ) ) {
-			if ( isset( self::$scripts['rating'] ) ) {
-				$script = "<script type='text/javascript' charset='UTF-8' id='polldaddyRatings'><!--//--><![CDATA[//><!--\n";
-				foreach( self::$scripts['rating'] as $rating ) {
-					$script .= "PDRTJS_settings_{$rating['id']}{$rating['item_id']}={$rating['settings']}; if ( typeof PDRTJS_RATING !== 'undefined' ){if ( typeof PDRTJS_{$rating['id']}{$rating['item_id']} == 'undefined' ){PDRTJS_{$rating['id']}{$rating['item_id']} = new PDRTJS_RATING( PDRTJS_settings_{$rating['id']}{$rating['item_id']} );}}";
-				}
-				$script .= "\n//--><!]]></script><script type='text/javascript' charset='UTF-8' async src='https://polldaddy.com/js/rating/rating.js'></script>";
-
-			}
-
-			if ( isset( self::$scripts['poll'] ) ) {
-				foreach( self::$scripts['poll'] as $poll ) {
-					$script .= "<script type='text/javascript' charset='UTF-8' async src='{$poll['url']}'></script>";
-				}
+			} else {
+				return '<!-- no crowdsignal output -->';
 			}
 		}
 
-		self::$scripts = false;
-		echo $script;
-	}
+		/**
+		 * Enqueue JavaScript containing all ratings / polls on the page.
+		 * Hooked into wp_footer
+		 *
+		 * @echo string $script.
+		 */
+		public function generate_scripts() {
+			$script = '';
 
-	/**
-	 * If the theme uses infinite scroll, include jquery at the start
-	 */
-	function check_infinite() {
-		if (
-			current_theme_supports( 'infinite-scroll' )
-			&& class_exists( 'The_Neverending_Home_Page' )
-			&& The_Neverending_Home_Page::archive_supports_infinity()
-		) {
-			wp_enqueue_script( 'jquery' );
-		}
-	}
-
-	/**
-	 * Dynamically load the .js, if needed
-	 *
-	 * This hooks in late (priority 11) to infinite_scroll_render to determine
-	 * a posteriori if a shortcode has been called.
-	 */
-	function crowdsignal_shortcode_infinite() {
-		// only try to load if a shortcode has been called and theme supports infinite scroll
-		if( self::$add_script ) {
-			$script_url = esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) );
-
-			// if the script hasn't been loaded, load it
-			// if the script loads successfully, fire an 'pd-script-load' event
-			echo <<<SCRIPT
-				<script type='text/javascript'>
-				//<![CDATA[
-				( function( d, c, j ) {
-					if ( !d.getElementById( j ) ) {
-						var pd = d.createElement( c ), s;
-						pd.id = j;
-						pd.async = true;
-						pd.src = '{$script_url}';
-						s = d.getElementsByTagName( c )[0];
-						s.parentNode.insertBefore( pd, s );
-					} else if ( typeof jQuery !== 'undefined' ) {
-						jQuery( d.body ).trigger( 'pd-script-load' );
+			if ( is_array( self::$scripts ) ) {
+				if ( isset( self::$scripts['rating'] ) ) {
+					$script = "<script type='text/javascript' charset='UTF-8' id='polldaddyRatings'><!--//--><![CDATA[//><!--\n";
+					foreach ( self::$scripts['rating'] as $rating ) {
+						$script .= "PDRTJS_settings_{$rating['id']}{$rating['item_id']}={$rating['settings']}; if ( typeof PDRTJS_RATING !== 'undefined' ){if ( typeof PDRTJS_{$rating['id']}{$rating['item_id']} == 'undefined' ){PDRTJS_{$rating['id']}{$rating['item_id']} = new PDRTJS_RATING( PDRTJS_settings_{$rating['id']}{$rating['item_id']} );}}";
 					}
-				} ( document, 'script', 'pd-polldaddy-loader' ) );
-				//]]>
-				</script>
+					$script .= "\n//--><!]]></script><script type='text/javascript' charset='UTF-8' async src='https://polldaddy.com/js/rating/rating.js'></script>";
+
+				}
+
+				if ( isset( self::$scripts['poll'] ) ) {
+					foreach ( self::$scripts['poll'] as $poll ) {
+						$script .= "<script type='text/javascript' charset='UTF-8' async src='{$poll['url']}'></script>";
+					}
+				}
+			}
+
+			self::$scripts = false;
+			echo $script;
+		}
+
+		/**
+		 * If the theme uses infinite scroll, include jquery at the start
+		 */
+		public function check_infinite() {
+			if (
+				current_theme_supports( 'infinite-scroll' )
+				&& class_exists( 'The_Neverending_Home_Page' )
+				&& The_Neverending_Home_Page::archive_supports_infinity()
+			) {
+				wp_enqueue_script( 'jquery' );
+			}
+		}
+
+		/**
+		 * Dynamically load the .js, if needed
+		 *
+		 * This hooks in late (priority 11) to infinite_scroll_render to determine
+		 * a posteriori if a shortcode has been called.
+		 */
+		public function crowdsignal_shortcode_infinite() {
+			// only try to load if a shortcode has been called and theme supports infinite scroll.
+			if ( self::$add_script ) {
+				$script_url = esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) );
+
+				/*
+				 * if the script hasn't been loaded, load it
+				 * if the script loads successfully, fire an 'pd-script-load' event
+				 */
+				echo <<<SCRIPT
+<script type='text/javascript'>
+//<![CDATA[
+( function( d, c, j ) {
+	if ( !d.getElementById( j ) ) {
+		var pd = d.createElement( c ), s;
+		pd.id = j;
+		pd.async = true;
+		pd.src = '{$script_url}';
+		s = d.getElementsByTagName( c )[0];
+		s.parentNode.insertBefore( pd, s );
+	} else if ( typeof jQuery !== 'undefined' ) {
+		jQuery( d.body ).trigger( 'pd-script-load' );
+	}
+} ( document, 'script', 'pd-polldaddy-loader' ) );
+//]]>
+</script>
 SCRIPT;
 
+			}
 		}
 	}
-}
 
-// kick it all off
-new CrowdsignalShortcode();
+	// Kick it all off.
+	new CrowdsignalShortcode();
 
-if ( ! function_exists( 'crowdsignal_link' ) ) {
-	// http://polldaddy.com/poll/1562975/?view=results&msg=voted
-	function crowdsignal_link( $content ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
-			return $content;
+	if ( ! function_exists( 'crowdsignal_link' ) ) {
+		/**
+		 * Replace link by embed.
+		 * Example: http://polldaddy.com/poll/1562975/?view=results&msg=voted
+		 *
+		 * @param string $content Post content.
+		 */
+		function crowdsignal_link( $content ) {
+			if ( Jetpack_AMP_Support::is_amp_request() ) {
+				return $content;
+			}
+
+			return preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", $content );
 		}
 
-		return preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", $content );
+		// higher priority because we need it before auto-link and autop get to it.
+		add_filter( 'the_content', 'crowdsignal_link', 1 );
+		add_filter( 'the_content_rss', 'crowdsignal_link', 1 );
 	}
 
-	// higher priority because we need it before auto-link and autop get to it
-	add_filter( 'the_content', 'crowdsignal_link', 1 );
-	add_filter( 'the_content_rss', 'crowdsignal_link', 1 );
-}
-
-	/**
-	 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
-	 * This should be removed after Core has the current regex is in our minimum version.
-	 *
-	 * @see https://core.trac.wordpress.org/ticket/46467
-	 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
-	 */
-wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
-
+		/**
+		 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
+		 * This should be removed after Core has the current regex is in our minimum version.
+		 *
+		 * @see https://core.trac.wordpress.org/ticket/46467
+		 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
+		 */
+	wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
 }

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -11,6 +11,7 @@
  * [crowdsignal survey="7676FB1FF2B56CE9"]
  * [polldaddy survey="7676FB1FF2B56CE9"]
  * [crowdsignal poll=9541291]
+ * [crowdsignal poll=9541291 type=slider]
  * [crowdsignal rating=8755352]
  *
  * @package Jetpack
@@ -355,6 +356,9 @@ if (
 				) {
 					return $poll_link;
 				} else {
+					/*
+					 * Slider poll.
+					 */
 					if (
 						'slider' === $attributes['type']
 						&& ! $inline

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -4,6 +4,7 @@
  *
  * Formats:
  * [polldaddy type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]
+ * [crowdsignal type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]
  * https://polldaddy.com/poll/7910844/
  * https://jeherve.survey.fm/a-survey
  * https://jeherve.survey.fm/a-survey-with-branches
@@ -557,12 +558,7 @@ if (
 							$domain = preg_replace( '/[^a-z0-9\-]/i', '', $attributes['domain'] );
 							$id     = preg_replace( '/[\/\?&\{\}]/', '', $attributes['id'] );
 
-							if ( 'crowdsignal.com' === $attributes['site'] ) {
-								$auto_src = esc_url( "https://{$domain}.survey.fm/{$id}" );
-							} else {
-								$auto_src = esc_url( "https://{$domain}.polldaddy.com/s/{$id}" );
-							}
-
+							$auto_src = esc_url( "https://{$domain}.survey.fm/{$id}" );
 							$auto_src = wp_parse_url( $auto_src );
 
 							if ( ! is_array( $auto_src ) || 0 === count( $auto_src ) ) {
@@ -573,13 +569,8 @@ if (
 								return '<!-- no crowdsignal output -->';
 							}
 
-							if ( strpos( $auto_src['host'], 'survey.fm' ) ) {
-								$domain = $auto_src['host'] . '/';
-							} else {
-								$domain = $auto_src['host'] . '/s/';
-							}
-
-							$id = ltrim( $auto_src['path'], '/' );
+							$domain = $auto_src['host'] . '/';
+							$id     = ltrim( $auto_src['path'], '/' );
 
 							$settings = array(
 								'type'   => $attributes['type'],

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -57,7 +57,7 @@ if (
 		/**
 		 * Register scripts that may be enqueued later on by the shortcode.
 		 */
-		public function register_scripts() {
+		public static function register_scripts() {
 			wp_register_script(
 				'crowdsignal-shortcode',
 				Jetpack::get_file_url_for_environment( '_inc/build/crowdsignal-shortcode.min.js', '_inc/crowdsignal-shortcode.js' ),

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -230,7 +230,10 @@ if (
 
 			self::$add_script = $infinite_scroll;
 
-			if ( intval( $attributes['rating'] ) > 0 && ! $no_script ) { // rating embed.
+			/*
+			 * Rating embed.
+			 */
+			if ( intval( $attributes['rating'] ) > 0 && ! $no_script ) {
 
 				if ( empty( $attributes['unique_id'] ) ) {
 					$attributes['unique_id'] = is_page() ? 'wp-page-' . $post->ID : 'wp-post-' . $post->ID;
@@ -322,7 +325,10 @@ if (
 						);
 					}
 				}
-			} elseif ( intval( $attributes['poll'] ) > 0 ) { // poll embed.
+			} elseif ( intval( $attributes['poll'] ) > 0 ) {
+				/*
+				 * Poll embed.
+				 */
 
 				if ( empty( $attributes['title'] ) ) {
 					$attributes['title'] = esc_html__( 'Take Our Poll', 'jetpack' );
@@ -455,7 +461,10 @@ if (
 						}
 					}
 				}
-			} elseif ( ! empty( $attributes['survey'] ) ) { // survey embed.
+			} elseif ( ! empty( $attributes['survey'] ) ) {
+				/*
+				 * Survey embed.
+				 */
 
 				if ( in_array(
 					$attributes['type'],

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -187,7 +187,7 @@ if (
 					'item_id'    => null,
 					'title'      => null,
 					'permalink'  => null,
-					'cb'         => 0,
+					'cb'         => 0, // cache buster. Helps with testing.
 					'type'       => 'button',
 					'body'       => '',
 					'button'     => '',

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -210,7 +210,9 @@ if (
 				return '<!-- Crowdsignal shortcode passed invalid attributes -->';
 			}
 
-			$inline          = ! in_the_loop();
+			$inline = ! in_the_loop()
+				&& ! Jetpack_Constants::is_defined( 'TESTING_IN_JETPACK' );
+
 			$no_script       = false;
 			$infinite_scroll = false;
 

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -158,6 +158,10 @@ if (
 		 * @param array $atts Shortcode attributes.
 		 */
 		public function polldaddy_shortcode( $atts ) {
+			if ( ! is_array( $atts ) ) {
+				return '<!-- Polldaddy shortcode passed invalid attributes -->';
+			}
+
 			$atts['site'] = 'polldaddy.com';
 			return $this->crowdsignal_shortcode( $atts );
 		}

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -430,7 +430,12 @@ if (
 								'crowdsignal-shortcode',
 								'crowdsignal_shortcode_options',
 								array(
-									'script_url' => esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) ),
+									'script_url' => esc_url_raw(
+										Jetpack::get_file_url_for_environment(
+											'_inc/build/polldaddy-shortcode.min.js',
+											'_inc/polldaddy-shortcode.js'
+										)
+									),
 								)
 							);
 
@@ -713,7 +718,12 @@ if (
 					'crowdsignal-shortcode',
 					'crowdsignal_shortcode_options',
 					array(
-						'script_url' => esc_url_raw( plugins_url( 'js/polldaddy-shortcode.js', __FILE__ ) ),
+						'script_url' => esc_url_raw(
+							Jetpack::get_file_url_for_environment(
+								'_inc/build/polldaddy-shortcode.min.js',
+								'_inc/polldaddy-shortcode.js'
+							)
+						),
 					)
 				);
 			}

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -177,6 +177,10 @@ if (
 			global $post;
 			global $content_width;
 
+			if ( ! is_array( $atts ) ) {
+				return '<!-- Crowdsignal shortcode passed invalid attributes -->';
+			}
+
 			$attributes = shortcode_atts(
 				array(
 					'survey'     => null,
@@ -206,10 +210,6 @@ if (
 				$atts,
 				'crowdsignal'
 			);
-
-			if ( ! is_array( $atts ) ) {
-				return '<!-- Crowdsignal shortcode passed invalid attributes -->';
-			}
 
 			$inline = ! in_the_loop()
 				&& ! Jetpack_Constants::is_defined( 'TESTING_IN_JETPACK' );

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -734,7 +734,12 @@ if (
 				return $content;
 			}
 
-			return preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", $content ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			return jetpack_preg_replace_outside_tags(
+				'!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i',
+				"\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				$content,
+				'polldaddy.com/poll'
+			);
 		}
 
 		// higher priority because we need it before auto-link and autop get to it.

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -2,6 +2,13 @@
 
 class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
+	public function setUp() {
+		parent::setUp();
+
+		// Register the scripts needed by the shortcode.
+		CrowdsignalShortcode::register_scripts();
+	}
+
 	/**
 	 * @author scotchfield
 	 * @covers CrowdSignal::crowdsignal_shortcode
@@ -56,6 +63,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			),
 			$shortcode_content
 		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-shortcode', 'enqueued' ) );
 	}
 
 	/**
@@ -76,6 +84,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			),
 			$shortcode_content
 		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-shortcode', 'enqueued' ) );
 	}
 
 	/**
@@ -96,6 +105,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			),
 			$shortcode_content
 		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
 	}
 
 	/**
@@ -116,6 +126,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			),
 			$shortcode_content
 		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
 
 		// Test AMP version. On AMP views, we only show a link.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -179,6 +190,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			),
 			$shortcode_content
 		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -51,7 +51,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a id="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content
@@ -71,10 +71,167 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a id="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content
 		);
+	}
+
+	/**
+	 * Test a basic legacy Polldaddy survey.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_polldaddy_survey() {
+		$id      = '7676FB1FF2B56CE9';
+		$content = '[polldaddy survey=' . $id . ']';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<a class="cs-embed pd-embed" href="https://polldaddy.com/s/%1$s" data-settings="{&quot;title&quot;:&quot;Take Our Survey&quot;,&quot;type&quot;:&quot;button&quot;,&quot;text_color&quot;:&quot;000000&quot;,&quot;back_color&quot;:&quot;FFFFFF&quot;,&quot;id&quot;:&quot;%1$s&quot;,&quot;site&quot;:&quot;polldaddy.com&quot;}">Take Our Survey</a>',
+				$id
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Test a basic Crowdsignal survey.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_survey() {
+		$id      = '7676FB1FF2B56CE9';
+		$content = '[crowdsignal survey=' . $id . ']';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<a class="cs-embed pd-embed" href="https://survey.fm/%1$s" data-settings="{&quot;title&quot;:&quot;Take Our Survey&quot;,&quot;type&quot;:&quot;button&quot;,&quot;text_color&quot;:&quot;000000&quot;,&quot;back_color&quot;:&quot;FFFFFF&quot;,&quot;id&quot;:&quot;%1$s&quot;,&quot;site&quot;:&quot;crowdsignal.com&quot;}">Take Our Survey</a>',
+				$id
+			),
+			$shortcode_content
+		);
+
+		// Test AMP version. On AMP views, we only show a link.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf(
+				'<a href="https://survey.fm/%1$s" target="_blank" rel="noopener noreferrer">Take Our Survey</a>',
+				$id
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Test a Crowdsignal survey in an iFrame.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_survey_iframe() {
+		$id      = '7676FB1FF2B56CE9';
+		$content = '[crowdsignal survey=' . $id . ' type="iframe" width="400" height="600"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<iframe src="https://survey.fm/%1$s?iframe=1" frameborder="0" width="400" height="600" scrolling="auto" allowtransparency="true" marginheight="0" marginwidth="0"><a href="https://survey.fm/%1$s" target="_blank" rel="noopener noreferrer">Take Our Survey</a></iframe>',
+				$id
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Test a Crowdsignal survey in an iFrame, using a custom domain name, and a custom title.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_survey_iframe_customdomain() {
+		$id      = '7676FB1FF2B56CE9';
+		$domain  = 'jeherve';
+		$name    = 'a-survey';
+		$title   = 'A test survey';
+		$content = sprintf(
+			'[crowdsignal survey="%1$s" type="iframe" width="400" height="auto" domain="%2$s" id="%3$s" title="%4$s"]',
+			$id,
+			$domain,
+			$name,
+			$title
+		);
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<div class="cs-embed pd-embed" data-settings="{&quot;type&quot;:&quot;iframe&quot;,&quot;auto&quot;:true,&quot;domain&quot;:&quot;%2$s.survey.fm\/&quot;,&quot;id&quot;:&quot;%3$s&quot;,&quot;site&quot;:&quot;crowdsignal.com&quot;}"></div><noscript><a href="https://survey.fm/%1$s" target="_blank" rel="noopener noreferrer">%4$s</a></noscript>',
+				$id,
+				$domain,
+				$name,
+				$title
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Test a basic legacy Polldaddy rating.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_polldaddy_rating() {
+		global $post;
+
+		$id      = 8755352;
+		$content = '[polldaddy rating=' . $id . ']';
+		$post    = $this->factory()->post->create_and_get( array( 'post_content' => $content ) );
+
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<div class="cs-rating pd-rating" id="pd_rating_holder_%1$d_post_%2$d"></div>',
+				$id,
+				$post->ID
+			),
+			$actual
+		);
+		wp_reset_postdata();
+	}
+
+	/**
+	 * Test a basic Crowdsignal rating.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_rating() {
+		global $post;
+
+		$id      = 8755352;
+		$content = '[crowdsignal rating=' . $id . ']';
+		$post    = $this->factory()->post->create_and_get( array( 'post_content' => $content ) );
+
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<div class="cs-rating pd-rating" id="pd_rating_holder_%1$d_post_%2$d"></div>',
+				$id,
+				$post->ID
+			),
+			$actual
+		);
+		wp_reset_postdata();
 	}
 }

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -88,6 +88,27 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test a Crowdsignal slider poll (sticks to the bottom right corner of the page).
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_poll_slider() {
+		$id      = 9541291;
+		$content = '[crowdsignal poll=' . $id . ' type="slider"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<div class="cs-embed pd-embed" data-settings="{&quot;type&quot;:&quot;slider&quot;,&quot;embed&quot;:&quot;poll&quot;,&quot;delay&quot;:100,&quot;visit&quot;:&quot;single&quot;,&quot;id&quot;:%1$d,&quot;site&quot;:&quot;crowdsignal.com&quot;}"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				$id
+			),
+			$shortcode_content
+		);
+		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
+	}
+
+	/**
 	 * Test a basic legacy Polldaddy survey.
 	 *
 	 * @since 7.4.0

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -38,4 +38,43 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	/**
+	 * Test a basic legacy Polldaddy poll.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_polldaddy_poll() {
+		$id      = 9541291;
+		$content = '[polldaddy poll=' . $id . ']';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<a id="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				$id
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Test a basic Crowdsignal poll.
+	 *
+	 * @since 7.4.0
+	 */
+	public function test_shortcodes_crowdsignal_poll() {
+		$id      = 9541291;
+		$content = '[crowdsignal poll=' . $id . ']';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals(
+			sprintf(
+				'<a id="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				$id
+			),
+			$shortcode_content
+		);
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -150,6 +150,11 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
 
 		// Test AMP version. On AMP views, we only show a link.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$shortcode_content = do_shortcode( $content );
 		$this->assertEquals(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR aims to fix all PHPCS warnings in the Crowdsignal / Polldaddy shortcode, so those files can be synced with WordPress.com and replace the existing shortcode there.

I made a few different changes:

- Fix PHPCS warnings
- Remove `GLOBAL_TAGS` check (we don't use that constant anywhere on WordPress.com or in Jetpack anymore).
- Remove `PADPRESS_LOADED` constant check (it was used by the Onswipe plugin, but that plugin is not in the repository anymore and we don't use the constant anywhere on WordPress.com anymore either).
- Modify the way JavaScript is enqueued. Rely on core functions (we now use `wp_register_script`, `wp_enqueue_script`, and `wp_add_inline_script` to enqueue JavaScript content on the pages).

#### Testing instructions:

**To test, you'll need to either run `yarn build` or add `define( 'SCRIPT_DEBUG', true );` to your `wp-config.php` file**

* You'll want to insert different shortcodes in your posts; some posts with only one shortcode, others with multiple shortcodes at once:
 * `[polldaddy type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]`
 * `[crowdsignal type="iframe" survey="EB151947E5950FCF" height="auto" domain="jeherve" id="a-survey-with-branches"]`
 * `https://polldaddy.com/poll/7910844/`
 * `https://jeherve.survey.fm/a-survey`
 * `https://jeherve.survey.fm/a-survey-with-branches`
 * `[crowdsignal type="iframe" survey="7676FB1FF2B56CE9" height="auto" domain="jeherve" id="a-survey"]`
 * `[crowdsignal survey="7676FB1FF2B56CE9"]`
 * `[polldaddy survey="7676FB1FF2B56CE9"]`
 * `[crowdsignal poll=9541291]`
 * `[crowdsignal poll=9541291 type=slider]`
 * `[crowdsignal rating=8755352]`
* You should check that the shortcodes are displayed properly on the post's page, but also on the home page. You'll find that in some scenarios (looking at the home page on a site with a theme that supports Infinite Scroll), only a link is displayed.

@donnchawp I would appreciate your review on this PR. I don't know of all the potential embed combinations one may use, so I am afraid I may have missed one. Could you take a look?

#### Remaining question:

On WordPress.com we have an additional `site` parameter for the shortcode, introduced in r181467-wpcom. I am not sure if it is still necessary, and if we should keep it. @donnchawp Could you take a look? Would it be okay to use the short domains for all embeds now?

#### Proposed changelog entry for your changes:

* None
