### PR TITLE
Settings - Writing: add toggle for Shortcode Embeds

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -46,7 +46,6 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 				'json-api',
 				'latex',
 				'notes',
-				'shortcodes',
 				'shortlinks',
 				'widget-visibility',
 				'widgets',

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -200,9 +200,10 @@ export class Composing extends React.Component {
 		const foundCopyPost = this.props.isModuleFound( 'copy-post' ),
 			foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
 			foundLatex = this.props.isModuleFound( 'latex' ),
-			foundMarkdown = this.props.isModuleFound( 'markdown' );
+			foundMarkdown = this.props.isModuleFound( 'markdown' ),
+			foundShortcodes = this.props.isModuleFound( 'shortcodes' );
 
-		if ( ! foundCopyPost && ! foundMarkdown && ! foundAtD ) {
+		if ( ! foundCopyPost && ! foundMarkdown && ! foundAtD && ! foundShortcodes ) {
 			return null;
 		}
 
@@ -210,6 +211,7 @@ export class Composing extends React.Component {
 			latex = this.props.module( 'latex' ),
 			atd = this.props.module( 'after-the-deadline' ),
 			copyPost = this.props.module( 'copy-post' ),
+			shortcodes = this.props.module( 'shortcodes' ),
 			unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
 			copyPostSettings = (
 				<SettingsGroup
@@ -289,6 +291,29 @@ export class Composing extends React.Component {
 					</FormFieldset>
 				</SettingsGroup>
 			),
+			shortcodeSettings = (
+				<SettingsGroup
+					module={ shortcodes }
+					support={ {
+						text: shortcodes.description,
+						link: 'https://jetpack.com/support/shortcode-embeds/',
+					} }
+				>
+					<FormFieldset>
+						<ModuleToggle
+							slug="shortcodes"
+							activated={ !! this.props.getOptionValue( 'shortcodes' ) }
+							toggling={ this.props.isSavingAnyOption( [ 'shortcodes' ] ) }
+							disabled={ this.props.isSavingAnyOption( [ 'shortcodes' ] ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Compose using shortcodes to embed media from popular sites' ) }
+							</span>
+						</ModuleToggle>
+					</FormFieldset>
+				</SettingsGroup>
+			),
 			atdSettings = (
 				<FoldableCard
 					onOpen={ this.trackOpenCard }
@@ -327,6 +352,7 @@ export class Composing extends React.Component {
 				{ foundCopyPost && copyPostSettings }
 				{ foundMarkdown && markdownSettings }
 				{ foundLatex && latexSettings }
+				{ foundShortcodes && shortcodeSettings }
 				{ foundAtD && atdSettings }
 			</SettingsCard>
 		);

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -46,6 +46,7 @@ export class Writing extends React.Component {
 			'copy-post',
 			'masterbar',
 			'markdown',
+			'shortcodes',
 			'after-the-deadline',
 			'custom-content-types',
 			'post-by-email',

--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -2,12 +2,12 @@
 
 /**
  * Module Name: Shortcode Embeds
- * Module Description: Embed media from popular sites without any coding.
+ * Module Description: Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.
  * Sort Order: 3
  * First Introduced: 1.1
  * Major Changes In: 1.2
  * Requires Connection: No
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Photos and Videos, Social, Writing, Appearance
  * Feature: Writing
  * Additional Search Queries: shortcodes, shortcode, embeds, media, bandcamp, dailymotion, facebook, flickr, google calendars, google maps, google+, polldaddy, recipe, recipes, scribd, slideshare, slideshow, slideshows, soundcloud, ted, twitter, vimeo, vine, youtube


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11934

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* add a toggle to the Composing group to activate Shortcodes
* make the feature searchable, even separated from other features in Composing
* remove searchable module
* don't activate Shortcode Embeds module by default

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* starting with a new site, Shortcode Embeds must not be active by default
* Go to Jetpack settings, Writing > Composing. Verify the toggle is there and that it works
* Try searching for shortcodes or any word in the shortcodes.php module header, it should appear in the search results

<img width="801" alt="Captura de Pantalla 2019-04-18 a la(s) 18 16 05" src="https://user-images.githubusercontent.com/1041600/56391813-231deb80-6206-11e9-9d9d-4738607a2580.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
