### PR TITLE
PSH: Remove Backups and Security except for higher plans

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -189,6 +189,12 @@ class Jetpack_Plugin_Search {
 		if ( 2 < count( $dismissed_hints ) ) {
 			return false;
 		}
+
+		$plan = Jetpack_Plan::get();
+		if ( isset( $plan['class'] ) && ( 'free' === $plan['class'] || 'personal' === $plan['class'] ) && 'vaultpress' === $hint ) {
+			return false;
+		}
+
 		return ! in_array( $hint, $dismissed_hints, true );
 	}
 


### PR DESCRIPTION
Backups and Security card mentions features that are not included on all levels that have access to the Backups module. As an immediate step, we should not display it to lower-levels

#### Changes proposed in this Pull Request:
* Exclude the VaultPress hint on free or personal plans.

#### Testing instructions:
* New free site, Plugins->Add New and look for "malware" - this should not show a hint both on master and in branch.
* Upgrade to Personal and repeat. This should not show a hint on this branch (does in master).
* Upgrade to either higher plan. Repeat. Hint should display.

#### Proposed changelog entry for your changes:
* n/a covered under previous CL.
