### PR TITLE
Add modules list link to Jetpack footer

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -60,6 +60,13 @@ export class Footer extends React.Component {
 		} );
 	};
 
+	trackModulesClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'modules',
+		} );
+	};
+
 	trackDebugClick = () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'footer_link',
@@ -88,6 +95,25 @@ export class Footer extends React.Component {
 				);
 			}
 			return '';
+		};
+
+		const maybeShowModules = () => {
+			if ( this.props.userCanManageOptions ) {
+				return (
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackModulesClick }
+							href={ this.props.siteAdminUrl + 'admin.php?page=jetpack_modules' }
+							title={ __( 'Access the full list of Jetpack modules available on your site.' ) }
+							className="jp-footer__link"
+						>
+							{ __( 'Modules', {
+								context: 'Navigation item. Noun. Links to a list of modules for Jetpack.',
+							} ) }
+						</a>
+					</li>
+				);
+			}
 		};
 
 		const maybeShowDebug = () => {
@@ -190,6 +216,7 @@ export class Footer extends React.Component {
 							{ __( 'Privacy', { context: 'Shorthand for Privacy Policy.' } ) }
 						</a>
 					</li>
+					{ maybeShowModules() }
 					{ maybeShowDebug() }
 					{ maybeShowReset() }
 					{ maybeShowDevCardFooterLink() }

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -98,7 +98,7 @@ export class Footer extends React.Component {
 		};
 
 		const maybeShowModules = () => {
-			if ( this.props.userCanManageOptions ) {
+			if ( this.props.siteConnectionStatus && this.props.userCanManageOptions ) {
 				return (
 					<li className="jp-footer__link-item">
 						<a

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -319,6 +319,9 @@ abstract class Jetpack_Admin_Page {
 					<?php } ?>
 					<?php if ( current_user_can( 'manage_options' ) ) { ?>
 						<li class="jp-footer__link-item">
+							<a href="<?php echo esc_url( admin_url() . 'admin.php?page=jetpack_modules' ); ?>" title="<?php esc_html_e( "Access the full list of Jetpack modules available on your site.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Modules', 'Navigation item', 'jetpack' ); ?></a>
+						</li>
+						<li class="jp-footer__link-item">
 							<a href="<?php echo esc_url( admin_url() . 'admin.php?page=jetpack-debugger' ); ?>" title="<?php esc_html_e( "Test your site's compatibility with Jetpack.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Debug', 'Navigation item', 'jetpack' ); ?></a>
 						</li>
 					<?php } ?>


### PR DESCRIPTION
Adds a link to the modules checklist in the footer of Jetpack so it's easier to get to. Partially addresses #11754.

#### Changes proposed in this Pull Request:

* Adds a "Modules" link in the plugin footer

#### Testing instructions:
* Look for a "Modules" link in the footer. Should be next to Debug, and shares the same options (`if current_user_can( 'manage_options' )`)
* Confirm the link goes to the modules checklist

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Added link to modules checklist in the footer
