### PR TITLE
Unit Tests: Add support for VVV 3.0's path. 

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -29,6 +29,9 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 } else if ( file_exists( '/vagrant/www/wordpress-develop/public_html/tests/phpunit/includes/bootstrap.php' ) ) {
 	// VVV
 	$test_root = '/vagrant/www/wordpress-develop/public_html/tests/phpunit';
+} else if ( file_exists( '/srv/www/wordpress-trunk/public_html/tests/phpunit/includes/bootstrap.php' ) ) {
+	// VVV 3.0
+	$test_root = '/srv/www/wordpress-trunk/public_html/tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-develop/tests/phpunit/includes/bootstrap.php' ) ) {
 	// Manual checkout & Jetpack's docker environment
 	$test_root = '/tmp/wordpress-develop/tests/phpunit';


### PR DESCRIPTION
Requires the wordpress-trunk site to be provisioned on VVV 3 and the tests config file added.

Split off of #12410

#### Changes proposed in this Pull Request:
* Adds support for unit testing with VVV 3.0

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:

* Install latest VVV (3.0).
* Edit your vvv-custom.yml to set "skip provision" to false for the wordpress-trunk site.
* vagrant up --provision
* Add a `wp-tests-config.php` file to `/srv/www/wordpress-trunk/public_html` that uses the same creds as wp-config.php with a db name of `wordpress_unit_tests`
* Run `phpunit` from the jetpack root directory. (e.g. /srv/www/wordpress-trunk/public_html/build/wp-content/plugins/jetpack/ or /srv/www/wordpress-one/public_html/wp-content/plugins/jetpack/

#### Proposed changelog entry for your changes:
* Unit Tests: Add support for testing using VVV 3.0.
