### PR TITLE
Vine: fix all phpcs warnings

### DIFF
--- a/modules/shortcodes/vine.php
+++ b/modules/shortcodes/vine.php
@@ -15,22 +15,34 @@
  * [embed]https://vine.co/v/bjHh0zHdgZT[/embed]
  * [embed width="300"]https://vine.co/v/bjHh0zHdgZT[/embed]
  * [embed type="postcard" width="300"]https://vine.co/v/bjHh0zHdgZT[/embed]
- **/
+ *
+ * @package Jetpack
+ */
 
+/**
+ * Handle Vine embeds.
+ *
+ * @param array  $matches Results after parsing the URL using the regex in wp_embed_register_handler().
+ * @param array  $attr    Embed attributes.
+ * @param string $url     The original URL that was matched by the regex.
+ * @param array  $rawattr The original unmodified attributes.
+ * @return string The embed HTML.
+ */
 function vine_embed_video( $matches, $attr, $url, $rawattr ) {
-	static $vine_flag_embedded_script;
-
 	$max_height = 300;
 	$type       = 'simple';
 
-	// Only allow 'postcard' or 'simple' types
-	if ( isset( $rawattr['type'] ) && $rawattr['type'] === 'postcard' ) {
+	// Only allow 'postcard' or 'simple' types.
+	if (
+		isset( $rawattr['type'] )
+		&& 'postcard' === $rawattr['type']
+	) {
 		$type = 'postcard';
 	}
 
 	$vine_size = Jetpack::get_content_width();
 
-	// If the user enters a value for width or height, we ignore the Jetpack::get_content_width()
+	// If the user enters a value for width or height, we ignore the Jetpack::get_content_width().
 	if ( isset( $rawattr['width'] ) || isset( $rawattr['height'] ) ) {
 		// 300 is the minimum size that Vine provides for embeds. Lower than that, the postcard embeds looks weird.
 		$vine_size = max( $max_height, min( $attr['width'], $attr['height'] ) );
@@ -41,17 +53,30 @@ function vine_embed_video( $matches, $attr, $url, $rawattr ) {
 	}
 
 	$url       = 'https://vine.co/v/' . $matches[1] . '/embed/' . $type;
-	$vine_html = sprintf( '<span class="embed-vine" style="display: block;"><iframe class="vine-embed" src="%s" width="%s" height="%s" frameborder="0"></iframe></span>', esc_url( $url ), (int) $vine_size, (int) $vine_size );
+	$vine_html = sprintf(
+		'<span class="embed-vine" style="display: block;"><iframe class="vine-embed" src="%1$s" width="%2$d" height="%3$d" frameborder="0"></iframe></span>',
+		esc_url( $url ),
+		(int) $vine_size,
+		(int) $vine_size
+	);
 
-	if ( $vine_flag_embedded_script !== true ) {
-		$vine_html                .= '<script async src="//platform.vine.co/static/scripts/embed.js" charset="utf-8"></script>';
-		$vine_flag_embedded_script = true;
-	}
+	wp_enqueue_script(
+		'vine-embed',
+		'https://platform.vine.co/static/scripts/embed.js',
+		array(),
+		JETPACK__VERSION,
+		true
+	);
 
 	return $vine_html;
 }
 wp_embed_register_handler( 'jetpack_vine', '#https?://vine.co/v/([a-z0-9]+).*#i', 'vine_embed_video' );
 
+/**
+ * Display the Vine shortcode.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function vine_shortcode( $atts ) {
 	global $wp_embed;
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This should bring the Vine shortcode in sync with WordPress.com.
It also moves away from enqueuing the JS inline to using wp_enqueue_script().

Tags: #touches_jetpack_files

Differential Revision: D27904-code

This commit syncs r191436-wpcom.

#### Testing instructions:

- Try inserting any of the embeds into post.
- You can also try to insert multiple vines into one post.

**Note that embeds should embed, but will not play. This is caused by an issue on Vine's end. I reported it to them here:
https://twittercommunity.com/t/vine-co-simple-embeds-broken/125569**
If it turns out that the embeds are not maintained anymore, I'll update our shortcode again to only display links.

#### Proposed changelog entry for your changes:

* None
