### PR TITLE
Build: Update composer.lock to latest changes in logo package

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-update/dont-symlink-packages",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "167f5c90d0f8c7224fdc8707e1ba107f",
+    "content-hash": "c97d2e3fbf0c921fd8e3254277b5b2b8",
     "packages": [
         {
             "name": "automattic/jetpack-logo",
@@ -12,8 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "9e99ef65b2600e06f2eaeaf435771194a174f40d",
-                "shasum": null
+                "reference": "9e99ef65b2600e06f2eaeaf435771194a174f40d"
             },
             "type": "library",
             "autoload": {


### PR DESCRIPTION
Updates composer.lock. Somehow it got out of sync.

![image](https://user-images.githubusercontent.com/746152/58826016-1159a180-8616-11e9-85fc-755a0ccbfd03.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Runs `composer update --lock`  after removing lockfile so it also fixed the branch reference for the jetpack-logo package to `dev-master`

#### Testing instructions:

* Check this branch
* Run `composer install` and confirm you don't get the message `Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.`


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
 * None needed
