### PR TITLE
Adding a yarn task to add the jetpack textdomain to composer packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 		"test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js gui",
 		"test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js modules",
 		"test-dangerci-and-adminpage-and-extensions": "yarn danger ci && yarn test-adminpage && yarn test-extensions",
-		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json}\""
+		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json}\"",
+		"packages:add-textdomain": "wpi18n addtextdomain --textdomain=jetpack --glob-pattern='packages/**/*.php'"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds a yarn task to add the `jetpack` text domain to files in the `./packages` directory.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a part of i18n work for Jetpack DNA.

#### Testing instructions:
Add or edit a PHP file somewhere in the composer `./packages/` directory and add an i18n function to it, using a text domain that is different from just `'jetpack'`.

As an example, you can open `./packages/logo/src/Logo.php` add replace the `esc_attr` function in line 44 with `esc_attr__` and use any string other than `'jetpack'` as the relevant text domain.

run `yarn packages:add-textdomain` in the project root. This should replace the text domain to `'jetpack'`.

#### Proposed changelog entry for your changes:
No change log needed as this is for build tools.
