### PR TITLE
Memberships: Check plan before displaying the block

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -141,19 +141,13 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	/**
 	 * Get a status of connection for the site. If this is Jetpack, pass the request to wpcom.
 	 *
-	 * @return array|WP_Error
+	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
 	public function get_status() {
-		$connected_account_id = Jetpack_Memberships::get_connected_account_id();
-		$connect_url          = '';
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			require_lib( 'memberships' );
-			$blog_id                              = get_current_blog_id();
-			$should_upgrade_to_access_memberships = should_upgrade_to_access_memberships( $blog_id );
-			if ( ! $connected_account_id ) {
-				$connect_url = get_memberships_connected_account_redirect( get_current_user_id(), $blog_id );
-			}
-			$products = get_memberships_plans( $blog_id );
+			$blog_id = get_current_blog_id();
+			return (array) get_memberships_settings_for_site( $blog_id );
 		} else {
 			$blog_id  = Jetpack_Options::get_option( 'id' );
 			$response = Jetpack_Client::wpcom_json_api_request_as_user(
@@ -169,18 +163,11 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 				return new WP_Error( 'wpcom_connection_error', __( 'Could not connect to WordPress.com', 'jetpack' ), 404 );
 			}
 			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
-			if ( ! $connected_account_id ) {
-				$connect_url = empty( $data['connect_url'] ) ? '' : $data['connect_url'];
+			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
+				return new WP_Error( $data['code'], $data['message'], 401 );
 			}
-			$products                             = empty( $data['products'] ) ? array() : $data['products'];
-			$should_upgrade_to_access_memberships = $data['should_upgrade_to_access_memberships'];
+			return $data;
 		}
-		return array(
-			'connected_account_id'                 => $connected_account_id,
-			'connect_url'                          => $connect_url,
-			'products'                             => $products,
-			'should_upgrade_to_access_memberships' => $should_upgrade_to_access_memberships,
-		);
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -148,7 +148,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		$connect_url          = '';
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			require_lib( 'memberships' );
-			$blog_id = get_current_blog_id();
+			$blog_id                              = get_current_blog_id();
+			$should_upgrade_to_access_memberships = should_upgrade_to_access_memberships( $blog_id );
 			if ( ! $connected_account_id ) {
 				$connect_url = get_memberships_connected_account_redirect( get_current_user_id(), $blog_id );
 			}
@@ -171,12 +172,14 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			if ( ! $connected_account_id ) {
 				$connect_url = empty( $data['connect_url'] ) ? '' : $data['connect_url'];
 			}
-			$products = empty( $data['products'] ) ? array() : $data['products'];
+			$products                             = empty( $data['products'] ) ? array() : $data['products'];
+			$should_upgrade_to_access_memberships = $data['should_upgrade_to_access_memberships'];
 		}
 		return array(
-			'connected_account_id' => $connected_account_id,
-			'connect_url'          => $connect_url,
-			'products'             => $products,
+			'connected_account_id'                 => $connected_account_id,
+			'connect_url'                          => $connect_url,
+			'products'                             => $products,
+			'should_upgrade_to_access_memberships' => $should_upgrade_to_access_memberships,
 		);
 	}
 }

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -42,6 +42,7 @@ class MembershipsButtonEdit extends Component {
 			connected: API_STATE_LOADING,
 			connectURL: null,
 			addingMembershipAmount: PRODUCT_NOT_ADDING,
+			shouldUpgrade: false,
 			products: [],
 			editedProductCurrency: 'USD',
 			editedProductPrice: 5,
@@ -71,10 +72,11 @@ class MembershipsButtonEdit extends Component {
 			result => {
 				const connectURL = result.connect_url;
 				const products = result.products;
+				const shouldUpgrade = result.should_upgrade_to_access_memberships;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
 					: API_STATE_NOTCONNECTED;
-				this.setState( { connected, connectURL, products } );
+				this.setState( { connected, connectURL, products, shouldUpgrade } );
 			},
 			result => {
 				const connectURL = null;
@@ -333,6 +335,24 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
+				{ this.state.shouldUpgrade && (
+					<Placeholder
+						icon={ <BlockIcon icon={ icon } /> }
+						label={ __( 'Memberships', 'jetpack' ) }
+						notices={ notices }
+					>
+						<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
+							{ __( "You'll need to upgrade your plan to use the Membership Button", 'jetpack' ) }
+							<br />
+							<br />
+							<Button isDefault isLarge href={ this.state.shouldUpgrade } target="_blank">
+								{ __( 'Upgrade Your Plan.', 'jetpack' ) }
+							</Button>
+							<br />
+							{ this.renderDisclaimer() }
+						</div>
+					</Placeholder>
+				) }
 				{ ( connected === API_STATE_LOADING ||
 					this.state.addingMembershipAmount === PRODUCT_FORM_SUBMITTED ) &&
 					! this.props.attributes.planId && (
@@ -340,32 +360,35 @@ class MembershipsButtonEdit extends Component {
 							<Spinner />
 						</Placeholder>
 					) }
-				{ ! this.props.attributes.planId && connected === API_STATE_NOTCONNECTED && (
-					<Placeholder
-						icon={ <BlockIcon icon={ icon } /> }
-						label={ __( 'Memberships', 'jetpack' ) }
-						notices={ notices }
-					>
-						<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
-							{ __(
-								'In order to start selling Membership plans, you have to connect to Stripe:',
-								'jetpack'
-							) }
-							<br />
-							<br />
-							<Button isDefault isLarge href={ connectURL } target="_blank">
-								{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }
-							</Button>
-							<br />
-							<br />
-							<Button isLink onClick={ this.apiCall }>
-								{ __( 'Re-check Connection', 'jetpack' ) }
-							</Button>
-							{ this.renderDisclaimer() }
-						</div>
-					</Placeholder>
-				) }
-				{ ! this.props.attributes.planId &&
+				{ ! this.state.shouldUpgrade &&
+					! this.props.attributes.planId &&
+					connected === API_STATE_NOTCONNECTED && (
+						<Placeholder
+							icon={ <BlockIcon icon={ icon } /> }
+							label={ __( 'Memberships', 'jetpack' ) }
+							notices={ notices }
+						>
+							<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
+								{ __(
+									'In order to start selling Membership plans, you have to connect to Stripe:',
+									'jetpack'
+								) }
+								<br />
+								<br />
+								<Button isDefault isLarge href={ connectURL } target="_blank">
+									{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }
+								</Button>
+								<br />
+								<br />
+								<Button isLink onClick={ this.apiCall }>
+									{ __( 'Re-check Connection', 'jetpack' ) }
+								</Button>
+								{ this.renderDisclaimer() }
+							</div>
+						</Placeholder>
+					) }
+				{ ! this.state.shouldUpgrade &&
+					! this.props.attributes.planId &&
 					connected === API_STATE_CONNECTED &&
 					products.length === 0 && (
 						<Placeholder
@@ -382,7 +405,8 @@ class MembershipsButtonEdit extends Component {
 							</div>
 						</Placeholder>
 					) }
-				{ ! this.props.attributes.planId &&
+				{ ! this.state.shouldUpgrade &&
+					! this.props.attributes.planId &&
 					this.state.addingMembershipAmount !== PRODUCT_FORM_SUBMITTED &&
 					connected === API_STATE_CONNECTED &&
 					products.length > 0 && (

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -43,6 +43,7 @@ class MembershipsButtonEdit extends Component {
 			connectURL: null,
 			addingMembershipAmount: PRODUCT_NOT_ADDING,
 			shouldUpgrade: false,
+			upgradeURL: '',
 			products: [],
 			editedProductCurrency: 'USD',
 			editedProductPrice: 5,
@@ -70,13 +71,23 @@ class MembershipsButtonEdit extends Component {
 		const fetch = { path, method };
 		apiFetch( fetch ).then(
 			result => {
+				if (
+					result.errors &&
+					Object.values( result.errors ) &&
+					Object.values( result.errors )[ 0 ][ 0 ]
+				) {
+					this.setState( { connected: null, connectURL: API_STATE_NOTCONNECTED } );
+					this.onError( Object.values( result.errors )[ 0 ][ 0 ] );
+					return;
+				}
 				const connectURL = result.connect_url;
 				const products = result.products;
 				const shouldUpgrade = result.should_upgrade_to_access_memberships;
+				const upgradeURL = result.upgrade_url;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
 					: API_STATE_NOTCONNECTED;
-				this.setState( { connected, connectURL, products, shouldUpgrade } );
+				this.setState( { connected, connectURL, products, shouldUpgrade, upgradeURL } );
 			},
 			result => {
 				const connectURL = null;
@@ -345,7 +356,7 @@ class MembershipsButtonEdit extends Component {
 							{ __( "You'll need to upgrade your plan to use the Membership Button.", 'jetpack' ) }
 							<br />
 							<br />
-							<Button isDefault isLarge href={ this.state.shouldUpgrade } target="_blank">
+							<Button isDefault isLarge href={ this.state.upgradeURL } target="_blank">
 								{ __( 'Upgrade Your Plan', 'jetpack' ) }
 							</Button>
 							<br />

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -342,11 +342,11 @@ class MembershipsButtonEdit extends Component {
 						notices={ notices }
 					>
 						<div className="components-placeholder__instructions wp-block-jetpack-membership-button">
-							{ __( "You'll need to upgrade your plan to use the Membership Button", 'jetpack' ) }
+							{ __( "You'll need to upgrade your plan to use the Membership Button.", 'jetpack' ) }
 							<br />
 							<br />
 							<Button isDefault isLarge href={ this.state.shouldUpgrade } target="_blank">
-								{ __( 'Upgrade Your Plan.', 'jetpack' ) }
+								{ __( 'Upgrade Your Plan', 'jetpack' ) }
 							</Button>
 							<br />
 							{ this.renderDisclaimer() }


### PR DESCRIPTION
This PR blocks the usage of a block (ahem) if you are on a free plan. This is a part of https://github.com/Automattic/wp-calypso/pull/32984#issuecomment-491805506

Additionallly, this PR simplifies the status endpoint, directly passes the response from WPCOM and makes it easier to fix pieces later.

## Screenshots

<img width="683" alt="Zrzut ekranu 2019-05-13 o 16 45 22" src="https://user-images.githubusercontent.com/3775068/57631382-adf0cc80-759f-11e9-9e6c-3a15e817b6ca.png">

## Testing instruction

### Jetpack ngrok solution

1. Make sure to check out D28126-code on your sandbox and `define( 'JETPACK__SANDBOX_DOMAIN', 'your-public-sandboxed-site' );`
2. Try to use a block on a site that is on a paid plan. You should get "connect stripe account" or - if you connected - product selection
3. Try to use on a free site. You should get "Uprade your site"

### WPCOM simple

You only need to test D28126-code on your sandbox
