### PR TITLE
Sync: Add/full sync start send range

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -98,8 +98,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * and sent to the server so that it knows a full sync is coming.
 		 *
 		 * @since 4.2.0
+		 * @since 7.3.0 Added $range arg.
+		 *
 		 * @param $full_sync_config - array
-		 * @param $range array @since 7.3.0
+		 * @param $range array
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	function init_full_sync_listeners( $callable ) {
 		// synthetic actions for full sync
-		add_action( 'jetpack_full_sync_start', $callable );
+		add_action( 'jetpack_full_sync_start', $callable, 10, 2 );
 		add_action( 'jetpack_full_sync_end', $callable, 10, 2 );
 		add_action( 'jetpack_full_sync_cancelled', $callable );
 	}
@@ -92,13 +92,24 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->set_config( $full_sync_config );
 		$this->set_enqueue_status( $enqueue_status );
 
+		$range = array();
+		// Only when we are sending the whole range do we want to send also the range
+		if ( isset( $full_sync_config['posts'] ) && $full_sync_config['posts'] === true ) {
+			$range['posts'] = $this->get_range( 'posts' );
+		}
+
+		if ( isset( $full_sync_config['comments'] ) && $full_sync_config['comments'] === true ) {
+			$range['comments'] = $this->get_range( 'comments' );
+		}
+
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it knows a full sync is coming.
 		 *
 		 * @since 4.2.0
+		 * $range added in 7.3.0
 		 */
-		do_action( 'jetpack_full_sync_start', $full_sync_config );
+		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
 
 		$this->continue_enqueuing( $full_sync_config, $enqueue_status );
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -178,8 +178,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * and sent to the server.
 		 *
 		 * @since 4.2.0
+		 * @since 7.3.0 Added $range arg.
+		 *
 		 * @param args ''
-		 * @param $range array @since 7.3.0
+		 * @param $range array 
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -92,22 +92,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->set_config( $full_sync_config );
 		$this->set_enqueue_status( $enqueue_status );
 
-		$range = array();
-		// Only when we are sending the whole range do we want to send also the range
-		if ( isset( $full_sync_config['posts'] ) && $full_sync_config['posts'] === true ) {
-			$range['posts'] = $this->get_range( 'posts' );
-		}
-
-		if ( isset( $full_sync_config['comments'] ) && $full_sync_config['comments'] === true ) {
-			$range['comments'] = $this->get_range( 'comments' );
-		}
-
+		$range = $this->get_content_range( $full_sync_config );
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it knows a full sync is coming.
 		 *
 		 * @since 4.2.0
-		 * $range added in 7.3.0
+		 * @param $full_sync_config - array
+		 * @param $range array @since 7.3.0
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
 
@@ -177,21 +169,15 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// setting autoload to true means that it's faster to check whether we should continue enqueuing
 		$this->update_status_option( 'queue_finished', time(), true );
 
-		$range = array();
-		// Only when we are sending the whole range do we want to send also the range
-		if ( isset( $configs['posts'] ) && $configs['posts'] === true ) {
-			$range['posts'] = $this->get_range( 'posts' );
-		}
-
-		if ( isset( $configs['comments'] ) && $configs['comments'] === true ) {
-			$range['comments'] = $this->get_range( 'comments' );
-		}
+		$range = $this->get_content_range( $configs );
 
 		/**
 		 * Fires when a full sync ends. This action is serialized
 		 * and sent to the server.
 		 *
 		 * @since 4.2.0
+		 * @param args ''
+		 * @param $range array @since 7.3.0
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
 	}
@@ -221,6 +207,19 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		return array();
+	}
+
+	private function get_content_range( $config ) {
+		$range = array();
+		// Only when we are sending the whole range do we want to send also the range
+		if ( isset( $config['posts'] ) && $config['posts'] === true ) {
+			$range['posts'] = $this->get_range( 'posts' );
+		}
+
+		if ( isset( $config['comments'] ) && $config['comments'] === true ) {
+			$range['comments'] = $this->get_range( 'comments' );
+		}
+		return $range;
 	}
 
 	function update_sent_progress_action( $actions ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -17,11 +17,29 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_enqueues_sync_start_action() {
+		$post = $this->factory->post->create();
+		$this->factory->comment->create_post_comments( $post, 11 );
+
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 		$this->assertTrue( $start_event !== false );
+
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+
+		list( $config, $range ) = $start_event->args;
+
+		$this->assertTrue( $config !== false );
+
+		$this->assertTrue( isset( $range['posts']->max ) );
+		$this->assertTrue( isset( $range['posts']->min ) );
+		$this->assertTrue( isset( $range['posts']->count ) );
+
+		$this->assertTrue( isset( $range['comments']->max ) );
+		$this->assertTrue( isset( $range['comments']->min ) );
+		$this->assertTrue( isset( $range['comments']->count ) );
+
 	}
 
 	// this only applies to the test replicastore - in production we overlay data
@@ -40,6 +58,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
+
+
+
 	}
 
 	function test_sync_start_resets_previous_sync_and_sends_full_sync_cancelled() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -58,9 +58,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
-
-
-
 	}
 
 	function test_sync_start_resets_previous_sync_and_sends_full_sync_cancelled() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We recetly send the range on full sync end. Since the query is fast we though it would be a good idea to also send it at the beginning of full sync.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* 

#### Testing instructions:
* Do The tests pass?
* Point your site to your .com sandbox. 
* Trigger a Full sync. (Use the jetapack debugger) 
* Notice the full sync start event add a new attribute to the as the full sync happens.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Enhancement: Full sync start send ranges of content.
