### PR TITLE
Build: Transpile punycode dependency

### DIFF
--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -69,8 +69,21 @@ const webpackConfig = getBaseWebpackConfig(
 	}
 );
 
+const transpileConfig = webpackConfig.module.rules.find( rule =>
+	rule.use.some( loader => loader.options.presets )
+);
+
 module.exports = {
 	...webpackConfig,
+	// The `module` override fixes https://github.com/Automattic/jetpack/issues/12511.
+	// @TODO Remove once there's a fix in `@automattic/calypso-build`
+	module: {
+		...webpackConfig.module,
+		rules: [
+			{ ...transpileConfig, exclude: /node_modules\/(?!punycode)/ },
+			..._.without( webpackConfig.module.rules, transpileConfig ),
+		],
+	},
 	plugins: [
 		...webpackConfig.plugins,
 		new CopyWebpackPlugin( [


### PR DESCRIPTION
Fixes #12511

#### Changes proposed in this Pull Request:

Build: Transpile punycode dependency

As described in #12511, our `punycode` npm dependency exposes an untranspiled ES6 file as its entrypoint, which broke IE11. This PR changes our `webpack.config.extensions.js` to transpile it. Props to @sirreal for the solution (https://github.com/Automattic/jetpack/issues/12511#issuecomment-497504746).

#### Testing instructions:

Verify that this fixes #12511:

1. In Internet Explorer 11, start writing a new post
2. Try inserting a new block. Verify that the `Jetpack` block category contains 11 (not just 6) blocks, that they all work, and that there aren't any errors thrown.

#### Proposed changelog entry for your changes:

Not sure this was broken in previous releases or snuck in since the last one. If it was present:

- Fix broken blocks in IE11
