### PR TITLE
Gutenberg: Add a premium block category

### DIFF
--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -43,7 +43,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: 'jetpack',
+	category: 'premium',
 
 	keywords: [
 		_x( 'shop', 'block search term', 'jetpack' ),

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -49,7 +49,7 @@ export const settings = {
 		},
 	},
 
-	category: 'jetpack',
+	category: 'premium',
 
 	keywords: [ __( 'ads', 'jetpack' ), 'WordAds', __( 'Advertisement', 'jetpack' ) ],
 

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -16,4 +16,9 @@ setCategories( [
 		title: 'Jetpack',
 		icon: <JetpackLogo />,
 	},
+	{
+		slug: 'premium',
+		title: 'Premium',
+		icon: <JetpackLogo />,
+	},
 ] );

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -19,6 +19,6 @@ setCategories( [
 	{
 		slug: 'premium',
 		title: 'Premium',
-		icon: <JetpackLogo />,
+		icon: <JetpackLogo fill="#d6b02c" />,
 	},
 ] );

--- a/extensions/shared/jetpack-logo.js
+++ b/extensions/shared/jetpack-logo.js
@@ -4,19 +4,25 @@
 import { Path, Polygon, SVG } from '@wordpress/components';
 import classNames from 'classnames';
 
-export default ( { size = 24, className } ) => (
-	<SVG
-		className={ classNames( 'jetpack-logo', className ) }
-		width={ size }
-		height={ size }
-		viewBox="0 0 32 32"
-	>
-		<Path
-			className="jetpack-logo__icon-circle"
-			fill="#00be28"
-			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
-		/>
-		<Polygon className="jetpack-logo__icon-triangle" fill="#fff" points="15,19 7,19 15,3 " />
-		<Polygon className="jetpack-logo__icon-triangle" fill="#fff" points="17,29 17,13 25,13 " />
-	</SVG>
-);
+export default ( { size = 24, className, fill } ) => {
+	if ( ! fill ) {
+		fill = '#00be28';
+	}
+
+	return (
+		<SVG
+			className={ classNames( 'jetpack-logo', className ) }
+			width={ size }
+			height={ size }
+			viewBox="0 0 32 32"
+		>
+			<Path
+				className="jetpack-logo__icon-circle"
+				fill={ fill }
+				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+			/>
+			<Polygon className="jetpack-logo__icon-triangle" fill="#fff" points="15,19 7,19 15,3 " />
+			<Polygon className="jetpack-logo__icon-triangle" fill="#fff" points="17,29 17,13 25,13 " />
+		</SVG>
+	);
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds a new "Premium" category to the block picker:

<img width="440" alt="Screenshot 2019-05-21 at 13 59 20" src="https://user-images.githubusercontent.com/275961/58098821-3db2fe00-7bd2-11e9-8534-97a03ddeae2a.png">

This makes it clear that these blocks are paid blocks, not free ones.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of Page Editor Plus: paAmJe-ll-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the post editor for a site with no plan
* Check that you don't see the Premium section
* Go to the post editor for a site with a plan
* Check that the Simple Payments button appears in a new category in the block picker:
<img width="440" alt="Screenshot 2019-05-21 at 13 59 20" src="https://user-images.githubusercontent.com/275961/58098821-3db2fe00-7bd2-11e9-8534-97a03ddeae2a.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog needed
