### PR TITLE
Extensions: Fix webpack config

### DIFF
--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -65,8 +65,10 @@ const webpackConfig = getBaseWebpackConfig( null, {
 	'output-path': path.join( __dirname, '_inc', 'blocks' ),
 } );
 
-module.exports = _.merge( {}, webpackConfig, {
+module.exports = {
+	...webpackConfig,
 	plugins: [
+		...webpackConfig.plugins,
 		new CopyWebpackPlugin( [
 			{
 				from: presetPath,
@@ -74,4 +76,4 @@ module.exports = _.merge( {}, webpackConfig, {
 			},
 		] ),
 	],
-} );
+};


### PR DESCRIPTION
Turns out `_.merge()` caused `CopyWebpackPlugin` to override the first item in `webpackConfig.plugins` ([`DefinePlugin`](https://github.com/Automattic/wp-calypso/blob/a75746a27bf87c546b34ca048bacd362a6736738/packages/calypso-build/webpack.config.js#L104=L107)) :roll_eyes: 

Discovered while working on https://github.com/Automattic/wp-calypso/pull/32083.

#### Changes proposed in this Pull Request:

Extensions: Fix webpack config by adding `CopyWebpackPlugin` through destructuring rather than `_.merge()`.

#### Testing instructions:

```
yarn distclean && yarn ci
yarn build-extensions
```

Verify that the above is true (e.g. by outputting the result of that `_.merge()` call on the `master` branch).

#### Proposed changelog entry for your changes:

* N/A
