### PR TITLE
WIP Gutenberg extensions: Never hide the Likes and Sharing sidebar

### DIFF
--- a/extensions/shared/jetpack-likes-and-sharing-panel.js
+++ b/extensions/shared/jetpack-likes-and-sharing-panel.js
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createSlotFill, PanelBody } from '@wordpress/components';
+// import { addQueryArgs } from '@wordpress/url';
+// import getWPAdminURL from '@wordpress/editor/utils/url';
 
 const { Fill, Slot } = createSlotFill( 'JetpackLikesAndSharingPanel' );
 
@@ -12,7 +14,15 @@ JetpackLikesAndSharingPanel.Slot = () => (
 	<Slot>
 		{ fills => {
 			if ( ! fills.length ) {
-				return null;
+				const sharingAdminLink = '/wp-admin/admin.php?page=jetpack#/sharing';
+				// const sharingAdminLink = addQueryArgs( "/wp-admin/admin.php", { page: "jetpack#/sharing" } );
+				// const sharingAdminLink = getWPAdminURL( 'admin.php', { page: 'jetpack#/sharing' } );
+				return (
+					<PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>
+						Visit <a href={ sharingAdminLink }>Sharing settings</a> in your Dashboard to allow
+						visitors to like and share your posts.
+					</PanelBody>
+				);
 			}
 
 			return <PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>;

--- a/extensions/shared/jetpack-plugin-sidebar.js
+++ b/extensions/shared/jetpack-plugin-sidebar.js
@@ -20,10 +20,6 @@ const JetpackPluginSidebar = ( { children } ) => <Fill>{ children }</Fill>;
 JetpackPluginSidebar.Slot = () => (
 	<Slot>
 		{ fills => {
-			if ( ! fills.length ) {
-				return null;
-			}
-
 			return (
 				<Fragment>
 					<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>


### PR DESCRIPTION
The original problem discovered this morning is that these metaboxes don't show up when editing a page.

The cause of this problem is that the nested SlotFill, `<JetpackLikesAndSharingPanel.Slot />`, doesn't trigger the parent SlotFill, `<JetpackLikesAndSharingPanel.Slot />` to appear.

@roccotripaldi and I tried hard to find a better solution to this but it appears there's a bug with nested SlotFills that prevents us from fixing it in a clean way.

The two obvious paths forward are:
1. Use two separate panels for the metaboxes. @roccotripaldi has a branch for that approach in https://github.com/Automattic/jetpack/commit/4626844baf1f585094d09a10dd5fb4e40d849cd4
1. Remove the conditional from the parent sidebar and then ensure that the Likes and Sharing panel always displays some content -- in this case, a link to the settings where these options can be enabled. The second exploration is this PR.

I have two issues with this implementation:
1. I can't figure out how to wrap a string containing a link in a translation call.
2. I'm not sure how to get the correct wp-admin link and link directly to `jetpack#/sharing` as `addQueryArgs` escapes the hash tag. Note that this code needs to run on WPCOM, but we don't need to handle this case because these modules cannot be disabled on WPCOM. So it's okay that the link is just for Jetpack admin.

Hopefully there is a simple answer to both questions.

As for the more complicated question of how we should fix the underlying problem or which band-aid we should use, I'm hoping more folks can weigh in after the weekend.

#### Changes proposed in this Pull Request:
* The Likes and Sharing sidebar will never be hidden even if both modules are disabled. Instead, it links to the Sharing settings in that case:

<img width="281" alt="Screen Shot 2019-04-12 at 6 44 16 PM" src="https://user-images.githubusercontent.com/52152/56073048-02abe800-5d53-11e9-8960-449c32feee33.png">


#### Testing instructions:

1. Edit both posts and pages and ensure that the Jetpack sidebar is always visible.
1. Enable and disable the Likes and Sharing button modules and ensure that checkboxes are only shown for active modules.
1. Finally, ensure the checkboxes still toggle the buttons on the front-end correctly.

#### Proposed changelog entry for your changes:
* Show Likes and Sharing settings when editing a page
