### PR TITLE
Dashboard footer: make sure the Modules link can be displayed.

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -16,7 +16,7 @@ import {
 	userCanManageOptions,
 	getSiteAdminUrl,
 } from 'state/initial-state';
-import { isInIdentityCrisis } from 'state/connection';
+import { isInIdentityCrisis, getSiteConnectionStatus } from 'state/connection';
 import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
 import DevCard from 'components/dev-card';
 import onKeyDownCallback from 'utils/onkeydown-callback';
@@ -231,11 +231,12 @@ export default connect(
 	state => {
 		return {
 			currentVersion: getCurrentVersion( state ),
-			userCanManageOptions: userCanManageOptions( state ),
-			isDevVersion: _isDevVersion( state ),
-			siteAdminUrl: getSiteAdminUrl( state ),
-			isInIdentityCrisis: isInIdentityCrisis( state ),
 			displayDevCard: canDisplayDevCard( state ),
+			isDevVersion: _isDevVersion( state ),
+			isInIdentityCrisis: isInIdentityCrisis( state ),
+			siteAdminUrl: getSiteAdminUrl( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
+			userCanManageOptions: userCanManageOptions( state ),
 		};
 	},
 	dispatch => {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Follow-up from #12182

The Modules link can only be displayed if a site is connected or in dev mode.
We check that in `maybeShowModules` with this.props.siteConnectionStatus, but the props was not passed down to the component before.

#### Testing instructions:

* Go to Jetpack > Dashboard.
* If your site is connected to WordPress.com or in dev mode, you should see a link in the footer of the page.
<img width="666" alt="screenshot 2019-05-09 at 16 06 45" src="https://user-images.githubusercontent.com/426388/57460119-d2ce0280-7274-11e9-9f99-e971ec6386a7.png">

#### Proposed changelog entry for your changes:

* Dashboard footer: make sure the Modules link can be displayed.
