### PR TITLE
Mixcloud: fix all PHPCS warnings in preparation for Fusion

### DIFF
--- a/modules/shortcodes/mixcloud.php
+++ b/modules/shortcodes/mixcloud.php
@@ -1,8 +1,8 @@
 <?php
-/*
+/**
  * Mixcloud embeds
  *
- * examples:
+ * Examples:
  * [mixcloud MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ /]
  * [mixcloud MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ width=640 height=480 /]
  * [mixcloud http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ /]
@@ -10,21 +10,29 @@
  * [mixcloud]http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]
  * [mixcloud]MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]
  * [mixcloud http://www.mixcloud.com/mat/playlists/classics/ width=660 height=208 hide_cover=1 hide_tracklist=1]
-*/
+ *
+ * @package Jetpack
+ */
 
-// Register oEmbed provider
-// Example URL: http://www.mixcloud.com/oembed/?url=http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/
+/*
+ * Register oEmbed provider
+ * Example URL: http://www.mixcloud.com/oembed/?url=http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/
+ */
 wp_oembed_add_provider( '#https?://(?:www\.)?mixcloud\.com/\S*#i', 'https://www.mixcloud.com/oembed', true );
 
-// Register mixcloud shortcode
-add_shortcode( 'mixcloud', 'mixcloud_shortcode' );
+/**
+ * Register mixcloud shortcode.
+ *
+ * @param array  $atts    Shortcode atttributes.
+ * @param string $content Post content.
+ */
 function mixcloud_shortcode( $atts, $content = null ) {
 
 	if ( empty( $atts[0] ) && empty( $content ) ) {
 		return '<!-- mixcloud error: invalid mixcloud resource -->';
 	}
 
-	$regular_expression = '/((?<=mixcloud\\.com\\/)[\\w-\\/]+$)|(^[\\w-\\/]+$)/i';
+	$regular_expression = '/((?<=mixcloud\.com\/)[\w\-\/]+$)|(^[\w\-\/]+$)/i';
 	preg_match( $regular_expression, $content, $match );
 	if ( ! empty( $match ) ) {
 		$resource_id = trim( $match[0] );
@@ -57,7 +65,7 @@ function mixcloud_shortcode( $atts, $content = null ) {
 		$atts
 	);
 
-	// remove falsey values
+	// remove falsey values.
 	$atts = array_filter( $atts );
 
 	$query_args = array( 'url' => $mixcloud_url );
@@ -73,3 +81,4 @@ function mixcloud_shortcode( $atts, $content = null ) {
 
 	return $response_body->html;
 }
+add_shortcode( 'mixcloud', 'mixcloud_shortcode' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This also updates the main regex to fix PHP warnings:
`Warning: preg_match(): Compilation failed: invalid range in character class at offset 24`

#### Testing instructions:

* Test any of the shortcode formats listed at the top of the file:
 * `[mixcloud MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ /]`
 * `[mixcloud MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ width=640 height=480 /]`
 * `[mixcloud http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ /]`
 * `[mixcloud http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/ width=640 height=480 /]`
 * `[mixcloud]http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]`
 * `[mixcloud]MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/[/mixcloud]`
 * `[mixcloud http://www.mixcloud.com/mat/playlists/classics/ width=660 height=208 hide_cover=1 hide_tracklist=1]`
* They should work.

#### Proposed changelog entry for your changes:

* Shortcodes: avoid any PHP warnings when inserting Mixcloud players in posts.
