### PR TITLE
Recurring Payments: Fix for mobile IOS + Wrong support doc

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -306,7 +306,7 @@ class MembershipsButtonEdit extends Component {
 	renderDisclaimer = () => {
 		return (
 			<div className="membership-button__disclaimer">
-				<ExternalLink href="https://en.support.wordpress.com/recurring-payments/#related-fees">
+				<ExternalLink href="https://en.support.wordpress.com/recurring-payments-button/#related-fees">
 					{ __( 'Read more about Recurring Payments and related fees.', 'jetpack' ) }
 				</ExternalLink>
 			</div>

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -17,7 +17,7 @@
 	border: none;
 	bottom: 0;
 	left: 0;
-	position: fixed;
+	position: absolute;
 	right: 0;
 	top: 0;
 	width: 100% !important;
@@ -28,7 +28,7 @@
 	margin: 0 !important;
 	height: 100% !important;
 	width: 100% !important;
-	position: fixed;
+	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;


### PR DESCRIPTION
During extensive testing, we discovered : 
a) that the checkout window does not scroll well on mobile IOS due to ios quirkiness.
b) That the link was leading to the wrong document - user-related instead of site owner related

### Testing instructions


- set up recurring payments
- open on mobile IOS or simulator (`open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/`)
- initiate checkout
  - scrolls with this PR
  - does not scroll without

For the link:

- set up block
- click the link about "related fees"
-  see the doc with the fees