### PR TITLE
Travis CI: run "external http" test group in cron builds

### DIFF
--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -6,7 +6,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-		export WP_TRAVISCI = "phpunit --group external-html"
+		export WP_TRAVISCI = "phpunit --group external-http"
 	fi
 
 	echo "Running phpunit with:"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -4,6 +4,11 @@ echo "Travis CI command: $WP_TRAVISCI"
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
+	# Run a external-html group tests
+	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+		export WP_TRAVISCI = "phpunit --group external-html"
+	fi
+
 	echo "Running phpunit with:"
 	echo " - $(phpunit --version)"
 	echo " - WordPress mode: $WP_MODE"


### PR DESCRIPTION
Adds a way to run an "external http" tests in CI for cron builds:
https://docs.travis-ci.com/user/cron-jobs/

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* run `external-http` tests for cron builds

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* wait for it

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* not needed
