### PR TITLE
Calypsoify: Fix Calypsoify so that it removes core menus correctly

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -37,6 +37,8 @@ class Jetpack_Calypsoify {
 
 		if ( $this->is_calypsoify_enabled ) {
 			add_action( 'admin_init', array( $this, 'setup_admin' ), 6 );
+			add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
+			add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
 		}
 
 		// Make this always available -- in case calypsoify gets toggled off.
@@ -56,8 +58,6 @@ class Jetpack_Calypsoify {
 		}
 
 		add_action( 'admin_init', array( $this, 'check_page' ) );
-		add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
-		add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ), 100 );
 		add_action( 'in_admin_header', array( $this, 'insert_sidebar_html' ) );
 		add_action( 'wp_before_admin_bar_render', array( $this, 'modify_masterbar' ), 100000 );


### PR DESCRIPTION
Fix Calypsoify so that it removes core menus when looking at the plugins section of WP-Admin. 

Fixes #12459

Before fix (core admin menus show):

<img width="940" alt="Screen Shot 2019-05-23 at 3 11 26 PM" src="https://user-images.githubusercontent.com/1464705/58290026-16dcff00-7d6d-11e9-8a3a-234657599040.png">

After fix (core admin menus hidden, only plugin menus show):

<img width="943" alt="Screen Shot 2019-05-23 at 3 10 55 PM" src="https://user-images.githubusercontent.com/1464705/58290034-24928480-7d6d-11e9-837b-1e681cb41f9e.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The admin_init hook is called after the admin_menu hook, so menus were never going to be removed correctly in the previous setup. I moved this out alongside the admin_menu hook call.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Calypso, and select the "Plugins" menu for a connected Jetpack site with this change.
* Confirm that you do not see the core menus.
* Go to /wp-admin/ and confirm that Calypsoify is disabled, and you see all core menus again.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed an issue with core menus displaying incorrectly when using Calypso.
