### PR TITLE
E2E Tests: Add simple slack reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"@automattic/wordpress-external-dependencies-plugin": "1.0.0",
 		"@babel/core": "7.4.0",
 		"@babel/register": "7.4.0",
+		"@slack/webhook": "5.0.0",
 		"@wordpress/browserslist-config": "2.4.0",
 		"@wordpress/e2e-test-utils": "1.1.0",
 		"@wordpress/element": "2.4.0",

--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { setBrowserViewport } from '@wordpress/e2e-test-utils';
+/**
+ * Internal dependencies
+ */
+import { registerSlackReporter } from '../reporters/slack';
 
 /**
  * Environment variables
@@ -10,6 +14,8 @@ const { PUPPETEER_TIMEOUT } = process.env;
 
 // The Jest timeout is increased because these tests are a bit slow
 jest.setTimeout( PUPPETEER_TIMEOUT || 100000 );
+
+registerSlackReporter();
 
 async function setupBrowser() {
 	await setBrowserViewport( 'large' );

--- a/tests/e2e/reporters/slack.js
+++ b/tests/e2e/reporters/slack.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { IncomingWebhook } from '@slack/webhook';
+
+export const sendFailureMessage = async test => {
+	const message = {
+		icon_emoji: ':gutenpack:',
+		text: test + ' cc <@U6NSPV1LY>',
+		username: 'Gutenpack testbot',
+	};
+
+	const { E2E_WEBHOOK } = process.env;
+
+	if ( ! E2E_WEBHOOK ) {
+		// eslint-disable-next-line no-console
+		console.log( 'Slack URL is not set' );
+		return false;
+	}
+
+	const hook = new IncomingWebhook( E2E_WEBHOOK );
+
+	await hook.send( message );
+	// return Promise.resolve();
+};
+
+export const registerSlackReporter = () => {
+	/**
+	 * jasmine reporter does not support async.
+	 * So we store the screenshot promise and wait for it before each test
+	 */
+	// const slackPromise = Promise.resolve();
+	// beforeEach( () => slackPromise );
+	// afterAll( () => slackPromise );
+
+	const tests = [];
+
+	/**
+	 * Send a slack notification on Failed test.
+	 * Jest standard reporters run in a separate process so they don't have
+	 * access to the page instance. Using jasmine reporter allows us to
+	 * have access to the test result, test name and page instance at the same time.
+	 */
+	jasmine.getEnv().addReporter( {
+		specDone: async result => {
+			tests.push( result );
+
+			// if ( result.status === 'failed' ) {
+			await sendFailureMessage( `FAILED TEST: ${ result.fullName }` );
+			// }
+		},
+	} );
+};

--- a/tests/e2e/reporters/slack.js
+++ b/tests/e2e/reporters/slack.js
@@ -45,9 +45,9 @@ export const registerSlackReporter = () => {
 		specDone: async result => {
 			tests.push( result );
 
-			// if ( result.status === 'failed' ) {
-			await sendFailureMessage( `FAILED TEST: ${ result.fullName }` );
-			// }
+			if ( result.status === 'failed' ) {
+				await sendFailureMessage( `FAILED TEST: ${ result.fullName }` );
+			}
 		},
 	} );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,6 +1232,20 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
 
+"@slack/types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.0.0.tgz#1dc7a63b293c4911e474197585c3feda012df17a"
+  integrity sha512-IktC4uD/CHfLQcSitKSmjmRu4a6+Nf/KzfS6dTgUlDzENhh26l8aESKAuIpvYD5VOOE6NxDDIAdPJOXBvUGxlg==
+
+"@slack/webhook@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/webhook/-/webhook-5.0.0.tgz#0044a3940afc16cbc607c71acdffddb9e9d4f161"
+  integrity sha512-cDj3kz3x9z9271xPNzlwb90DpKTYybG2OWPJHigJL8FegR80rzQyD0v4bGuStGGkHbAYDKE2BMpJambR55hnSg==
+  dependencies:
+    "@slack/types" "^1.0.0"
+    "@types/node" ">=8.9.0"
+    axios "^0.18.0"
+
 "@tannin/compile@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tannin/compile/-/compile-1.0.3.tgz#812af915e2ac6ecc6d7518680b40ec275db7670d"
@@ -1329,6 +1343,11 @@
 "@types/node@*":
   version "11.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
+
+"@types/node@>=8.9.0":
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
+  integrity sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2089,6 +2108,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -3454,7 +3481,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -4589,6 +4616,13 @@ focus-trap@5.0.1:
   dependencies:
     tabbable "^4.0.0"
     xtend "^4.0.1"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -5788,7 +5822,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@~2.0.3:
+is-buffer@^2.0.2, is-buffer@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==


### PR DESCRIPTION
This PR adds a way to send a slack notification into #e2e-jetpack-notif slack channel pinging me directly. This is useful since for now, e2e tests won't fail the builds.

slack webhook URL is included in Travis encrypted env variables, which means slack notifications won't work for forked PR's

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add a simple slack test results reporter for E2E tests

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p9dueE-Ju-p2

#### Testing instructions:

* Check the example of a message which should be sent on test failure: p1559576526000700-slack-e2e-jetpack-notif
* Make sure that message is not sent for a successful build.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* not needed
