### PR TITLE
Gutenberg/Publicize: Fix issue where no connections are shown for CPTs

### DIFF
--- a/_inc/lib/core-api/class-wpcom-rest-field-controller.php
+++ b/_inc/lib/core-api/class-wpcom-rest-field-controller.php
@@ -31,6 +31,9 @@ abstract class WPCOM_REST_API_V2_Field_Controller {
 		}
 
 		add_action( 'rest_api_init', array( $this, 'register_fields' ) );
+
+		// do this again later to collect any CPTs that get registered later
+		add_action( 'restapi_theme_init', array( $this, 'register_fields' ), 20 );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On WPCOM Simple Sites the Portfolio post type gets registered later, causing Publicize connections to be missing from the API.

Fixes #12147

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

There's another order-of-operations issue with `post_type_support('publicize')` versus the `register_field` call that adds the connections to the API endpoint.

This PR solves it the same way we did here: https://github.com/Automattic/jetpack/pull/12031/files -- by adding a second hook to `restapi_theme_init` that will run and pick up any late-registered CPTs.

In Jetpack this isn't an issue because the Portfolio post type is registered on `init`, but on WPCOM we're registering it on `restapi_theme_init` for reasons I'm not sure of. Another solution would be to change this on WPCOM to `init` but this has the comment `// If called via REST API, we need to register later in lifecycle` so I'm not sure what else it would break.

#### Testing instructions:
* Sandbox the API with D27384-code
* Starting at URL: https://wordpress.com/block-editor/edit/jetpack-portfolio/ on a Simple Site.
* Create a new project.
* Look at the editor sidebar and verify that it shows existing Publicize connections, if you have any; if you don't it shows a link to add more:

<img width="281" alt="Screen Shot 2019-04-24 at 2 59 45 PM" src="https://user-images.githubusercontent.com/52152/56700072-2c4b0480-66ad-11e9-9407-62a7a6ce3c69.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix a bug where Publicize connections were not shown in the editor on Portfolio post types for WPCOM Simple Sites
