### PR TITLE
Tracks: Add length limit when we save the Jetpack feature search input.

### DIFF
--- a/_inc/client/components/tracker/index.jsx
+++ b/_inc/client/components/tracker/index.jsx
@@ -14,7 +14,7 @@ export class Tracker extends Component {
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const record = this.props.analytics.tracks.recordEvent;
 
-		if ( nextProps.searchTerm !== this.props.searchTerm ) {
+		if ( nextProps.searchTerm !== this.props.searchTerm && nextProps.searchTerm.length >= 3 ) {
 			record( 'jetpack_wpa_search_term', { term: nextProps.searchTerm } );
 		}
 	}


### PR DESCRIPTION
* Fire event saving Jetpack feature searches only for texts longer than 3 chars.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to .../wp-admin/admin.php?page=jetpack#/settings'
* in the browser console use ```localStorage.setItem( 'debug', 'dops:analytics' );```
* start typing in the search box
* verify that only as text gets over 3 chars long, the event fires, e.g.
```dops:analytics Record event "jetpack_wpa_search_term" called with props {"term":"text","blog_id":160965497} ```
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Limit Jetpack feature search input text.
