### PR TITLE
API: Switch site frame nonce to user+site value

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -110,6 +110,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-edit-media-v1-2-endpoi
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-v1-2-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-v1-2-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-2-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-3-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-posts-v1-2-endpoint.php' );
 
 // Jetpack Only Endpoints

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -117,13 +117,13 @@ $json_jetpack_endpoints_dir = dirname( __FILE__ ) . '/json-endpoints/jetpack/';
 
 // This files instantiates the endpoints
 require_once( $json_jetpack_endpoints_dir . 'json-api-jetpack-endpoints.php' );
-require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-3-endpoint.php' );
 
 // **********
 // v1.3
 // **********
 
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-v1-3-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-3-endpoint.php' );
 
 // **********
 // v1.4

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -110,7 +110,6 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-edit-media-v1-2-endpoi
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-v1-2-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-v1-2-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-2-endpoint.php' );
-require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-3-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-posts-v1-2-endpoint.php' );
 
 // Jetpack Only Endpoints
@@ -118,6 +117,7 @@ $json_jetpack_endpoints_dir = dirname( __FILE__ ) . '/json-endpoints/jetpack/';
 
 // This files instantiates the endpoints
 require_once( $json_jetpack_endpoints_dir . 'json-api-jetpack-endpoints.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-3-endpoint.php' );
 
 // **********
 // v1.3

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -111,6 +111,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wordads',
 		'publicize_permanently_disabled',
 		'frame_nonce',
+		'frame_nonce_site_only',
 		'page_on_front',
 		'page_for_posts',
 		'headstart',
@@ -146,11 +147,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_store',
 		'woocommerce_is_active',
 		'frame_nonce',
+		'frame_nonce_site_only',
 		'design_type',
 		'wordads'
 	);
 
-	private $site;
+	protected $site;
 
 	// protected $compact = null;
 	protected $fields_to_include = '_all';
@@ -492,7 +494,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$options[ $key ] = $site->is_publicize_permanently_disabled();
 					break;
 				case 'frame_nonce' :
-					$options[ $key ] = $site->get_frame_nonce();
+					$options[ $key ] = $site->get_frame_nonce_site_only();
+					break;
+				case 'frame_nonce_site_only' :
+					$options[ $key ] = $site->get_frame_nonce_site_only();
 					break;
 				case 'page_on_front' :
 					if ( $custom_front_page ) {

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-3-endpoint.php
@@ -1,0 +1,35 @@
+<?php
+
+new WPCOM_JSON_API_GET_Site_V1_3_Endpoint(
+	array(
+		'description'        => 'Get information about a site.',
+		'group'              => 'sites',
+		'stat'               => 'sites:X',
+		'allowed_if_flagged' => true,
+		'method'             => 'GET',
+		'min_version'        => '1.3',
+		'max_version'        => '1.3',
+		'path'               => '/sites/%s',
+		'path_labels'        => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+		'query_parameters'   => array(
+			'context' => false,
+		),
+		'response_format'    => WPCOM_JSON_API_GET_Site_V1_3_Endpoint::$site_format,
+		'example_request'    => 'https://public-api.wordpress.com/rest/v1.3/sites/en.blog.wordpress.com/',
+	)
+);
+
+class WPCOM_JSON_API_GET_Site_V1_3_Endpoint extends WPCOM_JSON_API_GET_Site_V1_2_Endpoint {
+	protected function render_option_keys( &$options_response_keys ) {
+
+		$options = parent::render_option_keys( $options_response_keys );
+		if ( array_key_exists( 'frame_nonce', $options ) ) {
+			$site                   = $this->site;
+			$options['frame_nonce'] = $site->get_frame_nonce();
+		}
+
+		return $options;
+	}
+}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -108,6 +108,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return false;
 	}
 
+	function get_frame_nonce_site_only() {
+		return false;
+	}
+
 	function is_headstart_fresh() {
 		return false;
 	}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -105,16 +105,20 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
-	 * Creates a nonce to be used with iframed block editor requests to a Jetpack site.
-	 * Disabled on the Jetpack side.
+	 * Creates a nonce to allow an iframed block editor to make authenticated requests to a Jetpack site.
+	 *
+	 * Disabled here in Jetpack because the nonce is only needed when making calls from dotcom domains,
+	 * not when making calls on the same origin as we would be doing from `wp-admin/post.php` and friends.
 	 */
 	function get_frame_nonce() {
 		return false;
 	}
 
 	/**
-	 * Creates a post preview nonce for logged out users.
-	 * Disabled on the Jetpack side.
+	 * Creates a post preview nonce to use if the current user is logged out.
+	 *
+	 * Disabled here in Jetpack because the nonce is only needed when making calls from dotcom domains,
+	 * in the case where users create a post in Calypso but are logged out from their Jetpack site.
 	 */
 	function get_frame_nonce_site_only() {
 		return false;

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -104,10 +104,18 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return Jetpack::is_module_active( 'wordads' );
 	}
 
+	/**
+	 * Creates a nonce to be used with iframed block editor requests to a Jetpack site.
+	 * Disabled on the Jetpack side.
+	 */
 	function get_frame_nonce() {
 		return false;
 	}
 
+	/**
+	 * Creates a post preview nonce for logged out users.
+	 * Disabled on the Jetpack side.
+	 */
 	function get_frame_nonce_site_only() {
 		return false;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

On D27129-code we're changing the way the frame nonces are generated to use both the user ID and site ID. 

Since that will be an breaking change for the API (p7jreA-2hw-p2), we need to version the `/sites/:site` endpoint (which is where the frame nonces are serialized) in order to keep using the nonce generated from only the site ID on the existing versions (1.0 and 1.2) and switch to the user+site value on the new version (1.3).

Given Fusion is not able to apply these changes automatically, this will also need a diff in WP.com: D27153-code

#### Testing instructions:

- Make an authenticated call to `https://public-api.wordpress.com/rest/v1.2/me/sites?site_visibility=all&include_domain_only=true&site_activity=active&fields=ID,URL,options&options=frame_nonce_site_only,frame_nonce`.
- Verify that both `frame_nonce` and `frame_nonce_site_only` are returned with the same value for all WP.com and JP sites.
- Make an authenticated call to `https://public-api.wordpress.com/rest/v1.3/me/sites?site_visibility=all&include_domain_only=true&site_activity=active&fields=ID,URL,options&options=frame_nonce_site_only,frame_nonce`.
- For JP sites, check that `frame_nonce` has a different value now but `frame_nonce_site_only` still have the same value as before. For WP.com sites, both `frame_nonce` and `frame_nonce_site_only` still have the same value as before.

Repeat steps but replacing the API calls from `/me/sites` to `/sites/<SITE_SLUG_OR_ID>`.

#### Proposed changelog entry for your changes:

WPCOM API: Switch site frame nonces to new user and site specific values.
