### PR TITLE
Settings: module prioritization for Widgets or Widget Visibility

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -48,8 +48,6 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 				'notes',
 				'shortcodes',
 				'shortlinks',
-				'widget-visibility',
-				'widgets',
 			];
 
 			const allModules = this.props.modules,

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -52,6 +52,7 @@ export class Writing extends React.Component {
 			'infinite-scroll',
 			'minileven',
 			'widgets',
+			'widget-visibility',
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
@@ -91,7 +92,7 @@ export class Writing extends React.Component {
 					<CustomContentTypes { ...commonProps } />
 				) }
 				<ThemeEnhancements { ...commonProps } />
-				{ this.props.isModuleFound( 'widgets' ) && <Widgets { ...commonProps } /> }
+				<Widgets { ...commonProps } />
 				{ this.props.isModuleFound( 'post-by-email' ) && showPostByEmail && (
 					<PostByEmail
 						{ ...commonProps }

--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -56,7 +56,9 @@ class Widgets extends Component {
 					<SettingsGroup
 						module={ { module: 'widget-visibility' } }
 						support={ {
-							text: __( 'Configure widgets to appear only on certain posts or pages.' ),
+							text: __(
+								'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.'
+							),
 							link: 'https://jetpack.com/support/widget-visibility/',
 						} }
 					>
@@ -67,7 +69,9 @@ class Widgets extends Component {
 							toggling={ this.props.isSavingAnyOption( 'widget-visibility' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-							{ __( 'Control where widgets appear on your site with visibility settings' ) }
+							{ __(
+								'Enable widget visibility controls to display widgets only on particular posts or pages'
+							) }
 						</ModuleToggle>
 					</SettingsGroup>
 				) }

--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -9,6 +9,7 @@ import { translate as __ } from 'i18n-calypso';
  */
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModule } from 'state/modules';
+import { isModuleFound } from 'state/search';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
@@ -16,6 +17,12 @@ import { ModuleToggle } from 'components/module-toggle';
 class Widgets extends Component {
 	render() {
 		const isLinked = this.props.isLinked;
+		const foundWidgets = this.props.isModuleFound( 'widgets' );
+		const foundWidgetVisibility = this.props.isModuleFound( 'widget-visibility' );
+
+		if ( ! foundWidgets && ! foundWidgetVisibility ) {
+			return null;
+		}
 
 		return (
 			<SettingsCard
@@ -24,42 +31,46 @@ class Widgets extends Component {
 				module="widgets"
 				hideButton
 			>
-				<SettingsGroup
-					module={ { module: 'widgets' } }
-					support={ {
-						text: this.props.widgetsModule.description,
-						link: 'https://jetpack.com/support/extra-sidebar-widgets/',
-					} }
-				>
-					<ModuleToggle
-						slug="widgets"
-						disabled={ ! isLinked }
-						activated={ this.props.widgetsActive }
-						toggling={ this.props.isSavingAnyOption( 'widgets' ) }
-						toggleModule={ this.props.toggleModuleNow }
+				{ foundWidgets && (
+					<SettingsGroup
+						module={ { module: 'widgets' } }
+						support={ {
+							text: this.props.widgetsModule.description,
+							link: 'https://jetpack.com/support/extra-sidebar-widgets/',
+						} }
 					>
-						{ __(
-							'Make extra widgets available for use on your site including subscription forms and Twitter streams'
-						) }
-					</ModuleToggle>
-				</SettingsGroup>
-				<SettingsGroup
-					module={ { module: 'widget-visibility' } }
-					support={ {
-						text: __( 'Configure widgets to appear only on certain posts or pages.' ),
-						link: 'https://jetpack.com/support/widget-visibility/',
-					} }
-				>
-					<ModuleToggle
-						slug="widget-visibility"
-						disabled={ ! isLinked }
-						activated={ this.props.widgetVisibilityActive }
-						toggling={ this.props.isSavingAnyOption( 'widget-visibility' ) }
-						toggleModule={ this.props.toggleModuleNow }
+						<ModuleToggle
+							slug="widgets"
+							disabled={ ! isLinked }
+							activated={ this.props.widgetsActive }
+							toggling={ this.props.isSavingAnyOption( 'widgets' ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							{ __(
+								'Make extra widgets available for use on your site including subscription forms and Twitter streams'
+							) }
+						</ModuleToggle>
+					</SettingsGroup>
+				) }
+				{ foundWidgetVisibility && (
+					<SettingsGroup
+						module={ { module: 'widget-visibility' } }
+						support={ {
+							text: __( 'Configure widgets to appear only on certain posts or pages.' ),
+							link: 'https://jetpack.com/support/widget-visibility/',
+						} }
 					>
-						{ __( 'Control where widgets appear on your site with visibility settings' ) }
-					</ModuleToggle>
-				</SettingsGroup>
+						<ModuleToggle
+							slug="widget-visibility"
+							disabled={ ! isLinked }
+							activated={ this.props.widgetVisibilityActive }
+							toggling={ this.props.isSavingAnyOption( 'widget-visibility' ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							{ __( 'Control where widgets appear on your site with visibility settings' ) }
+						</ModuleToggle>
+					</SettingsGroup>
+				) }
 			</SettingsCard>
 		);
 	}
@@ -71,6 +82,7 @@ export default withModuleSettingsFormHelpers(
 			widgetVisibilityActive: ownProps.getOptionValue( 'widget-visibility' ),
 			widgetsActive: ownProps.getOptionValue( 'widgets' ),
 			widgetsModule: getModule( state, 'widgets' ),
+			isModuleFound: module_name => isModuleFound( state, module_name ),
 		};
 	} )( Widgets )
 );

--- a/modules/widget-visibility.php
+++ b/modules/widget-visibility.php
@@ -1,11 +1,10 @@
 <?php
-
 /**
  * Module Name: Widget Visibility
  * Module Description: Control where widgets appear on your site.
  * First Introduced: 2.4
  * Requires Connection: No
- * Auto Activate: Yes
+ * Auto Activate: No
  * Sort Order: 17
  * Module Tags: Appearance
  * Feature: Appearance

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -5,7 +5,7 @@
  * Sort Order: 4
  * First Introduced: 1.2
  * Requires Connection: No
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Social, Appearance
  * Feature: Appearance
  * Additional Search Queries: widget, widgets, facebook, gallery, twitter, gravatar, image, rss


### PR DESCRIPTION
This PR amends a few things that were missing so we can finally close #11933 and close #11936 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* don't activate Widgets or Widget Visibility by default
* make them separately searchable
* remove searchable module

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Starting with a new site, Widgets or Widget Visibility shouldn't be active 
* go to Jetpack settings and search for a string specific to each setting, like "logic" for widget visibility or "gallery" for widgets. They should appear in the search results

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
