### PR TITLE
Post Flair: Fix official LinkedIn and Pinterest buttons vertical alignement by displaying elements as a block

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -422,6 +422,10 @@ body .sd-content ul li.share-custom.no-icon a span {
 	margin: 0 !important;
 }
 
+.linkedin_button>span {
+	display: block !important;
+}
+
 .sd-social-official .sd-content .share-skype {
 	width: 55px;
 }

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -422,7 +422,7 @@ body .sd-content ul li.share-custom.no-icon a span {
 	margin: 0 !important;
 }
 
-.linkedin_button>span {
+.linkedin_button>span, .pinterest_button a {
 	display: block !important;
 }
 


### PR DESCRIPTION
Fixes #8883
Fixes #11407

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Force the LinkedIn's parent span & Pinterest link to be displayed as a block rather than an inline-block

Before:

<img width="200" alt="Screenshot 2019-04-12 at 14 28 27" src="https://user-images.githubusercontent.com/177929/56040927-74723a80-5d2f-11e9-9b16-288db73056da.png">

After:

<img width="168" alt="Screenshot 2019-04-12 at 14 28 41" src="https://user-images.githubusercontent.com/177929/56040942-789e5800-5d2f-11e9-8c17-524a8b2642ef.png">

#### Testing instructions:

* Add sharing buttons to a post or page including LinkedIn and Pinterest
* Make sure you are using the "official" buttons
* Are they aligned?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix official LinkedIn and Pinterest buttons vertical alignement
