### PR TITLE
Blocks - Tiled Gallery: make WordPress add an srcset to its images

### DIFF
--- a/extensions/blocks/tiled-gallery/gallery-image/save.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/save.js
@@ -31,6 +31,7 @@ export default function GalleryImageSave( props ) {
 			data-url={ origUrl }
 			data-width={ width }
 			src={ url }
+			className={ `wp-image-${ id }` } // WordPress adds an srcset when it sees wp-image-${ id }
 		/>
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12272

The issue was not transforming the images into a tiled gallery. It was the absence of a `wp-image-XX` class in the `img` tag. WP [checks this](https://github.com/WordPress/WordPress/blob/master/wp-includes/media.php#L1324) to add an `srcset` attribute.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add the relevant class that WP core needs to add an srcset

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* add a tiled gallery, add images
* preview. Ensure the images have an srcset.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tiled Gallery: HTML image tags now have a proper srcset attribute.
