### PR TITLE
Private Sites: reload page after activating or deactivating

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -373,7 +373,12 @@ export function maybeHideNavMenuItem( module, values ) {
 }
 
 export function maybeReloadAfterAction( newOptionValue ) {
-	const reloadForOptionValues = [ 'masterbar', 'jetpack_testimonial', 'jetpack_portfolio' ];
+	const reloadForOptionValues = [
+		'masterbar',
+		'jetpack_testimonial',
+		'jetpack_portfolio',
+		'private',
+	];
 
 	if ( some( reloadForOptionValues, optionValue => optionValue in newOptionValue ) ) {
 		window.location.reload();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Since Private sites change other modules' status, we must reload the page after toggling the module so the new status of the other modules can be updated.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This was discussed in p8oabR-mI-p2#comment-2957

#### Testing instructions:

* Go to Jetpack > Settings
* Enable the Private feature; the page should reload.
* Disable the Private feature; the page should reload.

#### Proposed changelog entry for your changes:

* None
