### PR TITLE
Upgrade prettier package

### DIFF
--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -73,8 +73,8 @@
 
 		overlay.fadeOut( 400, function() {
 			overlay.remove();
-			var widgetSection = document.querySelector(".widget.widget_eu_cookie_law_widget");
-			widgetSection.parentNode.removeChild(widgetSection);
+			var widgetSection = document.querySelector( '.widget.widget_eu_cookie_law_widget' );
+			widgetSection.parentNode.removeChild( widgetSection );
 		} );
 	}
 } )( jQuery );

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
 		"mockery": "2.1.0",
 		"nock": "10.0.6",
 		"node-wp-i18n": "1.2.3",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
+		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
 		"react-test-renderer": "16.8.6",
 		"sinon": "7.3.1",
 		"sinon-chai": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9175,9 +9175,9 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-"prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz":
-  version "1.16.4"
-  resolved "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz#06cbfb8c96bc095fff9c49ca1afe5075514d2f26"
+"prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz":
+  version "1.17.0"
+  resolved "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz#6528e5a8579619dbf31bd511de4a5c6800674db3"
 
 pretty-format@^24.7.0:
   version "24.7.0"


### PR DESCRIPTION
This is an easy one! Prettier is ready for an upgrade. See https://github.com/Automattic/wp-calypso/pull/32360

- Run old prettier
- Upgrade
- Run new prettier (no change, no commit)

## Testing
- Only formatting changes (no functional changes)
- `yarn && yarn reformat-files` - clean repo 