### PR TITLE
Masterbar: Add recovery mode menu item.

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -327,6 +327,9 @@ class A8C_WPCOM_Masterbar {
 
 		$this->add_me_submenu( $wp_admin_bar );
 		$this->add_write_button( $wp_admin_bar );
+
+		// Recovery mode exit.
+		wp_admin_bar_recovery_mode_menu( $wp_admin_bar );
 	}
 
 	/**


### PR DESCRIPTION
Allow users with the masterbar module active to exit recovery mode without needing to log out of their site.

* This adds the core wp_admin_bar_recovery_mode_menu() menu item to the masterbar, improving compatibility of Jetpack with the new core WordPress Site Health feature.

#### Testing instructions:
* Temporarily set wp_is_recovery_mode() in wp-includes/load.php to return an early true.
* Load wp-admin and observe that the Exit Recovery Mode menu item is present in the masterbar.
* Temporarily set wp_is_recovery_mode() to return an early false.
* Load wp-admin and observe that the Exit Recovery Mode menu item is not present in the masterbar.

#### Proposed changelog entry for your changes:
* Masterbar: Improve Site Health compatibility by adding recovery mode exit option.
