### PR TITLE
Tools: Add script for checking the development environment requirements

### DIFF
--- a/docs/development-environment-cli-support.md
+++ b/docs/development-environment-cli-support.md
@@ -1,0 +1,92 @@
+# Support page for the Development Environment Command line checker
+
+### Usage
+
+```sh
+tools/check-development-environment.sh
+```
+
+## Topics
+
+### Command is available: git
+
+You need GIT for contributing to Jetpack.
+
+### Command is available: n
+
+**n** is a node version manager. Similar and alternative to **nvm**.
+
+### Command is available: php
+
+PHP is needed all around the build process for Jetpack bundles.
+
+### Command is available: phpunit
+
+PHPUnit is the tool that helps us run unit tests for Jetpack.
+
+### Docker images are available
+
+The containers for the Jetpack docker images are created when you ran `yarn docker:up`.
+
+### Docker containers are available
+
+The containers for the Jetpack docker containers are created when you ran `yarn docker:up`.
+
+### Docker containers are running
+
+If you are using the Jetpack Docker Image, make sure you run `yarn docker:up`.
+
+### Docker Is Running
+
+make sure the Docker Daemon is running.
+
+### Node Modules are available
+
+The directory `node_modules` is where Jetpack's JavaScript dependencies live. It gets initialized by doing:
+
+```sh
+yarn
+```
+
+### Node version is proper
+
+For developing Jetpack you need Node > 10 nowadays.
+
+Confirm your version of node by running
+
+```sh
+node -v
+```
+
+### NVM is available
+
+The `nvm` command is not _really_ needed but it's a tool that allows you to install multiple nvm versions.
+
+You can also work with any global `node` command.
+
+### Repo is up to date
+
+Make sure you have the latest changes from the GitHub branch `master` in your local copy of `master` of the Jetpack repo.
+Make sure you have no changes staged and then.
+
+```
+git checkout master
+git fetch origin && git rebase
+```
+
+### Repo origin scheme is GIT
+
+Sometime one clones the Jetpack repo from the GitHub HTTP URL of the repo and thus we're not able to use SSH key authentication for pushing to the repo.
+
+The proper way to clone the Jetpack repository is to use the git URL for it.
+
+```sh
+git clone git@github.com:Automattic/jetpack.git
+```
+
+### Vendor dir is available
+The directory `vendor` is where Jetpack's PHP dependencies live. It gets initialized by doing:
+
+```sh
+composer install
+```

--- a/docs/development-environment-cli-support.md
+++ b/docs/development-environment-cli-support.md
@@ -36,9 +36,9 @@ The containers for the Jetpack docker containers are created when you ran `yarn 
 
 If you are using the Jetpack Docker Image, make sure you run `yarn docker:up`.
 
-### Docker Is Running
+### Docker Is running
 
-make sure the Docker Daemon is running.
+Make sure the Docker Daemon is running.
 
 ### Node Modules are available
 
@@ -50,9 +50,9 @@ yarn
 
 ### Node version is proper
 
-For developing Jetpack you need Node > 10 nowadays.
+We need to keep our Node version requirements updated frequently.
 
-Confirm your version of node by running
+Confirm your version of node by running the following command and check that it satisfies the requirements stated in the doc [Development Environment](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md).
 
 ```sh
 node -v
@@ -60,7 +60,7 @@ node -v
 
 ### NVM is available
 
-The `nvm` command is not _really_ needed but it's a tool that allows you to install multiple nvm versions.
+The `nvm` command is not _really_ needed but it's a tool that allows you to install multiple Node versions.
 
 You can also work with any global `node` command.
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -12,6 +12,16 @@ In most cases you want to have accessible an WordPress installation for Jetpack 
 * Yarn 1.7
 * PHP 7.0 (in case you are running WordPress locally)
 
+## Script for checking if your environment is ready for contributing to Jetpack
+
+We provide a script to help you in assessing if everything's ready on your system to contribute to Jetpack.
+
+```sh
+tools/check-development-environment.sh
+```
+
+You should expect to get no red `FAILED` check messages. If there happens to be one, you can follow the link mentioned in the status check to see what's needed to address the issue.
+
 ## A note on Node versions used for the build tasks
 
 We try to frequently keep the Node version we use up to date. So, eventually you may need to refresh your package dependencies (i.e., the `node_modules` directories). This is because some dependencies are built specifically for the Node version you used when you installed them (either by running `yarn build` or `yarn`).

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+grn=$'\e[1;32m'
+red=$'\e[1;31m'
+ylw=$'\e[1;33m'
+white=$'\e[0m'
+cyn=$'\e[1;36m'
+
+SUPPORT_BASE_URL=https://github.com/Automattic/jetpack/blob/add/check-development-environment-script/docs/development-environment-cli-support.md
+
+function output { printf $white"$@";  }
+function success { printf $grn"$@";  }
+function danger { printf $red"$@";  }
+function info { printf $cyn"$@";  }
+function warning { printf $ylw"$@";  }
+
+function command_exists_as_alias {
+	alias $1 2>/dev/null >/dev/null
+}
+
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+function node_version_is_proper {
+	REQUIRED=`cat .nvmrc`
+	version_gt `node -v |cut -b 2-` $REQUIRED
+}
+
+function command_is_available {
+	which -s $1 || command_exists_as_alias $1 || type $1 >/dev/null 2>/dev/null
+}
+function nvm_is_available {
+    [ -f ~/.nvm/nvm.sh ] && source ~/.nvm/nvm.sh && command_is_available nvm
+}
+
+function docker_is_running {
+	docker info >/dev/null 2>&1
+}
+
+function repo_is_up_to_date {
+	git fetch origin >/dev/null
+	git diff -s --exit-code master origin/master
+}
+
+function node_modules_are_available {
+	[ -d node_modules ]
+}
+
+function vendor_dir_is_available {
+	[ -d vendor ]
+}
+
+function is_git_dir {
+	[ -d .git ]
+}
+
+function repo_origin_scheme_is_git {
+	git remote -v | grep 'git@' >/dev/null
+}
+
+function docker_containers_are_running {
+	docker_is_running && docker ps | grep jetpack_wordpress >>/dev/null \
+		&& docker ps| grep jetpack_mysql >>/dev/null
+}
+
+function docker_containers_are_available {
+	docker_is_running && docker ps -a | grep jetpack_wordpress >>/dev/null \
+		&& docker ps -a | grep jetpack_mysql >>/dev/null
+}
+
+function docker_images_are_available {
+	docker_is_running && docker image ls | grep jetpack_wordpress >>/dev/null
+}
+
+function support_url {
+	if [ -z $2 ]; then
+		slug=`echo $1 | tr _ -`
+		echo "$SUPPORT_BASE_URL#$slug"
+	else
+		slug=`echo $1-$2 | tr _ -`
+		echo "$SUPPORT_BASE_URL#$slug"
+	fi
+}
+
+function assert {
+	output "* $1 $2":
+	$1 $2 && success " SUCCESS\n"
+	$1 $2 || danger " FAILED. Check $(support_url "$1" "$2" )\n"
+}
+
+function check {
+	output "* $1 $2":
+	$1 $2 && success " SUCCESS\n"
+	$1 $2 || output " NOPE. Check $(support_url "$1" "$2" )\n"
+}
+
+main() {
+	output "Jetpack development environment checking\n\n"
+	output "\nChecking under $PWD\n\n"
+	output "Tools for development, linting, unit testing\n"
+	output "============================================ \n\n"
+
+	assert command_is_available php
+	assert command_is_available phpunit
+	assert command_is_available composer
+	assert vendor_dir_is_available
+
+	output "\n\nJavaScript tooling\n"
+	output "======================\n\n"
+
+	assert command_is_available node
+	assert node_version_is_proper
+	assert command_is_available yarn
+	check  nvm_is_available || check command_is_available n
+	assert node_modules_are_available
+
+	output "\nJetpack Development Environment\n"
+	output "=================================\n\n"
+
+	assert command_is_available docker
+	check  docker_is_running
+	check  docker_images_are_available
+	check  docker_containers_are_available
+	check  docker_containers_are_running
+
+	output "\n\nTools for contributing\n"
+	output "==========================\n\n"
+
+	assert command_is_available git
+	assert is_git_dir
+	assert repo_origin_scheme_is_git
+	assert repo_is_up_to_date
+
+	# Clean terminal colors
+	echo $white
+
+}
+
+## Run main only if not source by another file
+(return 0 2>/dev/null) || main

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -6,7 +6,7 @@ ylw=$'\e[1;33m'
 white=$'\e[0m'
 cyn=$'\e[1;36m'
 
-SUPPORT_BASE_URL=https://github.com/Automattic/jetpack/blob/add/check-development-environment-script/docs/development-environment-cli-support.md
+SUPPORT_BASE_URL=https://github.com/Automattic/jetpack/blob/master/docs/development-environment-cli-support.md
 
 function output { printf $white"$@";  }
 function success { printf $grn"$@";  }


### PR DESCRIPTION
This PR provides a script `tools/check-development-environment.sh` for checking if everything that's needed for working with Jetpack is available on the system.

![image](https://user-images.githubusercontent.com/746152/56892518-48a4c380-6a56-11e9-9f6c-1e6fc7f40439.png)

When you run the script it will check a few things, and if one of the check files, it will provide al ink to a support document where we can help with further details on how to overcome the failed check.

![image](https://user-images.githubusercontent.com/746152/56892682-c668cf00-6a56-11e9-8cf2-654b0b59f81a.png)

![image](https://user-images.githubusercontent.com/746152/56892690-cd8fdd00-6a56-11e9-9221-48e734cd89fc.png)


Fixes nothing

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds script `tools/check-development-environment.sh`.
* Adds document `development-environment-cli-support.md`. which is where we linnk from the CLI to aid in setting up the environment
* ~Adds npm script `yarn check-development-environment`~. Removed it.
* Adds a reference to this script to the document `docs/development-environment.md`.

#### Testing instructions:

1. check out this branch locally
2. Run `tools/check-development-environment.sh.
3. Hopefully all check are green, but if you see one FAILED, confirm the link takes you to an informational section on the CLI Support document online.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* None needed
