### PR TITLE
Slideshow block: add image ids to add image in og:image tag

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -347,11 +347,10 @@ class Jetpack_PostImages {
 			}
 
 			/**
-			 * Parse content from Core Gallery blocks and Jetpack's Tiled Gallery blocks.
+			 * Parse content from Core Gallery blocks as well from Jetpack's Tiled Gallery and Slideshow blocks.
 			 * Gallery blocks include the ID of each one of the images in the gallery.
 			 */
-			if (
-				( 'core/gallery' === $block['blockName'] || 'jetpack/tiled-gallery' === $block['blockName'] )
+			if ( in_array( $block['blockName'], array( 'core/gallery', 'jetpack/tiled-gallery', 'jetpack/slideshow' ) )
 				&& ! empty( $block['attrs']['ids'] )
 			) {
 				foreach ( $block['attrs']['ids'] as $img_id ) {

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -49,10 +49,25 @@ class SlideshowEdit extends Component {
 			selectedImage: null,
 		};
 	}
+	setAttributes( attributes ) {
+		if ( attributes.ids ) {
+			throw new Error(
+				'The "ids" attribute should not be changed directly. It is managed automatically when "images" attribute changes'
+			);
+		}
+
+		if ( attributes.images ) {
+			attributes = {
+				...attributes,
+				ids: attributes.images.map( ( { id } ) => parseInt( id, 10 ) ),
+			};
+		}
+
+		this.props.setAttributes( attributes );
+	}
 	onSelectImages = images => {
-		const { setAttributes } = this.props;
 		const mapped = images.map( image => pickRelevantMediaFiles( image ) );
-		setAttributes( {
+		this.setAttributes( {
 			images: mapped,
 		} );
 	};
@@ -60,12 +75,12 @@ class SlideshowEdit extends Component {
 		return () => {
 			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
 			this.setState( { selectedImage: null } );
-			this.props.setAttributes( { images } );
+			this.setAttributes( { images } );
 		};
 	};
 	addFiles = files => {
 		const currentImages = this.props.attributes.images || [];
-		const { lockPostSaving, unlockPostSaving, noticeOperations, setAttributes } = this.props;
+		const { lockPostSaving, unlockPostSaving, noticeOperations } = this.props;
 		const lockName = 'slideshowBlockLock';
 		lockPostSaving( lockName );
 		mediaUpload( {
@@ -73,7 +88,7 @@ class SlideshowEdit extends Component {
 			filesList: files,
 			onFileChange: images => {
 				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
-				setAttributes( {
+				this.setAttributes( {
 					images: [ ...currentImages, ...imagesNormalized ],
 				} );
 				if ( ! imagesNormalized.every( image => isBlobURL( image.url ) ) ) {

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -31,6 +31,10 @@ const attributes = {
 		type: 'number',
 		default: 3,
 	},
+	ids: {
+		default: [],
+		type: 'array',
+	},
 	images: {
 		type: 'array',
 		default: [],


### PR DESCRIPTION
Add IDs to Slideshow block and plug them to image-class so that `og:image` gets correctly populated.

Without these, `og:image` tag will have an empty image for Publicize. sharing when there's only a slideshow in the page content.
 
#### Changes proposed in this Pull Request:

* Add ids to Slideshow block
* Add slideshow block to `ids` sniffer in `Jetpack_PostImages` class

#### Testing instructions:
* _Without_ this PR, create a slideshow block in. a post and save it
* Confirm that `og:image` tag is empty when looking at the page sources
* Confirm that when looking at block sources in the editor, no `ids` in args
* Apply this branch and re-build blocks
* Refresh the post with slideshow; confirm that the block doesn't invalidate
* Modify images and observe sources again; `ids` are now there
* Save and look at the page sources; `og:image` works. now

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
