### PR TITLE
Build: Base babel.config.js on calypso-build's

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,50 +1,9 @@
 const config = {
-	presets: [
-		[
-			'@babel/env',
-			{
-				useBuiltIns: 'entry',
-				corejs: 2,
-				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-				exclude: [ 'transform-typeof-symbol' ],
-			},
-		],
-		'@babel/react',
-	],
-	plugins: [
-		'@babel/plugin-proposal-class-properties',
-		'@babel/plugin-proposal-export-default-from',
-		'@babel/plugin-proposal-export-namespace-from',
-		'@babel/plugin-syntax-dynamic-import',
-		[
-			'@babel/transform-runtime',
-			{
-				corejs: false, // we polyfill so we don't need core-js
-				helpers: true,
-				regenerator: false,
-				useESModules: false,
-			},
-		],
-	],
+	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),
 	overrides: [
 		{
 			test: './extensions/',
-			plugins: [
-				[
-					'@wordpress/import-jsx-pragma',
-					{
-						scopeVariable: 'createElement',
-						source: '@wordpress/element',
-						isDefault: false,
-					},
-				],
-				[
-					'@babel/transform-react-jsx',
-					{
-						pragma: 'createElement',
-					},
-				],
-			],
+			presets: [ require( '@automattic/calypso-build/babel/wordpress-element' ) ],
 		},
 	],
 	env: {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"whatwg-fetch": "1.1.1"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "1.0.0-alpha.3",
+		"@automattic/calypso-build": "1.0.0-alpha.4",
 		"@automattic/wordpress-external-dependencies-plugin": "1.0.0-alpha.0",
 		"@babel/core": "7.4.0",
 		"@babel/plugin-proposal-class-properties": "7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,15 @@
 # yarn lockfile v1
 
 
-"@automattic/calypso-build@1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@automattic/calypso-build/-/calypso-build-1.0.0-alpha.3.tgz#552693c068810184c45de6ab131e691957da1647"
-  integrity sha512-4l011zIs8IddrZHL3pvVD3ZaPq9y4mVp1cgS4IcDF1Ivekgt3/E8+sw5ox3Ho74xpnmPvUkt9HflB3MOmtM3PQ==
+"@automattic/calypso-build@1.0.0-alpha.4":
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@automattic/calypso-build/-/calypso-build-1.0.0-alpha.4.tgz#4df46dc2ebaeb34f8d1b3ca4568e7e766cf70c02"
+  integrity sha512-mTWuIq1txyEFr88GyCwu8agYVhvXoyTJDlKharth0z58SGL+0l18iv/tr72iCi6FEZbaR779lVnMmvjPSednOA==
   dependencies:
     "@automattic/calypso-color-schemes" "^1.0.0"
     "@automattic/wordpress-external-dependencies-plugin" "^1.0.0-alpha.0"
+    "@babel/plugin-transform-react-jsx" "7.3.0"
+    "@wordpress/babel-plugin-import-jsx-pragma" "2.1.0"
     autoprefixer "9.4.4"
     babel-loader "8.0.5"
     browserslist "4.5.4"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Bump `@automattic/calypso-build` to 1.0.0-alpha.4
- Use that package's `babel.config.js` to base ours on.

#### Testing instructions:

```
yarn distclean && yarn
yarn build-extensions
```

Verify that blocks still work.

#### Proposed changelog entry for your changes:

Build: Base `babel.config.js` on `@automattic/calypso-build`'s