### PR TITLE
Packages: Add min stability and prefer-stable, and fix dep tree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,7 @@
 			"type": "path",
 			"url": "./packages/*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
 	"require": {
 		"composer/installers": "1.6.0",
 		"ext-openssl": "*",
-		"automattic/jetpack-connection": "^1.0",
-		"automattic/jetpack-options": "^1.0",
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,19 +4,22 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a6b3658e33a86548e8cb2a6a88a1b1c",
+    "content-hash": "71318fbdf71a58c06d0105e814840e64",
     "packages": [
         {
             "name": "automattic/jetpack-connection",
-            "version": "1.0.0",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "9dbcf84ab69da7d648e99580533624e2953c9874"
+                "reference": "254adf2ffee57d2a414ae2b5d26248255ea73899"
+            },
+            "require": {
+                "automattic/jetpack-options": "@dev"
             },
             "require-dev": {
-                "10up/wp_mock": "0.4.2",
-                "phpunit/phpunit": "7.*.*"
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
@@ -25,8 +28,9 @@
                 }
             },
             "scripts": {
-                "test": [
-                    "phpunit"
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ]
             },
             "license": [
@@ -36,16 +40,16 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "b2cebb6eb5d4da90374e17c232168088f76c4c49"
+                "reference": "b0ae55c9ff24bd1445057a1a9033eebc091dde90"
             },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "/legacy"
+                    "./legacy"
                 ]
             },
             "license": [
@@ -55,11 +59,11 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "aa3d128c9280d6186210a86b10f8bf5403f44be7"
+                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -84,11 +88,11 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "1.0.0",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
-                "reference": "43fc44d3adc959b2eebdf7971ba9c5fbca1aa3dd"
+                "reference": "f49df83b4c73f6896a7ca21fcca2538d61a8c87a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -236,11 +240,11 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
-                "reference": "b7f10b9ef30f077dfacf68c1b797a070b066a62a"
+                "reference": "8c7dc6036bf6125c31a574c14c6b0521247410ed"
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -628,13 +632,15 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-connection": 20,
+        "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-autoloader": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "ext-openssl": "*"

--- a/packages/autoloader/composer.json
+++ b/packages/autoloader/composer.json
@@ -13,5 +13,7 @@
 	},
 	"extra": {
 		"class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -24,7 +24,9 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "../*"
+			"url": "./../*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -3,7 +3,6 @@
 	"description": "Everything needed to connect to the Jetpack infrastructure",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.0.0",
 	"require": {
 		"automattic/jetpack-options": "^1.0"
 	},

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "^1.0"
+		"automattic/jetpack-options": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -21,5 +21,11 @@
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
-	}
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	]
 }

--- a/packages/constants/composer.json
+++ b/packages/constants/composer.json
@@ -6,7 +6,9 @@
 	"require": {},
 	"autoload": {
 		"classmap": [
-			"/legacy"
+			"./legacy"
 		]
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/logo/composer.json
+++ b/packages/logo/composer.json
@@ -18,5 +18,7 @@
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -2,7 +2,6 @@
 	"name": "automattic/jetpack-options",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.0.0",
 	"require": {
 		"automattic/jetpack-constants": "@dev"
 	},

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -20,7 +20,9 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "../*"
+			"url": "./../*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -17,5 +17,11 @@
 	},
 	"scripts": {
 		"test": "phpunit"
-	}
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	]
 }


### PR DESCRIPTION
After the latest commits in feature/jetpack-packages, it seems clean installation of composer inside packages doesn't work, because of version constraints:

![](https://cldup.com/zRo5q7ai7G.png)

#### Changes proposed in this Pull Request:
* Add min stability and prefer-stable to all packages and the root one, and fix dependency tree

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Go to the root directory of the repo.
* `rm -rf ./vendor`
* `rm -rf ./packages/**/vendor`
* `rm ./packages/**/composer.lock`
* Try `composer install` and verify it works.
* Try `composer install` in each package and verify it works.

Note: tests are expected to fail - this was introduced in #12562

#### Proposed changelog entry for your changes:
* Add min stability and prefer-stable to all packages and the root one, and fix dependency tree
