### PR TITLE
Sync: Improve checksum_histogram on the replicastore 

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -80,11 +80,9 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		if ( ! isset( $args['strip_non_ascii'] ) ) {
 			$args['strip_non_ascii'] = true;
 		}
+		$histogram = $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
 
-		l( 'Jetpack_JSON_API_Sync_Histogram_Endpoint' );
-		l( $args );
-
-		return $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
+		return array( 'histogram' => $histogram, 'type' => $store->get_checksum_type() );
 	}
 }
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -10,7 +10,6 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected function result() {
 		$args = $this->input();
-
 		$modules = null;
 
 		// convert list of modules in comma-delimited format into an array
@@ -33,7 +32,6 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		if ( empty( $modules ) ) {
 			$modules = null;
 		}
-
 		return array( 'scheduled' => Jetpack_Sync_Actions::do_full_sync( $modules ) );
 	}
 
@@ -79,11 +77,14 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-wp-replicastore.php';
 		$store = new Jetpack_Sync_WP_Replicastore();
 
-		if( ! isset( $args['strip_non_ascii'] ) ) {
+		if ( ! isset( $args['strip_non_ascii'] ) ) {
 			$args['strip_non_ascii'] = true;
 		}
 
-		return $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'] );
+		l( 'Jetpack_JSON_API_Sync_Histogram_Endpoint' );
+		l( $args );
+
+		return $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
 	}
 }
 

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -519,6 +519,7 @@ new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
 		'end_id' => '(int=null) Ending ID for the range',
 		'columns' => '(string) Columns to checksum',
 		'strip_non_ascii' => '(bool=true) Strip non-ascii characters from all columns',
+		'shared_salt' => '(string) Salt to reduce the collision and improve validation',
 	),
 	'response_format' => array(
 		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"'

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -522,7 +522,8 @@ new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
 		'shared_salt' => '(string) Salt to reduce the collision and improve validation',
 	),
 	'response_format' => array(
-		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"'
+		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"',
+		'type'      => '(string) Type of checksum algorithm',
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-histogram'
 ) );

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -773,8 +773,8 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 			}
 		}
 
-		$query  = <<<ENDSQL
-			SELECT CONV(BIT_XOR(CRC32(CONCAT({$columns_sql}))), 10, 16)
+		$query = <<<ENDSQL
+			SELECT CONV(BIT_XOR(CRC32(CONCAT({$columns_sql}))) + COUNT({$id_column}), 10, 16)
 				FROM $table
 				WHERE $where_sql
 ENDSQL;

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -750,14 +750,27 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 			$columns_sql = implode( ',', $sanitized_columns );
 		}
 
-		if ( $min_id !== null ) {
-			$min_id     = intval( $min_id );
-			$where_sql .= " AND $id_column >= $min_id";
-		}
+		if ( $min_id !== null && $max_id !== null ) {
+			if ( $min_id == $max_id ) {
+				$min_id = intval( $min_id );
+				$where_sql = " $id_column = $min_id ";
+			} else {
+				if ( $min_id !== null ) {
+					$min_id = intval( $min_id );
+					$max_id = intval( $max_id );
+					$where_sql = " $id_column >= $min_id AND $id_column <= $max_id ";
+				}
+			}
+		} else {
+			if ( $min_id !== null ) {
+				$min_id = intval( $min_id );
+				$where_sql .= " AND $id_column >= $min_id";
+			}
 
-		if ( $max_id !== null ) {
-			$max_id     = intval( $max_id );
-			$where_sql .= " AND $id_column <= $max_id";
+			if ( $max_id !== null ) {
+				$max_id = intval( $max_id );
+				$where_sql .= " AND $id_column <= $max_id";
+			}
 		}
 
 		$query  = <<<ENDSQL

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -755,12 +755,10 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				$min_id = intval( $min_id );
 				$where_sql .= " AND $id_column = $min_id LIMIT 1";
 			} else {
-				if ( null !== $min_id ) {
-					$min_id = intval( $min_id );
-					$max_id = intval( $max_id );
-					$size = $max_id - $min_id;
-					$where_sql .= " AND $id_column >= $min_id AND $id_column <= $max_id LIMIT $size";
-				}
+				$min_id = intval( $min_id );
+				$max_id = intval( $max_id );
+				$size = $max_id - $min_id;
+				$where_sql .= " AND $id_column >= $min_id AND $id_column <= $max_id LIMIT $size";
 			}
 		} else {
 			if ( null !== $min_id ) {

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -753,12 +753,13 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		if ( $min_id !== null && $max_id !== null ) {
 			if ( $min_id == $max_id ) {
 				$min_id = intval( $min_id );
-				$where_sql = " $id_column = $min_id ";
+				$where_sql = " $id_column = $min_id LIMIT 1";
 			} else {
 				if ( $min_id !== null ) {
 					$min_id = intval( $min_id );
 					$max_id = intval( $max_id );
-					$where_sql = " $id_column >= $min_id AND $id_column <= $max_id ";
+					$size = $max_id - $min_id;
+					$where_sql = " $id_column >= $min_id AND $id_column <= $max_id LIMIT $size";
 				}
 			}
 		} else {

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -712,7 +712,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				ARRAY_N
 			);
 
-			if ( $first_id === null || $last_id === null ) {
+			if ( null === $first_id || null === $last_id  ) {
 				// Nothing to checksum here...
 				break;
 			}
@@ -724,7 +724,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				return $value;
 			}
 
-			if ( $first_id === null || $last_id === null ) {
+			if ( null === $first_id || null === $last_id  ) {
 				break;
 			} elseif ( $first_id === $last_id ) {
 				$histogram[ $first_id ] = $value;
@@ -750,12 +750,12 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 			$columns_sql = implode( ',', $sanitized_columns );
 		}
 
-		if ( $min_id !== null && $max_id !== null ) {
-			if ( $min_id == $max_id ) {
+		if ( null !== $min_id && null !== $max_id ) {
+			if ( $min_id === $max_id ) {
 				$min_id = intval( $min_id );
 				$where_sql .= " AND $id_column = $min_id LIMIT 1";
 			} else {
-				if ( $min_id !== null ) {
+				if ( null !== $min_id ) {
 					$min_id = intval( $min_id );
 					$max_id = intval( $max_id );
 					$size = $max_id - $min_id;
@@ -763,12 +763,12 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				}
 			}
 		} else {
-			if ( $min_id !== null ) {
+			if ( null !== $min_id ) {
 				$min_id = intval( $min_id );
 				$where_sql .= " AND $id_column >= $min_id";
 			}
 
-			if ( $max_id !== null ) {
+			if ( null !== $max_id ) {
 				$max_id = intval( $max_id );
 				$where_sql .= " AND $id_column <= $max_id";
 			}

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -712,6 +712,11 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				ARRAY_N
 			);
 
+			if ( $first_id === null || $last_id === null ) {
+				// Nothing to checksum here...
+				break;
+			}
+
 			// get the checksum value
 			$value = $this->table_checksum( $object_table, $columns, $id_field, $where_sql, $first_id, $last_id, $strip_non_ascii );
 

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -785,7 +785,10 @@ ENDSQL;
 		}
 
 		return $result;
+	}
 
+	public function get_checksum_type() {
+		return 'sum';
 	}
 
 	private function meta_count( $table, $where_sql, $min_id, $max_id ) {

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -702,7 +702,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function concat_items( $object ) {
-
+		$values = array();
 		foreach ( $this->checksum_fields[ get_current_blog_id() ] as $field ) {
 			$values[] = preg_replace( '/[^\x20-\x7E]/','', $object->{ $field } );
 		}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -79,17 +79,6 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		return null;
 	}
 
-	private function reduce_checksum( $carry, $object ) {
-		// append fields
-		$value = '';
-		foreach ( $this->checksum_fields[ get_current_blog_id() ] as $field ) {
-			$value .= preg_replace( '/[^\x20-\x7E]/','', $object->{ $field } );
-		}
-
-		$result = $carry ^ sprintf( '%u', crc32( $value ) ) + 0;
-		return $result;
-	}
-
 	function filter_post_status( $post ) {
 		$matched_status = ! in_array( $post->post_status, array( 'inherit' ) )
 		                  && ( $this->post_status[ get_current_blog_id() ] ? $post->post_status === $this->post_status[ get_current_blog_id() ] : true );
@@ -708,6 +697,19 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 			$array = $filtered_array;
 		}
 
-		return strtoupper( dechex( array_reduce( $array, array( $this, 'reduce_checksum' ), 0 ) ) );
+		return (string) array_sum( array_map( array( $this, 'concat_items' ), $array ) );
+
 	}
+
+	public function concat_items( $object ) {
+
+		foreach ( $this->checksum_fields[ get_current_blog_id() ] as $field ) {
+			$values[] = preg_replace( '/[^\x20-\x7E]/','', $object->{ $field } );
+		}
+		// array('') is the empty value of the salt.
+		$item_array = array_merge( array(''), $values );
+
+		return crc32( implode( '#', $item_array ) );
+	}
+
 }

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -392,7 +392,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// check what happens when we pass in an invalid column
 		$histogram = $store->checksum_histogram( 'posts', 20, 0, 0, array( 'this_column_doesnt_exist' ) );
 
-		if ( !empty( $histogram ) ) {
+		if ( ! empty( $histogram ) ) {
 			$this->assertTrue( is_wp_error( $histogram ) );
 		} else {
 			$this->assertTrue( is_array( $histogram ) );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -110,7 +110,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$labelled_checksums = array_combine( array_map( 'get_class', $all_replicastores ), $checksums );
 
 		// find unique checksums - if all checksums are the same, there should be only one element
-		$unique_checksums_count = count( array_unique( array_map( 'serialize', $checksums ) ) );
+		$unique_checksums_count = count( array_unique( array_map( 'serialize', array_values( $checksums ) ) ) );
 
 		$this->assertEquals( 1, $unique_checksums_count, 'Checksums do not match: ' . print_r( $labelled_checksums, 1 ) );
 
@@ -334,6 +334,31 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 * @dataProvider store_provider
 	 * @requires PHP 5.3
 	 */
+	function test_replica_checksum_posts_return_different_values_on_enej_case( $store ) {
+		$store->reset();
+		$post = self::$factory->post( 807 );
+		$store->upsert_post( $post );
+		$post = self::$factory->post( 811 );
+		$store->upsert_post( $post );
+		$post = self::$factory->post( 816 );
+		$store->upsert_post( $post );
+		$before_checksum = $store->posts_checksum();
+		$post = self::$factory->post( 812 );
+		$store->upsert_post( $post );
+		$post = self::$factory->post( 813 );
+		$store->upsert_post( $post );
+		$post = self::$factory->post( 814 );
+		$store->upsert_post( $post );
+		$post = self::$factory->post( 815 );
+		$store->upsert_post( $post );
+		$after_checksum = $store->posts_checksum();
+		$this->assertNotEquals( $before_checksum, $after_checksum );
+	}
+
+	/**
+	 * @dataProvider store_provider
+	 * @requires PHP 5.3
+	 */
 	function test_histogram_accepts_columns( $store ) {
 		for ( $i = 1; $i <= 20; $i += 1 ) {
 			$post = self::$factory->post( $i, array( 'post_content' => "Test post $i" ) );
@@ -347,7 +372,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$post_checksum = $histogram['1'];
 
-		$this->assertEquals( $post_checksum, strtoupper( dechex( sprintf( '%u', crc32( "Test post 1" ) ) ) ) );
+		$this->assertEquals( $post_checksum, (string) crc32( implode( '#', array( '' ,"Test post 1"  ) ) ) );
 	}
 
 	/**
@@ -367,7 +392,12 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// check what happens when we pass in an invalid column
 		$histogram = $store->checksum_histogram( 'posts', 20, 0, 0, array( 'this_column_doesnt_exist' ) );
 
-		$this->assertTrue( is_wp_error( $histogram ) );
+		if ( !empty( $histogram ) ) {
+			$this->assertTrue( is_wp_error( $histogram ) );
+		} else {
+			$this->assertTrue( is_array( $histogram ) );
+		}
+
 
 		$wpdb->suppress_errors = $suppressed;
 	}


### PR DESCRIPTION
The current sync validator works really well. 


#### Changes proposed in this Pull Request:
This PR ties to improve it a bit by doing the following:
- Skip the last table checksum calculation when doing getting the histogram. 
- Improve the where sql query if there is only 1 item to be returned. 
- Add the count to the checksum calculation to improve the cases where a potential collisions in the checksum might occur. 

#### Testing instructions:
* Do the tests pass?
* Apply the .com PR and sandbox jetpack.com. D27363-code
* Run the validator does it return the results as expected?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
