### PR TITLE
Related Posts: do not use nested rules in vanilla CSS file

### DIFF
--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -54,9 +54,9 @@
 .jp-related-posts-i2__post-img-link {
 	order: -1;
 	line-height: 1em;
-	img {
-		width: 100%;
-	}
+}
+.jp-related-posts-i2__post-img-link img {
+	width: 100%;
 }
 
 /* List view */
@@ -88,9 +88,9 @@
 	}
 	.jp-related-posts-i2__post-img-link {
 		margin-top: 1rem;
-		img {
-			width: 350px;
-		}
+	}
+	.jp-related-posts-i2__post-img-link img {
+		width: 350px;
 	}
 }
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

In #11324 we made some changes to the Related Posts layout, and introduced nested rules for CSS. Since that is not supported in vanilla CSS, let's switch to regular CSS here.

This is already done on WordPress.com, in r190248-wpcom

#### Testing instructions:

* Start from a site with related posts appearing, and some of them with images.
* Apply patch.
* Edit a post that has related posts with images.
* Add a related posts block to that post.
* Make sure the block and its images look good in all browsers.

#### Proposed changelog entry for your changes:

* Related Posts: do not use nested rules in vanilla CSS file
