### PR TITLE
Shortlinks: add shortlinks in API responses to Pages and Attachments

### DIFF
--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -89,7 +89,7 @@ function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {
 }
 
 /**
- * Add Shortlinks to the REST API Post response.
+ * Add Shortlinks to the REST API responses.
  *
  * @since 6.9.0
  *
@@ -99,6 +99,7 @@ function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {
 function wpme_rest_register_shortlinks() {
 	register_rest_field(
 		array(
+			'attachment',
 			'page',
 			'post',
 		),

--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -98,7 +98,10 @@ function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {
  */
 function wpme_rest_register_shortlinks() {
 	register_rest_field(
-		'post',
+		array(
+			'page',
+			'post',
+		),
 		'jetpack_shortlink',
 		array(
 			'get_callback'    => 'wpme_rest_get_shortlink',


### PR DESCRIPTION
Adds shortlinks support to pages and attachments in REST API responses.

In `wpme_get_shortlink` you can see how shortlinks are supported by posts, pages and attachments:

https://github.com/Automattic/jetpack/blob/86ec2a8923675880a1fa7275ce88fea6c77971eb/modules/shortlinks.php#L73-L77

Previously only posts would receive `jetpack_shortlink` meta and thus the shortlink sidebar wouldn't show up in Gutenberg editor:

<img width="478" alt="Screenshot 2019-04-30 at 23 51 46" src="https://user-images.githubusercontent.com/87168/56992551-f6bd8400-6ba2-11e9-9725-c7bcae3f0bbe.png">

Relevant bit in the block editor implementation that checks for the meta field:

https://github.com/Automattic/jetpack/blob/86ec2a8923675880a1fa7275ce88fea6c77971eb/extensions/blocks/shortlinks/index.js#L43

wpcom side: D27654-code

Came up in p58i-7MO-p2



#### Changes proposed in this Pull Request:
-  Add `jetpack_shortlink` meta field to Page and Attachment REST API responses  

#### Testing instructions:

- Create or open an existing page (not a post) in Gutenberg editor
- Open Jetpack sidebar by pressing jetpack logo on top-right corner
- Confirm that you see shorturl panel


#### Proposed changelog entry for your changes:
- Add short link  support for pages in block editor
