### PR TITLE
Remove portfolio post type description

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -261,7 +261,6 @@ class Jetpack_Portfolio {
 		}
 
 		register_post_type( self::CUSTOM_POST_TYPE, array(
-			'description' => __( 'Portfolio Items', 'jetpack' ),
 			'labels' => array(
 				'name'                  => esc_html__( 'Projects',                   'jetpack' ),
 				'singular_name'         => esc_html__( 'Project',                    'jetpack' ),


### PR DESCRIPTION
Removes portfolio post type description. This displays on portfolio archives when category_description is used, and can not be edited by users.

Fixes: https://github.com/Automattic/jetpack/issues/12104


#### Testing instructions:
* Go to the portfolio archives in a theme that uses category_description
* The description should no longer say 'portfolio items'

#### Proposed changelog entry for your changes:

* Remove Portfolio post type description so that 'Portfolio Items' is not displayed on the portfolio archive.
