### PR TITLE
Likes and sharing panel: Render on demand

### DIFF
--- a/extensions/blocks/likes/index.js
+++ b/extensions/blocks/likes/index.js
@@ -1,15 +1,8 @@
 /**
  * Internal dependencies
  */
-import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 import LikesCheckbox from './likes-checkbox';
 
 export const name = 'likes';
 
-export const settings = {
-	render: ( { props } ) => (
-		<JetpackLikesAndSharingPanel>
-			<LikesCheckbox props={ props } />
-		</JetpackLikesAndSharingPanel>
-	),
-};
+export const settings = { render: LikesCheckbox };

--- a/extensions/blocks/likes/likes-checkbox.js
+++ b/extensions/blocks/likes/likes-checkbox.js
@@ -6,14 +6,21 @@ import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
+
 const LikesCheckbox = ( { areLikesEnabled, editPost } ) => (
-	<CheckboxControl
-		label={ __( 'Show likes.', 'jetpack' ) }
-		checked={ areLikesEnabled }
-		onChange={ value => {
-			editPost( { jetpack_likes_enabled: value } );
-		} }
-	/>
+	<JetpackLikesAndSharingPanel>
+		<CheckboxControl
+			label={ __( 'Show likes.', 'jetpack' ) }
+			checked={ areLikesEnabled }
+			onChange={ value => {
+				editPost( { jetpack_likes_enabled: value } );
+			} }
+		/>
+	</JetpackLikesAndSharingPanel>
 );
 
 // Fetch the post meta.

--- a/extensions/blocks/sharing/index.js
+++ b/extensions/blocks/sharing/index.js
@@ -1,15 +1,8 @@
 /**
  * Internal dependencies
  */
-import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 import SharingCheckbox from './sharing-checkbox';
 
 export const name = 'sharing';
 
-export const settings = {
-	render: ( { props } ) => (
-		<JetpackLikesAndSharingPanel>
-			<SharingCheckbox props={ props } />
-		</JetpackLikesAndSharingPanel>
-	),
-};
+export const settings = { render: SharingCheckbox };

--- a/extensions/blocks/sharing/sharing-checkbox.js
+++ b/extensions/blocks/sharing/sharing-checkbox.js
@@ -6,14 +6,21 @@ import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
+
 const SharingCheckbox = ( { isSharingEnabled, editPost } ) => (
-	<CheckboxControl
-		label={ __( 'Show sharing buttons.', 'jetpack' ) }
-		checked={ isSharingEnabled }
-		onChange={ value => {
-			editPost( { jetpack_sharing_enabled: value } );
-		} }
-	/>
+	<JetpackLikesAndSharingPanel>
+		<CheckboxControl
+			label={ __( 'Show sharing buttons.', 'jetpack' ) }
+			checked={ isSharingEnabled }
+			onChange={ value => {
+				editPost( { jetpack_sharing_enabled: value } );
+			} }
+		/>
+	</JetpackLikesAndSharingPanel>
 );
 
 // Fetch the post meta.

--- a/extensions/shared/jetpack-likes-and-sharing-panel.js
+++ b/extensions/shared/jetpack-likes-and-sharing-panel.js
@@ -3,21 +3,33 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createSlotFill, PanelBody } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import JetpackPluginSidebar from './jetpack-plugin-sidebar';
 
 const { Fill, Slot } = createSlotFill( 'JetpackLikesAndSharingPanel' );
 
-const JetpackLikesAndSharingPanel = ( { children } ) => <Fill>{ children }</Fill>;
+export { Fill as default };
 
-JetpackLikesAndSharingPanel.Slot = () => (
-	<Slot>
-		{ fills => {
-			if ( ! fills.length ) {
-				return null;
-			}
+registerPlugin( 'jetpack-likes-and-sharing-panel', {
+	render() {
+		return (
+			<Slot>
+				{ fills => {
+					if ( ! fills.length ) {
+						return null;
+					}
 
-			return <PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>;
-		} }
-	</Slot>
-);
-
-export default JetpackLikesAndSharingPanel;
+					return (
+						<JetpackPluginSidebar>
+							<PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>
+						</JetpackPluginSidebar>
+					);
+				} }
+			</Slot>
+		);
+	},
+} );

--- a/extensions/shared/jetpack-plugin-sidebar.js
+++ b/extensions/shared/jetpack-plugin-sidebar.js
@@ -11,37 +11,30 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import './jetpack-plugin-sidebar.scss';
 import JetpackLogo from './jetpack-logo';
-import JetpackLikesAndSharingPanel from './jetpack-likes-and-sharing-panel';
 
 const { Fill, Slot } = createSlotFill( 'JetpackPluginSidebar' );
 
-const JetpackPluginSidebar = ( { children } ) => <Fill>{ children }</Fill>;
-
-JetpackPluginSidebar.Slot = () => (
-	<Slot>
-		{ fills => {
-			const likesAndSharingPanel = <JetpackLikesAndSharingPanel.Slot />;
-			if ( ! fills.length && ! likesAndSharingPanel ) {
-				return null;
-			}
-
-			return (
-				<Fragment>
-					<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
-						Jetpack
-					</PluginSidebarMoreMenuItem>
-					<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
-						{ fills }
-						{ likesAndSharingPanel }
-					</PluginSidebar>
-				</Fragment>
-			);
-		} }
-	</Slot>
-);
+export { Fill as default };
 
 registerPlugin( 'jetpack-sidebar', {
-	render: () => <JetpackPluginSidebar.Slot />,
-} );
+	render: () => (
+		<Slot>
+			{ fills => {
+				if ( ! fills.length ) {
+					return null;
+				}
 
-export default JetpackPluginSidebar;
+				return (
+					<Fragment>
+						<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
+							Jetpack
+						</PluginSidebarMoreMenuItem>
+						<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
+							{ fills }
+						</PluginSidebar>
+					</Fragment>
+				);
+			} }
+		</Slot>
+	),
+} );

--- a/extensions/shared/jetpack-plugin-sidebar.js
+++ b/extensions/shared/jetpack-plugin-sidebar.js
@@ -20,7 +20,8 @@ const JetpackPluginSidebar = ( { children } ) => <Fill>{ children }</Fill>;
 JetpackPluginSidebar.Slot = () => (
 	<Slot>
 		{ fills => {
-			if ( ! fills.length ) {
+			const likesAndSharingPanel = <JetpackLikesAndSharingPanel.Slot />;
+			if ( ! fills.length && ! likesAndSharingPanel ) {
 				return null;
 			}
 
@@ -31,7 +32,7 @@ JetpackPluginSidebar.Slot = () => (
 					</PluginSidebarMoreMenuItem>
 					<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
 						{ fills }
-						<JetpackLikesAndSharingPanel.Slot />
+						{ likesAndSharingPanel }
 					</PluginSidebar>
 				</Fragment>
 			);


### PR DESCRIPTION
Likes and sharing are two independent plugins that render checkboxes in the same panel of the Jetpack sidebar.

There is an issue where the absence of other, unrelated sidebar panels causes the entire sidebar to be hidden, unintentionally hiding likes and sharing options:

https://github.com/Automattic/jetpack/blob/08a66d779ceb27fc5c98324ec4df8a0fa9f68f6f/extensions/shared/jetpack-plugin-sidebar.js#L23-L37

---

The likes and sharing panel becomes another plugin, very similar to the Jetpack sidebar. This allows slot/fill to work correctly at all the levels. It is an independent plugin so that it can register (render) the slot 1 time while being used by 0 or more independent plugins to cause the panel to render 0 or 1 times as necessary.

The panel is also a true fill of the Jetpack sidebar, fixing the initial problem where it was a sibling of the fills. The sidebar is not rendered if there are no fills, which is why the sibling approach was a problem. As a true fill, the existing mechanism to show/hide the sidebar remains untouched.

This PR also includes some Janitorial work around the existing sidebar and the slot/fills:
- Better use of named/default exports
- Do not attach slot to the fill as `FillComponent.Slot`. These slots are not intended to be rendered outside of these components, do not export them.
- Remove redundant component wrapping

---

## Testing instructions (from #12045):

1. Edit both posts and pages and ensure that the Jetpack sidebar is visible when necessary (sidebar contains panels).
1. Enable and disable the Likes and Sharing button modules and ensure that checkboxes are only shown for active modules.
1. Finally, ensure the checkboxes still toggle the buttons on the front-end correctly.

---

Supersedes: 
- Closes #12045 
- Closes #12049
- [fix/likes-shares-separate-boxes](https://github.com/Automattic/jetpack/tree/fix/likes-shares-separate-boxes) (no PR)