### PR TITLE
Unit tests: remove all block availability actions for Gutenberg tests

### DIFF
--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -23,6 +23,9 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 		delete_option( 'jetpack_excluded_extensions' );
+
+		// These action causing issues in tests in WPCOM context. Since we are not using any real block here,
+		// and we are testing block availability with block stubs - we safe to remove these actions for these tests.
 		remove_all_actions( 'jetpack_register_gutenberg_extensions' );
 		Jetpack_Gutenberg::init();
 	}

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -25,7 +25,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		delete_option( 'jetpack_excluded_extensions' );
 
 		// These action causing issues in tests in WPCOM context. Since we are not using any real block here,
-		// and we are testing block availability with block stubs - we safe to remove these actions for these tests.
+		// and we are testing block availability with block stubs - we are safe to remove these actions for these tests.
 		remove_all_actions( 'jetpack_register_gutenberg_extensions' );
 		Jetpack_Gutenberg::init();
 	}

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -23,6 +23,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extensions_whitelist' ) );
 		delete_option( 'jetpack_excluded_extensions' );
+		remove_all_actions( 'jetpack_register_gutenberg_extensions' );
 		Jetpack_Gutenberg::init();
 	}
 

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -69,7 +69,8 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block') );
 		Jetpack_Gutenberg::get_availability();
 		Jetpack_Gutenberg::get_availability();
-		remove_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block') );
+		$result = remove_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block') );
+		$this->assertTrue( $result );
 	}
 
 	function register_block() {


### PR DESCRIPTION
Gutenberg unit tests does not test actual blocks, although some of the block's code is executed in these tests. For example: https://github.com/Automattic/jetpack/blob/master/modules/videopress/class.videopress-gutenberg.php#L52

This is mostly fine in Jetpack environment, but it does not work as is in WPCOM due to plan requirement 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Unregister all `jetpack_register_gutenberg_extensions` actions before running the tests

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run and make sure the tests are passing as before: `phpunit --filter WP_Test_Jetpack_Gutenberg`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

*
