### PR TITLE
Calypsoify: Add support for switching to Classic when iframing the block editor.

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -7,6 +7,8 @@
 class Jetpack_Calypsoify {
 	static $instance = false;
 
+	public $is_calypsoify_enabled = false;
+
 	private function __construct() {
 		add_action( 'wp_loaded', array( $this, 'setup' ) );
 	}
@@ -20,9 +22,10 @@ class Jetpack_Calypsoify {
 	}
 
 	public function setup() {
+		$this->is_calypsoify_enabled = 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true );
 		add_action( 'admin_init', array( $this, 'check_param' ), 4 );
 
-		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+		if ( $this->is_calypsoify_enabled ) {
 			add_action( 'admin_init', array( $this, 'setup_admin' ), 6 );
 		}
 
@@ -367,6 +370,14 @@ class Jetpack_Calypsoify {
 	 */
 	public function get_close_gutenberg_url() {
 		return $this->get_calypso_url();
+	}
+
+	public function get_switch_to_classic_editor_url() {
+		return add_query_arg(
+			'set-editor',
+			'classic',
+			$this->is_calypsoify_enabled ? $this->get_calypso_url( get_the_ID() ) : false
+		);
 	}
 
 	public function check_param() {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -1,12 +1,22 @@
 <?php
-/*
+/**
  * This is Calypso skin of the wp-admin interface that is conditionally triggered via the ?calypsoify=1 param.
  * Ported from an internal Automattic plugin.
-*/
-
+ */
 class Jetpack_Calypsoify {
-	static $instance = false;
 
+	/**
+	 * Singleton instance of `Jetpack_Calypsoify`.
+	 *
+	 * @var object
+	 */
+	public static $instance = false;
+
+	/**
+	 * Is Calypsoify enabled, based on any value of `calypsoify` user meta.
+	 *
+	 * @var bool
+	 */
 	public $is_calypsoify_enabled = false;
 
 	private function __construct() {
@@ -372,6 +382,11 @@ class Jetpack_Calypsoify {
 		return $this->get_calypso_url();
 	}
 
+	/**
+	 * Returns the URL for switching the user's editor to the Calypso (WordPress.com Classic) editor.
+	 *
+	 * @return string
+	 */
 	public function get_switch_to_classic_editor_url() {
 		return add_query_arg(
 			'set-editor',

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -196,8 +196,8 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue the scripts for the WordPress.com block editor integration.
 	 */
 	public function enqueue_scripts() {
-		$debug         = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$version       = gmdate( 'YW' );
+		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		$version = gmdate( 'YW' );
 
 		$src_common = $debug
 			? '//widgets.wp.com/wpcom-block-editor/common.js?minify=false'
@@ -218,7 +218,6 @@ class Jetpack_WPCOM_Block_Editor {
 					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
 					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),
-				'isCalypsoify'    => $is_calypsoify,
 				'richTextToolbar' => array(
 					'justify'   => __( 'Justify', 'jetpack' ),
 					'underline' => __( 'Underline', 'jetpack' ),

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -215,7 +215,9 @@ class Jetpack_WPCOM_Block_Editor {
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
-					'isVisible' => false,
+					'isVisible' => $is_calypsoify,
+					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
+					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),
 				'isCalypsoify'    => $is_calypsoify,
 				'richTextToolbar' => array(

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -198,7 +198,6 @@ class Jetpack_WPCOM_Block_Editor {
 	public function enqueue_scripts() {
 		$debug         = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 		$version       = gmdate( 'YW' );
-		$is_calypsoify = 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true );
 
 		$src_common = $debug
 			? '//widgets.wp.com/wpcom-block-editor/common.js?minify=false'
@@ -215,7 +214,7 @@ class Jetpack_WPCOM_Block_Editor {
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
-					'isVisible' => $is_calypsoify,
+					'isVisible' => $this->is_iframed_block_editor(),
 					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
 					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),


### PR DESCRIPTION
When using WordPress.com to edit a WordPress.com site, we give a menu option in the block editor to easily switch to the Calypso editor. With upcoming support for editing Jetpack sites with the block editor on WordPress.com, this PR will give the same option for Jetpack users.

Note that the changes to `modules/calypsoify/class.jetpack-calypsoify.php` could have been a little simpler, but these changes bring it more in line with the `Calypsoify` class active on WP.com; knowing we'll be faced with bringing the two more in sync in the future, keeping them as similar as possible for now seems the prudent approach.

<img width="1348" alt="Screen Shot 2019-04-25 at 2 40 41 PM" src="https://user-images.githubusercontent.com/349751/56770251-4dbcf680-6768-11e9-8ebe-274632aa5c9d.png">

#### Testing instructions:
* Load `http://calypso.localhost:3000/block-editor/post/:JPsite` (`JPSite` being your test site with this Jetpack repo installed).
* Verify the block editor ellipsis menu does _not_ have the "Switch to Classic Editor" item.
* Switch your Jetpack plugin to this branch.
* Reload `http://calypso.localhost:3000/block-editor/post/:JPsite`.
* Verify the block editor ellipsis menu _does_ have the "Switch to Classic Editor" item.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* N/A
