### PR TITLE
Deprecated filters: remove duplicate key.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6379,7 +6379,6 @@ p {
 			'jetpack_lazy_images_skip_image_with_atttributes'        => 'jetpack_lazy_images_skip_image_with_attributes',
 			'jetpack_enable_site_verification'                       => null,
 			'can_display_jetpack_manage_notice'                      => null,
-			'can_display_jetpack_manage_notice'                      => 'jetpack_json_manage_api_enabled',
 			// Removed in Jetpack 7.3.0
 			'atd_load_scripts'                                       => null,
 			'atd_http_post_timeout'                                  => null,


### PR DESCRIPTION
Fixes #12303

#### Changes proposed in this Pull Request:

Let's use `null` instead of the new `jetpack_json_manage_api_enabled` filter, since that new filter does not behave the same way as the deprecated `can_display_jetpack_manage_notice` filter.

#### Testing instructions:

1. Enable `WP_DEBUG`
1. Add this to an mu-plugin:

```php
add_filter( 'can_display_jetpack_manage_notice', '__return_false' );
```

3. Open `wp-admin` in browser
4. You should see no errors in your error log.

#### Proposed changelog entry for your changes:

* Deprecated filters: remove duplicate key.
