### PR TITLE
Composer: avoid duplicate repositories key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,22 +22,6 @@
 		"phpcompatibility/phpcompatibility-wp": "2.0.0",
 		"automattic/jetpack-autoloader": "@dev"
 	},
-	"repositories": [
-		{
-			"type": "path",
-			"url": "./packages/jetpack-connection",
-			"options": {
-				"symlink": true
-			}
-		},
-		{
-			"type": "path",
-			"url": "./packages/jetpack-options",
-			"options": {
-				"symlink": true
-			}
-		}
-	],
 	"scripts": {
 		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.3-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
 		"php:lint": "composer install && vendor/bin/phpcs -p -s",

--- a/composer.lock
+++ b/composer.lock
@@ -36,7 +36,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "dev-fix/composer-repositories",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -55,7 +55,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-master",
+            "version": "dev-fix/composer-repositories",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -226,7 +226,7 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-master",
+            "version": "dev-fix/composer-repositories",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",

--- a/composer.lock
+++ b/composer.lock
@@ -226,7 +226,7 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-fix/composer-repositories",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",

--- a/composer.lock
+++ b/composer.lock
@@ -55,7 +55,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-fix/composer-repositories",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",

--- a/composer.lock
+++ b/composer.lock
@@ -36,7 +36,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-fix/composer-repositories",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Composer: avoid duplicate repositories key
Rely on wildcard instead. See #12483 for more info.

#### Testing instructions:

* Checkout the branch.
* Run `composer install`
* You should not get any errors.

#### Proposed changelog entry for your changes:

* None
