### PR TITLE
Check that newly added php files are included in phpcs whitelist

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -1,0 +1,13 @@
+// If the file path starts with anything like in the array below, it should be linted.
+module.exports = [
+	'_inc/lib/debugger/',
+	'_inc/lib/class.jetpack-password-checker.php',
+	'extensions/',
+	'sync/class.jetpack-sync-module-auth.php',
+	'class.jetpack-gutenberg.php',
+	'class.jetpack-plan.php',
+	'modules/module-extras.php',
+	'modules/module-info.php',
+	'modules/theme-tools/social-menu/',
+	'functions.opengraph.php',
+];

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,6 +6,7 @@
 const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
+const whitelist = require( './phpcs-whitelist' );
 let exitCode = 0;
 
 /**
@@ -27,20 +28,6 @@ function parseGitDiffToPathArray( command ) {
  * @return {boolean}        If the file matches the whitelist.
  */
 function phpcsFilesToFilter( file ) {
-	// If the file path starts with anything like in the array below, it should be linted.
-	const whitelist = [
-		'_inc/lib/debugger/',
-		'_inc/lib/class.jetpack-password-checker.php',
-		'extensions/',
-		'sync/class.jetpack-sync-module-auth.php',
-		'class.jetpack-gutenberg.php',
-		'class.jetpack-plan.php',
-		'modules/module-extras.php',
-		'modules/module-info.php',
-		'modules/theme-tools/social-menu/',
-		'functions.opengraph.php',
-	];
-
 	if ( -1 !== whitelist.findIndex( filePath => file.startsWith( filePath ) ) ) {
 		return true;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds a danger check about newly added php files to be whitelisted. 

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There are few ways to test it:
* Try committing a new .php file into that PR. it should trigger the danger warning
* Locally run `./node_modules/.bin/danger pr https://github.com/Automattic/jetpack/pull/9802` (or any other PR with new files).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* none
