### PR TITLE
Revert "Jetpack Options Package: just class map existing options class"

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -1,15 +1,49 @@
 <?php
 
+use \Automattic\Jetpack\Options\Manager as Options_Manager;
+
+if ( class_exists( '\Automattic\Jetpack\Options\Manager' ) ) :
+
+/**
+ * The option manager class that will eventually replace Jetpack_Options
+ */
+class Jetpack_Options_Manager extends Options_Manager {
+
+	/**
+	 * Returns an array of option names for a given type.
+	 *
+	 * @param string $type The type of option to return. Defaults to 'compact'.
+	 *
+	 * @return array
+	 */
+	public function get_option_names( $type = 'compact' ) {
+		switch ( $type ) {
+			case 'non-compact':
+			case 'non_compact':
+				return array( 'secrets' );
+
+			case 'private':
+				return array();
+
+			case 'network':
+				return array();
+		}
+
+		return array();
+	}
+}
+
+endif;
+
 class Jetpack_Options {
 
 	/**
 	 * An array that maps a grouped option type to an option name.
-	 *
 	 * @var array
 	 */
 	private static $grouped_options = array(
 		'compact' => 'jetpack_options',
-		'private' => 'jetpack_private_options',
+		'private' => 'jetpack_private_options'
 	);
 
 	/**
@@ -21,59 +55,59 @@ class Jetpack_Options {
 	 */
 	public static function get_option_names( $type = 'compact' ) {
 		switch ( $type ) {
-			case 'non-compact':
-			case 'non_compact':
-				return array(
-					'activated',
-					'active_modules',
-					'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
-					'available_modules',
-					'do_activate',
-					'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
-					'log',
-					'slideshow_background_color',
-					'widget_twitter',
-					'wpcc_options',
-					'relatedposts',
-					'file_data',
-					'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
-					'autoupdate_plugins_translations', // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated translation files.
-					'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
-					'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
-					'autoupdate_core',             // (bool)   Whether or not to autoupdate core
-					'autoupdate_translations',     // (bool)   Whether or not to autoupdate all translations
-					'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
-					'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
-					'site_icon_url',               // (string) url to the full site icon
-					'site_icon_id',                // (int)    Attachment id of the site icon file
-					'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
-					'restapi_stats_cache',         // (array) Stats Cache data.
-					'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-					'protect_whitelist',           // (array) IP Address for the Protect module to ignore
-					'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
-					'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
-					'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
-					'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
-					'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
-					'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
-					'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
-					'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
-					'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
-					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
-				);
+		case 'non-compact' :
+		case 'non_compact' :
+			return array(
+				'activated',
+				'active_modules',
+				'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
+				'available_modules',
+				'do_activate',
+				'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
+				'log',
+				'slideshow_background_color',
+				'widget_twitter',
+				'wpcc_options',
+				'relatedposts',
+				'file_data',
+				'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
+				'autoupdate_plugins_translations', // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated translation files.
+				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
+				'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
+				'autoupdate_core',             // (bool)   Whether or not to autoupdate core
+				'autoupdate_translations',     // (bool)   Whether or not to autoupdate all translations
+				'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
+				'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
+				'site_icon_url',               // (string) url to the full site icon
+				'site_icon_id',                // (int)    Attachment id of the site icon file
+				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+				'restapi_stats_cache',         // (array) Stats Cache data.
+				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
+				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
+				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
+				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
+				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
+				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
+				'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
+				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
+				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
+				'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
+				'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
+				'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
+			);
 
-			case 'private':
-				return array(
-					'blog_token',  // (string) The Client Secret/Blog Token of this site.
-					'user_token',  // (string) The User Token of this site. (deprecated)
-					'user_tokens',  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.
-				);
+		case 'private' :
+			return array(
+				'blog_token',  // (string) The Client Secret/Blog Token of this site.
+				'user_token',  // (string) The User Token of this site. (deprecated)
+				'user_tokens'  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.
+			);
 
-			case 'network':
-				return array(
-					'onboarding',                   // (string) Auth token to be used in the onboarding connection flow
-					'file_data',                     // (array) List of absolute paths to all Jetpack modules
-				);
+		case 'network' :
+			return array(
+				'onboarding',                   // (string) Auth token to be used in the onboarding connection flow
+				'file_data'                     // (array) List of absolute paths to all Jetpack modules
+			);
 		}
 
 		return array(
@@ -157,7 +191,7 @@ class Jetpack_Options {
 	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed  $default (optional)
+	 * @param mixed $default (optional)
 	 *
 	 * @return mixed
 	 */
@@ -186,7 +220,7 @@ class Jetpack_Options {
 	 * This does _not_ adjust the prefix in any way (does not prefix jetpack_%)
 	 *
 	 * @param string $name Option name
-	 * @param mixed  $default (optional)
+	 * @param mixed $default (optional)
 	 *
 	 * @return mixed
 	 */
@@ -194,9 +228,9 @@ class Jetpack_Options {
 		// In this function the name is not adjusted by prefixing jetpack_
 		// so if it has already prefixed, we'll replace it and then
 		// check if the option name is a network option or not
-		$jetpack_name      = preg_replace( '/^jetpack_/', '', $name, 1 );
+		$jetpack_name = preg_replace( '/^jetpack_/', '', $name, 1 );
 		$is_network_option = self::is_network_option( $jetpack_name );
-		$value             = $is_network_option ? get_site_option( $name ) : get_option( $name );
+		$value = $is_network_option ? get_site_option( $name ) : get_option( $name );
 
 		if ( false === $value && false !== $default ) {
 			if ( $is_network_option ) {
@@ -224,7 +258,7 @@ class Jetpack_Options {
 	 * Updates the single given option.  Updates jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed  $value Option value
+	 * @param mixed $value Option value
 	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
 	 *
 	 * @return bool Was the option successfully updated?
@@ -300,6 +334,7 @@ class Jetpack_Options {
 			} else {
 				$result = delete_option( "jetpack_$name" );
 			}
+
 		}
 
 		foreach ( array_keys( self::$grouped_options ) as $group ) {
@@ -359,8 +394,8 @@ class Jetpack_Options {
 	 * Updates an option via $wpdb query.
 	 *
 	 * @param string $name Option name.
-	 * @param mixed  $value Option value.
-	 * @param bool   $autoload Specifying whether to autoload or not.
+	 * @param mixed $value Option value.
+	 * @param bool $autoload Specifying whether to autoload or not.
 	 *
 	 * @return bool Is the option updated?
 	 */
@@ -410,7 +445,7 @@ class Jetpack_Options {
 	 * @since 5.4.0
 	 *
 	 * @param string $name Option name.
-	 * @param mixed  $default Default option value if option is not found.
+	 * @param mixed $default Default option value if option is not found.
 	 *
 	 * @return mixed Option value, or null if option is not found and default is not specified.
 	 */
@@ -450,7 +485,6 @@ class Jetpack_Options {
 		}
 		/**
 		 * Allows to disable particular raw options.
-		 *
 		 * @since 5.5.0
 		 *
 		 * @param array $disabled_raw_options An array of option names that you can selectively blacklist from being managed via direct database queries.
@@ -489,7 +523,7 @@ class Jetpack_Options {
 				'register',
 				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
 				'user_token',                  // (string) The User Token of this site. (deprecated)
-				'user_tokens',
+				'user_tokens'
 			);
 
 			// Remove the unsafe Jetpack options
@@ -574,7 +608,7 @@ class Jetpack_Options {
 
 		$options = array(
 			'jp_options' => $all_jp_options,
-			'wp_options' => $wp_options,
+			'wp_options' => $wp_options
 		);
 
 		return $options;
@@ -595,7 +629,7 @@ class Jetpack_Options {
 
 		// Delete all non-compact Jetpack options
 		foreach ( (array) self::get_option_names( 'non-compact' ) as $option_name ) {
-			self::delete_option( $option_name );
+			Jetpack_Options::delete_option( $option_name );
 		}
 
 		// Delete all options that can be reset via CLI, that aren't Jetpack options

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -539,6 +539,10 @@ class Jetpack {
 			Jetpack_Network::init();
 		}
 
+		add_filter( 'jetpack_connection_option_manager', function() {
+			return new Jetpack_Options_Manager();
+		} );
+
 		add_filter( 'jetpack_connection_secret_generator', function( $callable ) {
 			return function() {
 				return wp_generate_password( 32, false );

--- a/composer.lock
+++ b/composer.lock
@@ -36,7 +36,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -55,27 +55,17 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "aa3d128c9280d6186210a86b10f8bf5403f44be7"
-            },
-            "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "reference": "9e99ef65b2600e06f2eaeaf435771194a174f40d"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Automattic\\Jetpack\\Assets\\": "src/"
                 }
-            },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -88,7 +78,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
-                "reference": "43fc44d3adc959b2eebdf7971ba9c5fbca1aa3dd"
+                "reference": "0ff5d88cb668dcb7f8f54dfa4a19c87819e1dc78"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -99,9 +89,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "legacy"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\Options\\": "src"
+                }
             },
             "scripts": {
                 "test": [
@@ -236,7 +226,7 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-try/jetpack-connection-is-active",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",

--- a/jetpack.php
+++ b/jetpack.php
@@ -210,6 +210,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client.php'        );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-data.php'          );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php' );
 require_once( JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-actions.php' );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-options.php'       );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php'    );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php'   );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-error.php'         );

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -4,9 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"version": "1.0.0",
-	"require": {
-		"automattic/jetpack-options": "^1.0"
-	},
+	"require": {},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
 		"php-mock/php-mock": "^2.1"

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -11,9 +11,9 @@
 		"10up/wp_mock": "0.4.2"
 	},
 	"autoload": {
-		"classmap": [
-			"legacy"
-		]
+		"psr-4": {
+			"Automattic\\Jetpack\\Options\\": "src"
+		}
 	},
 	"scripts": {
 		"test": "phpunit"

--- a/packages/options/phpunit.xml
+++ b/packages/options/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="general">
+			<file>tests/Manager.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/options/src/Manager.php
+++ b/packages/options/src/Manager.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * The Jetpack Options manager class file.
+ *
+ * @package jetpack-options
+ */
+
+namespace Automattic\Jetpack\Options;
+
+/**
+ * The Jetpack Options Manager class that is used as a single gateway between WordPress options API
+ * and Jetpack.
+ */
+abstract class Manager {
+
+	/**
+	 * An array that maps a grouped option type to an option name.
+	 *
+	 * @var array
+	 */
+	protected $grouped_options = array(
+		'compact' => 'jetpack_options',
+		'private' => 'jetpack_private_options',
+	);
+
+	/**
+	 * Returns an array of option names for a given type.
+	 *
+	 * @param string $type The type of option to return. Defaults to 'compact'.
+	 *
+	 * @return array
+	 */
+	abstract public function get_option_names( $type );
+
+	/**
+	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
+	 *
+	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
+	 * @param mixed  $default (optional) the default value.
+	 *
+	 * @return mixed
+	 */
+	public function get_option( $name, $default = false ) {
+		if ( $this->is_valid( $name, 'non_compact' ) ) {
+			if ( $this->is_network_option( $name ) ) {
+				return get_site_option( "jetpack_$name", $default );
+			}
+
+			return get_option( "jetpack_$name", $default );
+		}
+
+		foreach ( array_keys( $this->grouped_options ) as $group ) {
+			if ( $this->is_valid( $name, $group ) ) {
+				return $this->get_grouped_option( $group, $name, $default );
+			}
+		}
+
+		// TODO: throw an exception here?
+
+		return $default;
+	}
+
+	/**
+	 * Returns a single value from a grouped option.
+	 *
+	 * @param String $group   name of the group, i.e., 'private'.
+	 * @param String $name    the name of the option to return.
+	 * @param Mixed  $default a default value in case the option is not found.
+	 * @return Mixed the option value or default if not found.
+	 */
+	protected function get_grouped_option( $group, $name, $default ) {
+		$options = get_option( $this->grouped_options[ $group ] );
+		if ( is_array( $options ) && isset( $options[ $name ] ) ) {
+			return $options[ $name ];
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Updates the single given option.  Updates jetpack_options or jetpack_$name as appropriate.
+	 *
+	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
+	 * @param mixed  $value Option value.
+	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
+	 *
+	 * @return bool Was the option successfully updated?
+	 */
+	public function update_option( $name, $value, $autoload = null ) {
+		/**
+		 * Fires before Jetpack updates a specific option.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param str $name The name of the option being updated.
+		 * @param mixed $value The new value of the option.
+		 */
+		do_action( 'pre_update_jetpack_option_' . $name, $name, $value );
+		if ( $this->is_valid( $name, 'non_compact' ) ) {
+			if ( $this->is_network_option( $name ) ) {
+				return update_site_option( "jetpack_$name", $value );
+			}
+
+			return update_option( "jetpack_$name", $value, $autoload );
+
+		}
+
+		foreach ( array_keys( $this->grouped_options ) as $group ) {
+			if ( $this->is_valid( $name, $group ) ) {
+				return $this->update_grouped_option( $group, $name, $value );
+			}
+		}
+
+		// TODO: throw an exception here?
+
+		return false;
+	}
+
+	/**
+	 * Updates a single value from a grouped option.
+	 *
+	 * @param String $group name of the group, i.e., 'private'.
+	 * @param String $name  the name of the option to update.
+	 * @param Mixed  $value the to update the option with.
+	 * @return Boolean was the update successful?
+	 */
+	protected function update_grouped_option( $group, $name, $value ) {
+		$options = get_option( $this->grouped_options[ $group ] );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$options[ $name ] = $value;
+
+		return update_option( $this->grouped_options[ $group ], $options );
+	}
+
+	/**
+	 * Deletes the given option.  May be passed multiple option names as an array.
+	 * Updates jetpack_options and/or deletes jetpack_$name as appropriate.
+	 *
+	 * @param string|array $names Option names. They must come _without_ `jetpack_%` prefix. The method will prefix the option names.
+	 *
+	 * @return bool Was the option successfully deleted?
+	 */
+	public function delete_option( $names ) {
+		$result = true;
+		$names  = (array) $names;
+
+		if ( ! $this->is_valid( $names ) ) {
+			// TODO: issue a warning here?
+			return false;
+		}
+
+		foreach ( array_intersect( $names, $this->get_option_names( 'non_compact' ) ) as $name ) {
+			if ( $this->is_network_option( $name ) ) {
+				$result = delete_site_option( "jetpack_$name" );
+			} else {
+				$result = delete_option( "jetpack_$name" );
+			}
+		}
+
+		foreach ( array_keys( $this->grouped_options ) as $group ) {
+			if ( ! $this->delete_grouped_option( $group, $names ) ) {
+				$result = false;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Deletes a single value from a grouped option.
+	 *
+	 * @param String $group   name of the group, i.e., 'private'.
+	 * @param Array  $names   the names of the option to delete.
+	 * @return Mixed the option value or default if not found.
+	 */
+	protected function delete_grouped_option( $group, $names ) {
+		$options = get_option( $this->grouped_options[ $group ], array() );
+
+		$to_delete = array_intersect( $names, $this->get_option_names( $group ), array_keys( $options ) );
+		if ( $to_delete ) {
+			foreach ( $to_delete as $name ) {
+				unset( $options[ $name ] );
+			}
+
+			return update_option( $this->grouped_options[ $group ], $options );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Is the option name valid?
+	 *
+	 * @param string      $name  The name of the option.
+	 * @param string|null $group The name of the group that the option is in. Default to null, which will search non_compact.
+	 *
+	 * @return bool Is the option name valid?
+	 */
+	public function is_valid( $name, $group = null ) {
+		if ( is_array( $name ) ) {
+			$compact_names = array();
+			foreach ( array_keys( $this->grouped_options ) as $_group ) {
+				$compact_names = array_merge( $compact_names, $this->get_option_names( $_group ) );
+			}
+
+			$result = array_diff( $name, $this->get_option_names( 'non_compact' ), $compact_names );
+
+			return empty( $result );
+		}
+
+		if ( is_null( $group ) || 'non_compact' === $group ) {
+			if ( in_array( $name, $this->get_option_names( $group ), true ) ) {
+				return true;
+			}
+		}
+
+		foreach ( array_keys( $this->grouped_options ) as $_group ) {
+			if ( is_null( $group ) || $group === $_group ) {
+				if ( in_array( $name, $this->get_option_names( $_group ), true ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if an option must be saved for the whole network in WP Multisite
+	 *
+	 * @param string $option_name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
+	 *
+	 * @return bool
+	 */
+	public function is_network_option( $option_name ) {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+		return in_array( $option_name, $this->get_option_names( 'network' ), true );
+	}
+
+	/**
+	 * Gets an option via $wpdb query.
+	 *
+	 * @since 5.4.0
+	 *
+	 * @param string $name Option name.
+	 * @param mixed  $default Default option value if option is not found.
+	 *
+	 * @return mixed Option value, or null if option is not found and default is not specified.
+	 */
+	function get_raw_option( $name, $default = null ) {
+		if ( $this->bypass_raw_option( $name ) ) {
+			return get_option( $name, $default );
+		}
+		global $wpdb;
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+				$name
+			)
+		);
+		$value = maybe_unserialize( $value );
+		if ( $value === null && $default !== null ) {
+			return $default;
+		}
+		return $value;
+	}
+	/**
+	 * This function checks for a constant that, if present, will disable direct DB queries Jetpack uses to manage certain options and force Jetpack to always use Options API instead.
+	 * Options can be selectively managed via a blacklist by filtering option names via the jetpack_disabled_raw_option filter.
+	 *
+	 * @param $name Option name
+	 *
+	 * @return bool
+	 */
+	function bypass_raw_option( $name ) {
+		if ( \Jetpack_Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
+			return true;
+		}
+		/**
+		 * Allows to disable particular raw options.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param array $disabled_raw_options An array of option names that you can selectively blacklist from being managed via direct database queries.
+		 */
+		$disabled_raw_options = apply_filters( 'jetpack_disabled_raw_options', array() );
+		return isset( $disabled_raw_options[ $name ] );
+	}
+}

--- a/packages/options/tests/Manager.php
+++ b/packages/options/tests/Manager.php
@@ -1,0 +1,246 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use Auutomattic\Jetpack\Options\Manager;
+
+class ManagerTest extends TestCase {
+	public function setUp() {
+		\WP_Mock::setUp();
+
+		$this->manager = new Manager_Test();
+	}
+
+	function test_get_private_option_returns_value() {
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options' ),
+			'return' => array( 'private_name' => true ),
+		) );
+
+		$value = $this->manager->get_option( 'private_name' );
+
+		// Did Jetpack_Options::get_option() properly return true?
+		$this->assertTrue( $value );
+	}
+
+	function test_get_network_option_returns_value() {
+		\WP_Mock::userFunction( 'get_site_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_network_name', false ),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => true,
+		) );
+
+		$value = $this->manager->get_option( 'network_name' );
+
+		// Did Jetpack_Options::get_option() properly return true?
+		$this->assertTrue( $value );
+	}
+
+	function test_get_non_compact_option_returns_value() {
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_uncompact_option_name', false ),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => false,
+		) );
+
+		$value = $this->manager->get_option( 'uncompact_option_name' );
+
+		// Did Jetpack_Options::get_option() properly return true?
+		$this->assertTrue( $value );
+	}
+
+	function test_delete_non_compact_option_returns_true_when_successfully_deleted() {
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_options', array() ),
+			'return' => array(),
+		) );
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options', array() ),
+			'return' => array(),
+		) );
+		\WP_Mock::userFunction( 'delete_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_uncompact_option_name' ),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => false,
+		) );
+
+		$deleted = $this->manager->delete_option( 'uncompact_option_name' );
+
+		// Did Jetpack_Options::delete_option() properly return true?
+		$this->assertTrue( $deleted );
+	}
+
+	function test_delete_network_option_returns_true_when_successfully_deleted() {
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_options', array() ),
+			'return' => array(),
+		) );
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options', array() ),
+			'return' => array(),
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'delete_site_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_network_name' ),
+			'return' => true,
+		) );
+
+		$deleted = $this->manager->delete_option( 'network_name' );
+
+		// Did Jetpack_Options::delete_option() properly return true?
+		$this->assertTrue( $deleted );
+	}
+
+	function test_delete_private_option_returns_true_when_successfully_deleted() {
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_options', array() ),
+			'return' => array(),
+		) );
+		\WP_Mock::userFunction( 'get_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options', array() ),
+			'return' => array( 'private_name' => false ),
+		) );
+		\WP_Mock::userFunction( 'update_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options', array() ),
+			'return' => true,
+		) );
+
+		$deleted = $this->manager->delete_option( 'private_name' );
+
+		// Did Jetpack_Options::delete_option() properly return true?
+		$this->assertTrue( $deleted );
+	}
+
+	function test_update_non_compact_option_returns_true_when_successfully_updated() {
+		\WP_Mock::expectAction(
+			'pre_update_jetpack_option_uncompact_option_name',
+			'uncompact_option_name',
+			true
+		);
+
+		\WP_Mock::userFunction( 'update_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_uncompact_option_name', true, NULL ),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => false,
+		) );
+
+		$updated = $this->manager->update_option( 'uncompact_option_name', true );
+
+		// Did Jetpack_Options::delete_option() properly return true?
+		$this->assertTrue( $updated );
+	}
+
+	function test_update_network_option_returns_true_when_successfully_updated() {
+		\WP_Mock::expectAction(
+			'pre_update_jetpack_option_network_name',
+			'network_name',
+			true
+		);
+
+		\WP_Mock::userFunction( 'update_site_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_network_name', true ),
+			'return' => true,
+		) );
+		\WP_Mock::userFunction( 'is_multisite', array(
+			'times' => 1,
+			'args' => array(),
+			'return' => true,
+		) );
+
+		$updated = $this->manager->update_option( 'network_name', true );
+
+		// Did Jetpack_Options::update_option() properly return true?
+		$this->assertTrue( $updated );
+	}
+
+	function test_update_private_option_returns_true_when_successfully_updated() {
+		\WP_Mock::expectAction(
+			'pre_update_jetpack_option_private_name',
+			'private_name',
+			true
+		);
+
+		\WP_Mock::userFunction( 'update_option', array(
+			'times' => 1,
+			'args' => array( 'jetpack_private_options', array( 'private_name' => true ) ),
+			'return' => true,
+		) );
+
+		$updated = $this->manager->update_option( 'private_name', true );
+
+		// Did Jetpack_Options::update_option() properly return true?
+		$this->assertTrue( $updated );
+	}
+
+	public function tearDown() {
+		\WP_Mock::tearDown();
+	}
+}
+
+class Manager_Test extends Manager {
+
+	/**
+	 * Returns an array of option names for a given type.
+	 *
+	 * @param string $type The type of option to return. Defaults to 'compact'.
+	 *
+	 * @return array
+	 */
+	public function get_option_names( $type = 'compact' ) {
+		switch ( $type ) {
+		case 'non-compact' :
+		case 'non_compact' :
+			return array(
+				'network_name',
+				'uncompact_option_name',
+			);
+
+		case 'private' :
+			return array(
+				'private_name'
+			);
+
+		case 'network' :
+			return array(
+				'network_name' // Network options must be listed a second time
+			);
+		}
+
+		return array(
+			'id'
+		);
+	}
+}

--- a/packages/options/tests/bootstrap.php
+++ b/packages/options/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+WP_Mock::bootstrap();


### PR DESCRIPTION
Reverts Automattic/jetpack#12562 as I assume it broke the connection package tests (see https://travis-ci.org/Automattic/jetpack/jobs/541622250) and it breaks the dependency tree (see https://travis-ci.org/Automattic/jetpack/jobs/541593344).

If we merge this, there won't be need for #12570 (for now).