### PR TITLE
WPCOM API: List post-types also return their "public" property

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -31,7 +31,8 @@ class WPCOM_JSON_API_List_Post_Types_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'map_meta_cap' => 'map_meta_cap',
 		'cap'          => 'capabilities',
 		'hierarchical' => 'hierarchical',
-		'show_ui'   => 'show_ui',
+		'public'       => 'public',
+		'show_ui'      => 'show_ui',
 		'publicly_queryable' => 'publicly_queryable',
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Helps fixing https://github.com/Automattic/wp-calypso/issues/22811 along with https://github.com/Automattic/wp-calypso/pull/32107.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The Sharing Buttons options in Calypso include all `show_in_rest` post types, but when updating them, we only save the `public` ones:

https://github.com/Automattic/jetpack/blob/9ef4f3741dfaab2a8cfc8850251a9c7208048f1b/modules/sharedaddy/sharing-service.php#L351

The WPCOM API doesn't return the `public` property—which is not inferable from other properties, regardless of [what the Codex implies](https://codex.wordpress.org/Function_Reference/register_post_type) (for example pages are `public`, but not `publicly_queryable`).

This diff simply adds the `public` property to the `GET /sites/:site/post-types` output.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Either test the endpoint directly by calling `GET /sites/:site/post-types` and making sure every elements in the response contain a `public` property, or:

* Run Calypso on the `fix/22811-sharing-options` branch.
* Open `/sharing/buttons` in Calypso on a JP site containing this change.
* Make sure it only shows the `public` post types. (See example screenshots)
* Try saving: all the options, none of the options, some options.
* Try reloading between each save to make sure the options are really updated.

| Correct | Incorrect |
| - | - |
| ![Screenshot 2019-04-08 at 15 13 22](https://user-images.githubusercontent.com/2070010/55731337-f30a6780-5a11-11e9-8d07-b1b0cc3f64b5.png) | ![Screenshot 2019-04-08 at 15 13 10](https://user-images.githubusercontent.com/2070010/55731358-faca0c00-5a11-11e9-887a-758f11c19709.png) |

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Add the `public` property to the Post Types endpoint response.