### PR TITLE
Update code that moves VP notices into the JP dashboard

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -7,7 +7,7 @@ class AdminNotices extends React.Component {
 	componentDidMount() {
 		const $adminNotices = jQuery( this.refs.adminNotices );
 		const dismiss =
-			'<span role="button" tabindex="0" class="dops-notice__dismiss"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path></g></svg><span class="screen-reader-text"></span></span>';
+			'<span role="button" tabindex="0" class="dops-notice__dismiss"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg><span class="screen-reader-text"/></span>';
 
 		const $vpDeactivationNotice = jQuery( '.vp-deactivated' );
 		if ( $vpDeactivationNotice.length > 0 ) {
@@ -16,7 +16,7 @@ class AdminNotices extends React.Component {
 					.addClass( 'dops-notice is-success is-dismissable' )
 					.removeClass( 'wrap vp-notice notice notice-success' );
 				const icon =
-					'<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>';
+					'<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></svg></span>';
 				$notice.wrapInner( '<span class="dops-notice__content">' );
 				$notice
 					.find( '.dops-notice__content' )
@@ -36,28 +36,31 @@ class AdminNotices extends React.Component {
 		const $vpNotice = jQuery( '.vp-notice' );
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function() {
-				const $success = jQuery( this ).hasClass( 'vp-registered' );
-				const $warningOrSuccess = $success ? 'is-success' : 'is-warning';
-				const $notice = jQuery( this )
-					.addClass( 'dops-notice vp-notice-jp ' + $warningOrSuccess )
-					.removeClass( 'wrap vp-notice' );
-				const icon = $success
-					? '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>'
-					: '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg></span>';
-				$notice.wrapInner( '<span class="dops-notice__content">' );
-				$notice.find( '.dops-notice__content' ).before( icon );
-				$notice
-					.find( '.vp-message' )
-					.removeClass( 'vp-message' )
-					.addClass( 'dops-notice__text' );
-				$notice.find( 'h3' ).replaceWith( function() {
-					return jQuery( '<strong />', { html: this.innerHTML } );
-				} );
-				$notice.find( 'p' ).replaceWith( function() {
-					return jQuery( '<div/>', { html: this.innerHTML } );
-				} );
+				const $notice = jQuery( this );
+				// If the notice doesn't have an icon, it's one of the old VP notices.
+				if ( 0 === $notice.find( '.dops-notice__icon' ).length ) {
+					const $success = $notice.hasClass( 'vp-registered' );
+					const $warningOrSuccess = $success ? 'is-success' : 'is-error';
+					$notice.addClass( 'dops-notice vp-notice-jp ' + $warningOrSuccess );
+					$notice.wrapInner( '<span class="dops-notice__content">' );
+					const icon = $success
+						? '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></svg></span>'
+						: '<span class="dops-notice__icon-wrapper"><svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></svg></span>';
+					$notice.find( '.dops-notice__content' ).before( icon );
+					$notice
+						.find( '.vp-message' )
+						.removeClass( 'vp-message' )
+						.addClass( 'dops-notice__text' );
+					$notice.find( 'h3' ).replaceWith( function() {
+						return jQuery( '<strong />', { html: this.innerHTML } );
+					} );
+					$notice.find( 'p' ).replaceWith( function() {
+						return jQuery( '<div/>', { html: this.innerHTML } );
+					} );
+					$notice.css( 'display', 'flex' );
+				}
 				$notice.find( 'a[href*="admin.php?page=vaultpress"]' ).remove();
-				$notice.prependTo( $adminNotices ).css( 'display', 'flex' );
+				$notice.prependTo( $adminNotices ).removeClass( 'wrap vp-notice' );
 			} );
 		}
 


### PR DESCRIPTION
This PR checks if the VP notices shown in the JP dashboard are the new ones introduced in VP restyle. In such case, it won't perform most of the tweaks, like inserting an icon, since they're already stylized like that, and will only move the notice into the JP dashboard.
Previous VP notices will still be tweaked and moved as usual.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* checks if the notices already has an icon, which is only included in the new VP notices. In such case, it will move the notice inside the JP dashboard without performing any other task.

#### Testing instructions:

* Go to the Jetpack dashboard
* Test with the current VaultPress. Easiest way to force VP to display a notice is to test in a localhost.
* Test with the new VaultPress UI branch https://github.com/Automattic/vaultpress/pull/6
* Ensure that in both cases, the notice is moved into the JP dashboard and the layout is correct.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed since the result is not visible to users.
