### PR TITLE
Tiled Gallery & Slideshow blocks: support transforming from core images

### DIFF
--- a/extensions/blocks/slideshow/transforms.js
+++ b/extensions/blocks/slideshow/transforms.js
@@ -4,20 +4,48 @@
 import { createBlock } from '@wordpress/blocks';
 import { filter } from 'lodash';
 
+/**
+ * Filter valid images
+ *
+ * @param {array} images Array of image objects
+ * @return {array} Array of image objects which have id and url
+ */
+function getValidImages( images ) {
+	return filter( images, ( { id, url } ) => id && url );
+}
+
 const transforms = {
 	from: [
 		{
 			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/image' ],
+			isMatch: attributes => getValidImages( attributes ).length > 0,
+			transform: attributes => {
+				const validImages = getValidImages( attributes );
+				return createBlock( 'jetpack/slideshow', {
+					images: validImages.map( ( { alt, caption, id, url } ) => ( {
+						alt,
+						caption,
+						id,
+						url,
+					} ) ),
+					ids: validImages.map( ( { id } ) => id ),
+				} );
+			},
+		},
+		{
+			type: 'block',
 			blocks: [ 'core/gallery', 'jetpack/tiled-gallery' ],
 			transform: attributes => {
-				const validImages = filter( attributes.images, ( { id, url } ) => id && url );
+				const validImages = getValidImages( attributes );
 				if ( validImages.length > 0 ) {
 					return createBlock( 'jetpack/slideshow', {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( {
-							id,
-							url,
+						images: validImages.map( ( { alt, caption, id, url } ) => ( {
 							alt,
 							caption,
+							id,
+							url,
 						} ) ),
 					} );
 				}

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -168,7 +168,7 @@ export const settings = {
 			},
 			{
 				type: 'block',
-				blocks: [ 'core/gallery' ],
+				blocks: [ 'core/gallery', 'jetpack/slideshow' ],
 				transform: attributes => {
 					const validImages = getValidImages( attributes.images );
 					if ( validImages.length > 0 ) {

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -41,6 +41,16 @@ const layoutStylesWithLabels = LAYOUT_STYLES.map( style => ( {
 	label: styleNames[ style.name ],
 } ) );
 
+/**
+ * Filter valid images
+ *
+ * @param {array} images Array of image objects
+ * @return {array} Array of image objects which have id and url
+ */
+function getValidImages( images ) {
+	return filter( images, ( { id, url } ) => id && url );
+}
+
 const blockAttributes = {
 	// Set default align
 	align: {
@@ -141,9 +151,26 @@ export const settings = {
 		from: [
 			{
 				type: 'block',
+				isMultiBlock: true,
+				blocks: [ 'core/image' ],
+				isMatch: attributes => getValidImages( attributes ).length > 0,
+				transform: attributes => {
+					const validImages = getValidImages( attributes );
+					return createBlock( `jetpack/${ name }`, {
+						images: validImages.map( ( { id, url, alt } ) => ( {
+							id,
+							url,
+							alt,
+						} ) ),
+						ids: validImages.map( ( { id } ) => id ),
+					} );
+				},
+			},
+			{
+				type: 'block',
 				blocks: [ 'core/gallery' ],
 				transform: attributes => {
-					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
+					const validImages = getValidImages( attributes.images );
 					if ( validImages.length > 0 ) {
 						return createBlock( `jetpack/${ name }`, {
 							images: validImages.map( ( { id, url, alt } ) => ( {
@@ -167,10 +194,10 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/image' ],
-				transform: ( { images } ) => {
+				transform: ( { align, images } ) => {
 					if ( images.length > 0 ) {
 						return images.map( ( { id, url, alt } ) =>
-							createBlock( 'core/image', { id, url, alt } )
+							createBlock( 'core/image', { align, id, url, alt } )
 						);
 					}
 					return createBlock( 'core/image' );


### PR DESCRIPTION
Add a bunch of transforms :tada:

(Pulled from https://github.com/Automattic/wp-calypso/pull/30301 where you can find earlier reviews)

Resolves https://github.com/Automattic/jetpack/issues/11785

#### Changes proposed in this Pull Request:
* Add "Core image(s)" to "Tiled gallery" -transform
* Add "Core image(s)" to "Slideshow" -transform
* Add `align` attribute in "Tiled gallery" to "Core image" -transform
* Add "Tiled gallery" to "Slideshow" transform

#### Testing instructions:
- Add core image blocks, tiled gallery block and Slideshow block to a post
- Convert them back and forth. Make sure some of them have captions defined (for tiled gallery) and alignment (for tiled gallery); observe everything work as expected
- Observe how you cannot convert image block(s) which consist only images pulled in via external URLs

#### Proposed changelog entry for your changes:
- Allow transforming image blocks to a Slideshow and Tiled gallery blocks
- Allow transforming Tiled gallery block to a slideshow block