### PR TITLE
Admin - Network: remove unwanted space between nav buttons

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -67,6 +67,9 @@
 	.dops-button-group {
 		flex-grow: 1;
 		align-self: center;
+		/* This fixes an unwanted space between the buttons in the network settings caused by a line break. */
+		/* Fixed here to keep PHP code readable. It's safe: .dops-button and .dops-button.is-compact specify a font size. */
+		font-size: 0;
 	}
 	@include breakpoint( "<480px" ) {
 		text-align: left;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #12197

The Jetpack network settings are written with PHP and to write the code to be readable and ordered, there are line breaks that were causing an unwanted spacing between the buttons in this navigation bar. Although the bug was visible in all browsers, the space node was only visible in the Firefox inspector, but not in Chrome or Safari.

<img width="461" alt="Captura de Pantalla 2019-05-03 a la(s) 11 27 31" src="https://user-images.githubusercontent.com/1041600/57144982-ab6cc680-6d98-11e9-8ad7-555fb7984de3.png">


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* sets a font size of 0 to get rid of spacing caused by line breaks in the code for the navigation buttons in the Jetpack network settings

<img width="340" alt="Captura de Pantalla 2019-05-03 a la(s) 11 30 22" src="https://user-images.githubusercontent.com/1041600/57144935-8c6e3480-6d98-11e9-8ff3-8675ae95fa46.png">


#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Jetpack network settings
* ensure the buttons look good
* go to the Jetpack admin for a single site
* ensure the buttons look good too

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix spacing issue in buttons in navigation on Jetpack network settings
