### PR TITLE
Calypsoify: Fix undefined index notice

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -314,7 +314,7 @@ class Jetpack_Calypsoify {
 	 * @return string
 	 */
 	private function get_calypso_origin() {
-		$origin = $_GET[ 'origin' ];
+		$origin    = ! empty( $_GET['origin'] ) ? $_GET['origin'] : 'https://wordpress.com';
 		$whitelist = array(
 			'http://calypso.localhost:3000',
 			'http://127.0.0.1:41050', // Desktop App


### PR DESCRIPTION
Fixes an undefined index notice in cases where `origin` is not set.

#### Testing instructions:
**Before checking out this branch:**
* If you develop Jetpack with its built-in Docker env, run `yarn docker:tail` to tail the error log.
* Go to `/wp-admin/post-new.php` in your dev environment and check for the notice to show up.

**After checking out this branch:**
* Reload `/wp-admin/post-new.php` in your dev environment and check that the notice does not show up.

Introduced in #12161.
