### PR TITLE
Check status of dev mode in navigation component and hide plan pages

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -18,6 +18,7 @@ import {
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 } from 'state/initial-state';
+import { getSiteDevMode } from 'state/connection';
 
 export class Navigation extends React.Component {
 	trackNavClick = target => {
@@ -39,6 +40,10 @@ export class Navigation extends React.Component {
 		this.trackNavClick( 'plans' );
 	};
 
+	noRenderNavInDevMode = () => {
+		return ! this.props.siteDevMode.isActive;
+	};
+
 	render() {
 		let navTabs;
 		if ( this.props.userCanManageModules ) {
@@ -51,20 +56,24 @@ export class Navigation extends React.Component {
 					>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
-					<NavItem
-						path="#/my-plan"
-						onClick={ this.trackMyPlanClick }
-						selected={ this.props.route.path === '/my-plan' }
-					>
-						{ __( 'My Plan', { context: 'Navigation item.' } ) }
-					</NavItem>
-					<NavItem
-						path="#/plans"
-						onClick={ this.trackPlansClick }
-						selected={ this.props.route.path === '/plans' }
-					>
-						{ __( 'Plans', { context: 'Navigation item.' } ) }
-					</NavItem>
+					{ this.noRenderNavInDevMode() && (
+						<NavItem
+							path="#/my-plan"
+							onClick={ this.trackMyPlanClick }
+							selected={ this.props.route.path === '/my-plan' }
+						>
+							{ __( 'My Plan', { context: 'Navigation item.' } ) }
+						</NavItem>
+					) }
+					{ this.noRenderNavInDevMode() && (
+						<NavItem
+							path="#/plans"
+							onClick={ this.trackPlansClick }
+							selected={ this.props.route.path === '/plans' }
+						>
+							{ __( 'Plans', { context: 'Navigation item.' } ) }
+						</NavItem>
+					) }
 				</NavTabs>
 			);
 		} else {
@@ -89,6 +98,7 @@ export class Navigation extends React.Component {
 
 Navigation.propTypes = {
 	route: PropTypes.object.isRequired,
+	siteDevMode: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 };
 
 export default connect( state => {
@@ -96,5 +106,6 @@ export default connect( state => {
 		userCanManageModules: _userCanManageModules( state ),
 		userCanViewStats: _userCanViewStats( state ),
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
+		siteDevMode: getSiteDevMode( state ),
 	};
 } )( Navigation );

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -18,7 +18,7 @@ import {
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 } from 'state/initial-state';
-import { getSiteDevMode } from 'state/connection';
+import { isDevMode } from 'state/connection';
 
 export class Navigation extends React.Component {
 	trackNavClick = target => {
@@ -40,10 +40,6 @@ export class Navigation extends React.Component {
 		this.trackNavClick( 'plans' );
 	};
 
-	noRenderNavInDevMode = () => {
-		return ! this.props.siteDevMode.isActive;
-	};
-
 	render() {
 		let navTabs;
 		if ( this.props.userCanManageModules ) {
@@ -56,7 +52,7 @@ export class Navigation extends React.Component {
 					>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
-					{ this.noRenderNavInDevMode() && (
+					{ ! this.props.isDevMode && (
 						<NavItem
 							path="#/my-plan"
 							onClick={ this.trackMyPlanClick }
@@ -65,7 +61,7 @@ export class Navigation extends React.Component {
 							{ __( 'My Plan', { context: 'Navigation item.' } ) }
 						</NavItem>
 					) }
-					{ this.noRenderNavInDevMode() && (
+					{ ! this.props.isDevMode && (
 						<NavItem
 							path="#/plans"
 							onClick={ this.trackPlansClick }
@@ -98,7 +94,7 @@ export class Navigation extends React.Component {
 
 Navigation.propTypes = {
 	route: PropTypes.object.isRequired,
-	siteDevMode: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+	isDevMode: PropTypes.bool.isRequired,
 };
 
 export default connect( state => {
@@ -106,6 +102,6 @@ export default connect( state => {
 		userCanManageModules: _userCanManageModules( state ),
 		userCanViewStats: _userCanViewStats( state ),
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
-		siteDevMode: getSiteDevMode( state ),
+		isDevMode: isDevMode( state ),
 	};
 } )( Navigation );

--- a/_inc/client/my-plan/my-plan-header.jsx
+++ b/_inc/client/my-plan/my-plan-header.jsx
@@ -24,8 +24,7 @@ class MyPlanHeader extends React.Component {
 
 	render() {
 		let planCard = '';
-		const planClass = 'dev' !== this.props.plan ? getPlanClass( this.props.plan ) : 'dev';
-		switch ( planClass ) {
+		switch ( getPlanClass( this.props.plan ) ) {
 			case 'is-free-plan':
 				planCard = (
 					<div className="jp-landing__plan-card">
@@ -117,30 +116,6 @@ class MyPlanHeader extends React.Component {
 							<p className="jp-landing__plan-features-text">
 								{ __(
 									'Full security suite, marketing and revenue automation tools, unlimited video hosting, unlimited themes, enhanced search, and priority support.'
-								) }
-							</p>
-						</div>
-					</div>
-				);
-				break;
-
-			case 'dev':
-				planCard = (
-					<div className="jp-landing__plan-card">
-						<div className="jp-landing__plan-card-img">
-							<img
-								src={ imagePath + '/plans/plan-free.svg' }
-								className="jp-landing__plan-icon"
-								alt={ __( 'Jetpack Free Plan' ) }
-							/>
-						</div>
-						<div className="jp-landing__plan-card-current">
-							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Your site is on Development Mode' ) }
-							</h3>
-							<p className="jp-landing__plan-features-text">
-								{ __(
-									'Once you connect, you can upgrade to a paid plan in order to unlock world-class security, spam protection tools, and priority support.'
 								) }
 							</p>
 						</div>


### PR DESCRIPTION
Check status of dev mode in navigation component and hide plan pages if dev mode is turned on. This was reported in #12119.

Fixes #12119 

My first PR against Jetpack so feedback is encouraged.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Load the dev mode state from the store
* Conditionally check the prob and render navigation accordingly 



#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/admin.php?page=jetpack#/dashboard
* Define `define( 'JETPACK_DEV_DEBUG', true );`
* Check the plan related navigation menu items are hidden when enabled.

Before:

<img width="1074" alt="56531905-3218dc80-652b-11e9-80df-fec215214f6b" src="https://user-images.githubusercontent.com/411945/56669714-7d58f980-66a9-11e9-8795-092929821adc.png">

After:

![Screenshot 2019-04-24 at 15 49 14](https://user-images.githubusercontent.com/411945/56669554-3f5bd580-66a9-11e9-8945-b2b11bfbbdb6.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Hide plan admin pages when debug mode is enabled
