### PR TITLE
AMP: check if the class exists before to use it

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -153,7 +153,10 @@ class Jetpack_Carousel {
 	}
 
 	function check_if_shortcode_processed_and_enqueue_assets( $output ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $output;
 		}
 
@@ -208,7 +211,10 @@ class Jetpack_Carousel {
 	 * @return string $content Post content.
 	 */
 	function check_content_for_blocks( $content ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $content;
 		}
 
@@ -354,7 +360,10 @@ class Jetpack_Carousel {
 	}
 
 	function set_in_gallery( $output ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $output;
 		}
 		$this->in_gallery = true;
@@ -372,7 +381,10 @@ class Jetpack_Carousel {
 	 * @return string Modified HTML content of the post
 	 */
 	function add_data_img_tags_and_enqueue_assets( $content ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $content;
 		}
 
@@ -426,7 +438,10 @@ class Jetpack_Carousel {
 	}
 
 	function add_data_to_images( $attr, $attachment = null ) {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $attr;
 		}
 
@@ -498,7 +513,10 @@ class Jetpack_Carousel {
 
 	function add_data_to_container( $html ) {
 		global $post;
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return $html;
 		}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1604,12 +1604,15 @@ EOT;
 	 */
 	protected function _enabled_for_request() {
 		$enabled = is_single()
-			&&
-				! is_admin()
-			&&
-				( !$this->_allow_feature_toggle() || $this->get_option( 'enabled' ) )
-			&&
-				! Jetpack_AMP_Support::is_amp_request();
+			&& ! is_admin()
+			&& ( ! $this->_allow_feature_toggle() || $this->get_option( 'enabled' ) );
+
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
+			$enabled = false;
+		}
 
 		/**
 		 * Filter the Enabled value to allow related posts to be shown on pages as well.

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -575,7 +575,10 @@ function sharing_maybe_enqueue_scripts() {
 }
 
 function sharing_add_footer() {
-	if ( Jetpack_AMP_Support::is_amp_request() ) {
+	if (
+		class_exists( 'Jetpack_AMP_Support' )
+		&& Jetpack_AMP_Support::is_amp_request()
+	) {
 		return;
 	}
 


### PR DESCRIPTION
Differential Revision: D26821-code

This commit syncs r190790-wpcom.

#### Changes proposed in this Pull Request:

* `Jetpack_AMP_Support` is not yet in use on WordPress.com, so we need to check if the class exists before to use it, on all files that are in sync with WordPress.com. 

#### Testing instructions:

* Create a post with a gallery
* Add a Facebook sharing button to that post.
* Try Liking that post.
* Comment on one of the images in the gallery.
* Load the post in an AMP view, and repeat the steps below.

In all cases:
- You should not see any js errors in the browser console.
- You should not get any PHP notices in your debug log.

#### Proposed changelog entry for your changes:

* None
