### PR TITLE
Shares and Likes: Fix Sidebar Slot/Fill Logic

### DIFF
--- a/extensions/blocks/likes/index.js
+++ b/extensions/blocks/likes/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
@@ -7,9 +12,10 @@ import LikesCheckbox from './likes-checkbox';
 export const name = 'likes';
 
 export const settings = {
-	render: ( { props } ) => (
-		<JetpackLikesAndSharingPanel>
-			<LikesCheckbox props={ props } />
-		</JetpackLikesAndSharingPanel>
+	render: () => (
+		<Fragment>
+			<LikesCheckbox />
+			<JetpackLikesAndSharingPanel.Slot />
+		</Fragment>
 	),
 };

--- a/extensions/blocks/likes/likes-checkbox.js
+++ b/extensions/blocks/likes/likes-checkbox.js
@@ -6,14 +6,21 @@ import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
+
 const LikesCheckbox = ( { areLikesEnabled, editPost } ) => (
-	<CheckboxControl
-		label={ __( 'Show likes.', 'jetpack' ) }
-		checked={ areLikesEnabled }
-		onChange={ value => {
-			editPost( { jetpack_likes_enabled: value } );
-		} }
-	/>
+	<JetpackLikesAndSharingPanel>
+		<CheckboxControl
+			label={ __( 'Show likes.', 'jetpack' ) }
+			checked={ areLikesEnabled }
+			onChange={ value => {
+				editPost( { jetpack_likes_enabled: value } );
+			} }
+		/>
+	</JetpackLikesAndSharingPanel>
 );
 
 // Fetch the post meta.

--- a/extensions/blocks/sharing/index.js
+++ b/extensions/blocks/sharing/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
@@ -7,9 +12,10 @@ import SharingCheckbox from './sharing-checkbox';
 export const name = 'sharing';
 
 export const settings = {
-	render: ( { props } ) => (
-		<JetpackLikesAndSharingPanel>
-			<SharingCheckbox props={ props } />
-		</JetpackLikesAndSharingPanel>
+	render: () => (
+		<Fragment>
+			<SharingCheckbox />
+			<JetpackLikesAndSharingPanel.Slot />
+		</Fragment>
 	),
 };

--- a/extensions/blocks/sharing/sharing-checkbox.js
+++ b/extensions/blocks/sharing/sharing-checkbox.js
@@ -6,14 +6,21 @@ import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
+
 const SharingCheckbox = ( { isSharingEnabled, editPost } ) => (
-	<CheckboxControl
-		label={ __( 'Show sharing buttons.', 'jetpack' ) }
-		checked={ isSharingEnabled }
-		onChange={ value => {
-			editPost( { jetpack_sharing_enabled: value } );
-		} }
-	/>
+	<JetpackLikesAndSharingPanel>
+		<CheckboxControl
+			label={ __( 'Show sharing buttons.', 'jetpack' ) }
+			checked={ isSharingEnabled }
+			onChange={ value => {
+				editPost( { jetpack_sharing_enabled: value } );
+			} }
+		/>
+	</JetpackLikesAndSharingPanel>
 );
 
 // Fetch the post meta.

--- a/extensions/shared/jetpack-likes-and-sharing-panel.js
+++ b/extensions/shared/jetpack-likes-and-sharing-panel.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { createSlotFill, PanelBody } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import JetpackPluginSidebar from './jetpack-plugin-sidebar';
+
 const { Fill, Slot } = createSlotFill( 'JetpackLikesAndSharingPanel' );
 
 const JetpackLikesAndSharingPanel = ( { children } ) => <Fill>{ children }</Fill>;
@@ -15,7 +20,11 @@ JetpackLikesAndSharingPanel.Slot = () => (
 				return null;
 			}
 
-			return <PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>;
+			return (
+				<JetpackPluginSidebar>
+					<PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>
+				</JetpackPluginSidebar>
+			);
 		} }
 	</Slot>
 );

--- a/extensions/shared/jetpack-plugin-sidebar.js
+++ b/extensions/shared/jetpack-plugin-sidebar.js
@@ -11,7 +11,6 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import './jetpack-plugin-sidebar.scss';
 import JetpackLogo from './jetpack-logo';
-import JetpackLikesAndSharingPanel from './jetpack-likes-and-sharing-panel';
 
 const { Fill, Slot } = createSlotFill( 'JetpackPluginSidebar' );
 
@@ -31,7 +30,6 @@ JetpackPluginSidebar.Slot = () => (
 					</PluginSidebarMoreMenuItem>
 					<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
 						{ fills }
-						<JetpackLikesAndSharingPanel.Slot />
 					</PluginSidebar>
 				</Fragment>
 			);


### PR DESCRIPTION
Alternative to #12045.

#### Changes proposed in this Pull Request:

This is supposed to fix the issue that the Likes and Shares Panel doesn't show up on _pages_ (as opposed to _posts_, where they work).

The problem seems to be that prior to this PR, the Likes and Shares Slot was displayed [_alongside_](https://github.com/Automattic/jetpack/blob/a095fd0cebdb2cf875ed96915d310e0d5dc1cbf0/extensions/shared/jetpack-plugin-sidebar.js#L34) other fills in the parent Jetpack Plugin Sidebar Slot, which in turn would be displayed depending on those fills. In other words, its visibility wasn't coupled to that of Likes and Shares: If there were Likes and Shares but no other fills, the sidebar would be hidden.

The fix is to make the Likes and Shares Slot just another of those Fills, so that the parent slot's visibility check takes it into account. 

#### Testing instructions:

* Edit both posts and pages and ensure that the Jetpack sidebar is always visible.
* Enable and disable the Likes and Sharing button modules and ensure that checkboxes are only shown for active modules.
* Finally, ensure the checkboxes still toggle the buttons on the front-end correctly.

#### Proposed changelog entry for your changes:

* Fix Sidebar Slot/Fill Logic
