### PR TITLE
Packages: Constants_Manager -> Constants

### DIFF
--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Class Jetpack_3rd_Party_Domain_Mapping

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Class Jetpack_3rd_Party_Domain_Mapping
@@ -41,7 +41,7 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	 * to try and hook a domain mapping plugin to the Jetpack sync filters for the home_url and site_url callables.
 	 */
 	function attempt_to_hook_domain_mapping_plugins() {
-		if ( ! Constants_Manager::is_defined( 'SUNRISE' ) ) {
+		if ( ! Constants::is_defined( 'SUNRISE' ) ) {
 			return;
 		}
 
@@ -60,7 +60,7 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	 * @return bool
 	 */
 	function hook_wordpress_mu_domain_mapping() {
-		if ( ! Constants_Manager::is_defined( 'SUNRISE_LOADED' ) || ! $this->function_exists( 'domain_mapping_siteurl' ) ) {
+		if ( ! Constants::is_defined( 'SUNRISE_LOADED' ) || ! $this->function_exists( 'domain_mapping_siteurl' ) ) {
 			return false;
 		}
 

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Subscribers: Get subscriber count

--- a/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Subscribers: Get subscriber count
@@ -43,7 +43,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	 */
 	public function get_subscriber_count( $request ) {
 		// Get the most up to date subscriber count when request is not a test
-		if ( ! Constants_Manager::is_defined( 'TESTING_IN_JETPACK' ) ) {
+		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {
 			delete_transient( 'wpcom_subscribers_total' );
 		}
 
@@ -58,7 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 
 if (
 	Jetpack::is_module_active( 'subscriptions' ) ||
-	( Constants_Manager::is_defined( 'TESTING_IN_JETPACK' ) && Constants_Manager::get_constant( 'TESTING_IN_JETPACK' ) )
+	( Constants::is_defined( 'TESTING_IN_JETPACK' ) && Constants::get_constant( 'TESTING_IN_JETPACK' ) )
 ) {
 	wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers' );
 }

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -5,7 +5,7 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Class Jetpack_Debug_Data

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -5,7 +5,7 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Class Jetpack_Debug_Data
@@ -318,8 +318,8 @@ class Jetpack_Debug_Data {
 		$idc_urls = array(
 			'home'       => Jetpack_Sync_Functions::home_url(),
 			'siteurl'    => Jetpack_Sync_Functions::site_url(),
-			'WP_HOME'    => Constants_Manager::is_defined( 'WP_HOME' ) ? Constants_Manager::get_constant( 'WP_HOME' ) : '',
-			'WP_SITEURL' => Constants_Manager::is_defined( 'WP_SITEURL' ) ? Constants_Manager::get_constant( 'WP_SITEURL' ) : '',
+			'WP_HOME'    => Constants::is_defined( 'WP_HOME' ) ? Constants::get_constant( 'WP_HOME' ) : '',
+			'WP_SITEURL' => Constants::is_defined( 'WP_SITEURL' ) ? Constants::get_constant( 'WP_SITEURL' ) : '',
 		);
 
 		$debug_info['idc_urls']         = array(

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -6,7 +6,7 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Wrapper function to safely register a gutenberg block type

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -6,7 +6,7 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Wrapper function to safely register a gutenberg block type
@@ -222,7 +222,7 @@ class Jetpack_Gutenberg {
 		 * @param boolean
 		 */
 		if ( apply_filters( 'jetpack_load_beta_blocks', false ) ) {
-			Constants_Manager::set_constant( 'JETPACK_BETA_BLOCKS', true );
+			Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
 		}
 
 		/**
@@ -320,7 +320,7 @@ class Jetpack_Gutenberg {
 
 		$preset_extensions = isset( $preset_extensions_manifest->production ) ? (array) $preset_extensions_manifest->production : array();
 
-		if ( Constants_Manager::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
+		if ( Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 			$beta_extensions = isset( $preset_extensions_manifest->beta ) ? (array) $preset_extensions_manifest->beta : array();
 			return array_unique( array_merge( $preset_extensions, $beta_extensions ) );
 		}
@@ -550,7 +550,7 @@ class Jetpack_Gutenberg {
 		}
 
 		$rtl        = is_rtl() ? '.rtl' : '';
-		$beta       = Constants_Manager::is_true( 'JETPACK_BETA_BLOCKS' ) ? '-beta' : '';
+		$beta       = Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ? '-beta' : '';
 		$blocks_dir = self::get_blocks_directory();
 
 		$editor_script = plugins_url( "{$blocks_dir}editor{$beta}.js", JETPACK__PLUGIN_FILE );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
 
 /*
@@ -1700,7 +1700,7 @@ class Jetpack {
 		 */
 		return (bool) apply_filters(
 			'jetpack_development_version',
-			! preg_match( '/^\d+(\.\d+)+$/', Constants_Manager::get_constant( 'JETPACK__VERSION' ) )
+			! preg_match( '/^\d+(\.\d+)+$/', Constants::get_constant( 'JETPACK__VERSION' ) )
 		);
 	}
 
@@ -6171,10 +6171,10 @@ p {
 	 * @return bool
 	 */
 	public static function sync_idc_optin() {
-		if ( Constants_Manager::is_defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
-			$default = Constants_Manager::get_constant( 'JETPACK_SYNC_IDC_OPTIN' );
+		if ( Constants::is_defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
+			$default = Constants::get_constant( 'JETPACK_SYNC_IDC_OPTIN' );
 		} else {
-			$default = ! Constants_Manager::is_defined( 'SUNRISE' ) && ! is_multisite();
+			$default = ! Constants::is_defined( 'SUNRISE' ) && ! is_multisite();
 		}
 
 		/**
@@ -6941,7 +6941,7 @@ p {
 	 * @return string The URL to the file
 	 */
 	public static function get_file_url_for_environment( $min_path, $non_min_path ) {
-		$path = ( Constants_Manager::is_defined( 'SCRIPT_DEBUG' ) && Constants_Manager::get_constant( 'SCRIPT_DEBUG' ) )
+		$path = ( Constants::is_defined( 'SCRIPT_DEBUG' ) && Constants::get_constant( 'SCRIPT_DEBUG' ) )
 			? $non_min_path
 			: $min_path;
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
 
 /*

--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "automattic/jetpack-asset-tools",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/asset-tools",
@@ -31,7 +31,7 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
@@ -65,11 +65,11 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "8dd7ab7dfd00b73455dd9d5b61c7c1f825967993",
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95",
                 "shasum": null
             },
             "require-dev": {
@@ -78,7 +78,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Automattic\\Jetpack\\Constants\\": "src/"
+                    "Automattic\\Jetpack\\": "src/"
                 }
             },
             "scripts": {
@@ -94,7 +94,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
@@ -132,7 +132,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -162,7 +162,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -189,7 +189,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
@@ -213,7 +213,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
@@ -368,7 +368,7 @@
     "packages-dev": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-dna-jitm-deps",
+            "version": "dev-update/bye-constants-manager",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",

--- a/jetpack.php
+++ b/jetpack.php
@@ -15,7 +15,6 @@ use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
  * Domain Path: /languages/
  */
 
-require plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.3.2' );
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
  * Domain Path: /languages/
  */
 
+require plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.3.2' );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Base class for working with plugins.
@@ -207,12 +207,12 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$reasons_can_not_modify_files['has_no_file_system_write_access'] =  __( 'The file permissions on this host prevent editing files.', 'jetpack' );
 		}
 
-		$disallow_file_mods = Constants_Manager::get_constant('DISALLOW_FILE_MODS' );
+		$disallow_file_mods = Constants::get_constant('DISALLOW_FILE_MODS' );
 		if ( $disallow_file_mods ) {
 			$reasons_can_not_modify_files['disallow_file_mods'] =  __( 'File modifications are explicitly disabled by a site administrator.', 'jetpack' );
 		}
 
-		$automatic_updater_disabled = Constants_Manager::get_constant( 'AUTOMATIC_UPDATER_DISABLED' );
+		$automatic_updater_disabled = Constants::get_constant( 'AUTOMATIC_UPDATER_DISABLED' );
 		if ( $automatic_updater_disabled ) {
 			$reasons_can_not_autoupdate['automatic_updater_disabled'] = __( 'Any autoupdates are explicitly disabled by a site administrator.', 'jetpack' );
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Base class for working with plugins.

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 	array(
@@ -294,7 +294,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	protected function update() {
 		$query_args = $this->query_args();
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] ) {
-			Constants_Manager::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
+			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
 		wp_clean_plugins_cache();
 		ob_start();

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 	array(

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 
@@ -36,7 +36,7 @@ class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		$query_args = $this->query_args();
 		if ( isset( $query_args['invite_accepted'] ) && $query_args['invite_accepted'] ) {
-			Constants_Manager::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
+			Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
 		}
 
 		if ( ! $user ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_JSON_API_User_Create_Endpoint extends Jetpack_JSON_API_Endpoint {
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -12,7 +12,7 @@
  * Additional Search Queries: security, jetpack protect, secure, protection, botnet, brute force, protect, login, bot, password, passwords, strong passwords, strong password, wp-login.php,  protect admin
  */
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -12,7 +12,7 @@
  * Additional Search Queries: security, jetpack protect, secure, protection, botnet, brute force, protect, login, bot, password, passwords, strong passwords, strong password, wp-login.php,  protect admin
  */
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
 
@@ -440,7 +440,7 @@ class Jetpack_Protect_Module {
 		/**
 		 * JETPACK_ALWAYS_PROTECT_LOGIN will always disable the login page, and use a page provided by Jetpack.
 		 */
-		if ( Constants_Manager::is_true( 'JETPACK_ALWAYS_PROTECT_LOGIN' ) ) {
+		if ( Constants::is_true( 'JETPACK_ALWAYS_PROTECT_LOGIN' ) ) {
 			$this->kill_login();
 		}
 

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -7,7 +7,7 @@
  * @since      5.8.0
  */
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Various helper functions for reuse throughout the Jetpack Search code.

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -7,7 +7,7 @@
  * @since      5.8.0
  */
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Various helper functions for reuse throughout the Jetpack Search code.
@@ -661,8 +661,8 @@ class Jetpack_Search_Helpers {
 	 */
 	public static function site_has_vip_index() {
 		$has_vip_index = (
-			Constants_Manager::is_defined( 'JETPACK_SEARCH_VIP_INDEX' ) &&
-			Constants_Manager::get_constant( 'JETPACK_SEARCH_VIP_INDEX' )
+			Constants::is_defined( 'JETPACK_SEARCH_VIP_INDEX' ) &&
+			Constants::get_constant( 'JETPACK_SEARCH_VIP_INDEX' )
 		);
 
 		/**

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -18,7 +18,7 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 // Keep compatibility with the PollDaddy plugin.
 if (

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -18,7 +18,7 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 // Keep compatibility with the PollDaddy plugin.
 if (
@@ -215,7 +215,7 @@ if (
 			);
 
 			$inline = ! in_the_loop()
-				&& ! Constants_Manager::is_defined( 'TESTING_IN_JETPACK' );
+				&& ! Constants::is_defined( 'TESTING_IN_JETPACK' );
 
 			$no_script       = false;
 			$infinite_scroll = false;

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
 
@@ -716,7 +716,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		return $request;
 	}
 
-	if ( Constants_Manager::is_true( 'IS_WPCOM' ) && Constants_Manager::is_true( 'REST_API_REQUEST' ) ) {
+	if ( Constants::is_true( 'IS_WPCOM' ) && Constants::is_true( 'REST_API_REQUEST' ) ) {
 		add_filter( 'rest_request_before_callbacks', 'wpcom_rest_request_before_callbacks');
 	}
 

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
 

--- a/packages/asset-tools/src/Manager.php
+++ b/packages/asset-tools/src/Manager.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Asset_Tools;
 
-use Automattic\Jetpack\Constants\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 class Manager {
 	/**

--- a/packages/asset-tools/src/Manager.php
+++ b/packages/asset-tools/src/Manager.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Asset_Tools;
 
-use Automattic\Jetpack\Constants\Manager as Jetpack_Constants;
+use Automattic\Jetpack\Constants\Constants as Jetpack_Constants;
 
 class Manager {
 	/**

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Connection\Manager_Interface;
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
@@ -436,8 +436,8 @@ class Manager implements Manager_Interface {
 				$possible_normal_tokens[] = $stored_blog_token;
 			}
 
-			$defined_tokens = Constants_Manager::is_defined( 'JETPACK_BLOG_TOKEN' )
-				? explode( ',', Constants_Manager::get_constant( 'JETPACK_BLOG_TOKEN' ) )
+			$defined_tokens = Constants::is_defined( 'JETPACK_BLOG_TOKEN' )
+				? explode( ',', Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
 				: array();
 
 			foreach ( $defined_tokens as $defined_token ) {

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Connection\Manager_Interface;
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com

--- a/packages/constants/README.md
+++ b/packages/constants/README.md
@@ -9,48 +9,48 @@ Testing constants is hard. Once you define a constant in PHP, it's defined. Cons
 Retrieve the value of a constant `CONSTANT_NAME` (returns `null` if it's not defined):
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
-$constant_value = Constants_Manager::get_constant( 'CONSTANT_NAME' );
+$constant_value = Constants::get_constant( 'CONSTANT_NAME' );
 ```
 
 Set the value of a constant `CONSTANT_NAME` to a particular value:
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
 $value = 'some value';
-Constants_Manager::set_constant( 'CONSTANT_NAME', $value );
+Constants::set_constant( 'CONSTANT_NAME', $value );
 ```
 
 Check whether a constant `CONSTANT_NAME` is defined:
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
-$defined = Constants_Manager::is_defined( 'CONSTANT_NAME' );
+$defined = Constants::is_defined( 'CONSTANT_NAME' );
 ```
 
 Check whether a constant `CONSTANT_NAME` is truthy:
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
-$is_truthy = Constants_Manager::is_true( 'CONSTANT_NAME' );
+$is_truthy = Constants::is_true( 'CONSTANT_NAME' );
 ```
 
 Delete the `CONSTANT_NAME` constant:
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
-Constants_Manager::clear_single_constant( 'CONSTANT_NAME' );
+Constants::clear_single_constant( 'CONSTANT_NAME' );
 ```
 
 Delete all known constants:
 
 ```php
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants as Constants;
 
-Constants_Manager::clear_constants();
+Constants::clear_constants();
 ```

--- a/packages/constants/README.md
+++ b/packages/constants/README.md
@@ -9,7 +9,7 @@ Testing constants is hard. Once you define a constant in PHP, it's defined. Cons
 Retrieve the value of a constant `CONSTANT_NAME` (returns `null` if it's not defined):
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 $constant_value = Constants::get_constant( 'CONSTANT_NAME' );
 ```
@@ -17,7 +17,7 @@ $constant_value = Constants::get_constant( 'CONSTANT_NAME' );
 Set the value of a constant `CONSTANT_NAME` to a particular value:
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 $value = 'some value';
 Constants::set_constant( 'CONSTANT_NAME', $value );
@@ -26,7 +26,7 @@ Constants::set_constant( 'CONSTANT_NAME', $value );
 Check whether a constant `CONSTANT_NAME` is defined:
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 $defined = Constants::is_defined( 'CONSTANT_NAME' );
 ```
@@ -34,7 +34,7 @@ $defined = Constants::is_defined( 'CONSTANT_NAME' );
 Check whether a constant `CONSTANT_NAME` is truthy:
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 $is_truthy = Constants::is_true( 'CONSTANT_NAME' );
 ```
@@ -42,7 +42,7 @@ $is_truthy = Constants::is_true( 'CONSTANT_NAME' );
 Delete the `CONSTANT_NAME` constant:
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 Constants::clear_single_constant( 'CONSTANT_NAME' );
 ```
@@ -50,7 +50,7 @@ Constants::clear_single_constant( 'CONSTANT_NAME' );
 Delete all known constants:
 
 ```php
-use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Constants;
 
 Constants::clear_constants();
 ```

--- a/packages/constants/composer.json
+++ b/packages/constants/composer.json
@@ -9,7 +9,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Automattic\\Jetpack\\Constants\\": "src/"
+			"Automattic\\Jetpack\\": "src/"
 		}
 	},
 	"scripts": {

--- a/packages/constants/src/Constants.php
+++ b/packages/constants/src/Constants.php
@@ -8,21 +8,21 @@
 namespace Automattic\Jetpack\Constants;
 
 /**
- * Class Automattic\Jetpack\Constants\Manager
+ * Class Automattic\Jetpack\Constants
  *
  * Testing constants is hard. Once you define a constant, it's defined. Constants Manager is an
  * abstraction layer so that unit tests can set "constants" for tests.
  *
- * To test your code, you'll need to swap out `defined( 'CONSTANT' )` with `Automattic\Jetpack\Constants\Manager::is_defined( 'CONSTANT' )`
- * and replace `CONSTANT` with `Automattic\Jetpack\Constants\Manager::get_constant( 'CONSTANT' )`. Then in the unit test, you can set the
- * constant with `Automattic\Jetpack\Constants\Manager::set_constant( 'CONSTANT', $value )` and then clean up after each test with something like
+ * To test your code, you'll need to swap out `defined( 'CONSTANT' )` with `Automattic\Jetpack\Constants::is_defined( 'CONSTANT' )`
+ * and replace `CONSTANT` with `Automattic\Jetpack\Constants::get_constant( 'CONSTANT' )`. Then in the unit test, you can set the
+ * constant with `Automattic\Jetpack\Constants::set_constant( 'CONSTANT', $value )` and then clean up after each test with something like
  * this:
  *
  * function tearDown() {
- *     Automattic\Jetpack\Constants\Manager::clear_constants();
+ *     Automattic\Jetpack\Constants::clear_constants();
  * }
  */
-class Manager {
+class Constants {
 	/**
 	 * A container for all defined constants.
 	 *
@@ -32,6 +32,18 @@ class Manager {
 	 * @var array.
 	 */
 	public static $set_constants = array();
+
+	/**
+	 * Checks if a "constant" has been set in constants Manager
+	 * and has the value of true
+	 *
+	 * @param string $name The name of the constant.
+	 *
+	 * @return bool
+	 */
+	public static function is_true( $name ) {
+		return self::is_defined( $name ) && self::get_constant( $name );
+	}
 
 	/**
 	 * Checks if a "constant" has been set in constants Manager, and if not,
@@ -45,17 +57,6 @@ class Manager {
 		return array_key_exists( $name, self::$set_constants )
 			? true
 			: defined( $name );
-	}
-	/**
-	 * Checks if a "constant" has been set in constants Manager
-	 * and has the value of true
-	 *
-	 * @param string $name The name of the constant.
-	 *
-	 * @return bool
-	 */
-	public static function is_true( $name ) {
-		return self::is_defined( $name ) && self::get_constant( $name );
 	}
 
 	/**
@@ -77,7 +78,7 @@ class Manager {
 	/**
 	 * Sets the value of the "constant" within constants Manager.
 	 *
-	 * @param string $name  The name of the constant.
+	 * @param string $name The name of the constant.
 	 * @param string $value The value of the constant.
 	 */
 	public static function set_constant( $name, $value ) {
@@ -97,6 +98,7 @@ class Manager {
 		}
 
 		unset( self::$set_constants[ $name ] );
+
 		return true;
 	}
 
@@ -107,4 +109,3 @@ class Manager {
 		self::$set_constants = array();
 	}
 }
-

--- a/packages/constants/src/Constants.php
+++ b/packages/constants/src/Constants.php
@@ -5,7 +5,7 @@
  * @package jetpack-constants
  */
 
-namespace Automattic\Jetpack\Constants;
+namespace Automattic\Jetpack;
 
 /**
  * Class Automattic\Jetpack\Constants

--- a/packages/constants/tests/php/test_Manager.php
+++ b/packages/constants/tests/php/test_Manager.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\TestCase;
 
 class Test_Manager extends TestCase {

--- a/packages/constants/tests/php/test_Manager.php
+++ b/packages/constants/tests/php/test_Manager.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 use PHPUnit\Framework\TestCase;
 
 class Test_Manager extends TestCase {
@@ -12,98 +12,98 @@ class Test_Manager extends TestCase {
 
 	public function tearDown() {
 		parent::tearDown();
-		Constants_Manager::$set_constants = array();
+		Constants::$set_constants = array();
 	}
 
-	// Constants_Manager::is_defined()
+	// Constants::is_defined()
 
 	function test_jetpack_constants_is_defined_when_constant_set_via_class() {
-		Constants_Manager::set_constant( 'TEST', 'hello' );
-		$this->assertTrue( Constants_Manager::is_defined( 'TEST' ) );
+		Constants::set_constant( 'TEST', 'hello' );
+		$this->assertTrue( Constants::is_defined( 'TEST' ) );
 	}
 
 	function test_jetpack_constants_is_defined_false_when_constant_not_set() {
-		$this->assertFalse( Constants_Manager::is_defined( 'UNDEFINED' ) );
+		$this->assertFalse( Constants::is_defined( 'UNDEFINED' ) );
 	}
 
 	function test_jetpack_constants_is_defined_true_when_set_with_define() {
-		$this->assertTrue( Constants_Manager::is_defined( 'JETPACK__VERSION' ) );
+		$this->assertTrue( Constants::is_defined( 'JETPACK__VERSION' ) );
 	}
 
 	function test_jetpack_constants_is_defined_when_constant_set_to_null() {
-		Constants_Manager::set_constant( 'TEST', null );
-		$this->assertTrue( Constants_Manager::is_defined( 'TEST' ) );
+		Constants::set_constant( 'TEST', null );
+		$this->assertTrue( Constants::is_defined( 'TEST' ) );
 	}
 
-	// Constants_Manager::get_constant()
+	// Constants::get_constant()
 
 	function test_jetpack_constants_default_to_constant() {
-		$this->assertEquals( Constants_Manager::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
+		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
 	}
 
 	function test_jetpack_constants_get_constant_null_when_not_set() {
-		$this->assertNull( Constants_Manager::get_constant( 'UNDEFINED' ) );
+		$this->assertNull( Constants::get_constant( 'UNDEFINED' ) );
 	}
 
 	function test_jetpack_constants_can_override_previously_defined_constant() {
 		$test_version = '1.0.0';
-		Constants_Manager::set_constant( 'JETPACK__VERSION', $test_version );
-		$this->assertEquals( Constants_Manager::get_constant( 'JETPACK__VERSION' ), $test_version );
+		Constants::set_constant( 'JETPACK__VERSION', $test_version );
+		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
 	}
 
 	function test_jetpack_constants_override_to_null_gets_null() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', null );
-		$this->assertNull( Constants_Manager::get_constant( 'JETPACK__VERSION' ) );
+		Constants::set_constant( 'JETPACK__VERSION', null );
+		$this->assertNull( Constants::get_constant( 'JETPACK__VERSION' ) );
 	}
 
-	// Constants_Manager::set_constant()
+	// Constants::set_constant()
 
 	function test_jetpack_constants_set_constants_adds_to_set_constants_array() {
 		$key = 'TEST';
-		Constants_Manager::set_constant( $key, '1' );
-		$this->assertArrayHasKey( $key, Constants_Manager::$set_constants );
-		$this->assertEquals( '1', Constants_Manager::$set_constants[ $key ] );
+		Constants::set_constant( $key, '1' );
+		$this->assertArrayHasKey( $key, Constants::$set_constants );
+		$this->assertEquals( '1', Constants::$set_constants[ $key ] );
 	}
 
-	// Constants_Manager::clear_constants()
+	// Constants::clear_constants()
 
 	function test_jetpack_constants_can_clear_all_constants() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '1.0.0' );
-		Constants_Manager::clear_constants();
-		$this->assertEmpty( Constants_Manager::$set_constants );
+		Constants::set_constant( 'JETPACK__VERSION', '1.0.0' );
+		Constants::clear_constants();
+		$this->assertEmpty( Constants::$set_constants );
 	}
 
-	// Constants_Manager::clear_single_constant()
+	// Constants::clear_single_constant()
 
 	function test_jetpack_constants_can_clear_single_constant() {
-		Constants_Manager::set_constant( 'FIRST', '1' );
-		Constants_Manager::set_constant( 'SECOND', '2' );
+		Constants::set_constant( 'FIRST', '1' );
+		Constants::set_constant( 'SECOND', '2' );
 
-		$this->assertCount( 2, Constants_Manager::$set_constants );
+		$this->assertCount( 2, Constants::$set_constants );
 
-		Constants_Manager::clear_single_constant( 'FIRST' );
+		Constants::clear_single_constant( 'FIRST' );
 
-		$this->assertCount( 1, Constants_Manager::$set_constants );
-		$this->assertContains( 'SECOND', array_keys( Constants_Manager::$set_constants ) );
+		$this->assertCount( 1, Constants::$set_constants );
+		$this->assertContains( 'SECOND', array_keys( Constants::$set_constants ) );
 	}
 
 	function test_jetpack_constants_can_clear_single_constant_when_null() {
-		Constants_Manager::set_constant( 'TEST', null );
-		$this->assertCount( 1, Constants_Manager::$set_constants );
+		Constants::set_constant( 'TEST', null );
+		$this->assertCount( 1, Constants::$set_constants );
 
-		Constants_Manager::clear_single_constant( 'TEST' );
+		Constants::clear_single_constant( 'TEST' );
 
-		$this->assertEmpty( Constants_Manager::$set_constants );
+		$this->assertEmpty( Constants::$set_constants );
 	}
 
 	// Jetpack_Constant::is_true
 	function test_jetpack_constants_is_true_method() {
-		$this->assertFalse( Constants_Manager::is_true( 'FOO' ), 'unset constant returns true' );
-		Constants_Manager::set_constant( 'FOO', false );
+		$this->assertFalse( Constants::is_true( 'FOO' ), 'unset constant returns true' );
+		Constants::set_constant( 'FOO', false );
 
-		$this->assertFalse( Constants_Manager::is_true( 'FOO' ), 'false constant returns true' );
-		Constants_Manager::set_constant( 'FOO', true );
+		$this->assertFalse( Constants::is_true( 'FOO' ), 'false constant returns true' );
+		Constants::set_constant( 'FOO', true );
 
-		$this->assertTrue( Constants_Manager::is_true( 'FOO' ), 'true constant returns false');
+		$this->assertTrue( Constants::is_true( 'FOO' ), 'true constant returns false');
 	}
 }

--- a/packages/options/legacy/class.jetpack-options.php
+++ b/packages/options/legacy/class.jetpack-options.php
@@ -1,16 +1,17 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_Options {
 
 	/**
 	 * An array that maps a grouped option type to an option name.
+	 *
 	 * @var array
 	 */
 	private static $grouped_options = array(
 		'compact' => 'jetpack_options',
-		'private' => 'jetpack_private_options'
+		'private' => 'jetpack_private_options',
 	);
 
 	/**
@@ -22,59 +23,59 @@ class Jetpack_Options {
 	 */
 	public static function get_option_names( $type = 'compact' ) {
 		switch ( $type ) {
-		case 'non-compact' :
-		case 'non_compact' :
-			return array(
-				'activated',
-				'active_modules',
-				'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
-				'available_modules',
-				'do_activate',
-				'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
-				'log',
-				'slideshow_background_color',
-				'widget_twitter',
-				'wpcc_options',
-				'relatedposts',
-				'file_data',
-				'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
-				'autoupdate_plugins_translations', // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated translation files.
-				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
-				'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
-				'autoupdate_core',             // (bool)   Whether or not to autoupdate core
-				'autoupdate_translations',     // (bool)   Whether or not to autoupdate all translations
-				'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
-				'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
-				'site_icon_url',               // (string) url to the full site icon
-				'site_icon_id',                // (int)    Attachment id of the site icon file
-				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
-				'restapi_stats_cache',         // (array) Stats Cache data.
-				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
-				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
-				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
-				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
-				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
-				'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
-				'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
-				'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
-				'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
-				'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
-				'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
-			);
+			case 'non-compact':
+			case 'non_compact':
+				return array(
+					'activated',
+					'active_modules',
+					'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
+					'available_modules',
+					'do_activate',
+					'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
+					'log',
+					'slideshow_background_color',
+					'widget_twitter',
+					'wpcc_options',
+					'relatedposts',
+					'file_data',
+					'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
+					'autoupdate_plugins_translations', // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated translation files.
+					'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
+					'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
+					'autoupdate_core',             // (bool)   Whether or not to autoupdate core
+					'autoupdate_translations',     // (bool)   Whether or not to autoupdate all translations
+					'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
+					'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
+					'site_icon_url',               // (string) url to the full site icon
+					'site_icon_id',                // (int)    Attachment id of the site icon file
+					'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+					'restapi_stats_cache',         // (array) Stats Cache data.
+					'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
+					'protect_whitelist',           // (array) IP Address for the Protect module to ignore
+					'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
+					'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
+					'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
+					'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
+					'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
+					'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
+					'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
+					'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
+					'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
+					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
+				);
 
-		case 'private' :
-			return array(
-				'blog_token',  // (string) The Client Secret/Blog Token of this site.
-				'user_token',  // (string) The User Token of this site. (deprecated)
-				'user_tokens'  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.
-			);
+			case 'private':
+				return array(
+					'blog_token',  // (string) The Client Secret/Blog Token of this site.
+					'user_token',  // (string) The User Token of this site. (deprecated)
+					'user_tokens',  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.
+				);
 
-		case 'network' :
-			return array(
-				'onboarding',                   // (string) Auth token to be used in the onboarding connection flow
-				'file_data'                     // (array) List of absolute paths to all Jetpack modules
-			);
+			case 'network':
+				return array(
+					'onboarding',                   // (string) Auth token to be used in the onboarding connection flow
+					'file_data',                     // (array) List of absolute paths to all Jetpack modules
+				);
 		}
 
 		return array(
@@ -158,7 +159,7 @@ class Jetpack_Options {
 	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed $default (optional)
+	 * @param mixed  $default (optional)
 	 *
 	 * @return mixed
 	 */
@@ -187,7 +188,7 @@ class Jetpack_Options {
 	 * This does _not_ adjust the prefix in any way (does not prefix jetpack_%)
 	 *
 	 * @param string $name Option name
-	 * @param mixed $default (optional)
+	 * @param mixed  $default (optional)
 	 *
 	 * @return mixed
 	 */
@@ -195,9 +196,9 @@ class Jetpack_Options {
 		// In this function the name is not adjusted by prefixing jetpack_
 		// so if it has already prefixed, we'll replace it and then
 		// check if the option name is a network option or not
-		$jetpack_name = preg_replace( '/^jetpack_/', '', $name, 1 );
+		$jetpack_name      = preg_replace( '/^jetpack_/', '', $name, 1 );
 		$is_network_option = self::is_network_option( $jetpack_name );
-		$value = $is_network_option ? get_site_option( $name ) : get_option( $name );
+		$value             = $is_network_option ? get_site_option( $name ) : get_option( $name );
 
 		if ( false === $value && false !== $default ) {
 			if ( $is_network_option ) {
@@ -225,7 +226,7 @@ class Jetpack_Options {
 	 * Updates the single given option.  Updates jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed $value Option value
+	 * @param mixed  $value Option value
 	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
 	 *
 	 * @return bool Was the option successfully updated?
@@ -301,7 +302,6 @@ class Jetpack_Options {
 			} else {
 				$result = delete_option( "jetpack_$name" );
 			}
-
 		}
 
 		foreach ( array_keys( self::$grouped_options ) as $group ) {
@@ -361,8 +361,8 @@ class Jetpack_Options {
 	 * Updates an option via $wpdb query.
 	 *
 	 * @param string $name Option name.
-	 * @param mixed $value Option value.
-	 * @param bool $autoload Specifying whether to autoload or not.
+	 * @param mixed  $value Option value.
+	 * @param bool   $autoload Specifying whether to autoload or not.
 	 *
 	 * @return bool Is the option updated?
 	 */
@@ -412,7 +412,7 @@ class Jetpack_Options {
 	 * @since 5.4.0
 	 *
 	 * @param string $name Option name.
-	 * @param mixed $default Default option value if option is not found.
+	 * @param mixed  $default Default option value if option is not found.
 	 *
 	 * @return mixed Option value, or null if option is not found and default is not specified.
 	 */
@@ -447,11 +447,12 @@ class Jetpack_Options {
 	 */
 	static function bypass_raw_option( $name ) {
 
-		if ( Constants_Manager::get_constant( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
+		if ( Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
 			return true;
 		}
 		/**
 		 * Allows to disable particular raw options.
+		 *
 		 * @since 5.5.0
 		 *
 		 * @param array $disabled_raw_options An array of option names that you can selectively blacklist from being managed via direct database queries.
@@ -490,7 +491,7 @@ class Jetpack_Options {
 				'register',
 				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
 				'user_token',                  // (string) The User Token of this site. (deprecated)
-				'user_tokens'
+				'user_tokens',
 			);
 
 			// Remove the unsafe Jetpack options
@@ -575,7 +576,7 @@ class Jetpack_Options {
 
 		$options = array(
 			'jp_options' => $all_jp_options,
-			'wp_options' => $wp_options
+			'wp_options' => $wp_options,
 		);
 
 		return $options;
@@ -596,7 +597,7 @@ class Jetpack_Options {
 
 		// Delete all non-compact Jetpack options
 		foreach ( (array) self::get_option_names( 'non-compact' ) as $option_name ) {
-			Jetpack_Options::delete_option( $option_name );
+			self::delete_option( $option_name );
 		}
 
 		// Delete all options that can be reset via CLI, that aren't Jetpack options

--- a/packages/options/legacy/class.jetpack-options.php
+++ b/packages/options/legacy/class.jetpack-options.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Options {
 

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -77,7 +77,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function should_initialize_sender() {
-		if ( Constants_Manager::is_true( 'DOING_CRON' ) ) {
+		if ( Constants::is_true( 'DOING_CRON' ) ) {
 			return self::sync_via_cron_allowed();
 		}
 

--- a/packages/sync/legacy/class.jetpack-sync-functions.php
+++ b/packages/sync/legacy/class.jetpack-sync-functions.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /*
  * Utility functions to generate data synced to wpcom

--- a/packages/sync/legacy/class.jetpack-sync-functions.php
+++ b/packages/sync/legacy/class.jetpack-sync-functions.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /*
  * Utility functions to generate data synced to wpcom
@@ -195,8 +195,8 @@ class Jetpack_Sync_Functions {
 			: 'site_url';
 
 		if (
-			! Constants_Manager::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
-			Constants_Manager::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
+			! Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
+			Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
 			$scheme = is_ssl() ? 'https' : 'http';
 			$url    = self::get_raw_url( $url_type );
@@ -271,8 +271,8 @@ class Jetpack_Sync_Functions {
 
 		// Since we disregard the constant for multisites in ms-default-filters.php,
 		// let's also use the db value if this is a multisite.
-		if ( ! is_multisite() && Constants_Manager::is_defined( $constant ) ) {
-			$value = Constants_Manager::get_constant( $constant );
+		if ( ! is_multisite() && Constants::is_defined( $constant ) ) {
+			$value = Constants::get_constant( $constant );
 		} else {
 			// Let's get the option from the database so that we can bypass filters. This will help
 			// ensure that we get more uniform values.

--- a/packages/sync/legacy/class.jetpack-sync-module-plugins.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-plugins.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 
@@ -67,7 +67,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		switch ( $details['action'] ) {
 			case 'update':
 				$state  = array(
-					'is_autoupdate' => Constants_Manager::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
+					'is_autoupdate' => Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
 				);
 				$errors = $this->get_errors( $upgrader->skin );
 				if ( $errors ) {

--- a/packages/sync/legacy/class.jetpack-sync-module-plugins.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-plugins.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 

--- a/packages/sync/legacy/class.jetpack-sync-module-posts.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-posts.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
@@ -318,7 +318,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			false;
 
 		$state = array(
-			'is_auto_save'                 => (bool) Constants_Manager::get_constant( 'DOING_AUTOSAVE' ),
+			'is_auto_save'                 => (bool) Constants::get_constant( 'DOING_AUTOSAVE' ),
 			'previous_status'              => $previous_status,
 			'just_published'               => $just_published,
 			'is_gutenberg_meta_box_update' => $this->is_gutenberg_meta_box_update(),

--- a/packages/sync/legacy/class.jetpack-sync-module-posts.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-posts.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 

--- a/packages/sync/legacy/class.jetpack-sync-module-protect.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-protect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * logs bruteprotect failed logins via sync

--- a/packages/sync/legacy/class.jetpack-sync-module-protect.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-protect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * logs bruteprotect failed logins via sync
@@ -18,7 +18,7 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 
 	function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = Jetpack_Protect_Module::instance();
-		if ( $protect->has_login_ability() && ! Constants_Manager::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( $protect->has_login_ability() && ! Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/packages/sync/legacy/class.jetpack-sync-module-updates.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
@@ -104,7 +104,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		// Core was autoudpated
 		if (
 			'update-core.php' !== $pagenow &&
-			! Constants_Manager::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
+			! Constants::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
 		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful

--- a/packages/sync/legacy/class.jetpack-sync-module-updates.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 

--- a/packages/sync/legacy/class.jetpack-sync-module-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-users.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;

--- a/packages/sync/legacy/class.jetpack-sync-module-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-users.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;
@@ -174,7 +174,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	 * @param String  $user_login the user login.
 	 * @param WP_User $user       the user object.
 	 */
-	 function wp_login_handler( $user_login, $user ) {
+	function wp_login_handler( $user_login, $user ) {
 		/**
 		 * Fires when a user is logged into a site.
 		 *
@@ -220,8 +220,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		$this->add_flags(
 			$user->ID,
 			array(
-				'warning'          => 'The password failed at least one strength test.',
-				'failures'         => $test_results['test_results']['failed'],
+				'warning'  => 'The password failed at least one strength test.',
+				'failures' => $test_results['test_results']['failed'],
 			)
 		);
 
@@ -248,7 +248,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( Constants_Manager::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
+		if ( Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -269,7 +269,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( Constants_Manager::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
+		if ( Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -434,14 +434,17 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		list( $user_ids, $previous_end ) = $args;
 
 		return array(
-			'users' => array_map( array( $this, 'sanitize_user_and_expand' ), get_users(
-				array(
-					'include' => $user_ids,
-					'orderby' => 'ID',
-					'order' => 'DESC'
+			'users'        => array_map(
+				array( $this, 'sanitize_user_and_expand' ),
+				get_users(
+					array(
+						'include' => $user_ids,
+						'orderby' => 'ID',
+						'order'   => 'DESC',
+					)
 				)
-			) ),
-			'previous_end' => $previous_end
+			),
+			'previous_end' => $previous_end,
 		);
 	}
 

--- a/packages/sync/legacy/class.jetpack-sync-sender.php
+++ b/packages/sync/legacy/class.jetpack-sync-sender.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * This class grabs pending actions from the queue and sends them

--- a/packages/sync/legacy/class.jetpack-sync-sender.php
+++ b/packages/sync/legacy/class.jetpack-sync-sender.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -51,7 +51,7 @@ class Jetpack_Sync_Sender {
 	public function maybe_set_user_from_token() {
 		$jetpack       = Jetpack::init();
 		$verified_user = $jetpack->verify_xml_rpc_signature();
-		if ( Constants_Manager::is_true( 'XMLRPC_REQUEST' ) &&
+		if ( Constants::is_true( 'XMLRPC_REQUEST' ) &&
 			! is_wp_error( $verified_user )
 			&& $verified_user
 		) {
@@ -202,7 +202,7 @@ class Jetpack_Sync_Sender {
 		}
 
 		/* Don't make the request block till we finish, if possible. */
-		if ( Constants_Manager::is_true( 'REST_REQUEST' ) || Constants_Manager::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( Constants::is_true( 'REST_REQUEST' ) || Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			$this->fastcgi_finish_request();
 		}
 

--- a/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
+++ b/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php';
 

--- a/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
+++ b/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php';
 
@@ -12,7 +12,7 @@ class MockDomainMapping extends Jetpack_3rd_Party_Domain_Mapping  {
 
 class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	function tearDown() {
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
 			remove_all_filters( $filter );
 		}
@@ -37,7 +37,7 @@ class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	}
 
 	function test_domain_mapping_should_stop_search_after_hooking_once() {
-		Constants_Manager::set_constant( 'SUNRISE', true );
+		Constants::set_constant( 'SUNRISE', true );
 
 		$stub = $this->getMockBuilder( 'MockDomainMapping' )
 			->setMethods( array( 'hook_wordpress_mu_domain_mapping', 'hook_wpmu_dev_domain_mapping' ) )
@@ -57,7 +57,7 @@ class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	}
 
 	function test_domain_mapping_mu_domain_mapping_not_hooked_when_function_not_exists() {
-		Constants_Manager::set_constant( 'SUNRISE_LOADED', true );
+		Constants::set_constant( 'SUNRISE_LOADED', true );
 
 		$stub = $this->getMockBuilder( 'MockDomainMapping' )
 			->setMethods( array( 'function_exists' ) )
@@ -76,7 +76,7 @@ class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	}
 
 	function test_domain_mapping_mu_domain_mapping_hooked_when_function_exists() {
-		Constants_Manager::set_constant( 'SUNRISE_LOADED', true );
+		Constants::set_constant( 'SUNRISE_LOADED', true );
 
 		$stub = $this->getMockBuilder( 'MockDomainMapping' )
 			->setMethods( array( 'function_exists' ) )

--- a/tests/php/general/test-class.jetpack-options.php
+++ b/tests/php/general/test-class.jetpack-options.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
@@ -50,7 +50,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
 
 	function test_raw_option_with_constant_does_not_by_pass_wp_cache_filters() {
-		Constants_Manager::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true);
+		Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true);
 		$option_name = 'test_option_with_constant';
 		add_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		add_filter( 'option_' . $option_name, array( $this, 'get_test_option_from_cache' ) );
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 
 		remove_action( 'added_option', array( $this, 'cache_option' ), 10, 2 );
 		remove_filter( 'option_'. $option_name, array( $this, 'get_test_option_from_cache' ) );
-		Constants_Manager::clear_single_constant( 'JETPACK_DISABLE_RAW_OPTIONS' );
+		Constants::clear_single_constant( 'JETPACK_DISABLE_RAW_OPTIONS' );
 	}
 
 	function test_raw_option_with_filter_does_not_by_pass_wp_cache_filters() {

--- a/tests/php/general/test-class.jetpack-options.php
+++ b/tests/php/general/test-class.jetpack-options.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class WP_Test_Jetpack_Options extends WP_UnitTestCase {
 

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**
@@ -33,7 +33,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 		Jetpack_Options::delete_option( 'user_tokens' );
 		Jetpack_Options::delete_option( 'master_user' );
 
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 		$this->connection = null;
 		parent::tearDown();
 	}
@@ -52,7 +52,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_no_args_returns_defined_blog_token_when_constant_set() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
 		$token = $this->connection->get_access_token();
 
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_no_args_returns_defined_blog_token_when_constant_set_and_no_stored_token() {
 		Jetpack_Options::delete_option( 'blog_token' );
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
 		$token = $this->connection->get_access_token();
 
@@ -72,7 +72,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 
 	public function test_get_access_token_with_stored_key_returns_stored_blog_token() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
 		$token = $this->connection->get_access_token( false, '12345' );
 
@@ -81,7 +81,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_magic_key_returns_stored_blog_token() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED );
 
 		$token = $this->connection->get_access_token( false, Connection_Manager::MAGIC_NORMAL_TOKEN_KEY );
 
@@ -92,7 +92,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_magic_key_returns_defined_blog_token_if_it_looks_like_a_stored_token_and_no_stored_token() {
 		Jetpack_Options::delete_option( 'blog_token' );
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::STORED );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::STORED );
 
 		$token = $this->connection->get_access_token( false, Connection_Manager::MAGIC_NORMAL_TOKEN_KEY );
 
@@ -101,7 +101,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_no_args_returns_first_defined_blog_token_when_constant_multi_set() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token();
 
@@ -111,7 +111,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_no_args_returns_first_defined_blog_token_when_constant_multi_set_and_no_stored_token() {
 		Jetpack_Options::delete_option( 'blog_token' );
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token();
 
@@ -120,7 +120,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_token_key_returns_matching_token_when_constant_multi_set() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token( false, ';foo;' );
 
@@ -130,7 +130,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_token_key_returns_matching_token_when_constant_multi_set_and_no_stored_token() {
 		Jetpack_Options::delete_option( 'blog_token' );
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token( false, ';foo;' );
 
@@ -139,7 +139,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_magic_key_returns_stored_token_when_constant_multi_set() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token( false, Connection_Manager::MAGIC_NORMAL_TOKEN_KEY );
 
@@ -149,7 +149,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_magic_key_returns_matching_token_when_constant_multi_set_and_no_stored_token() {
 		Jetpack_Options::delete_option( 'blog_token' );
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token( false, Connection_Manager::MAGIC_NORMAL_TOKEN_KEY );
 
@@ -158,7 +158,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_token_key_requires_full_key() {
-		Constants_Manager::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', self::DEFINED_MULTI );
 
 		$token = $this->connection->get_access_token( false, ';fo' );
 

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {
@@ -15,7 +15,7 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	public function tearDown() {
 		parent::tearDown();
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 	}
 
 	/**
@@ -381,17 +381,17 @@ EXPECTED;
 	}
 
 	function test_idc_optin_true_when_constant_true() {
-		Constants_Manager::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
 		$this->assertTrue( Jetpack::sync_idc_optin() );
 	}
 
 	function test_idc_optin_false_when_constant_false() {
-		Constants_Manager::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
 		$this->assertFalse( Jetpack::sync_idc_optin() );
 	}
 
 	function test_idc_optin_filter_overrides_constant() {
-		Constants_Manager::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
 		$this->assertFalse( Jetpack::sync_idc_optin() );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
@@ -431,7 +431,7 @@ EXPECTED;
 
 	function test_sync_error_idc_validation_returns_false_and_cleans_up_when_opted_out() {
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		Constants_Manager::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
 
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
@@ -509,27 +509,27 @@ EXPECTED;
 	}
 
 	function test_is_dev_version_true_with_alpha() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '4.3.1-alpha' );
+		Constants::set_constant( 'JETPACK__VERSION', '4.3.1-alpha' );
 		$this->assertTrue( Jetpack::is_development_version() );
 	}
 
 	function test_is_dev_version_true_with_beta() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '4.3-beta2' );
+		Constants::set_constant( 'JETPACK__VERSION', '4.3-beta2' );
 		$this->assertTrue( Jetpack::is_development_version() );
 	}
 
 	function test_is_dev_version_true_with_rc() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '4.3-rc2' );
+		Constants::set_constant( 'JETPACK__VERSION', '4.3-rc2' );
 		$this->assertTrue( Jetpack::is_development_version() );
 	}
 
 	function test_is_dev_version_false_with_number_dot_number() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '4.3' );
+		Constants::set_constant( 'JETPACK__VERSION', '4.3' );
 		$this->assertFalse( Jetpack::is_development_version() );
 	}
 
 	function test_is_dev_version_false_with_number_dot_number_dot_number() {
-		Constants_Manager::set_constant( 'JETPACK__VERSION', '4.3.1' );
+		Constants::set_constant( 'JETPACK__VERSION', '4.3.1' );
 		$this->assertFalse( Jetpack::is_development_version() );
 	}
 
@@ -800,7 +800,7 @@ EXPECTED;
 	 * @dataProvider get_file_url_for_environment_data_provider
 	 */
 	function test_get_file_url_for_environment( $min_path, $non_min_path, $is_script_debug, $expected, $not_expected ) {
-		Constants_Manager::set_constant( 'SCRIPT_DEBUG', $is_script_debug );
+		Constants::set_constant( 'SCRIPT_DEBUG', $is_script_debug );
 		$file_url = Jetpack::get_file_url_for_environment( $min_path, $non_min_path );
 
 		$this->assertContains( $$expected, $file_url );

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {

--- a/tests/php/modules/search/test-class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test-class.jetpack-search-helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 require_jetpack_file( 'modules/search/class.jetpack-search.php' );
 require_jetpack_file( 'modules/search/class.jetpack-search-helpers.php' );
@@ -51,7 +51,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 
 		unset( $GLOBALS['wp_customize'] );
 
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 		remove_all_filters( 'jetpack_search_has_vip_index' );
 	}
 
@@ -409,7 +409,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	 */
 	public function test_site_has_vip_index( $expected, $constant = null, $filter = false ) {
 		if ( ! is_null( $constant ) ) {
-			Constants_Manager::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $constant );
+			Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $constant );
 		}
 
 		if ( $filter ) {
@@ -423,7 +423,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	 * @dataProvider get_max_posts_per_page_data
 	 */
 	public function test_get_max_posts_per_page( $expected, $has_vip_index ) {
-		Constants_Manager::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
+		Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
 		$this->assertSame( $expected, Jetpack_Search_Helpers::get_max_posts_per_page() );
 	}
 
@@ -431,7 +431,7 @@ class WP_Test_Jetpack_Search_Helpers extends WP_UnitTestCase {
 	 * @dataProvider get_max_offset_data
 	 */
 	public function test_get_max_offset( $expected, $has_vip_index ) {
-		Constants_Manager::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
+		Constants::set_constant( 'JETPACK_SEARCH_VIP_INDEX', $has_vip_index );
 		$this->assertSame( $expected, Jetpack_Search_Helpers::get_max_offset() );
 	}
 

--- a/tests/php/modules/search/test-class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test-class.jetpack-search-helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 require_jetpack_file( 'modules/search/class.jetpack-search.php' );
 require_jetpack_file( 'modules/search/class.jetpack-search-helpers.php' );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 require_once 'test_class.jetpack-sync-base.php';
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 require_once 'test_class.jetpack-sync-base.php';
 
@@ -654,8 +654,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_get_raw_url_by_constant_bypasses_filters() {
-		Constants_Manager::set_constant( 'WP_HOME', 'http://constanturl.com' );
-		Constants_Manager::set_constant( 'WP_SITEURL', 'http://constanturl.com' );
+		Constants::set_constant( 'WP_HOME', 'http://constanturl.com' );
+		Constants::set_constant( 'WP_SITEURL', 'http://constanturl.com' );
 		add_filter( 'option_home', array( $this, '__return_filtered_url' ) );
 		add_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
 
@@ -669,7 +669,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
 		remove_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 	}
 
 	function test_get_raw_url_returns_with_http_if_is_ssl() {
@@ -688,7 +688,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_raw_home_url_is_https_when_is_ssl() {
-		Constants_Manager::set_constant( 'JETPACK_SYNC_USE_RAW_URL', true );
+		Constants::set_constant( 'JETPACK_SYNC_USE_RAW_URL', true );
 
 		$home_option = get_option( 'home' );
 
@@ -715,9 +715,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( 'http://filteredurl.com' !== Jetpack_Sync_Functions::home_url() );
 
 		// Now, without, which should return the filtered URL
-		Constants_Manager::set_constant( 'JETPACK_SYNC_USE_RAW_URL', false );
+		Constants::set_constant( 'JETPACK_SYNC_USE_RAW_URL', false );
 		$this->assertEquals( $this->__return_filtered_url(), Jetpack_Sync_Functions::home_url() );
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 
 		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
 		remove_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
@@ -940,7 +940,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$_GET['signature'] = base64_encode( hash_hmac( 'sha1', $normalize , 'secret', true ) );
 
 		// call one of the authenticated endpoints
-		Constants_Manager::set_constant( 'XMLRPC_REQUEST', true );
+		Constants::set_constant( 'XMLRPC_REQUEST', true );
 		$jetpack = Jetpack::init();
 		$jetpack->xmlrpc_methods( array() );
 		$jetpack->require_jetpack_authentication();
@@ -948,7 +948,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function mock_authenticated_xml_rpc_cleanup( $user_id ) {
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10 );
 
 		unset( $_GET['token'] );

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_sending_empties_queue() {
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_do_not_load_sender_if_is_cron_and_cron_sync_disabled() {
-		Constants_Manager::set_constant( 'DOING_CRON', true );
+		Constants::set_constant( 'DOING_CRON', true );
 		$settings = Jetpack_Sync_Settings::get_settings();
 		$settings['sync_via_cron'] = 0;
 		Jetpack_Sync_Settings::update_settings( $settings );
@@ -115,7 +115,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertNull( Jetpack_Sync_Actions::$sender );
 
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 		Jetpack_Sync_Settings::reset_data();
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_sending_empties_queue() {

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Test pluggable functionality for bruteprotect
@@ -28,9 +28,9 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 		$user_id = $this->factory->user->create();
 
 		$user = get_userdata( $user_id );
-		Constants_Manager::set_constant( 'XMLRPC_REQUEST', true ); // fake xmlrpc request
+		Constants::set_constant( 'XMLRPC_REQUEST', true ); // fake xmlrpc request
 		Jetpack_Protect_Module::instance()->log_failed_attempt( $user->user_email );
-		Constants_Manager::clear_single_constant( 'XMLRPC_REQUEST' );
+		Constants::clear_single_constant( 'XMLRPC_REQUEST' );
 		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_valid_failed_login_attempt' );

--- a/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Test pluggable functionality for bruteprotect

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 if ( ! class_exists( 'WP_Test_Jetpack_Sync_Plugins' ) ) {
 	$sync_dir        = dirname( __FILE__ );

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 if ( ! class_exists( 'WP_Test_Jetpack_Sync_Plugins' ) ) {
 	$sync_dir        = dirname( __FILE__ );
@@ -32,7 +32,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 
 	public function tearDown() {
 		parent::tearDown();
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 	}
 
 	public static function setUpBeforeClass() {
@@ -161,7 +161,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 			'api'    => '',
 		);
 
-		Constants_Manager::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
+		Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 
 		$this->set_error();
 		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( $plugin_defaults ) );
@@ -181,7 +181,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 			'api'    => '',
 		);
 
-		Constants_Manager::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
+		Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		$this->update_bulk_plugins( new WP_Ajax_Upgrader_Skin( $plugin_defaults ) );
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Testing CRUD on Posts

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Testing CRUD on Posts
@@ -47,7 +47,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertFalse( $event->args[3]['is_auto_save'] );
 
-		Constants_Manager::set_constant( 'DOING_AUTOSAVE', true );
+		Constants::set_constant( 'DOING_AUTOSAVE', true );
 
 		//Performing sync here (even though setup() does it) to sync REQUEST_URI
 		$user_id = $this->factory->user->create();

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Testing Updates Sync

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Testing Updates Sync
@@ -247,11 +247,11 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		global $wp_version, $pagenow;
 
 		$this->assertFalse( $pagenow === 'update-core.php' );
-		Constants_Manager::set_constant( 'REST_API_REQUEST', true );
+		Constants::set_constant( 'REST_API_REQUEST', true );
 		Jetpack_Sync_Modules::get_module( "updates" )->update_core( 'new_version' );
 		$this->sender->do_sync();
 
-		Constants_Manager::clear_single_constant( 'REST_API_REQUEST' );
+		Constants::clear_single_constant( 'REST_API_REQUEST' );
 
 		$autoupdate_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_autoupdated_successfully' );
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_updated_successfully' );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Constants;
+use Automattic\Jetpack\Constants;
 
 /**
  * Testing CRUD on Users

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\Jetpack\Constants\Manager as Constants_Manager;
+use Automattic\Jetpack\Constants\Constants;
 
 /**
  * Testing CRUD on Users
@@ -711,12 +711,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_invite_user_sync_invite_event() {
 		$this->server_event_storage->reset();
 		// Fake it till you make it
-		Constants_Manager::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
+		Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', true );
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );
@@ -730,12 +730,12 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_invite_user_sync_invite_event_false() {
 		$this->server_event_storage->reset();
 		// Fake it till we make it
-		Constants_Manager::set_constant( 'JETPACK_INVITE_ACCEPTED', false );
+		Constants::set_constant( 'JETPACK_INVITE_ACCEPTED', false );
 		// We modify the input here to mimick the same call structure of the update user endpoint.
 		Jetpack_SSO_Helpers::generate_user( $this->get_invite_user_data() );
 		$this->sender->do_sync();
 
-		Constants_Manager::clear_constants();
+		Constants::clear_constants();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( $event );


### PR DESCRIPTION
During Today's call, democracy talked an decided in favour of having more concise and ergonomic names.

#### Changes proposed in this Pull Request:
* Refactors `Constatns_Manager` into `Constants`
* Constants 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* Run `rm -rf ./vendor` inside Jetpack.
* Run `composer install` inside Jetpack.
* Verify that pass.
* Verify CI passes on this PR and 100% is green.
* Smoke test Jetpack to verify it still works well in both the admin and the frontend.
