### PR TITLE
Removed duplicate self-executing anonymous function

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -236,19 +236,15 @@ class Jetpack_Google_Analytics_Legacy {
 			global $product;
 			$product_sku_or_id = $product->get_sku() ? $product->get_sku() : "#" + $product->get_id();
 			wc_enqueue_js(
-				"jQuery( function( $ ) {
-					$( '.single_add_to_cart_button' ).click( function() {
-						_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
-					} );
+				"$( '.single_add_to_cart_button' ).click( function() {
+					_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
 				} );"
 			);
 		} else if ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
 			wc_enqueue_js(
-				"jQuery( function( $ ) {
-					$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
-						var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );
-						_gaq.push(['_trackEvent', 'Products', 'Add to Cart', label]);
-					} );
+				"$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
+					var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );
+					_gaq.push(['_trackEvent', 'Products', 'Add to Cart', label]);
 				} );"
 			);
 		}


### PR DESCRIPTION
By default `wc_enqueue_js` method comes with a built-in self-executing anonymous function which makes it unnecessary to write our own within the code.

Reference can be found [here](https://github.com/woocommerce/woocommerce/blob/9206d6f4dd55df6cc45ea3982656cc8ec7690a76/includes/wc-core-functions.php#L859).

#### Testing Instructions

1- Upgrade to Jetpack premium
2- Enter a GA Tracking code
3- Enable basic tracking which uses legacy `ga.js` to track
4- Visit the front-end and inspect the source to find the tracking code
5- See the duplication of the anonymous function

#### Proposed Changelog entry

* WooCommerce Analytics: remove duplicate self-executing anonymous function.