### PR TITLE
Gutenframe: Fix post content scrolling when floated sidebar is available.

### DIFF
--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -154,9 +154,7 @@ a {
 		margin-top: inherit;
 		height: 100%;
 	}
-}
 
-@media (min-width: 782px) {
 	body.is-iframed.is-fullscreen-mode .edit-post-layout__content {
 		overflow-y: inherit;
 	}

--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -154,8 +154,4 @@ a {
 		margin-top: inherit;
 		height: 100%;
 	}
-
-	body.is-iframed.is-fullscreen-mode .edit-post-layout__content {
-		overflow-y: inherit;
-	}
 }

--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -143,15 +143,3 @@ a {
 .revisions-tooltip {
   transform: translateY(-36px);
 }
-
-/* IFRAME MODIFICATIONS */
-.is-iframed .edit-post-layout .components-notice-list {
-	top: inherit;
-}
-
-@media (min-width: 600px) {
-	body.block-editor-page.is-iframed.is-fullscreen-mode {
-		margin-top: inherit;
-		height: 100%;
-	}
-}

--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -154,4 +154,8 @@ a {
 		margin-top: inherit;
 		height: 100%;
 	}
+
+	body.is-iframed.is-fullscreen-mode .edit-post-layout__content {
+		overflow-y: inherit;
+	}
 }

--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -154,7 +154,9 @@ a {
 		margin-top: inherit;
 		height: 100%;
 	}
+}
 
+@media (min-width: 782px) {
 	body.is-iframed.is-fullscreen-mode .edit-post-layout__content {
 		overflow-y: inherit;
 	}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -232,6 +232,13 @@ class Jetpack_WPCOM_Block_Editor {
 			)
 		);
 
+		wp_enqueue_style(
+			'wpcom-block-editor-styles',
+			'//widgets.wp.com/wpcom-block-editor/style.css',
+			array(),
+			$version
+		);
+
 		if ( $this->is_iframed_block_editor() ) {
 			$src_calypso_iframe_bridge = $debug
 				? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.js?minify=false'

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -232,9 +232,12 @@ class Jetpack_WPCOM_Block_Editor {
 			)
 		);
 
+		$src_styles = $debug
+			? '//widgets.wp.com/wpcom-block-editor/common.css?minify=false'
+			: '//widgets.wp.com/wpcom-block-editor/common.min.css';
 		wp_enqueue_style(
 			'wpcom-block-editor-styles',
-			'//widgets.wp.com/wpcom-block-editor/style.css',
+			$src_styles,
 			array(),
 			$version
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/32637

If a Jetpack site's block editor is iframed in Calypso, it is not possible to scroll content at screen widths that allow the sidebar to be displayed on the right. The issue does not exist for viewports that result in a 100% width if the sidebar is opened (such as mobile).

#### Testing instructions:
* Apply this branch to your Jetpack testing site.
* Make sure your testing site is opted in to Gutenberg, and does not have the Classic Editor/Gutenberg plugins active.
* Using local Calypso on `master`, start a new post in Gutenframe: `http://calypso.localhost:3000/block-editor/post/:JPsite`. You can also use `wpcalypso.wordpress.com`, if your test site has an SSL certificate; secure sites can only iframe other secure sites.
* Make sure your viewport is at least 782px wide and fullscreen mode is active.
* Insert content that overflows the visible window, and verify you can scroll that content.
* Save the post.
* Install/activate the latest version of the Gutenberg plugin.
* Reload the previous post in Gutenframe again.
* Verify you can still scroll the post content.
* Make sure you the scroll is also enabled on the WP Admin block editor (`/wp-admin/post-new.php`) with both the Gutenberg plugin active and inactive.

#### Proposed changelog entry
* n/a