### PR TITLE
Raw Options: prevent update_raw_option from creating multiple values

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -368,9 +368,17 @@ class Jetpack_Options {
 		global $wpdb;
 		$autoload_value = $autoload ? 'yes' : 'no';
 
+		$old_value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+				$name
+			)
+		);
+		if ( $old_value === $value ) {
+			return false;
+		}
+
 		$serialized_value = maybe_serialize( $value );
-		// try updating, if no update then insert
-		// TODO: try to deal with the fact that unchanged values can return updated_num = 0
 		// below we used "insert ignore" to at least suppress the resulting error
 		$updated_num = $wpdb->query(
 			$wpdb->prepare(
@@ -380,6 +388,7 @@ class Jetpack_Options {
 			)
 		);
 
+		// Try inserting the option if the value doesn't exits.
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
@@ -389,7 +398,7 @@ class Jetpack_Options {
 				)
 			);
 		}
-		return $updated_num;
+		return (bool)$updated_num;
 	}
 
 	/**

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -398,7 +398,7 @@ class Jetpack_Options {
 				)
 			);
 		}
-		return (bool)$updated_num;
+		return (bool) $updated_num;
 	}
 
 	/**

--- a/tests/php/test_class.jetpack-options.php
+++ b/tests/php/test_class.jetpack-options.php
@@ -109,4 +109,14 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		remove_filter( 'option_test_option', array( $this, 'get_test_option_from_cache' ) );
 	}
+
+	function test_raw_option_update_with_duplicate_value_returns_false() {
+		Jetpack_Options::delete_raw_option( 'test_option_2' );
+
+		Jetpack_Options::update_raw_option( 'test_option_2', 'blue' );
+		$this->assertEquals( 'blue', Jetpack_Options::get_raw_option( 'test_option_2' ) );
+
+		$this->assertFalse( Jetpack_Options::update_raw_option( 'test_option_2', 'blue' ) );
+		$this->assertTrue( Jetpack_Options::update_raw_option( 'test_option_2', 'yellow' ) );
+	}
 }


### PR DESCRIPTION
In some cases Jetpack_Options:update_raw_option() can create multiple values. 

Checking that the values do not match before updating them prevents that from happening.

#### Changes proposed in this Pull Request:
* Improves the Jetpack_Options:update_raw_option() by checking that what the current value doesn't match the value that we are inserting.

#### Testing instructions:
* Do the tests pass?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve `Jetpack_Options:update_raw_option`
