### PR TITLE
 Soundcloud: simplify shortcode and fix all phpcs warnings

### DIFF
--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -14,6 +14,7 @@
  * [soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=true" width="100%" height="450" iframe="true" /]
  * [soundcloud url="https://soundcloud.com/closetorgan/paul-is-dead" width=400 height=400]
  * [soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private"]
+ * [soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private" color="00cc11"]
  * <iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/150745932&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>
  *
  * @package Jetpack
@@ -121,6 +122,14 @@ function soundcloud_shortcode( $atts, $content = null ) {
 
 		if ( 'false' === $value || false === $value ) {
 			$query_args[ $name ] = 'false';
+		}
+	}
+
+	// Add the color parameter if it was specified and is a valid color.
+	if ( ! empty( $options['color'] ) ) {
+		$color = sanitize_hex_color_no_hash( $options['color'] );
+		if ( ! empty( $color ) ) {
+			$query_args['color'] = $color;
 		}
 	}
 

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -1,43 +1,23 @@
 <?php
-/*
-Plugin Name: SoundCloud Shortcode
-Plugin URI: https://wordpress.org/extend/plugins/soundcloud-shortcode/
-Description: Converts SoundCloud WordPress shortcodes to a SoundCloud widget. Example: [soundcloud]http://soundcloud.com/forss/flickermood[/soundcloud]
-Version: 2.3
-Author: SoundCloud Inc., simplified for Jetpack by Automattic, Inc.
-Author URI: http://soundcloud.com
-License: GPLv2
-
-Original version: Johannes Wagener <johannes@soundcloud.com>
-Options support: Tiffany Conroy <tiffany@soundcloud.com>
-HTML5 & oEmbed support: Tim Bormans <tim@soundcloud.com>
-*/
-
-/*
-A8C: Taken from http://plugins.svn.wordpress.org/soundcloud-shortcode/trunk/
-at revision 664386.
-
-Commenting out (instead of removing) and replacing code with custom modifs
-so it's eqsy to see what differs from the standard DOTORG version.
-
-All custom modifs are annoted with "A8C" keyword in comment.
-*/
-
 /**
- * Register oEmbed provider
+ * SoundCloud Shortcode
+ * Based on this plugin: https://wordpress.org/plugins/soundcloud-shortcode/
+ *
+ * Credits:
+ * Original version: Johannes Wagener <johannes@soundcloud.com>
+ * Options support: Tiffany Conroy <tiffany@soundcloud.com>
+ * HTML5 & oEmbed support: Tim Bormans <tim@soundcloud.com>
+ *
+ * Examples:
+ * [soundcloud]http://soundcloud.com/forss/flickermood[/soundcloud]
+ * [soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=false" width="100%" height="450" iframe="true" /]
+ * [soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=true" width="100%" height="450" iframe="true" /]
+ * [soundcloud url="https://soundcloud.com/closetorgan/paul-is-dead" width=400 height=400]
+ * [soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private"]
+ * <iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/150745932&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>
+ *
+ * @package Jetpack
  */
-
-/*
- A8C: oEmbed is handled now in core; see wp-includes/class-oembed.php
-wp_oembed_add_provider( '#https?://(?:api\.)?soundcloud\.com/.*#i', 'http://soundcloud.com/oembed', true );
-*/
-
-
-/**
- * Register SoundCloud shortcode
- */
-
-add_shortcode( 'soundcloud', 'soundcloud_shortcode' );
 
 /**
  * SoundCloud shortcode handler
@@ -50,207 +30,138 @@ add_shortcode( 'soundcloud', 'soundcloud_shortcode' );
  */
 function soundcloud_shortcode( $atts, $content = null ) {
 
-	// Custom shortcode options
-	$shortcode_options = array_merge( array( 'url' => trim( $content ) ), is_array( $atts ) ? $atts : array() );
+	// Custom shortcode options.
+	$shortcode_options = array_merge(
+		array( 'url' => trim( $content ) ),
+		is_array( $atts ) ? $atts : array()
+	);
 
-	// Turn shortcode option "param" (param=value&param2=value) into array
+	// The "url" option is required.
+	if ( empty( $shortcode_options['url'] ) ) {
+		if ( current_user_can( 'edit_posts' ) ) {
+			return esc_html__( 'Please specify a Soundcloud URL.', 'jetpack' );
+		} else {
+			return '<!-- Missing Soundcloud URL -->';
+		}
+	}
+
+	// Turn shortcode option "param" (param=value&param2=value) into array of params.
 	$shortcode_params = array();
 	if ( isset( $shortcode_options['params'] ) ) {
 		parse_str( html_entity_decode( $shortcode_options['params'] ), $shortcode_params );
+		$shortcode_options = array_merge(
+			$shortcode_options,
+			$shortcode_params
+		);
+		unset( $shortcode_options['params'] );
 	}
-	$shortcode_options['params'] = $shortcode_params;
 
-	/*
-	 A8C: The original plugin exposes options we don't. SoundCloud omits "visual" shortcode
-			option when false, so if logic here remains, impossible to have non-visual shortcode.
-	$player_type = soundcloud_get_option( 'player_type', 'visual' );
-	$isIframe    = $player_type !== 'flash';
-	$isVisual    = ! $player_type || $player_type === 'visual' || $shortcode_options['visual'];
-	*/
-
-	// User preference options
-	$plugin_options = array_filter(
+	$options = shortcode_atts(
+		// This list used to include an 'iframe' option. We don't include it anymore as we don't support the Flash player anymore.
 		array(
-			'iframe' => true, // A8C: See above comment; flash is not a supported option
-			'width'  => soundcloud_get_option( 'player_width' ),
-			'height' => soundcloud_url_has_tracklist( $shortcode_options['url'] ) ? soundcloud_get_option( 'player_height_multi' ) : soundcloud_get_option( 'player_height' ),
-			'params' => array_filter(
-				array(
-					'auto_play'     => soundcloud_get_option( 'auto_play' ),
-					'show_comments' => soundcloud_get_option( 'show_comments' ),
-					'color'         => soundcloud_get_option( 'color' ),
-					'visual'        => 'false', // A8C: Merged with params below at $options assignment
-				)
-			),
-		)
+			'url'           => '',
+			'width'         => soundcloud_get_option( 'player_width' ),
+			'height'        => soundcloud_url_has_tracklist( $shortcode_options['url'] ) ? soundcloud_get_option( 'player_height_multi' ) : soundcloud_get_option( 'player_height' ),
+			'auto_play'     => soundcloud_get_option( 'auto_play' ),
+			'hide_related'  => false,
+			'visual'        => false,
+			'show_comments' => soundcloud_get_option( 'show_comments' ),
+			'color'         => soundcloud_get_option( 'color' ),
+			'show_user'     => false,
+			'show_reposts'  => false,
+		),
+		$shortcode_options,
+		'soundcloud'
 	);
 
-	// Needs to be an array
-	if ( ! isset( $plugin_options['params'] ) ) {
-		$plugin_options['params'] = array();
-	}
-
-	// plugin options < shortcode options
-	$options = array_merge(
-		$plugin_options,
-		$shortcode_options
-	);
-
-	// plugin params < shortcode params
-	$options['params'] = array_merge(
-		$plugin_options['params'],
-		$shortcode_options['params']
-	);
-
-	// The "url" option is required
-	if ( ! isset( $options['url'] ) ) {
-		return '';
-	} else {
-		$options['url'] = trim( $options['url'] );
-	}
-
-	// Both "width" and "height" need to be integers
-	if ( isset( $options['width'] ) && ! preg_match( '/^\d+$/', $options['width'] ) ) {
-		// set to 0 so oEmbed will use the default 100% and WordPress themes will leave it alone
+	// "width" needs to be an integer.
+	if ( ! empty( $options['width'] ) && ! preg_match( '/^\d+$/', $options['width'] ) ) {
+		// set to 0 so oEmbed will use the default 100% and WordPress themes will leave it alone.
 		$options['width'] = 0;
 	}
-	if ( isset( $options['height'] ) && ! preg_match( '/^\d+$/', $options['height'] ) ) {
-		unset( $options['height'] );
+	// Set default width if not defined.
+	$width = ! empty( $options['width'] ) ? absint( $options['width'] ) : '100%';
+
+	// Set default height if not defined.
+	if (
+		empty( $options['height'] )
+		|| (
+			// "height" needs to be an integer.
+			! empty( $options['height'] )
+			&& ! preg_match( '/^\d+$/', $options['height'] )
+		)
+	) {
+		if (
+			soundcloud_url_has_tracklist( $options['url'] )
+			|| 'true' === $options['visual']
+		) {
+			$height = 450;
+		} else {
+			$height = 166;
+		}
+	} else {
+		$height = absint( $options['height'] );
 	}
 
-	// The "iframe" option must be true to load the iframe widget
-	$iframe = soundcloud_booleanize( $options['iframe'] );
-
-	// Remove visual parameter from Flash widget, when it's false because that's the default, or when displaying the smallest player
-	if ( $options['params']['visual'] && ( ! $iframe || ! soundcloud_booleanize( $options['params']['visual'] ) || ( isset( $options['height'] ) && '20' == $options['height'] ) ) ) {
-		unset( $options['params']['visual'] );
+	// Set visual to false when displaying the smallest player.
+	if ( '20' === $options['height'] ) {
+		$options['visual'] = false;
 	}
 
-	// Merge in "url" value
-	$options['params'] = array_merge(
-		array(
-			'url' => $options['url'],
-		),
-		$options['params']
+	// Build our list of Souncloud parameters.
+	$query_args = array(
+		'url' => rawurlencode( $options['url'] ),
 	);
 
-	// Return html embed code
-	if ( $iframe ) {
-		return soundcloud_iframe_widget( $options );
-	} else {
-		return soundcloud_flash_widget( $options );
+	// Add our options, if they are set to true or false.
+	foreach ( $options as $name => $value ) {
+		if ( 'true' === $value ) {
+			$query_args[ $name ] = 'true';
+		}
+
+		if ( 'false' === $value || false === $value ) {
+			$query_args[ $name ] = 'false';
+		}
 	}
+
+	// Build final embed URL.
+	$url = add_query_arg(
+		$query_args,
+		'https://w.soundcloud.com/player/'
+	);
+
+	return sprintf(
+		'<iframe width="%1$s" height="%2$d" scrolling="no" frameborder="no" src="%3$s"></iframe>',
+		esc_attr( $width ),
+		esc_attr( $height ),
+		$url
+	);
 }
+add_shortcode( 'soundcloud', 'soundcloud_shortcode' );
 
 /**
  * Plugin options getter
  *
- * @param  string|array $option  Option name
- * @param  mixed        $default Default value
+ * @param  string|array $option  Option name.
+ * @param  mixed        $default Default value.
  *
  * @return mixed                   Option value
  */
 function soundcloud_get_option( $option, $default = false ) {
 	$value = get_option( 'soundcloud_' . $option );
 
-	return $value === '' ? $default : $value;
-}
-
-/**
- * Booleanize a value
- *
- * @param  boolean|string $value
- *
- * @return boolean
- */
-function soundcloud_booleanize( $value ) {
-	return is_bool( $value ) ? $value : $value === 'true' ? true : false;
+	return '' === $value ? $default : $value;
 }
 
 /**
  * Decide if a url has a tracklist
  *
- * @param  string $url
+ * @param string $url Soundcloud URL.
  *
  * @return boolean
  */
 function soundcloud_url_has_tracklist( $url ) {
 	return preg_match( '/^(.+?)\/(sets|groups|playlists)\/(.+?)$/', $url );
-}
-
-/**
- * Parameterize url
- *
- * @param  array $match Matched regex
- *
- * @return string          Parameterized url
- */
-function soundcloud_oembed_params_callback( $match ) {
-	global $soundcloud_oembed_params;
-
-	// Convert URL to array
-	$url = parse_url( urldecode( $match[1] ) );
-	// Convert URL query to array
-	parse_str( $url['query'], $query_array );
-	// Build new query string
-	$query = http_build_query( array_merge( $query_array, $soundcloud_oembed_params ) );
-
-	return 'src="' . $url['scheme'] . '://' . $url['host'] . $url['path'] . '?' . $query;
-}
-
-/**
- * Iframe widget embed code
- *
- * @param  array $options Parameters
- *
- * @return string            Iframe embed code
- */
-function soundcloud_iframe_widget( $options ) {
-
-	// Build URL
-	$url = set_url_scheme( 'https://w.soundcloud.com/player/?' . http_build_query( $options['params'] ) );
-	// Set default width if not defined
-	$width = isset( $options['width'] ) && $options['width'] !== 0 ? $options['width'] : '100%';
-	// Set default height if not defined
-	$height = isset( $options['height'] ) && $options['height'] !== 0
-		? $options['height']
-		: ( soundcloud_url_has_tracklist( $options['url'] ) || ( isset( $options['params']['visual'] ) && soundcloud_booleanize( $options['params']['visual'] ) ) ? '450' : '166' );
-
-	return sprintf( '<iframe width="%s" height="%s" scrolling="no" frameborder="no" src="%s"></iframe>', $width, $height, $url );
-}
-
-/**
- * Legacy Flash widget embed code
- *
- * @param array $options Parameters
- *
- * @return string            Flash embed code
- */
-function soundcloud_flash_widget( $options ) {
-	// Build URL
-	$url = set_url_scheme( 'https://player.soundcloud.com/player.swf?' . http_build_query( $options['params'] ) );
-	// Set default width if not defined
-	$width = isset( $options['width'] ) && $options['width'] !== 0 ? $options['width'] : '100%';
-	// Set default height if not defined
-	$height = isset( $options['height'] ) && $options['height'] !== 0 ? $options['height'] : ( soundcloud_url_has_tracklist( $options['url'] ) ? '255' : '81' );
-
-	return preg_replace(
-		'/\s\s+/',
-		'',
-		sprintf(
-			'<object width="%s" height="%s">
-				<param name="movie" value="%s" />
-				<param name="allowscriptaccess" value="always" />
-				<embed width="%s" height="%s" src="%s" allowscriptaccess="always" type="application/x-shockwave-flash"></embed>
-			</object>',
-			$width,
-			$height,
-			$url,
-			$width,
-			$height,
-			$url
-		)
-	);
 }
 
 /**
@@ -268,12 +179,6 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 		return $content;
 	}
 
-	/*
-	 Sample embed code:
-
-		<iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/150745932&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>
-	*/
-
 	$regexes = array();
 
 	$regexes[] = '#<iframe[^>]+?src="((?:https?:)?//w\.soundcloud\.com/player/[^"\']++)"[^>]*+>\s*?</iframe>#i';
@@ -286,10 +191,10 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 
 		foreach ( $matches as $match ) {
 
-			// if pasted from the visual editor - prevent double encoding
+			// if pasted from the visual editor - prevent double encoding.
 			$match[1] = str_replace( '&amp;amp;', '&amp;', $match[1] );
 
-			$args = parse_url( html_entity_decode( $match[1] ), PHP_URL_QUERY );
+			$args = wp_parse_url( html_entity_decode( $match[1] ), PHP_URL_QUERY );
 			$args = wp_parse_args( $args );
 
 			if ( ! preg_match( '#^(?:https?:)?//api\.soundcloud\.com/.+$#i', $args['url'], $url_matches ) ) {
@@ -316,6 +221,7 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 
 			$replace_regex = sprintf( '#\s*%s\s*#', preg_quote( $match[0], '#' ) );
 			$content       = preg_replace( $replace_regex, sprintf( "\n\n%s\n\n", $shortcode ), $content );
+
 			/** This action is documented in modules/shortcodes/youtube.php */
 			do_action( 'jetpack_embed_to_shortcode', 'soundcloud', $url_matches[0] );
 		}
@@ -323,5 +229,4 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 
 	return $content;
 }
-
 add_filter( 'pre_kses', 'jetpack_soundcloud_embed_reversal' );

--- a/tests/php/modules/shortcodes/test-class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test-class.soundcloud.php
@@ -80,6 +80,20 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests albums with a custom color.
+	 *
+	 * @since 7.4.0
+	 */
+	public function tests_shortcodes_soundcloud_album_custom_color() {
+		$content = '[soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private" color="00cc11"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
+		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&show_user=false&show_reposts=false&color=00cc11', $shortcode_content );
+	}
+
+	/**
 	 * Shortcode reversals.
 	 */
 	public function test_shortcodes_soundcloud_reversal_player() {

--- a/tests/php/modules/shortcodes/test-class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test-class.soundcloud.php
@@ -30,7 +30,7 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&visual=true&auto_play=false&hide_related=false', $shortcode_content );
+		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&auto_play=false&hide_related=false&visual=true', $shortcode_content );
 	}
 
 	public function test_shortcodes_implicit_non_visual() {
@@ -49,6 +49,34 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
 		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&auto_play=false&hide_related=false', $shortcode_content );
+	}
+
+	/**
+	 * Test single tracks with no height specified.
+	 *
+	 * @since 7.4.0
+	 */
+	public function tests_shortcodes_soundcloud_single_track_no_height() {
+		$content = '[soundcloud url="https://soundcloud.com/closetorgan/paul-is-dead"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="100%" height="166"', $shortcode_content );
+		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fpaul-is-dead&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false', $shortcode_content );
+	}
+
+	/**
+	 * Tests albums with no height specified.
+	 *
+	 * @since 7.4.0
+	 */
+	public function tests_shortcodes_soundcloud_album_no_height() {
+		$content = '[soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
+		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false', $shortcode_content );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12265

#### Changes proposed in this Pull Request:

The shortcode was previously built off the old Soundcloud plugin. This simplifies some of the code, and brings it more in line with our other shortcodes.
Functionality should not change.

This also adds new tests to cover albums and tracks, and how their height should change.

#### Testing instructions:

* Try to insert any of the following embeds:
```
 * [soundcloud]http://soundcloud.com/forss/flickermood[/soundcloud]
 * [soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=false" width="100%" height="450" iframe="true" /]
 * [soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=true" width="100%" height="450" iframe="true" /]
 * [soundcloud url="https://soundcloud.com/closetorgan/paul-is-dead" width=400 height=400]
 * [soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private"]
 * <iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/150745932&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>
```

#### Proposed changelog entry for your changes:

* None
