### PR TITLE
Display Posts Widget: Remove overly opinionated CSS

### DIFF
--- a/modules/widgets/wordpress-post-widget/style.css
+++ b/modules/widgets/wordpress-post-widget/style.css
@@ -3,20 +3,13 @@
 }
 
 .jetpack-display-remote-posts h4 {
-	font-size: 90%;
 	margin: 5px 0;
 	padding: 0;
 }
 
-.jetpack-display-remote-posts h4 a {
-	text-decoration: none;
-}
-
 .jetpack-display-remote-posts p {
-	margin: 0 !important;
+	margin: 0;
 	padding: 0;
-	line-height: 1.4em !important;
-	font-size: 90%;
 }
 
 .jetpack-display-remote-posts img {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

We have some very opinionated CSS in the remote posts widget at the moment, in #1886 we were asked to remove the `!important` declarations, allowing themes greater control. I have gone a little further to ensure we inherit theme styles as much as possible.

I have done some basic testing the the twenty themes, most of these already supply custom CSS for the widget so there is not a great deal of change to be observed.

We could probably take this further and remove the margin values as well but I am reluctant to make too many changes in one sweep.

Fixes #1886

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The CSS has been simplified

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add "Display WordPress posts (Jetpack)" widget to a widget area
* Complete the fields, along with a random selection of options
* Observe the look and feel of the widget
* Pull down this PR
* Observe the look and feel of the widget

Are the differences a concern? Does the widget fit better or worse with the existing theme styles?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Display Posts Widget: Remove overly opinionated CSS, please check your themes
