### PR TITLE
Gutenframe: Redirect logged out users

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -89,6 +89,7 @@ class Jetpack_WPCOM_Block_Editor {
 				add_action( 'login_form', array( $this, 'maintain_redirect_to' ) );
 				add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
 				remove_action( 'login_init', 'send_frame_options_header' );
+				wp_add_inline_style( 'login', '.interim-login #login{padding-top:8%}' );
 			}
 		}
 	}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -81,11 +81,15 @@ class Jetpack_WPCOM_Block_Editor {
 		$args  = wp_parse_args( $query );
 
 		if ( ! empty( $args['frame-nonce'] ) && $this->framing_allowed( $args['frame-nonce'] ) ) {
-			$_REQUEST['interim-login'] = true;
-			add_action( 'wp_login', array( $this, 'do_redirect' ) );
-			add_action( 'login_form', array( $this, 'maintain_redirect_to' ) );
-			add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
-			remove_action( 'login_init', 'send_frame_options_header' );
+			if ( Jetpack::is_module_active( 'sso' ) ) {
+				add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+			} else {
+				$_REQUEST['interim-login'] = true;
+				add_action( 'wp_login', array( $this, 'do_redirect' ) );
+				add_action( 'login_form', array( $this, 'maintain_redirect_to' ) );
+				add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
+				remove_action( 'login_init', 'send_frame_options_header' );
+			}
 		}
 	}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -92,7 +92,7 @@ class Jetpack_WPCOM_Block_Editor {
 			} else {
 				$_REQUEST['interim-login'] = true;
 				add_action( 'wp_login', array( $this, 'do_redirect' ) );
-				add_action( 'login_form', array( $this, 'maintain_redirect_to' ) );
+				add_action( 'login_form', array( $this, 'add_login_html' ) );
 				add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
 				remove_action( 'login_init', 'send_frame_options_header' );
 				wp_add_inline_style( 'login', '.interim-login #login{padding-top:8%}' );
@@ -117,10 +117,17 @@ class Jetpack_WPCOM_Block_Editor {
 
 	/**
 	 * Maintains the `redirect_to` parameter in login form links.
+	 * Adds visual feedback of login in progress.
 	 */
-	public function maintain_redirect_to() {
+	public function add_login_html() {
 		?>
 		<input type="hidden" name="redirect_to" value="<?php echo esc_url( $_REQUEST['redirect_to'] ); ?>" />
+		<script type="application/javascript">
+			document.getElementById( 'loginform' ).addEventListener( 'submit' , function() {
+				document.getElementById( 'wp-submit' ).setAttribute( 'disabled', 'disabled' );
+				document.getElementById( 'wp-submit' ).value = '<?php echo esc_js( __( 'Logging In...', 'jetpack' ) ); ?>';
+			} );
+		</script>
 		<?php
 	}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -36,7 +36,6 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	private function __construct() {
 		if ( $this->is_iframed_block_editor() ) {
-			add_action( 'init', array( $this, 'show_error_if_logged_out' ) );
 			add_action( 'admin_init', array( $this, 'disable_send_frame_options_header' ), 9 );
 			add_filter( 'admin_body_class', array( $this, 'add_iframed_body_class' ) );
 		}
@@ -56,21 +55,6 @@ class Jetpack_WPCOM_Block_Editor {
 
 		// phpcs:ignore WordPress.Security.NonceVerification
 		return ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) && ! empty( $_GET['frame-nonce'] );
-	}
-
-	/**
-	 * Shows a custom message if the user is logged out.
-	 *
-	 * The iframed block editor can be only embedded in WordPress.com if the user is logged
-	 * into the Jetpack site. So we abort the default redirection to the login page (which
-	 * cannot be embedded in a iframe) and instead we explain that we need the user to log
-	 * into Jetpack.
-	 */
-	public function show_error_if_logged_out() {
-		if ( ! get_current_user_id() ) {
-			wp_safe_redirect( wp_login_url( $_SERVER['REQUEST_URI'] ) );
-			exit;
-		}
 	}
 
 	/**

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -96,7 +96,7 @@ class Jetpack_WPCOM_Block_Editor {
 		$query = wp_parse_url( urldecode( $_GET['redirect_to'] ), PHP_URL_QUERY );
 		$args  = wp_parse_args( $query );
 
-		if ( $this->framing_allowed( $args['frame-nonce'] ) ) {
+		if ( ! empty( $args['frame-nonce'] ) && $this->framing_allowed( $args['frame-nonce'] ) ) {
 			add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
 			remove_action( 'login_init', 'send_frame_options_header' );
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -67,14 +67,7 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	public function show_error_if_logged_out() {
 		if ( ! get_current_user_id() ) {
-			/* translators: %s: Login URL */
-			$message = __( 'Please <a href="%s" target="_blank" rel="noopener noreferrer">log into</a> your Jetpack-connected site to use the block editor on WordPress.com.', 'jetpack' );
-
-			wp_die(
-				sprintf( wp_kses_post( $message ), esc_url( wp_login_url() ) ),
-				'',
-				array( 'response' => 401 )
-			);
+			wp_safe_redirect( wp_login_url( $_SERVER['REQUEST_URI'] ) );
 		}
 	}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -100,8 +100,24 @@ class Jetpack_WPCOM_Block_Editor {
 			$_REQUEST['interim-login'] = true;
 			add_action( 'wp_login', array( $this, 'do_redirect' ) );
 			add_action( 'login_form', array( $this, 'maintain_redirect_to' ) );
+			add_filter( 'wp_login_errors', array( $this, 'add_login_message' ) );
 			remove_action( 'login_init', 'send_frame_options_header' );
 		}
+	}
+
+	/**
+	 * Adds a login message.
+	 *
+	 * Intended to soften the expectation mismatch of ending up with a login screen rather than the editor.
+	 *
+	 * @param WP_Error $errors WP Error object.
+	 * @return \WP_Error
+	 */
+	public function add_login_message( $errors ) {
+		$errors->remove( 'expired' );
+		$errors->add( 'info', __( 'Before we continue, please log in to your Jetpack site.', 'jetpack' ), 'message' );
+
+		return $errors;
 	}
 
 	/**

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -61,9 +61,25 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Prevents frame options header from firing if this is a whitelisted iframe request.
 	 */
 	public function disable_send_frame_options_header() {
-		if ( $this->framing_allowed() ) {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( $this->framing_allowed( $_GET['frame-nonce'] ) ) {
 			remove_action( 'admin_init', 'send_frame_options_header' );
 		}
+	}
+
+	/**
+	 * Adds custom admin body class if this is a whitelisted iframe request.
+	 *
+	 * @param string $classes Admin body classes.
+	 * @return string
+	 */
+	public function add_iframed_body_class( $classes ) {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( $this->framing_allowed( $_GET['frame-nonce'] ) ) {
+			$classes .= ' is-iframed ';
+		}
+
+		return $classes;
 	}
 
 	/**
@@ -140,30 +156,12 @@ class Jetpack_WPCOM_Block_Editor {
 	}
 
 	/**
-	 * Adds custom admin body class if this is a whitelisted iframe request.
-	 *
-	 * @param string $classes Admin body classes.
-	 * @return string
-	 */
-	public function add_iframed_body_class( $classes ) {
-		if ( $this->framing_allowed() ) {
-			$classes .= ' is-iframed ';
-		}
-
-		return $classes;
-	}
-
-	/**
 	 * Checks whether this is a whitelisted iframe request.
 	 *
-	 * @param string $nonce Optional. Nonce to verify. Default $_GET['frame-nonce'].
+	 * @param string $nonce Nonce to verify.
 	 * @return bool
 	 */
-	public function framing_allowed( $nonce = '' ) {
-		if ( empty( $nonce ) ) {
-			$nonce = $_GET['frame-nonce']; // phpcs:ignore WordPress.Security.NonceVerification
-		}
-
+	public function framing_allowed( $nonce ) {
 		$verified = $this->verify_frame_nonce( $nonce, 'frame-' . Jetpack_Options::get_option( 'id' ) );
 
 		if ( is_wp_error( $verified ) ) {

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -80,8 +80,12 @@ class Jetpack_WPCOM_Block_Editor {
 		$query = wp_parse_url( urldecode( $_REQUEST['redirect_to'] ), PHP_URL_QUERY );
 		$args  = wp_parse_args( $query );
 
+		// Check nonce and make sure this is a Gutenframe request.
 		if ( ! empty( $args['frame-nonce'] ) && $this->framing_allowed( $args['frame-nonce'] ) ) {
+
+			// If SSO is active, we'll let WordPress.com handle authentication...
 			if ( Jetpack::is_module_active( 'sso' ) ) {
+				// ...but only if it's not an Atomic site. They already do that.
 				if ( ! jetpack_is_atomic_site() ) {
 					add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
 				}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -82,7 +82,9 @@ class Jetpack_WPCOM_Block_Editor {
 
 		if ( ! empty( $args['frame-nonce'] ) && $this->framing_allowed( $args['frame-nonce'] ) ) {
 			if ( Jetpack::is_module_active( 'sso' ) ) {
-				add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+				if ( ! jetpack_is_atomic_site() ) {
+					add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+				}
 			} else {
 				$_REQUEST['interim-login'] = true;
 				add_action( 'wp_login', array( $this, 'do_redirect' ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/32904

Rather than just presenting users an error message, let's show them the login form. If the SSO module is enabled, then we don't show the SSO login form, but just logs in users by going through WP.com. The nice side effect of that is that Jetpack sites with SSO enabled won't even know they were ever logged out.

### Testing instructions:

Note: While testing an Atomic site, you can ensure you're logged out by being unproxied, logged in as a non-A8C user and using a private / incognito session.

#### Jetpack and Atomic sites with SSO disabled
* Go to https://wpcalypso.wordpress.com/block-editor/post/ and select a Jetpack or Atomic site where you're logged out.
* Confirm you see the login form.
* Submit your self-hosted credentials.
* Make sure you see the block editor now.

#### Jetpack and Atomic sites with SSO enabled
* Go to https://wpcalypso.wordpress.com/block-editor/post/ and select a Jetpack or Atomic site where you're logged out.
* Make sure you see the block editor without entering any credentials.

### Proposed changelog entry for your changes:
* Block Editor on WordPress.com: Redirects logged-out users to their sites block editor, rather than just showing an error message.
