### PR TITLE
Build: Remove polyfills

### DIFF
--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -74,12 +74,6 @@ import { translate as __ } from 'i18n-calypso';
 
 Some static HTML is generated from the JSX files and rendered on build time before a release to provide a non-javascript UI with basic functionality if the browser does not report javascript capabilities.
 
-#### Things we do to maintain compatibility for older browser
-
-* We include a **Babel** plugin in the building toolchain to translate incompatible object methods names which may be parsed as keywords in old javascript engines. (e.g. `.catch()`).
-* **Fetch API polyfill**. We use the [whatwg-fetch](https://github.com/github/fetch) polyfill.
-* **Promises Polyfill**. We use the [es6-promise](https://github.com/stefanpenner/es6-promise) polyfill.
-
 ## Internal API
 
 ### Action types
@@ -87,7 +81,6 @@ Some static HTML is generated from the JSX files and rendered on build time befo
 Action types dispatched during the UI lifecycle are listed in `state/action-types.js`.
 
 ### Available state selectors
-
 
 * **getActiveStatsTab( state )**
 * **getAdminEmailAddress( state )**

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-require( 'es6-promise' ).polyfill();
-import 'whatwg-fetch';
 import assign from 'lodash/assign';
 
 /**

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
 		"css-loader": "2.1.1",
 		"del": "4.1.0",
 		"email-validator": "2.0.4",
-		"es6-promise": "4.2.6",
 		"eslint": "5.15.3",
 		"eslint-config-prettier": "4.1.0",
 		"eslint-config-wpcalypso": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -160,8 +160,7 @@
 		"swiper": "4.5.0",
 		"uglify-save-license": "0.4.1",
 		"url-loader": "1.1.2",
-		"webpack": "4.29.6",
-		"whatwg-fetch": "1.1.1"
+		"webpack": "4.29.6"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "1.0.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13662,10 +13662,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
-
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,7 +5085,7 @@ es6-iterator@^2.0.1, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@4.2.6, es6-promise@^4.0.3:
+es6-promise@^4.0.3:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
 


### PR DESCRIPTION
Use `wp-polyfill` over explicit polyfills

```
                Asset      Size  Chunks                    Chunk Names
 admin.dops-style.css  76.2 KiB       0  [emitted]         admin
             admin.js  2.24 MiB       0  [emitted]  [big]  admin
static.dops-style.css  11.2 KiB       1  [emitted]         static
            static.js  1.45 MiB       1  [emitted]  [big]  static
```

| `master` | this branch | Δ |
| --- | --- | --- |
| 2386654 | 2373316 | - 13 KB |


#### Changes proposed in this Pull Request:

Remove explicit polyfills. The dashboard already depends on `wp-polyfill` which includes [`fetch`](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/dist/vendor/wp-polyfill-fetch.js) and [`Promise`](https://github.com/WordPress/WordPress/blob/447b956bb86483c614748c408ed99ed80333e5b3/wp-includes/js/dist/vendor/wp-polyfill.js).

https://github.com/Automattic/jetpack/blob/28a898d10ac99bbbc7ad5342df0238198caaafe6/_inc/lib/admin-pages/class.jetpack-react-page.php#L161-L167

#### Testing instructions:

Test the dashboard a browser that doesn't support `fetch`/`Promise`. Ensure network activity works as expected, like saving settings works as expected.

#### Proposed changelog entry for your changes:

* None
