### PR TITLE
Multisite: Use WP 5.1-era hook wp_initialize_site

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -70,10 +70,10 @@ class Jetpack_Network {
 			/*
 			 * If admin wants to automagically register new sites set the hook here
 			 *
-			 * This is a hacky way because xmlrpc is not available on wpmu_new_blog
+			 * This is a hacky way because xmlrpc is not available on wp_initialize_site
 			 */
 			if ( $this->get_option( 'auto-connect' ) == 1 ) {
-				add_action( 'wpmu_new_blog', array( $this, 'do_automatically_add_new_site' ) );
+				add_action( 'wp_initialize_site', array( $this, 'do_automatically_add_new_site' ) );
 			}
 		}
 
@@ -107,12 +107,15 @@ class Jetpack_Network {
 	 * Registers new sites upon creation
 	 *
 	 * @since 2.9
-	 * @uses  wpmu_new_blog
+	 * @since 7.4.0 Uses a WP_Site object.
+	 * @uses  wp_initialize_site
 	 *
-	 * @param int $blog_id
+	 * @param WP_Site $site
 	 **/
-	public function do_automatically_add_new_site( $blog_id ) {
-		$this->do_subsiteregister( $blog_id );
+	public function do_automatically_add_new_site( $site ) {
+		if ( is_a( $site, 'WP_Site') ) {
+			$this->do_subsiteregister( $site->id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11437
Requires: https://github.com/Automattic/jetpack/pull/12287

`wpmu_new_blog` is deprecated. Need to use `wp_initialize_site`.

#### Changes proposed in this Pull Request:
* Uses new hook.

#### Testing instructions:
* On a multisite running WP 5.1+, in Network Admin, choose option to automatically connect subsites.
* Create a new site.
* Verify no notices in the php log and the site connects.

#### Proposed changelog entry for your changes:
* Multisite: Use modern wp_initialize_site hook when automatically connecting new sites.
