### PR TITLE
Jumpstart - fix bottom margin to better fit my-plans (and other views)

### DIFF
--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -2,7 +2,7 @@
 
 .jp-jumpstart {
 	text-align: left;
-	margin: 0 auto rem( 32px );
+	margin: 0 auto rem( 16px );
 }
 
 .jp-jumpstart-card__content {


### PR DESCRIPTION
Fixes uneven spacing below Jumpstart

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Changed margin from `32px` to `16px`

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack Dashboard
* Navigate to My plans
* Check that margin spacing matches

#### Before:
![image](https://user-images.githubusercontent.com/1123119/56063153-b7caaa00-5d2b-11e9-8828-54aaf621f2cb.png)

#### After:
![image](https://user-images.githubusercontent.com/1123119/56063010-5dc9e480-5d2b-11e9-8b12-01fb507a0d96.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog needed
