### PR TITLE
Slideshow: Add wp-escape-html dependency to view

### DIFF
--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -25,6 +25,7 @@ jetpack_register_block(
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	$dependencies = array(
 		'lodash',
+		'wp-escape-html',
 		'wp-polyfill',
 	);
 


### PR DESCRIPTION
Fixes #11910

#### Changes proposed in this Pull Request:

* Add `wp-escape-html` dependency to Slideshow view script.

#### Testing instructions:

* Create a new post that only includes the Slideshow block.
* View the post on the frontend.
* Does the block work as expected?

#### Proposed changelog entry for your changes:

* Fix a bug that prevented the Slideshow block from functioning as expected on the frontend under most circumstances.