### PR TITLE
Packages: Move JITM tests to package and fix deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,7 @@
 			"type": "path",
 			"url": "./packages/*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b711e37a57a39e3470c4af334eab9c50",
+    "content-hash": "49dfae78b865b05e4de33278963c050b",
     "packages": [
         {
             "name": "automattic/jetpack-asset-tools",
@@ -30,11 +30,11 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "1.0.0",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "ca7edb2022bf0c5b1e045a2ad5d2c5229c364a4f"
+                "reference": "eb2ab1a317d710fbe651a20fa580d523e303d848"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -95,19 +95,28 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "de0110b1cce11fd0728ec3d8fcd03d457239354a"
+                "reference": "853d6934703fce515f16d5f3450cbb51ed05d09e"
             },
             "require": {
                 "automattic/jetpack-asset-tools": "@dev",
-                "automattic/jetpack-connection": "^1.0",
+                "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-logo": "@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Automattic\\Jetpack\\JITM\\": "src/"
                 }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -122,21 +131,11 @@
                 "url": "./packages/logo",
                 "reference": "aa3d128c9280d6186210a86b10f8bf5403f44be7"
             },
-            "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
-            },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Automattic\\Jetpack\\Assets\\": "src/"
                 }
-            },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -685,7 +684,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-options": 20,
@@ -695,7 +694,7 @@
         "automattic/jetpack-asset-tools": 20,
         "automattic/jetpack-autoloader": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "ext-openssl": "*"

--- a/packages/asset-tools/composer.json
+++ b/packages/asset-tools/composer.json
@@ -16,5 +16,7 @@
 			"type": "path",
 			"url": "../*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/autoloader/composer.json
+++ b/packages/autoloader/composer.json
@@ -13,5 +13,7 @@
 	},
 	"extra": {
 		"class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -3,7 +3,6 @@
 	"description": "Everything needed to connect to the Jetpack infrastructure",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.0.0",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev"

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -27,5 +27,7 @@
 			"type": "path",
 			"url": "../*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/constants/composer.json
+++ b/packages/constants/composer.json
@@ -17,5 +17,7 @@
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -28,5 +28,7 @@
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -9,6 +9,9 @@
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev"
 	},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+	},
 	"autoload": {
 		"psr-4": {
 			"Automattic\\Jetpack\\JITM\\": "src/"
@@ -19,5 +22,11 @@
 			"type": "path",
 			"url": "../*"
 		}
-	]
+	],
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	}
 }

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-asset-tools": "@dev",
-		"automattic/jetpack-connection": "^1.0",
+		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev"
 	},

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -10,7 +10,8 @@
 		"automattic/jetpack-constants": "@dev"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/packages/jitm/phpunit.xml.dist
+++ b/packages/jitm/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/jitm/tests/php/bootstrap.php
+++ b/packages/jitm/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -47,7 +47,7 @@ class Test_Jetpack_JITM extends TestCase {
 		$builder->setNamespace( __NAMESPACE__ )
 			->setName( 'apply_filters' )
 			->setFunction(
-				function () {
+				function() {
 					$current_args = func_get_args();
 					foreach ( $this->mocked_filters as $filter ) {
 						if ( array_slice( $filter, 0, -1 ) === $current_args ) {

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -59,6 +59,7 @@ class Test_Jetpack_JITM extends TestCase {
 		$this->apply_filters_mock = $builder->build();
 		$this->apply_filters_mock->enable();
 	}
+
 	protected function clear_mock_filters() {
 		$this->apply_filters_mock->disable();
 		unset( $this->mocked_filters );

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -1,14 +1,15 @@
 <?php
 
 use Automattic\Jetpack\JITM\Manager as Jetpack_JITM;
+use PHPUnit\Framework\TestCase;
 
-class WP_Test_Jetpack_JITM extends WP_UnitTestCase {
-	function test_jitm_disabled_by_filter() {
+class Test_Jetpack_JITM extends TestCase {
+	public function test_jitm_disabled_by_filter() {
 		add_filter( 'jetpack_just_in_time_msgs', '__return_false', 50 );
 		$this->assertFalse( Jetpack_JITM::init() );
 	}
 
-	function test_jitm_enabled_by_default() {
+	public function test_jitm_enabled_by_default() {
 		$this->assertTrue( ! ! Jetpack_JITM::init() );
 	}
 }

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -1,15 +1,66 @@
 <?php
 
+namespace Automattic\Jetpack\JITM;
+
 use Automattic\Jetpack\JITM\Manager as Jetpack_JITM;
+use phpmock\functions\FunctionProvider;
+use phpmock\Mock;
+use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
 
 class Test_Jetpack_JITM extends TestCase {
+	public function setUp() {
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( 'add_action' )
+			->setFunction( function() {} );
+		$builder->build()->enable();
+	}
+
+	public function tearDown() {
+		Mock::disableAll();
+	}
+
 	public function test_jitm_disabled_by_filter() {
-		add_filter( 'jetpack_just_in_time_msgs', '__return_false', 50 );
+		$this->mock_filters( array(
+			array( 'jetpack_just_in_time_msgs', false, false ),
+		) );
+
 		$this->assertFalse( Jetpack_JITM::init() );
+
+		$this->clear_mock_filters();
 	}
 
 	public function test_jitm_enabled_by_default() {
+		$this->mock_filters( array(
+			array( 'jetpack_just_in_time_msgs', false, true ),
+		) );
+
 		$this->assertTrue( ! ! Jetpack_JITM::init() );
+
+		$this->clear_mock_filters();
+	}
+
+	protected function mock_filters( $filters ) {
+		$this->mocked_filters = $filters;
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( 'apply_filters' )
+			->setFunction(
+				function () {
+					$current_args = func_get_args();
+					foreach ( $this->mocked_filters as $filter ) {
+						if ( array_slice( $filter, 0, -1 ) === $current_args ) {
+							return array_pop( $filter );
+						}
+					}
+				}
+			);
+		$this->apply_filters_mock = $builder->build();
+		$this->apply_filters_mock->enable();
+	}
+	protected function clear_mock_filters() {
+		$this->apply_filters_mock->disable();
+		unset( $this->mocked_filters );
 	}
 }

--- a/packages/logo/composer.json
+++ b/packages/logo/composer.json
@@ -18,5 +18,7 @@
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -20,5 +20,7 @@
 			"type": "path",
 			"url": "../*"
 		}
-	]
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -75,9 +75,6 @@
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
 		</testsuite>
-		<testsuite name="jitm">
-			<file>tests/php/test_class.jetpack-jitm.php</file>
-		</testsuite>
 		<testsuite name="affiliate">
 			<file>tests/php/test_class.jetpack-affiliate.php</file>
 		</testsuite>


### PR DESCRIPTION
This PR moves the existing JITM tests from the integration tests to unit tests, so they belong to the package. It also updates some dependencies that occur when we have more than 2 levels of depth.

#### Changes proposed in this Pull Request:
* Move the existing JITM tests to the JITM package.
* Fix the JITM tests so they work independently.
* Update the JITM tests so they run on CI.
* Update dependencies, lower minimum stability and add prefer-stable flag.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:

* Checkout this branch.
* Run `rm -rf ./vendor` inside Jetpack.
* Run `composer install` inside Jetpack.
* Navigate to `packages/jitm`
* Run `composer phpunit`.
* Verify that runs `composer install` internally, and then runs the package tests.
* Verify the package tests pass.
* Run `composer phpunit` again.
* Verify the second time is fast because the dependencies are already installed.
* Verify CI passes on this PR and 100% is green.

#### Proposed changelog entry for your changes:
* Make the JITM unit tests run independently.
