### PR TITLE
Sync: Add network_disable sync setting that only applies to networks

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -87,12 +87,24 @@ class Jetpack_Sync_Actions {
 
 	static function sync_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+		if ( ! Jetpack_Sync_Settings::is_sync_enabled() ) {
+			return false;
+		}
+		if ( Jetpack::is_development_mode() ) {
+			return false;
+		}
+		if ( Jetpack::is_staging_site() ) {
+			return false;
+		}
+		if ( ! Jetpack::is_active() ) {
+			if (
+				! defined( 'PHPUNIT_JETPACK_TESTSUITE' ) &&
+				! doing_action( 'jetpack_user_authorized' ) ) {
+				return false;
+			}
+		}
 
-		return (
-			Jetpack_Sync_Settings::is_sync_enabled()
-			&& ( doing_action( 'jetpack_user_authorized' ) || Jetpack::is_active() )
-			&& ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
-			|| defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+		return true;
 	}
 
 	static function sync_via_cron_allowed() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -86,6 +86,9 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function sync_allowed() {
+		if ( defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
+			return true;
+		}
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		if ( ! Jetpack_Sync_Settings::is_sync_enabled() ) {
 			return false;
@@ -97,9 +100,7 @@ class Jetpack_Sync_Actions {
 			return false;
 		}
 		if ( ! Jetpack::is_active() ) {
-			if (
-				! defined( 'PHPUNIT_JETPACK_TESTSUITE' ) &&
-				! doing_action( 'jetpack_user_authorized' ) ) {
+			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;
 			}
 		}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -87,11 +87,12 @@ class Jetpack_Sync_Actions {
 
 	static function sync_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
-		return ( ( ! Jetpack_Sync_Settings::get_setting( 'disable' )
-		         || ! Jetpack_Sync_Settings::get_setting( 'network_disable' ) )
-				 && ( doing_action( 'jetpack_user_authorized' ) || Jetpack::is_active() )
-				 && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
-			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+
+		return (
+			Jetpack_Sync_Settings::is_sync_enabled()
+			&& ( doing_action( 'jetpack_user_authorized' ) || Jetpack::is_active() )
+			&& ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
+			|| defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
 	static function sync_via_cron_allowed() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -87,7 +87,8 @@ class Jetpack_Sync_Actions {
 
 	static function sync_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
-		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' )
+		return ( ( ! Jetpack_Sync_Settings::get_setting( 'disable' )
+		         || ! Jetpack_Sync_Settings::get_setting( 'network_disable' ) )
 				 && ( doing_action( 'jetpack_user_authorized' ) || Jetpack::is_active() )
 				 && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -557,6 +557,11 @@ class Jetpack_Sync_Defaults {
 		return floor( $max_exec_time / 3 );
 	}
 
+	static function get_default_setting( $setting ) {
+		$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes
+		return Jetpack_Sync_Defaults::$$default_name;
+	}
+
 	static $default_network_options_whitelist = array(
 		'site_name',
 		'jetpack_protect_key',
@@ -578,6 +583,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist      = array();
 	static $default_comment_meta_whitelist   = array();
 	static $default_disable                  = 0; // completely disable sending data to wpcom
+	static $default_network_disable          = 0; // completely disable sending data to wpcom network wide
 	static $default_sync_via_cron            = 1; // use cron to sync
 	static $default_render_filtered_content  = 0; // render post_filtered_content
 	static $default_max_enqueue_full_sync    = 100; // max number of items to enqueue at a time when running full sync
@@ -586,4 +592,5 @@ class Jetpack_Sync_Defaults {
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 	static $default_sync_queue_lock_timeout  = 120; // 2 minutes
 	static $default_cron_sync_time_limit     = 30; // 30 seconds
+
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -86,7 +86,7 @@ class Jetpack_Sync_Listener {
 	// prevent adding items to the queue if it hasn't sent an item for 15 mins
 	// AND the queue is over 1000 items long (by default)
 	function can_add_to_queue( $queue ) {
-		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
+		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) || Jetpack_Sync_Settings::get_setting( 'network_disable' ) ) {
 			return false;
 		}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -86,7 +86,7 @@ class Jetpack_Sync_Listener {
 	// prevent adding items to the queue if it hasn't sent an item for 15 mins
 	// AND the queue is over 1000 items long (by default)
 	function can_add_to_queue( $queue ) {
-		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) || Jetpack_Sync_Settings::get_setting( 'network_disable' ) ) {
+		if ( ! Jetpack_Sync_Settings::is_sync_enabled() ) {
 			return false;
 		}
 

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -122,7 +122,7 @@ class Jetpack_Sync_Settings {
 			unset( self::$settings_cache[ $setting ] );
 
 			// if we set the disabled option to true, clear the queues
-			if ( ( 'disable' === $setting ) && ! ! $value ) {
+			if ( ( 'disable' === $setting || 'network_disable' ) && ! ! $value ) {
 				require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 				$listener = Jetpack_Sync_Listener::get_instance();
 				$listener->get_sync_queue()->reset();
@@ -132,7 +132,7 @@ class Jetpack_Sync_Settings {
 	}
 
 	static function is_network_setting( $setting ) {
-		return substr( $setting, 0, strlen('network_') ) === 'network_';
+		return substr( $setting, 0, strlen( 'network_' ) ) === 'network_';
 	}
 
 	// returns escapted SQL that can be injected into a WHERE clause

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -177,7 +177,7 @@ class Jetpack_Sync_Settings {
 	}
 
 	static function is_sync_enabled() {
-		return ! (  self::get_setting( 'disable' ) || self::get_setting( 'network_disable' ) );
+		return ! ( self::get_setting( 'disable' ) || self::get_setting( 'network_disable' ) );
 	}
 
 	static function set_doing_cron( $is_doing_cron ) {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -69,9 +69,8 @@ class Jetpack_Sync_Settings {
 
 		if ( false === $value ) { // no default value is set.
 			// We set one so that it gets autoloaded
-			$value        = Jetpack_Sync_Defaults::get_default_setting( $setting );
-			if ( substr( $setting, 0, strlen('network_') ) === 'network_' ) {
-
+			$value = Jetpack_Sync_Defaults::get_default_setting( $setting );
+			if ( self::is_network_setting( $setting ) ) {
 				update_site_option( self::SETTINGS_OPTION_PREFIX . $setting, $value );
 			} else {
 				update_option( self::SETTINGS_OPTION_PREFIX . $setting, $value, true );
@@ -132,7 +131,7 @@ class Jetpack_Sync_Settings {
 	}
 
 	static function is_network_setting( $setting ) {
-		return substr( $setting, 0, strlen( 'network_' ) ) === 'network_';
+		return strpos( $setting, 'network_' ) === 0;
 	}
 
 	// returns escapted SQL that can be injected into a WHERE clause

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -68,11 +68,11 @@ class Jetpack_Sync_Settings {
 		}
 
 		if ( false === $value ) { // no default value is set.
-			// We set one so that it gets autoloaded
 			$value = Jetpack_Sync_Defaults::get_default_setting( $setting );
 			if ( self::is_network_setting( $setting ) ) {
 				update_site_option( self::SETTINGS_OPTION_PREFIX . $setting, $value );
 			} else {
+				// We set one so that it gets autoloaded
 				update_option( self::SETTINGS_OPTION_PREFIX . $setting, $value, true );
 			}
 		}

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -121,7 +121,7 @@ class Jetpack_Sync_Settings {
 			unset( self::$settings_cache[ $setting ] );
 
 			// if we set the disabled option to true, clear the queues
-			if ( ( 'disable' === $setting || 'network_disable' ) && ! ! $value ) {
+			if ( ( 'disable' === $setting || 'network_disable' === $setting ) && ! ! $value ) {
 				require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 				$listener = Jetpack_Sync_Listener::get_instance();
 				$listener->get_sync_queue()->reset();

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -176,6 +176,10 @@ class Jetpack_Sync_Settings {
 		return defined( 'WP_IMPORTING' ) && WP_IMPORTING;
 	}
 
+	static function is_sync_enabled() {
+		return ! (  self::get_setting( 'disable' ) || self::get_setting( 'network_disable' ) );
+	}
+
 	static function set_doing_cron( $is_doing_cron ) {
 		// set to NULL to revert to WP_IMPORTING, the standard behavior
 		self::$is_doing_cron = $is_doing_cron;

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -36,6 +36,8 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 
 		Jetpack_Sync_Settings::update_settings( array( 'disable' => 1 ) );
 
+		$this->assertFalse( Jetpack_Sync_Settings::is_sync_enabled() );
+
 		// generating posts should no longer affect queue size
 		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
 		$post_id = $this->factory->post->create();
@@ -46,6 +48,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
 
 		Jetpack_Sync_Settings::update_settings( array( 'disable' => 0 ) );
+		$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
 	}
 
 	function test_settings_disable_network_enqueue_and_clears_queue() {
@@ -77,11 +80,14 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		if ( is_multisite() ) {
 			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
 			$this->assertEquals( 1, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
+			$this->assertFalse( Jetpack_Sync_Settings::is_sync_enabled() );
 			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 0 ) ); // reset things
+			$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
 		} else {
 			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
 			// Notice that the value is unchanged
 			$this->assertEquals( 0, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
+			$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -47,4 +47,42 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 
 		Jetpack_Sync_Settings::update_settings( array( 'disable' => 0 ) );
 	}
+
+	function test_settings_disable_network_enqueue_and_clears_queue() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with single site mode' );
+		}
+
+		$event = $this->server_event_storage->reset();
+
+		// create a post - this will end up in the queue before data is sent
+		$post_id = $this->factory->post->create();
+		$this->assertTrue( $this->listener->get_sync_queue()->size() > 0 );
+
+		Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
+
+		// generating posts should no longer affect queue size
+		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+		$post_id = $this->factory->post->create();
+		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+
+		// syncing sends no data
+		$this->sender->do_sync();
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 0 ) );
+	}
+
+	function test_setting_network_option_on_single_site_does_not_work() {
+		if ( is_multisite() ) {
+			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
+			$this->assertEquals( 1, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
+			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 0 ) ); // reset things
+		} else {
+			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
+			// Notice that the value is unchanged
+			$this->assertEquals( 0, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
+		}
+	}
+
 }

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 
 		// create a post - this will end up in the queue before data is sent
 		$post_id = $this->factory->post->create();
-		$this->assertTrue( $this->listener->get_sync_queue()->size() > 0 );
+		$this->assertTrue( $this->listener->get_sync_queue()->has_any_items() );
 
 		Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
 


### PR DESCRIPTION
This will allow us to disable the jetpack sync across the whole network.

Currently there is no good way to disable Jetpack Sync across the whole network. 
This will allow us to do just that. Previously we would have to target a specific site.
Or add a filter. 

#### Changes proposed in this Pull Request:
* Add a new network_disable setting in sync settings
* Allow the setting to be changed only via the main site. 
* Only set the settings for the main site.


#### Testing instructions:
* Do the tests pass?
* Go to '..'
* On a multisite site run the wp cli command 
`wp site option jetpack_sync_settings_network_disable  '1'`
Notice that no sites on the network send any more data to .com servers.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Add a way to disable sync on a network site.
