### PR TITLE
Add Jetpack Affiliate package

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\Jetpack\Partners\Affiliate as Affiliate;
+
 include_once( 'class.jetpack-admin-page.php' );
 
 // Builds the landing page and its menu
@@ -214,11 +216,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			? get_permalink( $last_post[0]->ID )
 			: get_home_url();
 
-		// Ensure that class to get the affiliate code is loaded
-		if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
-			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
-		}
-
 		return array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
 			'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
@@ -254,7 +251,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 				'roles' => $stats_roles,
 			),
-			'aff' => Jetpack_Affiliate::init()->get_affiliate_code(),
+			'aff' => Affiliate::init()->get_affiliate_code(),
 			'settings' => $this->get_flattened_settings( $modules ),
 			'userData' => array(
 //				'othersLinked' => Jetpack::get_other_linked_admins(),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,5 +1,5 @@
 <?php
-use Automattic\Jetpack\Partners\Affiliate as Affiliate;
+use Automattic\Jetpack\Partners\Affiliate;
 
 include_once( 'class.jetpack-admin-page.php' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Partners\Affiliate as Affiliate;
 
 /*
 Options:
@@ -4561,12 +4562,8 @@ p {
 			$url = add_query_arg( 'from', $from, $url );
 		}
 
-		// Ensure that class to get the affiliate code is loaded
-		if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
-			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
-		}
 		// Get affiliate code and add it to the URL
-		$url = Jetpack_Affiliate::init()->add_code_as_query_arg( $url );
+		$url = Affiliate::init()->add_code_as_query_arg( $url );
 
 		$calypso_env = $this->get_calypso_env();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Partners\Affiliate as Affiliate;
+use Automattic\Jetpack\Partners\Affiliate;
 
 /*
 Options:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-tracking": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
-		"automattic/jetpack-compat": "@dev"
+		"automattic/jetpack-compat": "@dev",
+		"automattic/jetpack-affiliate": "@dev"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,49 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c09d9b77fbe174fad981ff2c454e926b",
+    "content-hash": "7e2d82d82702db136be13cf61d05e472",
     "packages": [
         {
+            "name": "automattic/jetpack-affiliate",
+            "version": "dev-add/jetpack-aff-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/affiliate",
+                "reference": "776f8b1aa4ab5e7f078f4821c5f89dae64128882",
+                "shasum": null
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Partners\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Reads an affiliate code for Jetpack. Useful to add it to the connection URL so it's read by wpcom."
+        },
+        {
             "name": "automattic/jetpack-assets",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
-                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9"
+                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -40,11 +74,12 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
-                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb"
+                "reference": "9d9420600fc0e90ccd2907fee2ff432cf576b201",
+                "shasum": null
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -74,11 +109,12 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
-                "reference": "cd47566548267b29b0df1574a7c6be67de9c5cc9"
+                "reference": "cd47566548267b29b0df1574a7c6be67de9c5cc9",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -106,11 +142,12 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "0a0e293d73c17d59376590d56e5667b169d26877"
+                "reference": "0a0e293d73c17d59376590d56e5667b169d26877",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -142,11 +179,12 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95",
+                "shasum": null
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -169,44 +207,16 @@
             "description": "A wrapper for defining constants in a more testable way."
         },
         {
-            "name": "automattic/jetpack-status",
-            "version": "dev-master",
-            "dist": {
-                "type": "path",
-                "url": "./packages/status",
-                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
-                "shasum": null
-            },
-            "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
-        },
-        {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca"
+                "reference": "1c18ea7413c73015f6b0ac1100d3371491e717ce",
+                "shasum": null
             },
             "require": {
+                "automattic/jetpack-affiliate": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
@@ -238,11 +248,12 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
+                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -267,11 +278,12 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
-                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f"
+                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -292,16 +304,48 @@
             "description": "A wrapper for wp-options to manage specific Jetpack options."
         },
         {
+            "name": "automattic/jetpack-status",
+            "version": "dev-add/jetpack-aff-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/status",
+                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
+                "shasum": null
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
+        },
+        {
             "name": "automattic/jetpack-sync",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "b0d6e62ff20115d1ef5575ff46940fcbdb4bd2b0"
+                "reference": "8da64784868f0a94f4cc574b7d0ecffc564ca4c4",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-status": "@dev"
             },
             "type": "library",
             "autoload": {
@@ -317,11 +361,12 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-add/jetpack-aff-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
-                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85"
+                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-options": "@dev"
@@ -420,16 +465,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.1.1",
+            "version": "9.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +488,7 @@
                 "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -474,7 +519,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-30T23:16:27+00:00"
+            "time": "2019-06-27T19:58:56+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -679,12 +724,12 @@
             "version": "2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908",
                 "shasum": ""
             },
@@ -727,13 +772,13 @@
         "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-constants": 20,
-        "automattic/jetpack-status": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-tracking": 20,
         "automattic/jetpack-autoloader": 20,
-        "automattic/jetpack-compat": 20
+        "automattic/jetpack-compat": 20,
+        "automattic/jetpack-affiliate": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -66,7 +66,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
-	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 	$jitm = new Automattic\Jetpack\JITM();
 	$jitm->register();
 	jetpack_require_lib( 'debugger' );

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -1,6 +1,6 @@
 <?php
-
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\Partners\Affiliate;
 
 /**
  * Disable direct access and execution.
@@ -424,7 +424,7 @@ class Jetpack_Plugin_Search {
 	 */
 	private function get_upgrade_url( $feature ) {
 		$site_raw_url = Jetpack::build_raw_urls( get_home_url() );
-		$affiliateCode = Jetpack_Affiliate::init()->get_affiliate_code();
+		$affiliateCode = Affiliate::init()->get_affiliate_code();
 		$user = wp_get_current_user()->ID;
 		return "https://jetpack.com/redirect/?source=plugin-hint-upgrade-$feature&site=$site_raw_url&u=$user" .
 		       ( $affiliateCode ? "&aff=$affiliateCode" : '' );

--- a/packages/affiliate/README.md
+++ b/packages/affiliate/README.md
@@ -1,0 +1,15 @@
+## Jetpack Affiliate Code
+
+ This class introduces routines to get an affiliate code, that might be obtained from:
+- a `jetpack_affiliate_code` option in the WP database
+- an affiliate code returned by a filter bound to the `jetpack_affiliate_code` filter hook
+
+### Usage
+
+Display the default Jetpack logo:
+
+```php
+use Automattic\Jetpack\Partners\Affiliate;
+
+$aff_code = Affiliate::init()->get_affiliate_code();
+```

--- a/packages/affiliate/composer.json
+++ b/packages/affiliate/composer.json
@@ -1,0 +1,25 @@
+{
+	"name": "automattic/jetpack-affiliate",
+	"description": "Reads an affiliate code for Jetpack. Useful to add it to the connection URL so it's read by wpcom.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"version": "1.0.0",
+	"require": {},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"Automattic\\Jetpack\\Partners\\": "src/"
+		}
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
+}

--- a/packages/affiliate/composer.json
+++ b/packages/affiliate/composer.json
@@ -3,11 +3,12 @@
 	"description": "Reads an affiliate code for Jetpack. Useful to add it to the connection URL so it's read by wpcom.",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.0.0",
-	"require": {},
+	"require": {
+		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-status": "@dev"
+	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
-		"php-mock/php-mock": "^2.1"
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/packages/affiliate/composer.json
+++ b/packages/affiliate/composer.json
@@ -21,6 +21,12 @@
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		]
 	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
 	"minimum-stability": "dev",
 	"prefer-stable": true
 }

--- a/packages/affiliate/composer.json
+++ b/packages/affiliate/composer.json
@@ -8,7 +8,8 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/packages/affiliate/phpunit.xml.dist
+++ b/packages/affiliate/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/affiliate/src/Affiliate.php
+++ b/packages/affiliate/src/Affiliate.php
@@ -1,25 +1,33 @@
 <?php
+namespace Automattic\Jetpack\Partners;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	// Exit if accessed directly
-	exit;
+use Jetpack;
+
+if ( ! defined( 'ABSPATH' ) || ! is_admin() ) {
+	exit; // Exit if accessed directly or not in admin.
 }
 
 /**
  * This class introduces routines to get an affiliate code, that might be obtained from:
- * - an `jetpack_affiliate_code` option in the WP database
+ * - a `jetpack_affiliate_code` option in the WP database
  * - an affiliate code returned by a filter bound to the `jetpack_affiliate_code` filter hook
  *
  * @since 6.9.0
  */
-class Jetpack_Affiliate {
+class Affiliate {
 
 	/**
+	 * Class instance
+	 *
 	 * @since 6.9.0
-	 * @var Jetpack_Affiliate This class instance.
+	 *
+	 * @var Affiliate This class instance.
 	 **/
 	private static $instance = null;
 
+	/**
+	 * Affiliate constructor.
+	 */
 	private function __construct() {
 		if ( Jetpack::is_development_mode() ) {
 			return;
@@ -31,11 +39,11 @@ class Jetpack_Affiliate {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @return Jetpack_Affiliate | false
+	 * @return Affiliate | false
 	 */
 	public static function init() {
 		if ( is_null( self::$instance ) ) {
-			self::$instance = new Jetpack_Affiliate;
+			self::$instance = new Affiliate();
 		}
 		return self::$instance;
 	}
@@ -68,11 +76,13 @@ class Jetpack_Affiliate {
 	 * @return string The passed URL with the code added.
 	 */
 	public function add_code_as_query_arg( $url ) {
-		if ( '' !== ( $aff = $this->get_affiliate_code() ) ) {
+		$aff = $this->get_affiliate_code();
+		if ( '' !== $aff ) {
 			$url = add_query_arg( 'aff', $aff, $url );
 		}
 		return $url;
 	}
 }
 
-add_action( 'init', array( 'Jetpack_Affiliate', 'init' ) );
+add_action( 'init', array( 'Automattic\Jetpack\Partners\Affiliate', 'init' ) );
+

--- a/packages/affiliate/src/Affiliate.php
+++ b/packages/affiliate/src/Affiliate.php
@@ -1,25 +1,23 @@
 <?php
+/**
+ * Class to handle affiliate codes.
+ *
+ * @package affiliate
+ */
+
 namespace Automattic\Jetpack\Partners;
 
-use Jetpack;
-
-if ( ! defined( 'ABSPATH' ) || ! is_admin() ) {
-	exit; // Exit if accessed directly or not in admin.
-}
+use Automattic\Jetpack\Status;
 
 /**
  * This class introduces routines to get an affiliate code, that might be obtained from:
  * - a `jetpack_affiliate_code` option in the WP database
  * - an affiliate code returned by a filter bound to the `jetpack_affiliate_code` filter hook
- *
- * @since 6.9.0
  */
 class Affiliate {
 
 	/**
 	 * Class instance
-	 *
-	 * @since 6.9.0
 	 *
 	 * @var Affiliate This class instance.
 	 **/
@@ -29,15 +27,14 @@ class Affiliate {
 	 * Affiliate constructor.
 	 */
 	private function __construct() {
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			return;
 		}
 	}
 
 	/**
 	 * Initializes the class or returns the singleton
-	 *
-	 * @since 6.9.0
 	 *
 	 * @return Affiliate | false
 	 */
@@ -51,15 +48,11 @@ class Affiliate {
 	/**
 	 * Returns the affiliate code from database after filtering it.
 	 *
-	 * @since 6.9.0
-	 *
 	 * @return string The affiliate code.
 	 */
 	public function get_affiliate_code() {
 		/**
 		 * Allow to filter the affiliate code.
-		 *
-		 * @since 6.9.0
 		 *
 		 * @param string $aff_code The affiliate code, blank by default.
 		 */
@@ -68,8 +61,6 @@ class Affiliate {
 
 	/**
 	 * Returns the passed URL with the affiliate code added as a URL query arg.
-	 *
-	 * @since 6.9.0
 	 *
 	 * @param string $url The URL where the code will be added.
 	 *
@@ -83,6 +74,3 @@ class Affiliate {
 		return $url;
 	}
 }
-
-add_action( 'init', array( 'Automattic\Jetpack\Partners\Affiliate', 'init' ) );
-

--- a/packages/affiliate/src/Affiliate.php
+++ b/packages/affiliate/src/Affiliate.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Partners;
 
-use Automattic\Jetpack\Status;
-
 /**
  * This class introduces routines to get an affiliate code, that might be obtained from:
  * - a `jetpack_affiliate_code` option in the WP database
@@ -22,16 +20,6 @@ class Affiliate {
 	 * @var Affiliate This class instance.
 	 **/
 	private static $instance = null;
-
-	/**
-	 * Affiliate constructor.
-	 */
-	private function __construct() {
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
-			return;
-		}
-	}
 
 	/**
 	 * Initializes the class or returns the singleton

--- a/packages/affiliate/tests/php/bootstrap.php
+++ b/packages/affiliate/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/affiliate/tests/php/test_Affiliate.php
+++ b/packages/affiliate/tests/php/test_Affiliate.php
@@ -1,13 +1,16 @@
 <?php
 use Automattic\Jetpack\Partners\Affiliate;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
-use Automattic\Jetpack\JITM;
-use PHPUnit\Framework\TestCase;
 
-// Load required class to get the affiliate code
-require_once Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) . 'class.jetpack.php';
+class Test_Affiliate extends WP_UnitTestCase {
 
-class Test_Affiliate extends TestCase {
+	public function setUp() {
+		Jetpack_Constants::set_constant(
+			'JETPACK__PLUGIN_DIR',
+			dirname( dirname( dirname( dirname( __DIR__ ) ) ) )
+		);
+		require_once Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) . '/class.jetpack.php';
+	}
 
 	function test_affiliate_code_missing() {
 		$this->assertEmpty( Affiliate::init()->get_affiliate_code() );

--- a/packages/affiliate/tests/php/test_Affiliate.php
+++ b/packages/affiliate/tests/php/test_Affiliate.php
@@ -1,11 +1,11 @@
 <?php
 use Automattic\Jetpack\Partners\Affiliate;
-
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\JITM;
 use PHPUnit\Framework\TestCase;
 
 // Load required class to get the affiliate code
-require_once JETPACK__PLUGIN_DIR . 'class.jetpack.php';
+require_once Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) . 'class.jetpack.php';
 
 class Test_Affiliate extends TestCase {
 

--- a/packages/affiliate/tests/php/test_Affiliate.php
+++ b/packages/affiliate/tests/php/test_Affiliate.php
@@ -1,23 +1,21 @@
 <?php
-/**
- * Tests for Jetpack_Affiliate
- */
+use Automattic\Jetpack\Partners\Affiliate;
 
 use Automattic\Jetpack\JITM;
+use PHPUnit\Framework\TestCase;
 
 // Load required class to get the affiliate code
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack.php';
-require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 
-class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
+class Test_Affiliate extends TestCase {
 
 	function test_affiliate_code_missing() {
-		$this->assertEmpty( Jetpack_Affiliate::init()->get_affiliate_code() );
+		$this->assertEmpty( Affiliate::init()->get_affiliate_code() );
 	}
 
 	function test_affiliate_code_exists() {
 		add_option( 'jetpack_affiliate_code', 'abc123' );
-		$this->assertEquals( 'abc123', Jetpack_Affiliate::init()->get_affiliate_code() );
+		$this->assertEquals( 'abc123', Affiliate::init()->get_affiliate_code() );
 	}
 
 	function test_affiliate_connect_url_missing() {
@@ -35,7 +33,7 @@ class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
 		$source = 'somesource123';
 		$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
 		$user = 123;
-		$url = Jetpack_Affiliate::init()->add_code_as_query_arg(
+		$url = Affiliate::init()->add_code_as_query_arg(
 			"https://jetpack.com/redirect/?source={$source}&site={$normalized_site_url}&u={$user}"
 		);
 
@@ -44,4 +42,5 @@ class WP_Test_Jetpack_Affiliate extends WP_UnitTestCase {
 		$this->assertContains( "u=$user", $url );
 		$this->assertContains( 'aff=abc123', $url );
 	}
+
 }

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -9,7 +9,8 @@
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-tracking": "@dev"
+		"automattic/jetpack-tracking": "@dev",
+		"automattic/jetpack-affiliate": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\Partners\Affiliate as Affiliate;
 
 /**
  * Jetpack just in time messaging through out the admin
@@ -389,11 +390,9 @@ class JITM {
 				'u'      => $user->ID,
 			);
 
-			if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
-				require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
-			}
 			// Get affiliate code and add it to the array of URL parameters
-			if ( '' !== ( $aff = \Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
+			$aff = Affiliate::init()->get_affiliate_code();
+			if ( '' !== $aff ) {
 				$url_params['aff'] = $aff;
 			}
 

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -7,7 +7,7 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Partners\Affiliate as Affiliate;
+use Automattic\Jetpack\Partners\Affiliate;
 
 /**
  * Jetpack just in time messaging through out the admin

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -68,7 +68,7 @@ class Test_Status extends TestCase {
 		) );
 
 		$this->assertFalse( $this->status->is_development_mode() );
-		
+
 		$filters_mock->disable();
 	}
 
@@ -77,7 +77,7 @@ class Test_Status extends TestCase {
 	 */
 	public function test_is_development_mode_localhost() {
 		$this->mock_function( 'site_url', 'localhost' );
-		
+
 		$filters_mock = $this->mock_filters( array(
 			array( 'jetpack_development_mode', false, false ),
 			array( 'jetpack_development_mode', true, true ),
@@ -92,7 +92,7 @@ class Test_Status extends TestCase {
      * @covers Automattic\Jetpack\Status::is_development_mode
      *
      * @runInSeparateProcess
-     */	
+     */
 	public function test_is_development_mode_constant() {
 		$this->mock_function( 'site_url', $this->site_url );
 		$filters_mock = $this->mock_filters( array(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -75,9 +75,6 @@
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
 		</testsuite>
-		<testsuite name="affiliate">
-			<file>tests/php/test_class.jetpack-affiliate.php</file>
-		</testsuite>
 		<testsuite name="3rd-party">
 			<directory prefix="test_" suffix=".php">tests/php/3rd-party</directory>
 		</testsuite>


### PR DESCRIPTION
This PR will create a package for the class that reads and Affiliate code. It's later replaced where it was previously used, to add the affiliate code to the connection URL.

To be merged in https://github.com/Automattic/jetpack/pull/12527

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the `Jetpack_Affiliate` class to its own Composer package.
* in files where this class was used, import the namespaced class
* small tweaks in Jetpack_Affiliate class so it's PHPCS compliant

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* checkout the branch
* do `composer require automattic/jetpack-affiliate`
* do `wp option add jetpack_affiliate_code abc123` (or `yarn docker:wp option add jetpack_affiliate_code abc123`)
* go to WP Admin > Dashboard in a _disconnected_ site 
* verify that the URL of the Set up Jetpack button has the `aff` parameter with the right value

#### Proposed changelog entry
* Move Jetpack Affiliate code to a Composer package.