### PR TITLE
Debug Data: Improve master user output and remove tokens

### DIFF
--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -349,7 +349,7 @@ class Jetpack_Debug_Data {
 		$master_user = Jetpack_Options::get_option( 'master_user' );
 
 		if ( ! $master_user ) {
-			return 'No master user set.';
+			return __( 'No master user set.', 'jetpack' );
 		}
 
 		$user = new WP_User( $master_user );

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -160,7 +160,15 @@ class Jetpack_Debug_Data {
 			'private' => false,
 		);
 
-		/* Token information is private, but awareness if there one is set is helpful. */
+		/**
+		 * Token information is private, but awareness if there one is set is helpful.
+		 *
+		 * To balance out information vs privacy, we only display and include the "key",
+		 * which is a segment of the token prior to a period within the token and is
+		 * technically not private.
+		 *
+		 * If a token does not contain a period, then it is malformed and we report it as such.
+		 */
 		$user_id     = get_current_user_id();
 		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );
 		$blog_token  = Jetpack_Options::get_option( 'blog_token' );
@@ -173,9 +181,15 @@ class Jetpack_Debug_Data {
 		$tokenset = '';
 		if ( $blog_token ) {
 			$tokenset = 'Blog ';
+			$blog_key = substr( $blog_token, 0, strpos( $blog_token, '.' ) );
+			// Intentionally not translated since this is helpful when sent to Happiness.
+			$blog_key = ( $blog_key ) ? $blog_key : 'Potentially Malformed Token.';
 		}
 		if ( $user_token ) {
 			$tokenset .= 'User';
+			$user_key  = substr( $user_token, 0, strpos( $user_token, '.' ) );
+			// Intentionally not translated since this is helpful when sent to Happiness.
+			$user_key = ( $user_key ) ? $user_key : 'Potentially Malformed Token.';
 		}
 		if ( ! $tokenset ) {
 			$tokenset = 'None';
@@ -187,9 +201,19 @@ class Jetpack_Debug_Data {
 			'private' => false,
 		);
 		$debug_info['tokens_set']   = array(
-			'label' => 'Tokens defined',
-			'value' => $tokenset,
-			'private => false,',
+			'label'   => 'Tokens defined',
+			'value'   => $tokenset,
+			'private' => false,
+		);
+		$debug_info['blog_token']   = array(
+			'label'   => 'Blog token',
+			'value'   => ( $blog_token ) ? $blog_key : 'Not set.',
+			'private' => false,
+		);
+		$debug_info['user_token']   = array(
+			'label'   => 'User token',
+			'value'   => ( $user_token ) ? $user_key : 'Not set.',
+			'private' => false,
 		);
 
 		/** Jetpack Environmental Information */

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -191,16 +191,6 @@ class Jetpack_Debug_Data {
 			'value' => $tokenset,
 			'private => false,',
 		);
-		$debug_info['blog_token']   = array(
-			'label'   => 'Blog token',
-			'value'   => ( $blog_token ) ? $blog_token : 'Not set.',
-			'private' => true,
-		);
-		$debug_info['user_token']   = array(
-			'label'   => 'User token',
-			'value'   => ( $user_token ) ? $user_token : 'Not set.',
-			'private' => true,
-		);
 
 		/** Jetpack Environmental Information */
 		$debug_info['version']       = array(

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -156,7 +156,7 @@ class Jetpack_Debug_Data {
 		);
 		$debug_info['master_user']    = array(
 			'label'   => 'Jetpack Master User',
-			'value'   => Jetpack_Options::get_option( 'master_user' ),
+			'value'   => self::human_readable_master_user(),
 			'private' => false,
 		);
 
@@ -348,5 +348,26 @@ class Jetpack_Debug_Data {
 		}
 
 		return $debug_info;
+	}
+
+	/**
+	 * Returns a human readable string for which user is the master user.
+	 *
+	 * @return string
+	 */
+	private function human_readable_master_user() {
+		$master_user = Jetpack_Options::get_option( 'master_user' );
+
+		if ( ! $master_user ) {
+			return 'No master user set.';
+		}
+
+		$user = new WP_User( $master_user );
+
+		if ( ! $user ) {
+			return 'Master user no longer exists. Please disconnect and reconnect Jetpack.';
+		}
+
+		return sprintf( '#%1$d %2$s (%3$s)', $user->ID, $user->user_login, $user->user_email ); // Format: "#1 username (user@example.com)".
 	}
 }

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -183,7 +183,7 @@ class Jetpack_Debug_Data {
 
 		$debug_info['current_user'] = array(
 			'label'   => 'Current User',
-			'value'   => $user_id,
+			'value'   => self::human_readable_user( $user_id ),
 			'private' => false,
 		);
 		$debug_info['tokens_set']   = array(
@@ -357,6 +357,19 @@ class Jetpack_Debug_Data {
 		if ( ! $user ) {
 			return 'Master user no longer exists. Please disconnect and reconnect Jetpack.';
 		}
+
+		return self::human_readable_user( $user );
+	}
+
+	/**
+	 * Return human readable string for a given user object.
+	 *
+	 * @param WP_User|int $user Object or ID.
+	 *
+	 * @return string
+	 */
+	private function human_readable_user( $user ) {
+		$user = new WP_User( $user );
 
 		return sprintf( '#%1$d %2$s (%3$s)', $user->ID, $user->user_login, $user->user_email ); // Format: "#1 username (user@example.com)".
 	}

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -355,7 +355,7 @@ class Jetpack_Debug_Data {
 		$user = new WP_User( $master_user );
 
 		if ( ! $user ) {
-			return 'Master user no longer exists. Please disconnect and reconnect Jetpack.';
+			return __( 'Master user no longer exists. Please disconnect and reconnect Jetpack.', 'jetpack' );
 		}
 
 		return sprintf( '#%1$d %2$s (%3$s)', $user->ID, $user->user_login, $user->user_email ); // Format: "#1 username (user@example.com)".

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -206,12 +206,12 @@ class Jetpack_Debug_Data {
 			'private' => false,
 		);
 		$debug_info['blog_token']   = array(
-			'label'   => 'Blog token',
+			'label'   => 'Blog Token Key',
 			'value'   => ( $blog_token ) ? $blog_key : 'Not set.',
 			'private' => false,
 		);
 		$debug_info['user_token']   = array(
-			'label'   => 'User token',
+			'label'   => 'User Token Key',
 			'value'   => ( $user_token ) ? $user_key : 'Not set.',
 			'private' => false,
 		);


### PR DESCRIPTION
Improves the readability of the master user. Previously, it displayed the ID only. Now "#1 username (user@example.com)"

Removes part of the tokens. The actual full value is not that important for debugging. Previously, it was displayed, but marked "private" so it wouldn't save to the clipboard when clicking "copy". Now, it only displays the "key", which is public, so no concerns. Included in click-to-copy text.

#### Changes proposed in this Pull Request:
* Adds human readable master user function and removes part of the token.

#### Testing instructions:
* On WordPress 5.2 RC, visit Tools->Site Health->Debug Data->Jetpack. Look at the master user info. Try it on a site not connected or a site where the master user has been deleted.

#### Proposed changelog entry for your changes:
* not needed, amending new feature.
