### PR TITLE
Tokens: Clarify documentation about the structure of the token secret

### DIFF
--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -17,15 +17,22 @@ class Jetpack_Data {
 	 *    the Jetpack servers.
 	 * 2. User Tokens: These are "sub-"tokens. Each connected user account has one User Token.
 	 *
+	 * All tokens look like "{$token_key}.{$private}". $token_key is a public ID for the
+	 * token, and $private is a secret that should never be displayed anywhere or sent
+	 * over the network; it's used only for signing things.
+	 *
 	 * Blog Tokens can be "Normal" or "Special".
 	 * * Normal: The result of a normal connection flow. They look like
 	 *   "{$random_string_1}.{$random_string_2}"
+	 *   That is, $token_key and $private are both random strings.
 	 *   Sites only have one Normal Blog Token. Normal Tokens are found in either
 	 *   Jetpack_Options::get_option( 'blog_token' ) (usual) or the JETPACK_BLOG_TOKEN
 	 *   constant (rare).
 	 * * Special: A connection token for sites that have gone through an alternative
 	 *   connection flow. They look like:
-	 *   ";{$special_id};.{$random_string}"
+	 *   ";{$special_id}{$special_version};{$wpcom_blog_id};.{$random_string}"
+	 *   That is, $private is a random string and $token_key has a special structure with
+	 *   lots of semicolons.
 	 *   Most sites have zero Special Blog Tokens. Special tokens are only found in the
 	 *   JETPACK_BLOG_TOKEN constant.
 	 *

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -280,6 +280,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		list( $token_key ) = explode( '.', $blog_token->secret, 2 );
 		// Prophylactic check: anything else should never happen.
 		if ( $token_key && $token_key !== $blog_token->secret ) {
+			// Is the token a Special Token (@see class.jetpack-data.php)?
 			if ( preg_match( '/^;.\d+;\d+;$/', $token_key, $matches ) ) {
 				// The token key for a Special Token is public.
 				$params['token_key'] = $token_key;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
To handle both Normal Tokens and Special Tokens, https://github.com/Automattic/jetpack/pull/12164/ imposes some constraints on the structure of the token secret (a string).

Clarify what the different pieces of that structure are.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Neither.

#### Testing instructions:
* Read the comments.
* Do they make sense?

#### Proposed changelog entry for your changes:
None needed.