### PR TITLE
General: Fixes code owners in the tests/sync folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,4 +26,4 @@
 * @automattic/jetpack-crew
 
 /sync/ @automattic/poseidon @automattic/jetpack-crew
-/tests/php/sync @automattic/poseidon @automattic/jetpack-crew
+/tests/php/sync/ @automattic/poseidon @automattic/jetpack-crew


### PR DESCRIPTION
I was trying to merge but wasn't able to. 
https://github.com/Automattic/jetpack/pull/11975
I am hoping this PR would fix this issue.

#### Changes proposed in this Pull Request:
Adds a slash so that 
`tests/php/sync/` is a folder.


#### Testing instructions:
Will team Poseidon be able to merge https://github.com/Automattic/jetpack/pull/11975?

#### Proposed changelog entry for your changes:

None