### PR TITLE
Likes and Sharing Gutenberg extension: Add another hook to catch late-registered CPTs

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -632,6 +632,10 @@ function jetpack_post_likes_register_rest_field() {
 // Add Likes post_meta to the REST API Post response.
 add_action( 'rest_api_init', 'jetpack_post_likes_register_rest_field' );
 
+// Some CPTs (e.g. Jetpack portfolios and testimonials) get registered with
+// restapi_theme_init because they depend on theme support, so let's also hook to that
+add_action( 'restapi_theme_init', 'jetpack_post_likes_register_rest_field', 20 );
+
 /**
  * Set the Likes and Sharing Gutenberg extension availability
  */

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -610,6 +610,10 @@ function jetpack_post_sharing_register_rest_field() {
 // Add Sharing post_meta to the REST API Post response.
 add_action( 'rest_api_init', 'jetpack_post_sharing_register_rest_field' );
 
+// Some CPTs (e.g. Jetpack portfolios and testimonials) get registered with
+// restapi_theme_init because they depend on theme support, so let's also hook to that
+add_action( 'restapi_theme_init', 'jetpack_post_likes_register_rest_field', 20 );
+
 function sharing_admin_init() {
 	global $sharing_admin;
 


### PR DESCRIPTION
Eagle-eyed testers noticed that this extension (see #11709) wasn't working properly with some custom post types. This PR fixes it by running `register_rest_field` on both `rest_api_init` and `restapi_theme_init`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Some post types, such as [testimonials](https://github.com/Automattic/jetpack/blob/a7376a0f60c9c3306f84af5269bc13fd2704a36b/modules/custom-post-types/testimonial.php#L31) and [comics](https://github.com/Automattic/jetpack/blob/a7376a0f60c9c3306f84af5269bc13fd2704a36b/modules/custom-post-types/testimonial.php#L31), are conditionally registered if the theme supports them, so instead of being hooked to `rest_api_init` they hook to `restapi_theme_init`. This runs after `rest_api_init`, meaning they weren't getting the necessary API fields for the extension to work.

The default action priority is 10. SO if we hook to `restapi_theme_init` with a priority of 20 we'll get to add this functionality to any late-registered CPTs.

In testing I found that we still need to hook to `rest_api_init` in order for posts to function correctly -- I haven't dug into why (is the theme_init not called for endpoint requests for posts?) but I don't believe there's any harm in calling `register_rest_field` twice as it will simply [override](https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-includes/rest-api.php#L129) the prior call.

#### Testing instructions:
* Test out the Likes and Sharing sidebar extension (see below) with a custom post type. (Remember that Sharing buttons will only show up on a CPT if enabled in Settings->Sharing regardless of the checkbox setting.)
* Also verify there are no regressions when editing normal posts and pages.

Full testing instructions from #11709:

1. Double-check [sharing button prerequisites](https://github.com/Automattic/wp-calypso/pull/29744#issuecomment-459443781).
1. Make sure beta blocks are enabled with `define( 'JETPACK_BETA_BLOCKS', true );` in your `wp-config.php`.
1. Compile the blocks with `yarn build-extensions` in the checked-out branch.
1. Enable some kind of custom post type, e.g. testimonials
1. Load a new or existing CPT post in the block editor
1. The Likes and Sharing checkboxes should no longer be visible in the post sidebar under Discussion.
1. Under the Jetpack sidebar, there should be a Likes and Shares section with checkboxes to toggle these options:

<img width="299" alt="screen shot 2019-01-24 at 3 44 01 pm" src="https://user-images.githubusercontent.com/52152/51707327-e8355e80-1fee-11e9-9e90-4a915f255728.png">

5. Make sure you can set/unset them and that these settings are appropriately reflected on the front-end.

#### Proposed changelog entry for your changes:

* Fix an issue that caused the Likes and Sharing sidebar extension to be broken for some custom post types.
