### PR TITLE
Site Health: Remove 'Successful Test'

### DIFF
--- a/_inc/lib/debugger/debug-functions-for-php53.php
+++ b/_inc/lib/debugger/debug-functions-for-php53.php
@@ -42,7 +42,7 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 						' ',
 						str_replace( 'test__', '', $test['name'] )
 					)
-				) . ': ' . __( 'Successful test!', 'jetpack' );
+				);
 				$return = array(
 					'label'       => $label,
 					'status'      => 'good',


### PR DESCRIPTION
When viewing the passed tests section of Site Health, every Jetpack test was suffixed with "Successful Test" which is repetitive given it is in the "Passed Tests" section.

h/t @eliorivero 

#### Changes proposed in this Pull Request:
* Remove string.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
* WP 5.2: Visit Tools->Site Health->Passed Tests
* Confirm test name is present with no additional text.

#### Proposed changelog entry for your changes:
* Improve passed test messaging in Site Health.
