### PR TITLE
Masterbar: allow logging out of wpcom when logging out of site.

### DIFF
--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -13,14 +13,4 @@
 
 require dirname( __FILE__ ) . '/masterbar/masterbar.php';
 
-// In order to be able to tell if it's an AMP request or not we have to hook into parse_query at a later priority.
-add_action( 'admin_bar_init', 'jetpack_initialize_masterbar', 99 );
-
-/**
- * Initializes the Masterbar in case the request is not AMP.
- */
-function jetpack_initialize_masterbar() {
-	if ( ! Jetpack_AMP_Support::is_amp_request() ) {
-		new A8C_WPCOM_Masterbar();
-	}
-}
+new A8C_WPCOM_Masterbar();

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -74,6 +74,16 @@ class A8C_WPCOM_Masterbar {
 	 * Constructor
 	 */
 	public function __construct() {
+		add_action( 'admin_bar_init', array( $this, 'init' ) );
+
+		// Post logout on the site, also log the user out of WordPress.com.
+		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
+	}
+
+	/**
+	 * Initialize our masterbar.
+	 */
+	public function init() {
 		$this->locale  = $this->get_locale();
 		$this->user_id = get_current_user_id();
 
@@ -85,6 +95,14 @@ class A8C_WPCOM_Masterbar {
 		// Don't show the masterbar on WordPress mobile apps.
 		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
 			add_filter( 'show_admin_bar', '__return_false' );
+			return;
+		}
+
+		// Disable the Masterbar on AMP views.
+		if (
+			class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
 			return;
 		}
 
@@ -141,8 +159,6 @@ class A8C_WPCOM_Masterbar {
 			// Override Notification module to include RTL styles.
 			add_action( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', '__return_true' );
 		}
-
-		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12456

#### Changes proposed in this Pull Request:

This change avoids initialiazing all of the Masterbar after `admin_bar_init`. We want the module to be available after logging out as well, so the function hooked into `wp_logout` can be triggered.

#### Testing instructions:

0. Install and activate the AMP plugin.
1. Activate the WordPress.com Toolbar feature on your site, under Jetpack > Settings > Writing
1. Make sure you are logged in with your WordPress.com account.
1. In the masterbar, click on your gravatar.
1. Click sign out.
1. You will be signed out of your site, and should get signed out of WordPress.com as well.
1. Make sure you get no PHP warnings from the AMP plugin.
1. Make sure that in AMP views, the Masterbar is not active.

#### Proposed changelog entry for your changes:

* Masterbar: Log out of WordPress.com when logging out of site.
