### PR TITLE
API: Sync `/site/:site` endpoint code with WP.com

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -123,12 +123,14 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'podcasting_archive',
 		'is_domain_only',
 		'is_automated_transfer',
+		'is_wpcom_atomic',
 		'is_wpcom_store',
 		'signup_is_store',
 		'has_pending_automated_transfer',
 		'woocommerce_is_active',
 		'design_type',
 		'site_goals',
+		'site_segment',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -144,12 +146,13 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'publicize_permanently_disabled',
 		'ak_vp_bundle_enabled',
 		'is_automated_transfer',
+		'is_wpcom_atomic',
 		'is_wpcom_store',
 		'woocommerce_is_active',
 		'frame_nonce',
 		'frame_nonce_site_only',
 		'design_type',
-		'wordads'
+		'wordads',
 	);
 
 	protected $site;
@@ -367,7 +370,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'quota' :
 				$response[ $key ] = $this->site->get_quota();
 				break;
-			case 'launch_status' : 
+			case 'launch_status' :
 				$response[ $key ] = $this->site->get_launch_status();
 				break;
 		}
@@ -539,6 +542,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'blog_public':
 					$options[ $key ] = $site->get_blog_public();
 					break;
+				case 'is_wpcom_atomic':
+					$options[ $key ] = $site->is_wpcom_atomic();
+					break;
 				case 'is_wpcom_store':
 					$options[ $key ] = $site->is_wpcom_store();
 					break;
@@ -566,6 +572,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'site_goals':
 					$options[ $key ] = $site->get_site_goals();
+					break;
+				case 'site_segment':
+					$options[ $key ] = $site->get_site_segment();
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -638,4 +638,8 @@ abstract class SAL_Site {
 	function get_launch_status() {
 		return false;
 	}
+
+	function get_site_segment() {
+		return false;
+	}
 }

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -127,6 +127,10 @@ abstract class SAL_Site {
 		);
 	}
 
+	public function is_wpcom_atomic() {
+		return false;
+	}
+
 	public function is_wpcom_store() {
 		return false;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

On https://github.com/Automattic/jetpack/pull/12095, Fusion didn't create automatically the WordPress.com diff because the `json-endpoints/class.wpcom-json-api-get-site-endpoint.php` file was diverging.

This PR incorporates the missing code so both files are again synced and aligned.

#### Testing instructions:

- Head over to the "Run Fusion" tool in Mission Control (p9dueE-Hv-p2).
- Enter `json-endpoints/class.wpcom-json-api-get-site-endpoint.php` as Jetpack filepath.
- Enter `update/api-site-endpoint-sync-fusion` as branch name.
- Check file is in sync.
<img width="850" alt="Screen Shot 2019-04-26 at 14 47 48" src="https://user-images.githubusercontent.com/1233880/56785990-49f5a680-6832-11e9-89d6-ffa7e3c5cdf4.png">


#### Proposed changelog entry for your changes:
N/A