### PR TITLE
Add yarn script to run test for multisite

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -149,6 +149,11 @@ This will run unit tests for Jetpack. You can pass arguments to `phpunit` like s
 yarn docker:phpunit --filter=Protect
 ```
 
+This command runs the tests as a multi site install
+```sh
+yarn docker:phpunit-mu --filter=Protext
+```
+
 ### Starting over
 
 To remove all docker images, all mysql data, and all docker-related files from your local machine run:

--- a/docker/README.md
+++ b/docker/README.md
@@ -151,7 +151,7 @@ yarn docker:phpunit --filter=Protect
 
 This command runs the tests as a multi site install
 ```sh
-yarn docker:phpunit-mu --filter=Protext
+yarn docker:phpunit:multisite --filter=Protect
 ```
 
 ### Starting over

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"docker:multisite-convert": "yarn docker:compose exec wordpress bash -c \"/var/scripts/multisite-convert.sh\"",
 		"docker:sh": "yarn docker:compose exec wordpress bash",
 		"docker:phpunit": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist",
+		"docker:phpunit-mu": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/tests/php.multisite.xml",
 		"docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
 		"docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"docker:multisite-convert": "yarn docker:compose exec wordpress bash -c \"/var/scripts/multisite-convert.sh\"",
 		"docker:sh": "yarn docker:compose exec wordpress bash",
 		"docker:phpunit": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist",
-		"docker:phpunit-mu": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/tests/php.multisite.xml",
+		"docker:phpunit:multisite": "yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/tests/php.multisite.xml",
 		"docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
 		"docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",


### PR DESCRIPTION
Adds `yarn docker:phpunit:multisite` command that lets us run the wordpress multisite test suite much easier on the docker development.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `yarn docker:phpunit-mu` command that lets us run the wordpress multisite test suite much easier on the docker development.
*

#### Testing instructions:
* Start up the docker dev enviroment. 
* run `yarn docker:phpunit:multisite --filter=test_full_sync_sends_only_current_blog_users_in_multisite` 
* are the multi site test skipped or are they runnning as expected?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* New yarn command to run the multi site phpunit suite `yarn docker:phpunit-mu` 
