### PR TITLE
Change html height to auto when opening carousel

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -474,6 +474,9 @@ jQuery( document ).ready( function( $ ) {
 					$( window ).scrollTop( scroll );
 					$( '.jp-carousel-previous-button' ).hide();
 					$( '.jp-carousel-next-button' ).hide();
+					// Set height to original value
+					// Fix some themes where closing carousel brings view back to top
+					$( 'html' ).css( 'height', '' );
 				} )
 				.bind( 'jp_carousel.afterClose', function() {
 					if ( window.location.hash && history.back ) {
@@ -1690,6 +1693,10 @@ jQuery( document ).ready( function( $ ) {
 			) {
 				return;
 			}
+
+			// Set height to auto
+			// Fix some themes where closing carousel brings view back to top
+			$( 'html' ).css( 'height', 'auto' );
 
 			e.preventDefault();
 


### PR DESCRIPTION
Implements the fix proposed in this [commment](https://github.com/Automattic/jetpack/issues/1125#issuecomment-357769603).

Fixes #1125

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
It's a bit hard to test as you need a theme which has this issue. I tested it with the [wpVoyager](http://www.docs.purethemes.net/wpvoyager/) theme and the standard wordpress theme and everything worked as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Fix closing carousel view brings you back to top on certain themes
