### PR TITLE
Likes and Sharing: Hide metaboxes on private post types

### DIFF
--- a/extensions/blocks/likes/likes-checkbox.js
+++ b/extensions/blocks/likes/likes-checkbox.js
@@ -13,7 +13,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 
 const LikesCheckbox = ( { areLikesEnabled, editPost } ) => (
-	<PostTypeSupportCheck supportKeys="likes">
+	<PostTypeSupportCheck supportKeys="jetpack-post-likes">
 		<JetpackLikesAndSharingPanel>
 			<CheckboxControl
 				label={ __( 'Show likes.', 'jetpack' ) }

--- a/extensions/blocks/likes/likes-checkbox.js
+++ b/extensions/blocks/likes/likes-checkbox.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+import { PostTypeSupportCheck } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -12,15 +13,17 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 
 const LikesCheckbox = ( { areLikesEnabled, editPost } ) => (
-	<JetpackLikesAndSharingPanel>
-		<CheckboxControl
-			label={ __( 'Show likes.', 'jetpack' ) }
-			checked={ areLikesEnabled }
-			onChange={ value => {
-				editPost( { jetpack_likes_enabled: value } );
-			} }
-		/>
-	</JetpackLikesAndSharingPanel>
+	<PostTypeSupportCheck supportKeys="likes">
+		<JetpackLikesAndSharingPanel>
+			<CheckboxControl
+				label={ __( 'Show likes.', 'jetpack' ) }
+				checked={ areLikesEnabled }
+				onChange={ value => {
+					editPost( { jetpack_likes_enabled: value } );
+				} }
+			/>
+		</JetpackLikesAndSharingPanel>
+	</PostTypeSupportCheck>
 );
 
 // Fetch the post meta.

--- a/extensions/blocks/sharing/sharing-checkbox.js
+++ b/extensions/blocks/sharing/sharing-checkbox.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+import { PostTypeSupportCheck } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -12,15 +13,17 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 
 const SharingCheckbox = ( { isSharingEnabled, editPost } ) => (
-	<JetpackLikesAndSharingPanel>
-		<CheckboxControl
-			label={ __( 'Show sharing buttons.', 'jetpack' ) }
-			checked={ isSharingEnabled }
-			onChange={ value => {
-				editPost( { jetpack_sharing_enabled: value } );
-			} }
-		/>
-	</JetpackLikesAndSharingPanel>
+	<PostTypeSupportCheck supportKeys="sharing">
+		<JetpackLikesAndSharingPanel>
+			<CheckboxControl
+				label={ __( 'Show sharing buttons.', 'jetpack' ) }
+				checked={ isSharingEnabled }
+				onChange={ value => {
+					editPost( { jetpack_sharing_enabled: value } );
+				} }
+			/>
+		</JetpackLikesAndSharingPanel>
+	</PostTypeSupportCheck>
 );
 
 // Fetch the post meta.

--- a/extensions/blocks/sharing/sharing-checkbox.js
+++ b/extensions/blocks/sharing/sharing-checkbox.js
@@ -13,7 +13,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 
 const SharingCheckbox = ( { isSharingEnabled, editPost } ) => (
-	<PostTypeSupportCheck supportKeys="sharing">
+	<PostTypeSupportCheck supportKeys="jetpack-sharing-buttons">
 		<JetpackLikesAndSharingPanel>
 			<CheckboxControl
 				label={ __( 'Show sharing buttons.', 'jetpack' ) }

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -626,6 +626,12 @@ function jetpack_post_likes_register_rest_field() {
 				),
 			)
 		);
+
+		/**
+		 * Ensures all public internal post-types support `likes`
+		 * This feature support flag is used by the REST API and Gutenberg.
+		 */
+		add_post_type_support( $post_type, 'likes' );
 	}
 }
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -631,7 +631,7 @@ function jetpack_post_likes_register_rest_field() {
 		 * Ensures all public internal post-types support `likes`
 		 * This feature support flag is used by the REST API and Gutenberg.
 		 */
-		add_post_type_support( $post_type, 'likes' );
+		add_post_type_support( $post_type, 'jetpack-post-likes' );
 	}
 }
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -604,6 +604,12 @@ function jetpack_post_sharing_register_rest_field() {
 				),
 			)
 		);
+
+		/**
+		 * Ensures all public internal post-types support `sharing`
+		 * This feature support flag is used by the REST API and Gutenberg.
+		 */
+		add_post_type_support( $post_type, 'sharing' );
 	}
 }
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -609,7 +609,7 @@ function jetpack_post_sharing_register_rest_field() {
 		 * Ensures all public internal post-types support `sharing`
 		 * This feature support flag is used by the REST API and Gutenberg.
 		 */
-		add_post_type_support( $post_type, 'sharing' );
+		add_post_type_support( $post_type, 'jetpack-sharing-buttons' );
 	}
 }
 


### PR DESCRIPTION
One last follow-up to the Likes and Sharing sidebar! This fixes the bug where the Likes and Sharing checkboxes are shown on non-public post types such as reusable blocks.

This is a fix for the issue noted by @simison here: https://github.com/Automattic/jetpack/pull/12045#pullrequestreview-226502767

#### Changes proposed in this Pull Request:

* This follows the pattern used by the Publicize extension to use `add_post_type_support` (WP core) and `<PostTypeSupportCheck>` (from `@wordpress/editor`) to conditionally render only on supported post types.

#### Testing instructions (longer version [here](https://github.com/Automattic/jetpack/pull/12045#pullrequestreview-226502767)):
- Turn a block into a re-usable block
- Go to block picker, scroll down to "Reusable" category and choose "Manage All Reusable Blocks".
- You'll end up to `/wp-admin/edit.php?post_type=wp_block`
- Pick a re-usable block to modify
- Likes and Sharing should not be shown in the sidebar.
- Verify that the checkboxes are still shown correctly on public post types such as posts, pages, testimonials, etc.
- Disable individual modules and verify that only the active module gets a checkbox.
- Smoke test other behavior of this feature to check for regressions.

#### Proposed changelog entry for your changes:
* Don't show Likes and Sharing checkboxes when editing private post types.