### PR TITLE
General: Remove pre-5.1 era code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ matrix:
   - php: "5.2"
     env: WP_MODE=single WP_BRANCH=5.1
     dist: precise
-  - php: "5.2"
-    env: WP_MODE=single WP_BRANCH=5.0
-    dist: precise
   - if: branch !~ /(^branch-.*-built)/
     language: node_js
     env: WP_TRAVISCI="yarn lint"

--- a/jetpack.php
+++ b/jetpack.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '5.0' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.1' );
 
 define( 'JETPACK__VERSION',            '7.4-alpha' );
 define( 'JETPACK_MASTER_USER',         true );

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -374,16 +374,14 @@ class Jetpack_Plugin_Search {
 	 *
 	 * @since 7.1.0
 	 * @since 7.2.0 Only remove Jetpack.
+	 * @since 7.4.0 Simplify for WordPress 5.1+.
 	 *
 	 * @param array|object $plugin
 	 *
 	 * @return bool
 	 */
 	function filter_cards( $plugin ) {
-		// Take in account that before WordPress 5.1, the list of plugins is an array of objects.
-		// With WordPress 5.1 the list of plugins is an array of arrays.
-		$slug = is_array( $plugin ) ? $plugin['slug'] : $plugin->slug;
-		return ! in_array( $slug, array( 'jetpack' ), true );
+		return ! in_array( $plugin['slug'], array( 'jetpack' ), true );
 	}
 
 	/**

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -384,15 +384,17 @@ EOT;
 		);
 
 		/*
-		Below is a hack to get the block content to render correctly.
-
-		This functionality should be covered in /inc/blocks.php but due to an error,
-		this has not been fixed as of this writing.
-
-		Alda has submitted a patch to Core in order to have this issue fixed at
-		https://core.trac.wordpress.org/attachment/ticket/45495/do_blocks.diff and
-		hopefully it makes to to the final RC of WP 5.1.
-		*/
+		 * Below is a hack to get the block content to render correctly.
+		 *
+		 * This functionality should be covered in /inc/blocks.php but due to an error,
+		 * this has not been fixed as of this writing.
+		 *
+		 * Alda has submitted a patch to Core in order to have this issue fixed at
+		 * https://core.trac.wordpress.org/ticket/45495 and
+		 * made it into WordPress 5.2.
+		 *
+		 * @todo update when WP 5.2 is the minimum support version.
+		 */
 		$priority = has_filter( 'the_content', 'wpautop' );
 		remove_filter( 'the_content', 'wpautop', $priority );
 		add_filter( 'the_content', '_restore_wpautop_hook', $priority + 1 );

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -603,7 +603,7 @@ if ( ! function_exists( 'crowdsignal_link' ) ) {
 	 * This should be removed after Core has the current regex is in our minimum version.
 	 *
 	 * @see https://core.trac.wordpress.org/ticket/46467
-	 * @todo Confirm patch landed and remove once 5.2 is the minimum version.
+	 * @todo Remove once 5.2 is the minimum version.
 	 */
 wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -384,7 +384,14 @@ class Jetpack_Sync_Functions {
 		/* translators: %s is UTC offset, e.g. "+1" */
 		return sprintf( __( 'UTC%s', 'jetpack' ), $formatted_gmt_offset );
 	}
-	// New in WP 5.1
+
+	/**
+	 * Return list of paused themes.
+	 *
+	 * @todo Remove function_exists check when WP 5.2 is the minimum.
+	 *
+	 * @return array|bool Array of paused themes or false if unsupported.
+	 */
 	public static function get_paused_themes() {
 		if ( function_exists( 'wp_paused_themes' ) ) {
 			$paused_themes = wp_paused_themes();
@@ -392,7 +399,14 @@ class Jetpack_Sync_Functions {
 		}
 		return false;
 	}
-	// New in WP 5.1
+
+	/**
+	 * Return list of paused plugins.
+	 *
+	 * @todo Remove function_exists check when WP 5.2 is the minimum.
+	 *
+	 * @return array|bool Array of paused plugins or false if unsupported.
+	 */
 	public static function get_paused_plugins() {
 		if ( function_exists( 'wp_paused_plugins' ) ) {
 			$paused_plugins = wp_paused_plugins();

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -117,13 +117,4 @@ function in_running_uninstall_group() {
 
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist
-// @todo Remove version check when 5.1 is the minimum WP version.
-if ( file_exists( $test_root . '/includes/listener-loader.php' ) ) {
-	// version 5.1 and higher could have this set.
-	require $test_root . '/includes/listener-loader.php';
-} else {
-	if ( file_exists( require $test_root . '/includes/speed-trap-listener.php' ) ) {
-		echo 'UPDATE YOUR WP CORE TESTS HELPERS!';
-		require $test_root . '/includes/speed-trap-listener.php';
-	}
-}
+require $test_root . '/includes/listener-loader.php';


### PR DESCRIPTION
A quick first pass at removing code required for WP 5.0 compatibility as WP 5.2 is slated to ship today (making our minimum 5.1).

A couple references for 5.1 removal were for features that, in the end, didn't land in 5.1, so bumping them to 5.2 which landed them.

#### Changes proposed in this Pull Request:
* Remove legacy code.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Janitorial, not a new feature.

#### Testing instructions:
* Run unit tests, related posts, and plugin search hints.
*

#### Proposed changelog entry for your changes:
* n/a
