### PR TITLE
Fix: Updating or deactivating a module overwrites the available modules.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -436,7 +436,7 @@ class Jetpack {
 		delete_transient( self::$plugin_upgrade_lock_key );
 	}
 
-	function isArray( $arr ) {
+	static function isArray( $arr ) {
 		if ( ! is_array( $arr ) ) {
 			return array();
 		}
@@ -446,12 +446,13 @@ class Jetpack {
 	static function update_active_modules( $modules ) {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();
+	
 		$new_active_modules   = array();
 		$new_deactive_modules = array();
-		list(
-			$modules,
-			$current_modules,
-			$active_modules )   = array_map( 'isArray', array( $modules, $current_modules, $active_modules ) );
+		$current_modules      = ( is_array( $current_modules ) ) ? $current_modules : array();
+		$modules              = ( is_array( $modules ) ) ? $modules : array();
+		$active_modules       = ( is_array( $active_modules ) ) ? $active_modules : array();
+
 		$new_active_modules   = array_diff( $modules, $current_modules );
 		$new_deactive_modules = array_diff( $active_modules, $modules );
 		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -448,8 +448,8 @@ class Jetpack {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();
 		$new_active_modules   = array_diff( $modules, $current_modules );
-		$new_deactive_modules = array_diff( $active_modules, $modules );
-		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
+		$new_inactive_modules = array_diff( $active_modules, $modules );
+		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_inactive_modules );
 		$reindexed_modules    = array_values( $new_current_modules );
 		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $reindexed_modules ) );
 		

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -474,7 +474,7 @@ class Jetpack {
 			do_action( "jetpack_activate_module_$module", $module );
 		}
 			
-		foreach ( $new_deactive_modules as $module ) {
+		foreach ( $new_inactive_modules as $module ) {
 			/**
 			 * Fired after a module has been deactivated.
 			 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3017,7 +3017,7 @@ class Jetpack {
 
 		$jetpack = Jetpack::init();
 
-		$active = Jetpack_Options::get_option( 'active_modules', array() );
+		$active = Jetpack::get_active_modules();
 		$new    = array_filter( array_diff( $active, (array) $module ) );
 
 		return self::update_active_modules( $new );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -447,7 +447,6 @@ class Jetpack {
 	static function update_active_modules( $modules ) {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();
-
 		$new_active_modules   = array_diff( $modules, $current_modules );
 		$new_deactive_modules = array_diff( $active_modules, $modules );
 		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -448,15 +448,14 @@ class Jetpack {
 		$active_modules       = Jetpack::get_active_modules();
 		$new_active_modules   = array();
 		$new_deactive_modules = array();
-
-		list( $modules, $current_modules, $active_modules ) = array_map( 'isArray', array( $modules, $current_modules, $active_modules ) );
-
+		list(
+			$modules,
+			$current_modules,
+			$active_modules )   = array_map( 'isArray', array( $modules, $current_modules, $active_modules ) );
 		$new_active_modules   = array_diff( $modules, $current_modules );
 		$new_deactive_modules = array_diff( $active_modules, $modules );
-		
-		
-		$new_current_modules = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
-		$success             = Jetpack_Options::update_option( 'active_modules', array_unique( $new_current_modules ) );
+		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
+		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $new_current_modules ) );
 		
 		foreach( $new_active_modules as $module ) {
 			/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -451,7 +451,8 @@ class Jetpack {
 		$new_active_modules   = array_diff( $modules, $current_modules );
 		$new_deactive_modules = array_diff( $active_modules, $modules );
 		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
-		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $new_current_modules ) );
+		$reindexed_modules    = array_values( $new_current_modules );
+		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $reindexed_modules ) );
 		
 		foreach ( $new_active_modules as $module ) {
 			/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -436,19 +436,10 @@ class Jetpack {
 		delete_transient( self::$plugin_upgrade_lock_key );
 	}
 
-	static function isArray( $arr ) {
-		if ( ! is_array( $arr ) ) {
-			return array();
-		}
-		return $arr;
-	}
-
 	static function update_active_modules( $modules ) {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();
 	
-		$new_active_modules   = array();
-		$new_deactive_modules = array();
 		$current_modules      = ( is_array( $current_modules ) ) ? $current_modules : array();
 		$modules              = ( is_array( $modules ) ) ? $modules : array();
 		$active_modules       = ( is_array( $active_modules ) ) ? $active_modules : array();
@@ -458,7 +449,7 @@ class Jetpack {
 		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
 		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $new_current_modules ) );
 		
-		foreach( $new_active_modules as $module ) {
+		foreach ( $new_active_modules as $module ) {
 			/**
 			 * Fires when a specific module is activated.
 			 *
@@ -479,7 +470,7 @@ class Jetpack {
 			do_action( "jetpack_activate_module_$module", $module );
 		}
 			
-		foreach( $new_deactive_modules as $module ) {
+		foreach ( $new_deactive_modules as $module ) {
 			/**
 			 * Fired after a module has been deactivated.
 			 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -436,6 +436,14 @@ class Jetpack {
 		delete_transient( self::$plugin_upgrade_lock_key );
 	}
 
+	/**
+	 * Saves all the currently active modules to options.
+	 * Also fires Action hooks for each newly activated and deactived module.
+	 * 
+	 * @param $modules Array Array of active modules to be saved in options.
+	 * 
+	 * @return $success bool true for success, false for failure.
+	 */
 	static function update_active_modules( $modules ) {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -439,10 +439,6 @@ class Jetpack {
 	static function update_active_modules( $modules ) {
 		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
 		$active_modules       = Jetpack::get_active_modules();
-	
-		$current_modules      = ( is_array( $current_modules ) ) ? $current_modules : array();
-		$modules              = ( is_array( $modules ) ) ? $modules : array();
-		$active_modules       = ( is_array( $active_modules ) ) ? $active_modules : array();
 
 		$new_active_modules   = array_diff( $modules, $current_modules );
 		$new_deactive_modules = array_diff( $active_modules, $modules );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -436,56 +436,68 @@ class Jetpack {
 		delete_transient( self::$plugin_upgrade_lock_key );
 	}
 
+	function isArray( $arr ) {
+		if ( ! is_array( $arr ) ) {
+			return array();
+		}
+		return $arr;
+	}
+
 	static function update_active_modules( $modules ) {
-		$current_modules = Jetpack_Options::get_option( 'active_modules', array() );
+		$current_modules      = Jetpack_Options::get_option( 'active_modules', array() );
+		$active_modules       = Jetpack::get_active_modules();
+		$new_active_modules   = array();
+		$new_deactive_modules = array();
 
-		$success = Jetpack_Options::update_option( 'active_modules', array_unique( $modules ) );
+		list( $modules, $current_modules, $active_modules ) = array_map( 'isArray', array( $modules, $current_modules, $active_modules ) );
 
-		if ( is_array( $modules ) && is_array( $current_modules ) ) {
-			$new_active_modules = array_diff( $modules, $current_modules );
-			foreach( $new_active_modules as $module ) {
-				/**
-				 * Fires when a specific module is activated.
-				 *
-				 * @since 1.9.0
-				 *
-				 * @param string $module Module slug.
-				 * @param boolean $success whether the module was activated. @since 4.2
-				 */
-				do_action( 'jetpack_activate_module', $module, $success );
-
-				/**
-				 * Fires when a module is activated.
-				 * The dynamic part of the filter, $module, is the module slug.
-				 *
-				 * @since 1.9.0
-				 *
-				 * @param string $module Module slug.
-				 */
-				do_action( "jetpack_activate_module_$module", $module );
-			}
-
-			$new_deactive_modules = array_diff( $current_modules, $modules );
-			foreach( $new_deactive_modules as $module ) {
-				/**
-				 * Fired after a module has been deactivated.
-				 *
-				 * @since 4.2.0
-				 *
-				 * @param string $module Module slug.
-				 * @param boolean $success whether the module was deactivated.
-				 */
-				do_action( 'jetpack_deactivate_module', $module, $success );
-				/**
-				 * Fires when a module is deactivated.
-				 * The dynamic part of the filter, $module, is the module slug.
-				 *
-				 * @since 1.9.0
-				 *
-				 * @param string $module Module slug.
-				 */
-				do_action( "jetpack_deactivate_module_$module", $module );
-			}
+		$new_active_modules   = array_diff( $modules, $current_modules );
+		$new_deactive_modules = array_diff( $active_modules, $modules );
+		
+		
+		$new_current_modules = array_diff( array_merge( $current_modules, $new_active_modules ), $new_deactive_modules );
+		$success             = Jetpack_Options::update_option( 'active_modules', array_unique( $new_current_modules ) );
+		
+		foreach( $new_active_modules as $module ) {
+			/**
+			 * Fires when a specific module is activated.
+			 *
+			 * @since 1.9.0
+			 *
+			 * @param string $module Module slug.
+			 * @param boolean $success whether the module was activated. @since 4.2
+			 */
+			do_action( 'jetpack_activate_module', $module, $success );
+			/**
+			 * Fires when a module is activated.
+			 * The dynamic part of the filter, $module, is the module slug.
+			 *
+			 * @since 1.9.0
+			 *
+			 * @param string $module Module slug.
+			 */
+			do_action( "jetpack_activate_module_$module", $module );
+		}
+			
+		foreach( $new_deactive_modules as $module ) {
+			/**
+			 * Fired after a module has been deactivated.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @param string $module Module slug.
+			 * @param boolean $success whether the module was deactivated.
+			 */
+			do_action( 'jetpack_deactivate_module', $module, $success );
+			/**
+			 * Fires when a module is deactivated.
+			 * The dynamic part of the filter, $module, is the module slug.
+			 *
+			 * @since 1.9.0
+			 *
+			 * @param string $module Module slug.
+			 */
+			do_action( "jetpack_deactivate_module_$module", $module );
 		}
 
 		return $success;
@@ -3010,7 +3022,7 @@ class Jetpack {
 
 		$jetpack = Jetpack::init();
 
-		$active = Jetpack::get_active_modules();
+		$active = Jetpack_Options::get_option( 'active_modules', array() );
 		$new    = array_filter( array_diff( $active, (array) $module ) );
 
 		return self::update_active_modules( $new );

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -6,7 +6,7 @@ class MockJetpack extends Jetpack {
 	}
 }
 
-class WP_Test_Jetpackk extends WP_UnitTestCase {
+class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	static $activated_modules = array();
 	static $deactivated_modules = array();
@@ -259,18 +259,24 @@ EXPECTED;
 		Jetpack::update_active_modules( array( 'monitor' ) );
 		$this->assertEquals( self::$activated_modules, array( 'monitor' ) );
 		$this->assertEquals(  self::$deactivated_modules, array() );
+
+		// Simce we override the 'monitor' module, verify it does not appear in get_active_modules().
+		$active_modules = Jetpack::get_active_modules();
+		$this->assertEquals(  $active_modules, array() );
 	
+		// Verify that activating a new module does not deactivate 'monitor' module.
 		Jetpack::update_active_modules( array( 'stats' ) );
 		$this->assertEquals( self::$activated_modules, array( 'monitor', 'stats') );
 		$this->assertEquals(  self::$deactivated_modules, array() );
 	
 		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'e2e_test_filter' ) );
 	
+		// With the module override filter removed, verify that monitor module appears in get_active_modules().
 		$active_modules = Jetpack::get_active_modules();
-		error_log('active mods are '  . print_r($active_modules, true));
 		$this->assertEquals(  $active_modules, array( 'monitor', 'stats' ) );
 	}
 	
+	 // This filter overrides the 'monitor' module.
 	public static function e2e_test_filter( $modules ) {
 		$disabled_modules = array( 'monitor' );
 	

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -6,7 +6,7 @@ class MockJetpack extends Jetpack {
 	}
 }
 
-class WP_Test_Jetpack extends WP_UnitTestCase {
+class WP_Test_Jetpackk extends WP_UnitTestCase {
 
 	static $activated_modules = array();
 	static $deactivated_modules = array();
@@ -248,6 +248,41 @@ EXPECTED;
 		remove_action( 'jetpack_activate_module_stats', array( __CLASS__, 'track_activated_modules' ) );
 		remove_action( 'jetpack_deactivate_module_stats', array( __CLASS__, 'track_deactivated_modules' ) );
 	}
+
+	public function test_active_modules_filter_restores_state() {
+		self::reset_tracking_of_module_activation();
+	
+		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
+		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'e2e_test_filter' ) );
+	
+		Jetpack::update_active_modules( array( 'monitor' ) );
+		$this->assertEquals( self::$activated_modules, array( 'monitor' ) );
+		$this->assertEquals(  self::$deactivated_modules, array() );
+	
+		Jetpack::update_active_modules( array( 'stats' ) );
+		$this->assertEquals( self::$activated_modules, array( 'monitor', 'stats') );
+		$this->assertEquals(  self::$deactivated_modules, array() );
+	
+		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'e2e_test_filter' ) );
+	
+		$active_modules = Jetpack::get_active_modules();
+		error_log('active mods are '  . print_r($active_modules, true));
+		$this->assertEquals(  $active_modules, array( 'monitor', 'stats' ) );
+	}
+	
+	public static function e2e_test_filter( $modules ) {
+		$disabled_modules = array( 'monitor' );
+	
+		foreach ( $disabled_modules as $module_slug ) {
+			$found = array_search( $module_slug, $modules );
+			if ( false !== $found ) {
+				unset( $modules[ $found ] );
+			}
+		}
+	
+		return $modules;
+	}	
 
 	public function test_get_other_linked_admins_one_admin_returns_false() {
 		delete_transient( 'jetpack_other_linked_admins' );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -171,7 +171,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
-		$this->assertEquals( array( 'json-api' ), $synced_value );
+		$this->assertEquals( array( 'stats', 'json-api' ), $synced_value );
 	}
 
 	function test_sync_always_sync_changes_to_home_siteurl_right_away() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -171,7 +171,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
-		$this->assertEquals( array( 1 => 'json-api' ), $synced_value );
+		$this->assertEquals( array( 'json-api' ), $synced_value );
 	}
 
 	function test_sync_always_sync_changes_to_home_siteurl_right_away() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -171,7 +171,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
-		$this->assertEquals( array( 'stats', 'json-api' ), $synced_value );
+		$this->assertEquals( array( 1 => 'json-api' ), $synced_value );
 	}
 
 	function test_sync_always_sync_changes_to_home_siteurl_right_away() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The functions that update active modules and deactivate a module cause an unintended overwrite in the options table. The bug was introduced by the introduction of the `jetpack_active_modules ` filter in #8465.

The issue with `deactivate_module()`:

* This function fetches the array of active modules([#](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L3013)), but this is the filtered value([#](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L2703)). Persisting([#](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L3016))this filtered value to the options table will remove disabled modules from the table as an unintended consequence. 

The issue with `update_active_modules ()`:

* This function incorrectly persists the new list of modules to the options table ([#](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L442)) but if filters have been applied on the modules list, then saving them to options will remove disabled modules as an unintended consequence. 


This PR fixes these issues by ensuring that filtered modules do not get deleted from the options table. 


#### Testing instructions:
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->

Add the following code snippet in [jetpack.php](https://github.com/Automattic/jetpack/blob/master/jetpack.php):

1. 
```
if ( Jetpack::is_module_active( 'sso' ) ) {
	add_filter( 'jetpack_active_modules', 'jetpack_test_module_override', 9 );
	function jetpack_test_module_override( $modules ) {
		$disabled_modules = array(
			'sitemaps',
		);
	 
		foreach ( $disabled_modules as $module_slug ) {
			$found = array_search( $module_slug, $modules );
			if ( false !== $found ) {
				unset( $modules[ $found ] );
			}
		}
		 
		return $modules;
	}
}

```

The above snippet will disable the `sitemaps` module every time the `sso` module is enabled. 

2. Navigate to [Jetpack modules page](http://niranjan.ngrok.io/wp-admin/admin.php?page=jetpack_modules) and activate `Sitemaps` module. 
3. Next, activate `Secure sign on` module. See that the `sitemaps` module now shows as inactive.
4. Deactivate `Secure sign on`. Now, `sitemaps` still remains deactivated.

#### What is expected 

Deactivating `sso` should have restored `sitemaps` to the same state(active) it was before activating `sso`.

#### What happened instead

`sitemaps` remained deactivated 

#### Apply PR
Now, apply this PR and repeat the above testing instruction steps. Verify that after `sso` is deactivated, `sitemaps` is restored to its `active` state.

<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* TBD
