### PR TITLE
Private Sites: do not display feature hints or feature UI unless it is active

### DIFF
--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -18,6 +18,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { userCanManageModules } from 'state/initial-state';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { Private } from 'security/private.jsx';
 
 export const SearchableModules = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -38,12 +39,16 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 			}
 
 			// Only should be features that don't already have a UI, and we want to reveal in search.
-			const whitelist = [ 'contact-form', 'enhanced-distribution', 'json-api', 'notes' ];
+			const whitelist = [ 'contact-form', 'enhanced-distribution', 'json-api', 'notes', 'private' ];
 
 			const allModules = this.props.modules,
 				results = [];
 			forEach( allModules, ( moduleData, slug ) => {
 				if ( this.props.isModuleFound( slug ) && includes( whitelist, slug ) ) {
+					// The Private Sites gets its own card.
+					if ( 'private' === slug ) {
+						return results.push( <Private key={ slug } /> );
+					}
 					// Not available in dev mode
 					if ( this.props.isDevMode && this.props.isUnavailableInDevMode( moduleData.module ) ) {
 						return results.push(

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -21,7 +21,6 @@ import BackupsScan from './backups-scan';
 import Antispam from './antispam';
 import { ManagePlugins } from './manage-plugins';
 import { Monitor } from './monitor';
-import { Private } from './private';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
@@ -73,14 +72,13 @@ export class Security extends Component {
 			foundAkismet = this.isAkismetFound(),
 			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
-			foundMonitor = this.props.isModuleFound( 'monitor' ),
-			foundPrivateSites = this.props.isModuleFound( 'private' );
+			foundMonitor = this.props.isModuleFound( 'monitor' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor && ! foundPrivateSites ) {
+		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor ) {
 			return null;
 		}
 
@@ -108,7 +106,6 @@ export class Security extends Component {
 				<ManagePlugins { ...commonProps } />
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
-				{ foundPrivateSites && <Private { ...commonProps } /> }
 			</div>
 		);
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1816,9 +1816,14 @@ class Jetpack {
 		if ( self::is_module_active( 'private' ) ) {
 			self::load_modules( array( 'private' ) );
 		} else {
-			add_action( 'update_right_now_text', array( __CLASS__, 'add_public_dashboard_glance_items' ) );
-			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'wp_admin_glance_dashboard_style' ) );
-			add_filter( 'privacy_on_link_text', array( __CLASS__, 'private_site_privacy_on_link_text' ) );
+			/*
+			 * Do not display these links just yet.
+			 * The feature is still under development.
+			 * See https://github.com/Automattic/jetpack/issues/12499
+			 */
+			//add_action( 'update_right_now_text', array( __CLASS__, 'add_public_dashboard_glance_items' ) );
+			//add_action( 'admin_enqueue_scripts', array( __CLASS__, 'wp_admin_glance_dashboard_style' ) );
+			//add_filter( 'privacy_on_link_text', array( __CLASS__, 'private_site_privacy_on_link_text' ) );
 		}
 	}
 

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -84,8 +84,12 @@ function jetpack_widgets_add_suffix( $widget_name ) {
 }
 add_filter( 'jetpack_widget_name', 'jetpack_widgets_add_suffix' );
 
+/*
+ * Do not display these links just yet.
+ * The feature is still under development.
+ * See https://github.com/Automattic/jetpack/issues/12499
 add_action( 'blog_privacy_selector', 'jetpack_priv_notice_privacy_selector' );
-
+ */
 /**
  * Echos notice directing site owners to Jetpack's Private Site feature.
  */
@@ -97,7 +101,7 @@ function jetpack_priv_notice_privacy_selector() {
 		wp_kses(
 			printf(
 				/* translators: URL to the Jetpack dashboard. */
-				__( 'You can also make your site completely private by allowing only registered users to see it. <a href="%s">Go to Private Site settings</a>.', 'jetpack' ),
+				__( 'You can also make your site completely private by allowing only registered users to see it. <a href="%s">Go to Private Site settings</a>.', 'jetpack' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				esc_url( admin_url( 'admin.php?page=jetpack#/security?term=private' ) )
 			),
 			array( 'a' => array( 'href' => true ) )

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -132,7 +132,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'private' => array(
-				'name' => _x( 'Private site', 'Module Name', 'jetpack' ),
+				'name' => _x( 'Private site (Beta)', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Make your site only visible to you and users you approve.', 'Module Description', 'jetpack' ),
 			),
 

--- a/modules/private.php
+++ b/modules/private.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Private site
+ * Module Name: Private site (Beta)
  * Module Description: Make your site only visible to you and users you approve.
  * Sort Order: 9
  * First Introduced: 7.4.0


### PR DESCRIPTION
Related: #12499

If we decide to go that route, we'll also need #12501 imo.

#### Changes proposed in this Pull Request:

This PR changes the default behaviour of the Private Sites feature:
- The feature is still available on all sites.
- No links to turn it on appear in the dashboard widget or under Settings > Reading.
- If you have turned on the feature, the links to turn it off remain in the dashboard widget or under Settings > Reading.
- If you go to Jetpack > Settings > Security, you won't find the feature at the bottom of the page anymore. You can, however, find it if you look for it. This allows the links I mentioned above to keep working.
- It adds a Beta label to the feature name.

![image](https://user-images.githubusercontent.com/426388/58663208-4b802600-832c-11e9-80f7-d23a70e1c7c7.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Related discussion here: p8oabR-mI-p2#comment-2968

#### Testing instructions:

* Start a brand new site. 
* Do you see any messages about making your site private in the dashboard widget or under Settings > Reading? You should not.
* Go to Jetpack > Settings and search for "private"
* You should see the card appear, with the toggle.
* The Card title should include "Beta".
* Toggle the feature on; it should work as before.
* If you now look at the dashboard widget or under Settings > Reading, you should see links to turn the option off. 
* Click on those links: you should be directed to the Jetpack dashboard and you should be able to use the toggle to turn the feature off.

#### Proposed changelog entry for your changes:

* Private Sites: do not display feature hints or feature UI unless it is active.
