### PR TITLE
Contact Form: Do not display administrator's contact info in form

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3371,6 +3371,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_field( $type, $id, $label, $value, $class, $placeholder, $required ) {
+
 		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 		$field_class       = "class='" . trim( esc_attr( $type ) . ' ' . esc_attr( $class ) ) . "' ";
 		$wrap_classes = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds
@@ -3389,6 +3390,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ) );
 
 		$field = "\n<div {$shell_field_class} >\n"; // new in Jetpack 6.8.0
+		// If they are logged in, and this is their site, don't pre-populate fields
+		if ( current_user_can( 'manage_options' ) ) {
+			$value = '';
+		}
 		switch ( $type ) {
 			case 'email':
 				$field .= $this->render_email_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );


### PR DESCRIPTION
This functionality is behind a filter in Jetpack that is defaults off, but on WP.com, it is enabled. This brings over a WP.com change to not prefill contact form information for administrators on their own sites while still prefilling for lesser (or no) roles.

Differential Revision: D26744-code

This commit syncs r190195-wpcom.

#### Changes proposed in this Pull Request:
* Do not prefill administrator values when contact form prefilling is enabled. 

#### Testing instructions:
* Within Jetpack, set the `jetpack_auto_fill_logged_in_user` filter to true.
* Setup a contact form.
* With and without patch, visit the contact form while logged in.
* With patch, it should not prefill your information. Without patch it does.

#### Proposed changelog entry for your changes:
* Contact Form: When optionally prefilling contact information in a contact form, do not prefill for administrators on their own sites.

cc: @sixhours 
