### PR TITLE
Photon Functions: PHPCS fixes

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -5,7 +5,7 @@
  *
  * @see https://developer.wordpress.com/docs/photon/
  *
- * @param string $image_url URL to the publicly accessible image you want to manipulate
+ * @param string       $image_url URL to the publicly accessible image you want to manipulate
  * @param array|string $args An array of arguments, i.e. array( 'w' => '300', 'resize' => array( 123, 456 ) ), or in string form (w=123&h=456)
  * @return string The raw final URL. You should run this through esc_url() before displaying it.
  */
@@ -79,11 +79,11 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		return $image_url;
 	}
 
-	if ( is_array( $args ) ){
+	if ( is_array( $args ) ) {
 		// Convert values that are arrays into strings
 		foreach ( $args as $arg => $value ) {
 			if ( is_array( $value ) ) {
-				$args[$arg] = implode( ',', $value );
+				$args[ $arg ] = implode( ',', $value );
 			}
 		}
 
@@ -169,7 +169,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 */
 	$photon_domain = apply_filters( 'jetpack_photon_domain', "https://i{$subdomain}.wp.com", $image_url );
 	$photon_domain = trailingslashit( esc_url( $photon_domain ) );
-	$photon_url  = $photon_domain . $image_host_path;
+	$photon_url    = $photon_domain . $image_host_path;
 
 	/**
 	 * Add query strings to Photon URL.
@@ -214,24 +214,31 @@ add_filter( 'jetpack_photon_pre_args', 'jetpack_photon_parse_wpcom_query_args', 
 function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
 	$parsed_url = @parse_url( $image_url );
 
-	if ( ! $parsed_url )
+	if ( ! $parsed_url ) {
 		return $args;
+	}
 
-	$image_url_parts = wp_parse_args( $parsed_url, array(
-		'host'  => '',
-		'query' => ''
-	) );
+	$image_url_parts = wp_parse_args(
+		$parsed_url,
+		array(
+			'host'  => '',
+			'query' => '',
+		)
+	);
 
-	if ( '.files.wordpress.com' != substr( $image_url_parts['host'], -20 ) )
+	if ( '.files.wordpress.com' != substr( $image_url_parts['host'], -20 ) ) {
 		return $args;
+	}
 
-	if ( empty( $image_url_parts['query'] ) )
+	if ( empty( $image_url_parts['query'] ) ) {
 		return $args;
+	}
 
 	$wpcom_args = wp_parse_args( $image_url_parts['query'] );
 
-	if ( empty( $wpcom_args['w'] ) || empty( $wpcom_args['h'] ) )
+	if ( empty( $wpcom_args['w'] ) || empty( $wpcom_args['h'] ) ) {
 		return $args;
+	}
 
 	// Keep the crop by using "resize"
 	if ( ! empty( $wpcom_args['crop'] ) ) {
@@ -278,7 +285,7 @@ function jetpack_photon_url_scheme( $url, $scheme ) {
  * @see https://php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-changelog
  * @deprecated 7.8.0 Use wp_parse_url instead.
  *
- * @param string $url The URL to parse
+ * @param string  $url The URL to parse
  * @param integer $component Retrieve specific URL component
  * @return mixed Result of parse_url
  */

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -1,12 +1,20 @@
 <?php
+/**
+ * Generic functions using the Photon service.
+ *
+ * Some are used outside of the Photon module being active, so intentionally not within the module.
+ *
+ * @package jetpack
+ */
 
 /**
  * Generates a Photon URL.
  *
  * @see https://developer.wordpress.com/docs/photon/
  *
- * @param string       $image_url URL to the publicly accessible image you want to manipulate
- * @param array|string $args An array of arguments, i.e. array( 'w' => '300', 'resize' => array( 123, 456 ) ), or in string form (w=123&h=456)
+ * @param string       $image_url URL to the publicly accessible image you want to manipulate.
+ * @param array|string $args An array of arguments, i.e. array( 'w' => '300', 'resize' => array( 123, 456 ) ), or in string form (w=123&h=456).
+ * @param string|null  $scheme URL protocol.
  * @return string The raw final URL. You should run this through esc_url() before displaying it.
  */
 function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
@@ -72,23 +80,23 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		return $image_url;
 	}
 
-	$image_url_parts = @wp_parse_url( $image_url );
+	$image_url_parts = wp_parse_url( $image_url );
 
-	// Unable to parse
+	// Unable to parse.
 	if ( ! is_array( $image_url_parts ) || empty( $image_url_parts['host'] ) || empty( $image_url_parts['path'] ) ) {
 		return $image_url;
 	}
 
 	if ( is_array( $args ) ) {
-		// Convert values that are arrays into strings
+		// Convert values that are arrays into strings.
 		foreach ( $args as $arg => $value ) {
 			if ( is_array( $value ) ) {
 				$args[ $arg ] = implode( ',', $value );
 			}
 		}
 
-		// Encode values
-		// See https://core.trac.wordpress.org/ticket/17923
+		// Encode values.
+		// See https://core.trac.wordpress.org/ticket/17923 .
 		$args = rawurlencode_deep( $args );
 	}
 
@@ -97,7 +105,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if ( wp_endswith( strtolower( $image_url_parts['host'] ), '.files.wordpress.com' ) ) {
 		$is_wpcom_image = true;
 		if ( isset( $args['ssl'] ) ) {
-			// Do not send the ssl argument to prevent caching issues
+			// Do not send the ssl argument to prevent caching issues.
 			unset( $args['ssl'] );
 		}
 	}
@@ -110,8 +118,8 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
 	// Alternately, if it's a *.files.wordpress.com url, then keep the domain as is.
 	if (
-		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
-		|| $image_url_parts['host'] === wp_parse_url( $custom_photon_url, PHP_URL_HOST )
+		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ), true )
+		|| wp_parse_url( $custom_photon_url, PHP_URL_HOST ) === $image_url_parts['host']
 		|| $is_wpcom_image
 	) {
 		/*
@@ -145,14 +153,14 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		// However some source images are served via PHP so check the no-query-string extension.
 		// For future proofing, this is a blacklist of common issues rather than a whitelist.
 		$extension = pathinfo( $image_url_parts['path'], PATHINFO_EXTENSION );
-		if ( empty( $extension ) || in_array( $extension, array( 'php', 'ashx' ) ) ) {
+		if ( empty( $extension ) || in_array( $extension, array( 'php', 'ashx' ), true ) ) {
 			return $image_url;
 		}
 	}
 
 	$image_host_path = $image_url_parts['host'] . $image_url_parts['path'];
 
-	// Figure out which CDN subdomain to use
+	// Figure out which CDN subdomain to use.
 	srand( crc32( $image_host_path ) );
 	$subdomain = rand( 0, 2 );
 	srand();
@@ -196,7 +204,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		}
 	}
 
-	if ( isset( $image_url_parts['scheme'] ) && 'https' == $image_url_parts['scheme'] ) {
+	if ( isset( $image_url_parts['scheme'] ) && 'https' === $image_url_parts['scheme'] ) {
 		$photon_url = add_query_arg( array( 'ssl' => 1 ), $photon_url );
 	}
 
@@ -211,8 +219,15 @@ add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
  */
 add_filter( 'jetpack_photon_pre_args', 'jetpack_photon_parse_wpcom_query_args', 10, 2 );
 
+/**
+ * Parses WP.com-hosted image args to replicate the crop.
+ *
+ * @param mixed  $args Args set during Photon's processing.
+ * @param string $image_url URL of the image.
+ * @return array|string Args for Photon to use for the URL.
+ */
 function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
-	$parsed_url = @parse_url( $image_url );
+	$parsed_url = wp_parse_url( $image_url );
 
 	if ( ! $parsed_url ) {
 		return $args;
@@ -226,7 +241,7 @@ function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
 		)
 	);
 
-	if ( '.files.wordpress.com' != substr( $image_url_parts['host'], -20 ) ) {
+	if ( '.files.wordpress.com' !== substr( $image_url_parts['host'], -20 ) ) {
 		return $args;
 	}
 
@@ -240,7 +255,7 @@ function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
 		return $args;
 	}
 
-	// Keep the crop by using "resize"
+	// Keep the crop by using "resize".
 	if ( ! empty( $wpcom_args['crop'] ) ) {
 		if ( is_array( $args ) ) {
 			$args = array_merge( array( 'resize' => array( $wpcom_args['w'], $wpcom_args['h'] ) ), $args );
@@ -258,8 +273,16 @@ function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
 	return $args;
 }
 
+/**
+ * Sets the scheme for a URL
+ *
+ * @param string $url URL to set scheme.
+ * @param string $scheme Scheme to use. Accepts http, https, network_path.
+ *
+ * @return string URL.
+ */
 function jetpack_photon_url_scheme( $url, $scheme ) {
-	if ( ! in_array( $scheme, array( 'http', 'https', 'network_path' ) ) ) {
+	if ( ! in_array( $scheme, array( 'http', 'https', 'network_path' ), true ) ) {
 		if ( preg_match( '#^(https?:)?//#', $url ) ) {
 			return $url;
 		}
@@ -267,7 +290,7 @@ function jetpack_photon_url_scheme( $url, $scheme ) {
 		$scheme = 'http';
 	}
 
-	if ( 'network_path' == $scheme ) {
+	if ( 'network_path' === $scheme ) {
 		$scheme_slashes = '//';
 	} else {
 		$scheme_slashes = "$scheme://";
@@ -285,8 +308,8 @@ function jetpack_photon_url_scheme( $url, $scheme ) {
  * @see https://php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-changelog
  * @deprecated 7.8.0 Use wp_parse_url instead.
  *
- * @param string  $url The URL to parse
- * @param integer $component Retrieve specific URL component
+ * @param string  $url The URL to parse.
+ * @param integer $component Retrieve specific URL component.
  * @return mixed Result of parse_url
  */
 function jetpack_photon_parse_url( $url, $component = -1 ) {
@@ -295,6 +318,15 @@ function jetpack_photon_parse_url( $url, $component = -1 ) {
 }
 
 add_filter( 'jetpack_photon_skip_for_url', 'jetpack_photon_banned_domains', 9, 2 );
+
+/**
+ * Check to skip Photon for a known domain that shouldn't be Photonized.
+ *
+ * @param bool   $skip If the image should be skipped by Photon.
+ * @param string $image_url URL of the image.
+ *
+ * @return bool Should the image be skipped by Photon.
+ */
 function jetpack_photon_banned_domains( $skip, $image_url ) {
 	$banned_host_patterns = array(
 		'/^chart\.googleapis\.com$/',

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -163,7 +163,6 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	/*
 	 * Figure out which CDN subdomain to use.
 	 *
-	 * Previously, we used srand and rand, which had issues--most notably that some systems disable srand completely.
 	 * The goal is to have the same subdomain for any particular image to prevent multiple runs resulting in multiple
 	 * images needing to be downloaded by the browser.
 	 *

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -160,10 +160,18 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	$image_host_path = $image_url_parts['host'] . $image_url_parts['path'];
 
-	// Figure out which CDN subdomain to use.
-	srand( crc32( $image_host_path ) );
-	$subdomain = rand( 0, 2 );
-	srand();
+	/*
+	 * Figure out which CDN subdomain to use.
+	 *
+	 * Previously, we used srand and rand, which had issues--most notably that some systems disable srand completely.
+	 * The goal is to have the same subdomain for any particular image to prevent multiple runs resulting in multiple
+	 * images needing to be downloaded by the browser.
+	 *
+	 * We are providing our own generated value by taking the modulus of the crc32 value of the URL.
+	 *
+	 * Valid values are 0, 1, and 2.
+	 */
+	$subdomain = abs( crc32( $image_host_path ) % 3 );
 
 	/**
 	 * Filters the domain used by the Photon module.

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -172,6 +172,20 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 */
 	$subdomain = abs( crc32( $image_host_path ) % 3 );
 
+	/*
+	 * Need to perform a slowroll out per pMz3w-arH-p2
+	 *
+	 * 7.9 - Use the old method if the value is not 0.
+	 * 8.0 - Use the old method if the value is not 0 or 1.
+	 * 8.1 - Remove this completely.
+	 */
+	if ( 0 !== $subdomain ) {
+		// Figure out which CDN subdomain to use.
+		srand( crc32( $image_host_path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_srand
+		$subdomain = rand( 0, 2 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		srand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_srand
+	}
+
 	/**
 	 * Filters the domain used by the Photon module.
 	 *


### PR DESCRIPTION
functions.photon.php contains a number of PHPCS issues and use of outdated methods (`parse_url` with a wrapper to incompletely do what `wp_parse_url` does now, seeding a `rand`, etc).

The major change is to the way we determine the subdomain. The issue with the previous way, beyond the PHPCS violation, is that `srand` is disabled on some systems. The benefit of seeding with the image URL is to net a consistent subdomain to avoid the same image being served from two different subdomains, thus having a browser download the same image twice.

Since we don't really need anything particular randomized, we can convert the image path to a value between 0 and 2 using a combo of abs, crc32 and the `%` operator.

#### Changes proposed in this Pull Request:
* PHPCS fix and modernize Photon functions.

#### Testing instructions:
* WIth Jetpack and Image CDN/Photon, verify Photon URL is the same as before.

#### Proposed changelog entry for your changes:
* n/a, part of a general line item wrt PHPCS repair.
