### PR TITLE
Masterbar: avoid Fatal Errors on sites that do not run WP 5.2

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -329,7 +329,9 @@ class A8C_WPCOM_Masterbar {
 		$this->add_write_button( $wp_admin_bar );
 
 		// Recovery mode exit.
-		wp_admin_bar_recovery_mode_menu( $wp_admin_bar );
+		if ( function_exists( 'wp_admin_bar_recovery_mode_menu' ) ) {
+			wp_admin_bar_recovery_mode_menu( $wp_admin_bar );
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #12467

Jetpack is still compatible with WP 5.1+, and wp_admin_bar_recovery_mode_menu was introduced in 5.2, so we'll need a function check in here for a bit.

#### Testing instructions:

* Start with a site running WP 5.1.
* Connect the site to WordPress.com and enable the WordPress.com Toolbar feature.
* Make sure you get no fatal errors.

#### Proposed changelog entry for your changes:

* None
