### PR TITLE
Editor / Likes and Sharing: Set back_compat regardless of beta blocks

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -42,9 +42,8 @@ class Jetpack_Likes_Settings {
 		 * @param string Likes metabox title. Default to "Likes".
 		 */
 		$title = apply_filters( 'likes_meta_box_title', __( 'Likes', 'jetpack' ) );
-		$back_compat = Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ); // TODO: remove once the Likes extension is done with it's beta.
 		foreach( $post_types as $post_type ) {
-			add_meta_box( 'likes_meta', $title, array( $this, 'meta_box_content' ), $post_type, 'side', 'default', array( '__back_compat_meta_box' => $back_compat ) );
+			add_meta_box( 'likes_meta', $title, array( $this, 'meta_box_content' ), $post_type, 'side', 'default', array( '__back_compat_meta_box' => true ) );
 		}
 	}
 

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -141,10 +141,8 @@ function sharing_add_meta_box() {
 	 * @param string $var Sharing Meta Box title. Default is "Sharing".
 	 */
 	$title = apply_filters( 'sharing_meta_box_title', __( 'Sharing', 'jetpack' ) );
-	$back_compat = Jetpack_Constants::is_true( 'JETPACK_BETA_BLOCKS' ); // TODO: remove once the Sharing extension is done with it's beta.
-	if ( $post->ID !== get_option( 'page_for_posts' ) ) {
 		foreach( $post_types as $post_type ) {
-			add_meta_box( 'sharing_meta', $title, 'sharing_meta_box_content', $post_type, 'side', 'default', array( '__back_compat_meta_box' => $back_compat ) );
+			add_meta_box( 'sharing_meta', $title, 'sharing_meta_box_content', $post_type, 'side', 'default', array( '__back_compat_meta_box' => true ) );
 		}
 	}
 }

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -141,6 +141,7 @@ function sharing_add_meta_box() {
 	 * @param string $var Sharing Meta Box title. Default is "Sharing".
 	 */
 	$title = apply_filters( 'sharing_meta_box_title', __( 'Sharing', 'jetpack' ) );
+	if ( $post->ID !== get_option( 'page_for_posts' ) ) {
 		foreach( $post_types as $post_type ) {
 			add_meta_box( 'sharing_meta', $title, 'sharing_meta_box_content', $post_type, 'side', 'default', array( '__back_compat_meta_box' => true ) );
 		}


### PR DESCRIPTION
Looks like we forgot to remove a check when we took these extensions out of beta. This PR sets `back_compat_meta_box` to true whether or not beta blocks are enabled.

See #12055 

#### Testing instructions:
* Enable the Likes and Sharing modules on a site that does not have beta blocks set.
* Go to the block editor
* Verify that the Likes and Sharing metabox only appears in the Jetpack sidebar, not under the editor as in https://github.com/Automattic/wp-calypso/issues/32836 or in the main sidebar

Here's what you should not see:

<img width="297" alt="Screen Shot 2019-05-08 at 3 56 37 PM" src="https://user-images.githubusercontent.com/52152/57413730-14de4200-71aa-11e9-9042-7be63553b3da.png">


#### Proposed changelog entry for your changes:
* Fix a bug that caused Likes and Sharing checkboxes to be shown below the block editor
