### PR TITLE
Update Rewind references to Backup & Scan

### DIFF
--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -24,7 +24,7 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 }
 
 /**
- * If Rewind is enabled, remove its entry in sidebar, deactivate VaultPress, and show a notification.
+ * If Backup & Scan is enabled, remove its entry in sidebar, deactivate VaultPress, and show a notification.
  *
  * @since 5.8
  */

--- a/_inc/client/components/dev-card/index.jsx
+++ b/_inc/client/components/dev-card/index.jsx
@@ -289,7 +289,7 @@ export class DevCard extends React.Component {
 				</ul>
 				<hr />
 				<ul>
-					<strong>Rewind</strong>
+					<strong>Backup & Scan</strong>
 					<li>
 						<label htmlFor="rewindUnavailable">
 							<input

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -226,7 +226,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				return <LoadingCard />;
 			}
 
-			// Rewind is working in this site.
+			// Backup & Scan is working in this site.
 			if ( includes( [ 'provisioning', 'awaiting_credentials', 'active' ], rewindState ) ) {
 				return <BackupsScanRewind { ...this.props } rewindState={ rewindState } />;
 			}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1074,7 +1074,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( ! is_wp_error( $rewind_data ) ) {
 			return rest_ensure_response( array(
 					'code' => 'success',
-					'message' => esc_html__( 'Rewind data correctly received.', 'jetpack' ),
+					'message' => esc_html__( 'Backup & Scan data correctly received.', 'jetpack' ),
 					'data' => wp_json_encode( $rewind_data ),
 				)
 			);
@@ -1090,7 +1090,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		return new WP_Error(
 			'error_get_rewind_data',
-			esc_html__( 'Could not retrieve Rewind data.', 'jetpack' ),
+			esc_html__( 'Could not retrieve Backup & Scan data.', 'jetpack' ),
 			array( 'status' => 500 )
 		);
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7153,8 +7153,8 @@ p {
 	}
 
 	/**
-	 * Checks for whether Jetpack Rewind is enabled.
-	 * Will return true if the state of Rewind is anything except "unavailable".
+	 * Checks for whether Jetpack Backup & Scan is enabled.
+	 * Will return true if the state of Backup & Scan is anything except "unavailable".
 	 * @return bool|int|mixed
 	 */
 	public static function is_rewind_enabled() {
@@ -7184,7 +7184,7 @@ p {
 	public static function jetpack_tos_agreed() {
 		return Jetpack_Options::get_option( 'tos_agreed' ) || Jetpack::is_active();
 	}
-	
+
 	/**
 	 * Handles activating default modules as well general cleanup for the new connection.
 	 *

--- a/docker/README.md
+++ b/docker/README.md
@@ -212,7 +212,7 @@ You can access WordPress and Jetpack files via SFTP server container.
 
 You can tunnel to this container using [Ngrok](https://ngrok.com) or [other similar service](https://alternativeto.net/software/ngrok/).
 
-Tunnelling makes testing [Jetpack Rewind](https://jetpack.com/support/backups/) possible. Read more from ["Using Ngrok with Jetpack"](#using-ngrok-with-jetpack) section below.
+Tunnelling makes testing [Jetpack Backup & Scan](https://jetpack.com/support/backups/) possible. Read more from ["Using Ngrok with Jetpack"](#using-ngrok-with-jetpack) section below.
 
 ## Must Use Plugins directory
 
@@ -311,9 +311,9 @@ ngrok start jetpack jetpack-sftp
 
 You can inspect traffic between your WordPress/Jetpack container and WordPress.com using [the inspector](https://ngrok.com/docs#inspect).
 
-### Configuring Jetpack Rewind with Ngrok tunnel
+### Configuring Jetpack Backup & Scan with Ngrok tunnel
 
-You should now be able to configure [Jetpack Rewind](https://jetpack.com/support/backups/) credentials point to your Docker container:
+You should now be able to configure [Jetpack Backup & Scan](https://jetpack.com/support/backups/) credentials point to your Docker container:
 
 - Credential Type: `SSH/SFTP`
 - Server Address: `0.tcp.ngrok.io`


### PR DESCRIPTION
We want to be clear that the external facing name of our backup and security scanning features will be “Jetpack Backup” and “Jetpack Scan“. We won’t be using the terminology “rewind” anywhere as a product name.

Read more at p1HpG7-6z0-jetpackp2

