### PR TITLE
Settings: Add card and toggle for Extra Sidebar Widgets in the Writing tab

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -24,6 +24,7 @@ import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
 import ThemeEnhancements from './theme-enhancements';
 import PostByEmail from './post-by-email';
+import Widgets from './widgets';
 import { Masterbar } from './masterbar';
 import WritingMedia from './writing-media';
 
@@ -50,6 +51,7 @@ export class Writing extends React.Component {
 			'post-by-email',
 			'infinite-scroll',
 			'minileven',
+			'widgets',
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
@@ -97,6 +99,7 @@ export class Writing extends React.Component {
 						userCanManageModules={ this.props.userCanManageModules }
 					/>
 				) }
+				{ this.props.isModuleFound( 'widgets' ) && <Widgets { ...commonProps } /> }
 				{ ! showComposing && ! showPostByEmail && (
 					<Card>
 						{ __(

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -91,6 +91,7 @@ export class Writing extends React.Component {
 					<CustomContentTypes { ...commonProps } />
 				) }
 				<ThemeEnhancements { ...commonProps } />
+				{ this.props.isModuleFound( 'widgets' ) && <Widgets { ...commonProps } /> }
 				{ this.props.isModuleFound( 'post-by-email' ) && showPostByEmail && (
 					<PostByEmail
 						{ ...commonProps }
@@ -99,7 +100,6 @@ export class Writing extends React.Component {
 						userCanManageModules={ this.props.userCanManageModules }
 					/>
 				) }
-				{ this.props.isModuleFound( 'widgets' ) && <Widgets { ...commonProps } /> }
 				{ ! showComposing && ! showPostByEmail && (
 					<Card>
 						{ __(

--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+/**
+ * Internal dependencies
+ */
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { getModule } from 'state/modules';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+
+class Widgets extends Component {
+	render() {
+		const isActive = this.props.getOptionValue( 'widgets' ),
+			isLinked = this.props.isLinked;
+
+		return (
+			<SettingsCard
+				{ ...this.props }
+				header={ __( 'Widgets', { context: 'Settings header' } ) }
+				module="widgets"
+				hideButton
+			>
+				<SettingsGroup
+					module={ { module: 'widgets' } }
+					support={ {
+						text: this.props.widgetsModule.description,
+						link: 'https://jetpack.com/support/extra-sidebar-widgets/',
+					} }
+				>
+					<ModuleToggle
+						slug="widgets"
+						disabled={ ! isLinked }
+						activated={ isActive }
+						toggling={ this.props.isSavingAnyOption( 'widgets' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						{ __(
+							'Make extra widgets available for use on your site including images and Twitter streams'
+						) }
+					</ModuleToggle>
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		widgetsModule: getModule( state, 'widgets' ),
+	};
+} )( withModuleSettingsFormHelpers( Widgets ) );

--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -40,7 +40,7 @@ class Widgets extends Component {
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						{ __(
-							'Make extra widgets available for use on your site including images and Twitter streams'
+							'Make extra widgets available for use on your site including subscription forms and Twitter streams'
 						) }
 					</ModuleToggle>
 				</SettingsGroup>

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -229,7 +229,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'widgets' => array(
 				'name' => _x( 'Extra Sidebar Widgets', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Add images, Twitter streams, and more to your sidebar.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Provides additional widgets for use on your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'wordads' => array(

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Extra Sidebar Widgets
- * Module Description: Add images, Twitter streams, and more to your sidebar.
+ * Module Description: Provides additional widgets for use on your site.
  * Sort Order: 4
  * First Introduced: 1.2
  * Requires Connection: No


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11933

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds card and toggle for Extra Sidebar Widgets in the Writing tab above the Post By Email card reading:
    `Make extra widgets available for use on your site including subscription forms and Twitter streams.`
* Leverages the module description for the toggle's info popover and updates it to:
    `Provides additional widgets for use on your site.`

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/56199554-83990700-6013-11e9-8e8a-064e7e4f1e72.png)




#### Testing instructions:

* Checkout this branch and run yarn build or [launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=add/extra-sidebar-widgets-card&wp-debug-log).
* Visit the settings page and the Writing tab.
* Confirm you see a new card for Widgets.

#### Proposed changelog entry for your changes:

* Admin Page: Added toggle for activating the Extra Sidebar  Widgets module.
