### PR TITLE
Renovate: Only one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
 	"extends": [ "config:base" ],
 	"labels": [ "[Type] Janitorial", "[Status] Needs Review" ],
 	"prHourlyLimit": 1,
-	"supportPolicy": [ "lts_latest" ]
+	"supportPolicy": [ "lts_latest" ],
+	"groupName": "all"
 }


### PR DESCRIPTION
We have a ton of Renovate PRs. What if we just update deps every... week... in one go instead of dealing with as many PRs as it can throw at us?

See https://renovatebot.com/docs/faq/#use-a-single-branchpr-for-all-dependency-upgrades

#### Changes proposed in this Pull Request:
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a
