### PR TITLE
Jetpack Settings: Make Site Stats card not collapsible 

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -4,12 +4,10 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
-import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Card from 'components/card';
 import includes from 'lodash/includes';
 import filter from 'lodash/filter';
-import classNames from 'classnames';
 import { imagePath } from 'constants/urls';
 import analytics from 'lib/analytics';
 
@@ -173,91 +171,82 @@ class SiteStatsComponent extends React.Component {
 				header={ __( 'Site stats', { context: 'Settings header' } ) }
 				hideButton
 			>
-				<FoldableCard
-					onOpen={ this.trackOpenCard }
-					header={ __( 'Collecting valuable traffic stats and insights' ) }
-					clickableHeader={ true }
-					className={ classNames( 'jp-foldable-settings-standalone', {
-						'jp-foldable-settings-disable': unavailableInDevMode,
-					} ) }
+				<SettingsGroup
+					disableInDevMode
+					module={ stats }
+					support={ {
+						text: __(
+							'Displays information on your site activity, including visitors and popular posts or pages.'
+						),
+						link: 'https://jetpack.com/support/wordpress-com-stats/',
+					} }
 				>
-					<SettingsGroup
-						disableInDevMode
-						module={ stats }
-						support={ {
-							text: __(
-								'Displays information on your site activity, including visitors and popular posts or pages.'
-							),
-							link: 'https://jetpack.com/support/wordpress-com-stats/',
-						} }
-					>
-						<FormFieldset>
+					<FormFieldset>
+						<CompactFormToggle
+							checked={ !! this.props.getOptionValue( 'admin_bar' ) }
+							disabled={ ! isStatsActive || unavailableInDevMode }
+							toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
+							onChange={ this.handleStatsOptionToggle( 'admin_bar' ) }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Put a chart showing 48 hours of views in the admin bar' ) }
+							</span>
+						</CompactFormToggle>
+						<CompactFormToggle
+							checked={ !! this.props.getOptionValue( 'hide_smile' ) }
+							disabled={ ! isStatsActive || unavailableInDevMode }
+							toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
+							onChange={ this.handleStatsOptionToggle( 'hide_smile' ) }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Hide the stats smiley face image' ) }
+							</span>
+							<span className="jp-form-setting-explanation">
+								{ __( 'The image helps collect stats, but should work when hidden.' ) }
+							</span>
+						</CompactFormToggle>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLegend>{ __( 'Count logged in page views from' ) }</FormLegend>
+						{ Object.keys( siteRoles ).map( key => (
 							<CompactFormToggle
-								checked={ !! this.props.getOptionValue( 'admin_bar' ) }
-								disabled={ ! isStatsActive || unavailableInDevMode }
-								toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
-								onChange={ this.handleStatsOptionToggle( 'admin_bar' ) }
+								checked={ this.state[ `count_roles_${ key }` ] }
+								disabled={
+									! isStatsActive ||
+									unavailableInDevMode ||
+									this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] )
+								}
+								onChange={ this.handleRoleToggleChange( key, 'count_roles' ) }
+								key={ `count_roles-${ key }` }
 							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Put a chart showing 48 hours of views in the admin bar' ) }
-								</span>
+								<span className="jp-form-toggle-explanation">{ siteRoles[ key ].name }</span>
 							</CompactFormToggle>
-							<CompactFormToggle
-								checked={ !! this.props.getOptionValue( 'hide_smile' ) }
-								disabled={ ! isStatsActive || unavailableInDevMode }
-								toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
-								onChange={ this.handleStatsOptionToggle( 'hide_smile' ) }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Hide the stats smiley face image' ) }
-								</span>
-								<span className="jp-form-setting-explanation">
-									{ __( 'The image helps collect stats, but should work when hidden.' ) }
-								</span>
-							</CompactFormToggle>
-						</FormFieldset>
-						<FormFieldset>
-							<FormLegend>{ __( 'Count logged in page views from' ) }</FormLegend>
-							{ Object.keys( siteRoles ).map( key => (
-								<CompactFormToggle
-									checked={ this.state[ `count_roles_${ key }` ] }
-									disabled={
-										! isStatsActive ||
-										unavailableInDevMode ||
-										this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] )
-									}
-									onChange={ this.handleRoleToggleChange( key, 'count_roles' ) }
-									key={ `count_roles-${ key }` }
-								>
-									<span className="jp-form-toggle-explanation">{ siteRoles[ key ].name }</span>
-								</CompactFormToggle>
-							) ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormLegend>{ __( 'Allow stats reports to be viewed by' ) }</FormLegend>
-							<CompactFormToggle checked={ true } disabled={ true }>
-								<span className="jp-form-toggle-explanation">{ siteRoles.administrator.name }</span>
-							</CompactFormToggle>
-							{ Object.keys( siteRoles ).map(
-								key =>
-									'administrator' !== key && (
-										<CompactFormToggle
-											checked={ this.state[ `roles_${ key }` ] }
-											disabled={
-												! isStatsActive ||
-												unavailableInDevMode ||
-												this.props.isSavingAnyOption( [ 'stats', 'roles' ] )
-											}
-											onChange={ this.handleRoleToggleChange( key, 'roles' ) }
-											key={ `roles-${ key }` }
-										>
-											<span className="jp-form-toggle-explanation">{ siteRoles[ key ].name }</span>
-										</CompactFormToggle>
-									)
-							) }
-						</FormFieldset>
-					</SettingsGroup>
-				</FoldableCard>
+						) ) }
+					</FormFieldset>
+					<FormFieldset>
+						<FormLegend>{ __( 'Allow stats reports to be viewed by' ) }</FormLegend>
+						<CompactFormToggle checked={ true } disabled={ true }>
+							<span className="jp-form-toggle-explanation">{ siteRoles.administrator.name }</span>
+						</CompactFormToggle>
+						{ Object.keys( siteRoles ).map(
+							key =>
+								'administrator' !== key && (
+									<CompactFormToggle
+										checked={ this.state[ `roles_${ key }` ] }
+										disabled={
+											! isStatsActive ||
+											unavailableInDevMode ||
+											this.props.isSavingAnyOption( [ 'stats', 'roles' ] )
+										}
+										onChange={ this.handleRoleToggleChange( key, 'roles' ) }
+										key={ `roles-${ key }` }
+									>
+										<span className="jp-form-toggle-explanation">{ siteRoles[ key ].name }</span>
+									</CompactFormToggle>
+								)
+						) }
+					</FormFieldset>
+				</SettingsGroup>
 			</SettingsCard>
 		);
 	}


### PR DESCRIPTION
While working on https://github.com/Automattic/jetpack/pull/10669 we need to update a `Configure` link on Stats page to link to Jetpack (react) settings card. Unfortunately, Stats card appears as collapsed by default, so it might be confusing for folks looking for a stats configuration. This PR makes Stats card static(i.e. not collapsible) so it's settings could be easily discoverable  

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* make site stats settings card not collapsible

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/traffic`
* Make sure the stats card toggles are visible
* Check dev mode. make sure all the toggles are disabled


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Make stats settings card not collapsible


Before: 
<img width="1109" alt="12" src="https://user-images.githubusercontent.com/5654161/55948408-c42e0480-5c50-11e9-91bb-1b91cc59d1ca.png">

After:
<img width="1084" alt="22" src="https://user-images.githubusercontent.com/5654161/55948484-ef185880-5c50-11e9-95cd-24f5f541be20.png">


