### PR TITLE
Fix "View Full Site" and "View Mobile Site" for WordPress Subdirectory Installations

### DIFF
--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -128,7 +128,7 @@ function jetpack_mobile_available() {
 	if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 		$url_params[] = $_GET;
 	}
-	$target_url = esc_url(home_url(add_query_arg($url_params, $wp->request)));
+	$target_url = esc_url( home_url( add_query_arg( $url_params, $wp->request ) ) );
 	$anchor = '<a href="' . $target_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
 	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;">' . $anchor . '</div>';
 }

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -124,14 +124,10 @@ function jetpack_mobile_available() {
 	if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 		$url_params[] = $_GET;
 	}
-	$target_url = esc_url(
-		home_url(
-			add_query_arg(
+	$target_url = esc_url(home_url(add_query_arg(
 				$url_params,
 				$wp->request
-			)
-		)
-	);
+			)));
 	$anchor = '<a href="' . $target_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
 	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;">' . $anchor . '</div>';
 }

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -117,6 +117,10 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
+	/*
+	 * Create HTML markup with a link to "View Mobile Site".
+	 * The link adds "ak_action=accept_mobile" to the current URL.
+	 */
 	global $wp;
 	$url_params = array(
 		'ak_action' => 'accept_mobile',

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -117,7 +117,23 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
-	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. esc_url( home_url( add_query_arg('ak_action', 'accept_mobile') ) ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	global $wp;
+	$url_params = array(
+		'ak_action' => 'accept_mobile',
+	);
+	if ( is_array( $_GET ) && ! empty( $_GET ) ) {
+		$url_params[] = $_GET;
+	}
+	$target_url = esc_url(
+		home_url(
+			add_query_arg(
+				$url_params,
+				$wp->request
+			)
+		)
+	);
+	$anchor = '<a href="' . $target_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
+	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;">' . $anchor . '</div>';
 }
 
 function jetpack_mobile_request_handler() {

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -124,10 +124,7 @@ function jetpack_mobile_available() {
 	if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 		$url_params[] = $_GET;
 	}
-	$target_url = esc_url(home_url(add_query_arg(
-				$url_params,
-				$wp->request
-			)));
+	$target_url = esc_url(home_url(add_query_arg($url_params, $wp->request)));
 	$anchor = '<a href="' . $target_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
 	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;">' . $anchor . '</div>';
 }

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -128,8 +128,8 @@ function jetpack_mobile_available() {
 	if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 		$url_params[] = $_GET;
 	}
-	$target_url = esc_url( home_url( add_query_arg( $url_params, $wp->request ) ) );
-	$anchor = '<a href="' . $target_url . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
+	$target_url = home_url( add_query_arg( $url_params, $wp->request ) );
+	$anchor = '<a href="' . esc_url( $target_url ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a>';
 	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;">' . $anchor . '</div>';
 }
 

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -40,10 +40,7 @@
 			if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 				$url_params[] = $_GET;
 			}
-			$target_url = esc_url(
-				home_url(add_query_arg($url_params,
-						$wp->request
-					)));
+			$target_url = esc_url(home_url(add_query_arg($url_params, $wp->request)));
 		?>
 
 		<a href="<?php echo $target_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -27,7 +27,30 @@
 
 <footer id="colophon" role="contentinfo">
 	<div id="site-generator">
-		<a href="<?php echo esc_url( home_url( add_query_arg('ak_action', 'reject_mobile') ) ); ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+
+		<?php
+			/*
+			 * Construct "$target_url", which adds "ak_action=reject_mobile"
+			 * to the current URL.
+			 */
+			global $wp;
+			$url_params = array(
+				'ak_action' => 'reject_mobile',
+			);
+			if ( is_array( $_GET ) && ! empty( $_GET ) ) {
+				$url_params[] = $_GET;
+			}
+			$target_url = esc_url(
+				home_url(
+					add_query_arg(
+						$url_params,
+						$wp->request
+					)
+				)
+			);
+		?>
+
+		<a href="<?php echo $target_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
 
 		<?php
 			/**

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -40,10 +40,11 @@
 			if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 				$url_params[] = $_GET;
 			}
-			$target_url = esc_url( home_url( add_query_arg( $url_params, $wp->request ) ) );
+			$target_url = home_url( add_query_arg( $url_params, $wp->request ) );
 		?>
 
-		<a href="<?php echo $target_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+		<a href="<?php echo esc_url( $target_url ); ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a>
+		<br />
 
 		<?php
 			/**

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -40,7 +40,7 @@
 			if ( is_array( $_GET ) && ! empty( $_GET ) ) {
 				$url_params[] = $_GET;
 			}
-			$target_url = esc_url(home_url(add_query_arg($url_params, $wp->request)));
+			$target_url = esc_url( home_url( add_query_arg( $url_params, $wp->request ) ) );
 		?>
 
 		<a href="<?php echo $target_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -41,13 +41,9 @@
 				$url_params[] = $_GET;
 			}
 			$target_url = esc_url(
-				home_url(
-					add_query_arg(
-						$url_params,
+				home_url(add_query_arg($url_params,
 						$wp->request
-					)
-				)
-			);
+					)));
 		?>
 
 		<a href="<?php echo $target_url; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />


### PR DESCRIPTION
When WordPress is installed to a subdirectory, the "View Full Site" and "View Mobile Site" links do not work properly. Incidentally, the problem is masked when on a blog post page, but present on the home page.

For example, suppose a blog is hosted at `https://somesite.com/blog`, with this URL set for both `WordPress Address` and `Site Address` in the Wordpress settings (i.e., the blog is intended to be accessed at the subdirectory). Under this scenario, the "View Full Site" link expands to `https://somesite.com/blog/blog/?ak_action=reject_mobile`, which has an extra `blog/`. It should expand to `https://somesite.com/blog/?ak_action=reject_mobile`. The double occurrence of `blog` is due to the omitted `$url` argument to `add_query_arg` combined with the call to `home_url`. The call to `add_query_arg` returns `/blog/?ak_action=reject_mobile` and that is passed to `home_url` which returns `https://somesite.com/blog/blog/?ak_action=reject_mobile`.

The same thing happens for the "View Mobile Site" link.

The problem occurs on the blog's homepage, and results in a page not found. The same issue occurs on blog posts, where `blog/` is added to the URL twice, but it appears that Wordpress is robust to such malformed URLs.

#### Changes proposed in this Pull Request:

* This PR uses the approach proposed by @jeherve here: https://github.com/Automattic/jetpack/pull/11166#discussion_r251478911

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix, not a new/modified feature.

#### Testing instructions:

* To replicate the issue, navigate on a phone to a WordPress blog installed to a subdirectory, and click "View Full Page". The page will not be found (although further navigations will load the full site, not the mobile one).
* With the changes in this PR, the problem is not present.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix "View Full Site" and "View Mobile Site" for WordPress subdirectory installations
