### PR TITLE
Allow JITMs to be translated.

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -260,6 +260,7 @@ class Jetpack_JITM {
 			'external_user_id' => urlencode_deep( $user->ID ),
 			'query_string'     => urlencode_deep( $query ),
 			'mobile_browser'   => jetpack_is_mobile( 'smart' ) ? 1 : 0,
+			'_locale'          => get_user_locale(),
 		), sprintf( '/sites/%d/jitm/%s', $site_id, $message_path ) );
 
 		// attempt to get from cache


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* This change addresses the issue where JITMs aren't translated in either Calypso or wp-admin.
* This was originally addressed in #7267 but closed with no comment or integrated.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Jetpack site with a non-english language with this patch
* Ensure there's no plan
* Navigate to the comments section
* See a jitm about akismet in non-english

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Translate Just In Time messages
