### PR TITLE
Travis CI: add a script to trigger a custom phpunit job 

### DIFF
--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -4,6 +4,11 @@ echo "Travis CI command: $WP_TRAVISCI"
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
+echo "!!!! DEBUG OUTPUT"
+echo $WP_TRAVISCI
+echo $TRAVIS_EVENT_TYPE
+echo $PHPUNIT_COMMAND_OVERRIDE
+
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -4,17 +4,17 @@ echo "Travis CI command: $WP_TRAVISCI"
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
-echo "!!!! DEBUG OUTPUT"
-echo $WP_TRAVISCI
-echo $TRAVIS_EVENT_TYPE
-echo $PHPUNIT_COMMAND_OVERRIDE
-
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
-		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
+		export WP_TRAVISCI=""phpunit --group {PHPUNIT_COMMAND_OVERRIDE}"
 	fi
+
+	echo "!!!! DEBUG OUTPUT"
+echo $WP_TRAVISCI
+echo $TRAVIS_EVENT_TYPE
+echo $PHPUNIT_COMMAND_OVERRIDE
 
 	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -8,7 +8,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
-		export WP_TRAVISCI=""phpunit --group {PHPUNIT_COMMAND_OVERRIDE}"
+		export WP_TRAVISCI="phpunit --group {PHPUNIT_COMMAND_OVERRIDE}"
 	fi
 
 	echo "!!!! DEBUG OUTPUT"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -8,14 +8,8 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
-		export WP_TRAVISCI="phpunit --group ${PHPUNIT_COMMAND_OVERRIDE}"
+		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	fi
-
-	echo "!!!! DEBUG OUTPUT"
-	echo $WP_TRAVISCI
-	echo $TRAVIS_EVENT_TYPE
-	echo $PHPUNIT_COMMAND_OVERRIDE
-	echo $PHPUNIT_COMMAND_OVERRIDE2
 
 	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -12,9 +12,10 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	fi
 
 	echo "!!!! DEBUG OUTPUT"
-echo $WP_TRAVISCI
-echo $TRAVIS_EVENT_TYPE
-echo $PHPUNIT_COMMAND_OVERRIDE
+	echo $WP_TRAVISCI
+	echo $TRAVIS_EVENT_TYPE
+	echo $PHPUNIT_COMMAND_OVERRIDE
+	echo $PHPUNIT_COMMAND_OVERRIDE2
 
 	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -13,7 +13,7 @@ echo $PHPUNIT_COMMAND_OVERRIDE
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
-		export WP_TRAVISCI=${PHPUNIT_COMMAND_OVERRIDE}
+		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	fi
 
 	echo "Running \`$WP_TRAVISCI\` with:"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -7,9 +7,11 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
+	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
+		export WP_TRAVISCI=${PHPUNIT_COMMAND_OVERRIDE}
 	fi
 
-	echo "Running phpunit with:"
+	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"
 	echo " - WordPress mode: $WP_MODE"
 	echo " - WordPress branch: $WP_BRANCH"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -8,7 +8,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 		export WP_TRAVISCI="phpunit --group external-http"
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
-		export WP_TRAVISCI="phpunit --group {PHPUNIT_COMMAND_OVERRIDE}"
+		export WP_TRAVISCI="phpunit --group ${PHPUNIT_COMMAND_OVERRIDE}"
 	fi
 
 	echo "!!!! DEBUG OUTPUT"

--- a/tools/trigger-travis-build.sh
+++ b/tools/trigger-travis-build.sh
@@ -18,7 +18,7 @@ function send_travis_api_request {
 			\"config\": {
 				\"merge_mode\": \"deep_merge\",
 				\"env\": {
-					\"PHPUNIT_COMMAND_OVERRIDE\": \"phpunit --group ${GROUP_NAME}\"
+					\"global\": [\"PHPUNIT_COMMAND_OVERRIDE=${GROUP_NAME}\"]
 				},
 				\"branches\": {
 					\"only\": [\"${BRANCH_NAME}\"]
@@ -27,7 +27,7 @@ function send_travis_api_request {
 		}
 	}"
 
-	if [[ ! $DRY_RUN=="true" ]]; then
+	if [[ $DRY_RUN=="true" ]]; then
 		echo $DRY_RUN
 		echo "DRY RUN! Not sending an actual request"
 		echo $body

--- a/tools/trigger-travis-build.sh
+++ b/tools/trigger-travis-build.sh
@@ -18,7 +18,8 @@ function send_travis_api_request {
 			\"config\": {
 				\"merge_mode\": \"deep_merge\",
 				\"env\": {
-					\"global\": [\"PHPUNIT_COMMAND_OVERRIDE=${GROUP_NAME}\"]
+					\"PHPUNIT_COMMAND_OVERRIDE2\":\"${GROUP_NAME}\"
+					\"global\": [\"PHPUNIT_COMMAND_OVERRIDE=${GROUP_NAME}\", \"WP_TRAVISCI=phpunit\"]
 				},
 				\"branches\": {
 					\"only\": [\"${BRANCH_NAME}\"]

--- a/tools/trigger-travis-build.sh
+++ b/tools/trigger-travis-build.sh
@@ -27,7 +27,7 @@ function send_travis_api_request {
 		}
 	}"
 
-	if [[ $DRY_RUN=="true" ]]; then
+	if [ ! -z ${DRY_RUN} ]; then
 		echo $DRY_RUN
 		echo "DRY RUN! Not sending an actual request"
 		echo $body

--- a/tools/trigger-travis-build.sh
+++ b/tools/trigger-travis-build.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Instructions
+function usage {
+	echo "usage: $0 [ -g <groupname>] [-g <groupname> -b <branchname>]"
+	echo "  -g     Name of the test group or testsuite name as defined in phpunit.xml.dist (Default: external-http)"
+	echo "  -t     Custom Travis API token"
+	echo "  -b     Branch to use (Default: your local branch)"
+	echo "  -h     Show this message"
+	exit 0
+}
+
+function send_travis_api_request {
+	body="{
+		\"request\": {
+			\"branch\": \"${BRANCH_NAME}\",
+			\"config\": {
+				\"merge_mode\": \"deep_merge\",
+				\"env\": {
+					\"global\": ['PHPUNIT_COMMAND_OVERRIDE=\"phpunit --group ${GROUP_NAME}\"']
+				}
+			}
+		}
+	}"
+
+	echo $body
+
+		curl -v -s -X POST \
+		-H "Content-Type: application/json" \
+		-H "Accept: application/json" \
+		-H "Travis-API-Version: 3" \
+		-H "Authorization: token ${TRAVIS_TOKEN}" \
+		-d "$body" \
+		https://api.travis-ci.org/repo/Automattic%2Fjetpack/requests
+		# -H "Authorization: token ${TOKEN}" \
+}
+
+function validate_input {
+	for index in "${!opts_array[@]}"; do
+		# checking if the Travis token is properly set.
+		if [[ ${opts_array[index]} == "TOKEN" && -z "$TOKEN" ]]; then
+			if [ -z "$TRAVIS_TOKEN" ]; then
+				echo "Sorry! Travis token is not set. Make sure to set a \$TRAVIS_TOKEN env variable, or pass it via '-t' option. You can get one right here: https://travis-ci.org/account/preferences"
+				exit 1
+			else
+				TOKEN=$TRAVIS_TOKEN
+			fi
+
+		# figuring out what branch to use
+		elif [[ ${opts_array[index]} == "BRANCH_NAME" ]]; then
+			if [ -z "$BRANCH_NAME" ]; then
+				BRANCH_NAME=$CURRENT_BRANCH
+				echo "Using your current \"${CURRENT_BRANCH}\" branch."
+			fi
+
+		# figuring out what test group to run
+		elif [[ ${opts_array[index]} == "GROUP_NAME" ]]; then
+			if [ -z "$GROUP_NAME" ]; then
+				GROUP_NAME=$DEFAULT_GROUP
+				echo "Running tests for default \"${GROUP_NAME}\" test group."
+			fi
+		fi
+	done
+}
+
+# Current directory and current branch vars
+DIR=$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" )
+CURRENT_BRANCH=$( git branch | grep -e "^*" | cut -d' ' -f 2 )
+DEFAULT_GROUP="external-http"
+
+
+while getopts g:t:b: option; do
+	case "${option}" in
+		g)
+			GROUP_NAME=${OPTARG}
+			echo "GROUP_NAME: ${GROUP_NAME}"
+			;;
+		t)
+			TOKEN=${OPTARG}
+			echo "TOKEN: ${TOKEN}"
+			;;
+		b)
+			BRANCH_NAME=${OPTARG}
+			echo "BRANCH_NAME: ${BRANCH_NAME}"
+			;;
+		\? )
+			echo "Invalid Option: -$OPTARG" 1>&2
+			exit 1
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+opts_array=(GROUP_NAME TOKEN BRANCH_NAME)
+
+echo "!!!!!!!!!!!"
+validate_input
+echo "!!!!!!!!!!!"
+send_travis_api_request
+
+echo $response
+echo response
+
+# Make sure we don't have uncommitted changes.
+# if [[ -n $( git status -s --porcelain ) ]]; then
+# 	echo "Uncommitted changes found."
+# 	echo "Please deal with them and try again clean."
+# 	exit 1
+# fi
+
+
+# # Check the command
+# if [[ 'new' == $COMMAND || '-n' == $COMMAND ]]; then
+# 	echo "WHATEWER!!"
+# elif [[ 'update' = $COMMAND || '-u' = $COMMAND ]]; then
+# 	# It's possible they passed the branch name directly to the script
+# 	if [[ -z $2 ]]; then
+# 		read -p "What branch are you updating? (enter full branch name): " branch
+# 		UPDATE_BUILT_BRANCH=$branch
+# 	else
+# 		UPDATE_BUILT_BRANCH=$2
+# 	fi
+# elif [[ '-h' = $COMMAND ]]; then
+# 	usage
+# else
+# 	usage
+# fi

--- a/tools/trigger-travis-build.sh
+++ b/tools/trigger-travis-build.sh
@@ -18,8 +18,10 @@ function send_travis_api_request {
 			\"config\": {
 				\"merge_mode\": \"deep_merge\",
 				\"env\": {
-					\"PHPUNIT_COMMAND_OVERRIDE2\":\"${GROUP_NAME}\"
-					\"global\": [\"PHPUNIT_COMMAND_OVERRIDE=${GROUP_NAME}\", \"WP_TRAVISCI=phpunit\"]
+					\"global\": {
+						\"PHPUNIT_COMMAND_OVERRIDE\": \"'phpunit --group ${GROUP_NAME}'\",
+						\"WP_TRAVISCI\": \"phpunit\"
+					}
 				},
 				\"branches\": {
 					\"only\": [\"${BRANCH_NAME}\"]


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Script provides a way to trigger a Travis CI build with custom phpunit arguments, which allows running specific test group in CI.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a Travis API token from https://travis-ci.org/account/preferences
* You might want to use `-d` to not to trigger an actual CI build (there is a rate limit - 10 builds / hour) 
* run `./tools/trigger-travis-build.sh -h` to see available options
* run `./tools/trigger-travis-build.sh`. You should see a message about missing travis token
* run `TRAVIS_TOKEN=YOUR_TOKEN ./tools/trigger-travis-build.sh` and `./tools/trigger-travis-build.sh -t YOUR_TOKEN` to trigger a "default" route. 
* try  setting a branch name with `-b` flag
* try setting a test group with `-g` flag.

default Travis build is failing right now due to the issue with `json-api` multisite test: https://github.com/Automattic/jetpack/pull/12246

Example build can be found here: https://travis-ci.org/Automattic/jetpack/builds/529787510

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
