### PR TITLE
Travis Notifications: Remove oskosk, kraftbj, and jeherve from recipients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,6 @@ notifications:
      recipients:
        - enej.bajgoric@automattic.com
        - georgestephanis@automattic.com
-       - jeremy@automattic.com
        - miguel@automattic.com
        - rocco@automattic.com
        - smart@automattic.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ notifications:
        - allendav@automattic.com
        - beau@automattic.com
        - kraft@automattic.com
-       - oscar@automattic.com
        # Encrypted Slack notification address
        - secure: "WQdTdmYuifSW0hiJGXpQGKystMASC50QvxHlyUL5SM3h5GP8aCgeSsHuXvKPe3dT3Pffhk0dSHBfDtdWFwSHW/upURhg0vs4dm7+nxxvGZiTPzKcuAIjgvCoqWM7teyda/XqFGNSnv+XsT34uoyPhhFgd45T3oS+QQ3aNCruFak="
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,6 @@ notifications:
        - eric.binnion@automattic.com
        - allendav@automattic.com
        - beau@automattic.com
-       - kraft@automattic.com
        # Encrypted Slack notification address
        - secure: "WQdTdmYuifSW0hiJGXpQGKystMASC50QvxHlyUL5SM3h5GP8aCgeSsHuXvKPe3dT3Pffhk0dSHBfDtdWFwSHW/upURhg0vs4dm7+nxxvGZiTPzKcuAIjgvCoqWM7teyda/XqFGNSnv+XsT34uoyPhhFgd45T3oS+QQ3aNCruFak="
 


### PR DESCRIPTION
Removes @oskosk, @kraftbj and @jeherve  from recipients list for Travis notifications

#### Testing instructions:

* Confirm the change makes sense

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
