### PR TITLE
Gutenberg: Enable Likes and Sharing extension in production

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -4,12 +4,14 @@
 		"contact-form",
 		"contact-info",
 		"gif",
+		"likes",
 		"mailchimp",
 		"map",
 		"markdown",
 		"publicize",
 		"related-posts",
 		"repeat-visitor",
+		"sharing",
 		"shortlinks",
 		"simple-payments",
 		"slideshow",
@@ -18,5 +20,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "likes", "sharing", "seo" ]
+	"beta": [ "seo" ]
 }


### PR DESCRIPTION
We've had a call for testing up for a week and the only issue found is one with CPTs, for which I have a proposed fix in #12031. I think this is good to go especially once #12031 lands (though also I don't think the CPT issue is a blocker as long as we get it in for the next release).

#### Changes proposed in this Pull Request:

* Move the Likes and Sharing extensions into production!

#### Testing instructions:
* See testing instructions in #11709 

#### Proposed changelog entry for your changes:

* Enable Likes and Sharing metaboxes as a Gutenberg extension
