### PR TITLE
Memberships: Automatically select + min amount

### DIFF
--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -146,6 +146,7 @@ class MembershipsButtonEdit extends Component {
 						},
 					] ),
 				} );
+				this.setMembershipAmount( result.id );
 			},
 			result => {
 				this.setState( { addingMembershipAmount: PRODUCT_FORM } );

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -191,6 +191,7 @@ class MembershipsButtonEdit extends Component {
 						onChange={ this.handlePriceChange }
 						placeholder={ formatCurrency( 0, this.state.editedProductCurrency ) }
 						required
+						min="5.00"
 						step="1"
 						type="number"
 						value={ this.state.editedProductPrice || '' }

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -146,6 +146,7 @@ class MembershipsButtonEdit extends Component {
 						},
 					] ),
 				} );
+				// After successful adding of product, we want to select it. Presumably that is the product user wants.
 				this.setMembershipAmount( result.id );
 			},
 			result => {


### PR DESCRIPTION
@mtias has pointed out, that the current set up is a bit confusing.
After you add a new product, you have to CLICK it to display the button.

This change automatically preselects the new button, because you supposedly want to use the one you just created.

@rantoncuadrado  has discovered that you can use the field stepper to input a negative value. I fixed that on the way

### Testing instructions
- Use memberships block
- Add a new button, see it automatically selected.