### PR TITLE
Adjust JITM margin on Jetpack dashboard

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -163,7 +163,7 @@
 
  // if JITM appears inside of the jetpack dashboard adjust margins
  .jp-lower .jitm-card {
-   margin: 3rem 0 rem( 24px );
+   margin: 0 0 rem( 24px );
  }
 
 .jitm-banner.jitm-card {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove excess margin from JITM messages found within the Jetpack dashboard

Fixes #11597

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* None, style only.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Jetpack dashboard
* Ensure margin on JITM is correct

Before:

<img width="1269" alt="54577307-36505800-49c9-11e9-90e8-f2f6c66e14de" src="https://user-images.githubusercontent.com/411945/56812264-6e518300-6832-11e9-9667-cf4e8c83dc24.png">

After:

![Screenshot 2019-04-26 at 14 46 47](https://user-images.githubusercontent.com/411945/56812247-672a7500-6832-11e9-8230-c8b5c09b5b89.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog entry required
