### PR TITLE
Jetpack: Update content width to only return numeric values

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1825,7 +1825,7 @@ class Jetpack {
 	/**
 	 * Adds a line break for the 'Search Engines Discouraged' message
 	 * displayed in the 'At a Glance' dashboard widget.
-	 * 
+	 *
 	 * @param string $content Content of 'At A Glance' wp-admin dashboard widget.
 	 * @return string The modified content of the 'At a Glance' dashboard widget.
 	 */
@@ -1837,7 +1837,7 @@ class Jetpack {
 	/**
 	 * Basic styling for the wp-admin 'At a Glance' dashboard widget.
 	 * This is applied when the private module is inactive.
-	 * 
+	 *
 	 * @param string $hook Page Hook Suffix for the current page.
 	 */
 	public static function wp_admin_glance_dashboard_style( $hook ) {
@@ -1860,8 +1860,8 @@ class Jetpack {
 	 * @return string The modified content of the 'At a Glance' dashboard widget.
 	 */
 	public static function add_public_dashboard_glance_items( $content ) {
-		return 
-			$content . 
+		return
+			$content .
 			'<br><br>' .
 			wp_kses(
 				sprintf(
@@ -6003,7 +6003,9 @@ p {
 	 * Get $content_width, but with a <s>twist</s> filter.
 	 */
 	public static function get_content_width() {
-		$content_width = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : false;
+		$content_width = ( isset( $GLOBALS['content_width'] ) && is_numeric( $GLOBALS['content_width'] ) )
+			? $GLOBALS['content_width']
+			: false;
 		/**
 		 * Filter the Content Width value.
 		 *

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -251,11 +251,11 @@ EXPECTED;
 
 	public function test_active_modules_filter_restores_state() {
 		self::reset_tracking_of_module_activation();
-	
+
 		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
 		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
 		add_filter( 'jetpack_active_modules', array( __CLASS__, 'e2e_test_filter' ) );
-	
+
 		Jetpack::update_active_modules( array( 'monitor' ) );
 		$this->assertEquals( self::$activated_modules, array( 'monitor' ) );
 		$this->assertEquals(  self::$deactivated_modules, array() );
@@ -263,32 +263,32 @@ EXPECTED;
 		// Simce we override the 'monitor' module, verify it does not appear in get_active_modules().
 		$active_modules = Jetpack::get_active_modules();
 		$this->assertEquals(  $active_modules, array() );
-	
+
 		// Verify that activating a new module does not deactivate 'monitor' module.
 		Jetpack::update_active_modules( array( 'stats' ) );
 		$this->assertEquals( self::$activated_modules, array( 'monitor', 'stats') );
 		$this->assertEquals(  self::$deactivated_modules, array() );
-	
+
 		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'e2e_test_filter' ) );
-	
+
 		// With the module override filter removed, verify that monitor module appears in get_active_modules().
 		$active_modules = Jetpack::get_active_modules();
 		$this->assertEquals(  $active_modules, array( 'monitor', 'stats' ) );
 	}
-	
+
 	 // This filter overrides the 'monitor' module.
 	public static function e2e_test_filter( $modules ) {
 		$disabled_modules = array( 'monitor' );
-	
+
 		foreach ( $disabled_modules as $module_slug ) {
 			$found = array_search( $module_slug, $modules );
 			if ( false !== $found ) {
 				unset( $modules[ $found ] );
 			}
 		}
-	
+
 		return $modules;
-	}	
+	}
 
 	public function test_get_other_linked_admins_one_admin_returns_false() {
 		delete_transient( 'jetpack_other_linked_admins' );
@@ -820,6 +820,39 @@ EXPECTED;
 				false,
 				'min_path',
 				'non_min_path'
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_content_width_data
+	 */
+	public function test_get_content_width( $expected, $content_width ) {
+		$GLOBALS['content_width'] = $content_width;
+		$this->assertSame( $expected, Jetpack::get_content_width() );
+	}
+
+	public function get_content_width_data() {
+		return array(
+			'zero' => array(
+				0,
+				0,
+			),
+			'int' => array(
+				100,
+				100,
+			),
+			'numeric_string' => array(
+				'100',
+				'100',
+			),
+			'non_numeric_string' => array(
+				false,
+				'meh'
+			),
+			'content_width_not_set' => array(
+				false,
+				null,
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In zen-2039044, a user reported many of these warnings:

```
PHP Warning: A non-numeric value encountered in ...wp-content/plugins/jetpack/class.photon.php on line 926
```

When I was debugging this, I was able to reproduce the issue by trying to multiply an empty string times a number. So, it seems like the solution here is to make sure that `Jetpack::get_content_width()` returns a numeric value or false.

#### Changes proposed in this Pull Request:

* Only use the `$GLOBAL['content_width']` value when it is numeric

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* See 2039044-zen

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run phpunit tests: `phpunit --filter=test_get_content_width`

#### Proposed changelog entry for your changes:

* Update Jetpack::get_content_width() to ensure that only numeric values are used
