### PR TITLE
IE11 fixes for My Plan page and Jumpstart card

### DIFF
--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -9,7 +9,16 @@
 	display: flex;
 	margin-bottom: 0;
 
-	.jp-jumpstart-card__img,
+	.jp-jumpstart-card__img {
+		@include breakpoint( ">480px" ) {
+			flex: 1 0 rem( 100px );
+		}
+
+		@include breakpoint( ">660px" ) {
+			flex: 1 0 rem( 200px );
+		}
+	}
+
 	.jp-jumpstart-card__img img {
 		display: none;
 
@@ -23,7 +32,9 @@
 		}
 	}
 
+
 	.jp-jumpstart-card__description {
+		margin-left: 0;
 
 		@include breakpoint( ">480px" ) {
 			margin-left: 2rem;

--- a/_inc/client/my-plan/style.scss
+++ b/_inc/client/my-plan/style.scss
@@ -50,10 +50,11 @@
 
 .jp-landing__plan-features-card {
 	display: flex;
+	flex-basis: 32%;
 	flex-wrap: nowrap;
 	flex-grow: 1;
 	box-sizing: border-box;
-	max-width: 49.5%;
+	margin: 8px;
 	background-color: $white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
@@ -111,9 +112,12 @@
 .jp-landing__plan-features {
 	display: flex;
 	flex-wrap: wrap;
+	flex-direction: row;
 	align-items: stretch;
 	justify-content: space-between;
 	margin-bottom: rem( 32px );
+	margin-left: -8px;
+	margin-right: -8px;
 
 	@include breakpoint( "<660px" ) {
 		display: block;

--- a/_inc/client/my-plan/style.scss
+++ b/_inc/client/my-plan/style.scss
@@ -54,7 +54,7 @@
 	flex-wrap: nowrap;
 	flex-grow: 1;
 	box-sizing: border-box;
-	margin: 8px;
+	margin: rem( 8px );
 	background-color: $white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
@@ -82,22 +82,22 @@
 }
 
 .jp-landing__plan-features-img {
-	width: 90px;
-	margin-right: 8px;
+	width: rem( 90px );
+	margin-right: rem( 8px );
 	line-height: 1;
 
 	@include breakpoint( ">960px" ) {
-		width: 120px;
-		margin-right: 18px;
+		width: rem( 120px );
+		margin-right: rem( 18px );
 	}
 }
 
 .jp-landing__plan-features-icon {
 	display: block;
-	margin-left: -8px;
+	margin-left: rem( -8px );
 
 	@include breakpoint( ">480px" ) {
-		margin-left: -16px;
+		margin-left: rem( -16px );
 	}
 }
 
@@ -116,8 +116,8 @@
 	align-items: stretch;
 	justify-content: space-between;
 	margin-bottom: rem( 32px );
-	margin-left: -8px;
-	margin-right: -8px;
+	margin-left: rem( -8px );
+	margin-right: rem( -8px );
 
 	@include breakpoint( "<660px" ) {
 		display: block;
@@ -167,13 +167,13 @@
 }
 
 .jp-landing__plan-icon {
-	width: 82px;
+	width: rem( 82px );
 	position: relative;
-	left: -3px;
+	left: rem( -3px );
 
 	@include breakpoint( ">960px" ) {
-		width: 96px;
-		left: 2px;
+		width: rem( 96px );
+		left: rem( 2px );
 	}
 }
 


### PR DESCRIPTION
A small update to fix some IE11 Flexbox issues in Jetpack. Props to @MichaelArestad for the My Plan fix.

Fixes #12464 and #12481

#### Changes proposed in this Pull Request:
* CSS updates to Flexbox implementation on My Plan features grid so that it's 2 cards wide (except for small screens <480px) with no text overlaps.
* CSS fix for Jumpstart card where the text would overlap the illustration

#### Testing instructions:
* In IE11, go to Jetpack > My Plan page, note that the features grid should have no text overlap issues.
* On a newly connected Jetpack site, you'll see the Jumpstart card in the Dashboard, which should also have no text overlapping the illustration.

#### Proposed changelog entry for your changes:
* CSS fixes for IE11
