### PR TITLE
Blocks: add translation context to block search keywords

### DIFF
--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { getBlockType, createBlock } from '@wordpress/blocks';
 import { Path, Circle } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -26,7 +26,11 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
-	keywords: [ __( 'email', 'jetpack' ), __( 'feedback', 'jetpack' ), __( 'contact', 'jetpack' ) ],
+	keywords: [
+		_x( 'email', 'block search term', 'jetpack' ),
+		_x( 'feedback', 'block search term', 'jetpack' ),
+		_x( 'contact', 'block search term', 'jetpack' ),
+	],
 	category: 'jetpack',
 	supports: {
 		reusable: false,

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/components';
 
 /**
@@ -27,7 +27,11 @@ export const settings = {
 	title,
 	icon,
 	category: 'jetpack',
-	keywords: [ __( 'animated', 'jetpack' ), __( 'giphy', 'jetpack' ), __( 'image', 'jetpack' ) ],
+	keywords: [
+		_x( 'animated', 'block search term', 'jetpack' ),
+		_x( 'giphy', 'block search term', 'jetpack' ),
+		_x( 'image', 'block search term', 'jetpack' ),
+	],
 	description: __( 'Search for and insert an animated image.', 'jetpack' ),
 	attributes: {
 		align: {

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 export const settings = {
 	name: 'map',
@@ -25,7 +25,11 @@ export const settings = {
 		</svg>
 	),
 	category: 'jetpack',
-	keywords: [ __( 'map', 'jetpack' ), __( 'location', 'jetpack' ) ],
+	keywords: [
+		_x( 'map', 'block search term', 'jetpack' ),
+		_x( 'location', 'block search term', 'jetpack' ),
+		_x( 'navigation', 'block search term', 'jetpack' ),
+	],
 	description: __( 'Add an interactive map showing one or more locations.', 'jetpack' ),
 	attributes: {
 		align: {

--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { ExternalLink, Path, Rect, SVG } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
@@ -49,7 +49,11 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'formatting', 'jetpack' ), __( 'syntax', 'jetpack' ), __( 'markup', 'jetpack' ) ],
+	keywords: [
+		_x( 'formatting', 'block search term', 'jetpack' ),
+		_x( 'syntax', 'block search term', 'jetpack' ),
+		_x( 'markup', 'block search term', 'jetpack' ),
+	],
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Path, SVG } from '@wordpress/components';
 
 /**
@@ -71,7 +71,11 @@ export const name = 'slideshow';
 export const settings = {
 	title: __( 'Slideshow', 'jetpack' ),
 	category: 'jetpack',
-	keywords: [ __( 'image', 'jetpack' ), __( 'gallery', 'jetpack' ), __( 'slider', 'jetpack' ) ],
+	keywords: [
+		_x( 'image', 'block search term', 'jetpack' ),
+		_x( 'gallery', 'block search term', 'jetpack' ),
+		_x( 'slider', 'block search term', 'jetpack' ),
+	],
 	description: __( 'Add an interactive slideshow.', 'jetpack' ),
 	attributes,
 	supports: {

--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { isEmpty } from 'lodash';
 import { Path } from '@wordpress/components';
 import { RawHTML } from '@wordpress/element';
@@ -30,7 +30,11 @@ export const settings = {
 	),
 	category: 'jetpack',
 
-	keywords: [ __( 'subscribe', 'jetpack' ), __( 'join', 'jetpack' ), __( 'follow', 'jetpack' ) ],
+	keywords: [
+		_x( 'subscribe', 'block search term', 'jetpack' ),
+		_x( 'join', 'block search term', 'jetpack' ),
+		_x( 'follow', 'block search term', 'jetpack' ),
+	],
 
 	attributes: {
 		subscribePlaceholder: { type: 'string', default: __( 'Email Address', 'jetpack' ) },


### PR DESCRIPTION
Add translation context to block search keywords.

Just a minor change to test new build-deploy workflow for wpcom.

#### Changes proposed in this Pull Request:

* Add translators context for block search keywords 
* Add map block 3rd keyword: _"navigation"_ (3 is the maximum)

#### Testing instructions:

Do blocks still show up with these keywords in the block picker?

#### Proposed changelog entry for your changes:
-