### PR TITLE
Jumpstart: Respect jetpack_action_taken in jumpstart value for users that updated Jetpack to 7.3

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -322,6 +322,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
  * new_connection      : Brand new connection - Show
  * jumpstart_activated : Jump Start has been activated - dismiss
  * jumpstart_dismissed : Manual dismissal of Jump Start - dismiss
+ * jetpack_action_taken: Deprecated since 7.3 But still listed here to respect behaviour for old versions.
+ *                       Manual activation of a module already happened - dismiss.
  *
  * @todo move to functions.global.php when available
  * @since 3.6
@@ -335,6 +337,7 @@ function jetpack_show_jumpstart() {
 
 	$hide_options = array(
 		'jumpstart_activated',
+		'jetpack_action_taken',
 		'jumpstart_dismissed'
 	);
 


### PR DESCRIPTION
In #12099 we deprecated the behaviour by which activating or deactivating a module, or setting a Jetpack option disabled the Jumpstart card. But we need to respect users upgrading their Jetpacks and their previous state about the jumpstart. 


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Keeps the previous behaviour if `jetpack_action_taken` is the value present in the Jetpack jumpstart option

#### Testing instructions:

1. Before checking this branch... On any given connected site, set your jumpsart option to carry the value `jetpack_action_taken`. `wp jetpack options update jumpstart jetpack_action_taken`.
2. Check this branch
3. Confirm the Jumpstart card is shown in Jetpack's dashboard
4. Check this branch
5. Refresh the page, confirm it's gone.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed 
