### PR TITLE
Markdown Block: Update icon

### DIFF
--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { ExternalLink, Path, Rect, SVG } from '@wordpress/components';
+import { ExternalLink, Path, SVG } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -32,18 +32,9 @@ export const settings = {
 	),
 
 	icon: (
-		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">
-			<Rect
-				width="198"
-				height="118"
-				x="5"
-				y="5"
-				ry="10"
-				stroke="currentColor"
-				strokeWidth="10"
-				fill="none"
-			/>
-			<Path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
+		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+			<Path fill="none" d="M0 0h24v24H0V0z" />
+			<Path d="M21 12h-2.25V8.25H16.5V12h-2.25l3.375 3.75L21 12zM6 15.75v-4.5l2.25 3 2.25-3v4.5h2.25v-7.5H10.5l-2.25 3-2.25-3H3.75v7.5H6zm16.5 3.75h-21C.547 19.5 0 18.954 0 18V6c0-.954.547-1.5 1.5-1.5h21c.954 0 1.5.546 1.5 1.5v12c0 .954-.546 1.5-1.5 1.5z" />
 		</SVG>
 	),
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Update icon so it's consistent with Material icons

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In Post or Page, add a Markdown block via the Block picker
* Does the icon look out of place?

__Before:__
![1 before](https://user-images.githubusercontent.com/177929/57146937-678cb800-6dbe-11e9-9fa7-46a22d29c019.png)

__After:__
![2 after](https://user-images.githubusercontent.com/177929/57146952-6f4c5c80-6dbe-11e9-95cf-a2108a6bfc1e.png)

_Note:
Markdown icon via https://github.com/dcurtis/markdown-mark_

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Update Markdown Block icon so it's consistent with Material icons
