### PR TITLE
Sharing: Change Post Flair to request Facebook count from WPCOM API

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -607,10 +607,16 @@ function sharing_add_footer() {
 		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
+				/** This filter is documented in class.json-api-endpoints.php */
+				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+				$site_id    = $is_jetpack ? Jetpack_Options::get_option( 'id' ) : get_current_blog_id();
 				?>
 
 	<script type="text/javascript">
 		window.WPCOM_sharing_counts = <?php echo json_encode( array_flip( $sharing_post_urls ) ); ?>;
+		<?php if ( is_int( $site_id ) ): ?>
+		window.WPCOM_site_ID = <?php echo $site_id ?>;
+		<?php endif; ?>
 	</script>
 				<?php
 			endif;

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -594,17 +594,25 @@ function sharing_add_footer() {
 	 * @param bool true Control whether the sharing module should add any JavaScript to the site. Default to true.
 	 */
 	if ( apply_filters( 'sharing_js', true ) && sharing_maybe_enqueue_scripts() ) {
-
-		/**
-		 * Filter the display of sharing counts next to the sharing buttons.
-		 *
-		 * @module sharedaddy
-		 *
-		 * @since 3.2.0
-		 *
-		 * @param bool true Control the display of counters next to the sharing buttons. Default to true.
-		 */
-		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
+		if (
+			/**
+			 * Filter the display of sharing counts next to the sharing buttons.
+			 *
+			 * @module sharedaddy
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param bool true Control the display of counters next to the sharing buttons. Default to true.
+			 */
+			apply_filters( 'jetpack_sharing_counts', true )
+			&& is_array( $jetpack_sharing_counts )
+			&& count( $jetpack_sharing_counts )
+			// We cannot get Facebook sharing counts if a site is not connected to WordPress.com.
+			&& (
+				Jetpack::is_active()
+				|| ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			)
+		) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
 				/** This filter is documented in class.json-api-endpoints.php */


### PR DESCRIPTION
**Do not merge**

Related:
- D27003-code for WordPress.com
- p8F0Ux-1Bj-p2 for more details.

#### Changes proposed in this Pull Request:

**This patch is for use if the old Facebook share count endpoint does disappear and we need to restore the count on the FB button.**

* Facebook are due to close down their v2.8 API this week (see [this post](https://developers.facebook.com/docs/graph-api/changelog) for more info). When that happens, unversioned requests will supposedly be directed to the lowest available API. 
* With v2.9 of the FB API, the request and response formats are changing.
* Theoretically, this means the request to `//graph.facebook.com/?callback=WPCOMSharing.update_facebook_count&ids=[ URL ]` for the post flair FB share button will stop working, i.e. this share count bubble won't appear:

![preview-facebook-button](https://user-images.githubusercontent.com/426388/56231506-ea073f00-607e-11e9-8504-7a6f52924a06.png)

* The JS request to the API should fail gracefully. However, based on what happened in the past in #2495 (see [this Facebook bug](https://developers.facebook.com/bugs/1461118160858999) for more info), it's possible the unversioned endpoint may continue to work as before. In that case, we may choose to leave the request as is till we decide what to do.
* Using the WordPress.com REST API for all sharing button requests is significant; this consequently should not be merged without further discussion. See p8F0Ux-1Bj-p2 to find out more.

#### Testing instructions:

* Apply the patch.
* Add a Facebook sharing button to your site, using one of the non-official button types.
    * Click the button to share your post on Facebook; the button should still work with no JavaScript errors.
    * When loading any page with a button, you should see requests to the `sharing-buttons/facebook/count` endpoint being made.
    * The Facebook sharing counts should be displayed.
* Add a Pinterest button next to the Facebook button, and make sure that button works and counts well as well.

#### Proposed changelog entry for your changes:

* Sharing: implement new method to store counts for the Facebook sharing button.
