### PR TITLE
Jumpstart: Do not check for updated Jetpack options as precondition to show Jumpstart card in the dashboard

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -321,7 +321,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
  * The option can be of 4 things, and will be stored as such:
  * new_connection      : Brand new connection - Show
  * jumpstart_activated : Jump Start has been activated - dismiss
- * jetpack_action_taken: Manual activation of a module already happened - dismiss
  * jumpstart_dismissed : Manual dismissal of Jump Start - dismiss
  *
  * @todo move to functions.global.php when available
@@ -336,7 +335,6 @@ function jetpack_show_jumpstart() {
 
 	$hide_options = array(
 		'jumpstart_activated',
-		'jetpack_action_taken',
 		'jumpstart_dismissed'
 	);
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -88,7 +88,7 @@ class Jetpack_Options {
 			'identity_crisis_whitelist',    // (array)  An array of options, each having an array of the values whitelisted for it.
 			'gplus_authors',                // (array)  The Google+ authorship information for connected users.
 			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
-			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jumpstart_dismissed.
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
@@ -476,7 +476,7 @@ class Jetpack_Options {
 				'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
 				'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
 				'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
-				'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+				'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jumpstart_dismissed.
 
 				// non_compact
 				'activated',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -630,9 +630,6 @@ class Jetpack {
 		// returns HTTPS support status
 		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );
 
-		// If any module option is updated before Jump Start is dismissed, hide Jump Start.
-		add_action( 'update_option', array( $this, 'jumpstart_has_updated_module_option' ) );
-
 		// JITM AJAX callback function
 		add_action( 'wp_ajax_jitm_ajax',  array( $this, 'jetpack_jitm_ajax_callback' ) );
 
@@ -6657,38 +6654,6 @@ p {
 	 */
 	public static function get_jetpack_options_for_reset() {
 		return Jetpack_Options::get_options_for_reset();
-	}
-
-	/**
-	 * Check if an option of a Jetpack module has been updated.
-	 *
-	 * If any module option has been updated before Jump Start has been dismissed,
-	 * update the 'jumpstart' option so we can hide Jump Start.
-	 *
-	 * @param string $option_name
-	 *
-	 * @return bool
-	 */
-	public static function jumpstart_has_updated_module_option( $option_name = '' ) {
-		// Bail if Jump Start has already been dismissed
-		if ( 'new_connection' !== Jetpack_Options::get_option( 'jumpstart' ) ) {
-			return false;
-		}
-
-		$jetpack = Jetpack::init();
-
-		// Manual build of module options
-		$option_names = self::get_jetpack_options_for_reset();
-
-		if ( in_array( $option_name, $option_names['wp_options'] ) ) {
-			Jetpack_Options::update_option( 'jumpstart', 'jetpack_action_taken' );
-
-			//Jump start is being dismissed send data to MC Stats
-			$jetpack->stat( 'jumpstart', 'manual,'.$option_name );
-
-			$jetpack->do_stats( 'server_side' );
-		}
-
 	}
 
 	/*

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2985,16 +2985,6 @@ class Jetpack {
 		ob_end_clean();
 		Jetpack::catch_errors( false );
 
-		// A flag for Jump Start so it's not shown again. Only set if it hasn't been yet.
-		if ( 'new_connection' === Jetpack_Options::get_option( 'jumpstart' ) ) {
-			Jetpack_Options::update_option( 'jumpstart', 'jetpack_action_taken' );
-
-			//Jump start is being dismissed send data to MC Stats
-			$jetpack->stat( 'jumpstart', 'manual,'.$module );
-
-			$jetpack->do_stats( 'server_side' );
-		}
-
 		if ( $redirect ) {
 			wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 		}
@@ -3022,16 +3012,6 @@ class Jetpack {
 
 		$active = Jetpack::get_active_modules();
 		$new    = array_filter( array_diff( $active, (array) $module ) );
-
-		// A flag for Jump Start so it's not shown again.
-		if ( 'new_connection' === Jetpack_Options::get_option( 'jumpstart' ) ) {
-			Jetpack_Options::update_option( 'jumpstart', 'jetpack_action_taken' );
-
-			//Jump start is being dismissed send data to MC Stats
-			$jetpack->stat( 'jumpstart', 'manual,deactivated-'.$module );
-
-			$jetpack->do_stats( 'server_side' );
-		}
 
 		return self::update_active_modules( $new );
 	}


### PR DESCRIPTION
We used to skip showing Jumpstart if the user in some way had already updated a Jetpack option.

This PR proposes to remove this behaviour so to always show the Jumpstart card

Context: My comment in p1HpG7-6Aw-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Removes hook from the action `update_option`.
* Removes `Jetpack::jumpstart_has_updated_module_option()`.
* Removes usage of `jetpack_action_taken` option when a module is activated or deactivated. This was used to evaluate if showing the Jumpstart card or not.

#### Testing instructions:

1. Launch a fresh site.
2. Connect it 
3. Get back to the Jetpack dashboard. Confirm Jumpstart card is shown but do not click the button
4. Visit the Jetpack settings, turn on a module like Latext
5. Get back to the Jetpack dashboard and confirm the Jumpstart card still shows.

#### Proposed changelog entry for your changes:

* Admin Page: We made the Jumpstart card always show even when you have updated any Jetpack option before
