### PR TITLE
Compser: Read once, fail gracefully (and more)

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -173,7 +173,7 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
  * We want to fail gracefully if `composer install` has not been executed yet, so we are including the autoloader.
  * If `include` isn't able to load the autoloader, let's log the failure, pause Jetpack, and display a nice admin notice.
  */
-$jetpack_autoloader = JETPACK__PLUGIN_DIR . '/vendor/autoload.php';
+$jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload.php';
 if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not include the file. Otherwise, it returns 1 or whatever value is returned by the file, if any.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(

--- a/jetpack.php
+++ b/jetpack.php
@@ -150,8 +150,6 @@ function jetpack_admin_missing_autoloader() { ?>
  *
  * Lastly, we fire Jetpack::init() to fire up the engines.
  */
-
-
 if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
@@ -174,7 +172,9 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
  * If `include` isn't able to load the autoloader, let's log the failure, pause Jetpack, and display a nice admin notice.
  */
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload.php';
-if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not include the file. Otherwise, it returns 1 or whatever value is returned by the file, if any.
+if ( is_readable( $jetpack_autoloader ) ) {
+	require $jetpack_autoloader;
+} else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
 			sprintf(

--- a/jetpack.php
+++ b/jetpack.php
@@ -168,8 +168,8 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 /**
  * Load all the packages.
  *
- * We want to fail gracefully if `composer install` has not been executed yet, so we are including the autoloader.
- * If `include` isn't able to load the autoloader, let's log the failure, pause Jetpack, and display a nice admin notice.
+ * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
+ * If the autoloader is not present, let's log the failure, pause Jetpack, and display a nice admin notice.
  */
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload.php';
 if ( is_readable( $jetpack_autoloader ) ) {

--- a/jetpack.php
+++ b/jetpack.php
@@ -139,6 +139,19 @@ function jetpack_admin_missing_autoloader() { ?>
 	<?php
 }
 
+/**
+ * This is where the loading of Jetpack begins.
+ *
+ * First, we check for our supported version of PHP and load our composer autoloader. If either of these fail,
+ * we "pause" Jetpack by ending the loading process and displaying an admin_notice to inform the site owner.
+ *
+ * After both those things happen successfully, we require the legacy files, then add on to various hooks that we expect
+ * to always run.
+ *
+ * Lastly, we fire Jetpack::init() to fire up the engines.
+ */
+
+
 if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
@@ -154,7 +167,12 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 	return;
 }
 
-// Load all the packages.
+/**
+ * Load all the packages.
+ *
+ * We want to fail gracefully if `composer install` has not been executed yet, so we are including the autoloader.
+ * If `include` isn't able to load the autoloader, let's log the failure, pause Jetpack, and display a nice admin notice.
+ */
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . '/vendor/autoload.php';
 if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not include the file. Otherwise, it returns 1 or whatever value is returned by the file, if any.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/jetpack.php
+++ b/jetpack.php
@@ -156,9 +156,7 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 
 // Load all the packages.
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . '/vendor/autoload.php';
-if ( is_readable( $jetpack_autoloader ) ) {
-	require $jetpack_autoloader;
-} else {
+if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not the file. Otherwise, it returns 1 unless the included file returns a different value.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
 			sprintf(

--- a/jetpack.php
+++ b/jetpack.php
@@ -156,7 +156,7 @@ if ( version_compare( phpversion(), JETPACK__MINIMUM_PHP_VERSION, '<' ) ) {
 
 // Load all the packages.
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . '/vendor/autoload.php';
-if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not the file. Otherwise, it returns 1 unless the included file returns a different value.
+if ( ( include $jetpack_autoloader ) === false ) { // include returns false if it can not include the file. Otherwise, it returns 1 or whatever value is returned by the file, if any.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log(
 			sprintf(

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -56,6 +56,15 @@ if [[ $ADD_BETA_VERSION -eq 1 ]]; then
     echo "Now at version $CURRENT_VERSION!"
 fi
 
+# Checking for composer
+hash composer 2>/dev/null || {
+    echo >&2 "This script requires you to have composer package manager installed."
+    echo >&2 "Please install it following the instructions on https://getcomposer.org/. Aborting.";
+    exit 1;
+}
+
+composer --cwd $TARGET_DIR install
+
 # Checking for yarn
 hash yarn 2>/dev/null || {
     echo >&2 "This script requires you to have yarn package manager installed."

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -204,6 +204,15 @@ echo ""
 
 echo "Building Jetpack"
 
+# Checking for composer
+hash composer 2>/dev/null || {
+    echo >&2 "This script requires you to have composer package manager installed."
+    echo >&2 "Please install it following the instructions on https://getcomposer.org/. Aborting.";
+    exit 1;
+}
+
+composer install
+
 # Checking for yarn
 hash yarn 2>/dev/null || {
 	echo >&2 "This script requires you to have yarn package manager installed."

--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -41,6 +41,15 @@ echo ""
 
 echo "Building Jetpack"
 
+# Checking for composer
+hash composer 2>/dev/null || {
+    echo >&2 "This script requires you to have composer package manager installed."
+    echo >&2 "Please install it following the instructions on https://getcomposer.org/. Aborting.";
+    exit 1;
+}
+
+composer install
+
 # Checking for yarn
 hash yarn 2>/dev/null || {
     echo >&2 "This script requires you to have yarn package manager installed."


### PR DESCRIPTION
Various Composer-related improvements that should get in regardless if a particular package makes it in.

#### Changes proposed in this Pull Request:
* Instead of reading if we can read a file, then requiring it, we can include it and conditionally fail if the file can't be included.
* Run `composer install` on branches we expect use.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Run unbuilt Jetpack and visit wp-admin.

#### Proposed changelog entry for your changes:
* n/a
![2019-05-22 at 16 28](https://user-images.githubusercontent.com/88897/58210281-99eb5000-7cae-11e9-821b-f9c97adc2719.jpg)

