### PR TITLE
Tiled Gallery: Remove invalidating strip attribute from block save

### DIFF
--- a/extensions/blocks/tiled-gallery/utils/index.js
+++ b/extensions/blocks/tiled-gallery/utils/index.js
@@ -59,10 +59,9 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 		const size = Math.min( PHOTON_MAX_RESIZE, width, height );
 		src = photonImplementation( url, {
 			resize: `${ size },${ size }`,
-			strip: 'all',
 		} );
 	} else {
-		src = photonImplementation( url, { strip: 'all' } );
+		src = photonImplementation( url );
 	}
 
 	/**


### PR DESCRIPTION
Adding ?strip=all to the `img[src]` causes block invalidation. Revert
this invalidating change.

Introduced in #12061, discovered in D26982-code

#### Testing instructions:
* srcsets from #12061 continue to work well
* Older posts are not invalidated by missing `strip=all` on the src. The console in the editor would show a message like the following when loading an older post:

```
Block validation: Expected attribute `src` of value `https://example.com/image.jpg?strip=all`, saw `https://example.com/image.jpg`.
```

Will be handled as part of D26982-code.

#### Proposed changelog entry for your changes:

None