### PR TITLE
Slideshow Block: Fix Class Typo

### DIFF
--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -130,7 +130,7 @@ class Slideshow extends Component {
 					className="wp-block-jetpack-slideshow_container swiper-container"
 					ref={ this.slideshowRef }
 				>
-					<ul className="wp-block-jetpack-slideshow_swiper-wrappper swiper-wrapper">
+					<ul className="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
 							<li
 								className={ classnames(

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -20,7 +20,7 @@
 		}
 
 		// High specifity to override theme styles
-		.wp-block-jetpack-slideshow_swiper-wrappper,
+		.wp-block-jetpack-slideshow_swiper-wrapper,
 		.wp-block-jetpack-slideshow_slide {
 			padding: 0;
 			margin: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes Automattic/wp-calypso#33297

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This typo was initially something I noticed in Automattic/wp-calypso#31295 which confused me slightly then, but it doesn't have any impact on the block itself. Since there's an open issue for it and it's a very easy fix, may as well fix the class name. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* N/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Slideshow Block
* Verify that the styles for `wp-block-jetpack-slideshow_swiper-wrapper` are still present

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

Almost certainly not needed but if so:
* Slideshow block: fix typo in class name. 
