### PR TITLE
Update Gutenberg extensions docs i18n example

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -196,11 +196,15 @@ As of 04/2019, `wp.i18n` [doesn't support React elements in strings](https://git
 
 Not possible:
 
-> Still confused? Check out <a>documentation</a> for more!
+```js
+__( 'Still confused? Check out <a>documentation</a> for more!' )
+```
 
 Possible:
 
-> Still confused? <a>Check out documentation for more!</a>
+```jsx
+{ __( 'Still confused?' ) } <a>{ __( 'Check out documentation for more!' ) }</a>
+```
 
 ### Colors
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Fix markup for i18n example. `<a>` tag didn't render in HTML output making the example itself kinda confusing:

Rendered Markdown before/after:

<img width="891" alt="Screenshot 2019-04-24 at 15 50 23" src="https://user-images.githubusercontent.com/87168/56660774-e7bd6a00-66a8-11e9-9d97-b4201065f7fd.png">


#### Testing instructions:
🙄 

#### Proposed changelog entry for your changes:
📜 
