### PR TITLE
SSO: Fix overzelous login form interception

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -317,6 +317,21 @@ class Jetpack_SSO {
 	}
 
 	function login_init() {
+		if ( is_user_logged_in() ) {
+			$_request_redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : '';
+			$redirect_to = user_can( $user, 'edit_posts' ) ? admin_url() : self::profile_page_url();
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'redirect_to'               => $redirect_to,
+						'request_redirect_to'       => $_request_redirect_to,
+					),
+					admin_url()
+				)
+			);
+			exit;
+		}
+
 		global $action;
 
 		if ( Jetpack_SSO_Helpers::should_hide_login_form() ) {


### PR DESCRIPTION
Since we hook on login_init, which fires any time the login form
is loaded, we have to be careful about intercepting additional login
screens that aren't related to SSO.

Ref: https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-login.php#L472

For example, a two factor authentication plugin might add an additional
step to the login flow after Jetpack SSO.

#### Changes proposed in this Pull Request:

This PR detects if we've already successfully authenticated and
redirects to wp-admin as expected.

There may be better ways to fix this issue. Maybe after SSO is
successful, we need to unhook login_init altogether.

#### Testing instructions:

I've tested this by enabling two-factor and Jetpack SSO at the same
time. Without this patch, you're able to login and successfully submit
the two factor token, but then Jetpack intercepts the login form to
say SSO has failed. At that point, you're logged in and you can just
point your browser to /wp-admin/.

https://github.com/georgestephanis/two-factor/

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix overzealous login form interception