### PR TITLE
Memberships: disclaimer about fees

### DIFF
--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -19,7 +19,7 @@ import {
 	withNotices,
 	SelectControl,
 } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls, BlockIcon } from '@wordpress/editor';
 import { Fragment, Component } from '@wordpress/element';
 
 /**
@@ -317,12 +317,16 @@ class MembershipsButtonEdit extends Component {
 				{ ( connected === API_STATE_LOADING ||
 					this.state.addingMembershipAmount === PRODUCT_FORM_SUBMITTED ) &&
 					! this.props.attributes.planId && (
-						<Placeholder icon={ icon } notices={ notices }>
+						<Placeholder icon={ <BlockIcon icon={ icon } /> } notices={ notices }>
 							<Spinner />
 						</Placeholder>
 					) }
 				{ ! this.props.attributes.planId && connected === API_STATE_NOTCONNECTED && (
-					<Placeholder icon={ icon } label={ __( 'Memberships', 'jetpack' ) } notices={ notices }>
+					<Placeholder
+						icon={ <BlockIcon icon={ icon } /> }
+						label={ __( 'Memberships', 'jetpack' ) }
+						notices={ notices }
+					>
 						<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
 							{ __(
 								'In order to start selling Membership plans, you have to connect to Stripe:',
@@ -331,7 +335,7 @@ class MembershipsButtonEdit extends Component {
 							<br />
 							<br />
 							<Button isDefault isLarge href={ connectURL } target="_blank">
-								{ __( 'Connect to Stripe or set up account', 'jetpack' ) }
+								{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }
 							</Button>
 							<br />
 							<br />
@@ -345,7 +349,11 @@ class MembershipsButtonEdit extends Component {
 				{ ! this.props.attributes.planId &&
 					connected === API_STATE_CONNECTED &&
 					products.length === 0 && (
-						<Placeholder icon={ icon } label={ __( 'Memberships', 'jetpack' ) } notices={ notices }>
+						<Placeholder
+							icon={ <BlockIcon icon={ icon } /> }
+							label={ __( 'Memberships', 'jetpack' ) }
+							notices={ notices }
+						>
 							<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
 								{ __( 'Add your first Membership amount:', 'jetpack' ) }
 								<br />
@@ -359,7 +367,11 @@ class MembershipsButtonEdit extends Component {
 					this.state.addingMembershipAmount !== PRODUCT_FORM_SUBMITTED &&
 					connected === API_STATE_CONNECTED &&
 					products.length > 0 && (
-						<Placeholder icon={ icon } label={ __( 'Memberships', 'jetpack' ) } notices={ notices }>
+						<Placeholder
+							icon={ <BlockIcon icon={ icon } /> }
+							label={ __( 'Memberships', 'jetpack' ) }
+							notices={ notices }
+						>
 							<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
 								{ __( 'Select payment amount:', 'jetpack' ) }
 								{ this.renderMembershipAmounts() }

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -267,6 +267,31 @@ class MembershipsButtonEdit extends Component {
 		</div>
 	);
 
+	renderDisclaimer = () => {
+		return (
+			<div className="membership-button__disclaimer">
+				{ __( 'Read more about ', 'jetpack' ) }
+				<a
+					rel="noopener noreferer"
+					// eslint-disable-next-line react/jsx-no-target-blank
+					target="_blank"
+					href="https://en.support.wordpress.com/memberships/"
+				>
+					{ __( 'memberships', 'jetpack' ) }
+				</a>
+				{ __( ' and ', 'jetpack' ) }
+				<a
+					rel="noopener noreferer"
+					// eslint-disable-next-line react/jsx-no-target-blank
+					target="_blank"
+					href="https://en.support.wordpress.com/memberships/#related-fees"
+				>
+					{ __( 'related fees.', 'jetpack' ) }
+				</a>
+			</div>
+		);
+	};
+
 	render = () => {
 		const { className, notices } = this.props;
 		const { connected, connectURL, products } = this.state;
@@ -353,6 +378,7 @@ class MembershipsButtonEdit extends Component {
 								{ __( 'Or add another membership amount:', 'jetpack' ) }
 								<br />
 								{ this.renderAddMembershipAmount() }
+								{ this.renderDisclaimer() }
 							</div>
 						</Placeholder>
 					) }

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -11,6 +11,7 @@ import formatCurrency, { getCurrencyDefaults } from '@automattic/format-currency
 
 import {
 	Button,
+	ExternalLink,
 	PanelBody,
 	Placeholder,
 	Spinner,
@@ -270,24 +271,9 @@ class MembershipsButtonEdit extends Component {
 	renderDisclaimer = () => {
 		return (
 			<div className="membership-button__disclaimer">
-				{ __( 'Read more about ', 'jetpack' ) }
-				<a
-					rel="noopener noreferer"
-					// eslint-disable-next-line react/jsx-no-target-blank
-					target="_blank"
-					href="https://en.support.wordpress.com/memberships/"
-				>
-					{ __( 'memberships', 'jetpack' ) }
-				</a>
-				{ __( ' and ', 'jetpack' ) }
-				<a
-					rel="noopener noreferer"
-					// eslint-disable-next-line react/jsx-no-target-blank
-					target="_blank"
-					href="https://en.support.wordpress.com/memberships/#related-fees"
-				>
-					{ __( 'related fees.', 'jetpack' ) }
-				</a>
+				<ExternalLink href="https://en.support.wordpress.com/memberships/#related-fees">
+					{ __( 'Read more about memberships and related fees.', 'jetpack' ) }
+				</ExternalLink>
 			</div>
 		);
 	};

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -352,6 +352,7 @@ class MembershipsButtonEdit extends Component {
 							<Button isLink onClick={ this.apiCall }>
 								{ __( 'Re-check Connection', 'jetpack' ) }
 							</Button>
+							{ this.renderDisclaimer() }
 						</div>
 					</Placeholder>
 				) }
@@ -364,6 +365,7 @@ class MembershipsButtonEdit extends Component {
 								<br />
 								<br />
 								{ this.renderAddMembershipAmount() }
+								{ this.renderDisclaimer() }
 							</div>
 						</Placeholder>
 					) }

--- a/extensions/blocks/membership-button/editor.scss
+++ b/extensions/blocks/membership-button/editor.scss
@@ -30,4 +30,10 @@
 		border: 1px solid;
 		border-color: var( --color-error );
 	}
+
+	.membership-button__disclaimer {
+		margin-top: 20px;
+		font-style: italic;
+		color: var( --color-gray-400 );
+	}
 }

--- a/extensions/blocks/membership-button/editor.scss
+++ b/extensions/blocks/membership-button/editor.scss
@@ -34,6 +34,5 @@
 	.membership-button__disclaimer {
 		margin-top: 20px;
 		font-style: italic;
-		color: var( --color-gray-400 );
 	}
 }


### PR DESCRIPTION
This adds a disclaimer in the block, with a link explaining fees that Stripe collects in memberships system. This is important for legal reasons.

### Screenshots
![Zrzut ekranu 2019-05-3 o 11 18 22](https://user-images.githubusercontent.com/3775068/57129246-1cf74580-6d96-11e9-933a-7a4d70b78e97.png)



### Testing instructions

You can use https://jurassic.ninja/create/?jetpack-beta&branch=memberships/explain-fees

1. Enable Beta blocks in /wp-admin/options-general.php?page=companion_settings
2. Use Membership block
3. Notice the disclaimer.

