### PR TITLE
REST API: Add the `jetpack_frame_nonce` site option to sites endpoints.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -112,6 +112,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'publicize_permanently_disabled',
 		'frame_nonce',
 		'jetpack_frame_nonce',
+		'page_on_front',
 		'page_for_posts',
 		'headstart',
 		'headstart_is_fresh',
@@ -150,6 +151,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'woocommerce_is_active',
 		'frame_nonce',
 		'design_type',
+		'wordads',
 		'jetpack_frame_nonce',
 	);
 

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -111,7 +111,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wordads',
 		'publicize_permanently_disabled',
 		'frame_nonce',
-		'page_on_front',
+		'jetpack_frame_nonce',
 		'page_for_posts',
 		'headstart',
 		'headstart_is_fresh',
@@ -150,7 +150,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'woocommerce_is_active',
 		'frame_nonce',
 		'design_type',
-		'wordads',
+		'jetpack_frame_nonce',
 	);
 
 	private $site;
@@ -496,6 +496,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'frame_nonce' :
 					$options[ $key ] = $site->get_frame_nonce();
+					break;
+				case 'jetpack_frame_nonce' :
+					$options[ $key ] = $site->get_jetpack_frame_nonce();
 					break;
 				case 'page_on_front' :
 					if ( $custom_front_page ) {

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -150,9 +150,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_store',
 		'woocommerce_is_active',
 		'frame_nonce',
+		'jetpack_frame_nonce',
 		'design_type',
 		'wordads',
-		'jetpack_frame_nonce',
 	);
 
 	private $site;

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -61,6 +61,8 @@ abstract class SAL_Site {
 
 	abstract public function get_frame_nonce();
 
+	abstract public function get_jetpack_frame_nonce();
+
 	abstract public function allowed_file_types();
 
 	abstract public function get_post_formats();

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -108,6 +108,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return false;
 	}
 
+	function get_jetpack_frame_nonce() {
+		return false;
+	}
+
 	function is_headstart_fresh() {
 		return false;
 	}


### PR DESCRIPTION
This PR adds the `jetpack_frame_nonce` to existing sites endpoints. This will hold the nonce to be used by WordPress.com when iframing the block editor.

See: p3fqKv-6Hh-p2 (phase 2)

#### Testing instructions:
* Sandbox the API and switch to this branch on your Jetpack testing site.
* Apply D27770-code to the sandbox (that's the dotcom-side changes).
* Call both `https://public-api.wordpress.com/rest/v1.2/me/sites` and `https://public-api.wordpress.com/rest/v1.2/sites/:JPsite`.
* Verify that both have `frame_nonce` and `jetpack_frame_nonce` site options.
* Verify that those nonces are the same for dotcom sites, and different for Jetpack sites; the `jetpack_frame_nonce` field should have a format of `1556989999:1:b0eceb1ebee7646bxxxd915440a05a6d` for Jetpack sites.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* n/a
