### PR TITLE
API: Fixes php warnings in jetpack json api

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -79,6 +79,10 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-wp-replicastore.php';
 		$store = new Jetpack_Sync_WP_Replicastore();
 
+		if( ! isset( $args['strip_non_ascii'] ) ) {
+			$args['strip_non_ascii'] = true;
+		}
+
 		return $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'] );
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -518,7 +518,7 @@ new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
 		'start_id' => '(int=0) Starting ID for the range',
 		'end_id' => '(int=null) Ending ID for the range',
 		'columns' => '(string) Columns to checksum',
-		'strip_non_ascii', '(bool=true) Strip non-ascii characters from all columns',
+		'strip_non_ascii' => '(bool=true) Strip non-ascii characters from all columns',
 	),
 	'response_format' => array(
 		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"'


### PR DESCRIPTION
Fixes the following 
```
[08-Apr-2019 22:52:47 UTC] PHP Warning:  array_shift() expects parameter 1 to be array, string given in /var/www/html/wp-content/plugins/jetpack/class.json-api-endpoints.php on line 354
[08-Apr-2019 22:52:47 UTC] PHP Stack trace:
[08-Apr-2019 22:52:47 UTC] PHP   1. {main}() /var/www/html/xmlrpc.php:0
[08-Apr-2019 22:52:47 UTC] PHP   2. wp_xmlrpc_server->serve_request() /var/www/html/xmlrpc.php:86
[08-Apr-2019 22:52:47 UTC] PHP   3. IXR_Server->IXR_Server() /var/www/html/wp-includes/class-wp-xmlrpc-server.php:191
[08-Apr-2019 22:52:47 UTC] PHP   4. IXR_Server->__construct() /var/www/html/wp-includes/IXR/class-IXR-server.php:35
[08-Apr-2019 22:52:47 UTC] PHP   5. IXR_Server->serve() /var/www/html/wp-includes/IXR/class-IXR-server.php:27
[08-Apr-2019 22:52:47 UTC] PHP   6. IXR_Server->call() /var/www/html/wp-includes/IXR/class-IXR-server.php:65
[08-Apr-2019 22:52:47 UTC] PHP   7. IXR_Server->multiCall() /var/www/html/wp-includes/IXR/class-IXR-server.php:115
[08-Apr-2019 22:52:47 UTC] PHP   8. IXR_Server->call() /var/www/html/wp-includes/IXR/class-IXR-server.php:212
[08-Apr-2019 22:52:47 UTC] PHP   9. Jetpack_XMLRPC_Server->json_api() /var/www/html/wp-includes/IXR/class-IXR-server.php:127
[08-Apr-2019 22:52:47 UTC] PHP  10. WPCOM_JSON_API->serve() /var/www/html/wp-content/plugins/jetpack/class.jetpack-xmlrpc-server.php:757
[08-Apr-2019 22:52:47 UTC] PHP  11. WPCOM_JSON_API->process_request() /var/www/html/wp-content/plugins/jetpack/class.json-api.php:321
[08-Apr-2019 22:52:47 UTC] PHP  12. Jetpack_JSON_API_Endpoint->callback() /var/www/html/wp-content/plugins/jetpack/class.json-api.php:337
[08-Apr-2019 22:52:47 UTC] PHP  13. Jetpack_JSON_API_Sync_Histogram_Endpoint->result() /var/www/html/wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php:30
[08-Apr-2019 22:52:47 UTC] PHP  14. WPCOM_JSON_API_Endpoint->query_args() /var/www/html/wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php:71
[08-Apr-2019 22:52:47 UTC] PHP  15. WPCOM_JSON_API_Endpoint->cast_and_filter() /var/www/html/wp-content/plugins/jetpack/class.json-api-endpoints.php:239
[08-Apr-2019 22:52:47 UTC] PHP  16. array_shift() /var/www/html/wp-content/plugins/jetpack/class.json-api-endpoints.php:354
[08-Apr-2019 22:52:47 UTC] PHP Notice:  Undefined index: strip_non_ascii in /var/www/html/wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php on line 82
[08-Apr-2019 22:52:47 UTC] PHP Stack trace:
[08-Apr-2019 22:52:47 UTC] PHP   1. {main}() /var/www/html/xmlrpc.php:0
[08-Apr-2019 22:52:47 UTC] PHP   2. wp_xmlrpc_server->serve_request() /var/www/html/xmlrpc.php:86
[08-Apr-2019 22:52:47 UTC] PHP   3. IXR_Server->IXR_Server() /var/www/html/wp-includes/class-wp-xmlrpc-server.php:191
[08-Apr-2019 22:52:47 UTC] PHP   4. IXR_Server->__construct() /var/www/html/wp-includes/IXR/class-IXR-server.php:35
[08-Apr-2019 22:52:47 UTC] PHP   5. IXR_Server->serve() /var/www/html/wp-includes/IXR/class-IXR-server.php:27
[08-Apr-2019 22:52:47 UTC] PHP   6. IXR_Server->call() /var/www/html/wp-includes/IXR/class-IXR-server.php:65
[08-Apr-2019 22:52:47 UTC] PHP   7. IXR_Server->multiCall() /var/www/html/wp-includes/IXR/class-IXR-server.php:115
[08-Apr-2019 22:52:47 UTC] PHP   8. IXR_Server->call() /var/www/html/wp-includes/IXR/class-IXR-server.php:212
[08-Apr-2019 22:52:47 UTC] PHP   9. Jetpack_XMLRPC_Server->json_api() /var/www/html/wp-includes/IXR/class-IXR-server.php:127
[08-Apr-2019 22:52:47 UTC] PHP  10. WPCOM_JSON_API->serve() /var/www/html/wp-content/plugins/jetpack/class.jetpack-xmlrpc-server.php:757
[08-Apr-2019 22:52:47 UTC] PHP  11. WPCOM_JSON_API->process_request() /var/www/html/wp-content/plugins/jetpack/class.json-api.php:321
[08-Apr-2019 22:52:47 UTC] PHP  12. Jetpack_JSON_API_Endpoint->callback() /var/www/html/wp-content/plugins/jetpack/class.json-api.php:337
[08-Apr-2019 22:52:47 UTC] PHP  13. Jetpack_JSON_API_Sync_Histogram_Endpoint->result() /var/www/html/wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php:30
```

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes a type that is responsible for the error. 

#### Testing instructions:
* Go to the jetpack debugger and trigger the jetpack Sync Validator. 
* Notice that it doesn't produce a PHP warning. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes a php warning in json api.
