### PR TITLE
PSH: Use CDN instead of SEO as a hint term for Photon CDN

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -9,7 +9,7 @@
  * Auto Activate: No
  * Module Tags: Photos and Videos, Appearance, Recommended
  * Feature: Recommended, Appearance, Jumpstart
- * Additional Search Queries: site accelerator, accelerate, static, assets, javascript, css, files, performance, seo, bandwidth, content delivery network, pagespeed, combine js, optimize css
+ * Additional Search Queries: site accelerator, accelerate, static, assets, javascript, css, files, performance, cdn, bandwidth, content delivery network, pagespeed, combine js, optimize css
  */
 
 $GLOBALS['concatenate_scripts'] = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* SEO feels like a bit of a stretch here, but it doesn't appear for CDN.

Frankly, we probably should have only one hit for both Image and Asset CDN, so that may be a better change than just this.

#### Testing instructions:
* Go to Plugins->Add New, Search for `cdn`.
*

#### Proposed changelog entry for your changes:
* n/a
