### PR TITLE
Recurring Payments (Memberships) : simplify modal

### DIFF
--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -34,7 +34,7 @@ function activateSubscription( block, blogId, planId, lang ) {
 				'&lang=' +
 				lang +
 				'&display=alternate' +
-				'TB_iframe=true&height=600&width=410',
+				'TB_iframe=true',
 			null
 		);
 		window.addEventListener( 'message', handleIframeResult, false );

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -23,7 +23,7 @@ function handleIframeResult( eventFromIframe ) {
 	}
 }
 
-function activateSubscription( block, blogId, planId, poweredText, lang ) {
+function activateSubscription( block, blogId, planId, lang ) {
 	block.addEventListener( 'click', () => {
 		tb_show(
 			null,
@@ -33,16 +33,13 @@ function activateSubscription( block, blogId, planId, poweredText, lang ) {
 				planId +
 				'&lang=' +
 				lang +
-				'TB_iframe=true&height=600&width=400',
+				'&display=alternate' +
+				'TB_iframe=true&height=600&width=410',
 			null
 		);
 		window.addEventListener( 'message', handleIframeResult, false );
 		const tbWindow = document.querySelector( '#TB_window' );
 		tbWindow.classList.add( 'jetpack-memberships-modal' );
-		const footer = document.createElement( 'DIV' );
-		footer.classList.add( 'TB_footer' );
-		footer.innerHTML = poweredText;
-		tbWindow.appendChild( footer );
 	} );
 }
 
@@ -54,14 +51,8 @@ const initializeMembershipButtonBlocks = () => {
 		const blogId = block.getAttribute( 'data-blog-id' );
 		const planId = block.getAttribute( 'data-plan-id' );
 		const lang = block.getAttribute( 'data-lang' );
-		const poweredText = block
-			.getAttribute( 'data-powered-text' )
-			.replace(
-				'WordPress.com',
-				'<a href="https://wordpress.com" target="_blank" rel="noreferrer noopener">WordPress.com</a>'
-			);
 		try {
-			activateSubscription( block, blogId, planId, poweredText, lang );
+			activateSubscription( block, blogId, planId, lang );
 		} catch ( err ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Problem activating Recurring Payments ' + planId, err );

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -2,21 +2,23 @@
 /* stylelint-disable selector-max-id */
 
 .jetpack-memberships-modal #TB_title {
-	border-radius: 4px 4px 0 0;
+	display: none;
 }
 #TB_window.jetpack-memberships-modal {
-	border-radius: 4px;
-	background-color: $muriel-gray-0;
+	background-color: transparent;
 	background-image: url( 'https://s0.wp.com/i/loading/loading-64.gif' );
 	background-repeat: no-repeat;
-	background-position: center;
-	bottom: 10%;
+	background-position: 150px center;
+	bottom: 0;
 	margin-top: 0 !important;
-	top: 10%;
+	top: 0;
+	box-shadow: none;
+	-webkit-box-shadow: none;
+	-moz-box-shadow: none;
 }
 
 .jetpack-memberships-modal #TB_iframeContent {
-	height: calc( 100% - 50px ) !important;
+	height: 100% !important;
 }
 @media only screen and ( max-width: 480px ) {
 	#TB_window.jetpack-memberships-modal {
@@ -30,20 +32,4 @@
 	.jetpack-memberships-modal #TB_iframeContent {
 		width: 100% !important;
 	}
-}
-
-.jetpack-memberships-modal #TB_iframeContent {
-	height: calc( 100% - 80px ) !important;
-}
-.jetpack-memberships-modal .TB_footer {
-	border-top: 1px solid $muriel-gray-50;
-	color: $muriel-blue-200;
-	font-size: 13px;
-	padding: 4px 0;
-	text-align: center;
-}
-.jetpack-memberships-modal .TB_footer a,
-.jetpack-memberships-modal .TB_footer a:hover,
-.jetpack-memberships-modal .TB_footer a:visited {
-	color: $muriel-hot-blue-500;
 }

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -6,20 +6,37 @@
 }
 #TB_window.jetpack-memberships-modal {
 	background-color: transparent;
-	background-image: url( 'https://s0.wp.com/i/loading/loading-64.gif' );
+	background-image: url( 'https://s0.wp.com/i/loading/transparent-16.gif' );
 	background-repeat: no-repeat;
 	background-position: center 150px;
-	bottom: 0;
-	margin-top: 0 !important;
-	top: 0;
+	margin: 0 !important;
 	box-shadow: none;
 	-webkit-box-shadow: none;
 	-moz-box-shadow: none;
+	border: none;
+	bottom: 0;
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
+	width: 100% !important;
+	height: 100%;
 }
 
 .jetpack-memberships-modal #TB_iframeContent {
+	margin: 0 !important;
 	height: 100% !important;
+	width: 100% !important;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 }
+BODY.modal-open {
+	overflow: hidden;
+}
+
 @media only screen and ( max-width: 480px ) {
 	#TB_window.jetpack-memberships-modal {
 		bottom: 0;

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -33,20 +33,7 @@
 	right: 0;
 	bottom: 0;
 }
+/* This is a class added by Thickbox on open modals. */
 BODY.modal-open {
 	overflow: hidden;
-}
-
-@media only screen and ( max-width: 480px ) {
-	#TB_window.jetpack-memberships-modal {
-		bottom: 0;
-		left: 0;
-		margin-left: 0 !important;
-		right: 0;
-		top: 0;
-		width: 100% !important;
-	}
-	.jetpack-memberships-modal #TB_iframeContent {
-		width: 100% !important;
-	}
 }

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -6,7 +6,8 @@
 }
 #TB_window.jetpack-memberships-modal {
 	background-color: transparent;
-	background-image: url( 'https://s0.wp.com/i/loading/transparent-16.gif' );
+	background-image: url( 'https://s0.wp.com/i/loading/dark-200.gif' );
+	background-size: 50px;
 	background-repeat: no-repeat;
 	background-position: center 150px;
 	margin: 0 !important;

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -8,7 +8,7 @@
 	background-color: transparent;
 	background-image: url( 'https://s0.wp.com/i/loading/loading-64.gif' );
 	background-repeat: no-repeat;
-	background-position: 150px center;
+	background-position: center 150px;
 	bottom: 0;
 	margin-top: 0 !important;
 	top: 0;


### PR DESCRIPTION
This simplifies the modal:

- Moves basically all the logic inside the checkout window, reducing Jetpack code
- Removes hacky footer
- Improves behaviour CONSIDERABLY on mobile

## Screenshots

![Zrzut ekranu 2019-05-30 o 18 00 41](https://user-images.githubusercontent.com/3775068/58646089-f7ae1680-8304-11e9-8e38-3086f38527b8.png)
![Zrzut ekranu 2019-05-30 o 18 00 28](https://user-images.githubusercontent.com/3775068/58646090-f7ae1680-8304-11e9-8a9c-573b7dcea22c.png)
![Zrzut ekranu 2019-05-30 o 18 00 17](https://user-images.githubusercontent.com/3775068/58646091-f7ae1680-8304-11e9-8c50-6878b1e1ee25.png)

## Testing instructions - Jurassic Ninja

The problem with this is that you can only use real money and real stripe accounts. If you want sandbox payments, you need to use the ngrok flow

1. https://jurassic.ninja/create/?jetpack-beta&branch=memberships/tweak-modal
2. Connect Jetpack
3. Go to editor
4. Search for "Recurring payments" block
5. You will get a placeholder that will say "connect to stripe", click that
6. If you correctly set up the store sandbox, you will get "you can skip this form" at the top, click that
7. You will get redirected to docs on success
8. Now go back to gutenberg, click "Re-check Connection", wait
9. Now you should have a button to add product, click it, fill the form
10. choose your new product
11. Publish the page
12 Go to frontend, click the button that says contribution
13. go with the flow

## Testing instructions - Jetpack Docker

1. Set up Jetpack with docker and ngrok.io, connnect jetpack
2. Checkout this PR
3. Build blocks by
```
yarn build-extensions
```
5. Continue from point 3. in the previous instruction
