### PR TITLE
Travis: Remove PHP 5.2 from WP Master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,10 @@ matrix:
   include:
   # The versions listed below run within Precise distro with PHP 5.2 due to Travis limitation
   - php: "5.2"
-    env: WP_MODE=single WP_BRANCH=master
-    dist: precise
-  - php: "5.2"
     env: WP_MODE=single WP_BRANCH=latest
     dist: precise
   - php: "5.2"
     env: WP_MODE=single WP_BRANCH=previous
-    dist: precise
-  - php: "5.2"
-    env: WP_MODE=multi  WP_BRANCH=master
     dist: precise
   - if: branch !~ /(^branch-.*-built)/
     language: node_js


### PR DESCRIPTION
We don't need PHP 5.2 tests on WP master any longer.

Fixes #

#### Changes proposed in this Pull Request:
* Remove tests for WordPress master running on PHP 5.2. WP now requires 5.6+.

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:

* n/a
