### PR TITLE
 3rd party tools: update the way the files are required

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -1,23 +1,31 @@
 <?php
-
 /**
- * Placeholder to load 3rd party plugin tweaks until a legit system
- * is architected
+ * Compatibility files for third-party plugins.
+ * This is used to improve compatibility of specific Jetpack features with third-party plugins.
+ *
+ * @package Jetpack
  */
 
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/buddypress.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/vaultpress.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/beaverbuilder.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/debug-bar.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/class.jetpack-modules-overrides.php' );
+// Array of third-party compat files to always require.
+$compat_files = array(
+	'bbpress.php',
+	'beaverbuilder.php',
+	'bitly.php',
+	'buddypress.php',
+	'class.jetpack-amp-support.php',
+	'class.jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
+	'debug-bar.php',
+	'domain-mapping.php',
+	'polldaddy.php',
+	'qtranslate-x.php',
+	'vaultpress.php',
+	'wpml.php',
+	'woocommerce.php',
+	'woocommerce-services.php',
+);
 
-// We can't load this conditionally since polldaddy add the call in class constuctor.
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce-services.php' );
-require_once( JETPACK__PLUGIN_DIR . '3rd-party/class.jetpack-amp-support.php' );
+foreach ( $compat_files as $file ) {
+	if ( file_exists( JETPACK__PLUGIN_DIR . '/3rd-party/' . $file ) ) {
+		require_once JETPACK__PLUGIN_DIR . '/3rd-party/' . $file;
+	}
+}

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -1,5 +1,6 @@
 // If the file path starts with anything like in the array below, it should be linted.
 module.exports = [
+	'3rd-party/3rd-party.php',
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
 	'extensions/',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change:

- makes it easier to add new files to that list in the future.
- allows us to sync that file with WordPress.com. On WordPress.com, since some of the compat files do not exist, they just won't be required.
- orders the list alphabetically
- fixes all phpcs warnings

Syncing that file with WordPress.com will be useful from now on since we now have more and more AMP functions (provided by one of the third-party compat files on our list) across different synced files in the plugin.

Related: D26814-code

#### Testing instructions:

* Install the AMP plugin
* Add sharing buttons to your site.
* Load a page from your site in an AMP view (add `amp` to the URL)
* Make sure the sharing buttons have the custom AMP style and markup, thus confirming that the compat files are loaded.

#### Proposed changelog entry for your changes:

* None
