### PR TITLE
Added branches and tag information to the build checkout.

### DIFF
--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -41,6 +41,7 @@ fi
 git clone \
     --branch $TARGET_BRANCH \
     --depth 1000 \
+    --no-single-branch \
     git://github.com/$TARGET_REPO.git \
     $TARGET_DIR
 


### PR DESCRIPTION
Before we had a build script do a shallow checkout with no branch information, that rendered the 'get-version.sh' tool useless. This change fixes that problem.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a `--no-single-branch` to the build script checkout command.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Check out the branch, run `./tools/build-jetpack.sh -b branch-7.2`.
* After the checkout the builder should build Jetpack and you should see the message with the proper version like this: `Now at version 7.2.1-9473-g942722237!`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry needed.
