### PR TITLE
Connect flow: remove post-disconnect survey

### DIFF
--- a/_inc/client/components/jetpack-notices/dismissable.jsx
+++ b/_inc/client/components/jetpack-notices/dismissable.jsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import SimpleNotice from 'components/notice';
-import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -27,33 +25,6 @@ class DismissableNotices extends React.Component {
 		const notices = this.props.jetpackNotices;
 
 		switch ( notices ) {
-			case 'disconnected':
-				if ( this.props.isDismissed( notices ) ) {
-					return false;
-				}
-				return (
-					<div>
-						<SimpleNotice onDismissClick={ this.dismissJetpackActionNotice }>
-							{ __( 'You have successfully disconnected Jetpack' ) }
-							<br />
-							{ __(
-								'Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.',
-								{
-									components: {
-										a: (
-											<a
-												href="https://jetpack.com/survey-disconnected/"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</SimpleNotice>
-					</div>
-				);
-
 			default:
 				return false;
 		}


### PR DESCRIPTION
Fixes #12452

#### Changes proposed in this Pull Request:

This survey is not displayed to users since #10888, so there is really no need to keep this around.

#### Testing instructions:

* Go to Jetpack > Dashboard
* Scroll down to the connection area
* Disconnect your site from WordPress.com.
* Upon disconnecting, there will be a flash on the page before the connection modal appears again. Before the modal appears again, you should not see any notice about the disconnection survey.

#### Proposed changelog entry for your changes:

* None
