### PR TITLE
Pass through the `from` parameter when connecting an already connected Jetpack

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3931,6 +3931,7 @@ p {
 		}
 
 		if ( isset( $_GET['connect_url_redirect'] ) ) {
+			// @todo: Add validation against a known whitelist
 			$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
 			// User clicked in the iframe to link their accounts
 			if ( ! Jetpack::is_user_connected() ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3930,10 +3930,11 @@ p {
 			Jetpack::restate();
 		}
 
+		$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
+
 		if ( isset( $_GET['connect_url_redirect'] ) ) {
 			// User clicked in the iframe to link their accounts
 			if ( ! Jetpack::is_user_connected() ) {
-				$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
 				$redirect = ! empty( $_GET['redirect_after_auth'] ) ? $_GET['redirect_after_auth'] : false;
 
 				add_filter( 'allowed_redirect_hosts', array( &$this, 'allow_wpcom_environments' ) );
@@ -3950,7 +3951,7 @@ p {
 					wp_safe_redirect( Jetpack::admin_url() );
 					exit;
 				} else {
-					$connect_url = $this->build_connect_url( true, false, 'iframe' );
+					$connect_url = $this->build_connect_url( true, false, $from );
 					$connect_url .= '&already_authorized=true';
 					wp_redirect( $connect_url );
 					exit;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3930,9 +3930,8 @@ p {
 			Jetpack::restate();
 		}
 
-		$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
-
 		if ( isset( $_GET['connect_url_redirect'] ) ) {
+			$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
 			// User clicked in the iframe to link their accounts
 			if ( ! Jetpack::is_user_connected() ) {
 				$redirect = ! empty( $_GET['redirect_after_auth'] ) ? $_GET['redirect_after_auth'] : false;


### PR DESCRIPTION
If a user tries to connect Jetpack when the are already connected, they are redirected back to the onboarding flow in Calypso. See #3788.

Currently, if a `from` parameter is supplied (like `woocommerce-setup-wizard`), this is lost during the redirect. We are going to start using this parameter in Calypso to show some different copy/design elements during the flow, so passing this along will help users who hit this edge case.

To Test:
* You need to also have https://github.com/Automattic/wp-calypso/pull/32993 applied. There are some changes make sure the `from` is also passed on retry. https://github.com/Automattic/wp-calypso/pull/32993/files#diff-4082b3f22f0a998cdc936b484d8ea8f9 and https://github.com/Automattic/wp-calypso/pull/32993/files#diff-ff76e1701bebf84cf3e5a847ffd165d0R171.
* Try connecting a site to Jetpack that has already been connected. The best way I can find to do this is right now to to disconnect, grab the connect URL and set it aside, connect via the button, and then try connecting again manually via the URL. Append `&from=woocommerce-setup-wizard` and make sure it persists back to Calypso (purple styles should be retained).