### PR TITLE
Recurring Payments: Scroll to Window top on window open

### DIFF
--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -25,6 +25,7 @@ function handleIframeResult( eventFromIframe ) {
 
 function activateSubscription( block, blogId, planId, lang ) {
 	block.addEventListener( 'click', () => {
+		window.scrollTop( 0, 0 );
 		tb_show(
 			null,
 			'https://subscribe.wordpress.com/memberships/?blog=' +

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -25,7 +25,7 @@ function handleIframeResult( eventFromIframe ) {
 
 function activateSubscription( block, blogId, planId, lang ) {
 	block.addEventListener( 'click', () => {
-		window.scrollTop( 0, 0 );
+		window.scrollTo( 0, 0 );
 		tb_show(
 			null,
 			'https://subscribe.wordpress.com/memberships/?blog=' +


### PR DESCRIPTION
Currently, because of issues with ios safari, we switched the checkout window in memberships to `position:relative`

But the problem with that is that, when the user scrolls and then starts checkout, it can open outside of the window

<img width="873" alt="Zrzut ekranu 2019-06-4 o 10 41 20" src="https://user-images.githubusercontent.com/3775068/58864627-600a4880-86b5-11e9-960b-9a417d8a670a.png">

## Testing 

- put a recurring payment button on a site
- scroll down
- click the button
- see the site scrolling to top

