### PR TITLE
Tracks: Make Jetpack Connect (jpc) verification Tracks events be literals

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -421,6 +421,8 @@ class Jetpack_XMLRPC_Server {
 	 *
 	 * The 'authorize' and 'register' actions have additional error codes
 	 *
+	 * Possible values for action are `authorize`, `publicize` and `register`.
+	 *
 	 * state_missing: a state ( user id ) was not supplied
 	 * state_malformed: state is not the correct data type
 	 * invalid_state: supplied state does not match the stored state
@@ -435,6 +437,11 @@ class Jetpack_XMLRPC_Server {
 		if ( 'authorize' === $action ) {
 			$tracks_failure_event_name = 'jpc_verify_authorize_fail';
 			JetpackTracking::record_user_event( 'jpc_verify_authorize_begin', array(), $user );
+		}
+		if ( 'publicize' === $action ) {
+			// This action is used on a response from a direct XML-RPC done from WordPress.com
+			$tracks_failure_event_name = 'jpc_verify_publicize_fail';
+			JetpackTracking::record_user_event( 'jpc_verify_publicize_begin', array(), $user );
 		}
 		if ( 'register' === $action ) {
 			$tracks_failure_event_name = 'jpc_verify_register_fail';
@@ -477,6 +484,9 @@ class Jetpack_XMLRPC_Server {
 
 		if ( 'authorize' === $action ) {
 			JetpackTracking::record_user_event( 'jpc_verify_authorize_success', array(), $user );
+		}
+		if ( 'publicize' === $action ) {
+			JetpackTracking::record_user_event( 'jpc_verify_publicize_success', array(), $user );
 		}
 		if ( 'register' === $action ) {
 			JetpackTracking::record_user_event( 'jpc_verify_register_success', array(), $user );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -437,7 +437,7 @@ class Jetpack_XMLRPC_Server {
 			JetpackTracking::record_user_event( 'jpc_verify_authorize_begin', array(), $user );
 		}
 		if ( 'register' === $action ) {
-			$tracks_failure_event_name 'jpc_verify_register_fail';
+			$tracks_failure_event_name = 'jpc_verify_register_fail';
 			JetpackTracking::record_user_event( 'jpc_verify_register_begin', array(), $user );
 		}
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -430,8 +430,16 @@ class Jetpack_XMLRPC_Server {
 		$verify_secret = $params[1];
 		$state = isset( $params[2] ) ? $params[2] : '';
 		$user = get_user_by( 'id', $state );
-		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_begin', array(), $user );
-		$tracks_failure_event_name = 'jpc_verify_' . $action . '_fail';
+		$tracks_failure_event_name = '';
+
+		if ( 'authorize' === $action ) {
+			$tracks_failure_event_name = 'jpc_verify_authorize_fail';
+			JetpackTracking::record_user_event( 'jpc_verify_authorize_begin', array(), $user );
+		}
+		if ( 'register' === $action ) {
+			$tracks_failure_event_name 'jpc_verify_register_fail';
+			JetpackTracking::record_user_event( 'jpc_verify_register_begin', array(), $user );
+		}
 
 		if ( empty( $verify_secret ) ) {
 			return $this->error( new Jetpack_Error( 'verify_secret_1_missing', sprintf( 'The required "%s" parameter is missing.', 'secret_1' ), 400 ), $tracks_failure_event_name, $user );
@@ -467,7 +475,12 @@ class Jetpack_XMLRPC_Server {
 
 		Jetpack::delete_secrets( $action, $state );
 
-		JetpackTracking::record_user_event( 'jpc_verify_' . $action . '_success', array(), $user );
+		if ( 'authorize' === $action ) {
+			JetpackTracking::record_user_event( 'jpc_verify_authorize_success', array(), $user );
+		}
+		if ( 'register' === $action ) {
+			JetpackTracking::record_user_event( 'jpc_verify_register_success', array(), $user );
+		}
 
 		return $secrets['secret_2'];
 	}


### PR DESCRIPTION
Some Tracks event names were forged by concatenation before and thus it was complicated to find where they were triggered if starting the quest from Tracks logs.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates `Jetpack_XMLRPC_Server::verify_action()` to have those events named by literals instead of by concatenation of strings.

#### Testing instructions:

* Confirm changes make sense.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
