### PR TITLE
Update docs for Jetpack Gutenberg extensions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -156,7 +156,7 @@ define( 'SCRIPT_DEBUG', true );
 define( 'GUTENBERG_DEVELOPMENT_MODE', true );
 ```
 
-You could add these to `docker/wordpress/wp-config.php` in your Docker environment.
+You could modify `SCRIPT_DEBUG` from `docker/wordpress/wp-config.php` in your Docker environment and add `GUTENBERG_DEVELOPMENT_MODE` there as well, or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`).
 
 [G Debugger](https://wordpress.org/plugins/g-debugger/) plugin might come handy, too.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,7 +39,7 @@ If your block depends on another block, place them all in extensions folder:
 1. Use the [Jetpack Docker environment](https://github.com/Automattic/jetpack/tree/master/docker#readme).
 1. Start a new branch.
 1. Add your new extension's source files to the extensions/blocks directory.
-And add your extensions' slug the beta array in `extensions/index.json`. You can use Jetpack-CLI command to scaffold the block (see below).
+And add your extensions' slug to the beta array in `extensions/index.json`. You can use Jetpack-CLI command to scaffold the block (see below).
 By keeping your extension in the beta array, it's safe to do small PRs and merge frequently.
 1. Or modify existing extensions in the same folder.
 1. Run `yarn build-extensions [--watch]` to compile your changes.
@@ -162,7 +162,7 @@ You could modify `SCRIPT_DEBUG` from `docker/wordpress/wp-config.php` in your Do
 
 ### Don't worry about dependencies
 
-The build takes care of core dependencies for both editor and view -scripts. React, lodash and `@wordpress/*` [dependencies](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md) are externalized and automatically enqueued in PHP for your extension.
+The build takes care of core dependencies for both editor and view scripts. React, Lodash and `@wordpress/*` [dependencies](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md) are externalized and automatically enqueued in PHP for your extension.
 
 Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md#polyfill-scripts) enqueued so you can safely use methods not supported by older browsers such as IE11.
 
@@ -209,4 +209,4 @@ Possible:
 
 ### Icons
 
-Please use outline versions of [Material icons](https://material.io/tools/icons/?style=outline) to stay in line with Muriel guidelines. Don't rely on icons used in the core to avoid visual mixing up with core blocks.
+Please use outline versions of [Material icons](https://material.io/tools/icons/?style=outline) to stay in line with Muriel guidelines. Don't rely on icons used in WordPress core to avoid visual mixing up with core blocks.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -53,7 +53,7 @@ By keeping your extension in beta array, it's safe to do small PRs and merge fre
 Generally, all new extensions should start out as beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
-- In your Docker environment ( `docker/wordpress/wp-config` ), set the `JETPACK_BETA_BLOCKS` constant is set to `true`
+- In the wp-config for your Docker environment ( `docker/wordpress/wp-config` ), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
 - In the WordPress.com environment, a12s will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -170,7 +170,7 @@ Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPr
 
 Jetpack adds its own [plugin sidebar](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/plugin-sidebar-0/plugin-sidebar-1-up-and-running/) to the block editor. You can find it by choosing "Jetpack" from block editor's ellipsis menu or by pressing Jetpack icon in the "pinned plugins" toolbar.
 
-The sidebar itself is always registered in the editor and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
+The sidebar itself is always registered in the editor and populated using the [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
 
 Use the `JetpackPluginSidebar` component to render from anywhere in your plugin's code:
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -184,7 +184,7 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 </JetpackPluginSidebar>
 ```
 
-The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
+The sidebar won't show up at all if nothing is being rendered in the sidebar's "slot".
 
 Remember to be mindful of what post types you want to enable your sidebar section for: e.g. posts, pages, custom post types, and re-usable block post type (`/wp-admin/edit.php?post_type=wp_block`).
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -53,7 +53,7 @@ By keeping your extension in beta array, it's safe to do small PRs and merge fre
 Generally, all new extensions should start out as beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
-- Ensure that, in you Docker environment, the `JETPACK_BETA_BLOCKS` constant is set to `true`
+- Ensure that, in your Docker environment, the `JETPACK_BETA_BLOCKS` constant is set to `true`
 - In the WordPress.com environment, a12s will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,7 +39,7 @@ If your block depends on another block, place them all in extensions folder:
 1. Use the [Jetpack Docker environment](https://github.com/Automattic/jetpack/tree/master/docker#readme).
 1. Start a new branch.
 1. Add your new extension's source files to the extensions/blocks directory.
-And add your extensions' slug the beta array in `extensions/index.json`.
+And add your extensions' slug the beta array in `extensions/index.json`. You can use Jetpack-CLI command to scaffold the block (see below).
 By keeping your extension in the beta array, it's safe to do small PRs and merge frequently.
 1. Or modify existing extensions in the same folder.
 1. Run `yarn build-extensions [--watch]` to compile your changes.
@@ -50,6 +50,7 @@ By keeping your extension in the beta array, it's safe to do small PRs and merge
 1. When your block is ready to be shipped, move your extensions' slug from beta to production array in `extensions/index.json`
 
 ### Beta Extensions
+
 Generally, all new extensions should start out as a beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
@@ -57,41 +58,6 @@ Generally, all new extensions should start out as a beta.
 - In the WordPress.com environment, a12s will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
-
-### Can I use Jurassic Ninja to test blocks?
-Yes! Just like any other changes in Jetpack, also blocks work in Jurassic Ninja.
-
-Simply add branch name to the URL: jurassic.ninja/create/?jetpack-beta&branch=master or use other ninjastic features.
-
-### How do I merge extensions to Jetpack
-- Jetpack is released once a month, so be sure your team is aware of [upcoming code freezes](https://github.com/Automattic/Jetpack/milestones).
-- Make sure you and your team have tested your PR in both the Jetpack environment, and the WordPress.com environment.
-- Additionally, your PR will require approval from a Jetpack crew member.
-- Once merged, your extension will appear in the next release.
-
-### How do I merge extensions to WordPress.com?
-- Merge to Jetpack master first.
-- Now, merge the auto-generated diff on WordPress.com.
-- There's no need to wait on release schedules, in fact it is best if you merge your WordPress.com diff immediately after you've merged to Jetpack master.
-
-### What if I need to manually create a WordPress.com diff?
-You can build extensions from the Jetpack folder to your local sandbox folder and sync the whole sandbox like you always do:
-
-```bash
-yarn clean-extensions
-yarn build-extensions \
-  --output-path /PATH_TO_YOUR_SANDBOX/wp-content/mu-plugins/jetpack/_inc/blocks/ \
-  --watch
-```
-
-Alternatively, if you don’t need to touch PHP files, you can build extensions in the Jetpack folder without --output-path and use rsync to push files directly to your sandbox:
-
-```bash
-rsync -az --delete _inc/blocks/ \
-  YOUR_WPCOM_SANDBOX:/BLOCKS_PATH_IN_YOUR_SANDBOX/
-```
-
-To test extensions for a Simple site in Calypso, sandbox the simple site URL (`example.wordpress.com`). Calypso loads Gutenberg from simple sites’ wp-admin in an iframe.
 
 ## Scaffolding blocks with WP-CLI
 
@@ -129,6 +95,45 @@ Since it's added to the beta array, you need to load the beta blocks as explaine
 `wp jetpack scaffold block "Amazing Rock" --slug="good-music" --description="Rock the best music on your site"`
 
 `wp jetpack scaffold block "Jukebox" --keywords="music, audio, media"`
+
+### Can I use Jurassic Ninja to test blocks?
+
+Yes! Just like any other changes in Jetpack, also blocks work in Jurassic Ninja.
+
+Simply add branch name to the URL: jurassic.ninja/create/?jetpack-beta&branch=master or use other ninjastic features.
+
+### How do I merge extensions to Jetpack
+
+- Jetpack is released once a month, so be sure your team is aware of [upcoming code freezes](https://github.com/Automattic/Jetpack/milestones).
+- Make sure you and your team have tested your PR in both the Jetpack environment, and the WordPress.com environment.
+- Additionally, your PR will require approval from a Jetpack crew member.
+- Once merged, your extension will appear in the next release.
+
+### How do I merge extensions to WordPress.com?
+
+- Merge to Jetpack master first.
+- Now, merge the auto-generated diff on WordPress.com.
+- There's no need to wait on release schedules, in fact it is best if you merge your WordPress.com diff immediately after you've merged to Jetpack master.
+
+### What if I need to manually create a WordPress.com diff?
+
+You can build extensions from the Jetpack folder to your local sandbox folder and sync the whole sandbox like you always do:
+
+```bash
+yarn clean-extensions
+yarn build-extensions \
+  --output-path /PATH_TO_YOUR_SANDBOX/wp-content/mu-plugins/jetpack/_inc/blocks/ \
+  --watch
+```
+
+Alternatively, if you don’t need to touch PHP files, you can build extensions in the Jetpack folder without --output-path and use rsync to push files directly to your sandbox:
+
+```bash
+rsync -az --delete _inc/blocks/ \
+  YOUR_WPCOM_SANDBOX:/BLOCKS_PATH_IN_YOUR_SANDBOX/
+```
+
+To test extensions for a Simple site in Calypso, sandbox the simple site URL (`example.wordpress.com`). Calypso loads Gutenberg from simple sites’ wp-admin in an iframe.
 
 ## Good to know when developing Gutenberg extensions
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -186,7 +186,7 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
 
-Remember to be mindful of posts, pages, custom post types, and re-usable block post type.
+Remember to be mindful of what post types you want to enable your sidebar section for: e.g. posts, pages, custom post types, and re-usable block post type.
 
 See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are a great example of how to output content from several extensions to one sidebar section using "slots".
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -204,7 +204,7 @@ Possible:
 
 ### Colors
 
-- To stay consistent with Gutenberg, your extensions should follow [Gutenberg styles and visuals]. Use Gutenberg color variables where possible.
+- To stay consistent with Gutenberg, your extensions should follow [Gutenberg styles and visuals](https://wordpress.org/gutenberg/handbook/designers-developers/designers/block-design/). Use Gutenberg color variables where possible.
 - The build also supports [Muriel colors](https://github.com/Automattic/color-studio) via SASS variables (`$muriel-pink-300`) and CSS custom properties (`var( --muriel-pink-300 )`). Prefer CSS custom properties if possible.
 
 ### Icons

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -166,9 +166,11 @@ The build takes care of core dependencies for both editor and view -scripts. Rea
 
 Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md#polyfill-scripts) enqueued so you can safely use methods not supported by older browsers such as IE11.
 
-### Jetpack sidebar
+### Jetpack plugin sidebar
 
-Jetpack sidebar is always registered in the editor and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
+Jetpack adds its own [plugin sidebar](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/plugin-sidebar-0/plugin-sidebar-1-up-and-running/) to the block editor. You can find it by choosing "Jetpack" from block editor's ellipsis menu or by pressing Jetpack icon in the "pinned plugins" toolbar.
+
+The sidebar itself is always registered in the editor and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
 
 Just render with `JetpackPluginSidebar` component from anywhere in your plugin's code:
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -186,7 +186,7 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
 
-Remember to be mindful of what post types you want to enable your sidebar section for: e.g. posts, pages, custom post types, and re-usable block post type.
+Remember to be mindful of what post types you want to enable your sidebar section for: e.g. posts, pages, custom post types, and re-usable block post type (`/wp-admin/edit.php?post_type=wp_block`).
 
 See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are a great example of how to output content from several extensions to one sidebar section using "slots".
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -34,23 +34,23 @@ If your block depends on another block, place them all in extensions folder:
 
 ## Developing block editor extensions in Jetpack
 
-### High level overview of the development flow
+### High-level overview of the development flow
 
 1. Use the [Jetpack Docker environment](https://github.com/Automattic/jetpack/tree/master/docker#readme).
 1. Start a new branch.
 1. Add your new extension's source files to the extensions/blocks directory.
-And add your extensions's slug the beta array in `extensions/index.json`.
-By keeping your extension in beta array, it's safe to do small PRs and merge frequently.
+And add your extensions' slug the beta array in `extensions/index.json`.
+By keeping your extension in the beta array, it's safe to do small PRs and merge frequently.
 1. Or modify existing extensions in the same folder.
 1. Run `yarn build-extensions [--watch]` to compile your changes.
 1. Now test your changes in your Docker environment's wp-admin.
 1. Open a PR, and a WordPress.com diff will be automatically generated with your changes.
 1. Test the WordPress.com diff
 1. Once the code works well in both environments and has been approved by a Jetpack crew member, you can merge your branch!
-1. When your block is ready to be shipped, move your extensions's slug from beta to production array in `extensions/index.json`
+1. When your block is ready to be shipped, move your extensions' slug from beta to production array in `extensions/index.json`
 
 ### Beta Extensions
-Generally, all new extensions should start out as beta.
+Generally, all new extensions should start out as a beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
 - In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
@@ -106,7 +106,7 @@ We have a command in WP-CLI that allows to scaffold Jetpack blocks. Its syntax i
 - **title**: Block name, also used to create the slug. This parameter is required. If it's something like _Logo gallery_, the slug will be `logo-gallery`. It's also used to generate the class name when an external edit component is requested. Following this example, it would be `LogoGalleryEdit`.
 - **--slug**: Specific slug to identify the block that overrides the one generated base don the title.
 - **--description**: Allows to provide a text description of the block.
-- **--keywords**: Provide up to three keywords separated by comma so users  when they search for a block in the editor.
+- **--keywords**: Provide up to three keywords separated by a comma so users when they search for a block in the editor.
 
 ### Files
 
@@ -157,7 +157,7 @@ You could add these to `docker/wordpress/wp-config.php` in your Docker environme
 
 ### Don't worry about dependencies
 
-The build takes care of core dependencies for both editor and view -scripts. React, lodash and `@wordpress/*` [dependencies](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md) are externalised and automatically enqueued in PHP for your extension.
+The build takes care of core dependencies for both editor and view -scripts. React, lodash and `@wordpress/*` [dependencies](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md) are externalized and automatically enqueued in PHP for your extension.
 
 Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md#polyfill-scripts) enqueued so you can safely use methods not supported by older browsers such as IE11.
 
@@ -179,9 +179,9 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
 
-Remember to be mindful of posts, pages, custom post types and re-usable block post type.
+Remember to be mindful of posts, pages, custom post types, and re-usable block post type.
 
-See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are great example of how to output content from several extensions to one sidebar section using "slots".
+See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are a great example of how to output content from several extensions to one sidebar section using "slots".
 
 ### i18n
 
@@ -195,11 +195,11 @@ Possible:
 
 > Still confused? <a>Check out documentation for more!</a>
 
-### Colours
+### Colors
 
-- To stay consistent with Gutenberg, your extensions should follow [Gutenberg styles and visuals]. Use Gutenberg colour variables where possible.
-- The build also supports [Muriel colours](https://github.com/Automattic/color-studio) via SASS variables (`$muriel-pink-300`) and CSS custom properties (`var( --muriel-pink-300 )`). Prefer CSS custom properties if possible.
+- To stay consistent with Gutenberg, your extensions should follow [Gutenberg styles and visuals]. Use Gutenberg color variables where possible.
+- The build also supports [Muriel colors](https://github.com/Automattic/color-studio) via SASS variables (`$muriel-pink-300`) and CSS custom properties (`var( --muriel-pink-300 )`). Prefer CSS custom properties if possible.
 
 ### Icons
 
-Please use outline versions of [Material icons](https://material.io/tools/icons/?style=outline) to stay inline with Muriel guidelines. Don't rely on icons used in core to avoid visual mixing up with core blocks.
+Please use outline versions of [Material icons](https://material.io/tools/icons/?style=outline) to stay in line with Muriel guidelines. Don't rely on icons used in the core to avoid visual mixing up with core blocks.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -53,7 +53,7 @@ By keeping your extension in beta array, it's safe to do small PRs and merge fre
 Generally, all new extensions should start out as beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
-- Ensure that, in your Docker environment, the `JETPACK_BETA_BLOCKS` constant is set to `true`
+- In your Docker environment ( `docker/wordpress/wp-config` ), set the `JETPACK_BETA_BLOCKS` constant is set to `true`
 - In the WordPress.com environment, a12s will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -172,7 +172,7 @@ Jetpack adds its own [plugin sidebar](https://wordpress.org/gutenberg/handbook/d
 
 The sidebar itself is always registered in the editor and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
 
-Just render with `JetpackPluginSidebar` component from anywhere in your plugin's code:
+Use the `JetpackPluginSidebar` component to render from anywhere in your plugin's code:
 
 ```jsx
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -93,16 +93,6 @@ rsync -az --delete _inc/blocks/ \
 
 To test extensions for a Simple site in Calypso, sandbox the simple site URL (`example.wordpress.com`). Calypso loads Gutenberg from simple sites’ wp-admin in an iframe.
 
-## The Build
-
-- Compiled extensions are output to `_inc/blocks`
-- You can view the various build commands in `package.json`
-- You can see the build configuration in `webpack.config.extensions.js`
-
-If you need to modify the build process, bear in mind that config files are also
-synced to WordPress.com via Fusion. Consult with a Jetpack crew member to ensure
-you test the new build in both environments.
-
 ## Scaffolding blocks with WP-CLI
 
 We have a command in WP-CLI that allows to scaffold Jetpack blocks. Its syntax is as follows:
@@ -141,6 +131,16 @@ Since it's added to the beta array, you need to load the beta blocks as explaine
 `wp jetpack scaffold block "Jukebox" --keywords="music, audio, media"`
 
 ## Good to know when developing Gutenberg extensions
+
+## The Build
+
+- Compiled extensions are output to `_inc/blocks`
+- You can view the various build commands in `package.json`
+- You can see the build configuration in `webpack.config.extensions.js`
+
+If you need to modify the build process, bear in mind that config files are also
+synced to WordPress.com via Fusion. Consult with a Jetpack crew member to ensure
+you test the new build in both environments.
 
 ## Debugging
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -150,9 +150,9 @@ Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPr
 
 ### Jetpack sidebar
 
-Jetpack sidebar is registered on all Gutenberg editor pages and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme).
+Jetpack sidebar is always registered in the editor and filled using [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
 
-Just render to `JetpackPluginSidebar` from anywhere in the code:
+Just render with `JetpackPluginSidebar` component from anywhere in your plugin's code:
 
 ```jsx
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
@@ -164,10 +164,12 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 </JetpackPluginSidebar>
 ```
 
-Remember to be mindful of posts, pages, custom post types and re-usable blocks.
+The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
+
+Remember to be mindful of posts, pages, custom post types and re-usable block post type. See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts.
 
 ### i18n
-As of 04/2019 `wp.i18n` [doesn't support React elements in strings](https://github.com/WordPress/gutenberg/issues/9846). You will have to structure your copy so that links and other HTML can be translated separately.
+As of 04/2019, `wp.i18n` [doesn't support React elements in strings](https://github.com/WordPress/gutenberg/issues/9846). You will have to structure your copy so that links and other HTML can be translated separately.
 
 Not possible:
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -179,7 +179,9 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 The sidebar won't show up at all if nothing isn't rendering in the sidebar's "slot".
 
-Remember to be mindful of posts, pages, custom post types and re-usable block post type. See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts.
+Remember to be mindful of posts, pages, custom post types and re-usable block post type.
+
+See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are great example of how to output content from several extensions to one sidebar section using "slots".
 
 ### i18n
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -168,7 +168,7 @@ Extensions _always_ get [Gutenberg's polyfill scripts](https://github.com/WordPr
 
 ### Jetpack plugin sidebar
 
-Jetpack adds its own [plugin sidebar](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/plugin-sidebar-0/plugin-sidebar-1-up-and-running/) to the block editor. You can find it by choosing "Jetpack" from block editor's ellipsis menu or by pressing Jetpack icon in the "pinned plugins" toolbar.
+Jetpack adds its own [plugin sidebar](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/plugin-sidebar-0/plugin-sidebar-1-up-and-running/) to the block editor. You can find it by choosing "Jetpack" from block the editor's ellipsis menu or by pressing the Jetpack icon in the "pinned plugins" toolbar.
 
 The sidebar itself is always registered in the editor and populated using the [Slot Fill](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill#readme) mechanism.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -182,6 +182,7 @@ The sidebar won't show up at all if nothing isn't rendering in the sidebar's "sl
 Remember to be mindful of posts, pages, custom post types and re-usable block post type. See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts.
 
 ### i18n
+
 As of 04/2019, `wp.i18n` [doesn't support React elements in strings](https://github.com/WordPress/gutenberg/issues/9846). You will have to structure your copy so that links and other HTML can be translated separately.
 
 Not possible:
@@ -199,4 +200,4 @@ Possible:
 
 ### Icons
 
-Please use [Material icons](https://material.io/tools/icons/?style=outline) and don't rely on icons used in core to avoid visual mixing up.
+Please use outline versions of [Material icons](https://material.io/tools/icons/?style=outline) to stay inline with Muriel guidelines. Don't rely on icons used in core to avoid visual mixing up with core blocks.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -53,7 +53,7 @@ By keeping your extension in beta array, it's safe to do small PRs and merge fre
 Generally, all new extensions should start out as beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
-- In the wp-config for your Docker environment ( `docker/wordpress/wp-config` ), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
+- In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
 - In the WordPress.com environment, a12s will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
@@ -141,6 +141,19 @@ Since it's added to the beta array, you need to load the beta blocks as explaine
 `wp jetpack scaffold block "Jukebox" --keywords="music, audio, media"`
 
 ## Good to know when developing Gutenberg extensions
+
+## Debugging
+
+Setting these might be useful for debugging with block editor:
+
+```php
+define( 'SCRIPT_DEBUG', true );
+define( 'GUTENBERG_DEVELOPMENT_MODE', true );
+```
+
+You could add these to `docker/wordpress/wp-config.php` in your Docker environment.
+
+[G Debugger](https://wordpress.org/plugins/g-debugger/) plugin might come handy, too.
 
 ### Don't worry about dependencies
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -200,9 +200,3 @@ Possible:
 ### Icons
 
 Please use [Material icons](https://material.io/tools/icons/?style=outline) and don't rely on icons used in core to avoid visual mixing up.
-
-### Linking to wp-admin or Calypso
-
-<!-- @TODO: Document `getSiteFragment`? -->
-
-...

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -188,7 +188,7 @@ The sidebar won't show up at all if nothing isn't rendering in the sidebar's "sl
 
 Remember to be mindful of what post types you want to enable your sidebar section for: e.g. posts, pages, custom post types, and re-usable block post type (`/wp-admin/edit.php?post_type=wp_block`).
 
-See Publicize and Shortlinks for examples how to limit functionality only to some specific post types or posts. Likes & Shares extensions are a great example of how to output content from several extensions to one sidebar section using "slots".
+See [Publicize](blocks/publicize/index.js) and [Shortlinks](blocks/shortlinks/index.js) for examples how to limit functionality only to some specific post types or posts. The [Likes](blocks/likes/likes-checkbox.js) & [Sharing](blocks/sharing/sharing-checkbox.js) extensions are a great example of how to [output](shared/jetpack-likes-and-sharing-panel.js) content from several extensions to one sidebar section using "slots".
 
 ### i18n
 


### PR DESCRIPTION
Elaborate more about block development in `/extensions` docs.