### PR TITLE
General: Add Poseidon as code owners for sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,9 @@
 /class.jetpack-gutenberg.php @automattic/gutenpack
 /extensions/ @automattic/gutenpack
 
+/sync/ @poseidon
+/tests/php/sync @poseidon
+
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list
 * @automattic/jetpack-crew

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,8 +20,8 @@
 /class.jetpack-gutenberg.php @automattic/gutenpack
 /extensions/ @automattic/gutenpack
 
-/sync/ @poseidon
-/tests/php/sync @poseidon
+/sync/ @automattic/poseidon
+/tests/php/sync @automattic/poseidon
 
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently we get blocked for every change to sync. This PR will allows us to move faster and ship code specific to sync.

#### Changes proposed in this Pull Request:
* make @Automattic/poseidon  the code owner of sync and sync tests.

#### Testing instructions:
Merge see if we are still blocked. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None. 
*
