### PR TITLE
General: require PHP 5.3+ to be able to run Jetpack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ env:
 # so it doesn't need to be re-defined below.
 matrix:
   include:
-  # The versions listed below run within Precise distro with PHP 5.2 due to Travis limitation
-  # Hard-coding the versions since WP 5.2 has a PHP 5.6 minimum support.
-  # When removing this, remove corresponding setup functions in setup-travis.sh.
-  - php: "5.2"
-    env: WP_MODE=single WP_BRANCH=5.1
-    dist: precise
   - if: branch !~ /(^branch-.*-built)/
     language: node_js
     env: WP_TRAVISCI="yarn lint"

--- a/jetpack.php
+++ b/jetpack.php
@@ -96,6 +96,7 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
 
 /**
  * Outputs an admin notice for folks running an outdated version of PHP.
+ * @todo: Remove once WP 5.2 is the minimum version.
  *
  * @since 7.4.0
  */

--- a/jetpack.php
+++ b/jetpack.php
@@ -13,6 +13,7 @@
  */
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.1' );
+define( 'JETPACK__MINIMUM_PHP_VERSION', '5.3' );
 
 define( 'JETPACK__VERSION',            '7.4-alpha' );
 define( 'JETPACK_MASTER_USER',         true );
@@ -90,6 +91,44 @@ function jetpack_admin_unsupported_wp_notice() { ?>
 
 if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' ) ) {
 	add_action( 'admin_notices', 'jetpack_admin_unsupported_wp_notice' );
+	return;
+}
+
+/**
+ * Outputs an admin notice for folks running an outdated version of PHP.
+ *
+ * @since 7.4.0
+ */
+function jetpack_admin_unsupported_php_notice() { ?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'Jetpack requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying Jetpack.', 'jetpack' ); ?></p>
+		<p class="button-container">
+		<?php
+		printf(
+			'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+			esc_url( wp_get_update_php_url() ),
+			__( 'Learn more about updating PHP' ),
+			/* translators: accessibility text */
+			__( '(opens in a new tab)' )
+		);
+		?>
+	</p>
+	</div>
+	<?php
+}
+
+if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log(
+			sprintf(
+				/* translators: Placeholders are numbers, versions of PHP in use on the site, and required by Jetpack. */
+				esc_html__( 'Your version of PHP (%1$s) is lower than the version required by Jetpack (%2$s). Please update PHP to continue enjoying Jetpack.', 'jetpack' ),
+				esc_html( phpversion() ),
+				JETPACK__MINIMUM_PHP_VERSION
+			)
+		);
+	}
+	add_action( 'admin_notices', 'jetpack_admin_unsupported_php_notice' );
 	return;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, an
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 7.3.1
 Requires at least: 5.0
+Requires PHP: 5.3
 Tested up to: 5.2
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -30,12 +30,6 @@ latest)
 previous)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php --previous) git://develop.git.wordpress.org/ /tmp/wordpress-previous
 	;;
-5.0)
-	git clone --depth=1 --branch 5.0 git://develop.git.wordpress.org/ /tmp/wordpress-5.0
-	;;
-5.1)
-	git clone --depth=1 --branch 5.1 git://develop.git.wordpress.org/ /tmp/wordpress-5.1
-	;;
 esac
 
 clone_exit_code=$?


### PR DESCRIPTION
Given that Jetpack supports WordPress’ latest version (currently 5.2) as well as one version prior, we can't benefit from the changes introduced in WordPress 5.2 yet: **Jetpack currently supports WordPress 5.1, and the required PHP version set by WP 5.1 is PHP 5.2.** 
This PR aims to change that required PHP version for Jetpack, until WordPress 5.3 is released; at that point Jetpack can go back to following WordPress’ PHP requirements and thus require PHP 5.6.

#### Changes proposed in this Pull Request:

If a site runs WP 5.1 (where the PHP requirements are still PHP 5.2) and updates Jetpack:
1. We pause Jetpack (stop loading it).
2. We display an admin notice inviting folks to update PHP.
3. If `WP_DEBUG` is on, we log an error.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* More discussion here: p9dueE-Lz-p2

#### Testing instructions:

* Add the following to your `wp-config.php` file:
`define( 'JETPACK__MINIMUM_PHP_VERSION', '7.4' );`
* Load your dashboard.
* You should see this warning and Jetpack will not be loaded:
<img width="1423" alt="screenshot 2019-05-16 at 17 32 51" src="https://user-images.githubusercontent.com/426388/57868908-235cd700-7804-11e9-93e0-855acca3b79e.png">

#### Proposed changelog entry for your changes:

* General: Jetpack now requires PHP 5.3, and will display a notice if your site uses an older version of PHP.
