### PR TITLE
Debugger: Integration for WordPress 5.2 Site Health functionality

### DIFF
--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -9,9 +9,44 @@
 require_once 'class-jetpack-cxn-test-base.php';
 /* Jetpack Connection Tests */
 require_once 'class-jetpack-cxn-tests.php';
+
 /* Jetpack Debug Data */
 require_once 'class-jetpack-debug-data.php';
 /* The "In-Plugin Debugger" admin page. */
 require_once 'class-jetpack-debugger.php';
 
 add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );
+add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );
+add_action( 'wp_ajax_health-check-jetpack-local_testing_suite', 'jetpack_debugger_ajax_local_testing_suite' );
+
+/**
+ * Test runner for Core's Site Health module.
+ *
+ * @since 7.3.0
+ */
+function jetpack_debugger_ajax_local_testing_suite() {
+	check_ajax_referer( 'health-check-site-status' );
+	if ( ! current_user_can( 'jetpack_manage_modules' ) ) {
+		wp_send_json_error();
+	}
+	$tests = new Jetpack_Cxn_Tests();
+	wp_send_json_success( $tests->output_results_for_core_site_health() );
+}
+
+/**
+ * Adds the Jetpack Local Testing Suite to the Core Site Health system.
+ *
+ * @since 7.3.0
+ *
+ * @param array $tests Array of tests from Core's Site Health.
+ *
+ * @return array $tests Array of tests for Core's Site Health.
+ */
+function jetpack_debugger_site_status_tests( $tests ) {
+	$tests['async']['jetpack_test_suite'] = array(
+		'label' => __( 'Jetpack Tests', 'jetpack' ),
+		'test'  => 'jetpack_local_testing_suite',
+	);
+
+	return $tests;
+}

--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -9,5 +9,9 @@
 require_once 'class-jetpack-cxn-test-base.php';
 /* Jetpack Connection Tests */
 require_once 'class-jetpack-cxn-tests.php';
+/* Jetpack Debug Data */
+require_once 'class-jetpack-debug-data.php';
 /* The "In-Plugin Debugger" admin page. */
 require_once 'class-jetpack-debugger.php';
+
+add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -69,16 +69,16 @@ class Jetpack_Cxn_Test_Base {
 		if ( array_key_exists( $name, $this->tests ) ) {
 			return new WP_Error( __( 'Test names must be unique.', 'jetpack' ) );
 		}
-		if ( is_callable( $callable ) ) {
-			$this->tests[ $name ] = array(
-				'test'  => $callable,
-				'group' => $groups,
-				'type'  => $type,
-			);
-			return true;
+		if ( ! is_callable( $callable ) ) {
+			return new WP_Error( __( 'Tests must be valid PHP callables.', 'jetpack' ) );
 		}
 
-		return new WP_Error( __( 'Tests must be valid PHP callables.', 'jetpack' ) );
+		$this->tests[ $name ] = array(
+			'test'  => $callable,
+			'group' => $groups,
+			'type'  => $type,
+		);
+		return true;
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -277,7 +277,7 @@ class Jetpack_Cxn_Test_Base {
 				break;
 			case 'support':
 			case false:
-				$resolution = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
+				$resolution = __( 'Please contact Jetpack support.', 'jetpack' ); // @todo: Link to support.
 				break;
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -106,10 +106,8 @@ class Jetpack_Cxn_Test_Base {
 			}
 
 			// Next filter out any that do not match the type.
-			if ( 'all' !== $type ) {
-				if ( $type !== $value['type'] ) {
-					unset( $tests[ $name ] );
-				}
+			if ( 'all' !== $type && $type !== $value['type'] ) {
+				unset( $tests[ $name ] );
 			}
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -276,6 +276,7 @@ class Jetpack_Cxn_Test_Base {
 				$resolution = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
 				break;
 			case 'support':
+			case false:
 				$resolution = __( 'Please contact support.', 'jetpack' ); // @todo: Link to support.
 				break;
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -99,9 +99,7 @@ class Jetpack_Cxn_Test_Base {
 		$tests = array();
 		foreach ( $this->tests as $name => $value ) {
 			// Get all valid tests by group staged.
-			if ( 'all' === $group ) {
-				$tests[ $name ] = $value;
-			} elseif ( $group === $value['group'] ) {
+			if ( 'all' === $group || $group === $value['group'] ) {
 				$tests[ $name ] = $value;
 			}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -244,7 +244,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$result       = json_decode( $body );
 		$is_connected = (bool) $result->connected;
-		$message      = $result->message . wp_remote_retrieve_response_code( $response );
+		$message      = $result->message . ': ' . wp_remote_retrieve_response_code( $response );
 
 		if ( $is_connected ) {
 			return self::passing_test( $name );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -22,7 +22,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			if ( false === strpos( $method, 'test__' ) ) {
 				continue;
 			}
-			$this->add_test( array( $this, $method ) );
+			$this->add_test( array( $this, $method ), $method, 'direct' );
 		}
 
 		/**
@@ -44,8 +44,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			 * Intentionally added last as it checks for an existing failure state before attempting.
 			 * Generally, any failed location condition would result in the WP.com check to fail too, so
 			 * we will skip it to avoid confusing error messages.
+			 *
+			 * Note: This really should be an 'async' test.
 			 */
-			$this->add_test( array( $this, 'last__wpcom_self_test' ) );
+			$this->add_test( array( $this, 'last__wpcom_self_test' ), 'test__wpcom_self_test', 'direct' );
 		}
 	}
 

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -164,10 +164,9 @@ class Jetpack_Debug_Data {
 		$user_id     = get_current_user_id();
 		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );
 		$blog_token  = Jetpack_Options::get_option( 'blog_token' );
+		$user_token  = null;
 		if ( is_array( $user_tokens ) && array_key_exists( $user_id, $user_tokens ) ) {
 			$user_token = $user_tokens[ $user_id ];
-		} else {
-			$user_token = null;
 		}
 		unset( $user_tokens );
 

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -93,9 +93,13 @@ class Jetpack_Debug_Data {
 			'jetpack' => array(
 				'label'       => __( 'Jetpack', 'jetpack' ),
 				'description' => sprintf(
-					/* translators: URL is to jetpack.com's contact support page. */
-					__( 'Diagnostic information helpful to <a href="%s" target="_blank" rel="noopener noreferrer">your Jetpack Happiness team</a>', 'jetpack' ),
-					esc_html( 'https://jetpack.com/contact-support' )
+					/* translators: %1$s is URL to jetpack.com's contact support page. %2$s accessibility text */
+					__(
+						'Diagnostic information helpful to <a href="%1$s" target="_blank" rel="noopener noreferrer">your Jetpack Happiness team<span class="screen-reader-text">%2$s</span></a>',
+						'jetpack'
+					),
+					esc_html( 'https://jetpack.com/contact-support/' ),
+					__( '(opens in a new tab)', 'jetpack' )
 				),
 				'fields'      => self::debug_data(),
 			),

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -92,7 +92,11 @@ class Jetpack_Debug_Data {
 		$jetpack = array(
 			'jetpack' => array(
 				'label'       => __( 'Jetpack', 'jetpack' ),
-				'description' => __( 'Diagnostic information helpful to <a href="https://jetpack.com/contact-support">your Jetpack Happiness team</a>', 'jetpack' ),
+				'description' => sprintf(
+					/* translators: URL is to jetpack.com's contact support page. */
+					__( 'Diagnostic information helpful to <a href="%s" target="_blank">your Jetpack Happiness team</a>', 'jetpack' ),
+					esc_html( 'https://jetpack.com/contact-support' )
+				),
 				'fields'      => self::debug_data(),
 			),
 		);

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * Jetpack Debug Data for the legacy Jetpack debugger page and the WP 5.2-era Site Health sections.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Jetpack_Debug_Data
+ *
+ * Collect and return debug data for Jetpack.
+ *
+ * @since 7.3.0
+ */
+class Jetpack_Debug_Data {
+	/**
+	 * Determine the active plan and normalize it for the debugger results.
+	 *
+	 * @since 7.3.0
+	 *
+	 * @return string The plan slug.
+	 */
+	public static function what_jetpack_plan() {
+		$plan = Jetpack_Plan::get();
+		return ! empty( $plan['class'] ) ? $plan['class'] : 'undefined';
+	}
+
+	/**
+	 * Convert seconds to human readable time.
+	 *
+	 * A dedication function instead of using Core functionality to allow for output in seconds.
+	 *
+	 * @since 7.3.0
+	 *
+	 * @param int $seconds Number of seconds to convert to human time.
+	 *
+	 * @return string Human readable time.
+	 */
+	public static function seconds_to_time( $seconds ) {
+		$seconds = intval( $seconds );
+		$units   = array(
+			'week'   => WEEK_IN_SECONDS,
+			'day'    => DAY_IN_SECONDS,
+			'hour'   => HOUR_IN_SECONDS,
+			'minute' => MINUTE_IN_SECONDS,
+			'second' => 1,
+		);
+		// specifically handle zero.
+		if ( 0 === $seconds ) {
+			return '0 seconds';
+		}
+		$human_readable = '';
+		foreach ( $units as $name => $divisor ) {
+			$quot = intval( $seconds / $divisor );
+			if ( $quot ) {
+				$human_readable .= "$quot $name";
+				$human_readable .= ( abs( $quot ) > 1 ? 's' : '' ) . ', ';
+				$seconds        -= $quot * $divisor;
+			}
+		}
+		return substr( $human_readable, 0, -2 );
+	}
+
+	/**
+	 * Return debug data in the format expected by Core's Site Health Info tab.
+	 *
+	 * @since 7.3.0
+	 *
+	 * @param array $debug {
+	 *     The debug information already compiled by Core.
+	 *
+	 *     @type string  $label        The title for this section of the debug output.
+	 *     @type string  $description  Optional. A description for your information section which may contain basic HTML
+	 *                                 markup: `em`, `strong` and `a` for linking to documentation or putting emphasis.
+	 *     @type boolean $show_count   Optional. If set to `true` the amount of fields will be included in the title for
+	 *                                 this section.
+	 *     @type boolean $private      Optional. If set to `true` the section and all associated fields will be excluded
+	 *                                 from the copy-paste text area.
+	 *     @type array   $fields {
+	 *         An associative array containing the data to be displayed.
+	 *
+	 *         @type string  $label    The label for this piece of information.
+	 *         @type string  $value    The output that is of interest for this field.
+	 *         @type boolean $private  Optional. If set to `true` the field will not be included in the copy-paste text area
+	 *                                 on top of the page, allowing you to show, for example, API keys here.
+	 *     }
+	 * }
+	 *
+	 * @return array $args Debug information in the same format as the initial argument.
+	 */
+	public static function core_debug_data( $debug ) {
+		$jetpack = array(
+			'jetpack' => array(
+				'label'       => __( 'Jetpack', 'jetpack' ),
+				'description' => __( 'Diagnostic information helpful to <a href="https://jetpack.com/contact-support">your Jetpack Happiness team</a>', 'jetpack' ),
+				'fields'      => self::debug_data(),
+			),
+		);
+		$debug   = array_merge( $debug, $jetpack );
+		return $debug;
+	}
+
+	/**
+	 * Compile and return array of debug information.
+	 *
+	 * @since 7.3.0
+	 *
+	 * @return array $args {
+	 *          Associated array of arrays with the following.
+	 *         @type string  $label    The label for this piece of information.
+	 *         @type string  $value    The output that is of interest for this field.
+	 *         @type boolean $private  Optional. Set to true if data is sensitive (API keys, etc).
+	 * }
+	 */
+	private static function debug_data() {
+		$debug_info = array();
+
+		/* Add various important Jetpack options */
+		$debug_info['site_id']        = array(
+			'label'   => 'Jetpack Site ID',
+			'value'   => Jetpack_Options::get_option( 'id' ),
+			'private' => false,
+		);
+		$debug_info['ssl_cert']       = array(
+			'label'   => 'Jetpack SSL Verfication Bypass',
+			'value'   => ( Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) ? 'Yes' : 'No',
+			'private' => false,
+		);
+		$debug_info['time_diff']      = array(
+			'label'   => "Offset between Jetpack server's time and this server's time.",
+			'value'   => Jetpack_Options::get_option( 'time_diff' ),
+			'private' => false,
+		);
+		$debug_info['version_option'] = array(
+			'label'   => 'Current Jetpack Version Option',
+			'value'   => Jetpack_Options::get_option( 'version' ),
+			'private' => false,
+		);
+		$debug_info['old_version']    = array(
+			'label'   => 'Previous Jetpack Version',
+			'value'   => Jetpack_Options::get_option( 'old_version' ),
+			'private' => false,
+		);
+		$debug_info['public']         = array(
+			'label'   => 'Jetpack Site Public',
+			'value'   => ( Jetpack_Options::get_option( 'public' ) ) ? 'Public' : 'Private',
+			'private' => false,
+		);
+		$debug_info['master_user']    = array(
+			'label'   => 'Jetpack Master User',
+			'value'   => Jetpack_Options::get_option( 'master_user' ),
+			'private' => false,
+		);
+
+		/* Token information is private, but awareness if there one is set is helpful. */
+		$user_id     = get_current_user_id();
+		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );
+		$blog_token  = Jetpack_Options::get_option( 'blog_token' );
+		if ( is_array( $user_tokens ) && array_key_exists( $user_id, $user_tokens ) ) {
+			$user_token = $user_tokens[ $user_id ];
+		} else {
+			$user_token = null;
+		}
+		unset( $user_tokens );
+
+		$tokenset = '';
+		if ( $blog_token ) {
+			$tokenset = 'Blog ';
+		}
+		if ( $user_token ) {
+			$tokenset .= 'User';
+		}
+		if ( ! $tokenset ) {
+			$tokenset = 'None';
+		}
+
+		$debug_info['current_user'] = array(
+			'label'   => 'Current User',
+			'value'   => $user_id,
+			'private' => false,
+		);
+		$debug_info['tokens_set']   = array(
+			'label' => 'Tokens defined',
+			'value' => $tokenset,
+			'private => false,',
+		);
+		$debug_info['blog_token']   = array(
+			'label'   => 'Blog token',
+			'value'   => ( $blog_token ) ? $blog_token : 'Not set.',
+			'private' => true,
+		);
+		$debug_info['user_token']   = array(
+			'label'   => 'User token',
+			'value'   => ( $user_token ) ? $user_token : 'Not set.',
+			'private' => true,
+		);
+
+		/** Jetpack Environmental Information */
+		$debug_info['version']       = array(
+			'label'   => 'Jetpack Version',
+			'value'   => JETPACK__VERSION,
+			'private' => false,
+		);
+		$debug_info['jp_plugin_dir'] = array(
+			'label'   => 'Jetpack Directory',
+			'value'   => JETPACK__PLUGIN_DIR,
+			'private' => false,
+		);
+		$debug_info['plan']          = array(
+			'label'   => 'Plan Type',
+			'value'   => self::what_jetpack_plan(),
+			'private' => false,
+		);
+
+		foreach ( array(
+			'HTTP_HOST',
+			'SERVER_PORT',
+			'HTTPS',
+			'GD_PHP_HANDLER',
+			'HTTP_AKAMAI_ORIGIN_HOP',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_FASTLY_CLIENT_IP',
+			'HTTP_FORWARDED',
+			'HTTP_FORWARDED_FOR',
+			'HTTP_INCAP_CLIENT_IP',
+			'HTTP_TRUE_CLIENT_IP',
+			'HTTP_X_CLIENTIP',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+			'HTTP_X_FORWARDED',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_IP_TRAIL',
+			'HTTP_X_REAL_IP',
+			'HTTP_X_VARNISH',
+			'REMOTE_ADDR',
+		) as $header ) {
+			if ( isset( $_SERVER[ $header ] ) ) {
+				$debug_info[ $header ] = array(
+					'label'   => 'Server Variable ' . $header,
+					'value'   => ( $_SERVER[ $header ] ) ? $_SERVER[ $header ] : 'false',
+					'private' => false,
+				);
+			}
+		}
+
+		$debug_info['protect_header'] = array(
+			'label'   => 'Trusted IP',
+			'value'   => wp_json_encode( get_site_option( 'trusted_ip_header' ) ),
+			'private' => false,
+		);
+
+		/** Sync Debug Information */
+		/** Load Sync modules */
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
+		/** Load Sync sender */
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
+		/** Load Sync functions */
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-functions.php';
+
+		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		if ( $sync_module ) {
+			$sync_statuses              = $sync_module->get_status();
+			$human_readable_sync_status = array();
+			foreach ( $sync_statuses as $sync_status => $sync_status_value ) {
+				$human_readable_sync_status[ $sync_status ] =
+					in_array( $sync_status, array( 'started', 'queue_finished', 'send_started', 'finished' ), true )
+						? date( 'r', $sync_status_value ) : $sync_status_value;
+			}
+			$debug_info['full_sync'] = array(
+				'label'   => 'Full Sync Status',
+				'value'   => wp_json_encode( $human_readable_sync_status ),
+				'private' => false,
+			);
+		}
+
+		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
+
+		$debug_info['sync_size'] = array(
+			'label'   => 'Sync Queue Size',
+			'value'   => $queue->size(),
+			'private' => false,
+		);
+		$debug_info['sync_lag']  = array(
+			'label'   => 'Sync Queue Lag',
+			'value'   => self::seconds_to_time( $queue->lag() ),
+			'private' => false,
+		);
+
+		$full_sync_queue = Jetpack_Sync_Sender::get_instance()->get_full_sync_queue();
+
+		$debug_info['full_sync_size'] = array(
+			'label'   => 'Full Sync Queue Size',
+			'value'   => $full_sync_queue->size(),
+			'private' => false,
+		);
+		$debug_info['full_sync_lag']  = array(
+			'label'   => 'Full Sync Queue Lag',
+			'value'   => self::seconds_to_time( $full_sync_queue->lag() ),
+			'private' => false,
+		);
+
+		/**
+		 * IDC Information
+		 *
+		 * Must follow sync debug since it depends on sync functionality.
+		 */
+		$idc_urls = array(
+			'home'       => Jetpack_Sync_Functions::home_url(),
+			'siteurl'    => Jetpack_Sync_Functions::site_url(),
+			'WP_HOME'    => Jetpack_Constants::is_defined( 'WP_HOME' ) ? Jetpack_Constants::get_constant( 'WP_HOME' ) : '',
+			'WP_SITEURL' => Jetpack_Constants::is_defined( 'WP_SITEURL' ) ? Jetpack_Constants::get_constant( 'WP_SITEURL' ) : '',
+		);
+
+		$debug_info['idc_urls']         = array(
+			'label'   => 'IDC URLs',
+			'value'   => wp_json_encode( $idc_urls ),
+			'private' => false,
+		);
+		$debug_info['idc_error_option'] = array(
+			'label'   => 'IDC Error Option',
+			'value'   => wp_json_encode( Jetpack_Options::get_option( 'sync_error_idc' ) ),
+			'private' => false,
+		);
+		$debug_info['idc_optin']        = array(
+			'label'   => 'IDC Opt-in',
+			'value'   => Jetpack::sync_idc_optin(),
+			'private' => false,
+		);
+
+		// @todo -- Add testing results?
+		$cxn_tests               = new Jetpack_Cxn_Tests();
+		$debug_info['cxn_tests'] = array(
+			'label'   => 'Connection Tests',
+			'value'   => '',
+			'private' => false,
+		);
+		if ( $cxn_tests->pass() ) {
+			$debug_info['cxn_tests']['value'] = 'All Pass.';
+		} else {
+			$debug_info['cxn_tests']['value'] = wp_json_encode( $cxn_tests->list_fails() );
+		}
+
+		return $debug_info;
+	}
+}

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -112,7 +112,7 @@ class Jetpack_Debug_Data {
 	 *         @type boolean $private  Optional. Set to true if data is sensitive (API keys, etc).
 	 * }
 	 */
-	private static function debug_data() {
+	public static function debug_data() {
 		$debug_info = array();
 
 		/* Add various important Jetpack options */

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -94,7 +94,7 @@ class Jetpack_Debug_Data {
 				'label'       => __( 'Jetpack', 'jetpack' ),
 				'description' => sprintf(
 					/* translators: URL is to jetpack.com's contact support page. */
-					__( 'Diagnostic information helpful to <a href="%s" target="_blank">your Jetpack Happiness team</a>', 'jetpack' ),
+					__( 'Diagnostic information helpful to <a href="%s" target="_blank" rel="noopener noreferrer">your Jetpack Happiness team</a>', 'jetpack' ),
 					esc_html( 'https://jetpack.com/contact-support' )
 				),
 				'fields'      => self::debug_data(),

--- a/jetpack.php
+++ b/jetpack.php
@@ -127,6 +127,7 @@ if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
+	jetpack_require_lib( 'debugger' );
 }
 
 // Play nice with http://wp-cli.org/


### PR DESCRIPTION
WordPress 5.2 adds in a site health "testing suite" and common debug data source. This PR would add a single test to check for the overall local testing suite status and moves the Jetpack Advanced Debug Data to a section in the new debug data area.

#### Changes proposed in this Pull Request:
* WordPress 5.2 introduces a new Site Health tool and Jetpack integrates wonderfully with it!

#### Testing instructions:
* Connected Jetpack site running WP 5.2 beta.
* On 5.2-beta, visit Tools->Site Health. Does the Jetpack test run async (e.g. delayed response to allow time for remote http calls.
* Visit Debug Data. Does Jetpack have a section there?
* Press the copy to clipboard button. Paste. Are the user/blog tokens NOT present.
* On WP 5.0 or 5.1, anything weird? Visit the Jetpack Debugger -- verify the debug is still there (albeit with different more human readable labels)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
