### PR TITLE
Packages: Prepend Automattic\ to the Logo package namespace

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -1,6 +1,6 @@
 <?php
 
-use Jetpack\Assets\Logo;
+use Automattic\Jetpack\Assets\Logo;
 
 class Jetpack_Connection_Banner {
 	/**

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "b9ada94a1527c54a2daa3c3b7695a6f95e5a9715"
+                "reference": "171601ad9136a28616ef0189895c54dee5e7d2df",
+                "shasum": null
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Jetpack\\Assets\\": "src/"
+                    "Automattic\\Jetpack\\Assets\\": "src/"
                 }
             },
             "license": [

--- a/packages/logo/README.md
+++ b/packages/logo/README.md
@@ -7,7 +7,7 @@ A simple package that allows you to display a Jetpack logo somewhere.
 Display the default Jetpack logo:
 
 ```php
-use Jetpack\Assets\Logo;
+use Automattic\Jetpack\Assets\Logo;
 
 $logo = new Logo();
 echo $logo->render();
@@ -16,7 +16,7 @@ echo $logo->render();
 Display a custom Jetpack logo of your choice:
 
 ```php
-use Jetpack\Assets\Logo;
+use Automattic\Jetpack\Assets\Logo;
 
 $url = plugins_url( 'images/jetpack-logo.svg', __DIR__ );
 $logo = new Logo( $url );

--- a/packages/logo/composer.json
+++ b/packages/logo/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"autoload": {
 		"psr-4": {
-			"Jetpack\\Assets\\": "src/"
+			"Automattic\\Jetpack\\Assets\\": "src/"
 		}
 	}
 }

--- a/packages/logo/src/Logo.php
+++ b/packages/logo/src/Logo.php
@@ -5,7 +5,7 @@
  * @package jetpack-logo
  */
 
-namespace Jetpack\Assets;
+namespace Automattic\Jetpack\Assets;
 
 /**
  * Create and render a Jetpack logo.

--- a/tests/php/packages/logo/test_Logo.php
+++ b/tests/php/packages/logo/test_Logo.php
@@ -1,6 +1,6 @@
 <?php
 
-use Jetpack\Assets\Logo;
+use Automattic\Jetpack\Assets\Logo;
 
 class WP_Test_Logo extends WP_UnitTestCase {
 	function test_constructor_default_logo() {


### PR DESCRIPTION
I just realized we were missing our vendor name in our namespaces in the logo package. So this PR is adding it, and updating composer. Right on time, before ship the first version of the package 😉 

#### Changes proposed in this Pull Request:
* Prepend `Automattic\` to the Logo package namespace.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It's polishing the Logo package that we're aiming to ship with 7.4.

#### Testing instructions:

* Checkout this branch.
* Run `composer update`
* Open `/wp-admin/plugins.php` with a disconnected Jetpack.
* Verify you can see the logo.
* Verify tests still pass (`yarn docker:phpunit --filter WP_Test_Logo`).
* Verify we haven't missed any place to prepend the vendor name to.

#### Proposed changelog entry for your changes:

* Changelog not needed.
