### PR TITLE
Travis CI: Fix spaces syntax in run-travis.sh

### DIFF
--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -6,7 +6,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-		export WP_TRAVISCI = "phpunit --group external-http"
+		export WP_TRAVISCI="phpunit --group external-http"
 	fi
 
 	echo "Running phpunit with:"


### PR DESCRIPTION
Follow up to #12242, where I introduced syntax error in a variable assignment. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fix syntax error

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* run `WP_TRAVISCI=phpunit TRAVIS_EVENT_TYPE=cron ./tests/run-travis.sh`
* make sure script is not erroring before line 13

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* nope
