### PR TITLE
Masterbar: display a Hamburger menu on mobile

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -465,7 +465,7 @@ class A8C_WPCOM_Masterbar {
 		);
 
 		// Restore dashboard menu toggle that is needed on mobile views.
-		if ( is_admin() ) {
+		if ( is_admin() && wp_is_mobile() ) {
 			$wp_admin_bar->add_menu(
 				array(
 					'id'    => 'menu-toggle',

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -463,5 +463,16 @@ class A8C_WPCOM_Masterbar {
 				),
 			)
 		);
+
+		// Restore dashboard menu toggle that is needed on mobile views.
+		if ( is_admin() ) {
+			$wp_admin_bar->add_menu(
+				array(
+					'id'    => 'menu-toggle',
+					'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . esc_html__( 'Menu', 'jetpack' ) . '</span>',
+					'href'  => '#',
+				)
+			);
+		}
 	}
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -287,6 +287,9 @@ class A8C_WPCOM_Masterbar {
 
 		$this->add_me_submenu( $wp_admin_bar );
 		$this->add_write_button( $wp_admin_bar );
+
+		// Add a sidebar toggle on mobile.
+		wp_admin_bar_sidebar_toggle( $wp_admin_bar );
 	}
 
 	/**
@@ -463,16 +466,5 @@ class A8C_WPCOM_Masterbar {
 				),
 			)
 		);
-
-		// Restore dashboard menu toggle. This toggle is hidden with CSS on non-mobile views.
-		if ( is_admin() ) {
-			$wp_admin_bar->add_menu(
-				array(
-					'id'    => 'menu-toggle',
-					'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . esc_html__( 'Menu', 'jetpack' ) . '</span>',
-					'href'  => '#',
-				)
-			);
-		}
 	}
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -464,8 +464,8 @@ class A8C_WPCOM_Masterbar {
 			)
 		);
 
-		// Restore dashboard menu toggle that is needed on mobile views.
-		if ( is_admin() && wp_is_mobile() ) {
+		// Restore dashboard menu toggle. This toggle is hidden with CSS on non-mobile views.
+		if ( is_admin() ) {
 			$wp_admin_bar->add_menu(
 				array(
 					'id'    => 'menu-toggle',


### PR DESCRIPTION
Follow-up from #11766

#### Changes proposed in this Pull Request:

This Hamburger menu is necessary so folks can access the wp-admin navigation on mobile.

Without it, when on mobile, one has no way to go from one wp-admin page to another:

![image](https://user-images.githubusercontent.com/426388/57376488-62ee4800-71a0-11e9-81f4-bd3d1dacedeb.png)

#### Testing instructions:

* Connect Jetpack to WordPress.com on a new site, and enable the WordPress.com Toolbar feature under Jetpack > Settings > Writing
* On Mobile, go to the main wp-admin page, `/wp-admin/`
* Attempt to go to Tools > Site Health => You can't.
* Apply patch. 
* You now have a Hamburger menu you can use.
![image](https://user-images.githubusercontent.com/426388/57376628-ca0bfc80-71a0-11e9-861d-d0650e504ecd.png)


#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: restore navigation hamburger on mobile.
