### PR TITLE
Backups & Scan: Fix logic that displays loading card

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -221,7 +221,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				this.props.vaultPressData !== 'N/A' &&
 				false !== get( this.props.vaultPressData, [ 'data' ], false );
 
-			if ( ! hasRewindData || ( this.props.vaultPressActive && ! hasVpData ) ) {
+			if ( ! hasRewindData && ( this.props.vaultPressActive && ! hasVpData ) ) {
 				return <LoadingCard />;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes faulty logic that decides whether to show loading card on a free plan. No console errors nor network errors. 

<img width="768" alt="Screen Shot 2019-06-07 at 10 19 20 AM" src="https://user-images.githubusercontent.com/7129409/59110823-e325db80-890d-11e9-8f70-020c948269e2.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Free site
- Go to /security
- See an upgrade notice 
- Check with Rewind enabled
- Check with VP enabled and set up 

Do the same with paid plans. I'm not sure if this breaks them. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
