### PR TITLE
Subscriptions: display checkboxes above submit button.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -670,7 +670,7 @@ class Jetpack_Subscriptions {
 		 */
 		$str = apply_filters( 'jetpack_comment_subscription_form', $str );
 
-		return $submit_button . $str;
+		return $str . $submit_button;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #9983, #11149, and #12273 we changed the way the subscription fields were hooked into the comment form.

This makes sure the checkboxes appear above the submit button instead of below:

**Before**

![image](https://user-images.githubusercontent.com/426388/57732168-c266bf00-769c-11e9-98ce-73ddde3aada6.png)

**After**

![image](https://user-images.githubusercontent.com/426388/57732160-ba0e8400-769c-11e9-91e5-00b13a853054.png)


#### Testing instructions:

* Disable the Comment Form module under Jetpack > Settings > Discussion
* In Settings > Discussion, make sure the subscription checkboxes are set.
* Visit a post when logged in, and when logged out.
* The checkboxes should appear above the comment submit button in both cases.
* Try to subscribe and make sure you still can.

#### Proposed changelog entry for your changes:

* Subscriptions: display checkboxes above the comment submit button.