### PR TITLE
Connect flow: sanitize "from" parameter when building connect url

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4519,7 +4519,7 @@ p {
 		}
 
 		if ( $from ) {
-			$url = add_query_arg( 'from', sanitize_key( $from ), $url );
+			$url = add_query_arg( 'from', sanitize_text_field( $from ), $url );
 		}
 
 		// Ensure that class to get the affiliate code is loaded

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4519,7 +4519,7 @@ p {
 		}
 
 		if ( $from ) {
-			$url = add_query_arg( 'from', $from, $url );
+			$url = add_query_arg( 'from', sanitize_key( $from ), $url );
 		}
 
 		// Ensure that class to get the affiliate code is loaded

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4519,7 +4519,7 @@ p {
 		}
 
 		if ( $from ) {
-			$url = add_query_arg( 'from', sanitize_text_field( $from ), $url );
+			$url = add_query_arg( 'from', $from, $url );
 		}
 
 		// Ensure that class to get the affiliate code is loaded
@@ -4535,7 +4535,7 @@ p {
 			$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 		}
 
-		return $raw ? $url : esc_url( $url );
+		return $raw ? esc_url_raw( $url ) : esc_url( $url );
 	}
 
 	/**


### PR DESCRIPTION
Follow-up from #12351

#### Changes proposed in this Pull Request:

Since one can currently pass any "from" parameter when building that URL, let's sanitize that value.

#### Testing instructions:

* Start on a brand new site that has not been connected yet.
* Go to Jetpack > Dashboard.
* Make sure the "set up Jetpack" link still includes the `landing-page-bottom` from parameter.

#### Proposed changelog entry for your changes:

* Connect Flow: sanitize `from` parameter when building connection URL.
