### PR TITLE
Verification Tools Remove add_filter for removed function

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -17,5 +17,6 @@ module.exports = [
 	'modules/module-info.php',
 	'modules/sharedaddy.php',
 	'modules/theme-tools/social-menu/',
+	'modules/verification-tools.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 ];

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -17,7 +17,6 @@ function jetpack_load_verification_tools() {
 
 function jetpack_verification_tools_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
-	add_filter( 'jetpack_module_configuration_url_verification-tools', 'jetpack_verification_tools_configuration_url' );
 }
 add_action( 'jetpack_modules_loaded', 'jetpack_verification_tools_loaded' );
 

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Module Name: Site verification
  * Module Description: Establish your site's authenticity with external services.
@@ -9,12 +8,20 @@
  * Auto Activate: Yes
  * Feature: Engagement
  * Additional Search Queries: webmaster, seo, google, bing, pinterest, search, console
+ *
+ * @package Jetpack
  */
 
+/**
+ * Load Verification Tools code.
+ */
 function jetpack_load_verification_tools() {
-	include dirname( __FILE__ ) . "/verification-tools/blog-verification-tools.php";
+	include dirname( __FILE__ ) . '/verification-tools/blog-verification-tools.php';
 }
 
+/**
+ * Functionality to load for Verification Tools after all modules have been loaded.
+ */
 function jetpack_verification_tools_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
 }


### PR DESCRIPTION
Fixes #12217 

#### Changes proposed in this Pull Request:
* In https://github.com/Automattic/jetpack/pull/12181/ , we removed links to older dashboard links, but missed the add_filter call that used the function. This removes it.

#### Testing instructions:
* Tail the error log, view various JP dashboard pages and the full module list.
*

#### Proposed changelog entry for your changes:
* None. Introduced in 7.3.
