### PR TITLE
VaultPress module: Fix fatal on REST API request when forging configure URL.

### DIFF
--- a/modules/vaultpress.php
+++ b/modules/vaultpress.php
@@ -28,5 +28,6 @@ function vaultpress_jetpack_module_free_text() {
 }
 
 function vaultpress_jetpack_configure_url() {
+	include_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 	return menu_page_url( 'vaultpress', false );
 }


### PR DESCRIPTION

Fixes fatal when hitting the `/jetpack/v4/module/all` endpoint.

```
Uncaught Error: Call to undefined function menu_page_url() in modules/vaultpress.php:31`
```
#### Changes proposed in this Pull Request:

<!--- Explain what functional changes your PR includes -->

* includes `plugin.php` before calling `menu_page_url` to get a configure URL.

#### Testing instructions:

* Check out this branch (or using the Jetpack Beta Tester plugin).
* Monitor the log for the site (site should be connected)
* Visit calypso security settings (a request to `/jetpack/v4/module/all` gets done from there, 
* Confirm the log does not show any error.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed.
