### PR TITLE
Slideshow: Update mobile styles

### DIFF
--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -1,9 +1,15 @@
 @import '../../shared/styles/gutenberg-colors.scss';
 @import '../../shared/styles/jetpack-variables.scss';
 
+$break-small: 600px;
+
 .wp-block-jetpack-slideshow {
 	margin-bottom: $jetpack-block-margin-bottom;
 	position: relative;
+
+	[tabindex='-1']:focus {
+		outline: 0;
+	}
 
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
@@ -79,6 +85,11 @@
 		}
 	}
 
+	.wp-block-jetpack-slideshow_button-prev,
+	.wp-block-jetpack-slideshow_button-next {
+		display: none;
+	}
+
 	&.swiper-container-rtl .swiper-button-prev.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
 	.swiper-button-next.swiper-button-white,
@@ -119,6 +130,7 @@
 		cursor: text;
 		left: 0;
 		margin: 0 !important;
+		max-height: 100%;
 		padding: 0.75em;
 		position: absolute;
 		right: 0;
@@ -127,6 +139,10 @@
 		a {
 			color: inherit;
 		}
+	}
+
+	&[data-autoplay='true'] .wp-block-jetpack-slideshow_caption.gallery-caption {
+		max-height: calc( 100% - 68px );
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
@@ -160,6 +176,15 @@
 			background-color: currentColor;
 			opacity: 1;
 			transform: scale( 1 );
+		}
+	}
+}
+
+@media ( min-width: $break-small ) {
+	.wp-block-jetpack-slideshow {
+		.wp-block-jetpack-slideshow_button-prev,
+		.wp-block-jetpack-slideshow_button-next {
+			display: block;
 		}
 	}
 }

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -1,7 +1,6 @@
 @import '../../shared/styles/gutenberg-colors.scss';
+@import '../../shared/styles/gutenberg-variables.scss';
 @import '../../shared/styles/jetpack-variables.scss';
-
-$break-small: 600px;
 
 .wp-block-jetpack-slideshow {
 	margin-bottom: $jetpack-block-margin-bottom;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Optimise the mobile styles of the Slideshow Block and make sure we don't display unnecessary elements (prev/next arrow) on small screens.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Only display prev/next arrows when viewport is >= 600px
* Make sure captions fit properly within the slide and don't overflow the play/pause button.
* Make sure slides on focus (touch slide) don't display an outline

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with a Slideshow block
* Add a few images with a very very long caption
* How does the block look like?
* Enable autoplay
* How does the block look like?
* Resize your screen (or check the side on mobile), do you see the arrows?
* On on your desktop, do you see the arrows?

__Before:__
![Screenshot 2019-04-30 at 12 23 27](https://user-images.githubusercontent.com/177929/56958715-fc837d00-6b42-11e9-899e-cb220d030c5e.png)

__After:__
![Screenshot 2019-04-30 at 12 23 41](https://user-images.githubusercontent.com/177929/56958722-03aa8b00-6b43-11e9-93ec-47d5733ed3bf.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Slideshow Block: Depending on viewport, display prev/next arrows
* Slideshow Block: Remove outline when focussing on the block
