### PR TITLE
Update URLs to match new URLs in calypso

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -416,7 +416,7 @@ class MyPlanBody extends React.Component {
 										{ this.props.isModuleActivated( 'seo-tools' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'configure_seo' ) }
-												href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
+												href={ 'https://wordpress.com/marketing/traffic/' + this.props.siteRawUrl }
 											>
 												{ __( 'Configure site SEO' ) }
 											</Button>
@@ -455,7 +455,7 @@ class MyPlanBody extends React.Component {
 										{ this.props.isModuleActivated( 'google-analytics' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'configure_ga' ) }
-												href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl }
+												href={ 'https://wordpress.com/marketing/traffic/' + this.props.siteRawUrl }
 											>
 												{ __( 'Configure Google Analytics' ) }
 											</Button>
@@ -641,7 +641,7 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
-									href={ 'https://wordpress.com/sharing/' + this.props.siteRawUrl }
+									href={ 'https://wordpress.com/marketing/connections/' + this.props.siteRawUrl }
 								>
 									{ __( 'Start publicizing now' ) }
 								</Button>

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -43,7 +43,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						onClick={ this.trackClickConfigure }
 						target="_blank"
 						rel="noopener noreferrer"
-						href={ 'https://wordpress.com/sharing/' + siteRawUrl }
+						href={ 'https://wordpress.com/marketing/connections/' + siteRawUrl }
 					>
 						{ __( 'Connect your social media accounts' ) }
 					</Card>

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -52,7 +52,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							onClick={ this.trackClickConfigure }
 							target="_blank"
 							rel="noopener noreferrer"
-							href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }
+							href={ 'https://wordpress.com/marketing/sharing-buttons/' + siteRawUrl }
 						>
 							{ __( 'Configure your sharing buttons' ) }
 						</Card>

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -100,7 +100,7 @@ export class Traffic extends React.Component {
 					<SEO
 						{ ...commonProps }
 						configureUrl={
-							'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl + '#seo'
+							'https://wordpress.com/marketing/traffic/' + this.props.siteRawUrl + '#seo'
 						}
 					/>
 				) }
@@ -108,7 +108,7 @@ export class Traffic extends React.Component {
 					<GoogleAnalytics
 						{ ...commonProps }
 						configureUrl={
-							'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl + '#analytics'
+							'https://wordpress.com/marketing/traffic/' + this.props.siteRawUrl + '#analytics'
 						}
 					/>
 				) }

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -67,7 +67,7 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 				403
 			);
 		}
-		$connect_url = sprintf( 'https://wordpress.com/sharing/%s', rawurlencode( $site_id ) );
+		$connect_url = sprintf( 'https://wordpress.com/marketing/connections/%s', rawurlencode( $site_id ) );
 		return array(
 			'code'        => $this->is_connected() ? 'connected' : 'not_connected',
 			'connect_url' => $connect_url,

--- a/extensions/blocks/publicize/connection.js
+++ b/extensions/blocks/publicize/connection.js
@@ -37,7 +37,7 @@ class PublicizeConnection extends Component {
 						'jetpack'
 					) }
 				</p>
-				<ExternalLink href={ `https://wordpress.com/sharing/${ getSiteFragment() }` }>
+				<ExternalLink href={ `https://wordpress.com/marketing/connections/${ getSiteFragment() }` }>
 					{ __( 'Go to Sharing settings', 'jetpack' ) }
 				</ExternalLink>
 			</Notice>

--- a/extensions/blocks/publicize/settings-button.js
+++ b/extensions/blocks/publicize/settings-button.js
@@ -25,7 +25,7 @@ class PublicizeSettingsButton extends Component {
 
 		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
 		if ( siteFragment ) {
-			return `https://wordpress.com/sharing/${ siteFragment }`;
+			return `https://wordpress.com/marketing/connections/${ siteFragment }`;
 		}
 
 		// If running in WordPress.org wp-admin we redirect to Sharing settings in wp-admin.

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -446,13 +446,13 @@ class Jetpack_Plugin_Search {
 		switch ( $feature ) {
 			case 'sharing':
 			case 'publicize':
-				$configure_url = "https://wordpress.com/sharing/$siteFragment";
+				$configure_url = "https://wordpress.com/marketing/connections/$siteFragment";
 				break;
 			case 'seo-tools':
-				$configure_url = "https://wordpress.com/settings/traffic/$siteFragment#seo";
+				$configure_url = "https://wordpress.com/marketing/traffic/$siteFragment#seo";
 				break;
 			case 'google-analytics':
-				$configure_url = "https://wordpress.com/settings/traffic/$siteFragment#analytics";
+				$configure_url = "https://wordpress.com/marketing/traffic/$siteFragment#analytics";
 				break;
 			case 'wordads':
 				$configure_url = "https://wordpress.com/ads/settings/$siteFragment";

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -1234,7 +1234,7 @@ abstract class Publicize_Base {
 }
 
 function publicize_calypso_url() {
-	$calypso_sharing_url = 'https://wordpress.com/sharing/';
+	$calypso_sharing_url = 'https://wordpress.com/marketing/connections/';
 	if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'build_raw_urls' ) ) {
 		$site_suffix = Jetpack::build_raw_urls( home_url() );
 	} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -40,5 +40,5 @@ function jetpack_sharedaddy_configuration_url() {
 	}
 
 	$site_suffix = Jetpack::build_raw_urls( get_home_url() );
-	return 'https://wordpress.com/sharing/buttons/' . $site_suffix;
+	return 'https://wordpress.com/marketing/sharing-buttons/' . $site_suffix;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates URL's

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to: `/wp-admin/admin.php?page=jetpack#/my-plan`
* Click `Configure site SEO`, `Configure Google Analytics`, and `Start publicizing now`.
* Do they goto the expected pages?

* Go to: `/wp-admin/admin.php?page=jetpack#/sharing`
* Click `Connect your social media accounts` and `Configure your sharing buttons`
* Do they goto the expected pages?

* Go to: `/wp-admin/admin.php?page=jetpack#/traffic`
* Click `Configure your SEO settings` and `Configure your Google Analytics settings`
* Do they goto the expected pages?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Updated URL's to reflect URL changes in Calypso
