### PR TITLE
Prevent notice about JETPACK__PLUGIN_DIR already being defined when programmatically uninstalling Jetpack

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -11,7 +11,9 @@ if (
 	exit;
 }
 
-define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
+if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
+	define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
+}
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-options.php';
 
 Jetpack_Options::delete_all_known_options();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Related to https://github.com/Automattic/newspack-plugin/pull/9#issuecomment-482714782

Currently, uninstall.php defines the JETPACK__PLUGIN_DIR without checking if it's already been defined. This causes a `Notice: Constant JETPACK__PLUGIN_DIR already defined in /srv/www/newspack/wp-content/plugins/jetpack/uninstall.php on line 14` error when programmatically uninstalling Jetpack, since Jetpack constants have already been defined.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate Jetpack.
2. Add the following code snippet somewhere and refresh the page:
```
add_action( 'admin_init', function(){
	$plugin_file = 'jetpack/jetpack.php';
	deactivate_plugins( $plugin_file );
	delete_plugins( [ $plugin_file ] );
});
```
3. Before implementing this change, observe a notice is thrown when uninstalling, since Jetpack has loaded.
4. After implementing this change, observe no notice is thrown.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix - Prevent notice about JETPACK__PLUGIN_DIR already being defined when programmatically uninstalling Jetpack.
