### PR TITLE
Remove legacy notice targetted for IE10

### DIFF
--- a/_inc/client/static.jsx
+++ b/_inc/client/static.jsx
@@ -33,21 +33,3 @@ window.versionNotice = Server.renderToStaticMarkup(
 		<StaticWarning />
 	</Provider>
 );
-
-window.ieNotice = Server.renderToStaticMarkup(
-	<Provider store={ store }>
-		<div id="ie-legacy-notice" style={ { display: 'none' } }>
-			<StaticWarning />
-		</div>
-	</Provider>
-);
-
-window.ieNotice =
-	window.ieNotice +
-	'<script type="text/javascript">\n' +
-	'/*@cc_on\n' +
-	'if ( @_jscript_version <= 10) {\n' +
-	"jQuery( '#ie-legacy-notice' ).show();\n" +
-	'}\n' +
-	'@*/\n' +
-	'</script>';

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -33,9 +33,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Adding a redirect meta tag wrapped in noscript tags for all browsers in case they have JavaScript disabled
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
-
-		// Adding a redirect tag wrapped in browser conditional comments
-		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_script' ) );
 	}
 
 	/**
@@ -74,17 +71,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		echo '<noscript>';
 		$this->add_fallback_head_meta();
 		echo '</noscript>';
-	}
-
-	function add_legacy_browsers_head_script() {
-		echo
-			"<script type=\"text/javascript\">\n"
-			. "/*@cc_on\n"
-			. "if ( @_jscript_version <= 10) {\n"
-			. "window.location.href = '?page=jetpack_modules';\n"
-			. "}\n"
-			. "@*/\n"
-			. "</script>";
 	}
 
 	function jetpack_menu_order( $menu_order ) {

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -30,7 +30,6 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		// We have static.html so let's continue trying to fetch the others
 		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
 		$rest_api_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
-		$ie_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',
@@ -54,22 +53,10 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$rest_api_notice
 		);
 
-		$ie_notice = str_replace(
-			'#HEADER_TEXT#',
-			esc_html__( 'You are using an unsupported browser version.', 'jetpack' ),
-			$ie_notice
-		);
-		$ie_notice = str_replace(
-			'#TEXT#',
-			esc_html__( "Update your browser to unlock Jetpack's full potential!", 'jetpack' ),
-			$ie_notice
-		);
-
 		if ( ! $this->is_rest_api_enabled() ) {
 			echo $rest_api_notice;
 		}
 		echo $noscript_notice;
-		echo $ie_notice;
 		?>
 
 		<div class="page-content configure">

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -213,7 +213,6 @@ function buildStatic( done ) {
 					__dirname + '/../../_inc/build/static-version-notice.html',
 					window.versionNotice
 				);
-				fs.writeFileSync( __dirname + '/../../_inc/build/static-ie-notice.html', window.ieNotice );
 
 				done();
 			} );


### PR DESCRIPTION
Clean up some code that warns about legacy IE browsers (IE10 and older it seems: http://tanalin.com/en/articles/ie-version-js/ ).

Seems like at this point that's so old that it's not worth even having code around for. :-)

#### Changes proposed in this Pull Request:

* Remove IE10 legacy notifications

#### Testing instructions:
- Admin dash builds and works with `yarn build`
- Spin dust off your IE10 test bench 😀 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
