### PR TITLE
Shortcodes: fix all phpcs warnings for slideshare

### DIFF
--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -1,23 +1,30 @@
 <?php
 /**
- * Slideshare shortcode format:
+ * Slideshare shortcode
+ *
+ * Formats:
  * Old style (still compatible): [slideshare id=5342235&doc=camprock-101002163655-phpapp01&w=300&h=200]
  * New style: [slideshare id=5342235&w=300&h=200&fb=0&mw=0&mh=0&sc=no]
  *
  * Legend:
- *	id    = Document ID provided by Slideshare
- *	w     = Width of iFrame     (int)
- *	h     = Height of iFrame    (int)
- *	fb    = iFrame frameborder  (int)
- *	mw    = iFrame marginwidth  (int)
- *	mh    = iFrame marginheight (int)
- *	sc    = iFrame Scrollbar    (yes/no)
- *	pro   = Slideshare Pro      (yes/no)
- *	style = Inline CSS          (string)
- **/
+ *  id    = Document ID provided by Slideshare
+ *  w     = Width of iFrame     (int)
+ *  h     = Height of iFrame    (int)
+ *  fb    = iFrame frameborder  (int)
+ *  mw    = iFrame marginwidth  (int)
+ *  mh    = iFrame marginheight (int)
+ *  sc    = iFrame Scrollbar    (yes/no)
+ *  pro   = Slideshare Pro      (yes/no)
+ *  style = Inline CSS          (string)
+ *
+ * @package Jetpack
+ */
 
-add_shortcode( 'slideshare', 'slideshare_shortcode' );
-
+/**
+ * Register and display shortcode.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function slideshare_shortcode( $atts ) {
 	global $content_width;
 
@@ -43,17 +50,19 @@ function slideshare_shortcode( $atts ) {
 		$arguments
 	);
 
-	// check that the Slideshare ID contains letters, numbers and query strings
+	// check that the Slideshare ID contains letters, numbers and query strings.
 	$pattern = '/[^-_a-zA-Z0-9?=&]/';
 	if ( empty( $attr['id'] ) || preg_match( $pattern, $attr['id'] ) ) {
 		return '<!-- SlideShare error: id is missing or has illegal characters -->';
 	}
 
-	// check the width/height
-	$w = $attr['w'];
+	// check the width/height.
+	$w = intval( $attr['w'] );
+
+	// If no width was specified (or uses the wrong format), and if we have a $content_width, use that.
 	if ( empty( $w ) && ! empty( $content_width ) ) {
 		$w = intval( $content_width );
-	} elseif ( ! ( $w = intval( $w ) ) || $w < 300 || $w > 1600 ) {
+	} elseif ( $w < 300 || $w > 1600 ) { // If width was specified, but is too small/large, set default value.
 		$w = 425;
 	} else {
 		$w = intval( $w );
@@ -61,33 +70,33 @@ function slideshare_shortcode( $atts ) {
 
 	$h = ceil( $w * 348 / 425 ); // Note: user-supplied height is ignored.
 
-	if ( isset( $attr['pro'] ) && $attr['pro'] ) {
+	if ( ! empty( $attr['pro'] ) ) {
 		$source = 'https://www.slideshare.net/slidesharepro/' . $attr['id'];
 	} else {
 		$source = 'https://www.slideshare.net/slideshow/embed_code/' . $attr['id'];
 	}
 
-	if ( isset( $rel ) ) {
-		$source = add_query_arg( 'rel', intval( $rel ), $source );
+	if ( isset( $attr['rel'] ) ) {
+		$source = add_query_arg( 'rel', intval( $attr['rel'] ), $source );
 	}
 
-	if ( isset( $startSlide ) ) {
-		$source = add_query_arg( 'startSlide', intval( $startSlide ), $source );
+	if ( ! empty( $attr['startSlide'] ) ) {
+		$source = add_query_arg( 'startSlide', intval( $attr['startSlide'] ), $source );
 	}
 
 	$player = sprintf( "<iframe src='%s' width='%d' height='%d'", esc_url( $source ), $w, $h );
 
-	// check the frameborder
+	// check the frameborder.
 	if ( ! empty( $attr['fb'] ) || '0' === $attr['fb'] ) {
 		$player .= " frameborder='" . intval( $attr['fb'] ) . "'";
 	}
 
-	// check the margin width; if not empty, cast as int
+	// check the margin width; if not empty, cast as int.
 	if ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) {
 		$player .= " marginwidth='" . intval( $attr['mw'] ) . "'";
 	}
 
-	// check the margin height, if not empty, cast as int
+	// check the margin height, if not empty, cast as int.
 	if ( ! empty( $attr['mh'] ) || '0' === $attr['mh'] ) {
 		$player .= " marginheight='" . intval( $attr['mh'] ) . "'";
 	}
@@ -96,11 +105,11 @@ function slideshare_shortcode( $atts ) {
 		$player .= " style='" . esc_attr( $attr['style'] ) . "'";
 	}
 
-	// check the scrollbar; cast as a lowercase string for comparison
+	// check the scrollbar; cast as a lowercase string for comparison.
 	if ( ! empty( $attr['sc'] ) ) {
 		$sc = strtolower( $attr['sc'] );
 
-		if ( in_array( $sc, array( 'yes', 'no' ) ) ) {
+		if ( in_array( $sc, array( 'yes', 'no' ), true ) ) {
 			$player .= " scrolling='" . $sc . "'";
 		}
 	}
@@ -119,3 +128,4 @@ function slideshare_shortcode( $atts ) {
 	 */
 	return apply_filters( 'jetpack_slideshare_shortcode', $player, $atts );
 }
+add_shortcode( 'slideshare', 'slideshare_shortcode' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Shortcodes: fix all phpcs warnings for slideshare

#### Testing instructions:

* You can follow the instructions here to test:
* https://en.support.wordpress.com/slideshare/
* Here is an example:
* `[slideshare id=142624297&doc=wordpressmeetup-190428134705]`

#### Proposed changelog entry for your changes:

* None
