### PR TITLE
Contact Info & Map Widget: Remove Geocoding and add map to form

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -22,6 +22,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 * Constructor
 		 */
 		function __construct() {
+			global $pagenow;
+
 			$widget_ops = array(
 				'classname'                   => 'widget_contact_info',
 				'description'                 => __( 'Display a map with your location, hours, and contact information.', 'jetpack' ),
@@ -35,7 +37,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			);
 			$this->alt_option_name = 'widget_contact_info';
 
-			if ( is_customize_preview() ) {
+			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			}
 		}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -37,8 +37,10 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			);
 			$this->alt_option_name = 'widget_contact_info';
 
-			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+			if ( is_customize_preview() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			} elseif ( 'widgets.php' === $pagenow ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			}
 
 			add_action( 'wp_ajax_customize-contact-info-api-key', array( $this, 'ajax_check_api_key' ) );

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -113,6 +113,11 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 					 */
 					$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 					echo $this->build_map( $instance['address'], $api_key );
+				} elseif ( $showmap && is_customize_preview() && true !== $goodmap ) {
+					printf(
+						'<span class="contact-map-api-error" style="display: block;">%s</span>',
+						esc_html( $instance['goodmap'] )
+					);
 				}
 
 				$map_link = $this->build_map_link( $instance['address'] );

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -40,6 +40,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			}
+
+			add_action( 'wp_ajax_customize-contact-info-api-key', array( $this, 'ajax_check_api_key' ) );
 		}
 
 		/**
@@ -238,7 +240,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				</label>
 			</p>
 
-			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
+			<p class="jp-contact-info-admin-map jp-contact-info-embed-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<?php
 				if ( ! is_customize_preview() && true === $instance['goodmap'] ) {
 					echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -378,7 +380,6 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			}
 		}
 
-
 		/**
 		 * Check if the instance has a valid Map location.
 		 *
@@ -407,6 +408,21 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			}
 
 			return __( 'Please enter a valid Google API Key.', 'jetpack' );
+		}
+
+		/**
+		 * Check the Google Maps API key after an Ajax call from the widget's admin form in
+		 * the Customizer preview.
+		 */
+		function ajax_check_api_key() {
+			if ( isset( $_POST['apikey'] ) ) {
+				$apikey = wp_kses( $_POST['apikey'], array() );
+				$default_instance = $this->defaults();
+				$default_instance['apikey'] = $apikey;
+				wp_send_json( array( 'result' => esc_html( $this->has_good_map( $default_instance ) ) ) );
+			} else {
+				wp_die();
+			}
 		}
 
 	}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -259,10 +259,17 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			</p>
 
 			<?php
-			if ( ! is_customize_preview() ) {
+			if (
+				! is_customize_preview()
+				&& $instance['showmap']
+				&& ! empty( $instance['address'] )
+				&& ! empty( $apikey )
+			) {
 				?>
-				<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
-					<?php echo $this->build_map( $instance['address'], $apikey ); ?>
+				<p class="jp-contact-info-admin-map">
+					<?php
+						echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
 				</p>
 				<?php
 			}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -222,6 +222,15 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				20160727
 			);
 
+			if ( is_customize_preview() ) {
+				$customize_contact_info_api_key_nonce = wp_create_nonce( 'customize_contact_info_api_key' );
+				wp_localize_script(
+					'contact-info-admin',
+					'contact_info_api_key_ajax_obj',
+					array( 'nonce' => $customize_contact_info_api_key_nonce )
+				);
+			}
+
 			?>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
@@ -421,10 +430,12 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 */
 		function ajax_check_api_key() {
 			if ( isset( $_POST['apikey'] ) ) {
-				$apikey = wp_kses( $_POST['apikey'], array() );
-				$default_instance = $this->defaults();
-				$default_instance['apikey'] = $apikey;
-				wp_send_json( array( 'result' => esc_html( $this->has_good_map( $default_instance ) ) ) );
+				if ( check_ajax_referer( 'customize_contact_info_api_key' ) && current_user_can( 'customize' ) ) {
+					$apikey = wp_kses( $_POST['apikey'], array() );
+					$default_instance = $this->defaults();
+					$default_instance['apikey'] = $apikey;
+					wp_send_json( array( 'result' => esc_html( $this->has_good_map( $default_instance ) ) ) );
+				}
 			} else {
 				wp_die();
 			}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -180,19 +180,28 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				$instance['showmap'] = intval( $new_instance['showmap'] );
 			}
 
+			/*
+			 * If there have been any changes that may impact the map in the widget
+			 * (adding an address, address changes, new API key, API key change )
+			 * then we want to check whether our map can be displayed again.
+			 */
 			$update_goodmap = false;
 			if (
-				! isset( $instance['goodmap'] ) ||
-				! isset( $old_instance['address'] ) ||
-				$this->urlencode_address( $old_instance['address'] ) != $this->urlencode_address( $new_instance['address'] ) ||
-				! isset( $old_instance['apikey'] ) ||
-				$old_instance['apikey'] != $new_instance['apikey']
+				! isset( $instance['goodmap'] )
+				|| ! isset( $old_instance['address'] )
+				|| $this->urlencode_address( $old_instance['address'] ) !== $this->urlencode_address( $new_instance['address'] )
+				|| ! isset( $old_instance['apikey'] )
+				|| $old_instance['apikey'] !== $new_instance['apikey']
 			) {
 				$update_goodmap = true;
 			}
 
-			if ( empty( $instance['address'] ) || $instance['showmap'] === 0) {
-					$update_goodmap = false;
+			/*
+			 * If we have no address or don't want to show a map,
+			 * no need to check if the map is valid
+			 */
+			if ( empty( $instance['address'] ) || 0 === $instance['showmap'] ) {
+					$update_goodmap      = false;
 					$instance['goodmap'] = false;
 			}
 

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -249,7 +249,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				<?php
 				if ( ! is_customize_preview() && true === $instance['goodmap'] ) {
 					echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				} elseif ( true !== $instance['goodmap'] ) {
+				} elseif ( true !== $instance['goodmap'] && ! empty( $instance['goodmap'] ) ) {
 					printf(
 						'<span class="notice notice-warning" style="display: block;">%s</span>',
 						esc_html( $instance['goodmap'] )

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -48,7 +48,12 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 * Enqueue scripts and styles.
 		 */
 		public function enqueue_scripts() {
-			wp_enqueue_style( 'contact-info-map-css', plugins_url( 'contact-info/contact-info-map.css', __FILE__ ), null, 20160623 );
+			wp_enqueue_style(
+				'contact-info-map-css',
+				plugins_url( 'contact-info/contact-info-map.css', __FILE__ ),
+				array(),
+				JETPACK__VERSION
+			);
 		}
 
 

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -370,8 +370,13 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			/** This filter is documented in modules/widgets/contact-info.php */
 			$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 			if ( ! empty( $api_key ) ) {
-				$path          = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
-				$path          = add_query_arg( 'key', $api_key, $path );
+				$path          = add_query_arg(
+					array(
+						'q'   => rawurlencode( $instance['address'] ),
+						'key' => $api_key,
+					),
+					'https://www.google.com/maps/embed/v1/place'
+				);
 				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url_raw( $path ) ) );
 
 				return 200 === $response_code;

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -361,9 +361,9 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			/** This filter is documented in modules/widgets/contact-info.php */
 			$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 			if ( ! empty( $api_key ) ) {
-				$path = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
-				$path = add_query_arg( 'key', $api_key, $path );
-				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url( $path, null, null ) ) );
+				$path          = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
+				$path          = add_query_arg( 'key', $api_key, $path );
+				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url_raw( $path ) ) );
 
 				return 200 === $response_code;
 			}

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -5,7 +5,7 @@
 
 		$checkbox
 			.closest( '.widget' )
-			.find( '.jp-contact-info-apikey' )
+			.find( '.jp-contact-info-admin-map' )
 			.toggle( isChecked );
 	} );
 } )( window.jQuery );

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -24,23 +24,33 @@
 
 		var $apikey_input = widgetContainer.find( 'input[id*="apikey"]' );
 
-		$.post( ajaxurl, {
-			action: 'customize-contact-info-api-key',
-			apikey: $apikey_input.val(),
-		}, function( data ) {
-			var $map_element = $apikey_input.closest( '.jp-contact-info-admin-map' ).parent().find( '.jp-contact-info-embed-map' );
-			var $warning_span = $map_element.find( '[class*="notice"]' );
+		$.post(
+			ajaxurl,
+			{
+				action: 'customize-contact-info-api-key',
+				apikey: $apikey_input.val(),
+			},
+			function( data ) {
+				var $map_element = $apikey_input
+					.closest( '.jp-contact-info-admin-map' )
+					.parent()
+					.find( '.jp-contact-info-embed-map' );
+				var $warning_span = $map_element.find( '[class*="notice"]' );
 
-			if ( "1" !== data.result ) {
-				if ( $warning_span.length === 0 ) {
-					$map_element.append( '<span class="notice notice-warning" style="display: block;">' + data.result + '</span>' );
-				} else if ( $warning_span.text() !== data.result ) {
-					$warning_span.text( data.result );
+				if ( '1' !== data.result ) {
+					if ( $warning_span.length === 0 ) {
+						$map_element.append(
+							'<span class="notice notice-warning" style="display: block;">' +
+								data.result +
+								'</span>'
+						);
+					} else if ( $warning_span.text() !== data.result ) {
+						$warning_span.text( data.result );
+					}
+				} else {
+					$map_element.empty();
 				}
-			} else {
-				$map_element.empty();
 			}
-	    } );
-    } );
-
+		);
+	} );
 } )( window.jQuery );

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -1,3 +1,5 @@
+/* global ajaxurl */
+
 ( function( $ ) {
 	$( document ).on( 'change', '.jp-contact-info-showmap', function() {
 		var $checkbox = $( this ),
@@ -8,4 +10,37 @@
 			.find( '.jp-contact-info-admin-map' )
 			.toggle( isChecked );
 	} );
+
+	$( document ).on( 'widget-synced', function( event, widgetContainer ) {
+		// This event fires for all widgets, so restrict this to Contact Info widgets and the API key input.
+		if (
+			! widgetContainer.is( '[id*="widget_contact_info"]' ) ||
+			! $( document.activeElement ).is( 'input[id*="apikey"]' )
+		) {
+			return;
+		}
+
+		event.preventDefault();
+
+		var $apikey_input = widgetContainer.find( 'input[id*="apikey"]' );
+
+		$.post( ajaxurl, {
+			action: 'customize-contact-info-api-key',
+			apikey: $apikey_input.val(),
+		}, function( data ) {
+			var $map_element = $apikey_input.closest( '.jp-contact-info-admin-map' ).parent().find( '.jp-contact-info-embed-map' );
+			var $warning_span = $map_element.find( '[class*="notice"]' );
+
+			if ( "1" !== data.result ) {
+				if ( $warning_span.length === 0 ) {
+					$map_element.append( '<span class="notice notice-warning" style="display: block;">' + data.result + '</span>' );
+				} else if ( $warning_span.text() !== data.result ) {
+					$warning_span.text( data.result );
+				}
+			} else {
+				$map_element.empty();
+			}
+	    } );
+    } );
+
 } )( window.jQuery );

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -1,4 +1,4 @@
-/* global ajaxurl */
+/* global ajaxurl, contact_info_api_key_ajax_obj */
 
 ( function( $ ) {
 	$( document ).on( 'change', '.jp-contact-info-showmap', function() {
@@ -27,6 +27,7 @@
 		$.post(
 			ajaxurl,
 			{
+				_ajax_nonce: contact_info_api_key_ajax_obj.nonce,
 				action: 'customize-contact-info-api-key',
 				apikey: $apikey_input.val(),
 			},

--- a/modules/widgets/contact-info/contact-info-map.css
+++ b/modules/widgets/contact-info/contact-info-map.css
@@ -2,3 +2,12 @@
 	max-width: 100%;
 	border: 0;
 }
+
+.contact-map-api-error {
+	border-left-color: #ffb900;
+	border-left-style: solid;
+	border-left-width: 4px;
+	box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+	margin: 5px 0 15px;
+	padding: 1px 12px;
+}


### PR DESCRIPTION
Fixes #10355
Fixes #12925 
Fixes #12913 

#### Changes proposed in this Pull Request:
* Remove the use of the Google Maps Geocoding API. The Geocoding API is only used to verify that the address is valid. After these changes are made, users will need to enable only one Google Maps API (Maps Embed API).

* Add the Google Maps embedded map to the widget's admin form. This change will allow users to view the maps that will be shown on their site in the admin form. The users will be able to verify that the maps are correct and receive a useful error if the API key is invalid.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This change adds a feature to the existing Contact Info & Map widget.

#### Testing instructions:
1) Add a new Contact Info & Maps widget (Appearance -> Widgets -> Contact Info & Map), or access an existing Contact Info & Maps widget.

2) Check the Show Map checkbox to show the API key box and the embedded map.

3) The embedded map iframe will show this error when an API key is not entered:
     > Google Maps Platform rejected your request. You must use an API key to authenticate each request to Google Maps Platform APIs. For additional information, please refer to http://g.co/dev/maps-no-account

4) Enter an invalid API key. The embedded map iframe will show this error when an invalid API key is entered:
     > Google Maps Platform rejected your request. The provided API key is invalid.

5) Enter a valid Google Maps API key. (The Embed Maps API must be enabled for the API key.) Save the widget, and the embedded map will be shown in the admin form.

#### Proposed changelog entry for your changes:
Contact Info Widget: Remove use of the Geocoding API and add an embedded map to the admin form
