### PR TITLE
Admin - Plans: correctly place the dotted line under the currency symbol

### DIFF
--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -201,6 +201,10 @@ $plan-features-sidebar-width: 272px;
 
 .plan-price__yearly {
 	color: $gray-dark;
+
+	abbr {
+		text-underline-position: under;
+	}
 }
 
 .plans-mobile-notice {


### PR DESCRIPTION
This PR fixes a broken dotted underline due to the descendent of $

This prop and this specific value is recognized only by Chrome, which is where the issue was experienced.
[See the prop in w3](https://www.w3.org/TR/css-text-decor-3/#text-underline-position-property.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #8958

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add prop to move the underline below the descendent of the font

### Before

<img width="212" alt="Captura de Pantalla 2019-05-09 a la(s) 14 52 17" src="https://user-images.githubusercontent.com/1041600/57475968-f0e33500-726b-11e9-99c9-acc43396e80b.png">

### After

<img width="207" alt="Captura de Pantalla 2019-05-09 a la(s) 14 52 28" src="https://user-images.githubusercontent.com/1041600/57475970-f3458f00-726b-11e9-95a2-08ebf699ce1f.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Chrome
* Go to the Jetpack admin > Plans
* ensure the dotted underline looks good

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* This is so minor that it's not worth mentioning
