### PR TITLE
Publicize Gutenberg sidebar: remove Google+

### DIFF
--- a/extensions/blocks/publicize/connection.js
+++ b/extensions/blocks/publicize/connection.js
@@ -35,29 +35,6 @@ class PublicizeConnection extends Component {
 	};
 
 	/**
-	 * If this is the Google+ connection, display a notice.
-	 *
-	 * @param {string} serviceName Name of the connnected social network.
-	 * @returns {object} Message warning users of Google+ shutting down.
-	 */
-	maybeDisplayGooglePlusNotice = serviceName =>
-		'google-plus' === serviceName &&
-		this.state.showGooglePlusNotice && (
-			<Notice status="error" onRemove={ this.onRemoveGooglePlusNotice }>
-				{ __(
-					'Google+ will shut down in April 2019. You can keep posting with your existing Google+ connection through March.',
-					'jetpack'
-				) }
-				<ExternalLink
-					target="_blank"
-					href="https://www.blog.google/technology/safety-security/expediting-changes-google-plus/"
-				>
-					{ __( ' Learn more', 'jetpack' ) }.
-				</ExternalLink>
-			</Notice>
-		);
-
-	/**
 	 * Displays a message when a connection requires reauthentication. We used this when migrating LinkedIn API usage from v1 to v2,
 	 * since the prevous OAuth1 tokens were incompatible with OAuth2.
 	 *
@@ -117,7 +94,6 @@ class PublicizeConnection extends Component {
 
 		return (
 			<li>
-				{ this.maybeDisplayGooglePlusNotice( serviceName ) }
 				{ this.maybeDisplayLinkedInNotice() }
 				<div className="publicize-jetpack-connection-container">
 					<label htmlFor={ fieldId } className="jetpack-publicize-connection-label">

--- a/extensions/blocks/publicize/connection.js
+++ b/extensions/blocks/publicize/connection.js
@@ -21,19 +21,6 @@ import PublicizeServiceIcon from './service-icon';
 import getSiteFragment from '../../shared/get-site-fragment';
 
 class PublicizeConnection extends Component {
-	state = {
-		showGooglePlusNotice: true,
-	};
-
-	/**
-	 * Hide notice when it's removed
-	 */
-	onRemoveGooglePlusNotice = () => {
-		this.setState( {
-			showGooglePlusNotice: false,
-		} );
-	};
-
 	/**
 	 * Displays a message when a connection requires reauthentication. We used this when migrating LinkedIn API usage from v1 to v2,
 	 * since the prevous OAuth1 tokens were incompatible with OAuth2.

--- a/extensions/blocks/publicize/editor.scss
+++ b/extensions/blocks/publicize/editor.scss
@@ -41,9 +41,6 @@ $dark-gray-500: #555d66;
 	&.is-tumblr {
 		fill: var( --color-tumblr );
 	}
-	&.is-google-plus {
-		fill: var( --color-gplus );
-	}
 }
 
 .jetpack-publicize-connection-label {

--- a/extensions/blocks/publicize/service-icon.js
+++ b/extensions/blocks/publicize/service-icon.js
@@ -42,14 +42,6 @@ const TumblrIcon = (
 		</G>
 	</SVG>
 );
-const GooglePlusIcon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Rect x="0" fill="none" width="24" height="24" />
-		<G>
-			<Path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1.92 14.05c-2.235 0-4.05-1.814-4.05-4.05s1.815-4.05 4.05-4.05c1.095 0 2.01.4 2.71 1.057l-1.15 1.118c-.292-.275-.802-.6-1.56-.6-1.34 0-2.433 1.115-2.433 2.48s1.094 2.48 2.434 2.48c1.552 0 2.123-1.074 2.228-1.71h-2.232v-1.51h3.79c.058.255.102.494.102.83 0 2.312-1.55 3.956-3.887 3.956zm8.92-3.3h-1.25V14h-1.5v-1.25H15v-1.5h1.25V10h1.5v1.25H19v1.5z" />
-		</G>
-	</SVG>
-);
 
 export default ( { serviceName } ) => {
 	const defaultProps = {
@@ -66,8 +58,6 @@ export default ( { serviceName } ) => {
 			return <Icon icon={ LinkedinIcon } { ...defaultProps } />;
 		case 'tumblr':
 			return <Icon icon={ TumblrIcon } { ...defaultProps } />;
-		case 'google-plus':
-			return <Icon icon={ GooglePlusIcon } { ...defaultProps } />;
 	}
 
 	return null;


### PR DESCRIPTION
These connections should not show up anymore so it's safe to remove these in Publicize sidebar as well.

I don't have Google+ account connected and it's not possible to get one, so couldn't _really_ test.

See https://github.com/Automattic/wp-calypso/issues/31299

#### Changes proposed in this Pull Request:

* Remove Google+ stuff from Publicize sidebar

#### Testing instructions:
* `yarn build-extensions`
* Create new post and publish
* Nothing about Google+ in the Publicize sidebar


#### Proposed changelog entry for your changes:
* Remove Google+ deprecation notice from the Publicize sidebar in block editor.
