### PR TITLE
Add function to fetch user info with blog token

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -98,9 +98,10 @@ class Jetpack_XMLRPC_Server {
 	/**
 	 * This is used to verify whether a local user exists and what role they have,
 	 * for the purposes of verifying that they are still a valid master user.
-	 * @param local_user a local user ID or email address
+	 * @param local_user a local user ID, username or email address
 	 * @return id the user's ID
 	 * @return role the user's role
+	 * @return username the user's usernamee
 	 * @return email the user's email address
 	 */
 	function get_user( $request ) {
@@ -124,8 +125,11 @@ class Jetpack_XMLRPC_Server {
 
 		return array(
 			'id' => $user->ID,
+			'login' => $user->user_login,
 			'email' => $user->user_email,
 			'roles' => $user->roles,
+			'caps' => $user->caps,
+			'allcaps' => $user->allcaps,
 		);
 	}
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -101,11 +101,12 @@ class Jetpack_XMLRPC_Server {
 	 * @param local_user a local user ID, username or email address
 	 * @return id the user's ID
 	 * @return role the user's role
-	 * @return username the user's usernamee
+	 * @return login the user's login, aka username
 	 * @return email the user's email address
+	 * @return caps the user's capabilities
+	 * @return allcaps the user's granular capabilities, merged from role capabilities
 	 */
 	function get_user( $request ) {
-		// TODO ensure authorize with blog token?
 		$user = $this->fetch_and_verify_local_user( $request, 'jpc_get_user_fail' );
 
 		if ( is_wp_error( $user ) ) {

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -99,7 +99,10 @@ class Jetpack_XMLRPC_Server {
 	/**
 	 * Used to verify whether a local user exists and what role they have.
 	 *
-	 * @param int|string $user_id The local User's ID, username, or email address.
+	 * @param int|string|array $request One of:
+	 *                         int|string The local User's ID, username, or email address.
+	 *                         array      A request array containing:
+	 *                                    0: int|string The local User's ID, username, or email address.
 	 *
 	 * @return array|IXR_Error Information about the user, or error if no such user found:
 	 *                         roles:     string[] The user's rols.
@@ -109,7 +112,9 @@ class Jetpack_XMLRPC_Server {
 	 *                         allcaps    string[] The user's granular capabilities, merged from role capabilities.
 	 *                         token_key  string   The Token Key of the user's Jetpack token. Empty string if none.
 	 */
-	function get_user( $user_id ) {
+	function get_user( $request ) {
+		$user_id = is_array( $request ) ? $request[0] : $request;
+
 		if ( ! $user_id ) {
 			return $this->error(
 				new Jetpack_Error(

--- a/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -47,6 +47,23 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, $decoded_object->ID );
 	}
 
+	function test_xmlrpc_get_user() {
+		$user_id = $this->factory->user->create();
+		$user = get_user_by( 'ID', $user_id );
+		$server = new Jetpack_XMLRPC_Server();
+		$response = $server->get_user( array( 'local_user' => $user_id ) );
+
+		$this->assertEquals( $user_id, $response['id'] );
+		$this->assertEquals( $user->user_email, $response['email'] );
+		$this->assertEquals( sort( $user->roles ), sort( $response['roles'] ) );
+
+		$missing_response = $server->get_user( array( 'local_user' => 999999999 ) );
+
+		$this->assertEquals( 'IXR_Error', get_class( $missing_response ) );
+		$this->assertEquals( 404, $missing_response->code );
+		$this->assertEquals( 'Jetpack: [user_unknown] User not found.', $missing_response->message );
+	}
+
 	function test_xmlrpc_remote_register_fails_no_nonce() {
 		$server = new Jetpack_XMLRPC_Server();
 


### PR DESCRIPTION
In order to determine whether a valid user exists for an expired user token, we need an API secured by the blog token that we can use to query for user info. This will allow us to determine that:

(a) the user exists (or not)
(b) the user's role and capabilities are sufficient / correct
(c) whether the user's ID has changed (we can search by email or user_login too)

In theory we could use the REST API /users endpoint for this, but it requires a valid user token for a user who can manage users - a catch 22.

This PR adds an XMLRPC endpoint secured by the blog token which allows for this simple query. This is one step toward being able to auto-repair site connections.

#### Changes proposed in this Pull Request:
* Add a jetpack.getUser XMLRPC endpoint secured by the blog token

#### Testing instructions:

##### Manual Testing
Install https://gist.github.com/mdawaffe/51e28af952a0de281ad2c848c1f2594e as a plugin on your site. It provides the `wp jetpack-xmlrpc` WP-CLI command, which is helpful for making signed/unsigned XML-RPC requests to your site.

1. Make sure your site is connected to WordPress.com.
2. Make an unsigned XML-RPC `system.listMethods` request to core's XML-RPC endpoint. Ensure `jetpack.getUser` is **not** in the list.
   ```
   wp jetpack-xmlrpc --no-sign --endpoint=core system.listMethods
   ```
3. Make an unsigned XML-RPC `system.listMethods` request to Jetpack's classic XML-RPC endpoint. Ensure `jetpack.getUser` is **not** in the list.
   ```
   wp jetpack-xmlrpc --no-sign --endpoint=classic system.listMethods
   ```
4. Make an unsigned XML-RPC `system.listMethods` request to Jetpack's alternate XML-RPC endpoint. Ensure `jetpack.getUser` is **not** in the list.
   ```
   wp jetpack-xmlrpc --no-sign --endpoint=alternate system.listMethods
   ```
5. Make a blog-token-signed XML-RPC `system.listMethods` request to Jetpack's classic XML-RPC endpoint. Ensure `jetpack.getUser` **is** in the list.
   ```
   wp jetpack-xmlrpc --endpoint=classic system.listMethods
   ```
6. Make a blog-token-signed XML-RPC `jetpack.getUser` request. See the user details.
   ```
   wp jetpack-xmlrpc --endpoint=classic jetpack.getUser 1 # Substitute 1 for any user on the Jetpack site
   ```
7. Disconnect your site.
8. Start the Jetpack connection flow, but **stop** before the user authorization step. At this point, Jetpack is half connected: it has a Blog Token but no User Tokens. You can confirm this by doing `wp option get jetpack_private_options` and noting that there is no mention of any `user_tokens`.
9. Make a blog-token-signed XML-RPC `jetpack.getUser` request. See the user details.
   ```
   wp jetpack-xmlrpc --endpoint=classic jetpack.getUser 1 # Substitute 1 for any user on the Jetpack site
   ```
10. (You'll probably want to finish the connection process at this point.)

##### Automated Testing:
`phpunit --filter=WP_Test_Jetpack_XMLRPC_Server`

Note that the automated tests do not check that the new method is only accessible for signed XML-RPC requests :(