### PR TITLE
Dashboard: replace dismiss text/link for apps card with a button

### DIFF
--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -47,6 +47,17 @@ class AppsCard extends React.Component {
 		return (
 			<div className={ classes }>
 				<Card className="jp-apps-card__content">
+					{ this.props.userCanManageOptions && (
+						<Button
+							borderless
+							compact
+							className="jp-apps-card__dismiss"
+							href="javascript:void(0)"
+							onClick={ this.dismissCard }
+						>
+							<span className="dashicons dashicons-no" />
+						</Button>
+					) }
 					<div className="jp-apps-card__top">
 						<img src={ imagePath + 'get-apps.svg' } alt="" />
 					</div>
@@ -69,12 +80,6 @@ class AppsCard extends React.Component {
 						>
 							{ __( 'Download the free apps' ) }
 						</Button>
-						<br />
-						{ this.props.userCanManageOptions && (
-							<a href="javascript:void(0)" onClick={ this.dismissCard }>
-								{ __( 'I already use this app.' ) }
-							</a>
-						) }
 					</div>
 				</Card>
 			</div>

--- a/_inc/client/components/apps-card/style.scss
+++ b/_inc/client/components/apps-card/style.scss
@@ -15,6 +15,10 @@
 	}
 }
 
+.jp-apps-card__dismiss {
+
+}
+
 .jp-apps-card__top {
 	padding: rem( 60px ) 0 0;
 	background: #ffffff;

--- a/_inc/client/components/apps-card/style.scss
+++ b/_inc/client/components/apps-card/style.scss
@@ -16,7 +16,9 @@
 }
 
 .jp-apps-card__dismiss {
-
+	position: absolute;
+	top: 1px;
+	right: 8px;
 }
 
 .jp-apps-card__top {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #9215

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* remove text for dismiss link and convert it into a button with icon

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack admin settings
* check the Apps card at the bottom. The x button should look good, properly aligned and should work.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Update dismiss text in card promoting use of the mobile app, making it a button.
