### PR TITLE
Add User Agent detection for WordPress Desktop app

### DIFF
--- a/class.jetpack-user-agent.php
+++ b/class.jetpack-user-agent.php
@@ -1179,6 +1179,20 @@ class Jetpack_User_Agent_Info {
 	}
 
 
+	// Detect if user agent is the WordPress.com Desktop app.
+	static function is_wordpress_desktop_app( ) {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) )
+			return false;
+
+		$agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
+		$pos   = strpos( $agent, 'WordPressDesktop' );
+		if ( false !== $pos )
+			return true;
+		else
+			return false;
+	}
+
+
 	/*
 	 * is_blackberry_tablet() can be used to check the User Agent for a RIM blackberry tablet
 	 * The user agent of the BlackBerry® Tablet OS follows a format similar to the following:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This adds a new `Jetpack_User_Agent_Info::is_wordpress_desktop_app()` method to detect a request coming from the [WordPress Desktop app](https://apps.wordpress.com/desktop/)

Tags: #touches_jetpack_files
Differential Revision: D27548-code
This commit syncs r191332-wpcom.

#### Testing instructions:

This method isn't yet used in Jetpack.

#### Proposed changelog entry for your changes:

* None
