### PR TITLE
Fix visual bug with Jetpack Connect panel

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -62,7 +62,7 @@
 			right: 0;
 			bottom: rem( 20px );
 			left: 0;
-		z-index: 1001; // to sit over other elements
+		z-index: 9999; // to sit over other elements
 		background: rgb( 241, 241, 241 );
 		text-align: center;
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -62,7 +62,7 @@
 			right: 0;
 			bottom: rem( 20px );
 			left: 0;
-		z-index: 999; // to sit over other elements
+		z-index: 1001; // to sit over other elements
 		background: rgb( 241, 241, 241 );
 		text-align: center;
 


### PR DESCRIPTION
When Akismet is active (but not configured), and you install and activate the Jetpack plugin, the Dashboard shows a Jetpack Connect panel. However, the Jetpack Connect panel has a `z-index` of `999`, while the Akismet panel text has a `z-index` of `1000`, so the text appears on top of the panel. See screenshot:

![Screenshot_2019-05-01 Plugins ‹ Inadequate Jacket — WordPress](https://user-images.githubusercontent.com/4297811/57044577-b394fc80-6c06-11e9-8459-2ce06ab51064.png)

#### Changes proposed in this Pull Request:

* Bumping the `z-index` to `1001` to fix the visual bug

#### Testing instructions:
* Setup a new Jurassic Ninja site _without Jetpack_ pre-installed.
* Activate Akismet, but don't configure anything.
* Install Jetpack, and activate the plugin. 
* Navigate to the WP-Admin Dashboard to see the Jetpack Connect panel

#### Proposed changelog entry for your changes:
* Minor visual bug fix to the Jetpack Connect panel
