### PR TITLE
Medium: update embed method to reflect Medium changes

### DIFF
--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -1,16 +1,24 @@
 <?php
-
-// Embed support for Medium https://medium.com/p/3eaed64aed8a
-
 /**
- * Faux-oembed support for Medium permalinks
+ * Embed support for Medium
  *
- * e.g.
- * https://medium.com/help-center
- * https://medium.com/@richroll
+ * Supported formats:
+ * https://medium.com/p/3eaed64aed8a
+ * [medium url="https://medium.com/help-center" width="100%" border="false" collapsed="true"]
+ *
+ * @package Jetpack
  */
+
+// Faux-oembed support for Medium permalinks.
 wp_embed_register_handler( 'medium', '#^https?://medium.com/([a-zA-z0-9-_@]+)#', 'jetpack_embed_medium_oembed' );
 
+/**
+ * Callback to modify output of embedded Medium posts.
+ *
+ * @param array $matches Regex partial matches against the URL passed.
+ * @param array $attr    Attributes received in embed response.
+ * @param array $url     Requested URL to be embedded.
+ */
 function jetpack_embed_medium_oembed( $matches, $attr, $url ) {
 	$attr        = jetpack_embed_medium_args( $attr );
 	$attr['url'] = $url;
@@ -18,6 +26,11 @@ function jetpack_embed_medium_oembed( $matches, $attr, $url ) {
 	return jetpack_embed_medium_embed_html( $attr );
 }
 
+/**
+ * Return custom markup to display a Medium profile, collection, or story.
+ *
+ * @param array $args Attributes received in embed response.
+ */
 function jetpack_embed_medium_embed_html( $args ) {
 	$args = jetpack_embed_medium_args( $args );
 
@@ -27,16 +40,30 @@ function jetpack_embed_medium_embed_html( $args ) {
 
 	$args['type'] = jetpack_embed_medium_get_embed_type( $args['url'] );
 
-	return sprintf( '<script async src="https://static.medium.com/embed.js"></script><a class="m-%1$s" href="%2$s" target="_blank" data-width="%3$s" data-border="%4$s" data-collapsed="%5$s">View %1$s at Medium.com</a>', esc_attr( $args['type'] ), esc_url( $args['url'] ), esc_attr( $args['width'] ), esc_attr( $args['border'] ), esc_attr( $args['collapsed'] ) );
+	wp_enqueue_script(
+		'medium-embed',
+		'https://static.medium.com/embed.js',
+		array(),
+		JETPACK__VERSION,
+		true
+	);
+
+	return sprintf(
+		'<a class="m-%1$s" href="%2$s" target="_blank" data-width="%3$s" data-border="%4$s" data-collapsed="%5$s">%6$s</a>',
+		esc_attr( $args['type'] ),
+		esc_url( $args['url'] ),
+		esc_attr( $args['width'] ),
+		esc_attr( $args['border'] ),
+		esc_attr( $args['collapsed'] ),
+		esc_html__( 'View at Medium.com', 'jetpack' )
+	);
 }
 
 /**
  * Shortcode support that allows passing in URL
  *
- * [medium url="https://medium.com/help-center" width="100%" border="false" collapsed="true"]
+ * @param array $atts Shortcode attributes.
  */
-add_shortcode( 'medium', 'jetpack_embed_medium_shortcode' );
-
 function jetpack_embed_medium_shortcode( $atts ) {
 	$atts = jetpack_embed_medium_args( $atts );
 
@@ -45,9 +72,15 @@ function jetpack_embed_medium_shortcode( $atts ) {
 		return $wp_embed->shortcode( $atts, $atts['url'] );
 	}
 }
+add_shortcode( 'medium', 'jetpack_embed_medium_shortcode' );
 
+/**
+ * Get embed type (profile, collection, or story) based on Medium URL.
+ *
+ * @param string $url Medium URL.
+ */
 function jetpack_embed_medium_get_embed_type( $url ) {
-	$url_path = parse_url( $url, PHP_URL_PATH );
+	$url_path = wp_parse_url( $url, PHP_URL_PATH );
 	if ( preg_match( '/^\/@[\.\w]+$/', $url_path ) ) {
 		return 'profile';
 	} elseif ( preg_match( '/^\/[\da-zA-Z-]+$/', $url_path ) ) {
@@ -57,6 +90,11 @@ function jetpack_embed_medium_get_embed_type( $url ) {
 	return 'story';
 }
 
+/**
+ * Process Medium shortcode attributes.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function jetpack_embed_medium_args( $atts ) {
 	return shortcode_atts(
 		array(

--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -4,7 +4,6 @@
  *
  * Supported formats:
  * - Profiles: https://medium.com/@jeherve
- * - Collections: https://medium.com/s/user-friendly
  * - Stories: https://medium.com/@jeherve/this-is-a-story-19f582daaf5b
  * - And all the above in shortcode formats:
  * [medium url="https://medium.com/@jeherve/this-is-a-story-19f582daaf5b" width="100%" border="false" collapsed="true"]
@@ -42,6 +41,14 @@ function jetpack_embed_medium_embed_html( $args ) {
 	}
 
 	$args['type'] = jetpack_embed_medium_get_embed_type( $args['url'] );
+
+	if ( 'collection' === $args['type'] ) {
+		return sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			esc_url( $args['url'] ),
+			esc_html__( 'View this collection on Medium.com', 'jetpack' )
+		);
+	}
 
 	wp_enqueue_script(
 		'medium-embed',

--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -92,7 +92,7 @@ function jetpack_embed_medium_get_embed_type( $url ) {
 	$url_path = wp_parse_url( $url, PHP_URL_PATH );
 	if ( preg_match( '/^\/@[\.\w]+$/', $url_path ) ) {
 		return 'profile';
-	} elseif ( preg_match( '/^\/[\da-zA-Z-]+$/', $url_path ) ) {
+	} elseif ( preg_match( '/^\/(?:s)\/(.+)$/', $url_path ) ) {
 		return 'collection';
 	}
 

--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -3,8 +3,11 @@
  * Embed support for Medium
  *
  * Supported formats:
- * https://medium.com/p/3eaed64aed8a
- * [medium url="https://medium.com/help-center" width="100%" border="false" collapsed="true"]
+ * - Profiles: https://medium.com/@jeherve
+ * - Collections: https://medium.com/s/user-friendly
+ * - Stories: https://medium.com/@jeherve/this-is-a-story-19f582daaf5b
+ * - And all the above in shortcode formats:
+ * [medium url="https://medium.com/@jeherve/this-is-a-story-19f582daaf5b" width="100%" border="false" collapsed="true"]
  *
  * @package Jetpack
  */

--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -73,6 +73,12 @@ function jetpack_embed_medium_shortcode( $atts ) {
 	if ( ! empty( $atts['url'] ) ) {
 		global $wp_embed;
 		return $wp_embed->shortcode( $atts, $atts['url'] );
+	} else {
+		if ( current_user_can( 'edit_posts' ) ) {
+			return esc_html__( 'You did not provide a valid Medium URL.', 'jetpack' );
+		} else {
+			return '<!-- Missing Medium URL -->';
+		}
 	}
 }
 add_shortcode( 'medium', 'jetpack_embed_medium_shortcode' );

--- a/tests/php/modules/shortcodes/test-class.medium.php
+++ b/tests/php/modules/shortcodes/test-class.medium.php
@@ -1,0 +1,75 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [medium] exists.
+	 *
+	 * @since  7.3.0
+	 */
+	public function test_shortcodes_medium_exists() {
+		$this->assertEquals( shortcode_exists( 'medium' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcodes_medium_empty() {
+		$content = '[medium]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Missing Medium URL -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that a post with a link to a Profile page displays profile markup.
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcode_medium_faux_embed_profile() {
+		$profile_url = 'https://medium.com/@jeherve';
+
+		$content = apply_filters( 'the_content', $profile_url );
+
+		$this->assertContains(
+			'<a class="m-profile" href="' . $profile_url,
+			$content
+		);
+	}
+
+	/**
+	 * Verify that a post with a link to a Medium story displays story markup.
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcode_medium_faux_embed_story() {
+		$story_url = 'https://medium.com/@jeherve/this-is-a-story-19f582daaf5b';
+
+		$content = apply_filters( 'the_content', $story_url );
+
+		$this->assertContains(
+			'<a class="m-story" href="' . $story_url,
+			$content
+		);
+	}
+
+	/**
+	 * Verify that a post with a link to a Medium collection displays collection markup.
+	 *
+	 * @since 7.3.0
+	 */
+	public function test_shortcode_medium_faux_embed_collection() {
+		$collection_url = 'https://medium.com/s/user-friendly';
+
+		$content = apply_filters( 'the_content', $collection_url );
+
+		$this->assertContains(
+			'<a class="m-collection" href="' . $collection_url,
+			$content
+		);
+	}
+}

--- a/tests/php/modules/shortcodes/test-class.medium.php
+++ b/tests/php/modules/shortcodes/test-class.medium.php
@@ -5,7 +5,7 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 	/**
 	 * Verify that [medium] exists.
 	 *
-	 * @since  7.3.0
+	 * @since  7.4.0
 	 */
 	public function test_shortcodes_medium_exists() {
 		$this->assertEquals( shortcode_exists( 'medium' ), true );
@@ -14,7 +14,7 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 	/**
 	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
 	 *
-	 * @since 7.3.0
+	 * @since 7.4.0
 	 */
 	public function test_shortcodes_medium_empty() {
 		$content = '[medium]';
@@ -28,7 +28,7 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 	/**
 	 * Verify that a post with a link to a Profile page displays profile markup.
 	 *
-	 * @since 7.3.0
+	 * @since 7.4.0
 	 */
 	public function test_shortcode_medium_faux_embed_profile() {
 		$profile_url = 'https://medium.com/@jeherve';
@@ -44,7 +44,7 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 	/**
 	 * Verify that a post with a link to a Medium story displays story markup.
 	 *
-	 * @since 7.3.0
+	 * @since 7.4.0
 	 */
 	public function test_shortcode_medium_faux_embed_story() {
 		$story_url = 'https://medium.com/@jeherve/this-is-a-story-19f582daaf5b';

--- a/tests/php/modules/shortcodes/test-class.medium.php
+++ b/tests/php/modules/shortcodes/test-class.medium.php
@@ -58,9 +58,9 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that a post with a link to a Medium collection displays collection markup.
+	 * Verify that a post with a link to a Medium collection displays link (collection embeds are not supported anymore).
 	 *
-	 * @since 7.3.0
+	 * @since 7.4.0
 	 */
 	public function test_shortcode_medium_faux_embed_collection() {
 		$collection_url = 'https://medium.com/s/user-friendly';
@@ -68,7 +68,7 @@ class WP_Test_Jetpack_Shortcodes_Medium extends WP_UnitTestCase {
 		$content = apply_filters( 'the_content', $collection_url );
 
 		$this->assertContains(
-			'<a class="m-collection" href="' . $collection_url,
+			'<a href="' . $collection_url . '" target="_blank" rel="noopener noreferrer">View this collection on Medium.com</a>',
 			$content
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

I originally only wanted to make a few PHPCS fixes. In the process, I discovered some issues:

1. I changed the display of the HTML markup added alongside the embed script. Instead of displaying a text in English all the time, let's make that text translatable. Since part of the English string came from the embed type before, I simplified the string.
2. I found that the way we detected embed type for Medium collections was not correct anymore, so I updated the regex accordingly.
3. I created some unit tests to cover the different embed formats.
4. We now display a message to post authors when an embed can't be displayed.
5. We do not try to embed Medium Collections anymore as those are not supported. Instead we display a link to the collection.

Matching WordPress.com diff: D27479-code

#### Testing instructions:

* Try adding the following to a classic block:
 * - Profiles: `https://medium.com/@jeherve`
 * - Collections: `https://medium.com/s/user-friendly`
 * - Stories: `https://medium.com/@jeherve/this-is-a-story-19f582daaf5b`
 * - And all the above in shortcode formats, for example:
 * `[medium url="https://medium.com/@jeherve/this-is-a-story-19f582daaf5b" width="100%" border="false" collapsed="true"]`
* Everything should work. 
* Note that when trying to embed collections, you won't see an embed, but instead you will see a link to the collection. See why below.

#### Limitations

**In my tests, I can't seem to be able to embed collections, but I am not sure why.** 
`https://api.medium.com/_/embed/s/user-friendly` does not seem correct.

**Update**: I contacted Medium support about this, and they confirmed that the embeds are not supported anymore. The profile and story embeds still work, but they are not maintained. The Collection embeds do not work anymore, and there are no plans to get it fixed. As a result, I updated our shortcode to return a link instead of an embed in those cases.

#### Proposed changelog entry for your changes:

* Medium: update embed type detection for Collections.
