### PR TITLE
Social Icons SVG: switch to the presentation role

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -364,7 +364,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		$aria_hidden = ' aria-hidden="true"';
 
 		// Begin SVG markup.
-		$svg = '<svg class="icon icon-' . esc_attr( $args['icon'] ) . '"' . $aria_hidden . ' role="img">';
+		$svg = '<svg class="icon icon-' . esc_attr( $args['icon'] ) . '"' . $aria_hidden . ' role="presentation">';
 
 		/*
 		 * Display the icon.
@@ -526,7 +526,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'url'   => 'goodreads.com',
 				'icon'  => 'goodreads',
 				'label' => 'Goodreads',
-			),			
+			),
 			array(
 				'url'   => 'google.com',
 				'icon'  => 'google',


### PR DESCRIPTION
Fixes #12338

#### Changes proposed in this Pull Request:

Since the image is mostly decorative, and since we already hide it from screen readers with `aria-hidden="true"`, let's also set it as a decorative element.

#### Testing instructions:

* Add a Social Icons widget to your sidebar.
* Start an a11y audit with a tool like [the one](https://chrome.google.com/webstore/detail/siteimprove-accessibility/efcfolpjihicnikpmhnmphjhhpiclljc) suggested in #12338
* Make sure the SVG also appears properly on the page.

#### Proposed changelog entry for your changes:

* Social Icons SVG: switch to the presentation role for better accessibility.
