### PR TITLE
Add new Option for cross site search allowed ids

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -25,6 +25,7 @@ class Jetpack_Options {
 			return array(
 				'activated',
 				'active_modules',
+				'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
 				'available_modules',
 				'do_activate',
 				'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -80,6 +80,7 @@ class Jetpack_Sync_Defaults {
 		'wpcom_publish_comments_with_markdown',
 		'jetpack_activated',
 		'jetpack_available_modules',
+		'jetpack_allowed_xsite_search_ids',
 		'jetpack_autoupdate_plugins',
 		'jetpack_autoupdate_plugins_translations',
 		'jetpack_autoupdate_themes',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -136,6 +136,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_publish_posts_with_markdown'    => 'pineapple',
 			'wpcom_publish_comments_with_markdown' => 'pineapple',
 			'jetpack_activated'                    => 'pineapple',
+			'jetpack_allowed_xsite_search_ids'     => array( 99 ),
 			'jetpack_available_modules'            => 'pineapple',
 			'jetpack_autoupdate_plugins'           => 'pineapple',
 			'jetpack_autoupdate_plugins_translations' => 'pineapple',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds a new, whitelisted, non-compact option name - `allowed_xsite_search_ids`.

This option will contain an array of other blog ids that are allowed to search the current site's content.

This option will be synced to WP.com for use in the Search endpoint to control access on cross-site searches.

Happy to tweak the option name if there is something better!

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Adds a new option name. See p3QzjZ-Rh-p2 and p6jPRI-20f-p2

#### Testing instructions:

* `Jetpack_Options::update_option( 'allowed_xsite_search_ids', array( <some-jp-site-id> ) );` <-- should be ok and not complain about invalid option name
* Anything else? Needs a corresponding tweak on the WP.com side to allow this to be synced (WIP), then can verify it makes it up.

#### Proposed changelog entry for your changes:

* Add new option for cross-site search permissions
