### PR TITLE
Settings: remove Latex searchable module card. Make setting searchable.

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -38,13 +38,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 			}
 
 			// Only should be features that don't already have a UI, and we want to reveal in search.
-			const whitelist = [
-				'contact-form',
-				'enhanced-distribution',
-				'json-api',
-				'latex',
-				'notes',
-			];
+			const whitelist = [ 'contact-form', 'enhanced-distribution', 'json-api', 'notes' ];
 
 			const allModules = this.props.modules,
 				results = [];

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -203,7 +203,7 @@ export class Composing extends React.Component {
 			foundMarkdown = this.props.isModuleFound( 'markdown' ),
 			foundShortcodes = this.props.isModuleFound( 'shortcodes' );
 
-		if ( ! foundCopyPost && ! foundMarkdown && ! foundAtD && ! foundShortcodes ) {
+		if ( ! foundCopyPost && ! foundLatex && ! foundMarkdown && ! foundAtD && ! foundShortcodes ) {
 			return null;
 		}
 

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -45,6 +45,7 @@ export class Writing extends React.Component {
 			'carousel',
 			'copy-post',
 			'custom-css',
+			'latex',
 			'masterbar',
 			'markdown',
 			'shortcodes',


### PR DESCRIPTION
I'm afraid I overwrote this somewhere because I'm sure I added this before. This fixes my mistake: it removes the Beautiful Math searchable module card, and instead, makes the setting in "Writing tab > Composing" searchable.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #12034 since with this, all new settings created during this project are searchable

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* make Beautiful math setting searchable
* remove searchable module card

<img width="1066" alt="Captura de Pantalla 2019-04-22 a la(s) 18 30 55" src="https://user-images.githubusercontent.com/1041600/56533102-6ab9b580-652d-11e9-97b1-c8c18e033a03.png">

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings
* Start searching
* search for math, latex or something that matches the keywords in the latex.php module header
* verify the setting is displayed, and not the searchable module card

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Part of Module Prioritization
