### PR TITLE
Jetpack Network: Fix connection site creation date

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -458,7 +458,7 @@ class Jetpack_Network {
 		 * `Jetpack::get_assumed_site_creation_date()` to assume the site's creation date.
 		 */
 		$blog_details = get_blog_details();
-		$site_creation_date = $blog_details['registered'];
+		$site_creation_date = $blog_details->registered;
 
 		/**
 		 * Both `state` and `user_id` need to be sent in the request, even though they are the same value.


### PR DESCRIPTION
In #11450 we introduced a bug with how we handle `get_blog_details()` as an array instead of as a `WP_Site` object. This PR fixes that.

Fixes #11993.

#### Changes proposed in this Pull Request:

* Use `get_blog_details()` as an object instead of as an array.

#### Testing instructions:

* Go to "Jetpack" in wp-admin of a subsite in a multisite network.
* Connect the subsite.
* Verify you're able to connect.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix the registration date in the connection process for a subsite in a multisite network.
