### PR TITLE
Tiled Gallerys: Fix missing transient image and 404 request

### DIFF
--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -105,7 +105,7 @@ class GalleryImageEdit extends Component {
 					src={ isTransient ? undefined : url }
 					srcSet={ isTransient ? undefined : srcSet }
 					tabIndex="0"
-					style={ isTransient ? { backgroundImage: `url(${ url })` } : undefined }
+					style={ isTransient ? { backgroundImage: `url(${ origUrl })` } : undefined }
 				/>
 				{ isTransient && <Spinner /> }
 			</Fragment>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/12515

#### Changes proposed in this Pull Request:
A bad URL was used for the transient upload. The value was `undefined`, which resulted in setting a style as `background-image: url( undefined )`. This triggered a requrest to the relative url `undefined` -> `…/wp-admin/undefined`. It also resulted in no transient image being shown.

#### Testing instructions:
* Cannot reproduce https://github.com/Automattic/jetpack/issues/12515
* Add a Tiled Gallery block
* Click "upload" in the placeholder
* The image should be grayed out but visible while uploading.
* No 404 request (`/wp-admin/undefined`) is issued
* 😁 😁 😁 

#### Proposed changelog entry for your changes:
* Fixes a regression that was never released. No changelog necessary.
