### PR TITLE
Verification Tools: make sure they can be disabled by override

### DIFF
--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -61,7 +61,7 @@ class VerificationServicesComponent extends React.Component {
 	render() {
 		const verification = this.props.getModule( 'verification-tools' );
 
-		if ( 'inactive' === this.props.getModuleOverride( 'google-analytics' ) ) {
+		if ( 'inactive' === this.props.getModuleOverride( 'verification-tools' ) ) {
 			return (
 				<JetpackBanner
 					title={ verification.name }


### PR DESCRIPTION
Fixes #12498

#### Changes proposed in this Pull Request:

* Module overrides previously mixed Verification Tools and Google Analytics. This should fix things.

#### Testing instructions:

* Add the following to a functionality on your site:
```php
add_filter( 'option_jetpack_active_modules', 'jeherve_no_verification_tools' );
function jeherve_no_verification_tools( $modules ) {
	unset( $modules['verification-tools'] );
	return $modules;
}
```
* Go to Jetpack > Settings > Traffic
* The Verification Tools feature should not be available:
![image](https://user-images.githubusercontent.com/426388/58626987-63c55600-82d6-11e9-9227-7932a941da4c.png)

#### Proposed changelog entry for your changes:

* Verification Tools: make sure the feature can be disabled by override.
