### PR TITLE
Debugger: Utilize site health's ability to accept a callable

### DIFF
--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -5,48 +5,20 @@
  * @package Jetpack.
  */
 
+global $wp_version;
+
 /* Jetpack Connection Testing Framework */
 require_once 'class-jetpack-cxn-test-base.php';
 /* Jetpack Connection Tests */
 require_once 'class-jetpack-cxn-tests.php';
-
 /* Jetpack Debug Data */
 require_once 'class-jetpack-debug-data.php';
 /* The "In-Plugin Debugger" admin page. */
 require_once 'class-jetpack-debugger.php';
 
-add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );
-add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );
-add_action( 'wp_ajax_health-check-jetpack-local_testing_suite', 'jetpack_debugger_ajax_local_testing_suite' );
-
-/**
- * Test runner for Core's Site Health module.
- *
- * @since 7.3.0
- */
-function jetpack_debugger_ajax_local_testing_suite() {
-	check_ajax_referer( 'health-check-site-status' );
-	if ( ! current_user_can( 'jetpack_manage_modules' ) ) {
-		wp_send_json_error();
-	}
-	$tests = new Jetpack_Cxn_Tests();
-	wp_send_json_success( $tests->output_results_for_core_site_health() );
-}
-
-/**
- * Adds the Jetpack Local Testing Suite to the Core Site Health system.
- *
- * @since 7.3.0
- *
- * @param array $tests Array of tests from Core's Site Health.
- *
- * @return array $tests Array of tests for Core's Site Health.
- */
-function jetpack_debugger_site_status_tests( $tests ) {
-	$tests['async']['jetpack_test_suite'] = array(
-		'label' => __( 'Jetpack Tests', 'jetpack' ),
-		'test'  => 'jetpack_local_testing_suite',
-	);
-
-	return $tests;
+if ( version_compare( $wp_version, '5.2-alpha', 'ge' ) ) {
+	require_once 'debug-functions-for-php53.php';
+	add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );
+	add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );
+	add_action( 'wp_ajax_health-check-jetpack-local_testing_suite', 'jetpack_debugger_ajax_local_testing_suite' );
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -176,7 +176,7 @@ class Jetpack_Cxn_Test_Base {
 
 		if ( 'all' !== $type ) {
 			foreach ( $results as $test => $result ) {
-				if ( ! in_array( $type, $result['type'], true ) ) {
+				if ( $type !== $result['type'] ) {
 					unset( $results[ $test ] );
 				}
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -74,6 +74,7 @@ class Jetpack_Cxn_Test_Base {
 		}
 
 		$this->tests[ $name ] = array(
+			'name'  => $name,
 			'test'  => $callable,
 			'group' => $groups,
 			'type'  => $type,

--- a/_inc/lib/debugger/debug-functions-for-php53.php
+++ b/_inc/lib/debugger/debug-functions-for-php53.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * WP Site Health functionality temporarily stored in this file until all of Jetpack is PHP 5.3+
+ *
+ * @package Jetpack.
+ */
+
+/**
+ * Test runner for Core's Site Health module.
+ *
+ * @since 7.3.0
+ */
+function jetpack_debugger_ajax_local_testing_suite() {
+	check_ajax_referer( 'health-check-site-status' );
+	if ( ! current_user_can( 'jetpack_manage_modules' ) ) {
+		wp_send_json_error();
+	}
+	$tests = new Jetpack_Cxn_Tests();
+	wp_send_json_success( $tests->output_results_for_core_async_site_health() );
+}
+/**
+ * Adds the Jetpack Local Testing Suite to the Core Site Health system.
+ *
+ * @since 7.3.0
+ *
+ * @param array $core_tests Array of tests from Core's Site Health.
+ *
+ * @return array $core_tests Array of tests for Core's Site Health.
+ */
+function jetpack_debugger_site_status_tests( $core_tests ) {
+	$cxn_tests = new Jetpack_Cxn_Tests();
+	$tests     = $cxn_tests->list_tests( 'direct' );
+	foreach ( $tests as $test ) {
+		$core_tests['direct'][ $test['name'] ] = array(
+			'label' => __( 'Jetpack: ', 'jetpack' ) . $test['name'],
+			'test'  => function() use ( $test, $cxn_tests ) { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.Found
+				$results = $cxn_tests->run_test( $test['name'] );
+				// Test names are, by default, `test__some_string_of_text`. Let's convert to "Some String Of Text" for humans.
+				$label = ucwords(
+					str_replace(
+						'_',
+						' ',
+						str_replace( 'test__', '', $test['name'] )
+					)
+				) . ': ' . __( 'Successful test!', 'jetpack' );
+				$return = array(
+					'label'       => $label,
+					'status'      => 'good',
+					'badge'       => array(
+						'label' => __( 'Jetpack', 'jetpack' ),
+						'color' => 'green',
+					),
+					'description' => sprintf(
+						'<p>%s</p>',
+						__( 'This test successfully passed!', 'jetpack' )
+					),
+					'actions'     => '',
+					'test'        => 'jetpack_' . $test['name'],
+				);
+				if ( is_wp_error( $results ) ) {
+					return;
+				}
+				if ( false === $results['pass'] ) {
+					$return['label'] = $results['message'];
+					$return['status']      = $results['severity'];
+					$return['description'] = sprintf(
+						'<p>%s</p>',
+						$results['resolution']
+					);
+					if ( ! empty( $results['action'] ) ) {
+						$return['actions'] = sprintf(
+							'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+							esc_url( $results['action'] ),
+							__( 'Resolve', 'jetpack' ),
+							/* translators: accessibility text */
+							__( '(opens in a new tab)', 'jetpack' )
+						);
+					}
+				}
+
+				return $return;
+			},
+		);
+	}
+	$core_tests['async']['jetpack_test_suite'] = array(
+		'label' => __( 'Jetpack Tests', 'jetpack' ),
+		'test'  => 'jetpack_local_testing_suite',
+	);
+
+	return $core_tests;
+}
+

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -17,6 +17,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 			. 'grep -v "./vendor/" | '
 			. 'grep -v "jetpack-cli.php" | '
 			. 'grep -v "./_inc/class.jetpack-provision.php" | '
+			. 'grep -v "./_inc/lib/debugger/debug-functions-for-php53.php" | '
 			. 'grep -v -e \'^$\'; '
 			. 'done';
 


### PR DESCRIPTION
This PR merges into #11976.

Core's Site Health does not accept anything but a string of a function name, which is pretty limiting to us. #11976 has one test for all of Jetpack based on this premise since I do not want to have to manually make new functions for each test.

If https://core.trac.wordpress.org/ticket/46836 lands, we can use the dynamic method described in this PR to pull a list of tests and dynamically use an anonymous function to return the results for each test.

#### Changes proposed in this Pull Request
* Dynamically run individual tests for `direct` Jetpack tests.

#### Testing instructions:
* WP 5.2-beta plus apply latest patch from https://core.trac.wordpress.org/ticket/46836
* Visit Tools->Site Health
* See individual tests for each Jetpack direct test and one test added late via the async method.

#### Proposed changelog entry for your changes:
* Covered under #11976
