### PR TITLE
Sharing: update default sharing settings to include buttons.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -219,7 +219,10 @@ class Sharing_Service {
 		// Default services
 		if ( ! is_array( $enabled ) ) {
 			$enabled = array(
-				'visible' => array(),
+				'visible' => array(
+					'twitter',
+					'facebook',
+				),
 				'hidden'  => array(),
 			);
 
@@ -303,17 +306,17 @@ class Sharing_Service {
 	public function set_global_options( $data ) {
 		$options = get_option( 'sharing-options' );
 
-		// No options yet
+		// No options yet.
 		if ( ! is_array( $options ) ) {
 			$options = array();
 		}
 
-		// Defaults
+		// Defaults.
 		$options['global'] = array(
 			'button_style'  => 'icon-text',
 			'sharing_label' => $this->default_sharing_label,
 			'open_links'    => 'same',
-			'show'          => array(),
+			'show'          => array( 'post', 'page' ),
 			'custom'        => isset( $options['global']['custom'] ) ? $options['global']['custom'] : array(),
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Until now, when first enabling sharing buttons (which was done automatically when connecting Jetpack to WordPress.com), no buttons were automatically set for you. You had to go to Settings > Sharing to set some buttons and decide where they would be displayed.

Since we do not automatically activate the Sharing feature anymore (see #11558), it makes senses to add some default configuration (Facebook and Twitter buttons appearing on posts and pages) when you manually activate the feature.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Related discussion: 8oabR-p2#comment-2931

#### Testing instructions:

* Start from a brand new site.
* Connect Jetpack to WordPress.com.
* Go to Jetpack > Settings > Sharing and enable the Sharing feature.
* Go to the Sharing section in Calypso, or to Settings > Sharing in wp-admin
* You should see the 2 default sharing buttons (Facebook and Twitter) as well as the default settings to show the buttons on posts and pages.

#### Proposed changelog entry for your changes:

* Sharing: update default sharing settings to include buttons.
