### PR TITLE
A/B test to monitor the impact of removing the bar above the connection banner

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -44,6 +44,11 @@ class Jetpack_Connection_Banner {
 			false,
 			sprintf( 'connect-banner-%s-%s', $jp_version_banner_added, $current_screen->base )
 		);
+		// Add a tracks event corresponding to the A/B version displayed
+		$ab_test = Jetpack_Options::get_option( 'ab_connect_banner_green_bar' );
+		if ( in_array( $ab_test, array( 'a', 'b' ), true ) ) {
+			$url = add_query_arg( 'ab_connect_banner_green_bar', $ab_test, $url );
+		}
 		return add_query_arg( 'auth_approved', 'true', $url );
 	}
 
@@ -136,6 +141,33 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
+	 * Performs an A/B test showing or hiding the green bar at the top of the connection dialog displayed in Dashboard or Plugins.
+	 * We save which version we're showing so we always show the same to the same user.
+	 * The "A" version displays the green bar at the top.
+	 * The "B" version doesn't display it.
+	 *
+	 * @return void
+	 */
+	function get_ab_banner_top_bar() {
+		$ab_test = Jetpack_Options::get_option( 'ab_connect_banner_green_bar' );
+		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user
+		if ( ! $ab_test ) {
+			$ab_test = 1 === rand( 1, 2 ) ? 'a' : 'b';
+			Jetpack_Options::update_option( 'ab_connect_banner_green_bar', $ab_test);
+		}
+		if ( 'a' === $ab_test ) {
+			?>
+			<div class="jp-wpcom-connect__container-top-text">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
+				<span>
+			    <?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?>
+				</span>
+			</div>
+			<?php
+		}
+	}
+
+	/**
 	 * Renders the new connection banner as of 4.4.0.
 	 *
 	 * @since 7.2   Copy and visual elements reduced to show the new focus of Jetpack on Security and Performance.
@@ -143,10 +175,7 @@ class Jetpack_Connection_Banner {
 	 */
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
-			<div class="jp-wpcom-connect__container-top-text">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
-				<span><?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?></span>
-			</div>
+			<?php $this->get_ab_banner_top_bar(); ?>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -52,6 +52,7 @@ class Jetpack_Options {
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
+				'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
 				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 				'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -288,10 +288,12 @@
 .updated .notice-dismiss {
 	z-index: 1;
 	text-decoration: none;
-	&:before {
-		color: $white;
-	}
 }
+
+.jp-wpcom-connect__container-top-text + .jp-wpcom-connect__inner-container .notice-dismiss::before {
+	color: $white;
+}
+
 // end overrides
 
 .jp-wpcom-connect__container-top-text {


### PR DESCRIPTION
This PR adds an A/B test to check if removing the green bar at the top of the connection banner displayed on Dashboard and Plugins makes a difference in the rate of connections initiated from this banner. It also adds a new parameter to the connection URL, `ab_connect_banner_green_bar`, which will have the value `a` for the version with green bar, and `b` for the version with no bar.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #11955

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* adds an A/B test. 1 is A and means the green bar is shown. 2 is B and means the green bar is not shown
* adds a `ab_connect_banner_green_bar` parameter to the connection URL for the Set up button in this banner. Its value is `a` for the version with green bar, and `b` for the version with no bar.
* adds a Jetpack_Option `ab_connect_banner_green_bar` to save what we initially displayed to the user and consistently always display the same.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a site that can be connected
* go to Dashboard or Plugins
* whether you see the sidebar or not, reload and you should see the same
* inspect the Set up button. It should have the `ab_connect_banner_green_bar` parameter with `a` if you're seeing the green bar, and `b` if you're not seeing the bar.
You can use the WP CLI to forge different values, for example: 
`wp jetpack options update ab_connect_banner_green_bar b`

#### A version

<img width="1038" alt="Captura de Pantalla 2019-04-26 a la(s) 17 42 48" src="https://user-images.githubusercontent.com/1041600/56835571-f93e7780-684a-11e9-81fc-ced2d5f5fb10.png">

#### B version

<img width="1039" alt="Captura de Pantalla 2019-04-26 a la(s) 17 41 46" src="https://user-images.githubusercontent.com/1041600/56835579-fe032b80-684a-11e9-9a5c-c7a28b56c603.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Not necessary.
