### PR TITLE
Tiled Gallery: Improve uploading images layout

### DIFF
--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -19,6 +19,16 @@
 	padding-left: 4px;
 	padding-right: 4px;
 
+	&.is-style-square,
+	&.is-style-circle {
+		.tiled-gallery__item.is-transient img {
+			// Transient images (no src attribute) occupy no vertical space.
+			// If on a row by themself, the row is hidden.
+			// By setting the bottom margin, ensure they occupy the correct vertical space.
+			margin-bottom: 100%;
+		}
+	}
+
 	.tiled-gallery__item {
 		// Hide the focus outline that otherwise briefly appears when selecting a block.
 		> img:focus {
@@ -41,8 +51,16 @@
 			}
 		}
 
-		&.is-transient img {
-			opacity: 0.3;
+		&.is-transient {
+			height: 100%;
+			width: 100%;
+			img {
+				background-position: center;
+				background-size: cover;
+				height: 100%;
+				opacity: 0.3;
+				width: 100%;
+			}
 		}
 	}
 

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -101,6 +101,7 @@
 		position: absolute;
 		top: 50%;
 		left: 50%;
+		margin: 0;
 		transform: translate( -50%, -50% );
 	}
 

--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -83,6 +83,8 @@ class GalleryImageEdit extends Component {
 				break;
 		}
 
+		const isTransient = isBlobURL( origUrl );
+
 		const img = (
 			// Disable reason: Image itself is not meant to be interactive, but should
 			// direct image selection and unfocus caption fields.
@@ -99,10 +101,11 @@ class GalleryImageEdit extends Component {
 					onClick={ this.onImageClick }
 					onKeyDown={ this.onImageKeyDown }
 					ref={ this.img }
-					src={ url }
+					src={ isTransient ? undefined : url }
 					tabIndex="0"
+					style={ isTransient ? { backgroundImage: `url(${ url })` } : undefined }
 				/>
-				{ isBlobURL( origUrl ) && <Spinner /> }
+				{ isTransient && <Spinner /> }
 			</Fragment>
 			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */
 		);
@@ -112,7 +115,7 @@ class GalleryImageEdit extends Component {
 			<figure
 				className={ classnames( 'tiled-gallery__item', {
 					'is-selected': isSelected,
-					'is-transient': isBlobURL( origUrl ),
+					'is-transient': isTransient,
 					[ `filter__${ imageFilter }` ]: !! imageFilter,
 				} ) }
 			>

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -19,7 +19,7 @@ $tiled-gallery-max-column-count: 20;
 			@for $cols from 1 through $tiled-gallery-max-column-count {
 				&.columns-#{$cols} {
 					.tiled-gallery__col {
-						width: calc( ( 100% - ( #{$tiled-gallery-gutter} * ( #{$cols} - 1 ) ) ) / #{$cols} );
+						width: calc( ( 100% - #{ $tiled-gallery-gutter * ( $cols - 1 ) } ) / #{$cols} );
 					}
 				}
 			}


### PR DESCRIPTION
Improves the size of images while they're uploading. Particularly noticable with square and circle layouts.

Fixes #11784
Closes https://github.com/Automattic/wp-calypso/pull/29789 (supersedes)

Also improves the SASS to calculate some known values at compile time.
Removes margin on the spinner component so that it's properly centered.

#### Changes proposed in this Pull Request:

* Rework the layout logic when uploading images, especially for square and circle layouts.

#### Testing instructions:

* Add a tiled gallery block. Add an image.
* Set the layout to circle or square
* Upload more images by using the button at the bottom of the block when selected.
* The images should look correct while uploading.

Repeat the same steps when the column count is set to 1.
Test various layouts, there should be no regressions.

#### Proposed changelog entry for your changes:
* Tiled Gallery block: Improve layout handling of images while uploading.
