### PR TITLE
Update Sync Code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,8 +20,6 @@
 /class.jetpack-gutenberg.php @automattic/gutenpack
 /extensions/ @automattic/gutenpack
 
-/sync/ @automattic/poseidon
-/tests/php/sync @automattic/poseidon
 
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,6 @@
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list
 * @automattic/jetpack-crew
+
+/sync/ @automattic/poseidon @automattic/jetpack-crew
+/tests/php/sync @automattic/poseidon @automattic/jetpack-crew


### PR DESCRIPTION
I am hoping this will fix who can deploy the sync and sync tests code.

Accoring to https://help.github.com/en/articles/about-code-owners  
the code owners need to be listed below the * rule. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

#### Testing instructions:
Don't know deploy and find out?

#### Proposed changelog entry for your changes:
None 
