### PR TITLE
Sync: Full Sync End should include the range (min, max, count) on full sync end

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -187,20 +187,20 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	function get_range( $type ) {
 		global $wpdb;
-		if( ! in_array( $type, array( 'comments', 'posts' ) ) ) {
+		if ( ! in_array( $type, array( 'comments', 'posts' ) ) ) {
 			return array();
 		}
 
 		switch ( $type ) {
 			case 'posts':
-				$table = $wpdb->posts;
-				$id = 'ID';
+				$table     = $wpdb->posts;
+				$id        = 'ID';
 				$where_sql = Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
 
 				break;
 			case 'comments':
-				$table = $wpdb->comments;
-				$id = 'comment_ID';
+				$table     = $wpdb->comments;
+				$id        = 'comment_ID';
 				$where_sql = Jetpack_Sync_Settings::get_comments_filter_sql();
 				break;
 		}
@@ -208,6 +208,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( isset( $results[0] ) ) {
 			return $results[0];
 		}
+
 		return array();
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -168,11 +168,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		$range = array();
 		// Only when we are sending the whole range do we want to send also the range
-		if ( $configs['posts'] === true ) {
+		if ( isset( $configs['posts'] ) && $configs['posts'] === true ) {
 			$range['posts'] = $this->get_range( 'posts' );
 		}
 
-		if ( $configs['comments'] === true ) {
+		if ( isset( $configs['comments'] ) && $configs['comments'] === true ) {
 			$range['comments'] = $this->get_range( 'comments' );
 		}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -204,9 +204,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$where_sql = Jetpack_Sync_Settings::get_comments_filter_sql();
 				break;
 		}
-
-		$results = $wpdb->get_results( $wpdb->prepare( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table} WHERE %s" ), $where_sql );
-		if( isset( $results[0] ) ) {
+		$results = $wpdb->get_results( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table} WHERE {$where_sql}" );
+		if ( isset( $results[0] ) ) {
 			return $results[0];
 		}
 		return array();

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -165,7 +165,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		// setting autoload to true means that it's faster to check whether we should continue enqueuing
 		$this->update_status_option( 'queue_finished', time(), true );
-		
+
 		$range = array();
 		// Only when we are sending the whole range do we want to send also the range
 		if ( $configs['posts'] === true ) {
@@ -195,14 +195,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			case 'posts':
 				$table = $wpdb->posts;
 				$id = 'ID';
+				$where_sql = Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+
 				break;
 			case 'comments':
 				$table = $wpdb->comments;
 				$id = 'comment_ID';
+				$where_sql = Jetpack_Sync_Settings::get_comments_filter_sql();
 				break;
 		}
-		echo "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table}";
-		$results = $wpdb->get_results( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table}" );
+
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table} WHERE %s" ), $where_sql );
 		if( isset( $results[0] ) ) {
 			return $results[0];
 		}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -23,7 +23,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	function init_full_sync_listeners( $callable ) {
 		// synthetic actions for full sync
 		add_action( 'jetpack_full_sync_start', $callable );
-		add_action( 'jetpack_full_sync_end', $callable );
+		add_action( 'jetpack_full_sync_end', $callable, 10, 2 );
 		add_action( 'jetpack_full_sync_cancelled', $callable );
 	}
 
@@ -165,6 +165,16 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		// setting autoload to true means that it's faster to check whether we should continue enqueuing
 		$this->update_status_option( 'queue_finished', time(), true );
+		
+		$range = array();
+		// Only when we are sending the whole range do we want to send also the range
+		if ( $configs['posts'] === true ) {
+			$range['posts'] = $this->get_range( 'posts' );
+		}
+
+		if ( $configs['comments'] === true ) {
+			$range['comments'] = $this->get_range( 'comments' );
+		}
 
 		/**
 		 * Fires when a full sync ends. This action is serialized
@@ -172,7 +182,31 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.2.0
 		 */
-		do_action( 'jetpack_full_sync_end', '' );
+		do_action( 'jetpack_full_sync_end', '', $range );
+	}
+
+	function get_range( $type ) {
+		global $wpdb;
+		if( ! in_array( $type, array( 'comments', 'posts' ) ) ) {
+			return array();
+		}
+
+		switch ( $type ) {
+			case 'posts':
+				$table = $wpdb->posts;
+				$id = 'ID';
+				break;
+			case 'comments':
+				$table = $wpdb->comments;
+				$id = 'comment_ID';
+				break;
+		}
+		echo "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table}";
+		$results = $wpdb->get_results( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table}" );
+		if( isset( $results[0] ) ) {
+			return $results[0];
+		}
+		return array();
 	}
 
 	function update_sent_progress_action( $actions ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -759,8 +759,39 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( isset( $this->full_sync_end_checksum['comments'] ) );
 	}
 
-	function record_full_sync_end_checksum( $checksum ) {
-		$this->full_sync_end_checksum = $checksum;
+	function test_full_sync_end_sends_range() {
+		$this->create_dummy_data_and_empty_the_queue();
+		add_action( 'jetpack_full_sync_end', array( $this, 'record_full_sync_end_checksum' ), 10, 2 );
+
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
+
+		$this->assertTrue( isset( $this->full_sync_end_range ) );
+		$this->assertTrue( isset( $this->full_sync_end_range['posts']->max ) );
+		$this->assertTrue( isset( $this->full_sync_end_range['posts']->min ) );
+		$this->assertTrue( isset( $this->full_sync_end_range['posts']->count ) );
+
+		$this->assertTrue( isset( $this->full_sync_end_range['comments']->max ) );
+		$this->assertTrue( isset( $this->full_sync_end_range['comments']->min ) );
+		$this->assertTrue( isset( $this->full_sync_end_range['comments']->count ) );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_end' );
+
+		list( $checksum, $range ) = $event->args;
+		$this->assertTrue( isset( $range['posts']->max ) );
+		$this->assertTrue( isset( $range['posts']->min ) );
+		$this->assertTrue( isset( $range['posts']->count ) );
+
+		$this->assertTrue( isset( $range['comments']->max ) );
+		$this->assertTrue( isset( $range['comments']->min ) );
+		$this->assertTrue( isset( $range['comments']->count ) );
+	}
+
+	function record_full_sync_end_checksum( $checksum, $range ) {
+		// $checksum  has been deprecated...
+		$this->full_sync_end_range = $range;
 	}
 
 	function record_full_sync_start_config( $modules ) {


### PR DESCRIPTION
Sending the range of posts, comments that we care about so that we can compare that them a bit and clear them if we have to. 

This will allows us to get a better estimate into if we have the whole range of posts, comments.

<!--- Provide a general summary of your changes in the Title above -->
Improves full sync. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In this PR we add a way to send the range max, min IDs as well as the count. 
This will give us a rough idea of posts and comment that exist on 

#### Testing instructions:
* To the tests pass. 
* Run a full sync. Do you get the data that you expected in the jetpack_full_sync_end event.

#### Proposed changelog entry for your changes:
* Send a range on full sync end.
