### PR TITLE
Settings: don't show JITMs the first time the user visits the Jetpack admin

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -33,6 +33,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Adding a redirect meta tag wrapped in noscript tags for all browsers in case they have JavaScript disabled
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
+
+		// If this is the first time the user is viewing the admin, don't show JITMs.
+		// This filter is added just in time because this function is called on admin_menu
+		// and JITMs are initialized on admin_init
+		if ( Jetpack::is_active() && ! Jetpack_Options::get_option( 'first_admin_view', false ) ) {
+			Jetpack_Options::update_option( 'first_admin_view', true );
+			add_filter( 'jetpack_just_in_time_msgs', '__return_false' );
+		}
 	}
 
 	/**

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -406,4 +406,4 @@ class Jetpack_JITM {
 	}
 }
 
-add_action( 'init', array( 'Jetpack_JITM', 'init' ) );
+add_action( 'admin_init', array( 'Jetpack_JITM', 'init' ) );

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -95,6 +95,7 @@ class Jetpack_Options {
 			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget
 			'sso_first_login',              // (bool)   Is this the first time the user logins via SSO.
 			'dismissed_hints',              // (array)  Part of Plugin Search Hints. List of cards that have been dismissed.
+			'first_admin_view',             // (bool)   Set to true the first time the user views the admin. Usually after the initial connection.
 		);
 	}
 


### PR DESCRIPTION
This PR will suppress the site accelerator JITM for initial login. No JITMs will be shown the first time the user visits the Jetpack admin.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #12129
Fixes #10752

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* introduce a Jetpack Option `first_admin_view` that is set to `true` the first time the user visits the Jetpack admin page. 
* when it's the first time, the filter `jetpack_just_in_time_msgs` is set so JITMs won't be displayed
* delay JITM initialization to `admin_init` instead of `init`, so they can be disabled from within hooks in JP admin pages, that run on `admin_menu` without having to rewrite the pages code. Change is innocuous for the rest of the JITMs execution.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a new site using this branch
* Connect Jetpack, go back to JP admin
* the first time, you shouldn't see any JITM
* reload the page, you should see a JITM

You can also try throwing some errors like replacing this in class.jetpack-jitm.php
```php
if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
	error_log( 'no JITMs' );
	return false;
}
error_log( 'yes JITMs' );
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No JITMs will be shown when the user visits the admin for the first time.
