### PR TITLE
Build: Do not declare symlink strategy for the Jetpack Logo package 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,7 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "./packages/logo",
-			"options": {
-				"symlink": true
-			}
+			"url": "./packages/logo"
 		}
 	]
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {
 		"ext-openssl": "*",
-		"automattic/jetpack-logo": ">=1.0"
+		"automattic/jetpack-logo": "@dev"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,16 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "606acbf717542b339c479c7d95495004",
+    "content-hash": "167f5c90d0f8c7224fdc8707e1ba107f",
     "packages": [
         {
             "name": "automattic/jetpack-logo",
-            "version": "1.0.0",
+            "version": "dev-update/dont-symlink-packages",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "4149b3ba0eb2e71304675031fead83bbcd9e0a14"
+                "reference": "9e99ef65b2600e06f2eaeaf435771194a174f40d",
+                "shasum": null
             },
             "type": "library",
             "autoload": {
@@ -397,7 +398,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "automattic/jetpack-logo": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cabdf41576f13b9aeb418d860129cd9d",
+    "content-hash": "606acbf717542b339c479c7d95495004",
     "packages": [
         {
             "name": "automattic/jetpack-logo",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "171601ad9136a28616ef0189895c54dee5e7d2df"
+                "reference": "4149b3ba0eb2e71304675031fead83bbcd9e0a14"
             },
             "type": "library",
             "autoload": {
@@ -23,10 +23,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A logo for Jetpack",
-            "transport-options": {
-                "symlink": true
-            }
+            "description": "A logo for Jetpack"
         }
     ],
     "packages-dev": [

--- a/packages/logo/composer.json
+++ b/packages/logo/composer.json
@@ -2,7 +2,6 @@
 	"name": "automattic/jetpack-logo",
 	"description": "A logo for Jetpack",
 	"type": "library",
-	"version": "1.0.0",
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"autoload": {

--- a/packages/logo/composer.json
+++ b/packages/logo/composer.json
@@ -2,6 +2,7 @@
 	"name": "automattic/jetpack-logo",
 	"description": "A logo for Jetpack",
 	"type": "library",
+	"version": "1.0.0",
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"autoload": {

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -63,7 +63,7 @@ hash composer 2>/dev/null || {
     exit 1;
 }
 
-composer --cwd $TARGET_DIR install
+COMPOSER_MIRROR_PATH_REPOS=1 composer --cwd $TARGET_DIR install
 
 # Checking for yarn
 hash yarn 2>/dev/null || {

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -63,7 +63,7 @@ hash composer 2>/dev/null || {
     exit 1;
 }
 
-COMPOSER_MIRROR_PATH_REPOS=1 composer --cwd $TARGET_DIR install
+COMPOSER_MIRROR_PATH_REPOS=1 composer install --working-dir $TARGET_DIR
 
 # Checking for yarn
 hash yarn 2>/dev/null || {

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -72,7 +72,7 @@ hash yarn 2>/dev/null || {
     exit 1;
 }
 yarn --cwd $TARGET_DIR cache clean
-yarn --cwd $TARGET_DIR run build
+COMPOSER_MIRROR_PATH_REPOS=1 yarn --cwd $TARGET_DIR run build
 
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .svnignore

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -222,7 +222,7 @@ hash yarn 2>/dev/null || {
 
 # Start cleaning the cache.
 yarn cache clean
-yarn run build-production
+COMPOSER_MIRROR_PATH_REPOS=1 yarn run build-production
 echo "Done"
 
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.


### PR DESCRIPTION
When bundling the plugin, we remove `packages` so symlinks are not working there. 

This will allow us to work locally with symlinked packages, but rely on the environment variable `COMPOSER_MIRROR_PATH_REPOS` for build scripts

* Check the description of `COMPOSER_MIRROR_PATH_REPOS` in [Composer environment variables](https://getcomposer.org/doc/03-cli.md#environment-variables).
* Confirm that the default path strategy is symlink.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

The latter

#### Testing instructions:

1. check this branch
2. Remove the `vendor` directory
3. run `COMPOSER_MIRROR_PATH_REPOS=1 composer install` and confirm the `jetpack-logo` package is mirroed instead of symlinked. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
