### PR TITLE
SEO Tools: support taxonomy archive pages in page titles.

### DIFF
--- a/modules/seo-tools/jetpack-seo-titles.php
+++ b/modules/seo-tools/jetpack-seo-titles.php
@@ -156,7 +156,7 @@ class Jetpack_SEO_Titles {
 			return 'front_page';
 		}
 
-		if ( is_category() || is_tag() ) {
+		if ( is_category() || is_tag() || is_tax() ) {
 			return 'groups';
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The SEO Tools allows you to set a custom title for different types of pages, from your WordPress.com dashboard.
However, once you've done that and when viewing a taxonomy archive page, you get an incomplete title. This fixes is, since taxonomy archive pages are very similar to non-custom taxonomy archive pages like category or tag pages.


#### Testing instructions:

* Install a plugin that adds a custom taxonomy to your site. 
* Purchase a Professional plan.
* Go to Tools > Marketing in Calypso.
* Create some custom titles like so:
![image](https://user-images.githubusercontent.com/426388/58050065-9f318900-7b4e-11e9-9b13-6f253a2b589a.png)
* Visit one of the taxonomy archive pages on your site. You will see this:
![image](https://user-images.githubusercontent.com/426388/58050119-c5572900-7b4e-11e9-9f56-f390d297477b.png)

* Apply patch and refresh the page; you should see this:
![image](https://user-images.githubusercontent.com/426388/58050087-b3758600-7b4e-11e9-9412-eb24e9c64ab2.png)

#### Proposed changelog entry for your changes:

* SEO Tools: support taxonomy archive pages in page titles.
