### PR TITLE
My Plan: Remove features CTAs

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -175,7 +175,6 @@ class MyPlanBody extends React.Component {
 									this.props.siteRawUrl +
 									'?only=vaultpress'
 								}
-								className="is-primary"
 							>
 								{ __( 'View settings' ) }
 							</Button>
@@ -250,7 +249,6 @@ class MyPlanBody extends React.Component {
 											this.props.siteRawUrl +
 											'?only=akismet'
 										}
-										className="is-primary"
 									>
 										{ __( 'View settings' ) }
 									</Button>
@@ -283,7 +281,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateVideoPress }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'videopress' ) }
 											>
 												{ __( 'Activate video hosting' ) }
@@ -348,7 +345,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateAds }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'wordads' ) }
 											>
 												{ __( 'Start earning' ) }
@@ -386,7 +382,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateSearch }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'search' ) }
 											>
 												{ __( 'Activate Jetpack Search' ) }
@@ -423,7 +418,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateSeo }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'seo-tools' ) }
 											>
 												{ __( 'Activate SEO tools' ) }
@@ -462,7 +456,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateGoogleAnalytics }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'google-analytics' ) }
 											>
 												{ __( 'Activate Google Analytics' ) }
@@ -529,7 +522,6 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activatePublicize }
-												className="is-primary"
 												disabled={ this.props.isActivatingModule( 'publicize' ) }
 											>
 												{ __( 'Activate Publicize' ) }
@@ -713,7 +705,6 @@ class MyPlanBody extends React.Component {
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_explore_jetpack_plans' ) }
 									href={ '#/plans' }
-									className="is-primary"
 								>
 									{ __( 'Explore Jetpack plans' ) }
 								</Button>


### PR DESCRIPTION
Companion to https://github.com/Automattic/jetpack/pull/12429, part of https://github.com/Automattic/jetpack/issues/11997#issuecomment-494155147

Remove the primary buttons from My Plan feature cards. There were some cases of multiple primary buttons which is discouraged. The only primary button will be in the header as of https://github.com/Automattic/jetpack/pull/12429


#### Screens

##### Before

![before](https://user-images.githubusercontent.com/841763/58096626-d139fe00-7bd5-11e9-9817-05ca056d9154.png)

##### After

![after](https://user-images.githubusercontent.com/841763/58096625-d139fe00-7bd5-11e9-9049-fbbbd6570fd6.png)

#### Testing instructions:

* From `/wp-admin/admin.php?page=jetpack#/my-plan` on your Jetpack site
* There should be no primary buttons in the features for different plans like in the _after_ screenshot above.
* No other changes.