### PR TITLE
REST API: Fix missing post type in autosaves.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
@@ -75,6 +75,7 @@ class WPCOM_JSON_API_Autosave_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_
 
 		$post_data = array (
 			'post_ID'      => $post_id,
+			'post_type'    => $post->post_type,
 			'post_title'   => $input['title'],
 			'post_content' => $input['content'],
 			'post_excerpt' => $input['excerpt'],


### PR DESCRIPTION
We currently have warnings triggered by the API on autosave calls:

<img width="1492" alt="Screen Shot 2019-04-16 at 1 40 45 PM" src="https://user-images.githubusercontent.com/349751/56242497-48b3c500-604d-11e9-85c5-a80529f38563.png">

[`wp_create_post_autosave`](https://developer.wordpress.org/reference/functions/wp_create_post_autosave/) calls [`_wp_translate_postdata`](https://developer.wordpress.org/reference/functions/_wp_translate_postdata/), which expects a post type to be present (reasonable assumption, I'd say). This PR just adds the current post's post type to the post data passed into `wp_create_post_autosave`.

I haven't seen an actual buggy behaviour, but I'm sure it'll fix something somewhere ¯\_(ツ)_/¯

**Testing Instructions**
* Tail the error log of a JP test site.
* Open that site in Calypso, and edit a post in the Calypso editor.
* Make change, and click Preview (this will trigger an autosave).
* Observe the log warning.
* Apply this branch to test site.
* Repeat the above editing steps.
* Verify there's no logged error.