### PR TITLE
Masterbar: style Recovery mode button

### DIFF
--- a/modules/calypsoify/_colors.scss
+++ b/modules/calypsoify/_colors.scss
@@ -50,6 +50,7 @@ $gray-darken-30: $muriel-gray-600;
 
 // Alerts
 $alert-yellow:           $muriel-hot-yellow-400;
+$alert-orange:           $muriel-hot-orange-500;
 $alert-red:              $muriel-hot-red-400;
 $alert-green:            $muriel-hot-green-400;
 $alert-purple:           $muriel-hot-purple-400;

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -542,6 +542,10 @@ body,
 		font-size: 24px;
 		line-height: 1.45;
 	}
+
+	li#wp-admin-bar-recovery-mode {
+		background-color: $alert-orange !important;
+	}
 }
 
 /* WP Admin UI Mods */

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -75,6 +75,12 @@
 	font-size: 28px;
 }
 
+.jetpack-masterbar #wpadminbar #wp-admin-bar-recovery-mode {
+	background-color: #ca4a1f;
+	color: #fff;
+	margin-right: 1em;
+}
+
 @media screen and (max-width: 480px) {
 	.jetpack-masterbar.post-new-php.block-editor-page #wp-toolbar ul li {
 		flex: 1;
@@ -118,5 +124,9 @@
 
 	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-newdash {
 		order: 3;
+	}
+
+	.jetpack-masterbar #wpadminbar #wp-admin-bar-recovery-mode {
+		display: none;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The button was added in #12467.
This commit styles it so:
- It looks similar to the core Recovery mode button when seeing the default Masterbar.
- It uses the Calypso colors when the Masterbar is loaded by a user using Calypsoify

See discussion here to learn more about this:

https://github.com/Automattic/jetpack/pull/12467#issuecomment-496240491

**Before**

![](https://user-images.githubusercontent.com/426388/58427648-88d08380-80a0-11e9-85de-82aec4588586.png)

**After with the default Masterbar**

<img width="445" alt="screenshot 2019-05-29 at 16 22 59" src="https://user-images.githubusercontent.com/426388/58565171-8dc33d80-822e-11e9-9dee-9b0231ff3547.png">

**After with Calypsoify on**

<img width="506" alt="screenshot 2019-05-29 at 16 22 29" src="https://user-images.githubusercontent.com/426388/58565196-987dd280-822e-11e9-98f7-be09e67757eb.png">

#### Testing instructions:

* In `wp-includes/load.php`, locate the `wp_is_recovery_mode` function. Set it to return `true`.
* Under Jetpack > Settings > Writing, enable the WordPress.com Toolbar.
* Go to `http://yoursite/wp-admin/plugins.php?calypsoify=1`
* You should see the button looking as in the screenshot above, with Calypsoify on.
* The button should disappear on mobile viewports.
* Go to `http://yoursite/wp-admin/`
* Calypsoify should now be disabled, and the button should still be there but in a different color, matching the screenshot above.

#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: add colors to Recovery Mode button.
