### PR TITLE
Pinterest: fix all PHPCS warnings in preparation for Fusion

### DIFF
--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -3,10 +3,13 @@
  * Pinterest embeds
  *
  * Based on "Board Widget" example here: http://business.pinterest.com/widget-builder/#code
+ *
+ * Example URL: https://pinterest.com/pin/129056345550241149/
+ * Second Example URL: https://uk.pinterest.com/annsawesomepins/travel/
+ *
+ * @package Jetpack
  */
 
-// Example URL: http://pinterest.com/pinterest/pin-pets/
-// Second Example URL: https://uk.pinterest.com/annsawesomepins/travel/
 wp_embed_register_handler(
 	'pinterest',
 	'#'
@@ -20,12 +23,20 @@ wp_embed_register_handler(
 	'pinterest_embed_handler'
 );
 
+/**
+ * Callback to modify output of embedded Pinterest posts.
+ *
+ * @param array $matches Regex partial matches against the URL passed.
+ * @param array $attr    Attributes received in embed response.
+ * @param array $url     Requested URL to be embedded.
+ */
 function pinterest_embed_handler( $matches, $attr, $url ) {
-	// Pinterest's JS handles making the embed
+	// Pinterest's JS handles making the embed.
 	$script_src = '//assets.pinterest.com/js/pinit.js';
-	wp_enqueue_script( 'pinterest-embed', $script_src, array(), false, true );
 
-	$path = parse_url( $url, PHP_URL_PATH );
+	wp_enqueue_script( 'pinterest-embed', $script_src, array(), JETPACK__VERSION, true );
+
+	$path = wp_parse_url( $url, PHP_URL_PATH );
 	if ( 0 === strpos( $path, '/pin/' ) ) {
 		$embed_type = 'embedPin';
 	} elseif ( preg_match( '#^/([^/]+)/?$#', $path ) ) {
@@ -41,9 +52,12 @@ function pinterest_embed_handler( $matches, $attr, $url ) {
 
 	$return = sprintf( '<a data-pin-do="%s" href="%s"></a>', esc_attr( $embed_type ), esc_url( $url ) );
 
-	// If we're generating an embed view for the WordPress Admin via ajax...
+	// If we're generating an embed view for the WordPress Admin via ajax.
 	if ( doing_action( 'wp_ajax_parse-embed' ) ) {
-		$return .= sprintf( '<script src="%s"></script>', esc_url( $script_src ) );
+		$return .= sprintf(
+			'<script src="%s"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			esc_url( $script_src )
+		);
 	}
 
 	return $return;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Pinterest: fix all PHPCS warnings in preparation for Fusion
* I also updated the example URL since the previous one did not exist anymore.


#### Testing instructions:

* Try adding the following to a Classic block:
    - `https://pinterest.com/pin/129056345550241149/`
    - `https://uk.pinterest.com/annsawesomepins/travel/`

#### Proposed changelog entry for your changes:

* None
