### PR TITLE
Packages: Fix README alias example

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -54,7 +54,7 @@ $logo = new Logo();
 If you need to rule out conflicts, you can alias it:
 
 ```php
-use Automattic\Jetpack\Assets\Jetpack_Logo;
+use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 
 // other code...
 


### PR DESCRIPTION
This is a follow-up to #12576 and fixes the aliasing example in the packages README file.

#### Changes proposed in this Pull Request:
* Fixes the aliasing example in the packages README file

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Not needed.

#### Proposed changelog entry for your changes:
* Not needed.
