### PR TITLE
Membership block: link to calypso part

### DIFF
--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -45,6 +45,7 @@ class MembershipsButtonEdit extends Component {
 			shouldUpgrade: false,
 			upgradeURL: '',
 			products: [],
+			siteSlug: '',
 			editedProductCurrency: 'USD',
 			editedProductPrice: 5,
 			editedProductPriceValid: true,
@@ -84,10 +85,11 @@ class MembershipsButtonEdit extends Component {
 				const products = result.products;
 				const shouldUpgrade = result.should_upgrade_to_access_memberships;
 				const upgradeURL = result.upgrade_url;
+				const siteSlug = result.site_slug;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
 					: API_STATE_NOTCONNECTED;
-				this.setState( { connected, connectURL, products, shouldUpgrade, upgradeURL } );
+				this.setState( { connected, connectURL, products, shouldUpgrade, upgradeURL, siteSlug } );
 			},
 			result => {
 				const connectURL = null;
@@ -326,6 +328,14 @@ class MembershipsButtonEdit extends Component {
 							key: product.id,
 						} ) ) }
 					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Your members.', 'jetpack' ) }>
+					<ExternalLink href={ `https://wordpress.com/earn/memberships/${ this.state.siteSlug }` }>
+						{ __(
+							'You can find your earnings, subscribers and advanced product management here.',
+							'jetpack'
+						) }
+					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>
 		);

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -329,12 +329,9 @@ class MembershipsButtonEdit extends Component {
 						} ) ) }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Your members.', 'jetpack' ) }>
+				<PanelBody title={ __( 'Member Management', 'jetpack' ) }>
 					<ExternalLink href={ `https://wordpress.com/earn/memberships/${ this.state.siteSlug }` }>
-						{ __(
-							'You can find your earnings, subscribers and advanced product management here.',
-							'jetpack'
-						) }
+						{ __( 'See your earnings, subscriber list, and products.', 'jetpack' ) }
 					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>

--- a/extensions/blocks/membership-button/edit.jsx
+++ b/extensions/blocks/membership-button/edit.jsx
@@ -81,11 +81,13 @@ class MembershipsButtonEdit extends Component {
 					this.onError( Object.values( result.errors )[ 0 ][ 0 ] );
 					return;
 				}
-				const connectURL = result.connect_url;
-				const products = result.products;
-				const shouldUpgrade = result.should_upgrade_to_access_memberships;
-				const upgradeURL = result.upgrade_url;
-				const siteSlug = result.site_slug;
+				const {
+					connect_url: connectURL,
+					products,
+					should_upgrade_to_access_memberships: shouldUpgrade,
+					upgrade_url: upgradeURL,
+					site_slug: siteSlug,
+				} = result;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
 					: API_STATE_NOTCONNECTED;


### PR DESCRIPTION
Memberships has 2 primary interfaces: 
- Gutenberg block
- Management UI in calypso, with fancy stats.

This adds a link from the block sidebar to calypso part, as suggested by @mtias 

## Screenshots
![Zrzut ekranu 2019-05-24 o 13 15 47](https://user-images.githubusercontent.com/3775068/58324123-3be17880-7e26-11e9-8314-b34ce79cd1bb.png)



## Testing instructions

1. Insert "membership button block"
2. Configure some products
3. See a link in sidebar


