### PR TITLE
Jetpack DNA: add Standards Package

### DIFF
--- a/.github/files/mirror-.github/settings.json
+++ b/.github/files/mirror-.github/settings.json
@@ -1,0 +1,10 @@
+{
+	"repository": {
+		"has_issues": false,
+		"has_wiki": false,
+		"has_projects": false,
+		"allow_squash_merge": true,
+		"allow_merge_commit": false,
+		"allow_rebase_merge": false
+	}
+}


### PR DESCRIPTION
This replaces #12384

#### Changes proposed in this Pull Request:

* This PR introduces a set of standards (currently a copy of existing Jetpack standards) that could be used in other projects by just adding the package.
* Those standards are currently divided into 2 main categories:
    * dotfiles that are useful for development, but do not necessarily need to be checked in the repo, and can be shared with other repos.
    * Repo configuration files, that are used in combination with a GitHub webhook to enforce certain defaults (set of labels, branch protection, merge settings) on a repo when the files are present.

In future iterations, this set of standards will include more standards:
- GitHub issue / PR templates.
- Contributing docs.
- Release scripts

As is, this PR brings in changes from what is currently [another repo](https://github.com/Automattic/jetpack-standards). Once this is merged, the other repo will become a mirror of the package living in the Jetpack repo.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the DNA project.

**Note**: This PR currently includes the fix from #12546. I can rebase later on once the other PR is merged.

**TBD**: I think I may end up adding the 2 config files in `.github/` to `.gitignore`, like the other dotfiles. We don't need them in the Jetpack repo since the repo was already configured.

#### Testing instructions:

* Check out this branch.
* Run `yarn build`
* Check that the dotfiles that were removed in this PR are all added back to your working local copy.
* Check that the `.github/` directory now includes 2 new files, `labels.json` and `settings.json`.

#### Proposed changelog entry for your changes:

* Jetpack Standards: introduce new development package bundling useful tools to create and maintain a Jetpack project.
