### PR TITLE
AMP: remove deprecated Google+ icon

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -265,9 +265,6 @@ class Jetpack_AMP_Support {
 			'twitter'       => array(),
 			'pinterest'     => array(),
 			'whatsapp'      => array(),
-			'google-plus-1' => array(
-				'type' => 'gplus',
-			),
 			'tumblr'        => array(),
 			'linkedin'      => array(),
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Google+ is no more. Remove button from AMP compat class.

#### Testing instructions:

* Not much since the button is now gone.

#### Proposed changelog entry for your changes:

* None