### PR TITLE
Related Posts: do not add markup to attachment pages by default.

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1604,6 +1604,7 @@ EOT;
 	 */
 	protected function _enabled_for_request() {
 		$enabled = is_single()
+			&& ! is_attachment()
 			&& ! is_admin()
 			&& ( ! $this->_allow_feature_toggle() || $this->get_option( 'enabled' ) );
 


### PR DESCRIPTION
Fixes #12115


#### Changes proposed in this Pull Request:

`is_single` usually returns true for attachments, although it should not. This additional check should solve the issue mentioned in #12115.

If one wishes to enable Related Posts on attachment pages,
they will need to use the `jetpack_relatedposts_filter_enabled_for_request` filter.


#### Testing instructions:

* Start on a site without this patch, where Related Posts are enabled and working, and where the following toggle is enabled under Appearance > Customize > Related Posts.
![image](https://user-images.githubusercontent.com/426388/56571235-ce3ef400-65bc-11e9-83ab-be460e19f33a.png)

* Go to Media > Library on a site
* Click on "View" below one of your images.
* Notice the "Related" header, but no actual related posts.
* Check out this branch.
* Notice that the Related header disappears from attachment pages, but not from regular posts.

#### Proposed changelog entry for your changes:

* Related Posts: do not add markup to attachment pages by default.
