### PR TITLE
Related Posts: avoid translation issues with double quotes

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1535,7 +1535,7 @@ EOT;
 			foreach ( $categories as $category ) {
 				if ( 'uncategorized' != $category->slug && '' != trim( $category->name ) ) {
 					$post_cat_context = sprintf(
-						esc_html_x( 'In “%s”', 'in {category/tag name}', 'jetpack' ),
+						esc_html_x( 'In "%s"', 'in {category/tag name}', 'jetpack' ),
 						$category->name
 					);
 					/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes 3718-gh-jpop-issues

The curly quotes were added in #11220, but are not handled well by GlotPress. We need to revert to using regular double quotes.

See an example here:
https://translate.wordpress.org/projects/wp-plugins/jetpack/stable/fr/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=611116&filters%5Btranslation_id%5D=23407350

#### Testing instructions:

* Start on a site currently connected to WordPress.com, with related posts appearing at the bottom of your posts. Make sure some of those related posts belong to categories, so you can see the context under each related post image (`In "Category name"`)
* Go to Settings > General, and switch your site language to French.
* Go to Dashbboard > Updates, and update translations on your site.
* Visit one of your posts with related posts, and notice that the related posts' context is not translated.
* Apply this patch.
* Visit the post again; the context now says `Dans "Category Name"`.

#### Proposed changelog entry for your changes:

* Related Posts: avoid translation issues in Related Posts' context.
