### PR TITLE
Tests: Speed up lint test by 2x with `find -prune`

### DIFF
--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -1,25 +1,32 @@
 <?php
 
 class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
-
 	/**
 	 * Props to cfinke for the amazing piece of code.
 	 * @author zinigor
 	 * @since 4.8.1
+	 * @group lint
 	 */
 	public function test_php_lint() {
-		$command =
-			'for file in `find . -name "*.php"`; '
-			. 'do php -l "$file" | '
-			. 'grep -v "No syntax errors detected" | '
-			. 'grep -v "./tools/" | '
-			. 'grep -v "./tests/" | '
-			. 'grep -v "./vendor/" | '
-			. 'grep -v "jetpack-cli.php" | '
-			. 'grep -v "./_inc/class.jetpack-provision.php" | '
-			. 'grep -v "./_inc/lib/debugger/debug-functions-for-php53.php" | '
-			. 'grep -v -e \'^$\'; '
-			. 'done';
+		$exclude_paths = array(
+			'./docker',
+			'./tools',
+			'./tests',
+			'./vendor',
+			'./jetpack-cli.php',
+			'./_inc/class.jetpack-provision.php',
+			'./_inc/lib/debugger/debug-functions-for-php53.php',
+		);
+
+		// use -prune to prevent traversal of that path.
+		// use -print0 and read -d '' to support filenames containing funny characters.
+		$find = 'find . -path ' . join( ' -prune -o -path ', array_map( 'escapeshellarg', $exclude_paths ) ) . " -prune -o -name '*.php' -print0";
+		// only output lint results for a file if the lint fails.
+		$lint_all = $find . ' | while IFS= read -r -d "" file; do OUTPUT=$( php -l "$file" ); if [ 0 -ne $? ]; then echo "$OUTPUT"; fi; done';
+		$lint_all_in_jetpack = sprintf( 'cd %s; %s', escapeshellarg( dirname( dirname( __DIR__ ) ) ), $lint_all );
+
+		// read -d is a bashism
+		$command = sprintf( 'bash -c %s', escapeshellarg( $lint_all_in_jetpack ) );
 
 		exec( $command, $output );
 

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -23,7 +23,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 		$find = 'find . -path ' . join( ' -prune -o -path ', array_map( 'escapeshellarg', $exclude_paths ) ) . " -prune -o -name '*.php' -print0";
 		// only output lint results for a file if the lint fails.
 		$lint_all = $find . ' | while IFS= read -r -d "" file; do OUTPUT=$( php -l "$file" ); if [ 0 -ne $? ]; then echo "$OUTPUT"; fi; done';
-		$lint_all_in_jetpack = sprintf( 'cd %s; %s', escapeshellarg( dirname( dirname( __DIR__ ) ) ), $lint_all );
+		$lint_all_in_jetpack = sprintf( 'cd %s; %s', escapeshellarg( dirname( dirname( dirname( __FILE__ ) ) ) ), $lint_all );
 
 		// read -d is a bashism
 		$command = sprintf( 'bash -c %s', escapeshellarg( $lint_all_in_jetpack ) );

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 			'./tools',
 			'./tests',
 			'./vendor',
-			'./jetpack-cli.php',
+			'./class.jetpack-cli.php',
 			'./_inc/class.jetpack-provision.php',
 			'./_inc/lib/debugger/debug-functions-for-php53.php',
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Use `find -prune` to reduce the list of files we lint.
  Currently, we lint every file, then exclude some files via grep.
  With this patch, we lint only the files we want.
* Also adds `@group lint` to the test so that it can be more easily excluded with `--exclude-group=lint`.

#### Testing instructions:
1. `git checkout master`
2. Time the lint test, e.g.: `time yarn docker:phpunit --filter=WP_Test_Jetpack_PHP_Lint`
3. `git checkout update/lint-test-speed`
4. Time the lint test, e.g.: `time yarn docker:phpunit --filter=WP_Test_Jetpack_PHP_Lint`
5. See ~2x speed improvement.
6. Add some fatal syntax errors to some PHP files.
7. Run the lint test again and see it picks up the errors.

#### Proposed changelog entry for your changes:
None required.