### PR TITLE
Composer: Define local packages with a wildcard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "./packages/logo"
+			"url": "./packages/*"
 		}
 	]
 }


### PR DESCRIPTION
This PR updates our main composer.json to define the local packages in a single wildcard entry, so we won't have to define each package separately. Original idea brought by @gravityrail.

Overlaps a bit with #12480, will have to be rebased when it lands.

#### Changes proposed in this Pull Request:
* Composer: Define local packages with a wildcard

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This improves the existing main Jetpack composer.json a bit, so we don't have to update it every time we create a new package.

#### Testing instructions:

* Checkout this branch.
* `rm -rf ./vendor`
* `rm composer.lock`
* `composer update`
* Open /wp-admin/plugins.php with a disconnected Jetpack.
* Verify you can see the Jetpack logo properly.

#### Proposed changelog entry for your changes:
* Update composer.json to load packages with a wildcard.
