### PR TITLE
Remove inline learn more prompts on comments section

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -14,6 +14,9 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import CompactFormToggle from 'components/form/form-toggle/compact';
+import SupportInfo from 'components/support-info';
+
+import './style.scss';
 
 class CommentsComponent extends React.Component {
 	/**
@@ -135,110 +138,81 @@ class CommentsComponent extends React.Component {
 				{ ( foundGravatar || foundMarkdown || foundCommentLikes ) && (
 					<SettingsGroup>
 						{ foundGravatar && (
-							<FormFieldset>
-								<ModuleToggle
-									slug="gravatar-hovercards"
-									compact
-									activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
-									toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
-									toggleModule={ this.props.toggleModuleNow }
-								>
-									<span className="jp-form-toggle-explanation">
-										{ gravatar.description + ' ' }
-										<a
-											href={ gravatar.learn_more_button }
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											{ __( 'Learn more' ) }
-										</a>
-										<span className="jp-form-toggle-privacy-info">
-											<a
-												href={ gravatar.learn_more_button + '#privacy' }
-												target="_blank"
-												rel="noopener noreferrer"
-											>
-												{ __( 'Privacy Information' ) }
-											</a>
-										</span>
-									</span>
-								</ModuleToggle>
-							</FormFieldset>
+							<div className="jp-toggle-set">
+								<FormFieldset>
+									<ModuleToggle
+										slug="gravatar-hovercards"
+										compact
+										activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
+										toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
+										toggleModule={ this.props.toggleModuleNow }
+									>
+										<span className="jp-form-toggle-explanation">{ gravatar.description }</span>
+									</ModuleToggle>
+								</FormFieldset>
+								<SupportInfo
+									text={ __( 'Show Gravatar hover cards alongside comments.' ) }
+									link={ gravatar.learn_more_button }
+									privacyLink={ gravatar.learn_more_button + '#privacy' }
+								/>
+							</div>
 						) }
 						{ foundMarkdown && (
-							<FormFieldset>
-								<CompactFormToggle
-									checked={
-										!! this.props.getOptionValue(
-											'wpcom_publish_comments_with_markdown',
-											'markdown'
-										)
-									}
-									disabled={
-										this.props.isSavingAnyOption( [
+							<div className="jp-toggle-set">
+								<FormFieldset>
+									<CompactFormToggle
+										checked={
+											!! this.props.getOptionValue(
+												'wpcom_publish_comments_with_markdown',
+												'markdown'
+											)
+										}
+										disabled={
+											this.props.isSavingAnyOption( [
+												'markdown',
+												'wpcom_publish_comments_with_markdown',
+											] ) || 'inactive' === this.props.getModuleOverride( 'markdown' )
+										}
+										toggling={ this.props.isSavingAnyOption( [
 											'markdown',
 											'wpcom_publish_comments_with_markdown',
-										] ) || 'inactive' === this.props.getModuleOverride( 'markdown' )
-									}
-									toggling={ this.props.isSavingAnyOption( [
-										'markdown',
-										'wpcom_publish_comments_with_markdown',
-									] ) }
-									onChange={ this.handleMarkdownCommentsToggle }
-								>
-									<span className="jp-form-toggle-explanation">
-										{ __( 'Enable Markdown use for comments.' ) + ' ' }
-										<a
-											href={ markdown.learn_more_button }
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											{ __( 'Learn more' ) }
-										</a>
-										<span className="jp-form-toggle-privacy-info">
-											<a
-												href={ markdown.learn_more_button + '#privacy' }
-												target="_blank"
-												rel="noopener noreferrer"
-											>
-												{ __( 'Privacy Information' ) }
-											</a>
+										] ) }
+										onChange={ this.handleMarkdownCommentsToggle }
+									>
+										<span className="jp-form-toggle-explanation">
+											{ __( 'Enable Markdown use for comments.' ) }
 										</span>
-									</span>
-								</CompactFormToggle>
-							</FormFieldset>
+									</CompactFormToggle>
+								</FormFieldset>
+								<SupportInfo
+									text={ __( 'Allow readers to use markdown in comments.' ) }
+									link={ markdown.learn_more_button }
+									privacyLink={ markdown.learn_more_button + '#privacy' }
+								/>
+							</div>
 						) }
 						{ foundCommentLikes && (
-							<FormFieldset>
-								<ModuleToggle
-									slug="comment-likes"
-									compact
-									disabled={ commentLikesUnavailable }
-									activated={ commentLikesActive }
-									toggling={ this.props.isSavingAnyOption( 'comment-likes' ) }
-									toggleModule={ this.props.toggleModuleNow }
-								>
-									<span className="jp-form-toggle-explanation">
-										{ 'Enable comment likes.' + ' ' }
-										<a
-											href="https://jetpack.com/support/comment-likes/"
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											{ __( 'Learn more' ) }
-										</a>
-										<span className="jp-form-toggle-privacy-info">
-											<a
-												href="https://jetpack.com/support/comment-likes/#privacy"
-												target="_blank"
-												rel="noopener noreferrer"
-											>
-												{ __( 'Privacy Information' ) }
-											</a>
+							<div className="jp-toggle-set">
+								<FormFieldset>
+									<ModuleToggle
+										slug="comment-likes"
+										compact
+										disabled={ commentLikesUnavailable }
+										activated={ commentLikesActive }
+										toggling={ this.props.isSavingAnyOption( 'comment-likes' ) }
+										toggleModule={ this.props.toggleModuleNow }
+									>
+										<span className="jp-form-toggle-explanation">
+											{ __( 'Enable comment likes.' ) }
 										</span>
-									</span>
-								</ModuleToggle>
-							</FormFieldset>
+									</ModuleToggle>
+								</FormFieldset>
+								<SupportInfo
+									text={ __( 'Allow readers to like individual comments.' ) }
+									link="https://jetpack.com/support/comment-likes/"
+									privacyLink="https://jetpack.com/support/comment-likes/#privacy"
+								/>
+							</div>
 						) }
 					</SettingsGroup>
 				) }

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -151,7 +151,7 @@ class CommentsComponent extends React.Component {
 									</ModuleToggle>
 								</FormFieldset>
 								<SupportInfo
-									text={ __( 'Show Gravatar hover cards alongside comments.' ) }
+									text={ __( 'Show Gravatar hovercards alongside comments.' ) }
 									link={ gravatar.learn_more_button }
 									privacyLink={ gravatar.learn_more_button + '#privacy' }
 								/>

--- a/_inc/client/discussion/style.scss
+++ b/_inc/client/discussion/style.scss
@@ -1,0 +1,16 @@
+@import '../scss/rem';
+@import '../scss/layout';
+
+.jp-form-settings-group .jp-toggle-set {
+	position: relative;
+
+	.jp-support-info {
+		right: rem( -20px );
+		top: rem( 5px );
+
+		@include breakpoint( "<480px" ) {
+			right: rem( -32px );
+			top: rem( 5px );
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Moves the inline learn more and privacy links into an (i) icon (support info component), creating a more consistent approach to these links as suggested in #6908

I would like a review of the copy used in the pop overs:

> Show Gravatar hover cards alongside comments.'

> Allow readers to use markdown in comments.

> Allow readers to like individual comments.

Fixes #6908

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove inline 'learn more' prompts in favour of support info component

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Not a new feature, I am working through old PRs with the 'Needs Design / Review' labels and making chances as necessary. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings -> Discussion -> Comments
* View the inline more links on this card
* Pull down the new PR
* Compare the new approach, check it all screens sizes
* Also look for other learn more links I might have missed

Before:

![Screenshot 2019-05-08 at 17 11 54](https://user-images.githubusercontent.com/411945/57390493-655a9d00-71b4-11e9-9d43-894d29edf6e0.png)

After:

![Screenshot 2019-05-08 at 16 03 20](https://user-images.githubusercontent.com/411945/57390434-40662a00-71b4-11e9-91a2-913dd2b105d1.png)
![Screenshot 2019-05-08 at 16 03 28](https://user-images.githubusercontent.com/411945/57390435-40662a00-71b4-11e9-812c-2cf583e657a2.png)
![Screenshot 2019-05-08 at 16 03 39](https://user-images.githubusercontent.com/411945/57390436-40fec080-71b4-11e9-928e-9dc09249b2dc.png)
![Screenshot 2019-05-08 at 16 03 46](https://user-images.githubusercontent.com/411945/57390437-40fec080-71b4-11e9-961b-f57e14c7ea72.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed
