### PR TITLE
Admin Page: Do not show Apps card in settings page

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -66,7 +66,7 @@ export class Masthead extends React.Component {
 				''
 			),
 			isDashboardView = includes(
-				[ '/', '/dashboard', '/apps', '/my-plan', '/plans' ],
+				[ '/', '/dashboard', '/my-plan', '/plans' ],
 				this.props.route.path
 			),
 			isStatic = '' === this.props.route.path;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -50,6 +50,8 @@ import WelcomeNewPlan from 'components/welcome-new-plan';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import { getRewindStatus } from 'state/rewind';
 
+const dashboardRoutes = [ '#/', '#/dashboard', '#/my-plan', '#/plans' ];
+
 class Main extends React.Component {
 	UNSAFE_componentWillMount() {
 		this.props.setInitialState();
@@ -275,6 +277,12 @@ class Main extends React.Component {
 		);
 	};
 
+	shouldShowAppsCard() {
+		// Do not show in settings page
+		const hashRoute = '#' + this.props.route.path;
+		return this.props.isSiteConnected && includes( dashboardRoutes, hashRoute );
+	}
+
 	render() {
 		return (
 			<div>
@@ -285,7 +293,7 @@ class Main extends React.Component {
 					<JetpackNotices />
 					{ this.renderMainContent( this.props.route.path ) }
 					{ this.props.isSiteConnected && <SupportCard path={ this.props.route.path } /> }
-					{ this.props.isSiteConnected && <AppsCard /> }
+					{ this.shouldShowAppsCard() && <AppsCard /> }
 				</div>
 				<Footer siteAdminUrl={ this.props.siteAdminUrl } />
 				<Tracker analytics={ analytics } />
@@ -330,17 +338,16 @@ export default connect(
 window.wpNavMenuClassChange = function() {
 	let hash = window.location.hash;
 	const settingRoutes = [
-			'#/settings',
-			'#/general',
-			'#/discussion',
-			'#/security',
-			'#/performance',
-			'#/traffic',
-			'#/writing',
-			'#/sharing',
-			'#/privacy',
-		],
-		dashboardRoutes = [ '#/', '#/dashboard', '#/my-plan', '#/plans' ];
+		'#/settings',
+		'#/general',
+		'#/discussion',
+		'#/security',
+		'#/performance',
+		'#/traffic',
+		'#/writing',
+		'#/sharing',
+		'#/privacy',
+	];
 
 	// Clear currents
 	jQuery( '.current' ).each( function( i, obj ) {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -227,14 +227,12 @@ class Main extends React.Component {
 				);
 				break;
 			case '/settings':
-			case '/general':
-			case '/engagement':
 			case '/security':
-			case '/traffic':
-			case '/discussion':
 			case '/performance':
 			case '/writing':
 			case '/sharing':
+			case '/discussion':
+			case '/traffic':
 			case '/privacy':
 				navComponent = settingsNav;
 				pageComponent = (
@@ -339,13 +337,12 @@ window.wpNavMenuClassChange = function() {
 	let hash = window.location.hash;
 	const settingRoutes = [
 		'#/settings',
-		'#/general',
-		'#/discussion',
 		'#/security',
 		'#/performance',
-		'#/traffic',
 		'#/writing',
 		'#/sharing',
+		'#/discussion',
+		'#/traffic',
 		'#/privacy',
 	];
 


### PR DESCRIPTION
Fixes #11937

Makes the Apps Card not show in the settings page

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Ensures the Apps card is not shown on the settings page.
* Remove some old route path references to #engagement and #general .

#### Testing instructions:

* Checkout this branch or [launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=remove/apps-card-from-settings&wp-debug-log).
* Visit the admin page for Jetpack
* Confirm you see the Apps card in any page but settings (dashboard, my plan, plans).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Admin Page: Removed the Apps card from settings page.