### PR TITLE
WP.com Block Editor: Update version check to a daily basis.

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -203,7 +203,7 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	public function enqueue_scripts() {
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$version = gmdate( 'YW' );
+		$version = '20190502032107';
 
 		$src_common = $debug
 			? '//widgets.wp.com/wpcom-block-editor/common.js?minify=false'

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -203,7 +203,7 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	public function enqueue_scripts() {
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$version = '20190502032107';
+		$version = gmdate( 'Ymd' );
 
 		$src_common = $debug
 			? '//widgets.wp.com/wpcom-block-editor/common.js?minify=false'


### PR DESCRIPTION
This PR updates the requested version of the `wpcom-block-editor` scripts to a numeric representation of the day (eg. `20190502`).

<img width="463" alt="Screen Shot 2019-05-02 at 10 01 28 AM" src="https://user-images.githubusercontent.com/349751/57092920-66c22c00-6cc1-11e9-9c25-fb9259936a01.png">

#### Testing instructions:

- Load your Jetpack test site in the WordPress.com block editor: `https://wpcalypso.wordpress.com/block-editor/post/:JPsite` (note that due to mixed content restrictions, if your JP test site doesn't have SSL certs, you'll need to use a local Calypso install instead of `wpcalypso`).
- Verify the script version requested matches the above screenshot.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* n/a
