### PR TITLE
REST API: Fix remove post tag (Hide featured tag)

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -438,7 +438,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
 
 			// This filter is only appropriate on the front-end.
-			if ( is_admin() ) {
+			if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 				return $terms;
 			}
 


### PR DESCRIPTION
The "Hide featured tag" feature allows a webmaster to hide the featured tag from tags list, which is great. Unfortunately it does not ignore REST API requests, therefore removing the tag at each page update. This bug is really annoying because it causes tags to be actually removed from pages (not from posts though).

Fixes #7996 (looks like the closest one to my issue)

#### Testing instructions:
* Setup a featured tag
* Try to set it on a page (featured pages must be enabled, c.f. [featured content support page](https://jetpack.com/support/featured-content/))
* Check that the tag is not removed

This change has been tested on my personal website's live version.

#### Proposed changelog entry for your changes:
~Bugfix, not necessary I suppose?~
Theme Tools: Ensure Featured Content tag is retained on a post after saving.