### PR TITLE
Warn in log if user's WP version is too old for Jetpack

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -89,6 +89,7 @@ function jetpack_admin_unsupported_wp_notice() { ?>
 }
 
 if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' ) ) {
+	error_log("Your version of WordPress (" . $GLOBALS['wp_version'] . ") is lower than the required version, " . JETPACK__MINIMUM_WP_VERSION );
 	add_action( 'admin_notices', 'jetpack_admin_unsupported_wp_notice' );
 	return;
 }

--- a/jetpack.php
+++ b/jetpack.php
@@ -89,7 +89,16 @@ function jetpack_admin_unsupported_wp_notice() { ?>
 }
 
 if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' ) ) {
-	error_log("Your version of WordPress (" . $GLOBALS['wp_version'] . ") is lower than the required version, " . JETPACK__MINIMUM_WP_VERSION );
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log(
+			sprintf(
+				/* translators: Placeholders are numbers, versions of WordPress in use on the site, and required by WordPress. */
+				esc_html__( 'Your version of WordPress (%1$s) is lower than the version required by Jetpack (%2$s). Please update WordPress to continue enjoying Jetpack.', 'jetpack' ),
+				$GLOBALS['wp_version'],
+				JETPACK__MINIMUM_WP_VERSION
+			)
+		);
+	}
 	add_action( 'admin_notices', 'jetpack_admin_unsupported_wp_notice' );
 	return;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When I was testing another PR on VVV, the tests would fail with "class Jetpack not found" errors. It turns out that this was because I had an old (5.0-alpha) source tree in my VM, and there's an early return in jetpack.php if it detects an incompatible WordPress version.

My hope is that this change won't result in crazy verbose logging on sites with old versions of Jetpack, but... those sites are running an incompatible WordPress version anyway, so if it wasn't this weirdness it would be other weirdness. It also might be helpful in case they're missing the notices in their wp-admin.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Warn in logs if Jetpack plugin can't load due to incompatible WordPress version.

