### PR TITLE
Full Sync: Provide info when the data is empty.

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -103,6 +103,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.2.0
 		 * @since 7.3.0 Added $range arg.
+		 * @since 7.4.0 Added $empty arg.
 		 *
 		 * @param $full_sync_config
 		 * @param $range array

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -88,7 +88,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 					0,              // queued
 					false,          // current state
 				);
-			} else if( $include_empty && $total_items === 0 ) {
+			} else if ( $include_empty && $total_items === 0 ) {
 				$empty[ $module_name ] = true;
 			}
 		}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -105,9 +105,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 7.3.0 Added $range arg.
 		 * @since 7.4.0 Added $empty arg.
 		 *
-		 * @param array $full_sync_config
-		 * @param array $range
-		 * @param array $empty
+		 * @param array $full_sync_config Sync configuration for all sync modules.
+		 * @param array $range            Range of the sync items, containing min and max IDs for some item types.
+		 * @param array $empty            The modules with no items to sync during a full sync.
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range, $empty );
 
@@ -186,8 +186,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 * @since 7.3.0 Added $range arg.
 		 *
-		 * @param string $arg
-		 * @param array  $range
+		 * @param string $checksum Deprecated since 7.3.0 - @see https://github.com/Automattic/jetpack/pull/11945/
+		 * @param array  $range    Range of the sync items, containing min and max IDs for some item types.
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -105,9 +105,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 7.3.0 Added $range arg.
 		 * @since 7.4.0 Added $empty arg.
 		 *
-		 * @param $full_sync_config
-		 * @param $range array
-		 * @param $empty array
+		 * @param array $full_sync_config
+		 * @param array $range
+		 * @param array $empty
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range, $empty );
 
@@ -186,8 +186,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 * @since 7.3.0 Added $range arg.
 		 *
-		 * @param args ''
-		 * @param $range array 
+		 * @param string $arg
+		 * @param array  $range
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	function init_full_sync_listeners( $callable ) {
 		// synthetic actions for full sync
-		add_action( 'jetpack_full_sync_start', $callable, 10, 2 );
+		add_action( 'jetpack_full_sync_start', $callable, 10, 3 );
 		add_action( 'jetpack_full_sync_end', $callable, 10, 2 );
 		add_action( 'jetpack_full_sync_cancelled', $callable );
 	}
@@ -52,10 +52,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		$enqueue_status   = array();
 		$full_sync_config = array();
-
+		$include_empty = false;
+		$empty = array();
 		// default value is full sync
 		if ( ! is_array( $module_configs ) ) {
 			$module_configs = array();
+			$include_empty = true;
 			foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 				$module_configs[ $module->name() ] = true;
 			}
@@ -86,6 +88,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 					0,              // queued
 					false,          // current state
 				);
+			} else if( $include_empty && $total_items === 0 ) {
+				$empty[ $module_name ] = true;
 			}
 		}
 
@@ -100,10 +104,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 * @since 7.3.0 Added $range arg.
 		 *
-		 * @param $full_sync_config - array
+		 * @param $full_sync_config
 		 * @param $range array
+		 * @param $empty array
 		 */
-		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
+		do_action( 'jetpack_full_sync_start', $full_sync_config, $range, $empty );
 
 		$this->continue_enqueuing( $full_sync_config, $enqueue_status );
 

--- a/sync/class.jetpack-sync-module-network-options.php
+++ b/sync/class.jetpack-sync-module-network-options.php
@@ -48,7 +48,7 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		if ( ! is_multisite() ) {
-			return array( 0, true );
+			return array( null, true );
 		}
 
 		/**
@@ -66,7 +66,7 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 
 	function estimate_full_sync_actions( $config ) {
 		if ( ! is_multisite() ) {
-			return 0;
+			return null;
 		}
 
 		return 1;

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -35,7 +35,7 @@ abstract class Jetpack_Sync_Module {
 
 	public function estimate_full_sync_actions( $config ) {
 		// in subclasses, return the number of items yet to be enqueued
-		return 0;
+		return null;
 	}
 
 	public function get_full_sync_actions() {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -30,7 +30,7 @@ abstract class Jetpack_Sync_Module {
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		// in subclasses, return the number of actions enqueued, and next module state (true == done)
-		return array( 0, true );
+		return array( null, true );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -45,6 +45,40 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	}
 
+	function test_enqueues_sync_start_action_without_post_sends_empty_range() {
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+
+		list( $config, $range, $empty ) = $start_event->args;
+
+		$posts = get_posts();
+		if ( empty( $posts ) ) {
+			$this->assertTrue( $empty['posts'] );
+		}
+
+		$comments = get_comments();
+		if ( empty( $comments ) ) {
+			$this->assertTrue( $empty['comments'] );
+		}
+
+		$this->full_sync->reset_data();
+
+		$post = $this->factory->post->create();
+		$this->factory->comment->create_post_comments( $post, 1 );
+
+
+		$this->full_sync->start();
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+		list( $config, $range, $empty ) = $start_event->args;
+
+		$this->assertFalse( isset( $empty['posts'] ) );
+		$this->assertFalse( isset( $empty['comments'] ) );
+
+	}
+
 	// this only applies to the test replicastore - in production we overlay data
 	function test_sync_start_resets_storage() {
 		$this->factory->post->create();
@@ -859,6 +893,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( isset( $range['comments']->min ) );
 		$this->assertTrue( isset( $range['comments']->count ) );
 	}
+
+
 
 	function record_full_sync_end_checksum( $checksum, $range ) {
 		// $checksum  has been deprecated...

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -893,9 +893,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( isset( $range['comments']->min ) );
 		$this->assertTrue( isset( $range['comments']->count ) );
 	}
-
-
-
+	
 	function record_full_sync_end_checksum( $checksum, $range ) {
 		// $checksum  has been deprecated...
 		$this->full_sync_end_range = $range;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -893,7 +893,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( isset( $range['comments']->min ) );
 		$this->assertTrue( isset( $range['comments']->count ) );
 	}
-	
 	function record_full_sync_end_checksum( $checksum, $range ) {
 		// $checksum  has been deprecated...
 		$this->full_sync_end_range = $range;


### PR DESCRIPTION
When we do a full sync and some data is empty. We don't sync anything that tells us that the data is in fact empty. 

This PR. Tried to fix this by sending an array of empty data. 
This will enable us to remove posts and comments from sites that do not have them any more. 

#### Changes proposed in this Pull Request:


#### Testing instructions:
Do the tests pass? 

* Remove all the posts and comments from your site. 
* Do a full sync. Do you see that the empty argument is reporting looks like 
array( 'posts'= >true, 'comments' => true);



#### Proposed changelog entry for your changes:
* Sync: Send empty data during full sync start. 
