### PR TITLE
General: Use modern WordPress hook deprecation, part 1

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6627,19 +6627,19 @@ endif;
 
 		$filter_deprecated_list = array(
 			'can_display_jetpack_manage_notice' => array(
-				'replacement' => false,
+				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
 			'atd_http_post_timeout'             => array(
-				'replacement' => false,
+				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
 			'atd_service_domain'                => array(
-				'replacement' => false,
+				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
 			'atd_load_scripts'                  => array(
-				'replacement' => false,
+				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
 		);
@@ -6650,7 +6650,7 @@ endif;
 
 		$action_deprecated_list = array(
 			'atd_http_post_error' => array(
-				'replacement' => false,
+				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
 		);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6538,7 +6538,9 @@ endif;
 	}
 
 	/**
-	 * Throws warnings for deprecated hooks to be removed from Jetpack
+	 * Throws warnings for deprecated hooks to be removed from Jetpack that cannot remain in the original place in the code.
+	 *
+	 * @todo Convert these to use apply_filters_deprecated and do_action_deprecated and remove custom code.
 	 */
 	public function deprecated_hooks() {
 		global $wp_filter;
@@ -6584,12 +6586,7 @@ endif;
 			'jetpack_updated_theme'                        => 'jetpack_updated_themes',
 			'jetpack_lazy_images_skip_image_with_atttributes' => 'jetpack_lazy_images_skip_image_with_attributes',
 			'jetpack_enable_site_verification'             => null,
-			'can_display_jetpack_manage_notice'            => null,
 			// Removed in Jetpack 7.3.0
-			'atd_load_scripts'                             => null,
-			'atd_http_post_timeout'                        => null,
-			'atd_http_post_error'                          => null,
-			'atd_service_domain'                           => null,
 			'jetpack_widget_authors_exclude'               => 'jetpack_widget_authors_params',
 			// Removed in Jetpack 7.9.0
 			'jetpack_pwa_manifest'                         => null,
@@ -6626,6 +6623,40 @@ endif;
 					}
 				}
 			}
+		}
+
+		$filter_deprecated_list = array(
+			'can_display_jetpack_manage_notice' => array(
+				'replacement' => false,
+				'version'     => 'jetpack-7.3.0',
+			),
+			'atd_http_post_timeout'             => array(
+				'replacement' => false,
+				'version'     => 'jetpack-7.3.0',
+			),
+			'atd_service_domain'                => array(
+				'replacement' => false,
+				'version'     => 'jetpack-7.3.0',
+			),
+			'atd_load_scripts'                  => array(
+				'replacement' => false,
+				'version'     => 'jetpack-7.3.0',
+			),
+		);
+
+		foreach ( $filter_deprecated_list as $tag => $args ) {
+			apply_filters_deprecated( $tag, null, $args['version'], $args['replacement'] );
+		}
+
+		$action_deprecated_list = array(
+			'atd_http_post_error' => array(
+				'replacement' => false,
+				'version'     => 'jetpack-7.3.0',
+			),
+		);
+
+		foreach ( $action_deprecated_list as $tag => $args ) {
+			do_action_deprecated( $tag, null, $args['version'], $args['replacement'] );
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6645,7 +6645,9 @@ endif;
 		);
 
 		foreach ( $filter_deprecated_list as $tag => $args ) {
-			apply_filters_deprecated( $tag, null, $args['version'], $args['replacement'] );
+			if ( has_filter( $tag ) ) {
+				apply_filters_deprecated( $tag, array(), $args['version'], $args['replacement'] );
+			}
 		}
 
 		$action_deprecated_list = array(
@@ -6656,7 +6658,9 @@ endif;
 		);
 
 		foreach ( $action_deprecated_list as $tag => $args ) {
-			do_action_deprecated( $tag, null, $args['version'], $args['replacement'] );
+			if ( has_action( $tag ) ) {
+				do_action_deprecated( $tag, array(), $args['version'], $args['replacement'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
In WordPress 4.6, `apply_filters_deprecated` and `do_action_deprecated` were added to provide a way to announce deprecated hooks. Jetpack had an existing system that predated this, so let's work towards deprecated the extra login on our end.

Fixes #12345

#### Changes proposed in this Pull Request:
* Update system for notifying site owners if a filter is no longer available.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add duplication steps as seen in #12345 before and after.

#### Proposed changelog entry for your changes:
* Improved Compatibility: Use native WordPress functionality for deprecated hooks. 
