### PR TITLE
Update module headings to avoid notices

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -314,7 +314,6 @@ function jetpack_get_module_i18n_tag( $key ) {
 
 			// Modules with `Recommended` tag:
 			//  - modules/lazy-images.php
-			//  - modules/manage.php
 			//  - modules/minileven.php
 			//  - modules/monitor.php
 			//  - modules/photon-cdn.php
@@ -326,10 +325,6 @@ function jetpack_get_module_i18n_tag( $key ) {
 			//  - modules/sitemaps.php
 			//  - modules/stats.php
 			'Recommended' =>_x( 'Recommended', 'Module Tag', 'jetpack' ),
-
-			// Modules with `Centralized Management` tag:
-			//  - modules/manage.php
-			'Centralized Management' =>_x( 'Centralized Management', 'Module Tag', 'jetpack' ),
 
 			// Modules with `General` tag:
 			//  - modules/masterbar.php
@@ -349,5 +344,5 @@ function jetpack_get_module_i18n_tag( $key ) {
 			'Site Stats' =>_x( 'Site Stats', 'Module Tag', 'jetpack' ),
 		);
 	}
-	return $module_tags[ $key ];
+	return ! empty( $module_tags[ $key ] ) ? $module_tags[ $key ] : '';
 }

--- a/tools/build-module-headings-translations.php
+++ b/tools/build-module-headings-translations.php
@@ -85,7 +85,7 @@ foreach ( $tags as $tag => $files ) {
 }
 $file_contents .= "\t\t);
 \t}";
-$file_contents .= "\n\treturn \$module_tags[ \$key ];
+$file_contents .= "\n\treturn ! empty( \$module_tags[ \$key ] ) ? \$module_tags[ \$key ] : '';
 }\n";
 
 file_put_contents( "{$jp_dir}modules/module-headings.php", $file_contents );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should solve errors like the one below that keeps appearing in my logs following the changes in #9089.

```
[05-Apr-2019 07:38:17 UTC] PHP Notice:  Undefined index: Centralized Management in /var/www/html/wp-content/plugins/jetpack/modules/module-headings.php on line 341
[05-Apr-2019 07:38:17 UTC] PHP Stack trace:
[05-Apr-2019 07:38:17 UTC] PHP   1. {main}() /var/www/html/wp-admin/admin.php:0
[05-Apr-2019 07:38:17 UTC] PHP   2. require_once() /var/www/html/wp-admin/admin.php:34
[05-Apr-2019 07:38:17 UTC] PHP   3. require_once() /var/www/html/wp-load.php:37
[05-Apr-2019 07:38:17 UTC] PHP   4. require_once() /var/www/html/wp-config.php:107
[05-Apr-2019 07:38:17 UTC] PHP   5. do_action() /var/www/html/wp-settings.php:505
[05-Apr-2019 07:38:17 UTC] PHP   6. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:465
[05-Apr-2019 07:38:17 UTC] PHP   7. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:310
[05-Apr-2019 07:38:17 UTC] PHP   8. wp_widgets_init() /var/www/html/wp-includes/class-wp-hook.php:286
[05-Apr-2019 07:38:17 UTC] PHP   9. do_action() /var/www/html/wp-includes/widgets.php:1715
[05-Apr-2019 07:38:17 UTC] PHP  10. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:465
[05-Apr-2019 07:38:17 UTC] PHP  11. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:310
[05-Apr-2019 07:38:17 UTC] PHP  12. jetpack_search_widget_init() /var/www/html/wp-includes/class-wp-hook.php:286
[05-Apr-2019 07:38:17 UTC] PHP  13. Jetpack_Plan::supports() /var/www/html/wp-content/plugins/jetpack/modules/widgets/search.php:13
[05-Apr-2019 07:38:17 UTC] PHP  14. Jetpack_Plan::get() /var/www/html/wp-content/plugins/jetpack/class.jetpack-plan.php:208
[05-Apr-2019 07:38:17 UTC] PHP  15. Jetpack::get_module() /var/www/html/wp-content/plugins/jetpack/class.jetpack-plan.php:179
[05-Apr-2019 07:38:17 UTC] PHP  16. array_map() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:2491
[05-Apr-2019 07:38:17 UTC] PHP  17. Jetpack::translate_module_tag() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:2491
[05-Apr-2019 07:38:17 UTC] PHP  18. jetpack_get_module_i18n_tag() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:2583
```

#### Testing instructions:

* Apply branch
* Load any page of your site
* Make sure you do not see any errors in your log.

#### Proposed changelog entry for your changes:

* None
