### PR TITLE
Add ?checklist query param to checklist CTA route

### DIFF
--- a/_inc/client/my-plan/my-plan-header/checklist-cta.js
+++ b/_inc/client/my-plan/my-plan-header/checklist-cta.js
@@ -13,7 +13,7 @@ export default function ChecklistCta( { onClick, siteSlug } ) {
 	return (
 		<div className="jp-landing__plan-features-header-checklist-cta-container">
 			<Button
-				href={ `https://wordpress.com/plans/my-plan/${ siteSlug }` }
+				href={ `https://wordpress.com/plans/my-plan/${ siteSlug }?checklist` }
 				onClick={ onClick }
 				primary
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

There are plans to change the location of the checklist in Calypso. It
currently shares the my-plan route.

Once Jetpack ships, we'll be unable to modify the route until a future
version and have no way of knowing whether a particular route intends to
show the My Plan page or the Checklist which happens to exist on the My
Plan route at the moment.

By adding a `?checklist` query parameter which is initially unused,
we'll be able to identify the intent to show the Checklist on the My
Plan page and redirect to the checklist route when it is created.

#### Testing instructions:
* From `/wp-admin/admin.php?page=jetpack#/my-plan`
* See the Checklist cta:
  ![Screen Shot 2019-06-03 at 16 39 54](https://user-images.githubusercontent.com/841763/58810456-3fdb7a80-861e-11e9-891f-84c654bf9608.png)
* Notice that the URL from "View your setup checklist" now ends in `?checklist`. This is our query param to detect intent for redirection in Calypso.
* Click the URL. You should land at the My Plan page (with the checklist) in Calypso.
* No other changes.

#### Proposed changelog entry for your changes:

None.
