### PR TITLE
Add Calypso env getter

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -24,7 +24,7 @@ class Jetpack_Provision { //phpcs:ignore
 			// WP_SITEURL constants if the constant hasn't already been defined.
 			if ( isset( $named_args[ $url_arg ] ) ) {
 				if ( version_compare( phpversion(), '5.3.0', '>=' ) ) {
-					add_filter( $url_arg, function() use ( $url_arg, $named_args ) { // phpcs:ignore PHPCompatibility.PHP.NewClosure.Found
+					add_filter( $url_arg, function() use ( $url_arg, $named_args ) { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.Found
 						return $named_args[ $url_arg ];
 					}, 11 );
 				} elseif ( ! defined( $constant_name ) ) {
@@ -186,8 +186,9 @@ class Jetpack_Provision { //phpcs:ignore
 		}
 
 		// Add calypso env if set.
-		if ( getenv( 'CALYPSO_ENV' ) ) {
-			$url = add_query_arg( array( 'calypso_env' => getenv( 'CALYPSO_ENV' ) ), $url );
+		$calypso_env = Jetpack::get_calypso_env();
+		if ( ! empty( $calypso_env ) ) {
+			$url = add_query_arg( array( 'calypso_env' => $calypso_env ), $url );
 		}
 
 		$result = Jetpack_Client::_wp_remote_request( $url, $request );
@@ -278,7 +279,7 @@ class Jetpack_Provision { //phpcs:ignore
 	}
 
 	private static function get_api_host() {
-		$env_api_host = getenv( 'JETPACK_START_API_HOST', true );
+		$env_api_host = getenv( 'JETPACK_START_API_HOST', true ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.getenv_local_onlyFound
 		return $env_api_host ? $env_api_host : JETPACK__WPCOM_JSON_API_HOST;
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6999,6 +6999,10 @@ p {
 			return sanitize_key( $_GET['calypso_env'] );
 		}
 
+		if ( getenv( 'CALYPSO_ENV' ) ) {
+			return sanitize_key( getenv( 'CALYPSO_ENV' ) );
+		}
+
 		if ( defined( 'CALYPSO_ENV' ) && CALYPSO_ENV ) {
 			return sanitize_key( CALYPSO_ENV );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -552,7 +552,7 @@ class Jetpack {
 
 		$calypso_env = $this->get_calypso_env();
 
-		if ( ! empty( $calypso_env ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
+		if ( ! empty( $calypso_env ) && defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
 
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -550,7 +550,9 @@ class Jetpack {
 			add_filter( 'xmlrpc_methods', array( $this, 'remove_non_jetpack_xmlrpc_methods' ), 1000 );
 		}
 
-		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
+		$calypso_env = $this->get_calypso_env();
+
+		if ( ! empty( $calypso_env ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
 
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
@@ -4096,8 +4098,8 @@ p {
 						$url = add_query_arg( 'onboarding', $token, $url );
 					}
 
-					$calypso_env = ! empty( $_GET[ 'calypso_env' ] ) ? $_GET[ 'calypso_env' ] : false;
-					if ( $calypso_env ) {
+					$calypso_env = $this->get_calypso_env();
+					if ( ! empty( $calypso_env ) ) {
 						$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 					}
 
@@ -4529,8 +4531,10 @@ p {
 		// Get affiliate code and add it to the URL
 		$url = Jetpack_Affiliate::init()->add_code_as_query_arg( $url );
 
-		if ( isset( $_GET['calypso_env'] ) ) {
-			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );
+		$calypso_env = $this->get_calypso_env();
+
+		if ( ! empty( $calypso_env ) ) {
+			$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 		}
 
 		return $raw ? $url : esc_url( $url );
@@ -6980,6 +6984,26 @@ p {
 			set_transient( 'jetpack_rewind_enabled', $rewind_enabled, 10 * MINUTE_IN_SECONDS );
 		}
 		return $rewind_enabled;
+	}
+
+	/**
+	 * Return Calypso environment value; used for developing Jetpack and pairing
+	 * it with different Calypso enrionments, such as localhost.
+	 *
+	 * @since 7.4.0
+	 *
+	 * @return string Calypso environment
+	 */
+	public static function get_calypso_env() {
+		if ( ! empty( $_GET['calypso_env'] ) ) {
+			return sanitize_key( $_GET['calypso_env'] );
+		}
+
+		if ( defined( 'CALYPSO_ENV' ) && CALYPSO_ENV ) {
+			return sanitize_key( CALYPSO_ENV );
+		}
+
+		return '';
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6995,7 +6995,7 @@ p {
 	 * @return string Calypso environment
 	 */
 	public static function get_calypso_env() {
-		if ( ! empty( $_GET['calypso_env'] ) ) {
+		if ( isset( $_GET['calypso_env'] ) ) {
 			return sanitize_key( $_GET['calypso_env'] );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -550,9 +550,7 @@ class Jetpack {
 			add_filter( 'xmlrpc_methods', array( $this, 'remove_non_jetpack_xmlrpc_methods' ), 1000 );
 		}
 
-		$calypso_env = $this->get_calypso_env();
-
-		if ( ! empty( $calypso_env ) && defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
+		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
 
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -795,16 +795,12 @@ class Jetpack_SSO {
 				Jetpack::init()->store_json_api_authorization_token( $user->user_login, $user );
 
 			} else if ( ! $is_user_connected ) {
-				$calypso_env = ! empty( $_GET['calypso_env'] )
-					? sanitize_key( $_GET['calypso_env'] )
-					: '';
-
 				wp_safe_redirect(
 					add_query_arg(
 						array(
 							'redirect_to'               => $redirect_to,
 							'request_redirect_to'       => $_request_redirect_to,
-							'calypso_env'               => $calypso_env,
+							'calypso_env'               => Jetpack::get_calypso_env(),
 							'jetpack-sso-auth-redirect' => '1',
 						),
 						admin_url()


### PR DESCRIPTION
Adds a centralized getter method for Calypso environment.

Allows setting Calypso env via environment variable in addition to URL arg.

Handy for repeated testing of onboarding flows and later for setting this conveniently via environment variable in Jurassic Ninja setup.

#### Testing instructions:
- Add `define( 'CALYPSO_ENV', 'development' );` to your `wp-config.php` or `mu-plugins` file.
- Have disconnected Jetpack and open the dash
- "Set up Jetpack" button URL now has `&calypso_env=development` and it should bring you to `calypso.localhost:3000`
- Override environment variable via URL argument by adding `&calypso_env=wpcalypso` to URL, like so: `/wp-admin/admin.php?calypso_env=wpcalypso&page=jetpack#/`
- Confirm that "Set up Jetpack" now brings you to `wpcalypso.wordpress.com`

- I'm not quite sure how to test `_inc/class.jetpack-provision.php` 🤔 — happy to leave it out from this PR as well. 

#### Proposed changelog entry for your changes:

* —
