### PR TITLE
Jetpack_Plan: add monthly wpcom variants for bundles

### DIFF
--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -6,12 +6,16 @@ import includes from 'lodash/includes';
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
 export const PLAN_BUSINESS_2_YEARS = 'business-bundle-2y';
+export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_ECOMMERCE = 'ecommerce-bundle';
 export const PLAN_ECOMMERCE_2_YEARS = 'ecommerce-bundle-2y';
+export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
 export const PLAN_PREMIUM = 'value_bundle';
 export const PLAN_PREMIUM_2_YEARS = 'value_bundle-2y';
+export const PLAN_PREMIUM_MONTHLY = 'value_bundle-monthly';
 export const PLAN_PERSONAL = 'personal-bundle';
 export const PLAN_PERSONAL_2_YEARS = 'personal-bundle-2y';
+export const PLAN_PERSONAL_MONTHLY = 'personal-bundle-monthly';
 export const PLAN_FREE = 'free_plan';
 export const PLAN_JETPACK_FREE = 'jetpack_free';
 export const PLAN_JETPACK_PREMIUM = 'jetpack_premium';
@@ -118,21 +122,25 @@ export function getPlanClass( plan ) {
 			return 'is-free-plan';
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_2_YEARS:
+		case PLAN_PERSONAL_MONTHLY:
 		case PLAN_JETPACK_PERSONAL:
 		case PLAN_JETPACK_PERSONAL_MONTHLY:
 			return 'is-personal-plan';
 		case PLAN_PREMIUM:
 		case PLAN_PREMIUM_2_YEARS:
+		case PLAN_PREMIUM_MONTHLY:
 		case PLAN_JETPACK_PREMIUM:
 		case PLAN_JETPACK_PREMIUM_MONTHLY:
 			return 'is-premium-plan';
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_2_YEARS:
+		case PLAN_BUSINESS_MONTHLY:
 		case PLAN_JETPACK_BUSINESS:
 		case PLAN_JETPACK_BUSINESS_MONTHLY:
 		case PLAN_VIP:
 		case PLAN_ECOMMERCE:
 		case PLAN_ECOMMERCE_2_YEARS:
+		case PLAN_ECOMMERCE_MONTHLY:
 			return 'is-business-plan';
 		default:
 			return '';

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -130,6 +130,7 @@ class Jetpack_Plan {
 			'jetpack_personal',
 			'jetpack_personal_monthly',
 			'personal-bundle',
+			'personal-bundle-monthly',
 			'personal-bundle-2y',
 		);
 
@@ -144,6 +145,7 @@ class Jetpack_Plan {
 			'jetpack_premium',
 			'jetpack_premium_monthly',
 			'value_bundle',
+			'value_bundle-monthly',
 			'value_bundle-2y',
 		);
 
@@ -160,8 +162,10 @@ class Jetpack_Plan {
 			'jetpack_business',
 			'jetpack_business_monthly',
 			'business-bundle',
+			'business-bundle-monthly',
 			'business-bundle-2y',
 			'ecommerce-bundle',
+			'ecommerce-bundle-monthly',
 			'ecommerce-bundle-2y',
 			'vip',
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* `\Jetpack_Plan::get()` doesn't recognize the new(-ish) monthly business bundle as a business plan, and so some features are unavailable. We don't yet offer monthly variations of the other plans, but adding them to be on the safe side.

See p9F6qB-2Xb-p2

#### Testing instructions:
* I'm not sure :( See internal post linked above for example site to test against.

#### Proposed changelog entry for your changes:

* No changelog is needed
