### PR TITLE
Settings - Writing: introduce a toggle for Custom CSS

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -40,7 +40,6 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 			// Only should be features that don't already have a UI, and we want to reveal in search.
 			const whitelist = [
 				'contact-form',
-				'custom-css',
 				'enhanced-distribution',
 				'json-api',
 				'latex',

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -44,6 +44,7 @@ export class Writing extends React.Component {
 		const found = [
 			'carousel',
 			'copy-post',
+			'custom-css',
 			'masterbar',
 			'markdown',
 			'shortcodes',

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -202,7 +202,7 @@ class ThemeEnhancements extends React.Component {
 				) }
 				{ foundCustomCSS && (
 					<SettingsGroup
-						module="custom-css"
+						module={ { module: customCSS.module } }
 						support={ {
 							text: customCSS.description,
 							link: 'https://jetpack.com/support/custom-css/',

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -120,14 +120,16 @@ class ThemeEnhancements extends React.Component {
 
 	render() {
 		const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
+			foundCustomCSS = this.props.isModuleFound( 'custom-css' ),
 			foundMinileven = this.props.isModuleFound( 'minileven' );
 
-		if ( ! foundInfiniteScroll && ! foundMinileven ) {
+		if ( ! foundInfiniteScroll && ! foundMinileven && ! foundCustomCSS ) {
 			return null;
 		}
 
 		const infScr = this.props.getModule( 'infinite-scroll' );
 		const minileven = this.props.getModule( 'minileven' );
+		const customCSS = this.props.getModule( 'custom-css' );
 		const isMinilevenActive = this.props.getOptionValue( minileven.module );
 
 		const infiniteScrollDisabledByOverride =
@@ -196,6 +198,27 @@ class ThemeEnhancements extends React.Component {
 								</a>
 							</span>
 						) }
+					</SettingsGroup>
+				) }
+				{ foundCustomCSS && (
+					<SettingsGroup
+						module="custom-css"
+						support={ {
+							text: customCSS.description,
+							link: 'https://jetpack.com/support/custom-css/',
+						} }
+					>
+						<ModuleToggle
+							slug="custom-css"
+							activated={ !! this.props.getOptionValue( 'custom-css' ) }
+							toggling={ this.props.isSavingAnyOption( [ 'custom-css' ] ) }
+							disabled={ this.props.isSavingAnyOption( [ 'custom-css' ] ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Enhance CSS customization panel' ) }
+							</span>
+						</ModuleToggle>
 					</SettingsGroup>
 				) }
 				{ foundMinileven && (

--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -2,11 +2,11 @@
 
 /**
  * Module Name: Custom CSS
- * Module Description: Tweak your site’s CSS without modifying your theme.
+ * Module Description: Adds options for CSS preprocessor use, disabling the theme's CSS, or custom image width.
  * Sort Order: 2
  * First Introduced: 1.7
  * Requires Connection: No
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Appearance
  * Feature: Appearance
  * Additional Search Queries: css, customize, custom, style, editor, less, sass, preprocessor, font, mobile, appearance, theme, stylesheet


### PR DESCRIPTION
Since Custom CSS won't be active by default in the next version, we need this toggle so users can activate it.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #11932

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* add toggle for Custom CSS in Theme Enhancements
* make setting searchable
* remove searchable module
* don't activate Custom CSS module by default

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Settings > Writing tab
* Verify that the toggle is in the Theme Enhancements group

<img width="872" alt="Captura de Pantalla 2019-04-18 a la(s) 14 59 50" src="https://user-images.githubusercontent.com/1041600/56381732-155b6c80-61ec-11e9-916c-a68544a7798e.png">

* It should work. Verify the custom CSS enhancements in the Customizer. When it's on, for example, it adds a toggle for preprocessors.
* initiate a settings search, you should be able to find the feature. The old searchable module shouldn't show up.

<img width="867" alt="Captura de Pantalla 2019-04-18 a la(s) 14 58 39" src="https://user-images.githubusercontent.com/1041600/56381821-4340b100-61ec-11e9-94e2-862cb368c088.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* 
