### PR TITLE
Admin Page: Do not show Support Card in Settings page

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -281,6 +281,12 @@ class Main extends React.Component {
 		return this.props.isSiteConnected && includes( dashboardRoutes, hashRoute );
 	}
 
+	shouldShowSupportCard() {
+		// Do not show in settings page
+		const hashRoute = '#' + this.props.route.path;
+		return this.props.isSiteConnected && includes( dashboardRoutes, hashRoute );
+	}
+
 	render() {
 		return (
 			<div>
@@ -290,7 +296,7 @@ class Main extends React.Component {
 					<AdminNotices />
 					<JetpackNotices />
 					{ this.renderMainContent( this.props.route.path ) }
-					{ this.props.isSiteConnected && <SupportCard path={ this.props.route.path } /> }
+					{ this.shouldShowSupportCard() && <SupportCard path={ this.props.route.path } /> }
 					{ this.shouldShowAppsCard() && <AppsCard /> }
 				</div>
 				<Footer siteAdminUrl={ this.props.siteAdminUrl } />


### PR DESCRIPTION
Leaving this here but #11938 still needs some feedback.

Makes the Support Card not show in the settings page

Fixes #11938

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Ensures the support card is not shown on the settings page.

#### Testing instructions:

* Checkout this branch or [launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=remove/support-card-from-settings-page&wp-debug-log).
* Visit the admin page for Jetpack
* Confirm you see the Support card in any page but settings (dashboard, my plan, plans).


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Admin Page: Removed the support card from settings page.
