### PR TITLE
Remove the carousel title and description prefix blocklist

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1270,32 +1270,7 @@ jQuery( document ).ready( function( $ ) {
 			if ( ! value.match( ' ' ) && value.match( '_' ) ) {
 				return '';
 			}
-			// Prefix list originally based on http://commons.wikimedia.org/wiki/MediaWiki:Filename-prefix-blacklist
-			$( [
-				'CIMG', // Casio
-				'DSC_', // Nikon
-				'DSCF', // Fuji
-				'DSCN', // Nikon
-				'DUW', // some mobile phones
-				'GEDC', // GE
-				'IMG', // generic
-				'JD', // Jenoptik
-				'MGP', // Pentax
-				'PICT', // misc.
-				'Imagen', // misc.
-				'Foto', // misc.
-				'DSC', // misc.
-				'Scan', // Scanners
-				'SANY', // Sanyo
-				'SAM', // Samsung
-				'Screen Shot [0-9]+', // Mac screenshots
-			] ).each( function( key, val ) {
-				var regex = new RegExp( '^' + val );
-				if ( regex.test( value ) ) {
-					value = '';
-					return;
-				}
-			} );
+
 			return value;
 		},
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We currently check for certain blocklist words in the carousel module and remove the title or description if those words are discovered. It creates quite a bit of confusion when we modify content in this way as there is no indication to the user that this magic is happening. 

There is some context around the history of these changes at **p158lY-24f**. In summary:

> this function is meant to prevent the generating of titles based on filenames that weren’t created by a human.

I don't think the checks are robust enough. Based on the current set of exclusions for example, I cannot have a title/description called 'Scanning the mountains' or 'SAM & MATT' - both very plausible titles.

Fixes #12067

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Remove the carousel title and description prefix blocklist

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a carousel gallery and make sure one of the images has a title of "IMG1234"
* View the front end / theme and verify the title is not show in the full screen carousel
* Pull this PR down 
* Add `define( 'SCRIPT_DEBUG', true );` to your wp-config.php
* Refresh the page, the title of "IMG1234" should now be visible

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Remove the carousel title and description prefix blocklist
