### PR TITLE
Twitch.tv: fix all phpcs warnings and allow the use of HTTPS.

### DIFF
--- a/modules/shortcodes/twitchtv.php
+++ b/modules/shortcodes/twitchtv.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * twitch.tv shortcode
- * [twitchtv url='http://www.twitch.tv/paperbat' height='378' width='620' autoplay='false']
- * [twitchtv url='http://www.twitch.tv/paperbat/b/323486192' height='378' width='620' autoplay='false']
- **/
+ * Twitch.tv shortcode
+ *
+ * Examples:
+ * [twitchtv url='https://www.twitch.tv/paperbat' height='378' width='620' autoplay='false']
+ * [twitchtv url='https://www.twitch.tv/paperbat/b/323486192' height='378' width='620' autoplay='false']
+ *
+ * @package Jetpack
+ */
 
 /**
- * (Live URL) http://www.twitch.tv/paperbat
+ * (Live URL) https://www.twitch.tv/paperbat
  *
  * <iframe src="https://player.twitch.tv/?autoplay=false&#038;muted=false&#038;channel=paperbat" width="620" height="378" frameborder="0" scrolling="no" allowfullscreen></iframe>
  *
- * (Archive URL) http://www.twitch.tv/paperbat/v/323486192
+ * (Archive URL) https://www.twitch.tv/paperbat/v/323486192
  *
  * <iframe src="https://player.twitch.tv/?autoplay=false&#038;muted=false&#038;video=v323486192" width="620" height="378" frameborder="0" scrolling="no" allowfullscreen></iframe>
  *
- * @param $atts array User supplied shortcode arguments.
+ * @param array $atts User supplied shortcode arguments.
  *
  * @return string HTML output of the shortcode.
  */
@@ -35,7 +39,7 @@ function wpcom_twitchtv_shortcode( $atts ) {
 		return '<!-- Invalid twitchtv URL -->';
 	}
 
-	preg_match( '|^http://www.twitch.tv/([^/?]+)(/v/(\d+))?|i', $attr['url'], $match );
+	preg_match( '|^https?://www.twitch.tv/([^/?]+)(/v/(\d+))?|i', $attr['url'], $match );
 
 	$url_args = array(
 		'autoplay' => ( false !== $attr['autoplay'] && 'false' !== $attr['autoplay'] ) ? 'true' : 'false',
@@ -69,6 +73,5 @@ function wpcom_twitchtv_shortcode( $atts ) {
 		esc_attr( $height )
 	);
 }
-
 add_shortcode( 'twitch', 'wpcom_twitchtv_shortcode' );
 add_shortcode( 'twitchtv', 'wpcom_twitchtv_shortcode' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Merges r157561-wpcom and makes a few more changes.

#### Testing instructions:

* Try inserting shortcodes like so:
```
 * [twitchtv url='https://www.twitch.tv/paperbat' height='378' width='620' autoplay='false']
 * [twitchtv url='https://www.twitch.tv/paperbat/b/323486192' height='378' width='620' autoplay='false']
```

#### Proposed changelog entry for your changes:

* None
