### PR TITLE
Ensure Jetpack Sync Sender is not loaded when doing cron and sync during cron is disabled

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -77,6 +77,8 @@ class Jetpack_Sync_Actions {
 				is_admin()
 				||
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
+				||
+				( self::sync_via_cron_allowed() && Jetpack_Constants::is_true( 'DOING_CRON' ) )
 			)
 		) ) {
 			self::initialize_sender();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -69,22 +69,36 @@ class Jetpack_Sync_Actions {
 		 */
 		if ( apply_filters(
 			'jetpack_sync_sender_should_load',
-			(
-				( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] )
-				||
-				current_user_can( 'manage_options' )
-				||
-				is_admin()
-				||
-				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
-				||
-				( self::sync_via_cron_allowed() && Jetpack_Constants::is_true( 'DOING_CRON' ) )
-			)
+			self::should_initialize_sender()
 		) ) {
 			self::initialize_sender();
 			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
 			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ) );
 		}
+	}
+
+	static function should_initialize_sender() {
+		if ( Jetpack_Constants::is_true( 'DOING_CRON' ) ) {
+			return self::sync_via_cron_allowed();
+		}
+
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+			return true;
+		}
+
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		if ( is_admin() ) {
+			return true;
+		}
+
+		if ( defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	static function sync_allowed() {

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -103,6 +103,21 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( Jetpack_Sync_Actions::$sender !== null );
 	}
 
+	function test_do_not_load_sender_if_is_cron_and_cron_sync_disabled() {
+		Jetpack_Constants::set_constant( 'DOING_CRON', true );
+		$settings = Jetpack_Sync_Settings::get_settings();
+		$settings['sync_via_cron'] = 0;
+		Jetpack_Sync_Settings::update_settings( $settings );
+		Jetpack_Sync_Actions::$sender = null;
+
+		Jetpack_Sync_Actions::add_sender_shutdown();
+
+		$this->assertNull( Jetpack_Sync_Actions::$sender );
+
+		Jetpack_Constants::clear_constants();
+		Jetpack_Sync_Settings::reset_data();
+	}
+
 	function test_cleanup_cron_jobs_with_non_staggered_start() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Previously, Jetpack was syncing during cron even when syncing during cron was disabled. This PR ensures the Sync Sender is not loaded when doing cron and Jetpack has been set not to sync during cron. It also refactors the checking of other conditions for loading the Sync Sender a bit.
#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do the tests pass?
* 1. Set logging in https://github.com/Automattic/jetpack/blob/master/sync/class.jetpack-sync-sender.php#L110 
```
error_log( 'do_sync_and_set_delays: IS_CRON:' . (int) Jetpack_Constants::is_true( 'DOING_CRON' )  .' queue:' . $queue->id );
```
2. Set the site to have the cron disabled on sync. 
3. Trigger a full sync on a site. 
Notice in the error log that the sending is not happening when cron is set to true.


#### Proposed changelog entry for your changes:
No changelog entry needed
