### PR TITLE
PHP linting: show sniff codes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
 		"phpcompatibility/phpcompatibility-wp": "2.0.0"
 	},
 	"scripts": {
-		"php:compatibility": "composer install && vendor/bin/phpcs -p --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
-		"php:lint": "composer install && vendor/bin/phpcs -p",
+		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.2-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
+		"php:lint": "composer install && vendor/bin/phpcs -p -s",
 		"php:autofix": "composer install && vendor/bin/phpcbf",
-		"php:lint:errors": "composer install && vendor/bin/phpcs -p --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
 	}
 }


### PR DESCRIPTION
Add `-s` to `phpcs` commands to show exact failed sniff codes in reports, e.g. `HPCompatibility.FunctionUse.NewFunctionParameters.getenv_local_onlyFound`

It looks like I see these sniff codes already by running `yarn php:lint filename` but I didn't see them in pre-commit hooks and this fixes that.

#### Before

```
FILE: ...cuments/Work/Automattic/jetpack/_inc/class.jetpack-provision.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
  27 | ERROR | Closures / anonymous functions are not available in
     |       | PHP 5.2 or earlier
 282 | ERROR | The function getenv() does not have a parameter
     |       | "local_only" in PHP version 5.5.37 or earlier
----------------------------------------------------------------------
```

#### After

```
FILE: ...cuments/Work/Automattic/jetpack/_inc/class.jetpack-provision.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
  27 | ERROR | Closures / anonymous functions are not available in
     |       | PHP 5.2 or earlier
     |       | (PHPCompatibility.FunctionDeclarations.NewClosure.Found)
 282 | ERROR | The function getenv() does not have a parameter
     |       | "local_only" in PHP version 5.5.37 or earlier
     |       | (PHPCompatibility.FunctionUse.NewFunctionParameters.getenv_local_onlyFound)
----------------------------------------------------------------------
```


### Testing

Modify `_inc/class.jetpack-provision.php`

Run pre-commit hooks by running `git commit -am "testing linter"`
