### PR TITLE
Update module list configuration links

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -12,6 +12,7 @@ module.exports = [
 	'modules/masterbar/',
 	'modules/module-extras.php',
 	'modules/module-info.php',
+	'modules/sharedaddy.php',
 	'modules/theme-tools/social-menu/',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 ];

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -25,7 +25,6 @@ function grofiles_hovercards_init() {
 	add_action( 'load-edit-comments.php',      'grofiles_admin_cards' );
 	add_action( 'load-options-discussion.php', 'grofiles_admin_cards_forced' );
 
-	Jetpack::enable_module_configurable( __FILE__ );
 	add_filter( 'jetpack_module_configuration_url_gravatar-hovercards', 'gravatar_hovercards_configuration_url' );
 }
 

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -63,17 +63,6 @@ class Jetpack_Infinite_Scroll_Extras {
 	 */
 	public function action_jetpack_modules_loaded() {
 		Jetpack::enable_module_configurable( __FILE__ );
-		add_filter( 'jetpack_module_configuration_url_infinite-scroll', array( $this, 'infinite_scroll_configuration_url' ) );
-	}
-
-	/**
-	 * Overrides default configuration url
-	 *
-	 * @uses admin_url
-	 * @return string module settings URL
-	 */
-	public function infinite_scroll_configuration_url() {
-		return admin_url( 'options-reading.php#infinite-scroll-options' );
 	}
 
 	/**

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -31,7 +31,6 @@ class Jetpack_Photon_Static_Assets_CDN {
 		add_action( 'admin_print_styles', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'cdnize_assets' ) );
 		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ), 10, 2 );
-		Jetpack::enable_module_configurable( __FILE__ );
 	}
 
 	/**

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -31,6 +31,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		add_action( 'admin_print_styles', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'cdnize_assets' ) );
 		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ), 10, 2 );
+		Jetpack::enable_module_configurable( __FILE__ );
 	}
 
 	/**

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -24,5 +24,9 @@ function sharedaddy_loaded() {
 }
 
 function jetpack_sharedaddy_configuration_url() {
-	return admin_url( 'admin.php?page=jetpack#/settings?term=social%20buttons' );
+	// get URL from WP
+	$site_url = parse_url( get_site_url() );
+	// remove www. if present
+	$parsed_url = str_replace( 'www.', '', $site_url[ 'host' ] );
+	return 'https://wordpress.com/sharing/buttons/' . $parsed_url;
 }

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -24,9 +24,6 @@ function sharedaddy_loaded() {
 }
 
 function jetpack_sharedaddy_configuration_url() {
-	// get URL from WP
-	$site_url = parse_url( get_site_url() );
-	// remove www. if present
-	$parsed_url = str_replace( 'www.', '', $site_url[ 'host' ] );
-	return 'https://wordpress.com/sharing/buttons/' . $parsed_url;
+	$site_suffix  = Jetpack::build_raw_urls( get_home_url() );
+	return 'https://wordpress.com/sharing/buttons/' . $site_suffix;
 }

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -11,19 +11,34 @@
  * Module Tags: Social, Recommended
  * Feature: Engagement
  * Additional Search Queries: share, sharing, sharedaddy, social buttons, buttons, share facebook, share twitter, social media sharing, social media share, social share, icons, email, facebook, twitter, linkedin, pinterest, pocket, social widget, social media
+ *
+ * @package Jetpack
  */
 
-if ( !function_exists( 'sharing_init' ) )
-	include dirname( __FILE__ ).'/sharedaddy/sharedaddy.php';
+if ( ! function_exists( 'sharing_init' ) ) {
+	require dirname( __FILE__ ) . '/sharedaddy/sharedaddy.php';
+}
 
 add_action( 'jetpack_modules_loaded', 'sharedaddy_loaded' );
 
+/**
+ * Sharing module code loaded after all modules have been loaded.
+ */
 function sharedaddy_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 	add_filter( 'jetpack_module_configuration_url_sharedaddy', 'jetpack_sharedaddy_configuration_url' );
 }
 
+/**
+ * Return Jetpack Sharing configuration URL
+ *
+ * @return string Sharing config URL
+ */
 function jetpack_sharedaddy_configuration_url() {
-	$site_suffix  = Jetpack::build_raw_urls( get_home_url() );
+	if ( Jetpack::is_development_mode() || Jetpack::is_staging_site() || ! Jetpack::is_user_connected() ) {
+		return admin_url( 'options-general.php?page=sharing' );
+	}
+
+	$site_suffix = Jetpack::build_raw_urls( get_home_url() );
 	return 'https://wordpress.com/sharing/buttons/' . $site_suffix;
 }

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -20,4 +20,9 @@ add_action( 'jetpack_modules_loaded', 'sharedaddy_loaded' );
 
 function sharedaddy_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
+	add_filter( 'jetpack_module_configuration_url_sharedaddy', 'jetpack_sharedaddy_configuration_url' );
+}
+
+function jetpack_sharedaddy_configuration_url() {
+	return admin_url( 'admin.php?page=jetpack#/settings?term=social%20buttons' );
 }

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -21,8 +21,4 @@ function jetpack_verification_tools_loaded() {
 }
 add_action( 'jetpack_modules_loaded', 'jetpack_verification_tools_loaded' );
 
-function jetpack_verification_tools_configuration_url() {
-	return admin_url( 'admin.php?page=jetpack#/settings?term=site%20verification' );
-}
-
 jetpack_load_verification_tools();

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -22,7 +22,7 @@ function jetpack_verification_tools_loaded() {
 add_action( 'jetpack_modules_loaded', 'jetpack_verification_tools_loaded' );
 
 function jetpack_verification_tools_configuration_url() {
-	return admin_url( 'tools.php' );
+	return admin_url( 'admin.php?page=jetpack#/settings?term=site%20verification' );
 }
 
 jetpack_load_verification_tools();

--- a/modules/wordads.php
+++ b/modules/wordads.php
@@ -12,6 +12,7 @@
  */
 
 function jetpack_load_wordads() {
+	Jetpack::enable_module_configurable( __FILE__ );
 	require_once( dirname( __FILE__ ) . "/wordads/wordads.php" );
 }
 


### PR DESCRIPTION
This PR fixes two sub-issues outlined in #11754:

* Make all the "Configure" links direct the user to the Jetpack setting (when available)
* Add any missing "Configure" links if a setting is available

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Removed Gravatar config link
* Updated Infinite Scroll config link (points to the settings card now instead of Settings > Reading)
* Add Asset CDN config link
* Update Sharedaddy search terms in config link (from "sharedaddy" to "social buttons")
* Update Verification tools config link (points to settings card instead of `tools.php`)
* Add WordAds config link

#### Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack_modules`
* Confirm the changes above are present

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Updates to module list configuration links
