### PR TITLE
Sharing: only set default pages showing buttons when not set yet

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -316,7 +316,7 @@ class Sharing_Service {
 			'button_style'  => 'icon-text',
 			'sharing_label' => $this->default_sharing_label,
 			'open_links'    => 'same',
-			'show'          => array( 'post', 'page' ),
+			'show'          => ! isset( $options['global'] ) ? array( 'post', 'page' ) : array(),
 			'custom'        => isset( $options['global']['custom'] ) ? $options['global']['custom'] : array(),
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes https://github.com/Automattic/wp-calypso/issues/22811

Follow up from #12319

We only want to set a default set of pages where the buttons will appear when we first create our set of sharing options. Once you've set them, you should be able to unset them by unchecking all boxes in the form.

#### Testing instructions:

* On a brand new site, activate the Sharing buttons and go to Settings > Sharing.
* You should see both Pages and Posts checked for the "Show buttons on" option.
* If you are not on a brand new site, run `yarn docker:wp option delete sharing-options` to fake a new site. You should see the same set of defaults.
* Now either in Calypso https://wordpress.com/marketing/sharing-buttons/ or on Settings > Sharing, uncheck both boxes and save your changes.
* Your changes should stick.

#### Proposed changelog entry for your changes:

* None
