### PR TITLE
Sync: Add post type to non registed post type as well as blocked

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -181,6 +181,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$non_existant_post->post_modified     = $post->post_modified;
 			$non_existant_post->post_modified_gmt = $post->post_modified_gmt;
 			$non_existant_post->post_status       = 'jetpack_sync_non_registered_post_type';
+			$non_existant_post->post_type         = $post->post_type;
 
 			return $non_existant_post;
 		}
@@ -205,6 +206,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$blocked_post->post_modified     = $post->post_modified;
 			$blocked_post->post_modified_gmt = $post->post_modified_gmt;
 			$blocked_post->post_status       = 'jetpack_sync_blocked';
+			$blocked_post->post_type         = $post->post_type;
 
 			return $blocked_post;
 		}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -557,6 +557,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '', $synced_post->post_content_filtered );
 		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
 
+		$this->assertEquals( 'unregister_post_type', $synced_post->post_type );
+
 		// Also works for post type that was never registed
 		$post_id = $this->factory->post->create( array( 'post_type' => 'does_not_exist' ) );
 		$this->sender->do_sync();
@@ -565,6 +567,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'jetpack_sync_non_registered_post_type', $synced_post->post_status );
 		$this->assertEquals( '', $synced_post->post_content_filtered );
 		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
+		$this->assertEquals( 'does_not_exist', $synced_post->post_type );
 	}
 
 	function test_sync_post_jetpack_sync_prevent_sending_post_data_filter() {
@@ -589,6 +592,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( strtotime( $this->post->post_modified ) <= strtotime( $post->post_modified ) );
 		$this->assertTrue( strtotime( $this->post->post_modified_gmt ) <= strtotime( $post->post_modified_gmt ) );
 		$this->assertEquals( 'jetpack_sync_blocked', $post->post_status );
+		$this->assertEquals( 'post', $post->post_type );
 
 
 		// Since the filter is not there any more the sync should happen as expected.


### PR DESCRIPTION
By sending the post_type with the posts that we sync only to be able to tell us if we are in sync or now. Having the post type will allows us to better identify the posts in the future. If the post type switches to a blocked post we would be able to delete it for example. Right now we don't have enough info to be able to do it.

#### Changes proposed in this Pull Request:
* Send post_type when a post is blocked. 
- blocked post types are posts that are not resisted any more. 
- post that have been explicitly blocked with the filter.

#### Testing instructions:
* Do the test pass? 
* Add plugin that creates a new post type. Add the new cutsom post type. 
* Remove the plugin. 
* Notice that full sync now sends the post type. Info then we do the full sync.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Include post type with blocked posts
