### PR TITLE
Settings - Traffic: add setting for Shortlinks

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -45,7 +45,6 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 				'json-api',
 				'latex',
 				'notes',
-				'shortlinks',
 			];
 
 			const allModules = this.props.modules,

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -11,7 +11,7 @@ import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
 import { getSettings } from 'state/settings';
-import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isSiteConnected, isDevMode, isUnavailableInDevMode } from 'state/connection';
 import { isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
@@ -32,6 +32,7 @@ export class Traffic extends React.Component {
 			settings: this.props.settings,
 			siteRawUrl: this.props.siteRawUrl,
 			getModule: this.props.module,
+			isSiteConnected: this.props.isSiteConnected,
 			isDevMode: this.props.isDevMode,
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
 			getModuleOverride: this.props.getModuleOverride,
@@ -125,6 +126,7 @@ export default connect( state => {
 		isDevMode: isDevMode( state ),
 		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
+		isSiteConnected: isSiteConnected( state ),
 		lastPostUrl: getLastPostUrl( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 	};

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -18,6 +18,7 @@ import { SEO } from './seo';
 import { GoogleAnalytics } from './google-analytics';
 import { Ads } from './ads';
 import { SiteStats } from './site-stats';
+import Shortlinks from './shortlinks';
 import { RelatedPosts } from './related-posts';
 import { VerificationServices } from './verification-services';
 import Sitemaps from './sitemaps';
@@ -39,6 +40,7 @@ export class Traffic extends React.Component {
 		const foundSeo = this.props.isModuleFound( 'seo-tools' ),
 			foundAds = this.props.isModuleFound( 'wordads' ),
 			foundStats = this.props.isModuleFound( 'stats' ),
+			foundShortlinks = this.props.isModuleFound( 'shortlinks' ),
 			foundRelated = this.props.isModuleFound( 'related-posts' ),
 			foundVerification = this.props.isModuleFound( 'verification-tools' ),
 			foundSitemaps = this.props.isModuleFound( 'sitemaps' ),
@@ -52,6 +54,7 @@ export class Traffic extends React.Component {
 			! foundSeo &&
 			! foundAds &&
 			! foundStats &&
+			! foundShortlinks &&
 			! foundRelated &&
 			! foundVerification &&
 			! foundSitemaps &&
@@ -107,6 +110,7 @@ export class Traffic extends React.Component {
 					/>
 				) }
 				{ foundStats && <SiteStats { ...commonProps } /> }
+				{ foundShortlinks && <Shortlinks { ...commonProps } /> }
 				{ foundSitemaps && <Sitemaps { ...commonProps } /> }
 				{ foundVerification && <VerificationServices { ...commonProps } /> }
 			</div>

--- a/_inc/client/traffic/shortlinks.jsx
+++ b/_inc/client/traffic/shortlinks.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+/**
+ * Internal dependencies
+ */
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { getModule } from 'state/modules';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+
+class Shortlinks extends Component {
+	render() {
+		const isLinked = this.props.isLinked;
+
+		return (
+			<SettingsCard
+				{ ...this.props }
+				header={ __( 'Shortlinks', { context: 'Settings header' } ) }
+				module="shortlinks"
+				hideButton
+			>
+				<SettingsGroup
+					module={ { module: 'shortlinks' } }
+					support={ {
+						text: this.props.shortlinksModule.description,
+						link: 'https://jetpack.com/support/shortlinks/',
+					} }
+				>
+					<ModuleToggle
+						slug="shortlinks"
+						disabled={ ! isLinked }
+						activated={ this.props.shortlinksActive }
+						toggling={ this.props.isSavingAnyOption( 'shortlinks' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						{ __( 'Create short and simple links for all posts and pages' ) }
+					</ModuleToggle>
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+}
+
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		return {
+			shortlinksActive: ownProps.getOptionValue( 'shortlinks' ),
+			shortlinksModule: getModule( state, 'shortlinks' ),
+		};
+	} )( Shortlinks )
+);

--- a/_inc/client/traffic/shortlinks.jsx
+++ b/_inc/client/traffic/shortlinks.jsx
@@ -15,7 +15,7 @@ import { ModuleToggle } from 'components/module-toggle';
 
 class Shortlinks extends Component {
 	render() {
-		const isLinked = this.props.isLinked;
+		const { isSiteConnected } = this.props;
 
 		return (
 			<SettingsCard
@@ -30,10 +30,11 @@ class Shortlinks extends Component {
 						text: this.props.shortlinksModule.description,
 						link: 'https://jetpack.com/support/shortlinks/',
 					} }
+					disableInDevMode
 				>
 					<ModuleToggle
 						slug="shortlinks"
-						disabled={ ! isLinked }
+						disabled={ ! isSiteConnected }
 						activated={ this.props.shortlinksActive }
 						toggling={ this.props.isSavingAnyOption( 'shortlinks' ) }
 						toggleModule={ this.props.toggleModuleNow }

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Module Name: WP.me Shortlinks
- * Module Description: Create short and simple links for all posts and pages.
+ * Module Description: Generates shorter links so you can have more space to write on social media sites.
  * Sort Order: 8
  * First Introduced: 1.1
  * Requires Connection: Yes
- * Auto Activate: Yes
+ * Auto Activate: No
  * Module Tags: Social
  * Feature: Writing
  * Additional Search Queries: shortlinks, wp.me


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #11935

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* add a toggle for Shortlinks in the Traffic tab
* make the setting searchable
* remove searchable module
* don't activate Shortlinks by default

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack settings, Traffic tab. Ensure the toggle is there, above Sitemaps
* if Jetpack is in Development mode, the toggle must be disabled
<img width="941" alt="Captura de Pantalla 2019-04-18 a la(s) 18 52 17" src="https://user-images.githubusercontent.com/1041600/56393658-82cac580-620b-11e9-95b8-911fd2effa9a.png">

* Verify it works as expected

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
