### PR TITLE
Blocks - Tiled Gallery: fix transformation into a slideshow block

### DIFF
--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -203,6 +203,11 @@ export const settings = {
 					return createBlock( 'core/image' );
 				},
 			},
+			{
+				type: 'block',
+				blocks: [ 'jetpack/slideshow' ],
+				transform: ( { images } ) => createBlock( 'jetpack/slideshow', { images }, [] ),
+			},
 		],
 	},
 	edit,


### PR DESCRIPTION
This PR solves the issue where images were lost after transforming a tiled gallery into a slideshow block.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12255

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* declare transformation into a Slideshow as part of the the transform-to property

![tiledslide](https://user-images.githubusercontent.com/1041600/57255545-75467580-702a-11e9-86cf-1a9caa09461d.gif)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* add a tiled gallery, transform it to a slideshow, transform it back to a tiled gallery
* add images, repeat the transformations
* ensure it's correctly transformed

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tiled galleries can now be correctly transformed to a Slideshow and will retain the images.
