### PR TITLE
CXN Tests: Better unexpected state handling in wpcom connection test

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -225,6 +225,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::skipped_test( $name );
 		}
 
+		$id = Jetpack_Options::get_option( 'id' );
+
+		if ( ! is_int( $id ) ) {
+			return self::failing_test( $name, __( 'There is an unexpected value set as your site ID.', 'jetpack' ), 'cycle_connection' );
+		}
+
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
 			sprintf( '/jetpack-blogs/%d/test-connection', Jetpack_Options::get_option( 'id' ) ),
 			Jetpack_Client::WPCOM_JSON_API_VERSION
@@ -240,6 +246,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( ! $body ) {
 			$message = __( 'Connection test failed (empty response body)', 'jetpack' ) . wp_remote_retrieve_response_code( $response );
 			return self::failing_test( $name, $message );
+		}
+
+		if ( 404 === wp_remote_retrieve_response_code( $response ) ) {
+			return self::skipped_test( $name, __( 'The WordPress.com API returned a 404 error.', 'jetpack' ) );
 		}
 
 		$result       = json_decode( $body );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -227,10 +227,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$id = Jetpack_Options::get_option( 'id' );
 
-		if ( ! is_int( $id ) ) {
-			return self::failing_test( $name, __( 'There is an unexpected value set as your site ID.', 'jetpack' ), 'cycle_connection' );
-		}
-
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
 			sprintf( '/jetpack-blogs/%d/test-connection', Jetpack_Options::get_option( 'id' ) ),
 			Jetpack_Client::WPCOM_JSON_API_VERSION

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -225,8 +225,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::skipped_test( $name );
 		}
 
-		$id = Jetpack_Options::get_option( 'id' );
-
 		$response = Jetpack_Client::wpcom_json_api_request_as_blog(
 			sprintf( '/jetpack-blogs/%d/test-connection', Jetpack_Options::get_option( 'id' ) ),
 			Jetpack_Client::WPCOM_JSON_API_VERSION


### PR DESCRIPTION
Fixes #12325

#### Changes proposed in this Pull Request:
* Handle cases where the Jetpack ID is non-standard and if WP.com 404s.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* @eliorivero running it on his site.
* Manually set your Jetpack ID option to a random string.
* Run Site Health.

#### Proposed changelog entry for your changes:
* Site Health: Improve error messaging.
