### PR TITLE
Jetpack_modules - made actions visible without the need for hovering

### DIFF
--- a/scss/templates/_settings.scss
+++ b/scss/templates/_settings.scss
@@ -122,6 +122,7 @@
 				float: right;
 				padding: 0 0 1px;
 				visibility: visible;
+				position: static;
 
 				span {
 					margin-left: 5px;
@@ -135,7 +136,6 @@
 					padding-left: 10px;
 					visibility: visible;
 				};
-
 			}
 		}
 	}
@@ -148,12 +148,6 @@
 		}
 		&.unavailable {
 			opacity: 0.3;
-		}
-		td .row-actions span a {
-			opacity: 0;
-			&:focus {
-				opacity: 1;
-			}
 		}
 	}
 	&>thead>tr>th {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Part of #11754 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

I made actions visible all the time. Before, it was impossible to know they were there without having a mouse. It also was not possible to see them using keyboard navigation.

Alternate ideas:
1. Move the items into a dropdown (exploring shortly in another PR)
2. Leave them hidden, but make them appear on focus. I don't think that's super straightfoward to do and don't recommend it because it still makes them mysterious.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Go to '/wp-admin/admin.php?page=jetpack_modules'
* View the module list


#### Before
![image](https://user-images.githubusercontent.com/1123119/56828638-fa59af80-681e-11e9-84fb-1a293f516b0c.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/56828582-d5fdd300-681e-11e9-867c-1d17cac1a3d0.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* No changelog needed
