### PR TITLE
WordAds: Add location id to each ad call

### DIFF
--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -105,7 +105,7 @@ class Jetpack_WordAds_Gutenblock {
 
 		$height  = $ad_tag_ids[ $format ]['height'];
 		$width   = $ad_tag_ids[ $format ]['width'];
-		$snippet = $wordads->get_ad_snippet( $section_id, $height, $width, 'inline', $wordads->get_solo_unit_css() );
+		$snippet = $wordads->get_ad_snippet( $section_id, $height, $width, 'gutenberg', $wordads->get_solo_unit_css() );
 		return $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
 	}
 }

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -45,6 +45,22 @@ class WordAds {
 		),
 	);
 
+	/**
+	 * Mapping array of location slugs to placement ids
+	 *
+	 * @var array
+	 */
+	public static $ad_location_ids = array(
+		'top'           => 110,
+		'belowpost'     => 120,
+		'belowpost2'    => 130,
+		'sidebar'       => 140,
+		'widget'        => 150,
+		'gutenberg'     => 200,
+		'inline'        => 310,
+		'inline-plugin' => 320,
+	);
+
 	public static $SOLO_UNIT_CSS = 'float:left;margin-right:5px;margin-top:0px;';
 
 	/**
@@ -435,11 +451,11 @@ HTML;
 				$snippet = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
 				if ( $this->option( 'wordads_second_belowpost', true ) ) {
 					$section_id2 = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID2 : $this->params->blog_id . '4';
-					$snippet    .= $this->get_ad_snippet( $section_id2, $height, $width, $spot, 'float:left;margin-top:0px;' );
+					$snippet    .= $this->get_ad_snippet( $section_id2, $height, $width, $spot . '2', 'float:left;margin-top:0px;' );
 				}
 			} elseif ( 'inline' === $spot ) {
 				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '5';
-				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, 'mrec', self::$SOLO_UNIT_CSS );
+				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
 			}
 		} elseif ( 'house' == $type ) {
 			$leaderboard = 'top' == $spot && ! $this->params->mobile_device;
@@ -476,6 +492,11 @@ HTML;
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
 		$css = esc_attr( $css );
 
+		$loc_id = 100;
+		if ( isset( self::$ad_location_ids[$location] ) ) {
+			$loc_id = self::$ad_location_ids[$location];
+		}
+
 		return <<<HTML
 		<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 			<div id="atatags-{$ad_number}">
@@ -484,7 +505,7 @@ HTML;
 					__ATA.initSlot('atatags-{$ad_number}',  {
 						collapseEmpty: 'before',
 						sectionId: '{$section_id}',
-						location: '{$location}',
+						location: {$loc_id},
 						width: {$width},
 						height: {$height}
 					});

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -494,7 +494,7 @@ HTML;
 
 		$loc_id = 100;
 		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
-			$loc_id = self::$ad_location_ids[$location];
+			$loc_id = self::$ad_location_ids[ $location ];
 		}
 
 		return <<<HTML

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -493,7 +493,7 @@ HTML;
 		$css = esc_attr( $css );
 
 		$loc_id = 100;
-		if ( isset( self::$ad_location_ids[$location] ) ) {
+		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
 			$loc_id = self::$ad_location_ids[$location];
 		}
 


### PR DESCRIPTION
We're trying to improve the data about which ad locations are getting added and how much each unit is earning. The update adds some location info to the ad calls, but otherwise does not change functionality.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds `ad_location_ids` array and uses it in `get_ad_snippet`.
* Replaces `inline` with `gutenberg` in `gutenblock_render`'s `get_ad_snippet` call.

#### Testing instructions:
* Activate Ads module
* Create a post, add some ads, optionally add some ad widgets.
* View page source, see `location: <value>` exists in the `__ATA.cmd.push` calls.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added ad unit location id to ad calls
