### PR TITLE
General: Bump PHPCS rules

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
 	<config name="minimum_supported_wp_version" value="5.1" />
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.3-"/>
 
 	<rule ref="PHPCompatibilityWP"/>
 	<rule ref="WordPress-Core" />

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
-	<config name="minimum_supported_wp_version" value="5.0" />
+	<config name="minimum_supported_wp_version" value="5.1" />
 	<config name="testVersion" value="5.2-"/>
 
 	<rule ref="PHPCompatibilityWP"/>


### PR DESCRIPTION
We need to bump the minimum WP and PHP versions based on previous PRs.

#### Changes proposed in this Pull Request:
* Bump PHP and WP minimum

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add something not allowed in PHP 5.3 and run phpcs against it.
*

#### Proposed changelog entry for your changes:
* n/a
