### PR TITLE
Admin Page: Plans - Fix Plan Upgrade button click handler

### DIFF
--- a/_inc/client/plans/top-button.jsx
+++ b/_inc/client/plans/top-button.jsx
@@ -11,7 +11,7 @@ import Button from 'components/button';
 import analytics from 'lib/analytics';
 
 export default class TopButton extends React.Component {
-	clickHandler() {
+	clickHandler = () => {
 		const { planType, isActivePlan, productSlug } = this.props;
 
 		if ( ! isActivePlan ) {
@@ -23,7 +23,7 @@ export default class TopButton extends React.Component {
 			plan: productSlug,
 			page: 'Plans',
 		} );
-	}
+	};
 
 	render() {
 		const {


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

Fixes report in https://github.com/Automattic/jetpack/pull/12118#pullrequestreview-230005083

![image](https://user-images.githubusercontent.com/746152/56660038-f5f19300-6674-11e9-9cde-5b4e658e37cd.png)

Came from a manual refactor in #11095.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates click handler in plans upgrade button to be defined like a class property so to maintain scope

#### Testing instructions:

1. Check this branch on a connected site with a Free, Personal, or Premium plan
2. Visit the plans page 
3. Open the JS console
3. Click the Upgrade Plan button.
4. Confirm you see no JavaScript errors like `admin.js?ver=7.2.1:28549 Uncaught TypeError: Cannot read property 'props' of undefined 
    at clickHandler (admin.js?ver=7.2.1:28549)` 

#### Proposed changelog entry for your changes:

<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
