### PR TITLE
Sitemaps: ensure links to sitemaps appear in robots.txt

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -441,7 +441,7 @@ class Jetpack_Sitemap_Manager {
 		 *
 		 * @param bool $discover_sitemap Make default sitemap discoverable to robots.
 		 */
-		$discover_sitemap = apply_filters_deprecated( 'jetpack_sitemap_generate', true, 'jetpack-7.4.0', 'jetpack_sitemap_include_in_robotstxt' );
+		$discover_sitemap = apply_filters_deprecated( 'jetpack_sitemap_generate', array( true ), 'jetpack-7.4.0', 'jetpack_sitemap_include_in_robotstxt' );
 
 		/**
 		 * Filter whether to make the default sitemap discoverable to robots or not. Default true.
@@ -467,7 +467,7 @@ class Jetpack_Sitemap_Manager {
 		 *
 		 * @param bool $discover_news_sitemap Make default news sitemap discoverable to robots.
 		 */
-		$discover_news_sitemap = apply_filters_deprecated( 'jetpack_news_sitemap_generate', true, 'jetpack-7.4.0', 'jetpack_news_sitemap_include_in_robotstxt' );
+		$discover_news_sitemap = apply_filters_deprecated( 'jetpack_news_sitemap_generate', array( true ), 'jetpack-7.4.0', 'jetpack_news_sitemap_include_in_robotstxt' );
 
 		/**
 		 * Filter whether to make the news sitemap discoverable to robots or not. Default true.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Our use of the apply_filters_deprecated function was incorrect:

> the value and extra arguments passed to the original apply_filters() call must be passed here to $args as an array.
-- https://developer.wordpress.org/reference/functions/apply_filters_deprecated/

This PR ensures that sitemap links can continue to appear in the `robots.txt` file.

#### Testing instructions:

Testing instructions should be the same as in the original PR (#12444):

* Prior to patch, enable the Sitemaps feature.
* Go to `yoursite.com/robots.txt`, see no links to sitemaps.
* Apply patch
* The links should now appear.
* Add `add_filter( 'jetpack_sitemap_generate', '__return_false' );` to a functionality plugin.
* The sitemap link should disappear.
* Replace that filter with `jetpack_sitemap_include_in_robotstxt`. 
* The sitemap link should still be hidden.

#### Proposed changelog entry for your changes:

* Sitemaps: ensure links to sitemaps appear in robots.txt
