### PR TITLE
Plugins - fix Calypsoify border color in plugins

### DIFF
--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -667,16 +667,13 @@ body,
 		border-left: 4px solid $color-primary;
 	}
 
-	.plugins .active {
-		th,
-		td,
-		th.check-column {
-			background-color: $muriel-blue-0;
-		}
+	.plugins .active th,
+	.plugins .active td,
+	.plugins .active th.check-column,
+	.plugin-update-tr.active td {
+		background-color: $muriel-blue-0;
 	}
-
 }
-
 
 .wrap {
 	.wp-heading-inline + .page-title-action,

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -2,11 +2,11 @@
 
 body,
 #wp-content-editor-tools {
-  background: $gray-light;
+	background: $gray-light;
 }
 
 #wpwrap {
-  top: 14px;
+	top: 14px;
 }
 
 #wp-admin-bar-notes #wpnt-notes-unread-count.wpn-unread {
@@ -21,202 +21,202 @@ body,
 #screen-meta-links,
 .wp-submenu,
 #toplevel_page_jetpack {
-  display: none;
+	display: none;
 }
 
 .wp-menu-open .wp-submenu {
-  display: block;
+	display: block;
 }
 
 #adminmenuwrap,
 #adminmenuback,
 #adminmenu {
-  background: $muriel-white;
+	background: $muriel-white;
 }
 
 #adminmenuback {
-  border-right: 1px solid $muriel-gray-50;
+	border-right: 1px solid $muriel-gray-50;
 }
 
 #adminmenu,
 #adminmenuwrap,
 #adminmenuback,
 #adminmenu .wp-submenu {
-  width: 272px;
+	width: 272px;
 }
 
 #adminmenu {
-  margin-top: 71px;
+	margin-top: 71px;
 
-  .wp-has-current-submenu .wp-submenu,
-  .opensub .wp-submenu,
-  .opensub .wp-submenu:after,
-  a.wp-has-current-submenu:focus+.wp-submenu {
-    background: transparent !important;
-  }
+	.wp-has-current-submenu .wp-submenu,
+	.opensub .wp-submenu,
+	.opensub .wp-submenu:after,
+	a.wp-has-current-submenu:focus+.wp-submenu {
+		background: transparent !important;
+	}
 
-  li.menu-top:hover,
-  li.opensub>a.menu-top,
-  li>a.menu-top:focus,
-  li.wp-menu-open,
-  a:hover {
-    background: $gray-light;
-  }
+	li.menu-top:hover,
+	li.opensub>a.menu-top,
+	li>a.menu-top:focus,
+	li.wp-menu-open,
+	a:hover {
+		background: $gray-light;
+	}
 
-  .wp-submenu-head,
-  a.menu-top {
-    padding: 5px 0 5px 5px;
-  }
+	.wp-submenu-head,
+	a.menu-top {
+		padding: 5px 0 5px 5px;
+	}
 
-  .wp-has-current-submenu ul>li>a {
+	.wp-has-current-submenu ul>li>a {
 		padding: 11px 16px 11px 20px;
-    font-size: 14px;
-  }
+		font-size: 14px;
+	}
 
-  .wp-submenu a:hover {
-    background-color: $muriel-gray-50;
-  }
+	.wp-submenu a:hover {
+		background-color: $muriel-gray-50;
+	}
 
-  > li.wp-first-item {
-    border-bottom: 1px solid $rgba-grey;
-  }
+	> li.wp-first-item {
+		border-bottom: 1px solid $rgba-grey;
+	}
 
-  a.wp-has-current-submenu:after,
-  >li.current>a.current:after,
-  li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after {
-    border: none;
-  }
+	a.wp-has-current-submenu:after,
+	>li.current>a.current:after,
+	li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after {
+		border: none;
+	}
 
-  .dashicons,
-  .dashicons-before:before {
-    width: 24px;
-    height: 24px;
-    font-size: 24px;
-  }
+	.dashicons,
+	.dashicons-before:before {
+		width: 24px;
+		height: 24px;
+		font-size: 24px;
+	}
 
-  a,
-  div.wp-menu-image:before{
-    color: $gray-dark !important;
-  }
+	a,
+	div.wp-menu-image:before{
+		color: $gray-dark !important;
+	}
 
 
-  li.current a.menu-top,
-  li.wp-has-current-submenu a.wp-has-current-submenu {
-    background: $muriel-blue-50;
-  }
+	li.current a.menu-top,
+	li.wp-has-current-submenu a.wp-has-current-submenu {
+		background: $muriel-blue-50;
+	}
 
-  div.wp-menu-image.svg {
-    filter: brightness(0.25);
-  }
+	div.wp-menu-image.svg {
+		filter: brightness(0.25);
+	}
 
-  li.wp-menu-open div.wp-menu-image.svg {
-    filter: brightness(100);
-  }
+	li.wp-menu-open div.wp-menu-image.svg {
+		filter: brightness(100);
+	}
 
-  li.wp-menu-open div.wp-menu-image:before,
-  li.wp-menu-open div.wp-menu-name {
-    color: $color-primary !important;
-  }
+	li.wp-menu-open div.wp-menu-image:before,
+	li.wp-menu-open div.wp-menu-name {
+		color: $color-primary !important;
+	}
 
-  div.wp-menu-name {
-    color: $gray-text;
-    font-size: 15px;
-    padding: 9px 0 8px 41px;
-  }
+	div.wp-menu-name {
+		color: $gray-text;
+		font-size: 15px;
+		padding: 9px 0 8px 41px;
+	}
 
-  li.menu-top {
-    min-height: 46px;
-  }
+	li.menu-top {
+		min-height: 46px;
+	}
 
-  .awaiting-mod,
-  .update-plugins {
-    background-color: $color-primary;
-  }
+	.awaiting-mod,
+	.update-plugins {
+		background-color: $color-primary;
+	}
 }
 
 .no-js li.wp-has-current-submenu:hover .wp-submenu {
-  background: transparent !important;
+	background: transparent !important;
 }
 
 #wpcontent,
 #wpfooter {
-  margin-left: 272px;
+	margin-left: 272px;
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg,
 #toplevel_page_plugin-install div.wp-menu-image.svg {
-  background-size: 24px auto;
+	background-size: 24px auto;
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg {
-  position: relative;
-  left: -2px;
+	position: relative;
+	left: -2px;
 }
 
 #calypso-sidebar-header {
-  position: fixed;
-  top: 47px;
-  left: 0;
-  width: 272px;
-  height: 70px;
-  background: $white;
-  z-index: 10000;
+	position: fixed;
+	top: 47px;
+	left: 0;
+	width: 272px;
+	height: 70px;
+	background: $white;
+	z-index: 10000;
 
-  svg {
-    float: left;
-    position: relative;
-    left: 10px;
-    top: 23px;
-  }
+	svg {
+		float: left;
+		position: relative;
+		left: 10px;
+		top: 23px;
+	}
 
-  ul {
-    float: left;
-    position: relative;
-    top: 3px;
-    left: 15px;
+	ul {
+		float: left;
+		position: relative;
+		top: 3px;
+		left: 15px;
 
-    li {
-      margin: 0;
+		li {
+			margin: 0;
 
-      &#calypso-sitename {
-        font-size: 12px;
-        color: $gray-text-min;
-        overflow: hidden;
-        white-space: nowrap;
-        width: 225px;
+			&#calypso-sitename {
+				font-size: 12px;
+				color: $gray-text-min;
+				overflow: hidden;
+				white-space: nowrap;
+				width: 225px;
 
-        @media screen and (max-width:782px) {
-          width: 150px;
-        }
+				@media screen and (max-width:782px) {
+					width: 150px;
+				}
 
-        &:after {
-          content: '';
-          display: block;
-          position: absolute;
-          -webkit-touch-callout: none;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-          pointer-events: none;
-          background: -webkit-gradient(linear, left top, right top, from(rgba(255,255,255,0)), color-stop(90%, #fff));
-          background: linear-gradient(to right, rgba(255,255,255,0), #fff 90%);
-          top: 0px;
-          bottom: 0px;
-          right: 0px;
-          left: auto;
-          width: 20%;
-          height: auto;
-        }
-      }
+				&:after {
+					content: '';
+					display: block;
+					position: absolute;
+					-webkit-touch-callout: none;
+					-webkit-user-select: none;
+					-moz-user-select: none;
+					-ms-user-select: none;
+					user-select: none;
+					pointer-events: none;
+					background: -webkit-gradient(linear, left top, right top, from(rgba(255,255,255,0)), color-stop(90%, #fff));
+					background: linear-gradient(to right, rgba(255,255,255,0), #fff 90%);
+					top: 0px;
+					bottom: 0px;
+					right: 0px;
+					left: auto;
+					width: 20%;
+					height: auto;
+				}
+			}
 
-      &#calypso-plugins {
-        font-weight: bold;
-        color: $gray-text;
-        font-size: 16px;
-      }
-    }
-  }
+			&#calypso-plugins {
+				font-weight: bold;
+				color: $gray-text;
+				font-size: 16px;
+			}
+		}
+	}
 }
 
 /*
@@ -224,357 +224,357 @@ body,
 */
 
 .folded {
-  #adminmenu {
-    .wp-has-current-submenu .wp-submenu,
-    .opensub .wp-submenu,
-    .opensub .wp-submenu:after,
-    a.wp-has-current-submenu:focus+.wp-submenu {
-      background: $gray-lighten-30 !important;
-    }
+	#adminmenu {
+		.wp-has-current-submenu .wp-submenu,
+		.opensub .wp-submenu,
+		.opensub .wp-submenu:after,
+		a.wp-has-current-submenu:focus+.wp-submenu {
+			background: $gray-lighten-30 !important;
+		}
 
-    li.menu-top .wp-submenu>li>a {
-      padding: 7px 12px 7px 46px;
-      font-size: 14px;
-    }
+		li.menu-top .wp-submenu>li>a {
+			padding: 7px 12px 7px 46px;
+			font-size: 14px;
+		}
 
-    li.current.menu-top,
-    li.wp-has-current-submenu,
-    li.wp-has-current-submenu .wp-submenu .wp-submenu-head {
-      background: $muriel-blue-0;
-    }
+		li.current.menu-top,
+		li.wp-has-current-submenu,
+		li.wp-has-current-submenu .wp-submenu .wp-submenu-head {
+			background: $muriel-blue-0;
+		}
 
-    .wp-submenu .wp-submenu-head {
-      padding: 14px 4px 14px 11px;
-    }
+		.wp-submenu .wp-submenu-head {
+			padding: 14px 4px 14px 11px;
+		}
 
-    a.menu-top {
-      padding-left: 1px;
-    }
-  }
+		a.menu-top {
+			padding-left: 1px;
+		}
+	}
 
-  #wpcontent {
-    #calypso-sidebar-header {
-      width: 36px;
+	#wpcontent {
+		#calypso-sidebar-header {
+			width: 36px;
 
-      svg {
-        left: 6px;
-      }
+			svg {
+				left: 6px;
+			}
 
-      ul {
-        display: none;
-      }
-    }
-  }
+			ul {
+				display: none;
+			}
+		}
+	}
 
-  .no-js li.wp-has-current-submenu:hover .wp-submenu {
-    background: $gray-lighten-30 !important;
-  }
+	.no-js li.wp-has-current-submenu:hover .wp-submenu {
+		background: $gray-lighten-30 !important;
+	}
 
-  #toplevel_page_plugins div.wp-menu-image.svg {
-    position: relative;
-    left: -2px;
-  }
+	#toplevel_page_plugins div.wp-menu-image.svg {
+		position: relative;
+		left: -2px;
+	}
 }
 
 @media only screen and (max-width: 960px) {
-  #calypso-sidebar-header {
-    width: 36px;
+	#calypso-sidebar-header {
+		width: 36px;
 
-    ul {
-      display: none;
-    }
+		ul {
+			display: none;
+		}
 
-    svg {
-      left: 6px;
-    }
-  }
+		svg {
+			left: 6px;
+		}
+	}
 
-  #adminmenu a.menu-top {
-    padding-left: 1px;
-  }
+	#adminmenu a.menu-top {
+		padding-left: 1px;
+	}
 }
 
 @media screen and (max-width: 782px) {
-  #calypso-sidebar-header {
-    position: absolute;
-    display: none;
-    width: 190px;
-    top: -14px;
-  }
+	#calypso-sidebar-header {
+		position: absolute;
+		display: none;
+		width: 190px;
+		top: -14px;
+	}
 
-  .wp-responsive-open #calypso-sidebar-header {
-    display: block;
-  }
+	.wp-responsive-open #calypso-sidebar-header {
+		display: block;
+	}
 
-  #calypso-sidebar-header ul {
-    display: block;
-  }
+	#calypso-sidebar-header ul {
+		display: block;
+	}
 
-  .auto-fold #adminmenu .wp-menu-name {
-    margin-left: 0;
-  }
+	.auto-fold #adminmenu .wp-menu-name {
+		margin-left: 0;
+	}
 
-  .auto-fold #adminmenu {
-    top: -14px;
-  }
+	.auto-fold #adminmenu {
+		top: -14px;
+	}
 
-  .auto-fold #adminmenu .selected,
-  #adminmenu li.opensub>a.menu-top,
-  #adminmenu li>a.menu-top:focus,
-  #adminmenu li.wp-menu-open {
-    background: $muriel-blue-50 !important;
-  }
+	.auto-fold #adminmenu .selected,
+	#adminmenu li.opensub>a.menu-top,
+	#adminmenu li>a.menu-top:focus,
+	#adminmenu li.wp-menu-open {
+		background: $muriel-blue-50 !important;
+	}
 
-  #adminmenu .wp-submenu,
-  .auto-fold #adminmenu .selected .wp-submenu,
-  .auto-fold #adminmenu .wp-menu-open .wp-submenu,
-  #adminmenu a.wp-has-current-submenu:focus+.wp-submenu {
-    background: $muriel-white !important;
-  }
+	#adminmenu .wp-submenu,
+	.auto-fold #adminmenu .selected .wp-submenu,
+	.auto-fold #adminmenu .wp-menu-open .wp-submenu,
+	#adminmenu a.wp-has-current-submenu:focus+.wp-submenu {
+		background: $muriel-white !important;
+	}
 
-  .auto-fold #adminmenu li.selected div.wp-menu-image.svg {
-    filter: brightness(100);
-  }
+	.auto-fold #adminmenu li.selected div.wp-menu-image.svg {
+		filter: brightness(100);
+	}
 
-  .auto-fold #adminmenu li.selected div.wp-menu-image:before,
-  .auto-fold #adminmenu li.selected div.wp-menu-name {
-    color: $color-primary !important;
-  }
+	.auto-fold #adminmenu li.selected div.wp-menu-image:before,
+	.auto-fold #adminmenu li.selected div.wp-menu-name {
+		color: $color-primary !important;
+	}
 
-  #wpadminbar .quicklinks > ul > li > a,
-  #wpadminbar .quicklinks > ul > li > .ab-empty-item {
-    padding: 0 15px !important;
-  }
+	#wpadminbar .quicklinks > ul > li > a,
+	#wpadminbar .quicklinks > ul > li > .ab-empty-item {
+		padding: 0 15px !important;
+	}
 
-  #wpadminbar li#wp-admin-bar-ab-new-post a {
-    padding: 7px 15px !important;
-  }
+	#wpadminbar li#wp-admin-bar-ab-new-post a {
+		padding: 7px 15px !important;
+	}
 }
 
 @media screen and (max-width: 600px) {
-  #calypso-sidebar-header {
-    top: 32px;
-  }
+	#calypso-sidebar-header {
+		top: 32px;
+	}
 
-  .auto-fold #adminmenu {
-    top: 32px;
-  }
+	.auto-fold #adminmenu {
+		top: 32px;
+	}
 }
 
 @media screen and (max-width: 480px) {
-  #wpadminbar #wp-admin-bar-blog.my-sites > a.ab-item:before {
-    margin-top: 4px !important;
-  }
+	#wpadminbar #wp-admin-bar-blog.my-sites > a.ab-item:before {
+		margin-top: 4px !important;
+	}
 
-  #wpadminbar #wp-admin-bar-newdash > a.ab-item:before {
-    margin-top: 6px !important;
-  }
+	#wpadminbar #wp-admin-bar-newdash > a.ab-item:before {
+		margin-top: 6px !important;
+	}
 
-  #wpadminbar ul li#wp-admin-bar-ab-new-post a:before {
-    top: -5px !important;
-    margin-left: -12px !important;
-  }
+	#wpadminbar ul li#wp-admin-bar-ab-new-post a:before {
+		top: -5px !important;
+		margin-left: -12px !important;
+	}
 }
 
 /* Nav Bar */
 
 .nav-tab-wrapper,
 .wrap h2.nav-tab-wrapper {
-  margin: 10px 0 25px;
-  background: $white;
-  border: 1px solid $rgba-grey;
+	margin: 10px 0 25px;
+	background: $white;
+	border: 1px solid $rgba-grey;
 }
 
 .nav-tab {
-  border: none;
-  background: none;
-  font-weight: 400;
-  padding: 3px 13px 12px;
-  color: $color-primary;
+	border: none;
+	background: none;
+	font-weight: 400;
+	padding: 3px 13px 12px;
+	color: $color-primary;
 }
 
 .nav-tab-active,
 .nav-tab-active:focus,
 .nav-tab-active:focus:active,
 .nav-tab-active:hover {
-  background: transparent;
-  box-shadow: none;
+	background: transparent;
+	box-shadow: none;
 }
 
 .nav-tab:first-child {
-  margin-left: 0;
+	margin-left: 0;
 }
 
 .nav-tab-active,
 .nav-tab-active:focus,
 .nav-tab-active:focus:active {
-  border-bottom: 2px solid $gray-dark;
-  color: $gray-text;
+	border-bottom: 2px solid $gray-dark;
+	color: $gray-text;
 }
 
 /* Admin Bar */
 
 #wpadminbar {
-  background: $color-primary;
-  -webkit-box-shadow: none;
-  -mozilla-box-shadow: none;
-  height: 46px;
-  position: fixed;
+	background: $color-primary;
+	-webkit-box-shadow: none;
+	-mozilla-box-shadow: none;
+	height: 46px;
+	position: fixed;
 
-  .ab-top-menu > li {
-    > .ab-item {
-      font-size: 14px;
-    }
+	.ab-top-menu > li {
+		> .ab-item {
+			font-size: 14px;
+		}
 
-    &.hover > .ab-item {
-      background: $muriel-blue-300 !important;
-      color: $white;
-    }
-  }
+		&.hover > .ab-item {
+			background: $muriel-blue-300 !important;
+			color: $white;
+		}
+	}
 
-  * {
-    line-height: 46px;
-  }
+	* {
+		line-height: 46px;
+	}
 
-  .quicklinks a,
-  .quicklinks .ab-empty-item,
-  .shortlink-input {
-    height: 46px;
-  }
+	.quicklinks a,
+	.quicklinks .ab-empty-item,
+	.shortlink-input {
+		height: 46px;
+	}
 
-  .quicklinks {
-    > ul > li > a {
-      padding: 0 15px;
-    }
+	.quicklinks {
+		> ul > li > a {
+			padding: 0 15px;
+		}
 
-    > ul > li.current > a {
-      background: $_004967;
-    }
-  }
+		> ul > li.current > a {
+			background: $_004967;
+		}
+	}
 
-  &:not(.mobile) .ab-top-menu > li > .ab-item:focus,
-  &.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
-  .ab-top-menu > li.ab-hover > .ab-item {
-    background: transparent !important;
-  }
+	&:not(.mobile) .ab-top-menu > li > .ab-item:focus,
+	&.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
+	.ab-top-menu > li.ab-hover > .ab-item {
+		background: transparent !important;
+	}
 
-  &:not(.mobile) .ab-top-menu > li:hover > .ab-item {
-    background: $muriel-blue-300 !important;
-    color: #fff;
-  }
+	&:not(.mobile) .ab-top-menu > li:hover > .ab-item {
+		background: $muriel-blue-300 !important;
+		color: #fff;
+	}
 
-  .ab-top-menu > li.my-sites {
-    > .ab-item,
-    &.hover > .ab-item,
-    &.ab-hover > .ab-item {
-      background: $_004967 !important;
-    }
-  }
+	.ab-top-menu > li.my-sites {
+		> .ab-item,
+		&.hover > .ab-item,
+		&.ab-hover > .ab-item {
+			background: $_004967 !important;
+		}
+	}
 
-  #wp-admin-bar-blog.my-sites > a.ab-item:before,
-  #wp-admin-bar-newdash > a.ab-item:before {
-    margin-top: 12px;
-  }
+	#wp-admin-bar-blog.my-sites > a.ab-item:before,
+	#wp-admin-bar-newdash > a.ab-item:before {
+		margin-top: 12px;
+	}
 
-  ul li#wp-admin-bar-ab-new-post {
-    border-radius: 3px;
+	ul li#wp-admin-bar-ab-new-post {
+		border-radius: 3px;
 
-    a {
-      padding: 6px 15px;
-      color: $color-primary !important;
+		a {
+			padding: 6px 15px;
+			color: $color-primary !important;
 
-      span {
-        color: $color-primary !important;
-        font-size: 14px !important;
-      }
+			span {
+				color: $color-primary !important;
+				font-size: 14px !important;
+			}
 
-      &:before,
-      &:after {
-        background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="0" fill="none" width="24" height="24"/><g><path fill="%230087be" d="M21 14v5c0 1.105-.895 2-2 2H5c-1.105 0-2-.895-2-2V5c0-1.105.895-2 2-2h5v2H5v14h14v-5h2z"/><path fill="%230087be" d="M21 7h-4V3h-2v4h-4v2h4v4h2V9h4"/></g></svg>') !important;
-      }
-    }
+			&:before,
+			&:after {
+				background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="0" fill="none" width="24" height="24"/><g><path fill="%230087be" d="M21 14v5c0 1.105-.895 2-2 2H5c-1.105 0-2-.895-2-2V5c0-1.105.895-2 2-2h5v2H5v14h14v-5h2z"/><path fill="%230087be" d="M21 7h-4V3h-2v4h-4v2h4v4h2V9h4"/></g></svg>') !important;
+			}
+		}
 
-    &:hover,
-    &:hover > .ab-item {
-      background: $muriel-gray-0 !important;
-      opacity: 1;
-      border-radius: 3px !important;
-    }
-  }
+		&:hover,
+		&:hover > .ab-item {
+			background: $muriel-gray-0 !important;
+			opacity: 1;
+			border-radius: 3px !important;
+		}
+	}
 
-  li#wp-admin-bar-blog.menupop > .ab-sub-wrapper,
-  li#wp-admin-bar-newdash.menupop > .ab-sub-wrapper,
-  li#wp-admin-bar-my-account.menupop > .ab-sub-wrapper {
-    display: none !important;
-  }
+	li#wp-admin-bar-blog.menupop > .ab-sub-wrapper,
+	li#wp-admin-bar-newdash.menupop > .ab-sub-wrapper,
+	li#wp-admin-bar-my-account.menupop > .ab-sub-wrapper {
+		display: none !important;
+	}
 
-  li#wp-admin-bar-notes {
-    &.active,
-    &.active > .ab-item {
-      background: $_004967 !important;
-    }
+	li#wp-admin-bar-notes {
+		&.active,
+		&.active > .ab-item {
+			background: $_004967 !important;
+		}
 
-    > #wpnt-notes-panel2 {
-      top: 46px;
-    }
-  }
+		> #wpnt-notes-panel2 {
+			top: 46px;
+		}
+	}
 
-  .ab-top-menu > li.ab-active > .ab-item,
-  > #wp-toolbar .wpnt-show span.noticon,
-  #wp-admin-bar-notes.wpnt-show .noticon {
-    color: $white !important;
-  }
+	.ab-top-menu > li.ab-active > .ab-item,
+	> #wp-toolbar .wpnt-show span.noticon,
+	#wp-admin-bar-notes.wpnt-show .noticon {
+		color: $white !important;
+	}
 
-  .ab-active > a.ab-item:before,
-  #wp-admin-bar-notes.active .noticon-bell:before {
-    filter: brightness(100) !important;
-  }
+	.ab-active > a.ab-item:before,
+	#wp-admin-bar-notes.active .noticon-bell:before {
+		filter: brightness(100) !important;
+	}
 
-  .quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon,
-  > #wp-toolbar span.noticon,
-  #wp-admin-bar-notes .noticon {
-    top: 10px;
-  }
+	.quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon,
+	> #wp-toolbar span.noticon,
+	#wp-admin-bar-notes .noticon {
+		top: 10px;
+	}
 
-  > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
-  .ab-icon,
-  .ab-item:before {
-    font-size: 24px;
-    line-height: 1.45;
-  }
+	> #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
+	.ab-icon,
+	.ab-item:before {
+		font-size: 24px;
+		line-height: 1.45;
+	}
 }
 
 /* WP Admin UI Mods */
 
 .wrap {
-  margin: 20px 30px 25px 15px;
+	margin: 20px 30px 25px 15px;
 }
 
 @media screen and (max-width: 782px) {
-  .wrap {
-    margin: 10px 18px 10px 7px;
-  }
+	.wrap {
+		margin: 10px 18px 10px 7px;
+	}
 }
 
 .subsubsub,
 .wp-filter {
-  margin: 10px 0 25px;
-  background: $white;
-  border: 1px solid $rgba-grey;
-  width: 100%;
-  box-shadow: none;
-  padding: 0;
+	margin: 10px 0 25px;
+	background: $white;
+	border: 1px solid $rgba-grey;
+	width: 100%;
+	box-shadow: none;
+	padding: 0;
 }
 
 .subsubsub a,
 .filter-links li>a {
-  padding: 10px 15px;
-  display: inline-block;
-  font-size: 14px;
-  margin: 0;
+	padding: 10px 15px;
+	display: inline-block;
+	font-size: 14px;
+	margin: 0;
 	color: $color-link;
-  border-bottom: 2px solid $muriel-white;
-  outline: none;
+	border-bottom: 2px solid $muriel-white;
+	outline: none;
 
 	&:focus {
 		box-shadow: 0 0 0 1px $color-primary, 0 0 2px 1px $color-primary-light;
@@ -591,25 +591,25 @@ body,
 }
 
 .filter-links li>a {
-  padding: 16px;
+	padding: 16px;
 }
 
 .subsubsub a.current,
 .filter-links .current {
-  border-bottom: 2px solid $muriel-gray-700;
+	border-bottom: 2px solid $muriel-gray-700;
 }
 
 .count {
-  display: inline-block;
-  padding: 1px 6px;
-  border: solid 1px $gray;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: bold;
-  line-height: 14px;
-  color: $gray-text-min;
-  text-align: center;
-  margin-left: 2px;
+	display: inline-block;
+	padding: 1px 6px;
+	border: solid 1px $gray;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: bold;
+	line-height: 14px;
+	color: $gray-text-min;
+	text-align: center;
+	margin-left: 2px;
 }
 
 .plugins-php {
@@ -637,15 +637,15 @@ body,
 		}
 	}
 
-  .tablenav {
-    clear: none;
-    float: left;
-    margin-bottom: 15px;
+	.tablenav {
+		clear: none;
+		float: left;
+		margin-bottom: 15px;
 
-    .one-page .displaying-num {
-      display: none;
-    }
-  }
+		.one-page .displaying-num {
+			display: none;
+		}
+	}
 
 	.bulkactions {
 		select:focus {
@@ -654,56 +654,60 @@ body,
 		}
 	}
 
-  p.search-box {
-    margin-top: 5px;
+	p.search-box {
+		margin-top: 5px;
 
 		.wp-filter-search:focus {
 			border-color: $color-primary;
 			box-shadow: 0 0 2px $color-primary-light;
 		}
-  }
+	}
 
 	.plugins .active th {
 		border-left: 4px solid $color-primary;
 	}
 
-	.plugins .active th, .plugins .active td {
-		background-color: $muriel-blue-0;
+	.plugins .active {
+		th,
+		td,
+		th.check-column {
+			background-color: $muriel-blue-0;
+		}
 	}
 
 }
 
 
 .wrap {
-  .wp-heading-inline + .page-title-action,
-  .add-new-h2,
-  .add-new-h2:active,
-  .page-title-action,
-  .page-title-action:active {
-    background: $color-accent;
-    border-color: $color-accent-dark;
-    color: $white;
-    border-style: solid;
-    border-width: 1px 1px 2px;
-    cursor: pointer;
-    display: inline-block;
-    margin: 0 5px 0 0;
-    outline: 0;
-    overflow: hidden;
-    font-weight: 500;
-    text-overflow: ellipsis;
-    text-decoration: none;
-    vertical-align: middle;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    font-size: 13px;
-    line-height: 21px;
-    border-radius: 4px;
-    padding: 2px 10px 2px;
-    margin-bottom: 2px;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
+	.wp-heading-inline + .page-title-action,
+	.add-new-h2,
+	.add-new-h2:active,
+	.page-title-action,
+	.page-title-action:active {
+		background: $color-accent;
+		border-color: $color-accent-dark;
+		color: $white;
+		border-style: solid;
+		border-width: 1px 1px 2px;
+		cursor: pointer;
+		display: inline-block;
+		margin: 0 5px 0 0;
+		outline: 0;
+		overflow: hidden;
+		font-weight: 500;
+		text-overflow: ellipsis;
+		text-decoration: none;
+		vertical-align: middle;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+		font-size: 13px;
+		line-height: 21px;
+		border-radius: 4px;
+		padding: 2px 10px 2px;
+		margin-bottom: 2px;
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
 
 		&:hover {
 			background-color: $muriel-hot-pink-400;
@@ -713,34 +717,34 @@ body,
 			box-shadow: 0 0 0 2px $color-accent-light;
 			background-color: $muriel-hot-pink-400;
 		}
-  }
+	}
 }
 
 .wp-core-ui {
-  .button {
-    background: $white;
+	.button {
+		background: $white;
 
 		&:focus {
 			border-color: $color-primary;
 			box-shadow: 0 0 3px $color-primary-light;
 		}
-  }
+	}
 
-  .button-primary {
-    background: $color-primary;
-    border-color: $color-primary-dark;
-    color: $white;
-    text-shadow: none;
+	.button-primary {
+		background: $color-primary;
+		border-color: $color-primary-dark;
+		color: $white;
+		text-shadow: none;
 
 		&:hover, &:focus {
 			background-color: $muriel-blue-400;
 		}
-  }
+	}
 }
 
 .ui-tabs-nav li,
 .wp-switch-editor {
-  background-color: $gray-lighten-30 !important;
+	background-color: $gray-lighten-30 !important;
 }
 
 .plugin-card a, .popular-tags a, .filter-links>li>a {
@@ -768,12 +772,12 @@ div.mce-toolbar-grp,
 #post-status-info,
 .quicktags-toolbar,
 #major-publishing-actions {
-  background-color: $muriel-white;
-  border-color: $_d9e3ea;
+	background-color: $muriel-white;
+	border-color: $_d9e3ea;
 }
 
 .wp-filter .search-form {
-  margin-right: 10px;
+	margin-right: 10px;
 }
 
 // Shamelessly swiped from https://github.com/Automattic/wp-calypso/blob/59bdfeeb97eda4266ad39410cb0a074d2c88dbc8/client/components/forms/form-toggle
@@ -783,131 +787,131 @@ div.mce-toolbar-grp,
 // ==========================================================================
 
 .form-toggle[type="checkbox"] {
-  display: none;
+	display: none;
 }
 
 .form-toggle__switch {
-  position: relative;
-  display: inline-block;
-  border-radius: 12px;
-  box-sizing: border-box;
-  padding: 2px;
-  width: 40px;
-  height: 24px;
-  vertical-align: middle;
-  align-self: flex-start;
-  outline: 0;
-  cursor: pointer;
-  transition: all .4s ease, box-shadow 0s;
+	position: relative;
+	display: inline-block;
+	border-radius: 12px;
+	box-sizing: border-box;
+	padding: 2px;
+	width: 40px;
+	height: 24px;
+	vertical-align: middle;
+	align-self: flex-start;
+	outline: 0;
+	cursor: pointer;
+	transition: all .4s ease, box-shadow 0s;
 
-  &:before,
-  &:after {
-    position: relative;
-    display: block;
-    content: "";
-    width: 20px;
-    height: 20px;
-  }
-  &:after {
-    left: 0;
-    border-radius: 50%;
-    background: $white;
-    transition: all .2s ease;
-  }
-  &:before {
-    display: none;
-  }
-  .accessible-focus &:focus{
-    box-shadow: 0 0 0 2px $color-primary;
-  }
+	&:before,
+	&:after {
+		position: relative;
+		display: block;
+		content: "";
+		width: 20px;
+		height: 20px;
+	}
+	&:after {
+		left: 0;
+		border-radius: 50%;
+		background: $white;
+		transition: all .2s ease;
+	}
+	&:before {
+		display: none;
+	}
+	.accessible-focus &:focus{
+		box-shadow: 0 0 0 2px $color-primary;
+	}
 }
 
 .form-toggle__label {
-  cursor: pointer;
+	cursor: pointer;
 
-  .is-disabled & {
-    cursor: default;
-  }
+	.is-disabled & {
+		cursor: default;
+	}
 
-  .form-toggle__label-content {
-    flex: 0 1 100%;
-    margin-left: 12px;
-  }
+	.form-toggle__label-content {
+		flex: 0 1 100%;
+		margin-left: 12px;
+	}
 }
 
 .form-toggle {
-  .accessible-focus &:focus {
-    + .form-toggle__label .form-toggle__switch {
-      box-shadow: 0 0 0 2px $color-primary;
-    }
-    &:checked + .form-toggle__label .form-toggle__switch {
-      box-shadow: 0 0 0 2px $color-primary-light;
-    }
-  }
+	.accessible-focus &:focus {
+		+ .form-toggle__label .form-toggle__switch {
+			box-shadow: 0 0 0 2px $color-primary;
+		}
+		&:checked + .form-toggle__label .form-toggle__switch {
+			box-shadow: 0 0 0 2px $color-primary-light;
+		}
+	}
 
-  & + .form-toggle__label .form-toggle__switch {
-    background: $gray-lighten-10;
-  }
+	& + .form-toggle__label .form-toggle__switch {
+		background: $gray-lighten-10;
+	}
 
-  &:not( :disabled ) {
-    + .form-toggle__label:hover .form-toggle__switch {
-      background: $gray-lighten-20;
-    }
-  }
+	&:not( :disabled ) {
+		+ .form-toggle__label:hover .form-toggle__switch {
+			background: $gray-lighten-20;
+		}
+	}
 
-  &:checked{
-    + .form-toggle__label .form-toggle__switch {
-      background: $color-primary;
+	&:checked{
+		+ .form-toggle__label .form-toggle__switch {
+			background: $color-primary;
 
-      &:after {
-        left: 16px;
-      }
-    }
-  }
+			&:after {
+				left: 16px;
+			}
+		}
+	}
 
-  &:checked:not( :disabled ) {
-    + .form-toggle__label:hover .form-toggle__switch {
-      background: $color-primary-light;
-    }
-  }
+	&:checked:not( :disabled ) {
+		+ .form-toggle__label:hover .form-toggle__switch {
+			background: $color-primary-light;
+		}
+	}
 
-  &:disabled {
-    + label.form-toggle__label span.form-toggle__switch {
-      opacity: 0.25;
-      cursor: default;
-    }
-  }
+	&:disabled {
+		+ label.form-toggle__label span.form-toggle__switch {
+			opacity: 0.25;
+			cursor: default;
+		}
+	}
 }
 
 // Classes for toggle state before action is complete (updating plugin or something)
 .form-toggle.is-toggling {
-  + .form-toggle__label .form-toggle__switch {
-    background: $color-primary;
-  }
-  &:checked {
-    + .form-toggle__label .form-toggle__switch {
-      background: $gray-lighten-20;
-    }
-  }
+	+ .form-toggle__label .form-toggle__switch {
+		background: $color-primary;
+	}
+	&:checked {
+		+ .form-toggle__label .form-toggle__switch {
+			background: $gray-lighten-20;
+		}
+	}
 }
 
 .form-toggle.is-compact {
-  + .form-toggle__label .form-toggle__switch {
-    border-radius: 8px;
-    width: 24px;
-    height: 16px;
+	+ .form-toggle__label .form-toggle__switch {
+		border-radius: 8px;
+		width: 24px;
+		height: 16px;
 
-    &:before,
-    &:after {
-      width: 12px;
-      height: 12px;
-    }
-  }
-  &:checked {
-    + .form-toggle__label .form-toggle__switch {
-      &:after{
-        left: 8px;
-      }
-    }
-  }
+		&:before,
+		&:after {
+			width: 12px;
+			height: 12px;
+		}
+	}
+	&:checked {
+		+ .form-toggle__label .form-toggle__switch {
+			&:after{
+				left: 8px;
+			}
+		}
+	}
 }

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -663,6 +663,7 @@ body,
 		}
 	}
 
+	.plugin-update-tr.active td,
 	.plugins .active th {
 		border-left: 4px solid $color-primary;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #12074

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fixes border color of plugin with an update (lines 670)
* Apparently also converts spaces to tabs

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Before
![image](https://user-images.githubusercontent.com/1123119/56689736-03207900-6699-11e9-88fa-c33bfe6f1d3c.png)

#### After
![Screenshot 2019-04-26 at 12 44 03](https://user-images.githubusercontent.com/411945/56805447-fe86cc80-6820-11e9-8704-cc3913705067.png)

* Get any active plugin that needs updating (tweak version number manually if needed)
* Go to the plugins screen when it's calypsoified (/wp-admin/plugins.php?calypsoify=1)
* Observe the left border and background of the plugins table next to the plugin update notice

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog needed
