### PR TITLE
VR Shortcode: fix all PHPCS warnings and bring file in sync with WordPress.com

### DIFF
--- a/modules/shortcodes/vr.php
+++ b/modules/shortcodes/vr.php
@@ -1,19 +1,25 @@
 <?php
-
-// VR Viewer Shortcode
-// converts [vr] shortcode to an iframe viewer hosted on vr.me.sh
-
+/**
+ * VR Viewer Shortcode
+ * converts [vr] shortcode to an iframe viewer hosted on vr.me.sh
+ *
+ * @package Jetpack
+ */
 
 /**
  * Scrub URL paramaters for VR viewer
  *
- * @param url_params - parameter array which is passed to the jetpack_vr_viewer
- * @param url_params['url'] - url of 360 media
- * @param url_params['guid'] - guid for videopress
- * @param url_params['view'] - cinema, 360 - controls if panaroma view, or 360
- * @param url_params['rotation'] - number for rotating media
- * @param url_params['preview'] - show preview image or not
- * @return url_params array or false
+ * @param array $params {
+ *     parameter array which is passed to the jetpack_vr_viewer.
+ *
+ *     @type string $url url of 360 media
+ *     @type string $guid     guid for videopress
+ *     @type string $view     cinema, 360 - controls if panaroma view, or 360
+ *     @type string $rotation number for rotating media
+ *     @type string $preview  show preview image or not
+ * }
+ *
+ * @return array|false $url_params Array of URL parameters.
  */
 function jetpack_vr_viewer_get_viewer_url_params( $params ) {
 	$url_params = array();
@@ -42,11 +48,12 @@ function jetpack_vr_viewer_get_viewer_url_params( $params ) {
 /**
  * Get padding for IFRAME depending on view type
  *
- * @param view - string cinema, 360 - default cinema
- * @return css padding
+ * @param string $view string cinema, 360 - default cinema.
+ *
+ * @return string $css padding
  */
 function jetpack_vr_viewer_iframe_padding( $view ) {
-	if ( $view === '360' ) {
+	if ( '360' === $view ) {
 		return '100%'; // 1:1 square aspect for 360
 	}
 
@@ -58,20 +65,24 @@ function jetpack_vr_viewer_iframe_padding( $view ) {
  * The viewer code is hosted on vr.me.sh site which is then displayed
  * within posts via an IFRAME. This function returns the IFRAME html.
  *
- * @param url_params - parameter array which is passed to the jetpack_vr_viewer
- * @param url_params['url'] - url of 360 media
- * @param url_params['guid'] - guid for videopress
- * @param url_params['view'] - cinema, 360 - controls if panaroma view, or 360
- * @param url_params['rotation'] - number for rotating media
- * @param url_params['preview'] - show preview image or not
- * @return html - an iframe for viewer
+ * @param array $url_params {
+ *     parameter array which is passed to the jetpack_vr_viewer.
+ *
+ *     @type string $url url of 360 media
+ *     @type string $guid     guid for videopress
+ *     @type string $view     cinema, 360 - controls if panaroma view, or 360
+ *     @type string $rotation number for rotating media
+ *     @type string $preview  show preview image or not
+ * }
+ *
+ * @return string $rtn an iframe for viewer.
  */
 function jetpack_vr_viewer_get_html( $url_params ) {
 	global $content_width;
 
 	$iframe = add_query_arg( $url_params, 'https://vr.me.sh/view/' );
 
-	// set some defaults
+	// set some defaults.
 	$maxwidth = ( isset( $content_width ) ) ? $content_width : 720;
 	$view     = ( isset( $url_params['view'] ) ) ? $url_params['view'] : 'cinema';
 
@@ -97,6 +108,8 @@ function jetpack_vr_viewer_get_html( $url_params ) {
  * </iframe>
  * </div>
  *
+ * @param array $atts Shortcode attributes.
+ *
  * @return html - complete vr viewer html
  */
 function jetpack_vr_viewer_shortcode( $atts ) {
@@ -113,7 +126,7 @@ function jetpack_vr_viewer_shortcode( $atts ) {
 		$atts
 	);
 
-	// We offer a few ways to specify the URL
+	// We offer a few ways to specify the URL.
 	if ( $params[0] ) {
 		$params['url'] = $params[0];
 	} elseif ( $params['src'] ) {
@@ -125,12 +138,11 @@ function jetpack_vr_viewer_shortcode( $atts ) {
 		return jetpack_vr_viewer_get_html( $url_params );
 	}
 
-	// add check for user
+	// add check for user.
 	if ( current_user_can( 'edit_posts' ) ) {
 		return '[vr] shortcode requires a data source to be given';
 	} else {
 		return '';
 	}
 }
-
 add_shortcode( 'vr', 'jetpack_vr_viewer_shortcode' );

--- a/modules/shortcodes/vr.php
+++ b/modules/shortcodes/vr.php
@@ -86,7 +86,7 @@ function jetpack_vr_viewer_get_html( $url_params ) {
 	$maxwidth = ( isset( $content_width ) ) ? $content_width : 720;
 	$view     = ( isset( $url_params['view'] ) ) ? $url_params['view'] : 'cinema';
 
-	$rtn  = '<div style="position: relative; max-width: ' . $maxwidth . 'px; margin-left: auto; margin-right: auto; overflow: hidden;">';
+	$rtn  = '<div style="position: relative; max-width: ' . $maxwidth . 'px; margin-left: auto; margin-right: auto; overflow: hidden; margin-bottom: 1em;">';
 	$rtn .= '<div style="padding-top: ' . jetpack_vr_viewer_iframe_padding( $view ) . ';"></div>';
 	$rtn .= '<iframe style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; height: 100%" allowfullscreen="true" frameborder="0" width="100%" height="300" src="' . esc_url( $iframe ) . '">';
 	$rtn .= '</iframe>';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* VR Shortcode: fix all PHPCS warnings and bring file in sync with WordPress.com

#### Testing instructions:

* Add the following shortcode to a new post:
`[vr url="https://en-blog.files.wordpress.com/2016/12/regents_park.jpg" view="360"]`
* Does it work well?

#### Proposed changelog entry for your changes:

* None
