### PR TITLE
Plugin Autoupdates: do not show card on admin searches.

### DIFF
--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -74,13 +74,21 @@ export class Security extends Component {
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
 			foundMonitor = this.props.isModuleFound( 'monitor' ),
-			foundPrivateSites = this.props.isModuleFound( 'private' );
+			foundPrivateSites = this.props.isModuleFound( 'private' ),
+			isSearchTerm = this.props.searchTerm;
 
-		if ( ! this.props.searchTerm && ! this.props.active ) {
+		if ( ! isSearchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor && ! foundPrivateSites ) {
+		if (
+			! foundSso &&
+			! foundProtect &&
+			! foundAkismet &&
+			! foundBackups &&
+			! foundMonitor &&
+			! foundPrivateSites
+		) {
 			return null;
 		}
 
@@ -89,7 +97,7 @@ export class Security extends Component {
 				<QuerySite />
 				<Card
 					title={
-						this.props.searchTerm
+						isSearchTerm
 							? __( 'Security' )
 							: __(
 									'Keep your site safe with state-of-the-art security and receive notifications of technical problems.'
@@ -105,7 +113,7 @@ export class Security extends Component {
 						<QueryAkismetKeyCheck />
 					</div>
 				) }
-				<ManagePlugins { ...commonProps } />
+				{ ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
 				{ foundPrivateSites && <Private { ...commonProps } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Instead of displaying the Plugin Autoupdates card all the time, let's hide it when someone searches for an unrelated term.

**Before**

<img width="1098" alt="screenshot 2019-05-29 at 17 56 34" src="https://user-images.githubusercontent.com/426388/58571968-1d6ee900-823b-11e9-8e76-25bbc325f119.png">

**After*

<img width="1107" alt="screenshot 2019-05-29 at 17 52 34" src="https://user-images.githubusercontent.com/426388/58571983-2364ca00-823b-11e9-8565-c934448bb280.png">

#### Testing instructions:

* Go to Jetpack > Settings, and search for "Private", or "Monitor"
* Only the Private sites card should come up, or the Monitor card.
* Search for "plugin", and make sure the plugin autoupdates card appears.

#### Proposed changelog entry for your changes:

* Admin Page: do not show Plugin Autoupdates card on admin searches.
