### PR TITLE
Tracks Replace usage of add_user_meta for `update_user_meta` in tracks/client.php

### DIFF
--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -78,7 +78,7 @@ function jetpack_tracks_get_identity( $user_id ) {
 	// User is connected, but no meta is set yet.  Use WPCOM ID and set meta.
 	if ( Jetpack::is_user_connected( $user_id ) ) {
 		$wpcom_user_data = Jetpack::get_connected_user_data( $user_id );
-		add_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'], true );
+		update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
 
 		return array(
 			'_ut' => 'wpcom:user_id',


### PR DESCRIPTION
By the time we reach that code, the meta already exists and add_user_meta fails.

This meta is first initialized here for a connected user: https://github.com/Automattic/jetpack/blob/master/class.jetpack-tracks.php#L47

Also there's some sort of bug related to that line ^ , because for every connection the meta is set as empty. Seems like `get_connected_user_data()` returns an empty value every time at that point.

<!--- Provide a general summary of your changes in the Title above -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Just confirm that on any fresh connected site, `wp user meta get 1 jetpack_tracks_wpcom_id` returns empty
* Test this branch
* Visit the old stats page
* Run `wp user meta get 1 jetpack_tracks_wpcom_id` again and confirm your WordPress.com user is is returns now. 

#### Testing instructions:

<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
