### PR TITLE
Gist shortcode: bring in sync with WordPress.com and prepare for Fusion

### DIFF
--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -91,7 +91,7 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 	}
 
 	// Not a URL nor an ID? Only keep one of "username/id", "/username/id", "id".
-	if ( preg_match( '#^/?(([a-z0-9-_]+/)?([a-z0-9]+))$#i', $gist, $matches ) ) {
+	if ( preg_match( '#^/?(([a-z0-9_-]+/)?([a-z0-9]+))$#i', $gist, $matches ) ) {
 		$gist_info['id'] = $matches[1];
 
 		// If there is one, strip the GitHub username and only keep the ID.

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -84,7 +84,7 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 
 		// Keep the unique identifier without any leading or trailing slashes.
 		if ( ! empty( $parsed_url['path'] ) ) {
-			$gist_info['id'] = preg_replace( '/(?:\/)([^\.]+)\./', '$1', $parsed_url['path'] );
+			$gist_info['id'] = preg_replace( '/^\/([^\.]+)\./', '$1', $parsed_url['path'] );
 			// Overwrite $gist with our identifier to clean it up below.
 			$gist = $gist_info['id'];
 		}

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -90,12 +90,9 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 		}
 	}
 
-	// Not a URL nor an ID? Only keep one of "username/id", "/username/id", "id".
+	// Not a URL nor an ID? Look for "username/id", "/username/id", or "id", and only keep the ID.
 	if ( preg_match( '#^/?(([a-z0-9_-]+/)?([a-z0-9]+))$#i', $gist, $matches ) ) {
-		$gist_info['id'] = $matches[1];
-
-		// If there is one, strip the GitHub username and only keep the ID.
-		$gist_info['id'] = preg_replace( '#^.*/(?=[a-z0-9]+)#', '', $gist_info['id'] );
+		$gist_info['id'] = $matches[3];
 	}
 
 	return $gist_info;

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -111,7 +111,11 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 function github_gist_shortcode( $atts, $content = '' ) {
 
 	if ( empty( $atts[0] ) && empty( $content ) ) {
-		return '<!-- Missing Gist ID -->';
+		if ( current_user_can( 'edit_posts' ) ) {
+			return esc_html__( 'Please specify a Gist URL or ID.', 'jetpack' );
+		} else {
+			return '<!-- Missing Gist ID -->';
+		}
 	}
 
 	$id = ( ! empty( $content ) ) ? $content : $atts[0];
@@ -119,7 +123,11 @@ function github_gist_shortcode( $atts, $content = '' ) {
 	// Parse a URL to get an ID we can use.
 	$gist_info = jetpack_gist_get_shortcode_id( $id );
 	if ( empty( $gist_info['id'] ) ) {
-		return '<!-- Invalid Gist ID -->';
+		if ( current_user_can( 'edit_posts' ) ) {
+			return esc_html__( 'The Gist ID you provided is not valid. Please try a different one.', 'jetpack' );
+		} else {
+			return '<!-- Invalid Gist ID -->';
+		}
 	} else {
 		// Add trailing .json to all unique gist identifiers.
 		$id = $gist_info['id'] . '.json';

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -48,11 +48,15 @@ function github_gist_shortcode( $atts, $content = '' ) {
 	$id = ( ! empty( $content ) ) ? $content : $atts[0];
 
 	// Parse a URL.
-	if ( ! is_numeric( $id ) ) {
-		$id = preg_replace( '#https?://gist.github.com/([a-zA-Z0-9]+)#', '$1', $id );
-	}
-
-	if ( ! $id ) {
+	if ( ctype_alnum( $id ) ) {
+		// Simple shortcode, with just an ID. Proceed as normal.
+		$id = $id;
+	} elseif ( preg_match( '#^/?(([a-z0-9-_]+/)?([a-z0-9]+))$#i', $id, $matches ) ) {
+		// Matches one of "username/id", "/username/id", "id". Proceed as normal.
+		$id = $id;
+	} elseif ( wp_parse_url( $id ) && preg_match( '#^https?://gist.github.com/(([a-z0-9-_]+/)?([a-z0-9]+))$#i', $id, $matches ) ) {
+		$id = $matches[1];
+	} else {
 		return '<!-- Invalid Gist ID -->';
 	}
 

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -5,6 +5,16 @@
  *
  * Their JavaScript-based embed method is a lot better, so that's what we're using.
  *
+ * Supported formats:
+ * Full URL: https://gist.github.com/57cc50246aab776e110060926a2face2
+ * Full URL with username: https://gist.github.com/jeherve/57cc50246aab776e110060926a2face2
+ * Full URL linking to specific file: https://gist.github.com/jeherve/57cc50246aab776e110060926a2face2#file-wp-config-php
+ * Full URL, no username, linking to specific file: https://gist.github.com/57cc50246aab776e110060926a2face2#file-wp-config-php
+ * Gist ID: [gist]57cc50246aab776e110060926a2face2[/gist]
+ * Gist ID within tag: [gist 57cc50246aab776e110060926a2face2]
+ * Gist ID with username: [gist jeherve/57cc50246aab776e110060926a2face2]
+ * Gist private ID with username: [gist xknown/fc5891af153e2cf365c9]
+ *
  * @package Jetpack
  */
 

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -209,5 +209,5 @@ function github_gist_shortcode( $atts, $content = '' ) {
  */
 function github_gist_simple_embed( $id ) {
 	$id = str_replace( 'json', 'js', $id );
-	return '<script type="text/javascript" src="https://gist.github.com/' . $id . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	return '<script src="https://gist.github.com/' . $id . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -209,5 +209,5 @@ function github_gist_shortcode( $atts, $content = '' ) {
  */
 function github_gist_simple_embed( $id ) {
 	$id = str_replace( 'json', 'js', $id );
-	return '<script src="https://gist.github.com/' . $id . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	return '<script src="' . esc_url( "https://gist.github.com/$id" ) . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -136,7 +136,13 @@ function github_gist_shortcode( $atts, $content = '' ) {
 
 	// Replace - by . to get a real file name from slug.
 	if ( ! empty( $file ) ) {
-		$file = preg_replace( '/\-(?!.*\-)/', '.', $file );
+		// Find the last -.
+		$dash_position = strrpos( $file, '-' );
+		if ( false !== $dash_position ) {
+			// Replace the - by a period.
+			$file = substr_replace( $file, '.', $dash_position, 1 );
+		}
+
 		$file = rawurlencode( $file );
 	}
 

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -57,6 +57,26 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that calling the shortcode with an invalid character returns the error string.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_invalid_id() {
+		$content = '[gist !^#*@$]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
+	}
+
+	/**
 	 * Verify that a shortcode with only an ID returns the expected embed code.
 	 *
 	 * @covers ::github_gist_shortcode
@@ -78,6 +98,95 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
 			$shortcode_content
 		);
+	}
+
+	/**
+	 * Verify that a shortcode with a username and a public embed ID returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_public_id_with_username() {
+		$gist_id = 'mjangda/2978185';
+		$content = '[gist ' . $gist_id . ']';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with a username and a private embed ID returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_private_id_with_username() {
+		$gist_id = 'xknown/fc5891af153e2cf365c9';
+		$content = '[gist ' . $gist_id . ']';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with an invalid ID raw gist returns the "invalid" message.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_invalid_raw_gist() {
+		$gist_id = 'xknown/fc5891af153e2cf365c9/raw?';
+		$content = '[gist ' . $gist_id . ']';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that a shortcode with a non-gist URL returns the "invalid" message.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_invalid_url() {
+		$content = '[gist http://wordpress.com/]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals( '<!-- Invalid Gist ID -->', $shortcode_content );
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -113,7 +113,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -137,13 +137,86 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$shortcode_content = do_shortcode( $content );
 		$this->assertEquals(
 			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode linking to a specific file, with no username returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_no_username_direct_file() {
+		$gist_id        = '57cc50246aab776e110060926a2face2';
+		$file_name_slug = '#file-wp-config-php';
+		$file_name      = 'wp-config.php';
+
+		$content = '[gist https://gist.github.com/' . $gist_id . $file_name_slug . ']';
+
+		$expected_gist_id = sprintf(
+			'%1$s.json?file=%2$s',
+			$gist_id,
+			$file_name
+		);
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf(
+				'<amp-gist layout="fixed-height" data-gistid="%1$s" height="240" data-file="%2$s"></amp-gist>',
+				$gist_id,
+				$file_name
+			),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode linking to a specific file, with a username returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_username_direct_file() {
+		$gist_id        = 'jeherve/57cc50246aab776e110060926a2face2';
+		$file_name_slug = '#file-wp-config-php';
+		$file_name      = 'wp-config.php';
+
+		$expected_gist_id = sprintf(
+			'%1$s.json?file=%2$s',
+			basename( $gist_id ),
+			$file_name
+		);
+
+		$content = '[gist https://gist.github.com/' . $gist_id . $file_name_slug . ']';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf(
+				'<amp-gist layout="fixed-height" data-gistid="%1$s" height="240" data-file="%2$s"></amp-gist>',
+				basename( $gist_id ),
+				$file_name
+			),
 			$shortcode_content
 		);
 	}
@@ -269,7 +342,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 		ob_start();
 		the_content();
 		$actual = ob_get_clean();
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json?file=wp-config.php"></div>', $actual );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json?file=wp-config.php"></div>', $actual );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -277,7 +350,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 		the_content();
 		$actual = ob_get_clean();
 		$this->assertEquals(
-			wpautop( sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240" data-file="wp.config.php"></amp-gist>', basename( $gist_id ) ) ),
+			wpautop( sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240" data-file="wp-config.php"></amp-gist>', basename( $gist_id ) ) ),
 			$actual
 		);
 	}

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -83,9 +83,81 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 	 *
 	 * @since 6.6.0
 	 */
-	public function test_shortcodes_gist_id() {
+	public function test_shortcodes_gist_public_id_in_content() {
 		$gist_id = '57cc50246aab776e110060926a2face2';
 		$content = '[gist]' . $gist_id . '[/gist]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with only an ID returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_public_id() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist ' . $gist_id . ']';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with only a private ID in the content returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_private_id_in_content() {
+		$gist_id = 'fc5891af153e2cf365c9';
+		$content = '[gist]' . $gist_id . '[/gist]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with only a private ID returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_private_id() {
+		$gist_id = 'fc5891af153e2cf365c9';
+		$content = '[gist ' . $gist_id . ']';
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
@@ -263,19 +335,91 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that a shortcode with a URL returns the expected embed code.
+	 * Verify that a shortcode with a public URL returns the expected embed code.
 	 *
 	 * @covers ::github_gist_shortcode
 	 *
 	 * @since 6.6.0
 	 */
-	public function test_shortcodes_gist_full_url() {
+	public function test_shortcodes_gist_public_full_url() {
 		$gist_id = '57cc50246aab776e110060926a2face2';
 		$content = '[gist https://gist.github.com/' . $gist_id . ' /]';
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
 		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with a public URL in content returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_public_full_url_in_content() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist]https://gist.github.com/' . $gist_id . '[/gist]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with a private URL returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_private_full_url() {
+		$gist_id = 'xknown/fc5891af153e2cf365c9';
+		$content = '[gist https://gist.github.com/' . $gist_id . ' /]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that a shortcode with a private URL in content returns the expected embed code.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_gist_private_full_url_in_content() {
+		$gist_id = 'xknown/fc5891af153e2cf365c9';
+		$content = '[gist]https://gist.github.com/' . $gist_id . '[/gist]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Gist shortcode that ships with WordPress.com is quite different from the one in Jetpack. The 2 files were never kept in sync, and have diverged a lot over the years, to the point where they don't support the same range of formats.

To corrct this, I had to make a few changes to the shortcode:

- Extract all id sanitization in separate function, `jetpack_gist_get_shortcode_id`
- Strip username from gist ids. They are not necessary, and break the AMP implementation.

In addition to this, I fixed all phpcs warnings.

On  WordPress.com: D27151-code

#### Testing instructions:

* Add the following to a classic block in the editor:

```
<p>Supported formats:</p>
<p>Full URL</p>
<p>https://gist.github.com/57cc50246aab776e110060926a2face2</p>
<p>Full URL with username:</p>
<p>https://gist.github.com/jeherve/57cc50246aab776e110060926a2face2</p>
<p>Full URL linking to specific file:</p>
<p>https://gist.github.com/jeherve/57cc50246aab776e110060926a2face2#file-wp-config-php</p>
<p>Full URL, no username, linking to specific file:</p>
<p>https://gist.github.com/57cc50246aab776e110060926a2face2#file-wp-config-php</p>
<p>Gist ID:</p>
<p>[gist]57cc50246aab776e110060926a2face2[/gist]</p>
<p>Gist ID within tag:</p>
<p>[gist 57cc50246aab776e110060926a2face2]</p>
<p>Gist ID with username:</p>
<p>[gist jeherve/57cc50246aab776e110060926a2face2]</p>
<p>Gist private ID with username:</p>
<p>[gist xknown/fc5891af153e2cf365c9]</p>
<p>Invalid format:</p>
<p>[gist xknown/fc5891af153e2cf365c9/raw?]</p>
```

* All shortcodes should work, except for the last one.

#### Proposed changelog entry for your changes:

* Shortcodes: support a wider range of Gist embeds.
