### PR TITLE
Shortcodes: make sure unit tests run.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -50,7 +50,7 @@
 			<directory prefix="test_" suffix=".php">tests/php/modules/sharedaddy</directory>
 		</testsuite>
 		<testsuite name="shortcodes">
-			<directory prefix="test_" suffix=".php">tests/php/modules/shortcodes</directory>
+			<directory prefix="test" suffix=".php">tests/php/modules/shortcodes</directory>
 		</testsuite>
 		<testsuite name="widgets">
 			<directory prefix="test_" suffix=".php">tests/php/modules/widgets</directory>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The format was changed by mistake in 926490bc4a5e0f20ab72fc6e081292151b5f3d2d
This reverts that change.

#### Testing instructions:

* Run `yarn docker:phpunit --filter=WP_Test_Jetpack_Shortcodes_Gist`
* Make sure all unit tests are run.

#### Proposed changelog entry for your changes:

* None
