### PR TITLE
Build: Remove extra composer install command from build-jetpack.sh

### DIFF
--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -63,8 +63,6 @@ hash composer 2>/dev/null || {
     exit 1;
 }
 
-COMPOSER_MIRROR_PATH_REPOS=1 composer install --working-dir $TARGET_DIR
-
 # Checking for yarn
 hash yarn 2>/dev/null || {
     echo >&2 "This script requires you to have yarn package manager installed."

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -211,8 +211,6 @@ hash composer 2>/dev/null || {
     exit 1;
 }
 
-composer install
-
 # Checking for yarn
 hash yarn 2>/dev/null || {
 	echo >&2 "This script requires you to have yarn package manager installed."


### PR DESCRIPTION
Removes an extra `composer install` command from tools/build-jetpack.sh


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes a standalone run of `composer install` from `build-jetpack.sh`

#### Testing instructions:

* Confirm this branch was built by the Jetpack Beta Builder

**Note**: in the Beta Builder we have a clone of this repo from where we run `tools/build-jetpack.sh`.  For getting this change to work we need to apply the change manually until it's in master. Tested this and confirmed that the `composer install` run from `yarn build-php` is doing the proper thing.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
