### PR TITLE
Comments: Do not use HTTP 500 for non-server errors.

### DIFF
--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -236,9 +236,9 @@ class Highlander_Comments_Base {
 
 		if ( get_option( 'require_name_email' ) ) {
 			if ( 6 > strlen( $_POST['email'] ) || empty( $_POST['author'] ) ) {
-				wp_die( __( 'Error: please fill the required fields (name, email).', 'jetpack' ) );
+				wp_die( __( 'Error: please fill the required fields (name, email).', 'jetpack' ), 400 );
 			} elseif ( ! is_email( $_POST['email'] ) ) {
-				wp_die( __( 'Error: please enter a valid email address.', 'jetpack' ) );
+				wp_die( __( 'Error: please enter a valid email address.', 'jetpack' ), 400 );
 			}
 		}
 

--- a/modules/comments/base.php
+++ b/modules/comments/base.php
@@ -80,7 +80,7 @@ class Highlander_Comments_Base {
 		$signing = array();
 		foreach ( $parameters as $k => $v ) {
 			if ( ! is_scalar( $v ) ) {
-				return new WP_Error( 'invalid_input', __( 'Invalid request', 'jetpack' ) );
+				return new WP_Error( 'invalid_input', __( 'Invalid request', 'jetpack' ), array( 'status' => 400 ) );
 			}
 
 			$signing[] = "{$k}={$v}";

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -467,12 +467,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		$check = Jetpack_Comments::sign_remote_comment_parameters( $post_array, Jetpack_Options::get_option( 'blog_token' ) );
 		if ( is_wp_error( $check ) ) {
-			wp_die( $check );
+			wp_die( $check, 400 );
 		}
 
 		// Bail if token is expired or not valid
 		if ( $check !== $post_array['sig'] ) {
-			wp_die( __( 'Invalid security token.', 'jetpack' ) );
+			wp_die( __( 'Invalid security token.', 'jetpack' ), 400 );
 		}
 
 		/** This filter is documented in modules/comments/comments.php */
@@ -480,7 +480,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			// In case the comment POST is legit, but the comments are
 			// now disabled, we don't allow the comment
 
-			wp_die( __( 'Comments are not allowed.', 'jetpack' ) );
+			wp_die( __( 'Comments are not allowed.', 'jetpack' ), 403 );
 		}
 	}
 

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -467,7 +467,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		$check = Jetpack_Comments::sign_remote_comment_parameters( $post_array, Jetpack_Options::get_option( 'blog_token' ) );
 		if ( is_wp_error( $check ) ) {
-			wp_die( $check, 400 );
+			wp_die( $check );
 		}
 
 		// Bail if token is expired or not valid


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Jetpack should not be responding with HTTP 5xx errors when a client makes a bad or unauthorized requests. HTTP 4xx should be used for such requests.

#### Testing instructions:
It's annoying. Do the following for both `master` and this branch (`update/comments-should-not-die-with-500`).

1. Edit modules/comments/comments.php so that the signature check always fails. Something like the following will work:
```diff
diff --git a/modules/comments/comments.php b/modules/comments/comments.php
index e352ab7f8..cfbc9a92b 100644
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -471,4 +471,6 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
+$check = '';
+
 		// Bail if token is expired or not valid
 		if ( $check !== $post_array['sig'] ) {
```
2. Ensure Jetpack Comments is enabled.
3. Compose a comment on a post. Do not yet submit it.
4. In your browser console, look at the network requests log.
5. Submit the comment.

In master, you'll see the wp-comments-post.php request has a 500 response. In this branch, you'll see a 400.

Remember to undo the hack from step 1 :)

#### Proposed changelog entry for your changes:
* Use HTTP 4xx status codes for comment errors.