### PR TITLE
DashItem - Remove Upgrade cases from ProStatus component

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -113,22 +113,8 @@ class ProStatus extends React.Component {
 				break;
 			case 'free':
 			case 'personal':
-				type = 'upgrade';
-				status = 'is-warning';
-				if ( ! this.props.isCompact ) {
-					message = __( 'No scanning', {
-						context: 'Short warning message about site having no security scan.',
-					} );
-				}
-				action = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
-				actionUrl = this.props.paidFeatureUpgradeUrl;
-				break;
 			case 'pro':
-				type = 'upgrade';
-				status = 'is-warning';
-				action = __( 'Upgrade', { context: 'Caption for a button to purchase a pro plan.' } );
-				actionUrl = this.props.planProUpgradeUrl;
-				break;
+				return;
 			case 'secure':
 				status = 'is-success';
 				message = __( 'Secure', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed the cases that show a SimpleNotice with an Upgrade CTA from DashItems

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the At a Glance Tuneup project

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to At a Glance after connecting Jetpack on a Free plan
* Make sure the Upgrade notice is no longer visible
* Check to see if we broke any other statuses there or in settings (looks like ProStatus is used in Settings)

#### Before
![image](https://user-images.githubusercontent.com/1123119/59061860-b5835880-8861-11e9-9b03-10ac9fda5560.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/59061730-60474700-8861-11e9-8e17-0a993dc5cd2e.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed for this one, but we'll want one when we introduce the new Upgrade notices.
