### PR TITLE
Shortcodes: fix all phpcs warnings for TED videos.

### DIFF
--- a/modules/shortcodes/ted.php
+++ b/modules/shortcodes/ted.php
@@ -1,23 +1,36 @@
 <?php
-/*
+/**
  * TED Player embed code
  * http://www.ted.com
  *
+ * Examples:
  * http://www.ted.com/talks/view/id/210
  * http://www.ted.com/talks/marc_goodman_a_vision_of_crimes_in_the_future.html
  * [ted id="210" lang="en"]
  * [ted id="http://www.ted.com/talks/view/id/210" lang="en"]
  * [ted id=1539 lang=fr width=560 height=315]
+ *
+ * @package Jetpack
  */
 
 wp_oembed_add_provider( '!https?://(www\.)?ted.com/talks/view/id/.+!i', 'http://www.ted.com/talks/oembed.json', true );
 wp_oembed_add_provider( '!https?://(www\.)?ted.com/talks/[a-zA-Z\-\_]+\.html!i', 'http://www.ted.com/talks/oembed.json', true );
 
+/**
+ * Get the unique ID of a TED video.
+ * Used in Jetpack_Media_Meta_Extractor.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function jetpack_shortcode_get_ted_id( $atts ) {
 	return ( ! empty( $atts['id'] ) ? $atts['id'] : 0 );
 }
 
-add_shortcode( 'ted', 'shortcode_ted' );
+/**
+ * Handle Ted Shortcode.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function shortcode_ted( $atts ) {
 	global $wp_embed;
 
@@ -42,10 +55,12 @@ function shortcode_ted( $atts ) {
 
 	unset( $atts['id'] );
 
-	$args = array();
+	$args         = array();
+	$embed_size_w = get_option( 'embed_size_w' );
+
 	if ( is_numeric( $atts['width'] ) ) {
 		$args['width'] = $atts['width'];
-	} elseif ( $embed_size_w = get_option( 'embed_size_w' ) ) {
+	} elseif ( $embed_size_w ) {
 		$args['width'] = $embed_size_w;
 	} elseif ( ! empty( $GLOBALS['content_width'] ) ) {
 		$args['width'] = (int) $GLOBALS['content_width'];
@@ -53,7 +68,7 @@ function shortcode_ted( $atts ) {
 		$args['width'] = 500;
 	}
 
-	// Default to a 16x9 aspect ratio if there's no height set
+	// Default to a 16x9 aspect ratio if there's no height set.
 	if ( is_numeric( $atts['height'] ) ) {
 		$args['height'] = $atts['height'];
 	} else {
@@ -69,9 +84,14 @@ function shortcode_ted( $atts ) {
 
 	return $retval;
 }
+add_shortcode( 'ted', 'shortcode_ted' );
 
 /**
  * Filter the request URL to also include the $lang parameter
+ *
+ * @param string $provider URL of provider that supplies the tweet we're requesting.
+ * @param string $url      URL of tweet to embed.
+ * @param array  $args     Parameters supplied to shortcode and passed to wp_oembed_get.
  */
 function ted_filter_oembed_fetch_url( $provider, $url, $args ) {
 	return add_query_arg( 'lang', $args['lang'], $provider );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* fix all phpcs warnings for TED videos.

#### Testing instructions:

* Try adding any of the following embeds to a post:
```
 * http://www.ted.com/talks/view/id/210
 * http://www.ted.com/talks/marc_goodman_a_vision_of_crimes_in_the_future.html
 * [ted id="210" lang="en"]
 * [ted id="http://www.ted.com/talks/view/id/210" lang="en"]
 * [ted id=1539 lang=fr width=560 height=315]
```

#### Proposed changelog entry for your changes:

* None
