### PR TITLE
Travis: Hard-code WP 5.0 and 5.1 for PHP 5.2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,13 @@ env:
 matrix:
   include:
   # The versions listed below run within Precise distro with PHP 5.2 due to Travis limitation
+  # Hard-coding the versions since WP 5.2 has a PHP 5.6 minimum support.
+  # When removing this, remove corresponding setup functions in setup-travis.sh.
   - php: "5.2"
-    env: WP_MODE=single WP_BRANCH=latest
+    env: WP_MODE=single WP_BRANCH=5.1
     dist: precise
   - php: "5.2"
-    env: WP_MODE=single WP_BRANCH=previous
+    env: WP_MODE=single WP_BRANCH=5.0
     dist: precise
   - if: branch !~ /(^branch-.*-built)/
     language: node_js

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -30,6 +30,12 @@ latest)
 previous)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php --previous) git://develop.git.wordpress.org/ /tmp/wordpress-previous
 	;;
+5.0)
+	git clone --depth=1 --branch 5.0 git://develop.git.wordpress.org/ /tmp/wordpress-5.0
+	;;
+5.1)
+	git clone --depth=1 --branch 5.1 git://develop.git.wordpress.org/ /tmp/wordpress-5.1
+	;;
 esac
 
 clone_exit_code=$?


### PR DESCRIPTION
WordPress 5.2 branched off of `trunk` today and will only support PHP 5.6+. While we still support WordPress 5.0 and 5.1, we'll need to still test PHP 5.2, but can avoid Travis automatically start fataling with our usual "latest/previous" branch management methodology.

#### Changes proposed in this Pull Request:
* Define the WP versions in the PHP 5.2 tests.

#### Testing instructions:
* Confirm Travis PHP 5.2 tests pass.

#### Proposed changelog entry for your changes:
* n/a
