### PR TITLE
Manage: Properly check if manage through API is disabled

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -33,7 +33,7 @@ class Jetpack_Autoupdate {
 	private function __construct() {
 		if (
 			/** This filter is documented in class.jetpack-json-api-endpoint.php */
-			apply_filters( 'jetpack_json_api_requests_enabled', true )
+			apply_filters( 'jetpack_json_manage_api_enabled', true )
 		) {
 			add_filter( 'auto_update_theme', array( $this, 'autoupdate_theme' ), 10, 2 );
 			add_filter( 'auto_update_core', array( $this, 'autoupdate_core' ), 10, 2 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6547,7 +6547,7 @@ p {
 			'jetpack_lazy_images_skip_image_with_atttributes'        => 'jetpack_lazy_images_skip_image_with_attributes',
 			'jetpack_enable_site_verification'                       => null,
 			'can_display_jetpack_manage_notice'                      => null,
-			'can_display_jetpack_manage_notice'                      => 'jetpack_json_api_requests_enabled',
+			'can_display_jetpack_manage_notice'                      => 'jetpack_json_manage_api_enabled',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -79,7 +79,7 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 			 *
 			 * @param bool $check_validation Whether to allow API requests
 			 */
-			apply_filters( 'jetpack_json_api_requests_enabled', $check_validation )
+			! apply_filters( 'jetpack_json_api_requests_enabled', $check_validation )
 		) {
 			return new WP_Error( 'unauthorized_full_access', __( 'Full management mode is off for this site.', 'jetpack' ), 403 );
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -73,8 +73,8 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 			'GET' !== $this->method &&
 			/**
 			 * Filter to disallow JSON API requests to the site.
-			 * Setting to false disallow you to manage your site remotely from WordPress.com
-			 * and disallow plugin auto-updates.
+			 * Setting to false disallows you to manage your site remotely from WordPress.com
+			 * and disallows plugin auto-updates.
 			 *
 			 * @since 7.3.0
 			 *

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -79,7 +79,7 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 			 *
 			 * @param bool $check_validation Whether to allow API requests
 			 */
-			! apply_filters( 'jetpack_json_api_requests_enabled', $check_validation )
+			! apply_filters( 'jetpack_json_manage_api_enabled', $check_validation )
 		) {
 			return new WP_Error( 'unauthorized_full_access', __( 'Full management mode is off for this site.', 'jetpack' ), 403 );
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -73,11 +73,12 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 			'GET' !== $this->method &&
 			/**
 			 * Filter to disallow JSON API requests to the site.
-			 * Setting to false will not allow you to manage your site remotely from WordPress.com and disallow plugin auto-updates.
+			 * Setting to false disallow you to manage your site remotely from WordPress.com
+			 * and disallow plugin auto-updates.
 			 *
 			 * @since 7.3.0
 			 *
-			 * @param bool $check_validation Whether to allow API requests
+			 * @param bool $check_validation Whether to allow API requests to manage the site
 			 */
 			! apply_filters( 'jetpack_json_manage_api_enabled', $check_validation )
 		) {


### PR DESCRIPTION
With #9089 the filter `jetpack_json_api_requests_enabled` was introduced to check if we should allow management through API (to replace a previous  check of the manage module being active):
* The check for validating an update request was not properly evaluated
* The name is confusing. I'm proposing here to rename it to `jetpack_json_manage_api_enabled`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates to check if the filter returns false for returning an error
* Updates the filter name from `jetpack_json_api_requests_enabled` to `jetpack_json_manage_api_enabled`.


#### Testing instructions:

* First step is to wait until Automattic/wp-calypso/pull/32009 gets merged
* Visit plugins management page in calypso for your site
*  Attempt to update a plugin.
* Confirm the update succeeds.


<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
