### PR TITLE
Admin Page: Remove references to manage as module

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -16,7 +16,6 @@ import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import QueryPluginUpdates from 'components/data/query-plugin-updates';
 import { getPluginUpdates } from 'state/at-a-glance';
-import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
 class DashPluginUpdates extends Component {
@@ -25,7 +24,6 @@ class DashPluginUpdates extends Component {
 		siteRawUrl: PropTypes.string.isRequired,
 		siteAdminUrl: PropTypes.string.isRequired,
 		pluginUpdates: PropTypes.any.isRequired,
-		isModuleAvailable: PropTypes.bool.isRequired,
 	};
 
 	activateAndRedirect( e ) {
@@ -107,12 +105,10 @@ class DashPluginUpdates extends Component {
 
 	render() {
 		return (
-			this.props.isModuleAvailable && (
-				<div>
-					<QueryPluginUpdates />
-					{ this.getContent() }
-				</div>
-			)
+			<div>
+				<QueryPluginUpdates />
+				{ this.getContent() }
+			</div>
 		);
 	}
 }
@@ -120,5 +116,4 @@ class DashPluginUpdates extends Component {
 export default connect( state => ( {
 	pluginUpdates: getPluginUpdates( state ),
 	isDevMode: isDevMode( state ),
-	isModuleAvailable: isModuleAvailable( state, 'manage' ),
 } ) )( DashPluginUpdates );

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -26,15 +26,6 @@ class DashPluginUpdates extends Component {
 		pluginUpdates: PropTypes.any.isRequired,
 	};
 
-	activateAndRedirect( e ) {
-		e.preventDefault();
-		this.props
-			.activateManage()
-			.then(
-				( window.location = 'https://wordpress.com/plugins/manage/' + this.props.siteRawUrl )
-			);
-	}
-
 	getContent() {
 		const labelName = __( 'Plugin Updates' );
 		const pluginUpdates = this.props.pluginUpdates;

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -74,7 +74,10 @@ export class DashItem extends Component {
 				includes(
 					[ 'monitor', 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ],
 					this.props.module
-				) && this.props.isDevMode ? (
+				) &&
+				this.props.isDevMode &&
+				// Avoid toggle for manage as it's no longer a module
+				'manage' !== this.props.module ? (
 					''
 				) : (
 					<ModuleToggle

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -71,11 +71,11 @@ export class DashItem extends Component {
 
 		if ( '' !== this.props.module ) {
 			toggle =
-				includes(
+				( includes(
 					[ 'monitor', 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ],
 					this.props.module
 				) &&
-				this.props.isDevMode &&
+					this.props.isDevMode ) ||
 				// Avoid toggle for manage as it's no longer a module
 				'manage' === this.props.module ? (
 					''

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -77,7 +77,7 @@ export class DashItem extends Component {
 				) &&
 				this.props.isDevMode &&
 				// Avoid toggle for manage as it's no longer a module
-				'manage' !== this.props.module ? (
+				'manage' === this.props.module ? (
 					''
 				) : (
 					<ModuleToggle

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -75,21 +75,13 @@ export class Security extends Component {
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
-			foundMonitor = this.props.isModuleFound( 'monitor' ),
-			foundManage = this.props.isModuleFound( 'manage' );
+			foundMonitor = this.props.isModuleFound( 'monitor' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if (
-			! foundSso &&
-			! foundProtect &&
-			! foundAkismet &&
-			! foundBackups &&
-			! foundMonitor &&
-			! foundManage
-		) {
+		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor ) {
 			return null;
 		}
 
@@ -112,7 +104,7 @@ export class Security extends Component {
 						<QueryAkismetKeyCheck />
 					</div>
 				) }
-				{ foundManage && <ManagePlugins { ...commonProps } /> }
+				<ManagePlugins { ...commonProps } />
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
 			</div>

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -33,10 +33,6 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 		}
 
 		configLink = () => {
-			if ( this.props.isUnavailableInDevMode( 'manage' ) ) {
-				return;
-			}
-
 			return (
 				<Card
 					compact

--- a/_inc/client/state/search/test/selectors.js
+++ b/_inc/client/state/search/test/selectors.js
@@ -10,9 +10,9 @@ describe( 'Module found selector', () => {
 			jetpack: {
 				modules: {
 					items: {
-						manage: {
-							module: 'manage',
-							name: 'Manage',
+						photon: {
+							module: 'photon',
+							name: 'Photon',
 							description: 'Description',
 							learn_more_button: 'Learn more',
 							long_description: 'Long Description',
@@ -32,7 +32,7 @@ describe( 'Module found selector', () => {
 
 	describe( 'when there is no search term', () => {
 		it( 'returns true for every module', () => {
-			expect( isModuleFound( state, 'manage' ) ).to.be.true;
+			expect( isModuleFound( state, 'photon' ) ).to.be.true;
 		} );
 		it( 'returns false for modules that do not exist', () => {
 			expect( isModuleFound( state, 'make-everything-fast' ) ).to.be.false;
@@ -42,7 +42,7 @@ describe( 'Module found selector', () => {
 
 	describe( 'for an existing module', () => {
 		[
-			'manage',
+			'photon',
 			'Description',
 			'Learn',
 			'Long',
@@ -56,7 +56,7 @@ describe( 'Module found selector', () => {
 				it( 'should match', () => {
 					state.jetpack.search.searchTerm = term;
 
-					expect( isModuleFound( state, 'manage' ) ).to.be.true;
+					expect( isModuleFound( state, 'photon' ) ).to.be.true;
 				} );
 			} );
 		} );
@@ -71,7 +71,7 @@ describe( 'Module found selector', () => {
 				it( 'should not match', () => {
 					state.jetpack.search.searchTerm = term;
 
-					expect( isModuleFound( state, 'manage' ) ).to.be.false;
+					expect( isModuleFound( state, 'photon' ) ).to.be.false;
 				} );
 			} );
 		} );


### PR DESCRIPTION
Follow up to  #9089 

Currently in `master` the plugin management cards are not shown. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Makes the Manage  card in Settings -> Security not depend on a module state
* Makes the Manage Plugins card in the dashboard not depend on a module state
* Removes an event handler that was no longer used for a long time.


#### Testing instructions:

* checkout this branch
* Run `yarn build`
* Visit the Jetpack dashboard and confirm the plugin updates card is shown
  
  ![image](https://user-images.githubusercontent.com/746152/55526108-1cba3c00-566a-11e9-9715-f84f3b409b87.png)

* Visite the settings page and confirm the plugins autoupdate cards is shown under the Security tab.
  
  ![image](https://user-images.githubusercontent.com/746152/55526123-322f6600-566a-11e9-8783-8f1c03711349.png)


#### Proposed changelog entry for your changes:
* None needed
