### PR TITLE
Sharing: Improve contrast for accessibility.

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -89,7 +89,7 @@ body.highlander-dark h3.sd-title:before {
 	font-family: "Open Sans", sans-serif;
 	font-weight: normal;
 	border-radius: 3px;
-	color: #777 !important;
+	color: #545454 !important;
 	background: #f8f8f8;
 	border: 1px solid #cccccc;
 	box-shadow: 0 1px 0 rgba(0,0,0,.08);
@@ -753,4 +753,3 @@ div.sharedaddy.sharedaddy-dark #sharing_email {
 	height: 123px;
 	margin: 0 0 1em 0;
 }
-


### PR DESCRIPTION
Bumps accessibility rating for sharing buttons to WCAG AA & AAA Text
Props https://titan.as for submission via email.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #3227

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Darken the text/icons used in sharing buttons to #545454 to improve accessibility.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Sharing buttons and add some to a post via Settings> Sharing 
* Make sure you're using "Icon + text" or "Text only" as the button style option
* View a post and observe sharing buttons.

**Before:**
<img width="471" alt="Screen Shot 2019-04-22 at 1 38 23 PM" src="https://user-images.githubusercontent.com/108942/56522747-ee5eac80-6503-11e9-8d51-d7c93a1ea59a.png">

**After:**
<img width="449" alt="Screen Shot 2019-04-22 at 1 30 49 PM" src="https://user-images.githubusercontent.com/108942/56522777-f6b6e780-6503-11e9-85d3-0256cffff9e1.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Improve accessibility of sharing buttons by increasing contrast ratio. Props https://titan.as