### PR TITLE
Sharing: Change WhatsApp URL for Firefox for desktop

### DIFF
--- a/class.jetpack-user-agent.php
+++ b/class.jetpack-user-agent.php
@@ -695,6 +695,28 @@ class Jetpack_User_Agent_Info {
 			return false;
 	}
 
+	/*
+	 * Detects if the current browser is Firefox for desktop
+	 *
+	 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox
+	 * Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion
+	 * The platform section will include 'Mobile' for phones and 'Tablet' for tablets.
+	 *
+	 */
+	static function is_firefox_desktop() {
+
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+
+		$ua = strtolower( $_SERVER['HTTP_USER_AGENT'] );
+
+		if ( false !== strpos( $ua, 'firefox' ) && false === strpos( $ua, 'mobile' ) && false === strpos( $ua, 'tablet' ) ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 	/*
 	 * Detects if the current browser is FirefoxOS Native browser

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1701,7 +1701,15 @@ class Jetpack_Share_WhatsApp extends Sharing_Source {
 	public function process_request( $post, array $post_data ) {
 		// Record stats
 		parent::process_request( $post, $post_data );
-		$url = 'https://api.whatsapp.com/send?text=' . rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
+
+		// Firefox for desktop doesn't handle the "api.whatsapp.com" URL properly, so use "web.whatsapp.com"
+		if ( Jetpack_User_Agent_Info::is_firefox_desktop() ) {
+			$url = 'https://web.whatsapp.com/send?text=';
+		} else {
+			$url = 'https://api.whatsapp.com/send?text=';
+		}
+
+		$url .= rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
 		wp_redirect( $url );
 		exit;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #12069 

The Firefox desktop browser redirects the "https://api.whatsapp.com/send?..." URL to an invalid address: "whatsapp://send?..."

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Detect whether the user's browser is Firefox for desktop using the HTTP user-agent.
* Use the "web.whatsapp.com/..." URL for WhatsApp sharing in Firefox for desktop.
* Use the "api.whatsapp.com/..." URL for WhatsApp sharing in other browsers, including Firefox mobile. This URL is preferred because it shows a send confirmation page before showing the QR code page on desktops. Also, it opens the WhatApp app on mobile devices.

#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. 

-->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Sharing and the WhatsApp button on a post.
* Open the post in Firefox for desktop, and click the post's WhatsApp button.
* The resulting URL should be "https://web.whatsapp.com", and a QR code page should be displayed.
* Open the post in Chrome, Firefox mobile, and other supported browsers, and click the post's WhatsApp button.
* The resulting URL should be "https://api.whatsapp.com/send?...", and a send confirmation page should be displayed or the mobile app should be opened.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Sharing: use "web.whatsapp.com" instead of "api.whatsapp.com" in Firefox for desktop