### PR TITLE
totally remove js script from ig, instead of preg replace

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -139,6 +139,7 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	$url_args = array(
 		'url'      => $instagram_http_url,
 		'maxwidth' => $atts['width'],
+		'omitscript'=> 1
 	);
 
 	if ( $atts['hidecaption'] ) {
@@ -191,9 +192,13 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 			true
 		);
 		// there's a script in the response, which we strip on purpose since it's added by this ^ script
+		/*
 		$ig_embed = preg_replace( '@<(script)[^>]*?>.*?</\\1>@si', '', $response_body->html );
-
 		return $ig_embed;
+		*/
+
+		//no need for preg replace as the js file is automatically omitted via api call
+		return $response_body->html;
 	}
 
 	return '<!-- instagram error: no embed found -->';

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -191,7 +191,6 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 			false,
 			true
 		);
-		//no need for preg replace as the js file is automatically omitted via api call
 		return $response_body->html;
 	}
 

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -191,12 +191,6 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 			false,
 			true
 		);
-		// there's a script in the response, which we strip on purpose since it's added by this ^ script
-		/*
-		$ig_embed = preg_replace( '@<(script)[^>]*?>.*?</\\1>@si', '', $response_body->html );
-		return $ig_embed;
-		*/
-
 		//no need for preg replace as the js file is automatically omitted via api call
 		return $response_body->html;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As per existing Instagram module on jetpack, fully utilize the Instagram api endpoint on removing the js file from the returned content.

https://www.instagram.com/developer/embedding/
 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* update instagram module, instead of using preg-replace to remove the js script returned by instagram API, use the omitscript parameter

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* paste any public instagram post within wordpress post

* use the instagram embed shortcode [instragram url="placeInstagramURLhere"]

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* update instagram module, added omitscript parameter on oembed
