### PR TITLE
Connection Package: add `is_active` method

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -1,5 +1,7 @@
 <?php //phpcs:ignore
 
+use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 class Jetpack_Provision { //phpcs:ignore
 
 	/**
@@ -47,8 +49,9 @@ class Jetpack_Provision { //phpcs:ignore
 			);
 		}
 
-		$blog_id    = Jetpack_Options::get_option( 'id' );
-		$blog_token = Jetpack_Data::get_access_token();
+		$connection_manager = new Connection_Manager();
+		$blog_id            = Jetpack_Options::get_option( 'id' );
+		$blog_token         = $connection_manager->get_access_token();
 
 		if ( ! $blog_id || ! $blog_token || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 /**
  * Client = Plugin
  * Client Server = API Methods the Plugin must respond to
@@ -181,8 +183,8 @@ class Jetpack_Client_Server {
 		if ( ! $role ) {
 			return new Jetpack_Error( 'role', __( 'An administrator for this blog must set up the Jetpack connection.', 'jetpack' ) );
 		}
-
-		$client_secret = Jetpack_Data::get_access_token();
+		$connection_manager = new Connection_Manager();
+		$client_secret = $connection_manager->get_access_token();
 		if ( ! $client_secret ) {
 			return new Jetpack_Error( 'client_secret', __( 'You need to register your Jetpack before connecting it.', 'jetpack' ) );
 		}

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 class Jetpack_Client {
 	const WPCOM_JSON_API_VERSION = '1.1';
 
@@ -30,8 +32,8 @@ class Jetpack_Client {
 		if ( 'header' != $args['auth_location'] ) {
 			$args['auth_location'] = 'query_string';
 		}
-
-		$token = Jetpack_Data::get_access_token( $args['user_id'] );
+		$connection_manager = new Connection_Manager();
+		$token = $connection_manager->get_access_token( $args['user_id'] );
 		if ( !$token ) {
 			return new Jetpack_Error( 'missing_token' );
 		}

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -1,50 +1,7 @@
 <?php
 
 class Jetpack_Data {
-	/*
-	 * Used internally when we want to look for the Normal Blog Token
-	 * without knowing its token key ahead of time.
-	 */
-	const MAGIC_NORMAL_TOKEN_KEY = ';normal;';
-
 	/**
-	 * Gets the requested token.
-	 *
-	 * Tokens are one of two types:
-	 * 1. Blog Tokens: These are the "main" tokens. Each site typically has one Blog Token,
-	 *    though some sites can have multiple "Special" Blog Tokens (see below). These tokens
-	 *    are not associated with a user account. They represent the site's connection with
-	 *    the Jetpack servers.
-	 * 2. User Tokens: These are "sub-"tokens. Each connected user account has one User Token.
-	 *
-	 * All tokens look like "{$token_key}.{$private}". $token_key is a public ID for the
-	 * token, and $private is a secret that should never be displayed anywhere or sent
-	 * over the network; it's used only for signing things.
-	 *
-	 * Blog Tokens can be "Normal" or "Special".
-	 * * Normal: The result of a normal connection flow. They look like
-	 *   "{$random_string_1}.{$random_string_2}"
-	 *   That is, $token_key and $private are both random strings.
-	 *   Sites only have one Normal Blog Token. Normal Tokens are found in either
-	 *   Jetpack_Options::get_option( 'blog_token' ) (usual) or the JETPACK_BLOG_TOKEN
-	 *   constant (rare).
-	 * * Special: A connection token for sites that have gone through an alternative
-	 *   connection flow. They look like:
-	 *   ";{$special_id}{$special_version};{$wpcom_blog_id};.{$random_string}"
-	 *   That is, $private is a random string and $token_key has a special structure with
-	 *   lots of semicolons.
-	 *   Most sites have zero Special Blog Tokens. Special tokens are only found in the
-	 *   JETPACK_BLOG_TOKEN constant.
-	 *
-	 * In particular, note that Normal Blog Tokens never start with ";" and that
-	 * Special Blog Tokens always do.
-	 *
-	 * When searching for a matching Blog Tokens, Blog Tokens are examined in the following
-	 * order:
-	 * 1. Defined Special Blog Tokens (via the JETPACK_BLOG_TOKEN constant)
-	 * 2. Stored Normal Tokens (via Jetpack_Options::get_option( 'blog_token' ))
-	 * 3. Defined Normal Tokens (via the JETPACK_BLOG_TOKEN constant)
-	 *
 	 * @deprecated 7.5 Use Connection_Manager instead
 	 *
 	 * @param int|false    $user_id   false: Return the Blog Token. int: Return that user's User Token.
@@ -58,69 +15,5 @@ class Jetpack_Data {
 		_deprecated_function( __METHOD__, '7.5', 'Connection_Manager' );
 		$connection_manager = new Connection_Manager();
 		return $connection_manager->get_access_token( $user_id, $token_key );
-	}
-
-	/**
-	 * This function mirrors Jetpack_Data::is_usable_domain() in the WPCOM codebase.
-	 *
-	 * @param $domain
-	 * @param array $extra
-	 *
-	 * @deprecated
-	 *
-	 * @return bool|WP_Error
-	 */
-	public static function is_usable_domain( $domain, $extra = array() ) {
-
-		// If it's empty, just fail out.
-		if ( ! $domain ) {
-			return new WP_Error( 'fail_domain_empty', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', 'jetpack' ), $domain ) );
-		}
-
-		/**
-		 * Skips the usuable domain check when connecting a site.
-		 *
-		 * Allows site administrators with domains that fail gethostname-based checks to pass the request to WP.com
-		 *
-		 * @since 4.1.0
-		 *
-		 * @param bool If the check should be skipped. Default false.
-		 */
-		if ( apply_filters( 'jetpack_skip_usuable_domain_check', false ) ) {
-			return true;
-		}
-
-		// None of the explicit localhosts.
-		$forbidden_domains = array(
-			'wordpress.com',
-			'localhost',
-			'localhost.localdomain',
-			'127.0.0.1',
-			'local.wordpress.test',         // VVV
-			'local.wordpress-trunk.test',   // VVV
-			'src.wordpress-develop.test',   // VVV
-			'build.wordpress-develop.test', // VVV
-		);
-		if ( in_array( $domain, $forbidden_domains ) ) {
-			return new WP_Error( 'fail_domain_forbidden', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', 'jetpack' ), $domain ) );
-		}
-
-		// No .test or .local domains
-		if ( preg_match( '#\.(test|local)$#i', $domain ) ) {
-			return new WP_Error( 'fail_domain_tld', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', 'jetpack' ), $domain ) );
-		}
-
-		// No WPCOM subdomains
-		if ( preg_match( '#\.wordpress\.com$#i', $domain ) ) {
-			return new WP_Error( 'fail_subdomain_wpcom', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is a subdomain of WordPress.com.', 'jetpack' ), $domain ) );
-		}
-
-		// If PHP was compiled without support for the Filter module (very edge case)
-		if ( ! function_exists( 'filter_var' ) ) {
-			// Just pass back true for now, and let wpcom sort it out.
-			return true;
-		}
-
-		return true;
 	}
 }

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 class Jetpack_Data {
 	/**
 	 * @deprecated 7.5 Use Connection_Manager instead
@@ -12,7 +14,6 @@ class Jetpack_Data {
 	 * @return object|false
 	 */
 	public static function get_access_token( $user_id = false, $token_key = false ) {
-		_deprecated_function( __METHOD__, '7.5', 'Connection_Manager' );
 		$connection_manager = new Connection_Manager();
 		return $connection_manager->get_access_token( $user_id, $token_key );
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1552,9 +1552,13 @@ class Jetpack {
 
 	/**
 	 * Is Jetpack active?
+     *
+     * @deprecated 7.5 Use Connection_Manager instead.
 	 */
 	public static function is_active() {
-		return (bool) Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+	    _deprecated_function( __METHOD__, '7.5', 'Connection_Manager' );
+	    $connection_manager = new Connection_Manager();
+	    return $connection_manager->is_active();
 	}
 
 	/**
@@ -1706,14 +1710,12 @@ class Jetpack {
 
 	/**
 	 * Is a given user (or the current user if none is specified) linked to a WordPress.com user?
+     *
+     * @deprecated Use Conncection_Manager instead.
 	 */
 	public static function is_user_connected( $user_id = false ) {
-		$user_id = false === $user_id ? get_current_user_id() : absint( $user_id );
-		if ( ! $user_id ) {
-			return false;
-		}
-
-		return (bool) Jetpack_Data::get_access_token( $user_id );
+	    $connection_manager = new Connection_Manager();
+	    return $connection_manager->is_user_connected( $user_id );
 	}
 
 	/**
@@ -1774,7 +1776,7 @@ class Jetpack {
 	}
 
 	function current_user_is_connection_owner() {
-		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+		$user_token = self::init()->connection_manager()->get_access_token( JETPACK_MASTER_USER );
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id;
 	}
 
@@ -3433,7 +3435,8 @@ p {
 				'homeurl' => parse_url( get_home_url(), PHP_URL_HOST ),
 			) );
 			foreach ( $domains_to_check as $domain ) {
-				$result = Jetpack_Data::is_usable_domain( $domain );
+			    $connection_manager = new Connection_Manager();
+				$result = $connection_manager->is_usable_domain( $domain );
 				if ( is_wp_error( $result ) ) {
 					return $result;
 				}
@@ -3790,7 +3793,7 @@ p {
 
 		$media_keys = array_keys( $_FILES['media'] );
 
-		$token = Jetpack_Data::get_access_token( get_current_user_id() );
+		$token = self::init()->connection_manager->get_access_token( get_current_user_id() );
 		if ( ! $token || is_wp_error( $token ) ) {
 			return new Jetpack_Error( 'unknown_token', 'Unknown Jetpack token', 403 );
 		}
@@ -4501,7 +4504,7 @@ p {
 			return false;
 		}
 
-		$token = Jetpack_Data::get_access_token();
+		$token = self::init()->connection_manager->get_access_token();
 		if ( ! $token || is_wp_error( $token ) ) {
 			return false;
 		}
@@ -4525,7 +4528,7 @@ p {
 	 */
 	function build_connect_url( $raw = false, $redirect = false, $from = false, $register = false ) {
 		$site_id = Jetpack_Options::get_option( 'id' );
-		$blog_token = Jetpack_Data::get_access_token();
+		$blog_token = self::init()->connection_manager->get_access_token();
 
 		if ( $register || ! $blog_token || ! $site_id ) {
 			$url = Jetpack::nonce_url_no_esc( Jetpack::admin_url( 'action=register' ), 'jetpack-register' );
@@ -5266,7 +5269,7 @@ p {
 			}
 		}
 
-		$token = Jetpack_Data::get_access_token( $user_id, $token_key );
+		$token = self::init()->connection_manager->get_access_token( $user_id, $token_key );
 		if ( ! $token ) {
 			return false;
 		}
@@ -5889,7 +5892,7 @@ p {
 			: $environment;
 
 		list( $envToken, $envVersion, $envUserId ) = explode( ':', $environment['token'] );
-		$token = Jetpack_Data::get_access_token( $envUserId, $envToken );
+		$token = self::init()->connection_manager->get_access_token( $envUserId, $envToken );
 		if ( ! $token || empty( $token->secret ) ) {
 			wp_die( __( 'You must connect your Jetpack plugin to WordPress.com to use this feature.' , 'jetpack' ) );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -22,7 +22,7 @@ jetpack_do_activate (bool)
 	Flag for "activating" the plugin on sites where the activation hook never fired (auto-installs)
 */
 
-use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 require_once( JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php' );
 
@@ -538,10 +538,6 @@ class Jetpack {
 		if ( is_multisite() ) {
 			Jetpack_Network::init();
 		}
-
-		add_filter( 'jetpack_connection_option_manager', function() {
-			return new Jetpack_Options_Manager();
-		} );
 
 		add_filter( 'jetpack_connection_secret_generator', function( $callable ) {
 			return function() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1552,7 +1552,6 @@ class Jetpack {
      * @deprecated 7.5 Use Connection_Manager instead.
 	 */
 	public static function is_active() {
-	    _deprecated_function( __METHOD__, '7.5', 'Connection_Manager' );
 	    $connection_manager = new Connection_Manager();
 	    return $connection_manager->is_active();
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3435,8 +3435,8 @@ p {
 				'homeurl' => parse_url( get_home_url(), PHP_URL_HOST ),
 			) );
 			foreach ( $domains_to_check as $domain ) {
-			    $connection_manager = new Connection_Manager();
-				$result = $connection_manager->is_usable_domain( $domain );
+				$connection_manager = new Connection_Manager();
+				$result             = $connection_manager->is_usable_domain( $domain );
 				if ( is_wp_error( $result ) ) {
 					return $result;
 				}

--- a/composer.lock
+++ b/composer.lock
@@ -12,7 +12,11 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "9dbcf84ab69da7d648e99580533624e2953c9874"
+                "reference": "48f68c81c28517fb3991cff222aa32d295505243"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-options": "^1.0"
             },
             "require-dev": {
                 "10up/wp_mock": "0.4.2",
@@ -36,7 +40,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "dev-add/is-active-to-connection-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -55,7 +59,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-master",
+            "version": "dev-add/is-active-to-connection-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -226,7 +230,7 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-master",
+            "version": "dev-add/is-active-to-connection-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -7,6 +7,7 @@
  * @package Jetpack
  */
 
+use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
 /**
  * WordPress.com Block editor for Jetpack
  */
@@ -196,8 +197,8 @@ class Jetpack_WPCOM_Block_Editor {
 		if ( ! $this->nonce_user_id ) {
 			return false;
 		}
-
-		$token = Jetpack_Data::get_access_token( $this->nonce_user_id );
+		$connection_manager = new Connection_Manager();
+		$token              = $connection_manager->get_access_token( $this->nonce_user_id );
 		if ( ! $token ) {
 			return false;
 		}
@@ -241,7 +242,8 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	public function filter_salt( $salt, $scheme ) {
 		if ( 'jetpack_frame_nonce' === $scheme ) {
-			$token = Jetpack_Data::get_access_token( $this->nonce_user_id );
+			$connection_manager = new Connection_Manager();
+			$token              = $connection_manager->get_access_token( $this->nonce_user_id );
 
 			if ( $token ) {
 				$salt = $token->secret;

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -4,7 +4,10 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"version": "1.0.0",
-	"require": {},
+	"require": {
+		"automattic/jetpack-options": "^1.0",
+		"automattic/jetpack-constants": "@dev"
+	},
 	"require-dev": {
 		"phpunit/phpunit": "7.*.*",
 		"10up/wp_mock": "0.4.2"

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -14,10 +14,15 @@ use Automattic\Jetpack\Connection\Manager_Interface;
  * and Jetpack.
  */
 class Manager implements Manager_Interface {
-
-	const SECRETS_MISSING     = 'secrets_missing';
-	const SECRETS_EXPIRED     = 'secrets_expired';
-	const SECRETS_OPTION_NAME = 'secrets';
+	/*
+	 * Used internally when we want to look for the Normal Blog Token
+	 * without knowing its token key ahead of time.
+	 */
+	const MAGIC_NORMAL_TOKEN_KEY = ';normal;';
+	const SECRETS_MISSING        = 'secrets_missing';
+	const SECRETS_EXPIRED        = 'secrets_expired';
+	const SECRETS_OPTION_NAME    = 'secrets';
+	const MASTER_USER            = true;
 
 	/**
 	 * The object for managing options.
@@ -54,7 +59,7 @@ class Manager implements Manager_Interface {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		return false;
+		return (bool) $this->get_access_token( self::MASTER_USER );
 	}
 
 	/**
@@ -65,7 +70,12 @@ class Manager implements Manager_Interface {
 	 * @return Boolean is the user connected?
 	 */
 	public function is_user_connected( $user_id ) {
-		return $user_id;
+		$user_id = false === $user_id ? get_current_user_id() : absint( $user_id );
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		return (bool) $this->get_access_token( $user_id );
 	}
 
 	/**
@@ -277,5 +287,196 @@ class Manager implements Manager_Interface {
 	 */
 	public function disconnect_site() {
 
+	}
+
+	/**
+	 * Gets the requested token.
+	 *
+	 * Tokens are one of two types:
+	 * 1. Blog Tokens: These are the "main" tokens. Each site typically has one Blog Token,
+	 *    though some sites can have multiple "Special" Blog Tokens (see below). These tokens
+	 *    are not associated with a user account. They represent the site's connection with
+	 *    the Jetpack servers.
+	 * 2. User Tokens: These are "sub-"tokens. Each connected user account has one User Token.
+	 *
+	 * All tokens look like "{$token_key}.{$private}". $token_key is a public ID for the
+	 * token, and $private is a secret that should never be displayed anywhere or sent
+	 * over the network; it's used only for signing things.
+	 *
+	 * Blog Tokens can be "Normal" or "Special".
+	 * * Normal: The result of a normal connection flow. They look like
+	 *   "{$random_string_1}.{$random_string_2}"
+	 *   That is, $token_key and $private are both random strings.
+	 *   Sites only have one Normal Blog Token. Normal Tokens are found in either
+	 *   Jetpack_Options::get_option( 'blog_token' ) (usual) or the JETPACK_BLOG_TOKEN
+	 *   constant (rare).
+	 * * Special: A connection token for sites that have gone through an alternative
+	 *   connection flow. They look like:
+	 *   ";{$special_id}{$special_version};{$wpcom_blog_id};.{$random_string}"
+	 *   That is, $private is a random string and $token_key has a special structure with
+	 *   lots of semicolons.
+	 *   Most sites have zero Special Blog Tokens. Special tokens are only found in the
+	 *   JETPACK_BLOG_TOKEN constant.
+	 *
+	 * In particular, note that Normal Blog Tokens never start with ";" and that
+	 * Special Blog Tokens always do.
+	 *
+	 * When searching for a matching Blog Tokens, Blog Tokens are examined in the following
+	 * order:
+	 * 1. Defined Special Blog Tokens (via the JETPACK_BLOG_TOKEN constant)
+	 * 2. Stored Normal Tokens (via Jetpack_Options::get_option( 'blog_token' ))
+	 * 3. Defined Normal Tokens (via the JETPACK_BLOG_TOKEN constant)
+	 *
+	 * @param int|false    $user_id   false: Return the Blog Token. int: Return that user's User Token.
+	 * @param string|false $token_key If provided, check that the token matches the provided input.
+	 *                                false                                : Use first token. Default.
+	 *                                Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY : Use first Normal Token.
+	 *                                non-empty string                     : Use matching token
+	 * @return object|false
+	 */
+	public function get_access_token( $user_id = false, $token_key = false ) {
+		$possible_special_tokens = array();
+		$possible_normal_tokens  = array();
+
+		if ( $user_id ) {
+			if ( ! $user_tokens = $this->option_manager->get_option( 'user_tokens' ) ) {
+				return false;
+			}
+			if ( self::MASTER_USER === $user_id ) {
+				if ( ! $user_id = $this->option_manager->get_option( 'master_user' ) ) {
+					return false;
+				}
+			}
+			if ( ! isset( $user_tokens[ $user_id ] ) || ! $user_tokens[ $user_id ] ) {
+				return false;
+			}
+			$user_token_chunks = explode( '.', $user_tokens[ $user_id ] );
+			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
+				return false;
+			}
+			if ( $user_id != $user_token_chunks[2] ) {
+				return false;
+			}
+			$possible_normal_tokens[] = "{$user_token_chunks[0]}.{$user_token_chunks[1]}";
+		} else {
+			$stored_blog_token = $this->option_manager->get_option( 'blog_token' );
+			if ( $stored_blog_token ) {
+				$possible_normal_tokens[] = $stored_blog_token;
+			}
+
+			$defined_tokens = \Jetpack_Constants::is_defined( 'JETPACK_BLOG_TOKEN' )
+				? explode( ',', \Jetpack_Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
+				: array();
+
+			foreach ( $defined_tokens as $defined_token ) {
+				if ( ';' === $defined_token[0] ) {
+					$possible_special_tokens[] = $defined_token;
+				} else {
+					$possible_normal_tokens[] = $defined_token;
+				}
+			}
+		}
+
+		if ( self::MAGIC_NORMAL_TOKEN_KEY === $token_key ) {
+			$possible_tokens = $possible_normal_tokens;
+		} else {
+			$possible_tokens = array_merge( $possible_special_tokens, $possible_normal_tokens );
+		}
+
+		if ( ! $possible_tokens ) {
+			return false;
+		}
+
+		$valid_token = false;
+
+		if ( false === $token_key ) {
+			// Use first token.
+			$valid_token = $possible_tokens[0];
+		} elseif ( self::MAGIC_NORMAL_TOKEN_KEY === $token_key ) {
+			// Use first normal token.
+			$valid_token = $possible_tokens[0]; // $possible_tokens only contains normal tokens because of earlier check.
+		} else {
+			// Use the token matching $token_key or false if none.
+			// Ensure we check the full key.
+			$token_check = rtrim( $token_key, '.' ) . '.';
+
+			foreach ( $possible_tokens as $possible_token ) {
+				if ( hash_equals( substr( $possible_token, 0, strlen( $token_check ) ), $token_check ) ) {
+					$valid_token = $possible_token;
+					break;
+				}
+			}
+		}
+
+		if ( ! $valid_token ) {
+			return false;
+		}
+
+		return (object) array(
+			'secret'           => $valid_token,
+			'external_user_id' => (int) $user_id,
+		);
+	}
+
+	/**
+	 * This function mirrors Jetpack_Data::is_usable_domain() in the WPCOM codebase.
+	 *
+	 * @param $domain
+	 * @param array  $extra
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function is_usable_domain( $domain, $extra = array() ) {
+
+		// If it's empty, just fail out.
+		if ( ! $domain ) {
+			return new WP_Error( 'fail_domain_empty', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', 'jetpack' ), $domain ) );
+		}
+
+		/**
+		 * Skips the usuable domain check when connecting a site.
+		 *
+		 * Allows site administrators with domains that fail gethostname-based checks to pass the request to WP.com
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param bool If the check should be skipped. Default false.
+		 */
+		if ( apply_filters( 'jetpack_skip_usuable_domain_check', false ) ) {
+			return true;
+		}
+
+		// None of the explicit localhosts.
+		$forbidden_domains = array(
+			'wordpress.com',
+			'localhost',
+			'localhost.localdomain',
+			'127.0.0.1',
+			'local.wordpress.test',         // VVV
+			'local.wordpress-trunk.test',   // VVV
+			'src.wordpress-develop.test',   // VVV
+			'build.wordpress-develop.test', // VVV
+		);
+		if ( in_array( $domain, $forbidden_domains ) ) {
+			return new WP_Error( 'fail_domain_forbidden', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', 'jetpack' ), $domain ) );
+		}
+
+		// No .test or .local domains
+		if ( preg_match( '#\.(test|local)$#i', $domain ) ) {
+			return new WP_Error( 'fail_domain_tld', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', 'jetpack' ), $domain ) );
+		}
+
+		// No WPCOM subdomains
+		if ( preg_match( '#\.WordPress\.com$#i', $domain ) ) {
+			return new WP_Error( 'fail_subdomain_wpcom', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is a subdomain of WordPress.com.', 'jetpack' ), $domain ) );
+		}
+
+		// If PHP was compiled without support for the Filter module (very edge case)
+		if ( ! function_exists( 'filter_var' ) ) {
+			// Just pass back true for now, and let wpcom sort it out.
+			return true;
+		}
+
+		return true;
 	}
 }

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Connection;
 
-use Automattic\Jetpack\Connection\Manager_Interface;
+use Automattic\Jetpack\Options\Manager as Options_Manager;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
@@ -172,7 +172,7 @@ class Manager implements Manager_Interface {
 			 *
 			 * @param Jetpack_Options an option manager object.
 			 */
-			$this->option_manager = apply_filters( 'jetpack_connection_option_manager', false );
+			$this->option_manager = apply_filters( 'jetpack_connection_option_manager', new Options_Manager() );
 		}
 
 		return $this->option_manager;

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -339,11 +339,11 @@ class Manager implements Manager_Interface {
 		$possible_normal_tokens  = array();
 
 		if ( $user_id ) {
-			if ( ! $user_tokens = $this->option_manager->get_option( 'user_tokens' ) ) {
+			if ( ! $user_tokens = $this->get_option_manager()->get_option( 'user_tokens' ) ) {
 				return false;
 			}
 			if ( self::MASTER_USER === $user_id ) {
-				if ( ! $user_id = $this->option_manager->get_option( 'master_user' ) ) {
+				if ( ! $user_id = $this->get_option_manager()->get_option( 'master_user' ) ) {
 					return false;
 				}
 			}
@@ -359,7 +359,7 @@ class Manager implements Manager_Interface {
 			}
 			$possible_normal_tokens[] = "{$user_token_chunks[0]}.{$user_token_chunks[1]}";
 		} else {
-			$stored_blog_token = $this->option_manager->get_option( 'blog_token' );
+			$stored_blog_token = $this->get_option_manager()->get_option( 'blog_token' );
 			if ( $stored_blog_token ) {
 				$possible_normal_tokens[] = $stored_blog_token;
 			}

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -62,6 +62,10 @@ class Manager implements Manager_Interface {
 		return (bool) $this->get_access_token( self::MASTER_USER );
 	}
 
+	public function get_magic_normal_token_key() {
+		return self::MAGIC_NORMAL_TOKEN_KEY;
+	}
+
 	/**
 	 * Returns true if the user with the specified identifier is connected to
 	 * WordPress.com.

--- a/packages/options/src/Manager.php
+++ b/packages/options/src/Manager.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Options;
  * The Jetpack Options Manager class that is used as a single gateway between WordPress options API
  * and Jetpack.
  */
-abstract class Manager {
+class Manager {
 
 	/**
 	 * An array that maps a grouped option type to an option name.
@@ -30,7 +30,9 @@ abstract class Manager {
 	 *
 	 * @return array
 	 */
-	abstract public function get_option_names( $type );
+	public function get_option_names( $type ) {
+		return array();
+	}
 
 	/**
 	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -3,10 +3,14 @@
 /**
  * @covers Jetpack_Data
  */
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	const STORED  = '12345.67890';
 	const DEFINED = ';hello;.world';
 	const DEFINED_MULTI = ';hello;.world,;foo;.bar,looks-like-a.stored-token';
+
+	public $connection = null;
 
 	public function setUp() {
 		parent::setUp();
@@ -21,6 +25,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 			7 => 'user-seven.siete.1', // malformed: wrong user ID.
 		] );
 		Jetpack_Options::update_option( 'master_user', 2 );
+		$this->connection = new Connection_Manager();
 	}
 
 	public function tearDown() {
@@ -79,7 +84,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	public function test_get_access_token_with_magic_key_returns_stored_blog_token() {
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
-		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
+		$token = Jetpack_Data::get_access_token( false, $this->connection->get_magic_normal_token_key()  );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -90,7 +95,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::STORED );
 
-		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
+		$token = Jetpack_Data::get_access_token( false, $this->connection->get_magic_normal_token_key() );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -137,7 +142,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	public function test_get_access_token_with_magic_key_returns_stored_token_when_constant_multi_set() {
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
-		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
+		$token = Jetpack_Data::get_access_token( false, $this->connection->get_magic_normal_token_key() );
 
 		$this->assertEquals( self::STORED, $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );
@@ -147,7 +152,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
-		$token = Jetpack_Data::get_access_token( false, Jetpack_Data::MAGIC_NORMAL_TOKEN_KEY );
+		$token = Jetpack_Data::get_access_token( false, $this->connection->get_magic_normal_token_key() );
 
 		$this->assertEquals( 'looks-like-a.stored-token', $token->secret );
 		$this->assertEquals( 0, $token->external_user_id );

--- a/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
+++ b/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 require_once dirname( __FILE__ ) . '/../../../../modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 
 /**
@@ -79,7 +81,8 @@ class WP_Test_Jetpack_WPCOM_Block_Editor extends WP_UnitTestCase {
 	 */
 	public function filter_salt( $salt, $scheme ) {
 		if ( 'jetpack_frame_nonce' === $scheme ) {
-			$token = Jetpack_Data::get_access_token( $this->user_id );
+			$connection_manager = new Connection_Manager();
+			$token = $connection_manager->get_access_token( $this->user_id );
 
 			if ( $token ) {
 				$salt = $token->secret;


### PR DESCRIPTION
The Connection_Manager is_active will replace `Jetpack::is_active`
I'm not yet going through the code base to remove usage, but instead throwing a deprecated notice.

`is_active` was dependent on `Jetpack_Data::get_access_token()`
I've also deprectated that method and started removing usages.
There remains some to remove, I'd ideally like to remove `class.jetpack-data.php` altogether.

To test:
Ensure you can still connect / disconnect a site.