### PR TITLE
CLI: Add a new command that lets you remove the callback checksum across all sites on a network

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -364,7 +364,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					if ( $count_fixes ) {
 						WP_CLI::success(
 							sprintf(
-								__( "Successfully reset %s on %s sites.", 'jetpack' ),
+								__( 'Successfully reset %s on %s sites.', 'jetpack' ),
 								$option,
 								$count_fixes
 							)

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -254,7 +254,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 */
 	public function reset( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'prompt';
-		if ( ! in_array( $action, array( 'options', 'modules', 'sync-checksum' ) ) ) {
+		if ( ! in_array( $action, array( 'options', 'modules', 'sync-checksum' ), true ) ) {
 			/* translators: %s is a command like "prompt" */
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -262,7 +262,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		// Are you sure?
 		jetpack_cli_are_you_sure();
 
-		$is_dry_run  = ! empty( $assoc_args['dry-run'] );
+		$is_dry_run = ! empty( $assoc_args['dry-run'] );
 
 		switch ( $action ) {
 			case 'options':

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -263,12 +263,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( $is_dry_run ) {
 			WP_CLI::warning(
-				__(
-					"\nThis is a `Dry Run`.\n" .
-					"No actions will be taken.\n" .
-					"The following messages will give you preview of what will happen when you run this command.\n\n",
-					'jetpack'
-				)
+				__( "\nThis is a dry run.\n", 'jetpack' ) .
+				__( "No actions will be taken.\n", 'jetpack' ) .
+				__( "The following messages will give you preview of what will happen when you run this command.\n\n", 'jetpack' )
 			);
 		} else {
 			// We only need to confirm "Are you sure?" when we are not doing a dry run.
@@ -335,14 +332,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 			case 'sync-checksum':
 				$option = 'jetpack_callables_sync_checksum';
 
-
-
 				if ( is_multisite() ) {
 					$offset = isset( $assoc_args['offset'] ) ? (int) $assoc_args['offset'] : 0;
-					// 1000 is a good limit since we don't expect the number of sites to be more then 1000 on sites
-					// Offset can be used to paginate and try to clean up more sites.
-					$sites        = get_sites( array( 'number' => 1000, 'offset' => $offset ) );
-					$count_fixes  = 0;
+
+					/*
+					 * 1000 is a good limit since we don't expect the number of sites to be more than 1000
+					 * Offset can be used to paginate and try to clean up more sites.
+					 */
+					$sites       = get_sites( array( 'number' => 1000, 'offset' => $offset ) );
+					$count_fixes = 0;
 					foreach ( $sites as $site ) {
 						switch_to_blog( $site->blog_id );
 						$count = self::count_option( $option );
@@ -350,11 +348,21 @@ class Jetpack_CLI extends WP_CLI_Command {
 							if ( ! $is_dry_run ) {
 								delete_option( $option );
 							}
-							WP_CLI::line( sprintf( __( 'Deleted %s %s options from %s', 'jetpack' ), $count, $option, "{$site->domain}{$site->path}" ) );
+							WP_CLI::line(
+								sprintf(
+									/* translators: %1$d is a number, %2$s is the name of an option, %2$s is the site URL. */
+									__( 'Deleted %1$d %2$s options from %3$s', 'jetpack' ),
+									$count,
+									$option,
+									"{$site->domain}{$site->path}"
+								)
+							);
 							$count_fixes++;
 							if ( ! $is_dry_run ) {
-								// We could be deleting a lot of options rows at the same time.
-								// Allow some time for replication to catch up.
+								/*
+								 * We could be deleting a lot of options rows at the same time.
+								 * Allow some time for replication to catch up.
+								 */
 								sleep( 3 );
 							}
 						}
@@ -364,7 +372,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 					if ( $count_fixes ) {
 						WP_CLI::success(
 							sprintf(
-								__( 'Successfully reset %s on %s sites.', 'jetpack' ),
+								/* translators: %1$s is the name of an option, %2$d is a number of sites. */
+								__( 'Successfully reset %1$s on %2$d sites.', 'jetpack' ),
 								$option,
 								$count_fixes
 							)
@@ -382,7 +391,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 					}
 					WP_CLI::success(
 						sprintf(
-							__( 'Deleted %s %s options', 'jetpack' ),
+							/* translators: %1$d is a number, %2$s is the name of an option. */
+							__( 'Deleted %1$d %2$s options', 'jetpack' ),
 							$count,
 							$option
 						)
@@ -401,15 +411,16 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * Normally an option would only appear 1 since the option key is supposed to be unique
 	 * but if a site hasn't updated the DB schema then that would not be the case.
 	 *
-	 * @param $option
+	 * @param string $option Option name.
 	 *
 	 * @return int
 	 */
-	static function count_option( $option ) {
+	private static function count_option( $option ) {
 		global $wpdb;
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM $wpdb->options WHERE option_name = %s", $option
+				"SELECT COUNT(*) FROM $wpdb->options WHERE option_name = %s",
+				$option
 			)
 		);
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -333,7 +333,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI::error( __( 'Please specify if you would like to reset your options, modules or sync-checksum', 'jetpack' ) );
 				break;
 			case 'sync-checksum':
-				global $wpdb;
 				$option = 'jetpack_callables_sync_checksum';
 
 				if ( is_multisite() && function_exists( 'get_sites' ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -399,7 +399,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	/**
 	 * Return the number of times an option appears
 	 * Normally an option would only appear 1 since the option key is supposed to be unique
-	 * but if a site hasn't update the DB schema then that would not be the case.
+	 * but if a site hasn't updated the DB schema then that would not be the case.
 	 *
 	 * @param $option
 	 *

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -352,8 +352,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 							}
 							WP_CLI::line( sprintf( __( 'Deleted %s %s options from %s', 'jetpack' ), $count, $option, "{$site->domain}{$site->path}" ) );
 							$count_fixes++;
-							$sleep_duration = ( $is_dry_run ? 1 : 3 );
-							sleep( $sleep_duration ); // Allow some time for replication to catch up.
+							if ( ! $is_dry_run ) {
+								// We could be deleting a lot of options rows at the same time.
+								// Allow some time for replication to catch up.
+								sleep( 3 );
+							}
 						}
 
 						restore_current_blog();

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -387,7 +387,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					return;
 				}
 
-				WP_CLI::success( __( "No options were deleted.", 'jetpack' ) );
+				WP_CLI::success( __( 'No options were deleted.', 'jetpack' ) );
 				break;
 
 		}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -367,7 +367,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 					if ( ! $is_dry_run ) {
 						delete_option( $option );
 					}
-					WP_CLI::success( sprintf( __( 'Deleted %s %s options', 'jetpack' ), $count, $option ) );
+					WP_CLI::success(
+						sprintf(
+							__( 'Deleted %s %s options', 'jetpack' ),
+							$count,
+							$option
+						)
+					);
 					return;
 				}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -259,11 +259,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}
 
-		// Are you sure?
-		jetpack_cli_are_you_sure();
-
 		$is_dry_run = ! empty( $assoc_args['dry-run'] );
 
+		if ( ! $is_dry_run ) {
+			// We only need to confirm "Are you sure?" when we are not doing a dry run.
+			jetpack_cli_are_you_sure();
+		}
+		
 		switch ( $action ) {
 			case 'options':
 				$options_to_reset = Jetpack_Options::get_options_for_reset();

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -355,7 +355,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 						restore_current_blog();
 					}
 					if ( $count_fixes ) {
-						WP_CLI::success( sprintf( __( "Successfully reset %s on %s sites.", 'jetpack' ), $option, $count_fixes ) );
+						WP_CLI::success(
+							sprintf(
+								__( "Successfully reset %s on %s sites.", 'jetpack' ),
+								$option,
+								$count_fixes
+							)
+						);
 					} else {
 						WP_CLI::success( __( "No options were deleted.", 'jetpack' ) );
 					}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -391,7 +391,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 	static function count_option( $option ) {
 		global $wpdb;
-		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->options WHERE option_name = %s", $option ) );
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM $wpdb->options WHERE option_name = %s", $option
+			)
+		);
 
 	}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -370,7 +370,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 							)
 						);
 					} else {
-						WP_CLI::success( __( "No options were deleted.", 'jetpack' ) );
+						WP_CLI::success( __( 'No options were deleted.', 'jetpack' ) );
 					}
 					return;
 				}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -348,7 +348,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 							}
 							WP_CLI::line( sprintf( __( 'Deleted %s %s options from %s', 'jetpack' ), $count, $option, "{$site->domain}{$site->path}" ) );
 							$count_fixes++;
-							$sleep_duration = ( $is_dry_run ? 1 : 20 );
+							$sleep_duration = ( $is_dry_run ? 1 : 3 );
 							sleep( $sleep_duration ); // Allow some time for replication to catch up.
 						}
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -335,7 +335,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				}
 
 				if ( is_multisite() && function_exists( 'get_sites' ) ) {
-					$sites  = get_sites( array( 'number' => 1000 ) );
+					$sites        = get_sites( array( 'number' => 1000 ) );
 					$count_fixes  = 0;
 					foreach ( $sites as $site ) {
 						switch_to_blog( $site->blog_id );


### PR DESCRIPTION
Currently some site experience a problem where we create numerous `jetpack_callables_sync_checksum` options being added because of sync.

This happens on old sites with old db schemas where `option_name` wasn't unique.

This PR provides a new wp cli command that helps remove the option that appears multiple times in the table.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a wp cli command that deletes the `jetpack_callables_sync_checksum` across all the sites on the network as well as on single sites.

#### Testing instructions:
* Setup a multi site.
* Create the option in the table multiple times. (This part is tricky since in newer wp install this is not possible) 
* Does remove all the instances of that option? 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* A new wp cli command. 
