### PR TITLE
Sync: Store and retrieve granular item count data

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -295,7 +295,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$totals = array();
 
 		foreach ( $actions as $action ) {
-			$name = $this->get_action_name( $action );
+			$name          = $this->get_action_name( $action );
 			$action_totals = $this->get_action_totals( $action );
 			if ( ! isset( $totals[ $name ] ) ) {
 				$totals[ $name ] = 0;

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -280,7 +280,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	public function get_action_totals( $queue_item ) {
-		if ( is_array( $queue_item ) && isset( $queue_item[1] ) && isset( $queue_item[1][0] ) ) {
+		if ( is_array( $queue_item ) && isset( $queue_item[1][0] ) ) {
 			if ( is_array( $queue_item[1][0] ) ) {
 				// Let's count the items we sync in this action.
 				return count( $queue_item[1][0] );

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -262,7 +262,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$this->update_status_option( $status_option_name, $items_sent );
 			}
 
-			if ( $items_sent_total !== 0 ) {
+			if ( 0 !== $items_sent_total ) {
 				$this->update_status_option( $total_option_name, $items_sent_total );
 			}
 		}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -279,6 +279,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return false;
 	}
 
+	/**
+	 * Retrieve the total number of items we're syncing in a particular queue item (action).
+	 * `$queue_item[1]` is expected to contain chunks of items, and `$queue_item[1][0]`
+	 * represents the first (and only) chunk of items to sync in that action.
+	 *
+	 * @param array $queue_item Item of the sync queue that corresponds to a particular action.
+	 * @return int Total number of items in the action.
+	 */
 	public function get_action_totals( $queue_item ) {
 		if ( is_array( $queue_item ) && isset( $queue_item[1][0] ) ) {
 			if ( is_array( $queue_item[1][0] ) ) {
@@ -291,6 +299,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return 0;
 	}
 
+	/**
+	 * Retrieve the total number of items for a set of actions, grouped by action name.
+	 *
+	 * @param array $actions An array of actions.
+	 * @return array An array, representing the total number of items, grouped per action.
+	 */
 	public function get_actions_totals( $actions ) {
 		$totals = array();
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -350,7 +350,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$status['sent'][ $name ] = $sent;
 			}
 
-			if ( $sent_total = $this->get_status_option( "{$name}_sent_total" ) ) {
+			$sent_total = $this->get_status_option( "{$name}_sent_total" );
+			if ( $sent_total ) {
 				$status['sent_total'][ $name ] = $sent_total;
 			}
 		}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -11,6 +11,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync_start_config;
 	private $synced_user_ids;
 
+	private $test_posts_count = 20;
+	private $test_comments_count = 11;
+
 	public function setUp() {
 		parent::setUp();
 		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
@@ -868,11 +871,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function create_dummy_data_and_empty_the_queue() {
 		// lets create a bunch of posts
-		for ( $i = 0; $i < 20; $i += 1 ) {
+		for ( $i = 0; $i < $this->test_posts_count; $i += 1 ) {
 			$post = $this->factory->post->create();
 		}
 		// lets create a bunch of comments
-		$this->factory->comment->create_post_comments( $post, 11 );
+		$this->factory->comment->create_post_comments( $post, $this->test_comments_count );
 
 		// reset the data before the full sync
 		$this->sender->reset_data();
@@ -959,8 +962,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'options'   => -1,
 				'themes'    => -1,
 				'updates'   => -1,
-				'posts'     => 20,
-				'comments'  => 11,
+				'posts'     => $this->test_posts_count,
+				'comments'  => $this->test_comments_count,
 				'users'     => 1,
 				'terms'     => 1
 			),

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -891,6 +891,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'finished'       => null,
 				'total'          => array(),
 				'sent'           => array(),
+				'sent_total'     => array(),
 				'queue'          => array(),
 				'config'         => null,
 			)

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -930,6 +930,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNull( $full_sync_status['send_started'] );
 		$this->assertNull( $full_sync_status['finished'] );
 		$this->assertInternalType( 'array', $full_sync_status['sent'] );
+		$this->assertInternalType( 'array', $full_sync_status['sent_total'] );
 	}
 
 	function test_full_sync_status_after_end() {
@@ -952,6 +953,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'users'     => 1,
 				'terms'     => 1
 			),
+			'sent_total'  => array(
+				'constants' => -1,
+				'functions' => -1,
+				'options'   => -1,
+				'themes'    => -1,
+				'updates'   => -1,
+				'posts'     => 20,
+				'comments'  => 11,
+				'users'     => 1,
+				'terms'     => 1
+			),
 			'queue' => array(
 				'constants' => 1,
 				'functions' => 1,
@@ -967,10 +979,12 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		if ( is_multisite() ) {
 			$should_be_status['queue']['network_options'] = 1;
 			$should_be_status['sent']['network_options']  = 1;
+			$should_be_status['sent_total']['network_options']  = -1;
 		}
 
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );
 		$this->assertEquals( $full_sync_status['sent'], $should_be_status['sent'] );
+		$this->assertEquals( $full_sync_status['sent_total'], $should_be_status['sent_total'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
 		$this->assertInternalType( 'int', $full_sync_status['send_started'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -11,7 +11,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync_start_config;
 	private $synced_user_ids;
 
-	private $test_posts_count = 20;
+	private $test_posts_count    = 20;
 	private $test_comments_count = 11;
 
 	public function setUp() {
@@ -980,8 +980,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			)
 		);
 		if ( is_multisite() ) {
-			$should_be_status['queue']['network_options'] = 1;
-			$should_be_status['sent']['network_options']  = 1;
+			$should_be_status['queue']['network_options']       = 1;
+			$should_be_status['sent']['network_options']        = 1;
 			$should_be_status['sent_total']['network_options']  = -1;
 		}
 


### PR DESCRIPTION
This updates our full sync module to store granular information about the item counts for each module, 
and adds that information to the set of status data that we pass to the `/sync/status` endpoint.

Part of #11985.

#### Changes proposed in this Pull Request:

* Now store the total sent items during full sync for each module in a new set of options.
* Pass the granular total sent items information to the sync status endpoint.
* Delete the new set of options when sync status is cleared.
* Amend the tests to include cases for the new functionality.

#### Testing instructions:

* Apply D27227-code and follow the test instructions there.

#### Proposed changelog entry for your changes:

* Now storing, maintaining and retrieving granular module item count information as part of the sync status endpoint.
