### PR TITLE
Mailchimp Block & Publicize: Fix Set Up Link

### DIFF
--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -43,7 +43,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						onClick={ this.trackClickConfigure }
 						target="_blank"
 						rel="noopener noreferrer"
-						href={ 'https://wordpress.com/sharing/' + siteRawUrl }
+						href={ 'https://wordpress.com/marketing/connections/' + siteRawUrl }
 					>
 						{ __( 'Connect your social media accounts' ) }
 					</Card>

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -67,7 +67,7 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 				403
 			);
 		}
-		$connect_url = sprintf( 'https://wordpress.com/sharing/%s', rawurlencode( $site_id ) );
+		$connect_url = sprintf( 'https://wordpress.com/marketing/connections/%s', rawurlencode( $site_id ) );
 		return array(
 			'code'        => $this->is_connected() ? 'connected' : 'not_connected',
 			'connect_url' => $connect_url,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #12186

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fixes the broken link when setting up the Mailchimp Block

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit the Gutenberg editor and add a Mailchimp Block, assuming you've not linked your account yet
* Click "Set up Mailchimp form"
* Verify that you're now redirected to the correct URL

**Edit:** I originally intended this for just the Mailchimp block, but I also just noticed that this is an issue at `/wp-admin/admin.php?page=jetpack#/sharing`, which this PR also proposes fixing since it's the same link causing the problem.

<img width="1100" alt="Screenshot 2019-04-28 at 22 11 44" src="https://user-images.githubusercontent.com/43215253/56870162-f5555580-6a02-11e9-9179-5184db990171.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

Not sure if it's entirely necessary tbh, but if it is, maybe this?

* Mailchimp Block & Publicize: Fix link for setting up connection.
