### PR TITLE
Tiled gallery & Slideshow: use `BlockIcon` component in mediaPlaceholders

### DIFF
--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -9,6 +9,7 @@ import { isBlobURL } from '@wordpress/blob';
 import { withDispatch } from '@wordpress/data';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
@@ -29,6 +30,7 @@ import {
 /**
  * Internal dependencies
  */
+import { icon } from '.';
 import Slideshow from './slideshow';
 import './editor.scss';
 
@@ -184,7 +186,7 @@ class SlideshowEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-gallery"
+						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
 						labels={ {
 							title: __( 'Slideshow', 'jetpack' ),

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -11,7 +11,7 @@ import edit from './edit';
 import save from './save';
 import transforms from './transforms';
 
-const icon = (
+export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M0 0h24v24H0z" fill="none" />
 		<Path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z" />

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -6,6 +6,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { filter, get, pick } from 'lodash';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
@@ -207,7 +208,7 @@ class TiledGalleryEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon={ <div className="tiled-gallery__media-placeholder-icon">{ icon }</div> }
+						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
 						labels={ {
 							title: __( 'Tiled Gallery', 'jetpack' ),

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -106,18 +106,9 @@
 
 	// Hide captions and upload buttons in style picker preview
 	.editor-block-preview__content & {
-		/* @TODO Caption has been commented out */
-		// figcaption,
 		.editor-media-placeholder {
 			display: none;
 		}
-	}
-
-	// Matches with `.dashicon` in `MediaPlaceholder` component
-	.tiled-gallery__media-placeholder-icon {
-		height: 20px;
-		margin-right: 1ch; // stylelint-disable-line unit-whitelist
-		width: 20px;
 	}
 }
 

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -104,7 +104,7 @@
 		transform: translate( -50%, -50% );
 	}
 
-	// Hide captions and upload buttons in style picker preview
+	// Hide upload buttons in style picker preview
 	.editor-block-preview__content & {
 		.editor-media-placeholder {
 			display: none;


### PR DESCRIPTION
Small polish to media placeholder icons. Mostly to remove a CSS hack.

### Before

<img width="685" alt="Screenshot 2019-04-25 at 21 02 15" src="https://user-images.githubusercontent.com/87168/56757674-79a69f00-679d-11e9-8007-3eb0d31dcb3a.png">


### After

<img width="691" alt="Screenshot 2019-04-25 at 20 34 57" src="https://user-images.githubusercontent.com/87168/56757669-76abae80-679d-11e9-8311-39c700f8924e.png">


#### Changes proposed in this Pull Request:
- Use Slideshow's own icon in media placeholder
- Use `BlockIcon` component for spacing, instead of custom CSS. The component has been there for a while already and when Tiled gallery was implemented, it either didn't exist or it wasn't documented well at that point.

#### Testing instructions:
- Build extensions  `yarn build-extensions`
- Insert Tiled gallery and Slideshow blocks to the post
- Ensure no visual differences in placeholder's icon placement/spacing/size
- Slideshow block has its own icon now

#### Proposed changelog entry for your changes:
—
