### PR TITLE
Development Environment Check: Improve detection of command availability by using the command: type

### DIFF
--- a/docs/development-environment-cli-support.md
+++ b/docs/development-environment-cli-support.md
@@ -26,9 +26,15 @@ PHPUnit is the tool that helps us run unit tests for Jetpack.
 
 ### Command is available: docker
 
-The command `docker` comes installed with the Docker app in most environments.
+The command `docker` comes with the Docker app in most environments.
 
 This command is essential for running the Jetpack Docker Development Environment.
+
+### Command is available: docker-compose
+
+The command `docker-compose` comes with the Docker app in most environments nowawadays but it wasn not the case with old versions of the Docker app.
+
+This command is needed for leveraging the multiple docker containers that encompass the Jetpack Docker Development Environment.
 
 ### Docker images are available
 

--- a/docs/development-environment-cli-support.md
+++ b/docs/development-environment-cli-support.md
@@ -24,6 +24,12 @@ PHP is needed all around the build process for Jetpack bundles.
 
 PHPUnit is the tool that helps us run unit tests for Jetpack.
 
+### Command is available: docker
+
+The command `docker` comes installed with the Docker app in most environments.
+
+This command is essential for running the Jetpack Docker Development Environment.
+
 ### Docker images are available
 
 The containers for the Jetpack docker images are created when you ran `yarn docker:up`.

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -122,6 +122,7 @@ main() {
 	output "\n==============================\n\n"
 
 	check command_is_available docker
+	check command_is_available docker-compose
 	check  docker_is_running
 	check  docker_images_are_available
 	check  docker_containers_are_available

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -88,13 +88,13 @@ function support_url {
 function assert {
 	output "* $1 $2":
 	$1 $2 && success " SUCCESS\n"
-	$1 $2 || danger " FAILED. Check $(support_url "$1" "$2" )\n"
+	$1 $2 || danger " FAILED.\n\tCheck $(support_url "$1" "$2" )\n"
 }
 
 function check {
 	output "* $1 $2":
 	$1 $2 && success " SUCCESS\n"
-	$1 $2 || output " NOPE. Check $(support_url "$1" "$2" )\n"
+	$1 $2 || output " NOPE.\n\tCheck $(support_url "$1" "$2" )\n"
 }
 
 main() {

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -25,8 +25,12 @@ function node_version_is_proper {
 	version_gt `node -v |cut -b 2-` $REQUIRED
 }
 
+function which {
+	type "$1" >>/dev/null 2>&1
+}
+
 function command_is_available {
-	which -s $1 || command_exists_as_alias $1 || type $1 >/dev/null 2>/dev/null
+	which $1 || command_exists_as_alias $1 || type $1 >/dev/null 2>/dev/null
 }
 function nvm_is_available {
     [ -f ~/.nvm/nvm.sh ] && source ~/.nvm/nvm.sh && command_is_available nvm
@@ -38,7 +42,7 @@ function docker_is_running {
 
 function repo_is_up_to_date {
 	git fetch origin >/dev/null
-	git diff -s --exit-code master origin/master
+	git diff --exit-code master origin/master
 }
 
 function node_modules_are_available {
@@ -94,18 +98,19 @@ function check {
 }
 
 main() {
-	output "Jetpack development environment checking\n\n"
+	output "Jetpack development environment check\n\n"
 	output "\nChecking under $PWD\n\n"
-	output "Tools for development, linting, unit testing\n"
-	output "============================================ \n\n"
+
+	output "Tools for development, linting, unit testing PHP\n"
+	output "================================================ \n\n"
 
 	assert command_is_available php
 	assert command_is_available phpunit
 	assert command_is_available composer
 	assert vendor_dir_is_available
 
-	output "\n\nJavaScript tooling\n"
-	output "======================\n\n"
+	output "\n\nTools for development, linting, unit testing JavaScript"
+	output "\n ======================================================\n\n"
 
 	assert command_is_available node
 	assert node_version_is_proper
@@ -113,17 +118,17 @@ main() {
 	check  nvm_is_available || check command_is_available n
 	assert node_modules_are_available
 
-	output "\nJetpack Development Environment\n"
-	output "=================================\n\n"
+	output "\nDocker Development Environment"
+	output "\n==============================\n\n"
 
-	assert command_is_available docker
+	check command_is_available docker
 	check  docker_is_running
 	check  docker_images_are_available
 	check  docker_containers_are_available
 	check  docker_containers_are_running
 
-	output "\n\nTools for contributing\n"
-	output "==========================\n\n"
+	output "\n\nTools for contributing"
+	output "\n======================\n\n"
 
 	assert command_is_available git
 	assert is_git_dir

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -42,7 +42,7 @@ function docker_is_running {
 
 function repo_is_up_to_date {
 	git fetch origin >/dev/null
-	git diff --exit-code master origin/master
+	git diff -s --exit-code master origin/master
 }
 
 function node_modules_are_available {


### PR DESCRIPTION
The GNU/Linux version of `which` does not support the `-s` argument

Fixes running the script in environments like CentOS

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Introduces bash function `which` as wrapper to `type`
* Updates some headers to look better
* Adds docs for the docker command availability check.
* Adds check and docs for availability of the command: `docker-compose`.
* Makes the support link be rendered on next line, with a tab character at the beginning

#### Testing instructions:

1. Check out this branch in your sandboxes.
2. Confirm the output looks fine without any error about `which` not supporting the `-s` argument


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

None needed