### PR TITLE
Facebook Embeds: support new video URL format

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -58,7 +58,7 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 	if (
 		false !== strpos( $url, 'video.php' )
 		|| false !== strpos( $url, '/videos/' )
-		|| false !== strpos( $url, '/watch/' )
+		|| false !== strpos( $url, '/watch' )
 	) {
 		$embed = sprintf( '<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>', esc_url( $url ) );
 	} else {

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -9,7 +9,7 @@ define( 'JETPACK_FACEBOOK_EMBED_REGEX', '#^https?://(www.)?facebook\.com/([^/]+)
 define( 'JETPACK_FACEBOOK_ALTERNATE_EMBED_REGEX', '#^https?://(www.)?facebook\.com/permalink.php\?([^\s]+)#' );
 define( 'JETPACK_FACEBOOK_PHOTO_EMBED_REGEX', '#^https?://(www.)?facebook\.com/photo.php\?([^\s]+)#' );
 define( 'JETPACK_FACEBOOK_PHOTO_ALTERNATE_EMBED_REGEX', '#^https?://(www.)?facebook\.com/([^/]+)/photos/([^/]+)?#' );
-define( 'JETPACK_FACEBOOK_VIDEO_EMBED_REGEX', '#^https?://(www.)?facebook\.com/video.php\?([^\s]+)#' );
+define( 'JETPACK_FACEBOOK_VIDEO_EMBED_REGEX', '#^https?://(www.)?facebook\.com/(?:video.php|watch\/?)\?([^\s]+)#' );
 define( 'JETPACK_FACEBOOK_VIDEO_ALTERNATE_EMBED_REGEX', '#^https?://(www.)?facebook\.com/([^/]+)/videos/([^/]+)?#' );
 
 
@@ -34,7 +34,11 @@ wp_embed_register_handler( 'facebook-photo', JETPACK_FACEBOOK_PHOTO_EMBED_REGEX,
 wp_embed_register_handler( 'facebook-alternate-photo', JETPACK_FACEBOOK_PHOTO_ALTERNATE_EMBED_REGEX, 'jetpack_facebook_embed_handler' );
 
 /*
- * Videos e.g. https://www.facebook.com/video.php?v=772471122790796
+ * Videos
+ *
+ * Formats:
+ * https://www.facebook.com/video.php?v=2836814009877992
+ * https://www.facebook.com/watch/?v=2836814009877992
  */
 wp_embed_register_handler( 'facebook-video', JETPACK_FACEBOOK_VIDEO_EMBED_REGEX, 'jetpack_facebook_embed_handler' );
 
@@ -51,7 +55,11 @@ wp_embed_register_handler( 'facebook-alternate-video', JETPACK_FACEBOOK_VIDEO_AL
  * @param array $url     Requested URL to be embedded.
  */
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
-	if ( false !== strpos( $url, 'video.php' ) || false !== strpos( $url, '/videos/' ) ) {
+	if (
+		false !== strpos( $url, 'video.php' )
+		|| false !== strpos( $url, '/videos/' )
+		|| false !== strpos( $url, '/watch/' )
+	) {
 		$embed = sprintf( '<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>', esc_url( $url ) );
 	} else {
 		$width = 552; // As of 01/2017, the default width of Facebook embeds when no width attribute provided.

--- a/tests/php/modules/shortcodes/test-class.facebook.php
+++ b/tests/php/modules/shortcodes/test-class.facebook.php
@@ -3,6 +3,14 @@
 class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 
 	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		wp_reset_postdata();
+		parent::tearDown();
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers ::jetpack_facebook_shortcode_handler
 	 * @since 3.2
@@ -24,4 +32,93 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	/**
+	 * Test a Facebook Video using the old, first format (video.php)
+	 *
+	 * @covers ::jetpack_facebook_embed_handler
+	 *
+	 * @since 7.5.0
+	 */
+	public function test_shortcodes_facebook_video_old() {
+		global $post;
+
+		$fb_video_id = '546877659119730';
+		$url         = 'https://www.facebook.com/video.php?v=' . $fb_video_id;
+		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				$url
+			),
+			$actual
+		);
+	}
+
+	/**
+	 * Test a Facebook Video using the new format (watch/)
+	 *
+	 * @covers ::jetpack_facebook_embed_handler
+	 *
+	 * @since 7.5.0
+	 */
+	public function test_shortcodes_facebook_video_new() {
+		global $post;
+
+		$fb_video_id = '546877659119730';
+		$url         = 'https://www.facebook.com/watch/?v=' . $fb_video_id;
+		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				$url
+			),
+			$actual
+		);
+	}
+
+	/**
+	 * Test a Facebook Video using the alternate format (pagename/videos/xxx)
+	 *
+	 * @covers ::jetpack_facebook_embed_handler
+	 *
+	 * @since 7.5.0
+	 */
+	public function test_shortcodes_facebook_video_alternate() {
+		global $post;
+
+		$fb_video_id = '546877659119730';
+		$url         = 'https://www.facebook.com/AutomatticInc/videos/' . $fb_video_id;
+		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				$url
+			),
+			$actual
+		);
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.facebook.php
+++ b/tests/php/modules/shortcodes/test-class.facebook.php
@@ -62,13 +62,13 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test a Facebook Video using the new format (watch/)
+	 * Test a Facebook Video using the "watch/" format
 	 *
 	 * @covers ::jetpack_facebook_embed_handler
 	 *
 	 * @since 7.5.0
 	 */
-	public function test_shortcodes_facebook_video_new() {
+	public function test_shortcodes_facebook_video_watch_format() {
 		global $post;
 
 		$fb_video_id = '546877659119730';

--- a/tests/php/modules/shortcodes/test-class.facebook.php
+++ b/tests/php/modules/shortcodes/test-class.facebook.php
@@ -46,7 +46,6 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$url         = 'https://www.facebook.com/video.php?v=' . $fb_video_id;
 		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 
-		do_action( 'init' );
 		setup_postdata( $post );
 
 		// Test HTML version.
@@ -76,7 +75,6 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$url         = 'https://www.facebook.com/watch/?v=' . $fb_video_id;
 		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 
-		do_action( 'init' );
 		setup_postdata( $post );
 
 		// Test HTML version.
@@ -106,7 +104,6 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$url         = 'https://www.facebook.com/AutomatticInc/videos/' . $fb_video_id;
 		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 
-		do_action( 'init' );
 		setup_postdata( $post );
 
 		// Test HTML version.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Facebook now offers a new video URL format:
https://www.facebook.com/watch/?v=2836814009877992

Let's support it in our Facebook embeds.

#### Testing instructions:

* Make sure the Shortcode embeds module is active on your site.
* In a new post, add the following to a classic block:
```
https://www.facebook.com/video.php?v=2836814009877992
https://www.facebook.com/watch/?v=2836814009877992
https://www.facebook.com/AutomatticInc/videos/2836814009877992/
```
* All videos should be displayed nicely.

#### Proposed changelog entry for your changes:

* Faceboook Embeds: support new video URL format
