### PR TITLE
Build: Remove redundant lines from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,14 +84,4 @@ const webpackConfig = {
 	devtool: devMode ? 'source-map' : false,
 };
 
-if ( ! devMode ) {
-	// Create global process.env.NODE_ENV constant available at the browser window
-	// eslint-disable-next-line no-new
-	new webpack.DefinePlugin( {
-		// This has effect on the react lib size
-		// TODO switch depending on actual environment
-		'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
-	} );
-}
-
 module.exports = webpackConfig;


### PR DESCRIPTION
These lines instantiate a webpack plugin that is not added to the
config. The appear to serve no purpose.

#### Testing instructions:

There should be no observable changes, this is intended to eliminate dead code. The dashboard bundle should remain unchanged when build for different environments:

* NODE_ENV=development yarn build-client
* NODE_ENV=production yarn build-client