### PR TITLE
Connection: Select One of Multiple Blog Tokens

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -48,7 +48,7 @@ class Jetpack_Provision { //phpcs:ignore
 		}
 
 		$blog_id    = Jetpack_Options::get_option( 'id' );
-		$blog_token = Jetpack_Options::get_option( 'blog_token' );
+		$blog_token = Jetpack_Data::get_access_token();
 
 		if ( ! $blog_id || ! $blog_token || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.
@@ -61,7 +61,7 @@ class Jetpack_Provision { //phpcs:ignore
 			}
 
 			$blog_id    = Jetpack_Options::get_option( 'id' );
-			$blog_token = Jetpack_Options::get_option( 'blog_token' );
+			$blog_token = Jetpack_Data::get_access_token();
 		}
 
 		// If the user isn't specified, but we have a current master user, then set that to current user.

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -170,24 +170,19 @@ class Jetpack_Debug_Data {
 		 * If a token does not contain a period, then it is malformed and we report it as such.
 		 */
 		$user_id     = get_current_user_id();
-		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );
-		$blog_token  = Jetpack_Options::get_option( 'blog_token' );
-		$user_token  = null;
-		if ( is_array( $user_tokens ) && array_key_exists( $user_id, $user_tokens ) ) {
-			$user_token = $user_tokens[ $user_id ];
-		}
-		unset( $user_tokens );
+		$blog_token = Jetpack_Data::get_access_token();
+		$user_token = Jetpack_Data::get_access_token( $user_id );
 
 		$tokenset = '';
 		if ( $blog_token ) {
 			$tokenset = 'Blog ';
-			$blog_key = substr( $blog_token, 0, strpos( $blog_token, '.' ) );
+			$blog_key = substr( $blog_token, 0, strpos( $blog_token->secret, '.' ) );
 			// Intentionally not translated since this is helpful when sent to Happiness.
 			$blog_key = ( $blog_key ) ? $blog_key : 'Potentially Malformed Token.';
 		}
 		if ( $user_token ) {
 			$tokenset .= 'User';
-			$user_key  = substr( $user_token, 0, strpos( $user_token, '.' ) );
+			$user_key  = substr( $user_token, 0, strpos( $user_token->secret, '.' ) );
 			// Intentionally not translated since this is helpful when sent to Happiness.
 			$user_key = ( $user_key ) ? $user_key : 'Potentially Malformed Token.';
 		}

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -169,20 +169,20 @@ class Jetpack_Debug_Data {
 		 *
 		 * If a token does not contain a period, then it is malformed and we report it as such.
 		 */
-		$user_id     = get_current_user_id();
+		$user_id    = get_current_user_id();
 		$blog_token = Jetpack_Data::get_access_token();
 		$user_token = Jetpack_Data::get_access_token( $user_id );
 
 		$tokenset = '';
 		if ( $blog_token ) {
 			$tokenset = 'Blog ';
-			$blog_key = substr( $blog_token, 0, strpos( $blog_token->secret, '.' ) );
+			$blog_key = substr( $blog_token->secret, 0, strpos( $blog_token->secret, '.' ) );
 			// Intentionally not translated since this is helpful when sent to Happiness.
 			$blog_key = ( $blog_key ) ? $blog_key : 'Potentially Malformed Token.';
 		}
 		if ( $user_token ) {
 			$tokenset .= 'User';
-			$user_key  = substr( $user_token, 0, strpos( $user_token->secret, '.' ) );
+			$user_key  = substr( $user_token->secret, 0, strpos( $user_token->secret, '.' ) );
 			// Intentionally not translated since this is helpful when sent to Happiness.
 			$user_key = ( $user_key ) ? $user_key : 'Potentially Malformed Token.';
 		}

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -4,9 +4,11 @@ class Jetpack_Data {
 	/**
 	 * Gets locally stored token
 	 *
+	 * @param int|false $user_id false: Return the Blog Token. int: Return that user's User Token.
+	 * @param string|false $token_key: If provided, check that the stored token matches the provided $token_key.
 	 * @return object|false
 	 */
-	public static function get_access_token( $user_id = false ) {
+	public static function get_access_token( $user_id = false, $token_key = false ) {
 		if ( $user_id ) {
 			if ( !$tokens = Jetpack_Options::get_option( 'user_tokens' ) ) {
 				return false;
@@ -30,6 +32,13 @@ class Jetpack_Data {
 		} else {
 			$token = Jetpack_Options::get_option( 'blog_token' );
 			if ( empty( $token ) ) {
+				return false;
+			}
+		}
+
+		if ( false !== $token_key ) {
+			$token_check = rtrim( $token_key, '.' ) . '.';
+			if ( ! hash_equals( substr( $token, 0, strlen( $token_check ) ), $token_check ) ) {
 				return false;
 			}
 		}

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -33,8 +33,8 @@ class Jetpack_Data {
 			}
 			$tokens = array( "{$token_chunks[0]}.{$token_chunks[1]}" );
 		} else {
-			$tokens = defined( 'JETPACK__BLOG_TOKEN' ) && ';stored;' !== $token_key
-				? array( JETPACK__BLOG_TOKEN )
+			$tokens = defined( 'JETPACK__BLOG_TOKENS' ) && ';stored;' !== $token_key
+				? explode( ',', JETPACK__BLOG_TOKENS )
 				: array();
 
 			$token = Jetpack_Options::get_option( 'blog_token' );

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -5,7 +5,7 @@ class Jetpack_Data {
 	 * Used internally when we want to look for the Normal Blog Token
 	 * without knowing its token key ahead of time.
 	 */
-	const MAGIC_NORMAL_TOKEN_KEY = ';stored;';
+	const MAGIC_NORMAL_TOKEN_KEY = ';normal;';
 
 	/**
 	 * Gets the requested token.

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -38,11 +38,13 @@ class Jetpack_Data {
 				: array();
 
 			$stored_blog_token = Jetpack_Options::get_option( 'blog_token' );
-			if ( empty( $stored_blog_token ) && empty( $possible_tokens ) ) {
-				return false;
+			if ( $stored_blog_token ) {
+				$possible_tokens[] = $stored_blog_token;
 			}
 
-			$possible_tokens[] = $stored_blog_token;
+			if ( ! $possible_tokens ) {
+				return false;
+			}
 		}
 
 		$valid_token = false;

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -21,57 +21,57 @@ class Jetpack_Data {
 					return false;
 				}
 			}
-			if ( !isset( $user_tokens[$user_id] ) || !$token = $user_tokens[$user_id] ) {
+			if ( !isset( $user_tokens[$user_id] ) || ! $user_tokens[$user_id] ) {
 				return false;
 			}
-			$token_chunks = explode( '.', $token );
-			if ( empty( $token_chunks[1] ) || empty( $token_chunks[2] ) ) {
+			$user_token_chunks = explode( '.', $user_tokens[$user_id] );
+			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
 				return false;
 			}
-			if ( $user_id != $token_chunks[2] ) {
+			if ( $user_id != $user_token_chunks[2] ) {
 				return false;
 			}
-			$tokens = array( "{$token_chunks[0]}.{$token_chunks[1]}" );
+			$possible_tokens = array( "{$user_token_chunks[0]}.{$user_token_chunks[1]}" );
 		} else {
-			$tokens = Jetpack_Constants::is_defined( 'JETPACK_BLOG_TOKEN' ) && ';stored;' !== $token_key
+			$possible_tokens = Jetpack_Constants::is_defined( 'JETPACK_BLOG_TOKEN' ) && ';stored;' !== $token_key
 				? explode( ',', Jetpack_Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
 				: array();
 
-			$token = Jetpack_Options::get_option( 'blog_token' );
-			if ( empty( $token ) && empty( $tokens ) ) {
+			$stored_blog_token = Jetpack_Options::get_option( 'blog_token' );
+			if ( empty( $stored_blog_token ) && empty( $possible_tokens ) ) {
 				return false;
 			}
 
-			$tokens[] = $token;
+			$possible_tokens[] = $stored_blog_token;
 		}
+
+		$valid_token = false;
 
 		if ( false === $token_key ) {
 			// Use first token.
-			$token = $tokens[0];
+			$valid_token = $possible_tokens[0];
 		} elseif ( ';stored;' === $token_key ) {
 			// Use first stored token.
-			$token = $tokens[0]; // $tokens only contains stored tokens because of earlier check.
+			$valid_token = $possible_tokens[0]; // $tokens only contains stored tokens because of earlier check.
 		} else {
 			// Use the token matching $token_key or false if none.
 			// Ensure we check the full key.
 			$token_check = rtrim( $token_key, '.' ) . '.';
 
-			$valid_token = false;
-			foreach ( $tokens as $token ) {
-				if ( hash_equals( substr( $token, 0, strlen( $token_check ) ), $token_check ) ) {
-					$valid_token = $token;
+			foreach ( $possible_tokens as $possible_token ) {
+				if ( hash_equals( substr( $possible_token, 0, strlen( $token_check ) ), $token_check ) ) {
+					$valid_token = $possible_token;
+					break;
 				}
 			}
+		}
 
-			if ( ! $valid_token ) {
-				return false;
-			}
-
-			$token = $valid_token;
+		if ( ! $valid_token ) {
+			return false;
 		}
 
 		return (object) array(
-			'secret' => $token,
+			'secret' => $valid_token,
 			'external_user_id' => (int) $user_id,
 		);
 	}

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -33,8 +33,8 @@ class Jetpack_Data {
 			}
 			$tokens = array( "{$token_chunks[0]}.{$token_chunks[1]}" );
 		} else {
-			$tokens = defined( 'JETPACK__BLOG_TOKENS' ) && ';stored;' !== $token_key
-				? explode( ',', JETPACK__BLOG_TOKENS )
+			$tokens = defined( 'JETPACK_BLOG_TOKEN' ) && ';stored;' !== $token_key
+				? explode( ',', JETPACK_BLOG_TOKEN )
 				: array();
 
 			$token = Jetpack_Options::get_option( 'blog_token' );

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -33,8 +33,8 @@ class Jetpack_Data {
 			}
 			$tokens = array( "{$token_chunks[0]}.{$token_chunks[1]}" );
 		} else {
-			$tokens = defined( 'JETPACK_BLOG_TOKEN' ) && ';stored;' !== $token_key
-				? explode( ',', JETPACK_BLOG_TOKEN )
+			$tokens = Jetpack_Constants::is_defined( 'JETPACK_BLOG_TOKEN' ) && ';stored;' !== $token_key
+				? explode( ',', Jetpack_Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
 				: array();
 
 			$token = Jetpack_Options::get_option( 'blog_token' );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -759,7 +759,13 @@ class Jetpack_XMLRPC_Server {
 		$old_user = wp_get_current_user();
 		wp_set_current_user( $user_id );
 
-		$token = Jetpack_Data::get_access_token( get_current_user_id() );
+		if ( $user_id ) {
+			$token_key = false;
+		} else {
+			$token_key = Jetpack::init()->xmlrpc_verification['token_key'];
+		}
+
+		$token = Jetpack_Data::get_access_token( $user_id, $token_key );
 		if ( !$token || is_wp_error( $token ) ) {
 			return false;
 		}

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -190,7 +190,7 @@ class Jetpack_XMLRPC_Server {
 			);
 		}
 
-		if ( ! Jetpack_Options::get_option( 'id' ) || ! Jetpack_Options::get_option( 'blog_token' ) || ! empty( $request['force'] ) ) {
+		if ( ! Jetpack_Options::get_option( 'id' ) || ! Jetpack_Data::get_access_token() || ! empty( $request['force'] ) ) {
 			wp_set_current_user( $user->ID );
 
 			// This code mostly copied from Jetpack::admin_page_load.

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -762,7 +762,9 @@ class Jetpack_XMLRPC_Server {
 		if ( $user_id ) {
 			$token_key = false;
 		} else {
-			$token_key = Jetpack::init()->xmlrpc_verification['token_key'];
+			$jetpack   = Jetpack::init();
+			$verified  = $jetpack->verify_xml_rpc_signature();
+			$token_key = $verified['token_key'];
 		}
 
 		$token = Jetpack_Data::get_access_token( $user_id, $token_key );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5195,13 +5195,8 @@ p {
 			}
 		}
 
-		$token = Jetpack_Data::get_access_token( $user_id );
+		$token = Jetpack_Data::get_access_token( $user_id, $token_key );
 		if ( ! $token ) {
-			return false;
-		}
-
-		$token_check = "$token_key.";
-		if ( ! hash_equals( substr( $token->secret, 0, strlen( $token_check ) ), $token_check ) ) {
 			return false;
 		}
 
@@ -5284,8 +5279,9 @@ p {
 		}
 
 		$this->xmlrpc_verification = array(
-			'type'    => $token_type,
-			'user_id' => $token->external_user_id,
+			'type'      => $token_type,
+			'token_key' => $token_key,
+			'user_id'   => $token->external_user_id,
 		);
 
 		return $this->xmlrpc_verification;
@@ -5822,7 +5818,7 @@ p {
 			: $environment;
 
 		list( $envToken, $envVersion, $envUserId ) = explode( ':', $environment['token'] );
-		$token = Jetpack_Data::get_access_token( $envUserId );
+		$token = Jetpack_Data::get_access_token( $envUserId, $envToken );
 		if ( ! $token || empty( $token->secret ) ) {
 			wp_die( __( 'You must connect your Jetpack plugin to WordPress.com to use this feature.' , 'jetpack' ) );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4429,9 +4429,9 @@ p {
 	 */
 	function build_connect_url( $raw = false, $redirect = false, $from = false, $register = false ) {
 		$site_id = Jetpack_Options::get_option( 'id' );
-		$token = Jetpack_Options::get_option( 'blog_token' );
+		$blog_token = Jetpack_Data::get_access_token();
 
-		if ( $register || ! $token || ! $site_id ) {
+		if ( $register || ! $blog_token || ! $site_id ) {
 			$url = Jetpack::nonce_url_no_esc( Jetpack::admin_url( 'action=register' ), 'jetpack-register' );
 
 			if ( ! empty( $redirect ) ) {

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -276,7 +276,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$params['has_cookie_consent']  = (int) ! empty( $commenter['comment_author_email'] );
 		}
 
-		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, Jetpack_Options::get_option( 'blog_token' ) );
+		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, Jetpack_Data::get_access_token()->secret );
 		if ( is_wp_error( $signature ) ) {
 			$signature = 'error';
 		}

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -276,7 +276,14 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$params['has_cookie_consent']  = (int) ! empty( $commenter['comment_author_email'] );
 		}
 
-		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, Jetpack_Data::get_access_token()->secret );
+		$blog_token = Jetpack_Data::get_access_token();
+		list( $token_key ) = explode( '.', $blog_token->secret, 2 );
+		// Prophylactic check: anything else should never happen.
+		if ( $token_key && $token_key !== $blog_token->secret ) {
+			$params['token_key'] = $token_key;
+		}
+
+		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, $blog_token->secret );
 		if ( is_wp_error( $signature ) ) {
 			$signature = 'error';
 		}

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -280,7 +280,11 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		list( $token_key ) = explode( '.', $blog_token->secret, 2 );
 		// Prophylactic check: anything else should never happen.
 		if ( $token_key && $token_key !== $blog_token->secret ) {
-			$params['token_key'] = $token_key;
+			if ( preg_match( '/^;.\d+;\d+;$/', $token_key, $matches ) ) {
+				$params['token_key'] = $token_key;
+			} else {
+				$params['token_key'] = ';stored;';
+			}
 		}
 
 		$signature = Jetpack_Comments::sign_remote_comment_parameters( $params, $blog_token->secret );

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -281,9 +281,16 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		// Prophylactic check: anything else should never happen.
 		if ( $token_key && $token_key !== $blog_token->secret ) {
 			if ( preg_match( '/^;.\d+;\d+;$/', $token_key, $matches ) ) {
+				// The token key for a Special Token is public.
 				$params['token_key'] = $token_key;
 			} else {
-				$params['token_key'] = ';stored;';
+				/*
+				 * The token key for a Normal Token is public but
+				 * looks like sensitive data. Since there can only be
+				 * one Normal Token per site, avoid concern by
+				 * sending the magic "use the Normal Token" token key.
+				 */
+				$params['token_key'] = Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY;
 			}
 		}
 

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -462,7 +462,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		$post_array = stripslashes_deep( $_POST );
 
 		// Bail if missing the Jetpack token
-		if ( ! isset( $post_array['sig'] ) ) {
+		if ( ! isset( $post_array['sig'] ) || ! isset( $post_array['token_key'] ) ) {
 			unset( $_POST['hc_post_as'] );
 
 			return;
@@ -472,13 +472,17 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$post_array['hc_avatar'] = htmlentities( $post_array['hc_avatar'] );
 		}
 
-		$check = Jetpack_Comments::sign_remote_comment_parameters( $post_array, Jetpack_Options::get_option( 'blog_token' ) );
+		$blog_token = Jetpack_Data::get_access_token( false, $post_array['token_key'] );
+		if ( ! $blog_token ) {
+			wp_die( __( 'Unknown security token.', 'jetpack' ), 400 );
+		}
+		$check = Jetpack_Comments::sign_remote_comment_parameters( $post_array, $blog_token->secret );
 		if ( is_wp_error( $check ) ) {
 			wp_die( $check );
 		}
 
 		// Bail if token is expired or not valid
-		if ( $check !== $post_array['sig'] ) {
+		if ( ! hash_equals( $check, $post_array['sig'] ) ) {
 			wp_die( __( 'Invalid security token.', 'jetpack' ), 400 );
 		}
 

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	public function test_get_access_token_with_magic_key_returns_stored_blog_token() {
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
-		$token = Jetpack_Data::get_access_token( false, ';stored;' );
+		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::STORED );
 
-		$token = Jetpack_Data::get_access_token( false, ';stored;' );
+		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -137,7 +137,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	public function test_get_access_token_with_magic_key_returns_stored_token_when_constant_multi_set() {
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
-		$token = Jetpack_Data::get_access_token( false, ';stored;' );
+		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -147,7 +147,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
-		$token = Jetpack_Data::get_access_token( false, ';stored;' );
+		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
 
 		$this->assertEquals( 'looks-like-a.stored-token', $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -9,6 +9,8 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	const DEFINED_MULTI = 'hello.world,foo.bar';
 
 	public function setUp() {
+		parent::setUp();
+
 		Jetpack_Options::update_option( 'blog_token', self::STORED );
 		Jetpack_Options::update_option( 'user_tokens', [
 			1 => 'user-one.uno.1',

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @covers Jetpack_Data
+ */
+class WP_Test_Jetpack_Data extends WP_UnitTestCase {
+	const STORED  = '12345.67890';
+	const DEFINED = 'hello.world';
+	const DEFINED_MULTI = 'hello.world,foo.bar';
+
+	public function setUp() {
+		Jetpack_Options::update_option( 'blog_token', self::STORED );
+		Jetpack_Options::update_option( 'user_tokens', [
+			1 => 'user-one.uno.1',
+			2 => 'user-two.dos.2',
+			4 => 'user-four.cuatro',   // malformed: missing user ID.
+			5 => 'user-four-cuatro-5', // malformed: wrong structrue.
+			6 => '',                   // malformed: falsey value.
+			7 => 'user-seven.siete.1', // malformed: wrong user ID.
+		] );
+		Jetpack_Options::update_option( 'master_user', 2 );
+	}
+
+	public function tearDown() {
+		Jetpack_Options::delete_option( 'blog_token' );
+		Jetpack_Options::delete_option( 'user_tokens' );
+		Jetpack_Options::delete_option( 'master_user' );
+
+		Jetpack_Constants::clear_constants();
+
+		parent::tearDown();
+	}
+
+	public function test_get_access_token_with_no_args_returns_false_when_no_blog_token() {
+		Jetpack_Options::delete_option( 'blog_token' );
+		$token = Jetpack_Data::get_access_token();
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_no_args_returns_blog_token() {
+		$token = Jetpack_Data::get_access_token();
+
+		$this->assertEquals( self::STORED, $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_no_args_returns_defined_blog_token_when_constant_set() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+
+		$token = Jetpack_Data::get_access_token();
+
+		$this->assertEquals( self::DEFINED, $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_stored_key_returns_stored_blog_token() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+
+		$token = Jetpack_Data::get_access_token( false, '12345' );
+
+		$this->assertEquals( self::STORED, $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_magic_key_returns_stored_blog_token() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+
+		$token = Jetpack_Data::get_access_token( false, ';stored;' );
+
+		$this->assertEquals( self::STORED, $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_no_args_returns_first_defined_blog_token_when_constant_multi_set() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+
+		$token = Jetpack_Data::get_access_token();
+
+		$this->assertEquals( 'hello.world', $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_token_key_returns_matching_token_when_constant_multi_set() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+
+		$token = Jetpack_Data::get_access_token( false, 'foo' );
+
+		$this->assertEquals( 'foo.bar', $token->secret );
+		$this->assertEquals( 0, $token->external_user_id );
+	}
+
+	public function test_get_access_token_with_token_key_requires_full_key() {
+		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+
+		$token = Jetpack_Data::get_access_token( false, 'fo' );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_user_id_returns_false_when_no_user_tokens() {
+		Jetpack_Options::delete_option( 'user_tokens' );
+
+		$token = Jetpack_Data::get_access_token( 1 );
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_user_id() {
+		$token = Jetpack_Data::get_access_token( 1 );
+
+		$this->assertEquals( 'user-one.uno', $token->secret );
+	}
+
+	public function test_get_access_token_with_master_user_returns_false_when_no_master_user() {
+		Jetpack_Options::delete_option( 'master_user' );
+		$token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_master_user() {
+		$token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+
+		$this->assertEquals( 'user-two.dos', $token->secret );
+	}
+
+	public function test_get_access_token_with_unconnected_user() {
+		$token = Jetpack_Data::get_access_token( 3 );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_malformed_token_with_missing_user_id() {
+		$token = Jetpack_Data::get_access_token( 4 );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_malformed_token_with_wrong_structure() {
+		$token = Jetpack_Data::get_access_token( 5 );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_malformed_token_with_falsey_value() {
+		$token = Jetpack_Data::get_access_token( 6 );
+
+		$this->assertFalse( $token );
+	}
+
+	public function test_get_access_token_with_malformed_token_with_wrong_user_id() {
+		$token = Jetpack_Data::get_access_token( 7 );
+
+		$this->assertFalse( $token );
+	}
+}


### PR DESCRIPTION
In certain situations, it is useful to:
* Not rely on the database for the blog token, and
* Allow multiple blog tokens per site (for secret rotation, for example).

### Changes proposed in this Pull Request:
* Allow the blog token to be set via a new `JETPACK_BLOG_TOKEN` constant.
* Support multiple blog tokens in `Jetpack_Data::get_access_token()` by returning either the first or the one matching the provided `$token_key`.
* Never call `Jetpack_Options::get_option( 'blog_token' )` directly. Switch to `Jetpack_Data::get_access_token()`
* Since the blog token is used to sign Jetpack Comments iframes, tweak the iframe's parameters to send and receive `$token_key` hints about which blog token to use.

### Testing instructions:

#### Automated Tests

`phpunit --filter=WP_Test_Jetpack_Data`

#### Manual Tests

1. Get the blog token value by doing:
   `wp jetpack options get blog_token`
2. In your wp-config.php file:
   `define( 'JETPACK_BLOG_TOKEN', '{that blog token value you just found}' );`
3. `wp jetpack options delete blog_token`
   You now have a site with no stored blog token. Instead, the Jetpack will use the blog token you defined in the `JETPACK_BLOG_TOKEN` constant.
4. Go to wp-admin/ → Tools → Site Health → Info
5. Click "Jetpack"
6. Scroll down and see that "Blog Public Key" and "User Public Key" are set and that the Blog Public Key matches the token you found in step 1.


##### Testing XML-RPC & JSON API
1. Blog Token Test:
   `curl -i 'https://public-api.wordpress.com/rest/v1/sites/{YOUR_JETPACK_SITE}'`
2. User Token Test:
   1. Go to https://developer.wordpress.com/docs/api/console/
   2. Make sure you're logged in to WordPress.com as a user that corresponds to a connected user on the Jetpack site.
   3. Select "WP.COM API", "v1.1", "GET"
   4. `/sites/{YOUR_JETPACK_SITE}`
   5. Hit enter
3. For both, you should see some a JSON response of site data.

##### Testing OAuth2 Connections
1. Create an OAuth2 app and make sure you can obtain an OAuth2 token for a Jetpack site.

This is super annoying to test unless you already have a working app. Automatticians can find one at p9dueE-MU-p2.

##### Testing Jetpack Comments
1. Make sure you have Jetpack Comments turned on (wp-admin/ → Jetpack → Settings → Discussion → "Let readers use WordPress.com…"
2. Go to a post's permalink.
3. See that the Comments iframe displays correctly.
4. Submit a comment.
5. See that the comment ends up in the Jetpack site's comments at wp-admin/ → Comments.

### Proposed changelog entry for your changes:
None required.