### PR TITLE
Business Hours: Update front-end of the description list

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -135,6 +135,8 @@ function jetpack_business_hours_render( $attributes ) {
 
 	$content .= '</dl>';
 
+	Jetpack_Gutenberg::load_assets_as_required( 'business-hours' );
+
 	/**
 	 * Allows folks to filter the HTML content for the Business Hours block
 	 *

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -8,6 +8,7 @@ import { Path } from '@wordpress/components';
  * Internal dependencies
  */
 import './editor.scss';
+import './style.scss';
 import BusinessHours from './edit';
 import renderMaterialIcon from '../../shared/render-material-icon';
 

--- a/extensions/blocks/business-hours/style.scss
+++ b/extensions/blocks/business-hours/style.scss
@@ -1,0 +1,27 @@
+.jetpack-business-hours {
+  &:before,
+  &:after {
+    content: "";
+    display: table;
+    table-layout: fixed;
+  }
+
+  &:after {
+    clear: both;
+  }
+
+  dt,
+  dd {
+      float: left;
+  }
+
+  dt {
+      clear: both;
+      font-weight: bold;
+      margin-right: 0.5rem;
+  }
+
+  dd {
+      margin: 0;
+  }
+}

--- a/extensions/blocks/business-hours/view.js
+++ b/extensions/blocks/business-hours/view.js
@@ -1,0 +1,5 @@
+/**
+ * Internal dependencies
+ */
+
+import './style.scss';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Reduce the size taken by the Business Hours on a page.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure parent element clears floats
* Have the terms and descriptions on the same line
* Terms elements should be bold to differentiate them from the descriptions (in case theme doesn't already style this)
* Overwrite description's default margin
* Add small right margin to terms

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Business Hours block to any post and page
* Notice the new style in the editor when block is unfocussed
* Notice the new style on the front-end

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/57865310-3e741a80-77f5-11e9-9824-ad5e68e8f01f.jpg)
_Twenty Nineteen / Shoreditch_

__After:__

![2 after](https://user-images.githubusercontent.com/177929/57865331-4af87300-77f5-11e9-8ac8-99887b3c5787.jpg)
_Twenty Nineteen / Shoreditch_

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Business Hours: Update front-end of the description list