### PR TITLE
Extensions: Include chunkhash in chunk filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"whatwg-fetch": "1.1.1"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "1.0.0-beta.2",
+		"@automattic/calypso-build": "1.0.0-beta.4",
 		"@babel/core": "7.4.0",
 		"@babel/plugin-proposal-class-properties": "7.4.0",
 		"@babel/plugin-proposal-export-default-from": "7.2.0",

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -64,7 +64,7 @@ const webpackConfig = getBaseWebpackConfig(
 			'editor-beta': editorBetaScript,
 			...viewBlocksScripts,
 		},
-		'output-chunk-filename': '[name].[contenthash].js',
+		'output-chunk-filename': '[name].[chunkhash].js',
 		'output-path': path.join( __dirname, '_inc', 'blocks' ),
 	}
 );

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -64,7 +64,7 @@ const webpackConfig = getBaseWebpackConfig(
 			'editor-beta': editorBetaScript,
 			...viewBlocksScripts,
 		},
-		'output-chunk-filename': '[name].[chunkhash].js',
+		'output-chunk-filename': '[name].[contenthash].js',
 		'output-path': path.join( __dirname, '_inc', 'blocks' ),
 	}
 );

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -64,6 +64,7 @@ const webpackConfig = getBaseWebpackConfig(
 			'editor-beta': editorBetaScript,
 			...viewBlocksScripts,
 		},
+		'output-chunk-filename': '[name].[chunkhash].js',
 		'output-path': path.join( __dirname, '_inc', 'blocks' ),
 	}
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@automattic/calypso-build@1.0.0-beta.2":
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@automattic/calypso-build/-/calypso-build-1.0.0-beta.2.tgz#d1dd9619392aa57aeef67cda3f703303f38388d0"
-  integrity sha512-unRf3yPwV1/6i/yd8UTxWP7zxDoMnG/vvT/6dvDr/CCna3Q9JRtKM5YhMqjvwDKr80XYBFysoA3heIk4truHiA==
+"@automattic/calypso-build@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@automattic/calypso-build/-/calypso-build-1.0.0-beta.4.tgz#b9fa33e1a9b16943d43e7eabe13f3718456fea3e"
+  integrity sha512-YepaQ6lAqOv0hwmUSEuoCgkP6v2O0CT5NbdAvtytsMP7bvVpeBI6zLrd+riJ8wxdp9I3ID1KoOzHUhEzdEf4ow==
   dependencies:
     "@automattic/calypso-color-schemes" "^1.0.0"
     "@automattic/wordpress-external-dependencies-plugin" "^1.0.0"


### PR DESCRIPTION
Entrypoints (scripts added with `wp_enqueue_script`) are cache busted by version.
Chunks, however, have stable names. Chunks are scripts that are not directly enqueued, but required at runtime. They do not receive the same cache busting request. This can lead to stale, invalid chunks —through caching—being used in a newer bundle, which causes errors.

By adding `[chunkhash]`, we can ensure that the correct chunk is served for a given entrypoint.

#### Changes proposed in this Pull Request:

* Add `output-chunk-filename` with `[chunkhash]` webpack option.

#### Testing instructions:
* `yarn && yarn clean-extensions && yarn build-extensions`
* See that most filenames continue to be simple, readable names.
* Chunks names, however, have a unique hash, like `vendors~swiper.e358270f2a9e45d1e22f.js`

```
                         slideshow/view.css   6.31 KiB         slideshow/view  [emitted]  slideshow/view
                   slideshow/view.deps.json   27 bytes         slideshow/view  [emitted]  slideshow/view
                          slideshow/view.js   66.3 KiB         slideshow/view  [emitted]  slideshow/view
                     slideshow/view.rtl.css   6.31 KiB         slideshow/view  [emitted]  slideshow/view
                     tiled-gallery/view.css   9.73 KiB     tiled-gallery/view  [emitted]  tiled-gallery/view
    vendors~swiper.e358270f2a9e45d1e22f.css   21.8 KiB         vendors~swiper  [emitted]  vendors~swiper
     vendors~swiper.e358270f2a9e45d1e22f.js    283 KiB         vendors~swiper  [emitted]  vendors~swiper
vendors~swiper.e358270f2a9e45d1e22f.rtl.css   21.8 KiB         vendors~swiper  [emitted]  vendors~swiper
```

#### Proposed changelog entry for your changes:

* None
