### PR TITLE
Travis: Add yarn build to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ matrix:
   - if: branch !~ /(^branch-.*-built)/
     language: node_js
     env: WP_TRAVISCI="yarn test-dangerci-and-adminpage-and-extensions"
+  - if: branch !~ /(^branch-.*-built)/
+    language: node_js
+    env: WP_TRAVISCI="yarn build"
 
 cache:
   directories:

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -44,7 +44,7 @@
 @import '../components/settings-card/style';
 @import '../components/settings-group/style';
 @import '../components/apps-card/style';
-@import '../components/jetpack-dialogue/style';
+@import '../components/jetpack-dialoogue/style';
 
 
 // Page Templates

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -44,7 +44,7 @@
 @import '../components/settings-card/style';
 @import '../components/settings-group/style';
 @import '../components/apps-card/style';
-@import '../components/jetpack-dialoogue/style';
+@import '../components/jetpack-dialogue/style';
 
 
 // Page Templates


### PR DESCRIPTION
Adds `yarn build` to the Travis matrix

Some changes like affecting scss builds are only noticeable when they fail only if we attempt to build

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds `yarn build` to the Travis matrix

#### Testing instructions:


* Confirm Travis jobs run properly on this PR.

#### Proposed changelog entry for your changes:

* None needed
