### PR TITLE
Feature Hints: update design to make card stand out more

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -207,9 +207,14 @@ class Jetpack_Plugin_Search {
 				'activating'     => esc_html__( 'Activating', 'jetpack' ),
 				'logo'           => 'https://ps.w.org/jetpack/assets/icon.svg?rev=1791404',
 				'legend'         => esc_html__(
-					'Jetpack is trusted by millions to help secure and speed up their WordPress site. Make the most of it today.',
+					'This suggestion was made by Jetpack, the security and performance plugin already installed on your site.',
 					'jetpack'
 				),
+				'supportText'    => esc_html__(
+					'Learn more about these suggestions.',
+					'jetpack'
+				),
+				'supportLink'    => 'https://jetpack.com/support/plugin-search-hints/',
 				'hideText'       => esc_html__( 'Hide this suggestion', 'jetpack' ),
 			)
 		);

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -215,7 +215,7 @@ class Jetpack_Plugin_Search {
 					'Learn more about these suggestions.',
 					'jetpack'
 				),
-				'supportLink'    => 'https://jetpack.com/support/plugin-search-hints/',
+				'supportLink'    => 'https://jetpack.com/redirect/?source=plugin-hint-learn-support',
 				'hideText'       => esc_html__( 'Hide this suggestion', 'jetpack' ),
 			)
 		);

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -200,6 +200,7 @@ class Jetpack_Plugin_Search {
 			array(
 				'nonce'          => wp_create_nonce( 'wp_rest' ),
 				'base_rest_url'  => rest_url( '/jetpack/v4' ),
+				'poweredBy'      => esc_html__( 'by Jetpack (installed)', 'jetpack' ),
 				'manageSettings' => esc_html__( 'Configure', 'jetpack' ),
 				'activateModule' => esc_html__( 'Activate Module', 'jetpack' ),
 				'getStarted'     => esc_html__( 'Get started', 'jetpack' ),

--- a/modules/plugin-search/plugin-search.css
+++ b/modules/plugin-search/plugin-search.css
@@ -2,6 +2,10 @@
 	margin: 0 0 4px 0;
 }
 
+.plugin-card-jetpack-plugin-search .action-links {
+	position: relative;
+}
+
 .plugin-card-jetpack-plugin-search .plugin-action-buttons {
 	white-space: nowrap;
 }

--- a/modules/plugin-search/plugin-search.css
+++ b/modules/plugin-search/plugin-search.css
@@ -1,3 +1,7 @@
+.plugin-card-jetpack-plugin-search h3 {
+	margin: 0 0 4px 0;
+}
+
 .plugin-card-jetpack-plugin-search .plugin-action-buttons {
 	white-space: nowrap;
 }

--- a/modules/plugin-search/plugin-search.css
+++ b/modules/plugin-search/plugin-search.css
@@ -58,9 +58,13 @@
 	margin: 0 24px 0 16px;
 }
 
-@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px)
-.plugin-card-jetpack-plugin-search .plugin-action-buttons li {
-    display: block;
+@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px) {
+	.plugin-card-jetpack-plugin-search .plugin-action-buttons li {
+		display: block;
+	}
+	.plugin-card-jetpack-plugin-search .plugin-action-buttons li button {
+		margin-right: 0;
+	}
 }
 
 /* Hides the link to dismiss cards when it's in action links are before being moved to bottom row*/

--- a/modules/plugin-search/plugin-search.css
+++ b/modules/plugin-search/plugin-search.css
@@ -58,6 +58,11 @@
 	margin: 0 24px 0 16px;
 }
 
+@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px)
+.plugin-card-jetpack-plugin-search .plugin-action-buttons li {
+    display: block;
+}
+
 /* Hides the link to dismiss cards when it's in action links are before being moved to bottom row*/
 .action-links .jetpack-plugin-search__dismiss {
 	display: none;

--- a/modules/plugin-search/plugin-search.css
+++ b/modules/plugin-search/plugin-search.css
@@ -2,11 +2,26 @@
 	margin: 0 0 4px 0;
 }
 
+.plugin-card-jetpack-plugin-search .column-name,
+.plugin-card-jetpack-plugin-search .column-description {
+	margin-right: 20px;
+}
+
 .plugin-card-jetpack-plugin-search .action-links {
-	position: relative;
+	overflow: auto;
+	position: static;
+}
+
+@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px) {
+	.plugin-card-jetpack-plugin-search .action-links {
+		margin-left: 0;
+	}
 }
 
 .plugin-card-jetpack-plugin-search .plugin-action-buttons {
+	margin: 0;
+	width: 100%;
+	text-align: left;
 	white-space: nowrap;
 }
 

--- a/modules/plugin-search/plugin-search.js
+++ b/modules/plugin-search/plugin-search.js
@@ -49,6 +49,11 @@ var JetpackPSH = {};
 					'" width="32" />' +
 					'<p class="jetpack-plugin-search__text">' +
 					jetpackPluginSearch.legend +
+					' <a class="jetpack-plugin-search__support_link" href="' +
+					jetpackPluginSearch.supportLink +
+					'" target="_blank" rel="noopener noreferrer" data-track="support_link" >' +
+					jetpackPluginSearch.supportText +
+					'</a>' +
 					'</p>' +
 					'</div>';
 
@@ -208,6 +213,15 @@ var JetpackPSH = {};
 					var $this = $( this );
 					JetpackPSH.trackEvent(
 						'wpa_plugin_search_learn_more',
+						$this.data( 'module' ),
+						$this.get( 0 )
+					);
+				} )
+				.on( 'click', '.jetpack-plugin-search__support_link', function( event ) {
+					event.preventDefault();
+					var $this = $( this );
+					JetpackPSH.trackEvent(
+						'wpa_plugin_search_support_link',
 						$this.data( 'module' ),
 						$this.get( 0 )
 					);

--- a/modules/plugin-search/plugin-search.js
+++ b/modules/plugin-search/plugin-search.js
@@ -38,6 +38,19 @@ var JetpackPSH = {};
 		},
 
 		/**
+		 * Update title of the card to add a mention that the result is from the Jetpack plugin.
+		 */
+		updateCardTitle: function() {
+			var hint = JetpackPSH.getCard();
+
+			if ( 'object' === typeof hint && null !== hint ) {
+				var title = hint.querySelector( '.column-name h3' );
+				title.outerHTML =
+					title.outerHTML + '<strong>' + jetpackPluginSearch.poweredBy + '</strong>';
+			}
+		},
+
+		/**
 		 * Replace bottom row of the card to insert logo, text and link to dismiss the card.
 		 */
 		replaceCardBottom: function() {
@@ -65,7 +78,7 @@ var JetpackPSH = {};
 		},
 
 		/**
-		 * Check if plugin card list nodes changed. If there's a Jetpack PSH card, replace the bottom row.
+		 * Check if plugin card list nodes changed. If there's a Jetpack PSH card, replace the title and the bottom row.
 		 * @param {array} mutationsList
 		 */
 		replaceOnNewResults: function( mutationsList ) {
@@ -74,6 +87,7 @@ var JetpackPSH = {};
 					'childList' === mutation.type &&
 					1 === document.querySelectorAll( '.plugin-card-jetpack-plugin-search' ).length
 				) {
+					JetpackPSH.updateCardTitle();
 					JetpackPSH.replaceCardBottom();
 				}
 			} );
@@ -179,6 +193,9 @@ var JetpackPSH = {};
 			if ( JetpackPSH.$pluginFilter.length < 1 ) {
 				return;
 			}
+
+			// Update title to show that the suggestion is from Jetpack.
+			JetpackPSH.updateCardTitle();
 
 			// Replace PSH bottom row on page load
 			JetpackPSH.replaceCardBottom();

--- a/modules/plugin-search/plugin-search.js
+++ b/modules/plugin-search/plugin-search.js
@@ -51,6 +51,25 @@ var JetpackPSH = {};
 		},
 
 		/**
+		 * Move action links below description.
+		 */
+		moveActionLinks: function() {
+			var hint = JetpackPSH.getCard();
+			if ( 'object' === typeof hint && null !== hint ) {
+				var descriptionContainer = hint.querySelector( '.column-description' );
+				// Keep only the first paragraph. The second is the plugin author.
+				var descriptionText = descriptionContainer.querySelector( 'p:first-child' );
+				var actionLinks = hint.querySelector( '.action-links' );
+
+				// Change the contents of the description, to keep the description text and the action links.
+				descriptionContainer.innerHTML = descriptionText.outerHTML + actionLinks.outerHTML;
+
+				// Remove the action links from their default location.
+				actionLinks.parentNode.removeChild( actionLinks );
+			}
+		},
+
+		/**
 		 * Replace bottom row of the card to insert logo, text and link to dismiss the card.
 		 */
 		replaceCardBottom: function() {
@@ -88,6 +107,7 @@ var JetpackPSH = {};
 					1 === document.querySelectorAll( '.plugin-card-jetpack-plugin-search' ).length
 				) {
 					JetpackPSH.updateCardTitle();
+					JetpackPSH.moveActionLinks();
 					JetpackPSH.replaceCardBottom();
 				}
 			} );
@@ -196,6 +216,9 @@ var JetpackPSH = {};
 
 			// Update title to show that the suggestion is from Jetpack.
 			JetpackPSH.updateCardTitle();
+
+			// Update the description and action links.
+			JetpackPSH.moveActionLinks();
 
 			// Replace PSH bottom row on page load
 			JetpackPSH.replaceCardBottom();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR brings in a number of changes to the hint cards:
- The text at the bottom of the card is updated, and now includes a support link.
- You can now see a "by Jetpack (installed)" tagline below the feature title.
- The action links are now below the feature description instead of next to it.

**Before**

![image](https://user-images.githubusercontent.com/426388/55513435-f2ff1600-5665-11e9-8e49-696bfe0562ea.png)

**After**

![image](https://user-images.githubusercontent.com/426388/55513411-e37fcd00-5665-11e9-8ea0-4c77da662033.png)

- Internal reference: p1HpG7-6xi-p2

#### Testing instructions:

* In different browsers and different widths, view the card (search for "cdn" or for "tweet" while connected to WordPress.com)
* Make sure the card looks good everywhere.
* Make sure the support link works. You can use `localStorage.setItem( 'debug', 'dops:analytics' );` to check what happens when clicking on the link.

#### Proposed changelog entry for your changes:

* Feature Hints: update design to make card stand out more
