### PR TITLE
AMP: check if class exists before to use it.

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -117,7 +117,10 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function frontend_init() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return;
 		}
 

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -235,7 +235,10 @@ CONTAINER;
 
 			$item_id = esc_js( $item_id );
 
-			if ( Jetpack_AMP_Support::is_amp_request() ) {
+			if (
+				class_exists( 'Jetpack_AMP_Support' )
+				&& Jetpack_AMP_Support::is_amp_request()
+			) {
 				return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $permalink ), esc_html( trim( $title ) ) );
 			} elseif ( $inline ) {
 				return <<<SCRIPT
@@ -279,7 +282,10 @@ CONTAINER;
 			$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
 			$poll_link = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $poll_url ), esc_html( $title ) );
 
-			if ( $no_script || Jetpack_AMP_Support::is_amp_request() ) {
+			if (
+				$no_script
+				|| ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() )
+			) {
 				return $poll_link;
 			} else {
 				if ( $type == 'slider' && !$inline ) {

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -74,7 +74,10 @@ class Milestone_Widget extends WP_Widget {
 	}
 
 	public static function enqueue_template() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+		class_exists( 'Jetpack_AMP_Support' )
+		&& Jetpack_AMP_Support::is_amp_request()
+	) {
 			return;
 		}
 
@@ -179,7 +182,10 @@ class Milestone_Widget extends WP_Widget {
 	 * Hooks into the "wp_footer" action.
 	 */
 	function localize_script() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return;
 		}
 


### PR DESCRIPTION
**Not ready for review yet. Waiting on D26821-code to land**

#### Changes proposed in this Pull Request:

This is important for files that are currently in sync with WordPress.com,
where we don't include the Jetpack_AMP_Support class yet.

See D26821-code for more details.

#### Testing instructions:

* All features should remain as before when the AMP plugin is active. (see #11195 for some examples)
* You should also not see any errors / notices in your logs.

#### Proposed changelog entry for your changes:

* None
