### PR TITLE
Adding post-install script to run wpi18n on ./packages and ./vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,16 @@
 		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.3-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
 		"php:lint": "composer install && vendor/bin/phpcs -p -s",
 		"php:autofix": "composer install && vendor/bin/phpcbf",
-		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"modifyPackageTextDomain": [
+			"./node_modules/node-wp-i18n/bin/wpi18n addtextdomain --textdomain=jetpack --glob-pattern='(packages|vendor)/**/*.php'"
+		],
+		"post-install-cmd": [
+			"@modifyPackageTextDomain"
+		]
+	},
+	"scripts-descriptions": {
+		"modifyPackageTextDomain": "Modify text domains in external packages"
 	},
 	"repositories": [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds a post-install script to run wpi18n on ./packages and ./vendor.

This facilitates internationalization work on user-facing translatable strings in composer packages we may use.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Relates 3919-gh-jpop-issues
* See also paZDrL-A-p2

#### Testing instructions:

Run `composer install` in your terminal and see if it runs the `wpi18n addtextdomain …` command.

#### Proposed changelog entry for your changes:
No changelog entry needed as this is a change to our dev tools.
