### PR TITLE
Plugin Search Hints: only display feature suggestion when your plan supports it

### DIFF
--- a/modules/vaultpress.php
+++ b/modules/vaultpress.php
@@ -10,6 +10,7 @@
  * Auto Activate: Yes
  * Feature: Security, Health
  * Additional Search Queries: backup, cloud backup, database backup, restore, wordpress backup, backup plugin, wordpress backup plugin, back up, backup wordpress, backwpup, vaultpress, backups, off-site backups, offsite backup, offsite, off-site, antivirus, malware scanner, security, virus, viruses, prevent viruses, scan, anti-virus, antimalware, protection, safe browsing, malware, wp security, wordpress security
+ * Plans: personal, business, premium
  */
 
 add_action( 'jetpack_modules_loaded', 'vaultpress_jetpack_stub' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Until now, when searching for "search" or "backups" under Plugins > Add New, we would display suggestions for the Search feature or the Backups feature, even though those features require a plan purchase.

With this PR, we make sure features are only suggested when your site uses a plan that supports it. That will allow you to get to know about Jetpack Backups / Jetpack Search if you purchased a plan but did not turn on the feature yet.

Fixes #11828 

#### Testing instructions:

* Start on a brand new free Jetpack site. Connect that site to WordPress.com.
* Go to Plugins > Add New, and search for "cdn"
    * You should see a suggestion for our Image CDN feature.
* Now search for "backups", or "akismet".
    * You should not see any Jetpack plugin search hints.
* Head to Jetpack > Dashboard > Plans, and follow the flow to purchase a personal plan.
* Head back to your site.
* Go to Plugins > Add New, and search for "backups"
    * You should now see a suggestion for Jetpack Backups
* Now search for "search"
    * You should not see any Jetpack plugin search hints.
* Head to Jetpack > Dashboard > Plans, and follow the flow to upgrade to a Professional plan.
* Head back to your site.
* Go to Plugins > Add New, and search for "search"
    * You should now see a suggestion for Jetpack Search

#### Proposed changelog entry for your changes:

* Plugin Search Hints: only display feature suggestion when your plan supports it
