### PR TITLE
Memberships: fix button presentation

### DIFF
--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -302,6 +302,7 @@ class MembershipsButtonEdit extends Component {
 			</InspectorControls>
 		);
 		const blockClasses = classnames( className, [
+			'wp-block-button__link',
 			'components-button',
 			'is-primary',
 			'is-button',

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -41,15 +41,7 @@ class Jetpack_Memberships {
 	 *
 	 * @var array
 	 */
-	private static $tags_allowed_in_the_button = array(
-		'br'     => array(),
-		'em'     => array(),
-		'strong' => array(),
-		'p'      => array(),
-		'img'    => array(
-			'src' => array(),
-		),
-	);
+	private static $tags_allowed_in_the_button = array( 'br' => array() );
 	/**
 	 * Classic singleton pattern
 	 *

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -217,6 +217,7 @@ class Jetpack_Memberships {
 		);
 
 		$classes = array(
+			'wp-block-button__link',
 			'components-button',
 			'is-primary',
 			'is-button',

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -35,6 +35,21 @@ class Jetpack_Memberships {
 	 * @var string
 	 */
 	private static $button_block_name = 'membership-button';
+
+	/**
+	 * These are defaults for wp_kses ran on the membership button.
+	 *
+	 * @var array
+	 */
+	private static $tags_allowed_in_the_button = array(
+		'br'     => array(),
+		'em'     => array(),
+		'strong' => array(),
+		'p'      => array(),
+		'img'    => array(
+			'src' => array(),
+		),
+	);
 	/**
 	 * Classic singleton pattern
 	 *
@@ -243,7 +258,7 @@ class Jetpack_Memberships {
 			esc_attr( get_locale() ),
 			esc_attr( implode( $classes, ' ' ) ),
 			esc_attr( $button_styles ),
-			esc_html( $data['button_label'] )
+			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button )
 		);
 	}
 


### PR DESCRIPTION
During Membership beta, @dbspringer has discovered, that membership button does not render line breaks and @mtias has stumbled upon the horrible fact, that on some themes `button` is not styled and displays with no panache whatsoever.

To fix this I:

- Replaced `esc_html` with `wp_kses` to not cut out `<br/> ` and few other tags.
- Attached `wp-block-button__link` class which is shipped with Gutenberg by default

### Screenshot

![Zrzut ekranu 2019-05-20 o 17 01 04](https://user-images.githubusercontent.com/3775068/58033483-da1ec700-7b24-11e9-874d-2260ae18c19b.png)


### Testing instruction

- Use testing instructions from https://github.com/Automattic/jetpack/pull/9802
- Do a line break and publish - see if there is line break on frontend


