### PR TITLE
Settings: Add toggle for Latex / Beautiful Math under Writing, Composing settings

### DIFF
--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -199,6 +199,7 @@ export class Composing extends React.Component {
 	render() {
 		const foundCopyPost = this.props.isModuleFound( 'copy-post' ),
 			foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
+			foundLatex = this.props.isModuleFound( 'latex' ),
 			foundMarkdown = this.props.isModuleFound( 'markdown' );
 
 		if ( ! foundCopyPost && ! foundMarkdown && ! foundAtD ) {
@@ -206,6 +207,7 @@ export class Composing extends React.Component {
 		}
 
 		const markdown = this.props.module( 'markdown' ),
+			latex = this.props.module( 'latex' ),
 			atd = this.props.module( 'after-the-deadline' ),
 			copyPost = this.props.module( 'copy-post' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
@@ -264,6 +266,27 @@ export class Composing extends React.Component {
 					</FormFieldset>
 				</SettingsGroup>
 			),
+			latexSettings = (
+				<SettingsGroup
+					module={ latex }
+					support={ {
+						text: __( 'Use LaTeX markup for complex equations and other geekery.' ),
+						link: 'https://jetpack.com/support/beautiful-math-with-latex/',
+					} }
+				>
+					<FormFieldset>
+						<ModuleToggle
+							slug="latex"
+							activated={ !! this.props.getOptionValue( 'latex' ) }
+							toggling={ this.props.isSavingAnyOption( [ 'latex' ] ) }
+							disabled={ this.props.isSavingAnyOption( [ 'latex' ] ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">{ latex.description }</span>
+						</ModuleToggle>
+					</FormFieldset>
+				</SettingsGroup>
+			),
 			atdSettings = (
 				<FoldableCard
 					onOpen={ this.trackOpenCard }
@@ -301,6 +324,7 @@ export class Composing extends React.Component {
 			>
 				{ foundCopyPost && copyPostSettings }
 				{ foundMarkdown && markdownSettings }
+				{ foundLatex && latexSettings }
 				{ foundAtD && atdSettings }
 			</SettingsCard>
 		);

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -270,7 +270,9 @@ export class Composing extends React.Component {
 				<SettingsGroup
 					module={ latex }
 					support={ {
-						text: __( 'Use LaTeX markup for complex equations and other geekery.' ),
+						text: __(
+							'Use the LaTeX markup language to write mathematical equations and formulas.'
+						),
 						link: 'https://jetpack.com/support/beautiful-math-with-latex/',
 					} }
 				>

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Beautiful Math
- * Module Description: Use the LaTeX markup language to write mathematical equations and formulas
+ * Module Description: Use the LaTeX markup language to write mathematical equations and formulas.
  * Sort Order: 12
  * First Introduced: 1.1
  * Requires Connection: No

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Beautiful Math
- * Module Description: Use LaTeX markup for complex equations and other geekery.
+ * Module Description: Use the LaTeX markup language to write mathematical equations and formulas
  * Sort Order: 12
  * First Introduced: 1.1
  * Requires Connection: No

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -80,7 +80,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'latex' => array(
 				'name' => _x( 'Beautiful Math', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Use the LaTeX markup language to write mathematical equations and formulas', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Use the LaTeX markup language to write mathematical equations and formulas.', 'Module Description', 'jetpack' ),
 			),
 
 			'lazy-images' => array(

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -80,7 +80,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'latex' => array(
 				'name' => _x( 'Beautiful Math', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Use LaTeX markup for complex equations and other geekery.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Use the LaTeX markup language to write mathematical equations and formulas', 'Module Description', 'jetpack' ),
 			),
 
 			'lazy-images' => array(


### PR DESCRIPTION
Add a toggle in the Composing section for activating Latex support

Fixes #11931

Note that #11931 is waiting for design review still.

#### Changes proposed in this Pull Request:

Adds a toggle in the Composing section for activating Latex support

#### Testing instructions:

* Checkout this branch and run `yarn build` or [launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=add/beautiful-math-card&wp-debug-log).
* Visit the settings page and the Writing tab.
* Confirm you see a toggle for Latex.

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/55646848-99f0c880-57b2-11e9-9fc8-fcc18de9b640.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added setting for activating Latex support
