### PR TITLE
Tiled gallery block: remove commented-out captions code

### DIFF
--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -47,12 +47,7 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 export const pickRelevantMediaFiles = image => {
-	const imageProps = pick( image, [
-		[ 'alt' ],
-		[ 'id' ],
-		[ 'link' ],
-		/* @TODO Captions disabled [ 'caption' ], */
-	] );
+	const imageProps = pick( image, [ [ 'alt' ], [ 'id' ], [ 'link' ] ] );
 	imageProps.url =
 		get( image, [ 'sizes', 'large', 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) ||

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -44,48 +44,7 @@
 		&.is-transient img {
 			opacity: 0.3;
 		}
-
-		/* @TODO Caption has been commented out */
-		// .editor-rich-text {
-		// 	position: absolute;
-		// 	bottom: 0;
-		// 	width: 100%;
-		// 	max-height: 100%;
-		// 	overflow-y: auto;
-		// }
-
-		// .editor-rich-text figcaption:not( [data-is-placeholder-visible='true'] ) {
-		// 	position: relative;
-		// 	overflow: hidden;
-		// 	color: var( --color-white );
-		// }
-
-		// &.is-selected .editor-rich-text {
-		// 	// IE calculates this incorrectly, so leave it to modern browsers.
-		// 	@supports ( position: sticky ) {
-		// 		right: 0;
-		// 		left: 0;
-		// 		margin-top: -4px;
-		// 	}
-
-		// 	// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
-		// 	.editor-rich-text__inline-toolbar {
-		// 		top: 0;
-		// 	}
-
-		// 	// Make extra space for the inline toolbar.
-		// 	.editor-rich-text__tinymce {
-		// 		padding-top: 48px;
-		// 	}
-		// }
 	}
-
-	// Circle layout doesn't support captions
-	// @TODO handle this in the component
-	/* @TODO Caption has been commented out */
-	// &.is-style-circle .tiled-gallery__item .editor-rich-text {
-	// 	display: none;
-	// }
 
 	.tiled-gallery__add-item {
 		margin-top: $tiled-gallery-gutter;

--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -9,39 +9,13 @@ import { IconButton, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 import { withSelect } from '@wordpress/data';
 
-/* @TODO Caption has been commented out */
-// import { RichText } from '@wordpress/editor';
-
 class GalleryImageEdit extends Component {
 	img = createRef();
-
-	/* @TODO Caption has been commented out */
-	// state = {
-	// 	captionSelected: false,
-	// };
-
-	// onSelectCaption = () => {
-	// 	if ( ! this.state.captionSelected ) {
-	// 		this.setState( {
-	// 			captionSelected: true,
-	// 		} );
-	// 	}
-
-	// 	if ( ! this.props.isSelected ) {
-	// 		this.props.onSelect();
-	// 	}
-	// };
 
 	onImageClick = () => {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
-
-		// if ( this.state.captionSelected ) {
-		// 	this.setState( {
-		// 		captionSelected: false,
-		// 	} );
-		// }
 	};
 
 	onImageKeyDown = event => {
@@ -53,16 +27,6 @@ class GalleryImageEdit extends Component {
 			this.props.onRemove();
 		}
 	};
-
-	/* @TODO Caption has been commented out */
-	// static getDerivedStateFromProps( props, state ) {
-	// 	// unselect the caption so when the user selects other image and comeback
-	// 	// the caption is not immediately selected
-	// 	if ( ! props.isSelected && state.captionSelected ) {
-	// 		return { captionSelected: false };
-	// 	}
-	// 	return null;
-	// }
 
 	componentDidUpdate() {
 		const { alt, height, image, link, url, width } = this.props;
@@ -96,7 +60,6 @@ class GalleryImageEdit extends Component {
 		const {
 			'aria-label': ariaLabel,
 			alt,
-			// caption,
 			height,
 			id,
 			imageFilter,
@@ -105,7 +68,6 @@ class GalleryImageEdit extends Component {
 			linkTo,
 			onRemove,
 			origUrl,
-			// setAttributes,
 			url,
 			width,
 		} = this.props;
@@ -167,17 +129,6 @@ class GalleryImageEdit extends Component {
 				{ /* Keep the <a> HTML structure, but ensure there is no navigation from edit */
 				/* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 				{ href ? <a>{ img }</a> : img }
-				{ /* ( ! RichText.isEmpty( caption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
-						isSelected={ this.state.captionSelected }
-						onChange={ newCaption => setAttributes( { caption: newCaption } ) }
-						unstableOnFocus={ this.onSelectCaption }
-						inlineToolbar
-					/>
-				) */ }
 			</figure>
 		);
 	}

--- a/extensions/blocks/tiled-gallery/gallery-image/save.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/save.js
@@ -4,22 +4,8 @@
 import classnames from 'classnames';
 import { isBlobURL } from '@wordpress/blob';
 
-/* @TODO Caption has been commented out */
-// import { RichText } from '@wordpress/editor';
-
 export default function GalleryImageSave( props ) {
-	const {
-		alt,
-		// caption,
-		imageFilter,
-		height,
-		id,
-		link,
-		linkTo,
-		origUrl,
-		url,
-		width,
-	} = props;
+	const { alt, imageFilter, height, id, link, linkTo, origUrl, url, width } = props;
 
 	if ( isBlobURL( origUrl ) ) {
 		return null;
@@ -55,9 +41,6 @@ export default function GalleryImageSave( props ) {
 			} ) }
 		>
 			{ href ? <a href={ href }>{ img }</a> : img }
-			{ /* ! RichText.isEmpty( caption ) && (
-				<RichText.Content tagName="figcaption" value={ caption } />
-			) */ }
 		</figure>
 	);
 }

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -74,11 +74,6 @@ const blockAttributes = {
 				selector: 'img',
 				source: 'attribute',
 			},
-			caption: {
-				selector: 'figcaption',
-				source: 'html',
-				type: 'string',
-			},
 			height: {
 				attribute: 'data-height',
 				selector: 'img',
@@ -151,11 +146,10 @@ export const settings = {
 					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
 					if ( validImages.length > 0 ) {
 						return createBlock( `jetpack/${ name }`, {
-							images: validImages.map( ( { id, url, alt, caption } ) => ( {
+							images: validImages.map( ( { id, url, alt } ) => ( {
 								id,
 								url,
 								alt,
-								caption,
 							} ) ),
 						} );
 					}
@@ -175,8 +169,8 @@ export const settings = {
 				blocks: [ 'core/image' ],
 				transform: ( { images } ) => {
 					if ( images.length > 0 ) {
-						return images.map( ( { id, url, alt, caption } ) =>
-							createBlock( 'core/image', { id, url, alt, caption } )
+						return images.map( ( { id, url, alt } ) =>
+							createBlock( 'core/image', { id, url, alt } )
 						);
 					}
 					return createBlock( 'core/image' );

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -71,8 +71,6 @@ export default class Layout extends Component {
 			<Image
 				alt={ img.alt }
 				aria-label={ ariaLabel }
-				// @TODO Caption has been commented out
-				// caption={ img.caption }
 				height={ img.height }
 				id={ img.id }
 				imageFilter={ imageFilter }

--- a/extensions/blocks/tiled-gallery/layout/test/fixtures/image-sets.js
+++ b/extensions/blocks/tiled-gallery/layout/test/fixtures/image-sets.js
@@ -2,7 +2,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 163,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/architecture-bay-bridge-356830.jpg',
 		height: 2048,
 		width: 8192,
@@ -10,7 +9,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 162,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/bloom-blossom-flora-40797-1.jpg',
 		height: 1562,
 		width: 3531,
@@ -18,7 +16,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 161,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/architecture-building-city-597049.jpg',
 		height: 4221,
 		width: 2818,
@@ -26,7 +23,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 160,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/architecture-art-blue-699466.jpg',
 		height: 4032,
 		width: 3024,
@@ -34,7 +30,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 159,
-		caption: '',
 		url:
 			'https://example.files.wordpress.com/2018/12/black-and-white-construction-ladder-54335.jpg',
 		height: 3193,
@@ -43,7 +38,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 158,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/architecture-buildings-city-1672110.jpg',
 		height: 6000,
 		width: 4000,
@@ -51,7 +45,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 157,
-		caption: '',
 		url:
 			'https://example.files.wordpress.com/2018/12/architectural-design-architecture-black-and-white-1672122-1.jpg',
 		height: 3401,
@@ -60,7 +53,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 156,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/grass-hd-wallpaper-lake-127753.jpg',
 		height: 2198,
 		width: 7999,
@@ -68,7 +60,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 122,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/texaco-car-1.jpg',
 		height: 599,
 		width: 800,
@@ -76,7 +67,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 92,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/43824553435_ea38cbc92a_m.jpg',
 		height: 159,
 		width: 240,
@@ -84,7 +74,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 90,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/42924685680_7b5632e58e_m.jpg',
 		height: 150,
 		width: 240,
@@ -92,7 +81,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 89,
-		caption: '',
 		url:
 			'https://example.files.wordpress.com/2018/12/31962299833_1e106f7f7a_z-1-e1545262352979.jpg',
 		height: 427,
@@ -101,7 +89,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 88,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/12/29797558147_3c72afa8f4_k.jpg',
 		height: 1511,
 		width: 2048,
@@ -109,7 +96,6 @@ export const imageSet1 = [
 	{
 		alt: '',
 		id: 8,
-		caption: '',
 		url: 'https://example.files.wordpress.com/2018/11/person-smartphone-office-table.jpeg',
 		height: 1067,
 		width: 1600,

--- a/extensions/blocks/tiled-gallery/variables.scss
+++ b/extensions/blocks/tiled-gallery/variables.scss
@@ -1,5 +1,4 @@
 $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
-$tiled-gallery-caption-background-color: #000;
 $tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -111,25 +111,4 @@ $tiled-gallery-max-column-count: 20;
 		padding: 0;
 		width: 100%;
 	}
-
-	/* @TODO Caption has been commented out */
-	// figcaption {
-	// 	position: absolute;
-	// 	bottom: 0;
-	// 	width: 100%;
-	// 	max-height: 100%;
-	// 	overflow: auto;
-	// 	padding: 40px 10px 5px;
-	// 	color: var( --color-white );
-	// 	text-align: center;
-	// 	font-size: $root-font-size;
-	// 	// stylelint-disable function-parentheses-space-inside
-	// 	background: linear-gradient(
-	// 		0deg,
-	// 		rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.7 ) 0,
-	// 		rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.3 ) 60%,
-	// 		transparent
-	// 	);
-	// 	// stylelint-enable function-parentheses-space-inside
-	// }
 }


### PR DESCRIPTION
Remove already commented-out code for Tiled gallery captions.

This feature isn't going to be added any time soon so better not to carry un-used core around. See https://github.com/Automattic/jetpack/11794

#### Changes proposed in this Pull Request:

* Code cleanup

#### Testing instructions:
* Using `master` branch, create new post and add tiled gallery block
* Switch to this branch and `yarn build-extensions`
* Open the post again, block should not deprecate and should work just fine otherwise, too.


#### Proposed changelog entry for your changes:
* 
