### PR TITLE
Tiled gallery & Slideshow blocks: fix transforms between blocks

### DIFF
--- a/extensions/blocks/slideshow/transforms.js
+++ b/extensions/blocks/slideshow/transforms.js
@@ -20,9 +20,9 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],
-			isMatch: attributes => getValidImages( attributes ).length > 0,
-			transform: attributes => {
-				const validImages = getValidImages( attributes );
+			isMatch: images => getValidImages( images ).length > 0,
+			transform: images => {
+				const validImages = getValidImages( images );
 				return createBlock( 'jetpack/slideshow', {
 					images: validImages.map( ( { alt, caption, id, url } ) => ( {
 						alt,
@@ -37,8 +37,8 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/gallery', 'jetpack/tiled-gallery' ],
-			transform: attributes => {
-				const validImages = getValidImages( attributes );
+			transform: ( { images } ) => {
+				const validImages = getValidImages( images );
 				if ( validImages.length > 0 ) {
 					return createBlock( 'jetpack/slideshow', {
 						images: validImages.map( ( { alt, caption, id, url } ) => ( {
@@ -47,6 +47,7 @@ const transforms = {
 							id,
 							url,
 						} ) ),
+						ids: validImages.map( ( { id } ) => id ),
 					} );
 				}
 				return createBlock( 'jetpack/slideshow' );
@@ -57,12 +58,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/gallery' ],
-			transform: ( { images } ) => createBlock( 'core/gallery', { images } ),
-		},
-		{
-			type: 'block',
-			blocks: [ 'jetpack/tiled-gallery' ],
-			transform: ( { images } ) => createBlock( 'jetpack/tiled-gallery', { images }, [] ),
+			transform: ( { images, ids } ) => createBlock( 'core/gallery', { images, ids } ),
 		},
 		{
 			type: 'block',

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -153,9 +153,9 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ 'core/image' ],
-				isMatch: attributes => getValidImages( attributes ).length > 0,
-				transform: attributes => {
-					const validImages = getValidImages( attributes );
+				isMatch: images => getValidImages( images ).length > 0,
+				transform: images => {
+					const validImages = getValidImages( images );
 					return createBlock( `jetpack/${ name }`, {
 						images: validImages.map( ( { id, url, alt } ) => ( {
 							id,
@@ -169,8 +169,8 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/gallery', 'jetpack/slideshow' ],
-				transform: attributes => {
-					const validImages = getValidImages( attributes.images );
+				transform: ( { images } ) => {
+					const validImages = getValidImages( images );
 					if ( validImages.length > 0 ) {
 						return createBlock( `jetpack/${ name }`, {
 							images: validImages.map( ( { id, url, alt } ) => ( {
@@ -178,6 +178,7 @@ export const settings = {
 								url,
 								alt,
 							} ) ),
+							ids: validImages.map( ( { id } ) => id ),
 						} );
 					}
 					return createBlock( `jetpack/${ name }` );
@@ -188,8 +189,8 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/gallery' ],
-				transform: ( { images, columns, linkTo } ) =>
-					createBlock( 'core/gallery', { images, columns, imageCrop: true, linkTo } ),
+				transform: ( { images, ids, columns, linkTo } ) =>
+					createBlock( 'core/gallery', { images, ids, columns, imageCrop: true, linkTo } ),
 			},
 			{
 				type: 'block',


### PR DESCRIPTION
Fix lost attributes, fix colliding transforms and improve confusing variable names.

Fixes https://github.com/Automattic/jetpack/issues/12255, closes https://github.com/Automattic/jetpack/pull/12278 (supersedes)

#### Changes proposed in this Pull Request:
- In "from core/image" transforms use `images` instead of `attributes` for less confusion
- Remove "to tiled gallery" transform in Slideshow block since Tiled gallery already has "from Slideshow" transform. Otherwise, we get JS failure.
- Ensure we create `ids` attribute between core gallery, tiled gallery and slideshow transform so that blocks don't end up without them.
- Ensure we pass `attributes.images` array, not `attributes` object  to `getValidImages()` function.


#### Testing instructions:
There is lot to click but this is fairly straightforward: ensure that you can transform between _all_ these blocks with and without images: tiled gallery, slideshow, core gallery, image.

With image blocks test also by selecting multiple images (using shift key). Bonus points if one or all of the images contain URLs (and not uploaded images).

Confirm by looking at code editor that slideshow, tiled gallery and core gallery blocks have `ids` attribute after each transformation:
<img width="300" alt="Screenshot 2019-05-07 at 14 29 26" src="https://user-images.githubusercontent.com/87168/57296916-daf03b80-70d6-11e9-8ccb-d7f96d28cecf.png">

<img width="487" alt="Screenshot 2019-05-07 at 14 29 26" src="https://user-images.githubusercontent.com/87168/57296921-df1c5900-70d6-11e9-9874-f51c3f01b9c7.png">

The only transform you won't find is from core/image to slideshow & tiled gallery when the block does not have an image. When the block has an image, the transform **is** available. No change with `master` here; just something to confirm it works as it used to.

<img width="777" alt="Screenshot 2019-05-07 at 14 50 26" src="https://user-images.githubusercontent.com/87168/57297161-8600f500-70d7-11e9-961d-5e8929464f63.png">

It's easy enough to add but that would be a new feature so not in the scope of this PR.


#### Proposed changelog entry for your changes:
*
