### PR TITLE
Settings: introduce toggle for Site Verification

### DIFF
--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -100,7 +100,7 @@ class VerificationServicesComponent extends React.Component {
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">
-							{ __( 'Activate verification tools' ) }
+							{ __( 'Verify your site with various services' ) }
 						</span>
 					</ModuleToggle>
 					<p>

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -11,6 +11,7 @@ import { get, includes } from 'lodash';
  * Internal dependencies
  */
 import { FormFieldset, FormLabel } from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -23,10 +24,6 @@ class VerificationServicesComponent extends React.Component {
 		bing: 'msvalidate.01',
 		pinterest: 'p:domain_verify',
 		yandex: 'yandex-verification',
-	};
-
-	activateVerificationTools = () => {
-		return this.props.updateOptions( { 'verification-tools': true } );
 	};
 
 	getMetaTag( serviceName = '', content = '' ) {
@@ -78,23 +75,12 @@ class VerificationServicesComponent extends React.Component {
 			);
 		}
 
-		// Show one-way activation banner if not active
-		if ( ! this.props.getOptionValue( 'verification-tools' ) ) {
-			return (
-				<JetpackBanner
-					callToAction={ __( 'Activate' ) }
-					title={ verification.name }
-					icon="cog"
-					description={ verification.long_description }
-					onClick={ this.activateVerificationTools }
-				/>
-			);
-		}
+		const isVerificationActive = !! this.props.getOptionValue( verification.module );
 
 		return (
 			<SettingsCard
 				{ ...this.props }
-				module="verification-tools"
+				module={ verification.module }
 				saveDisabled={ this.props.isSavingAnyOption( [ 'google', 'bing', 'pinterest', 'yandex' ] ) }
 			>
 				<SettingsGroup
@@ -106,6 +92,17 @@ class VerificationServicesComponent extends React.Component {
 						link: 'https://jetpack.com/support/site-verification-tools',
 					} }
 				>
+					<ModuleToggle
+						slug={ verification.module }
+						activated={ isVerificationActive }
+						toggling={ this.props.isSavingAnyOption( [ verification.module ] ) }
+						disabled={ this.props.isSavingAnyOption( [ verification.module ] ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Activate verification tools' ) }
+						</span>
+					</ModuleToggle>
 					<p>
 						{ __(
 							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
@@ -154,6 +151,7 @@ class VerificationServicesComponent extends React.Component {
 							value={ this.getSiteVerificationValue( 'google' ) }
 							placeholder={ this.getMetaTag( 'google', '1234' ) }
 							{ ...this.props }
+							disabled={ this.props.isUpdating( 'google' ) || ! isVerificationActive }
 						/>
 						<FormLabel className="jp-form-input-with-prefix" key="verification_service_bing">
 							<span>{ __( 'Bing' ) }</span>
@@ -162,7 +160,7 @@ class VerificationServicesComponent extends React.Component {
 								value={ this.getSiteVerificationValue( 'bing' ) }
 								placeholder={ this.getMetaTag( 'bing', '1234' ) }
 								className="code"
-								disabled={ this.props.isUpdating( 'bing' ) }
+								disabled={ this.props.isUpdating( 'bing' ) || ! isVerificationActive }
 								onChange={ this.props.onOptionChange }
 							/>
 						</FormLabel>
@@ -173,7 +171,7 @@ class VerificationServicesComponent extends React.Component {
 								value={ this.getSiteVerificationValue( 'pinterest' ) }
 								placeholder={ this.getMetaTag( 'pinterest', '1234' ) }
 								className="code"
-								disabled={ this.props.isUpdating( 'pinterest' ) }
+								disabled={ this.props.isUpdating( 'pinterest' ) || ! isVerificationActive }
 								onChange={ this.props.onOptionChange }
 							/>
 						</FormLabel>
@@ -184,7 +182,7 @@ class VerificationServicesComponent extends React.Component {
 								value={ this.getSiteVerificationValue( 'yandex' ) }
 								placeholder={ this.getMetaTag( 'yandex', '1234' ) }
 								className="code"
-								disabled={ this.props.isUpdating( 'yandex' ) }
+								disabled={ this.props.isUpdating( 'yandex' ) || ! isVerificationActive }
 								onChange={ this.props.onOptionChange }
 							/>
 						</FormLabel>

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
 import ExternalLink from 'components/external-link';
@@ -32,6 +33,14 @@ import { userCanManageOptions } from 'state/initial-state';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 
 class GoogleVerificationServiceComponent extends React.Component {
+	static propTypes = {
+		disabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		disabled: false,
+	};
+
 	state = {
 		inputVisible: false,
 	};
@@ -181,7 +190,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 							value={ this.props.value }
 							placeholder={ this.props.placeholder }
 							className="code"
-							disabled={ this.props.isUpdating( 'google' ) }
+							disabled={ this.props.disabled }
 							onChange={ this.props.onOptionChange }
 							onKeyPress={ this.handleOnTextInputKeyPress }
 						/>
@@ -191,7 +200,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 									primary
 									type="button"
 									className="jp-form-site-verification-edit-button"
-									disabled={ this.props.isUpdating( 'google' ) }
+									disabled={ this.props.disabled }
 									onClick={ this.quickSave }
 								>
 									{ __( 'Save' ) }
@@ -199,7 +208,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 								<Button
 									type="button"
 									className="jp-form-site-verification-edit-button"
-									disabled={ this.props.isUpdating( 'google' ) }
+									disabled={ this.props.disabled }
 									onClick={ this.handleClickCancel }
 								>
 									{ __( 'Cancel' ) }
@@ -292,7 +301,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 			this.props.fetchingSiteData ||
 			this.props.fetchingGoogleSiteVerify ||
 			this.props.isVerifyingGoogleSite ||
-			this.props.isUpdating( 'google' );
+			this.props.disabled;
 
 		return (
 			<div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #12123 

![verification](https://user-images.githubusercontent.com/1041600/56608149-7dd98d80-65e0-11e9-86cc-3e625cb753a0.gif)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* remove banner for Site verification 
* introduce searchable toggle that activates/deactivates Site verification
* adds new prop `disabled` to `GoogleVerificationServiceComponent`
* when Site verification is disabled, all fields and buttons are disabled

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack settings > Traffic
* You should see the settings card
* Toggle labeled "Activate verification tools" should work properly 
* search for the feature, you should find it

<img width="920" alt="Captura de Pantalla 2019-04-23 a la(s) 15 53 47" src="https://user-images.githubusercontent.com/1041600/56608222-a6fa1e00-65e0-11e9-96d8-bc0800f37e6e.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Part of module prioritization
