### PR TITLE
Subscriptions: hook checkboxes in comment submit field, not button

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -79,7 +79,7 @@ class Jetpack_Subscriptions {
 			add_action( 'template_redirect', array( $this, 'widget_submit' ) );
 
 		// Set up the comment subscription checkboxes
-		add_filter( 'comment_form_submit_button', array( $this, 'comment_subscribe_init' ), 10, 2 );
+		add_filter( 'comment_form_submit_field', array( $this, 'comment_subscribe_init' ), 10, 2 );
 
 		// Catch comment posts and check for subscriptions.
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );
@@ -596,7 +596,7 @@ class Jetpack_Subscriptions {
 	 *
 	 * Set up and add the comment subscription checkbox to the comment form.
 	 *
-	 * @param string $submit_button HTML markup for the submit button.
+	 * @param string $submit_button HTML markup for the submit field.
 	 * @param array  $args          Arguments passed to `comment_form()`.
 	 */
 	function comment_subscribe_init( $submit_button, $args ) {
@@ -670,7 +670,7 @@ class Jetpack_Subscriptions {
 		 */
 		$str = apply_filters( 'jetpack_comment_subscription_form', $str );
 
-		return $str . $submit_button;
+		return $submit_button . $str;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11957

#### Changes proposed in this Pull Request:

In #9983 and #11149, we changed the way the subscription fields were hooked into the comment form.

This makes sure we use the right hook for the job.

#### Testing instructions:

* Disable the Comment Form module. 
* In Settings > Discussion, make sure the subscription checkboxes are set.
* Visit a post when logged in, and when logged out.
* The checkboxes should appear above the comment submit button in both cases.
* Try to subscribe and make sure you still can.

#### Proposed changelog entry for your changes:

* Subscriptions: display checkboxes below the comment form with no errors or conflicts with other plugins.
