### PR TITLE
Connection flow: Trigger action jetpack_user_authorized after we saved the token

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -102,10 +102,18 @@ class Jetpack_Client_Server {
 		return Jetpack::connection()->get_token( $data );
 	}
 
+	/**
+	 * Returns an instance of the Jetpack object.
+	 *
+	 * @return Automattic\Jetpack
+	 */
 	public function get_jetpack() {
 		return Jetpack::init();
 	}
 
+	/**
+	 * Kills the current process.
+	 */
 	public function do_exit() {
 		exit;
 	}

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1873,13 +1873,6 @@ class Manager {
 			return new \WP_Error( 'scope', 'current_user_cannot', $code );
 		}
 
-		/**
-		 * Fires after user has successfully received an auth token.
-		 *
-		 * @since 3.9.0
-		 */
-		do_action( 'jetpack_user_authorized' );
-
 		return (string) $json->access_token;
 	}
 
@@ -2051,6 +2044,13 @@ class Manager {
 		$is_master_user = ! $this->is_active();
 
 		Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+
+		/**
+		 * Fires after user has successfully received an auth token.
+		 *
+		 * @since 3.9.0
+		 */
+		do_action( 'jetpack_user_authorized' );
 
 		if ( ! $is_master_user ) {
 			/**


### PR DESCRIPTION
As part of the [Events validation](https://github.com/Automattic/jetpack/projects/22) project, I got to see that we're attempting to log events before we get to have a token stored. Thus, by the moment we try to figure out the WordPress.com user data for the user in order to log an event, we get null data. 


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Moves the `do_action()` for `Jetpack_Client_Server::jetpack_user_authorized` out of `get_token()` and places at the end of `Jetpack_Client_Server::authorize`)

#### Testing instructions:

Incoming

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
