### PR TITLE
Release: make sure the autoloader is available in release branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 ## FOLDERS
 /.sass-cache/
 /node_modules
-/vendor/
+vendor/bin
+vendor/dealerdirect
+vendor/phpcompatibility
+vendor/sirbrillig
+vendor/squizlabs
+vendor/wp-coding-standards
 /wpcom-test-backup/
 /.vscode/
 
@@ -45,4 +50,6 @@ phpcs.xml
 /css
 _inc/jetpack-strings.php
 /modules/**/*/block.js
-
+/vendor/automattic/
+/vendor/composer/
+/vendor/autoload.php

--- a/.svnignore
+++ b/.svnignore
@@ -59,4 +59,5 @@ extensions/**/*.png
 extensions/**/*.sass
 extensions/**/*.scss
 extensions/**/*.svg
+packages
 **/__snapshots__

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -230,7 +230,7 @@ rm -rf TMP_REMOTE_BUILT_VERSION
 rm -rf TMP_LOCAL_BUILT_VERSION
 
 echo "Rsync'ing everything over from Git except for .git and npm stuffs."
-rsync -r --exclude='*.git*' --exclude=node_modules $DIR/* TMP_LOCAL_BUILT_VERSION
+rsync -r --copy-links --exclude='*.git*' --exclude=node_modules $DIR/* TMP_LOCAL_BUILT_VERSION
 echo "Done!"
 
 echo "Purging paths included in .svnignore"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We need it to be able to load the dependencies we need for Jetpack to run.

#### Testing instructions:

This is a bit hard to test as our tools expect you to create a release branch from master.

* Edit `tools/build-release-branch.sh` on top of this branch, and comment lines 105 and 160 (We don't want to start from `master`).
* Run `tools/build-release-branch.sh -n`
* Enter a test version.
* Make sure the built branch that is created has all the tools we need for Jetpack to work (`/vendor/autoload.php`, `vendor/composer`, and `/vendor/automattic/`)
* Make sure the `packages` directory is not there.

#### Proposed changelog entry for your changes:

* None
