### PR TITLE
Gutenframe: Re-enable links to manage reusable blocks

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -269,6 +269,7 @@ class Jetpack_Calypsoify {
 			'calypsoifyGutenberg',
 			array(
 				'closeUrl'   => $this->get_close_gutenberg_url(),
+				'manageReusableBlocksUrl' => $this->get_calypso_origin() . '/types/wp_block' . $this->get_site_suffix(),
 			)
 		);
 	}
@@ -323,6 +324,19 @@ class Jetpack_Calypsoify {
 			'https://wordpress.com',
 		);
 		return in_array( $origin, $whitelist ) ? $origin : 'https://wordpress.com';
+
+		function get_site_suffix() {
+			if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'build_raw_urls' ) ) {
+				$site_suffix = Jetpack::build_raw_urls( home_url() );
+			} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+				$site_suffix = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+			}
+
+			if ( $site_suffix ) {
+				return "/${site_suffix}";
+			}
+			return '';
+		}
 	}
 
 	/**

--- a/modules/calypsoify/mods-gutenberg.js
+++ b/modules/calypsoify/mods-gutenberg.js
@@ -2,20 +2,6 @@
 /* global wp, calypsoifyGutenberg */
 
 jQuery( function( $ ) {
-	/**
-	 * Checks self and top to determine if we are being loaded in an iframe.
-	 * Can't use window.frameElement because we are being embedded from a different origin.
-	 * @returns {boolean} Returns `true` if we are being loaded in an iframe,
-	 *  else `false`.
-	 */
-	function inIframe() {
-		try {
-			return window.self !== window.top;
-		} catch ( e ) {
-			return true;
-		}
-	}
-
 	if (
 		wp &&
 		wp.data &&
@@ -39,26 +25,4 @@ jQuery( function( $ ) {
 		var href = $( this ).attr( 'href' );
 		$( this ).attr( 'href', href.replace( '&classic-editor', '' ) );
 	} );
-
-	if ( inIframe() ) {
-		// Modify Notice action links in order to open them in parent window and not in a child iframe.
-		var viewPostLinkSelectors = [
-			'.components-notice-list .components-notice__action.is-link', // View Post link in success notice
-			'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
-			'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
-		].join( ',' );
-		$( '#editor' ).on( 'click', viewPostLinkSelectors, function( e ) {
-			e.preventDefault();
-			window.open( this.href, '_top' );
-		} );
-
-		var manageReusableBlocksLinkSelectors = [
-			'.editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
-			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
-		].join( ',' );
-		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, function( e ) {
-			e.preventDefault();
-			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
-		} );
-	}
 } );

--- a/modules/calypsoify/mods-gutenberg.js
+++ b/modules/calypsoify/mods-gutenberg.js
@@ -2,6 +2,20 @@
 /* global wp, calypsoifyGutenberg */
 
 jQuery( function( $ ) {
+	/**
+	 * Checks self and top to determine if we are being loaded in an iframe.
+	 * Can't use window.frameElement because we are being embedded from a different origin.
+	 * @returns {boolean} Returns `true` if we are being loaded in an iframe,
+	 *  else `false`.
+	 */
+	function inIframe() {
+		try {
+			return window.self !== window.top;
+		} catch ( e ) {
+			return true;
+		}
+	}
+
 	if (
 		wp &&
 		wp.data &&
@@ -25,4 +39,26 @@ jQuery( function( $ ) {
 		var href = $( this ).attr( 'href' );
 		$( this ).attr( 'href', href.replace( '&classic-editor', '' ) );
 	} );
+
+	if ( inIframe() ) {
+		// Modify Notice action links in order to open them in parent window and not in a child iframe.
+		var viewPostLinkSelectors = [
+			'.components-notice-list .components-notice__action.is-link', // View Post link in success notice
+			'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
+			'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
+		].join( ',' );
+		$( '#editor' ).on( 'click', viewPostLinkSelectors, function( e ) {
+			e.preventDefault();
+			window.open( this.href, '_top' );
+		} );
+
+		var manageReusableBlocksLinkSelectors = [
+			'.editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
+			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
+		].join( ',' );
+		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, function( e ) {
+			e.preventDefault();
+			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
+		} );
+	}
 } );

--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -9,12 +9,6 @@
   display: none;
 }
 
-/* Hides the Manage Reusable Blocks links */
-.editor-inserter__manage-reusable-blocks,
-a.components-menu-item__button[href*="post_type=wp_block"] {
-  display: none;
-}
-
 .edit-post-sidebar__panel-tab {
 	&.is-active {
 		border-color: $color-primary;


### PR DESCRIPTION
In D26034-code we unhid the Manage Reusable Blocks links on WPCOM Simple Sites by removing some styles from Calypsoify that were hiding them. These changes now need to be synced to Jetpack.

Fixes https://github.com/Automattic/wp-calypso/issues/32746

#### Changes proposed in this Pull Request:
* Re-enable links to manage reusable blocks

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Re-enables a feature in the block editor

#### Testing instructions:
* Load a site with this patch applied within the Gutenberg iframe and open the block editor.
* Add a block to reusable blocks if you don't have one already
* Verify that links to manage reusable blocks are present in the sidebar and in the add block menu:

<img src="https://user-images.githubusercontent.com/1233880/57057257-66865880-6ce2-11e9-9442-bbfde2ef0650.png" />

* Verify that both links go to the Calypso block manager at  `/types/wp_block/:siteSlug`
* In wp-admin's block editor, these links should still be present, and go to `wp-admin/edit.php?post_type=wp_block`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Block editor: Allow managing reusable blocks when iframed in Calypso
