### PR TITLE
Fix/respect client defined store_sandbox cookie when fetching plan data

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1334,10 +1334,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$site_id = Jetpack_Options::get_option( 'id' );
 
 		if ( ! $site_id ) {
-			 new WP_Error( 'site_id_missing' );
+			new WP_Error( 'site_id_missing' );
 		}
 
-		$response = Jetpack_Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', $site_id ) .'?force=wpcom', '1.1' );
+		$args = array( 'headers' => array() );
+
+		if ( isset( $_COOKIE ) && isset( $_COOKIE['store_sandbox'] ) ) {
+			$secret                    = $_COOKIE['store_sandbox'];
+			$args['headers']['Cookie'] = "store_sandbox=$secret;";
+		}
+
+		$response = Jetpack_Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', $site_id ) .'?force=wpcom', '1.1', $args );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'site_data_fetch_failed' );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1339,6 +1339,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$args = array( 'headers' => array() );
 
+		// Allow use a store sandbox. Internal ref: PCYsg-IA-p2.
 		if ( isset( $_COOKIE ) && isset( $_COOKIE['store_sandbox'] ) ) {
 			$secret                    = $_COOKIE['store_sandbox'];
 			$args['headers']['Cookie'] = "store_sandbox=$secret;";


### PR DESCRIPTION
This PR allows using Plan from store sandbox instead of production.  
FG page with some context (internal ref): PCYsg-IA-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It's tough.
* You need to have a site with a purchased plan via `store_sandbox` cookie. More details here: PCYsg-IA-p2
* Visit `/wp-admin/admin.php?page=jetpack#/my-plan`. Make sure you can not see your purchased plan from the previous step. 
* Set a cookie via your dev-tools console, replace SECRET with value from SS, and domain to match yours: `document.cookie="store_sandbox=SECRET;domain=.eu.ngrok.io;path=/"`
* Reload the page. you should see your sandboxed plan. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add a way to fetch plan data from `store_sandbox`
