### PR TITLE
Business Hours: Simplify hours format

### DIFF
--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -118,7 +118,6 @@ function jetpack_business_hours_render( $attributes ) {
 				continue;
 			}
 			$days_hours .= sprintf(
-				/* Translators: Business opening hours info. */
 				'%1$s - %2$s',
 				date( $time_format, $opening ),
 				date( $time_format, $closing )

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -119,7 +119,7 @@ function jetpack_business_hours_render( $attributes ) {
 			}
 			$days_hours .= sprintf(
 				/* Translators: Business opening hours info. */
-				_x( 'From %1$s to %2$s', 'from business opening hour to closing hour', 'jetpack' ),
+				'%1$s - %2$s',
 				date( $time_format, $opening ),
 				date( $time_format, $closing )
 			);

--- a/extensions/blocks/business-hours/components/day-preview.js
+++ b/extensions/blocks/business-hours/components/day-preview.js
@@ -21,13 +21,13 @@ class DayPreview extends Component {
 
 	renderInterval = ( interval, key ) => {
 		return (
-			<dd key={ key }>
+			<span key={ key }>
 				{ sprintf(
-					_x( 'From %s to %s', 'from business opening hour to closing hour', 'jetpack' ),
+					'%s - %s',
 					this.formatTime( interval.opening ),
 					this.formatTime( interval.closing )
 				) }
-			</dd>
+			</span>
 		);
 	};
 
@@ -40,11 +40,11 @@ class DayPreview extends Component {
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
-				{ isEmpty( hours ) ? (
-					<dd>{ _x( 'Closed', 'business is closed on a full day', 'jetpack' ) }</dd>
-				) : (
-					hours.map( this.renderInterval )
-				) }
+				<dd>
+					{ isEmpty( hours )
+						? _x( 'Closed', 'business is closed on a full day', 'jetpack' )
+						: hours.map( this.renderInterval ) }
+				</dd>
 			</Fragment>
 		);
 	}

--- a/extensions/blocks/business-hours/editor.scss
+++ b/extensions/blocks/business-hours/editor.scss
@@ -3,6 +3,10 @@
 .wp-block-jetpack-business-hours {
 	overflow: hidden;
 
+	dd span {
+		display: block;
+	}
+
 	.business-hours__row {
 		display: flex;
 


### PR DESCRIPTION
Simpler format for the hours, not having to rely on translations, with the use of a dash rather than "From [...] to".

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the repetitious "From [...] to"
* Simply use a dash to differentiate opening to closing hours
* Update editor view to make sure multiple hours for the same day are on a separate line

See #12393 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Business Hours block to any post and page
* Notice the new format in the editor
* Notice the new format on the front-end

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/57932951-ef40ef00-78b3-11e9-8ce5-a330d9b90459.png)
_Editor / Front-end (Shoreditch)_

__After:__

![2 after](https://user-images.githubusercontent.com/177929/57932982-fd8f0b00-78b3-11e9-8217-690d9136d273.png)
_Editor / Front-end (Shoreditch)_

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Business Hours: Simplify hours format