### PR TITLE
Settings: Hide section subheadings when searching for features

### DIFF
--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -56,14 +56,16 @@ export class Discussion extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __(
-							'Open your site to comments and invite subscribers to get alerts about your latest work.'
-						) }
-						className="jp-settings-description"
-					/>
-				) }
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Discussion' )
+							: __(
+									'Open your site to comments and invite subscribers to get alerts about your latest work.'
+							  )
+					}
+					className="jp-settings-description"
+				/>
 				<Comments
 					{ ...commonProps }
 					isModuleFound={ this.props.isModuleFound }

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -56,14 +56,14 @@ export class Discussion extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __(
-						'Open your site to comments and invite subscribers to get alerts about your latest work.'
-					) }
-					className="jp-settings-description"
-				/>
-
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __(
+							'Open your site to comments and invite subscribers to get alerts about your latest work.'
+						) }
+						className="jp-settings-description"
+					/>
+				) }
 				<Comments
 					{ ...commonProps }
 					isModuleFound={ this.props.isModuleFound }

--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -44,14 +44,14 @@ class Performance extends Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __(
-						'Load pages faster, optimize images, and speed up your visitors’ experience.'
-					) }
-					className="jp-settings-description"
-				/>
-
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __(
+							'Load pages faster, optimize images, and speed up your visitors’ experience.'
+						) }
+						className="jp-settings-description"
+					/>
+				) }
 				<SpeedUpSite { ...commonProps } />
 				<Media { ...commonProps } />
 				<Search { ...commonProps } />

--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -44,14 +44,14 @@ class Performance extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __(
-							'Load pages faster, optimize images, and speed up your visitors’ experience.'
-						) }
-						className="jp-settings-description"
-					/>
-				) }
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Performance' )
+							: __( 'Load pages faster, optimize images, and speed up your visitors’ experience.' )
+					}
+					className="jp-settings-description"
+				/>
 				<SpeedUpSite { ...commonProps } />
 				<Media { ...commonProps } />
 				<Search { ...commonProps } />

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -85,14 +85,16 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __(
-							'Keep your site safe with state-of-the-art security and receive notifications of technical problems.'
-						) }
-						className="jp-settings-description"
-					/>
-				) }
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Security' )
+							: __(
+									'Keep your site safe with state-of-the-art security and receive notifications of technical problems.'
+							  )
+					}
+					className="jp-settings-description"
+				/>
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundMonitor && <Monitor { ...commonProps } /> }
 				{ foundAkismet && (

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -85,14 +85,14 @@ export class Security extends Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __(
-						'Keep your site safe with state-of-the-art security and receive notifications of technical problems.'
-					) }
-					className="jp-settings-description"
-				/>
-
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __(
+							'Keep your site safe with state-of-the-art security and receive notifications of technical problems.'
+						) }
+						className="jp-settings-description"
+					/>
+				) }
 				{ foundBackups && <BackupsScan { ...commonProps } /> }
 				{ foundMonitor && <Monitor { ...commonProps } /> }
 				{ foundAkismet && (

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -53,13 +53,14 @@ class Sharing extends Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __( 'Share your content on social media and increase audience engagement.' ) }
-						className="jp-settings-description"
-					/>
-				) }
-
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Sharing' )
+							: __( 'Share your content on social media and increase audience engagement.' )
+					}
+					className="jp-settings-description"
+				/>
 				{ foundPublicize && <Publicize { ...commonProps } /> }
 				{ foundSharing && <ShareButtons { ...commonProps } /> }
 				{ foundLikes && <Likes { ...commonProps } /> }

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -53,11 +53,12 @@ class Sharing extends Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __( 'Share your content on social media and increase audience engagement.' ) }
-					className="jp-settings-description"
-				/>
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __( 'Share your content on social media and increase audience engagement.' ) }
+						className="jp-settings-description"
+					/>
+				) }
 
 				{ foundPublicize && <Publicize { ...commonProps } /> }
 				{ foundSharing && <ShareButtons { ...commonProps } /> }

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -67,14 +67,16 @@ export class Traffic extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __(
-							'Maximize your site’s visibility in search engines and view traffic stats in real time.'
-						) }
-						className="jp-settings-description"
-					/>
-				) }
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Traffic' )
+							: __(
+									'Maximize your site’s visibility in search engines and view traffic stats in real time.'
+							  )
+					}
+					className="jp-settings-description"
+				/>
 				{ foundAds && (
 					<Ads
 						{ ...commonProps }

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -67,14 +67,14 @@ export class Traffic extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __(
-						'Maximize your site’s visibility in search engines and view traffic stats in real time.'
-					) }
-					className="jp-settings-description"
-				/>
-
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __(
+							'Maximize your site’s visibility in search engines and view traffic stats in real time.'
+						) }
+						className="jp-settings-description"
+					/>
+				) }
 				{ foundAds && (
 					<Ads
 						{ ...commonProps }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -76,13 +76,14 @@ export class Writing extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-
-				<Card
-					title={ __(
-						'Compose content the way you want to and streamline your publishing experience.'
-					) }
-					className="jp-settings-description"
-				/>
+				{ ! this.props.searchTerm && (
+					<Card
+						title={ __(
+							'Compose content the way you want to and streamline your publishing experience.'
+						) }
+						className="jp-settings-description"
+					/>
+				) }
 
 				{ this.props.isModuleFound( 'carousel' ) && <WritingMedia { ...commonProps } /> }
 				{ this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -76,15 +76,16 @@ export class Writing extends React.Component {
 		return (
 			<div>
 				<QuerySite />
-				{ ! this.props.searchTerm && (
-					<Card
-						title={ __(
-							'Compose content the way you want to and streamline your publishing experience.'
-						) }
-						className="jp-settings-description"
-					/>
-				) }
-
+				<Card
+					title={
+						this.props.searchTerm
+							? __( 'Writing' )
+							: __(
+									'Compose content the way you want to and streamline your publishing experience.'
+							  )
+					}
+					className="jp-settings-description"
+				/>
 				{ this.props.isModuleFound( 'carousel' ) && <WritingMedia { ...commonProps } /> }
 				{ this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
 					<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />


### PR DESCRIPTION
Since the module search might throw results that are not strictly encompassed in the current tab, the titles should be adjusted to provide context lost by the removed navigation.

Fixes #12091

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Swap the subheadings to match the section navigation during a module search
 
#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack settings
* Click on the magnifying glass to start searching
* type something that actually has results, like "search"
* check the subheadings correctly separate the sections and make sense

Before:

![Screenshot 2019-04-25 at 15 54 13](https://user-images.githubusercontent.com/411945/56745704-c32dc480-6772-11e9-9842-8103620778bc.png)

After:

![Screenshot 2019-04-25 at 15 41 16](https://user-images.githubusercontent.com/411945/56745734-d04ab380-6772-11e9-954d-240861bbb6c3.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Clearer headings when searching for modules in the settings section
