### PR TITLE
Admin Page: change the color of heading and text in support card

### DIFF
--- a/_inc/client/components/support-card/style.scss
+++ b/_inc/client/components/support-card/style.scss
@@ -6,7 +6,6 @@
 .jp-support-card__description {
 	font-size: rem( 14px);
 	line-height: 1.65;
-	color: $blue-text;
 
 	&:first-of-type {
 		margin-top: 4px;
@@ -67,7 +66,6 @@
 }
 
 .jp-support-card__header {
-	color: $blue-heading;
 	font-weight: 400;
 	font-size: rem( 21px );
 	margin: 0;


### PR DESCRIPTION
Fixes #12495

#### Changes proposed in this Pull Request:

* This brings the support card more in line with the other cards in the dashboard.


**Before**

![](https://user-images.githubusercontent.com/426388/58621187-1db5c580-82c9-11e9-932c-6a0e56994df5.jpg)

**After**

![image](https://user-images.githubusercontent.com/426388/58622097-24453c80-82cb-11e9-8941-4c8e3285a134.png)


#### Testing instructions:

* Go to Jetpack > Dashboard, and scroll down to the bottom of the page?
* Does the support card look good?

#### Proposed changelog entry for your changes:

* Admin Page: change the color of heading and text in support card
