### PR TITLE
Remove admin menu toggle in new post screen

### DIFF
--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -72,6 +72,7 @@
 
 .jetpack-masterbar.post-new-php.block-editor-page #wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
 	color: #fff !important;
+	font-size: 28px;
 }
 
 @media screen and (max-width: 480px) {

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -60,7 +60,63 @@
 	display: inline-block;
 }
 
-/* Remove the admin menu toggle in Gutenberg - https://github.com/Automattic/jetpack/issues/12320 */
-.jetpack-masterbar.post-new-php.block-editor-page #wp-admin-bar-menu-toggle {
+/* Move the admin menu toggle in Gutenberg - https://github.com/Automattic/jetpack/issues/12320 */
+.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar #wp-admin-bar-ab-new-post {
 	display: none;
+}
+
+.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar #wp-admin-bar-menu-toggle {
+	top: -4px;
+	position: relative;
+}
+
+.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
+	color: #fff !important;
+}
+
+@media screen and (max-width: 480px) {
+	.jetpack-masterbar.post-new-php.block-editor-page #wp-toolbar ul li {
+		flex: 1;
+		width: auto !important;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar ul#wp-admin-bar-root-default {
+		width: 60%;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar ul#wp-admin-bar-top-secondary {
+		width: 40%;
+	}
+
+	.wp-admin.jetpack-masterbar.post-new-php.block-editor-page .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
+		left: 0;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	.wp-admin.jetpack-masterbar.post-new-php.block-editor-page .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
+		left: 0 !important;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wp-toolbar,
+	.jetpack-masterbar.post-new-php.block-editor-page #wp-toolbar ul {
+		display: flex;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar ul#wp-admin-bar-root-default {
+		flex-grow: 1;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-menu-toggle {
+		order: 1;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-blog {
+		order: 2;
+	}
+
+	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-newdash {
+		order: 3;
+	}
+
 }

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -59,3 +59,8 @@
 #wpadminbar .quicklinks li#wp-admin-bar-my-account #wp-admin-bar-user-info .ab-sign-out {
 	display: inline-block;
 }
+
+/* Remove the admin menu toggle in Gutenberg - https://github.com/Automattic/jetpack/issues/12320 */
+.jetpack-masterbar.post-new-php.block-editor-page #wp-admin-bar-menu-toggle {
+	display: none;
+}

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -119,5 +119,4 @@
 	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-newdash {
 		order: 3;
 	}
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This is a little heavy handed but with so little space on narrow screens, I think it is probably best to remove the hamburger menu and go vegan in order to resolve the visual issues we are seeing:

Fixes #12320

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide the admin menu toggle in the Gutenberg editor

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the WordPress.com toolbar feature.
* On mobile, go to Posts > Add New
* You'll see the hamburger no longer interferes with the editor

Before:

![57451783-84176d00-7262-11e9-88e0-54d2b2d0f093](https://user-images.githubusercontent.com/411945/57532428-8a294e80-7333-11e9-854c-91cd24d2be42.png)

After:

![Screenshot 2019-05-10 at 14 51 48](https://user-images.githubusercontent.com/411945/57532463-9f05e200-7333-11e9-85ff-7655c4aa1da7.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None, CSS fix
