### PR TITLE
Set a correct user role for multisite plugin installation API test

### DIFF
--- a/tests/php/json-api/test-class.json-api-plugins-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-plugins-endpoints.php
@@ -100,6 +100,10 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {
+		if ( is_multisite() ) {
+			wp_get_current_user()->set_role( 'manage_network');
+		}
+
 		$endpoint = new Jetpack_JSON_API_Plugins_Install_Endpoint( array(
 			'stat'            => 'plugins:1:new',
 			'method'          => 'POST',

--- a/tests/php/json-api/test-class.json-api-plugins-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-plugins-endpoints.php
@@ -4,6 +4,12 @@ require_jetpack_file( 'class.json-api.php' );
 require_jetpack_file( 'class.json-api-endpoints.php' );
 
 class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
+	private static $super_admin_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$super_admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( self::$super_admin_user_id );
+	}
 
 	public function setUp() {
 		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
@@ -101,7 +107,7 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {
 		if ( is_multisite() ) {
-			wp_get_current_user()->set_role( 'manage_network');
+			wp_set_current_user( self::$super_admin_user_id );
 		}
 
 		$endpoint = new Jetpack_JSON_API_Plugins_Install_Endpoint( array(


### PR DESCRIPTION
A small change that fixes `test_Jetpack_API_Plugins_Install_Endpoint` for multisite configuration

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* fix `test_Jetpack_API_Plugins_Install_Endpoint` for multisite configuration

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* run `yarn docker:phpunit --group external-http -c /var/www/html/wp-content/plugins/jetpack/tests/php.multisite.xml`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* nope
