### PR TITLE
Debug Data: Update site health debug data to clarify keys are public

### DIFF
--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -206,12 +206,12 @@ class Jetpack_Debug_Data {
 			'private' => false,
 		);
 		$debug_info['blog_token']   = array(
-			'label'   => 'Blog Token Key',
+			'label'   => 'Blog Public Key',
 			'value'   => ( $blog_token ) ? $blog_key : 'Not set.',
 			'private' => false,
 		);
 		$debug_info['user_token']   = array(
-			'label'   => 'User Token Key',
+			'label'   => 'User Public Key',
 			'value'   => ( $user_token ) ? $user_key : 'Not set.',
 			'private' => false,
 		);


### PR DESCRIPTION
The key is "public" and by itself, can't be used for anything. To help clarify this, let's update the description.

#### Changes proposed in this Pull Request:
* `Token` => `Public`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Go to Tools->Site Health->Info -- see that Jetpack's section has a "Blog Public Key" entry.

#### Proposed changelog entry for your changes:
* I don't think we need to changelog it, but "Site Health: Improve descriptions of debug data"
