### PR TITLE
Reverting part of Jitm package to use global Jetpack class

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -497,7 +497,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_jitm_message( $request ) {
 		$jitm = new JITM_Manager();
 
-		if ( ! $jitm ) {
+		if ( ! $jitm->register() ) {
 			return array();
 		}
 
@@ -513,7 +513,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function delete_jitm_message( $request ) {
 		$jitm = new JITM_Manager();
 
-		if ( ! $jitm ) {
+		if ( ! $jitm->register() ) {
 			return true;
 		}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -511,9 +511,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool Always True
 	 */
 	public static function delete_jitm_message( $request ) {
-		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php' );
-
-		$jitm = Jetpack_JITM::init();
+		$jitm = new JITM_Manager();
 
 		if ( ! $jitm ) {
 			return true;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -690,7 +690,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', array( $this, 'should_suppress_jitms' ), 9 );
+		add_filter( 'jetpack_just_in_time_msgs', array( $this, 'is_not_active_or_development_mode' ), 9 );
 
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
@@ -7107,7 +7107,7 @@ p {
 		}
 	}
 
-	function should_suppress_jitms( $maybe ) {
+	function is_not_active_or_development_mode( $maybe ) {
 		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
 			return false;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -689,7 +689,13 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
+		add_filter( 'jetpack_just_in_time_msgs', function( $display ) {
+			if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
+				return false;
+			}
+            return true;
+		}, 9 );
+
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
 		// If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -690,12 +690,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', function( $display ) {
-			if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
-				return false;
-			}
-            return true;
-		}, 9 );
+		add_filter( 'jetpack_just_in_time_msgs', array( $this, 'should_suppress_jitms' ), 9 );
 
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
@@ -7110,5 +7105,12 @@ p {
 				delete_user_meta( $user_id, $meta_key );
 			}
 		}
+	}
+
+	function should_suppress_jitms( $maybe ) {
+		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -29,6 +29,7 @@ use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use \Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 
 require_once( JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php' );
+require_once( dirname( __FILE__ ) . '/_inc/lib/tracks/client.php' );
 
 class Jetpack {
 	public $xmlrpc_server = null;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -690,7 +690,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', array( $this, 'is_not_active_or_development_mode' ), 9 );
+		add_filter( 'jetpack_just_in_time_msgs', array( $this, 'is_active_and_not_development_mode' ), 9 );
 
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9);
 
@@ -7107,7 +7107,7 @@ p {
 		}
 	}
 
-	function is_not_active_or_development_mode( $maybe ) {
+	function is_active_and_not_development_mode( $maybe ) {
 		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
 			return false;
 		}

--- a/jetpack.php
+++ b/jetpack.php
@@ -241,6 +241,7 @@ if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );
 	$jitm = new JITM_Manager();
+	$jitm->register();
 	jetpack_require_lib( 'debugger' );
 }
 

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -17,43 +17,12 @@ class Manager {
 	const PACKAGE_VERSION = '1.0';
 
 	/**
-	 * @var Jetpack_JITM
-	 **/
-	private static $instance = null;
-
-	/**
-	 * Initializes the class, or returns the singleton
-	 *
-	 * @return Manager | false
-	 */
-	static function init() {
-		/**
-		 * Filter to turn off all just in time messages
-		 *
-		 * @since 3.7.0
-		 * @since 5.4.0 Correct docblock to reflect default arg value
-		 *
-		 * @param bool false Whether to show just in time messages.
-		 */
-		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
-			return false;
-		}
-
-		if ( is_null( self::$instance ) ) {
-			self::$instance = new Manager();
-		}
-
-		return self::$instance;
-	}
-
-	/**
 	 * Jetpack_JITM constructor.
 	 */
 	public function __construct() {
-		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
-			return;
+		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
+			return false;
 		}
-
 		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
 	}
 

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -50,12 +50,10 @@ class Manager {
 	 * Jetpack_JITM constructor.
 	 */
 	public function __construct() {
-		/*
-		$jetpack_connection = new Jetpack_Connection();
-		if ( ! $jetpack_connection->is_active() || $jetpack_connection->is_development_mode() ) {
+		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
 			return;
 		}
-		*/
+
 		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
 	}
 

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -16,14 +16,18 @@ class Manager {
 
 	const PACKAGE_VERSION = '1.0';
 
+	private $is_prepare_jitms_callback_added;
+
 	/**
 	 * Jetpack_JITM constructor.
 	 */
 	public function __construct() {
 		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
+			$this->is_prepare_jitms_callback_added = false;
 			return false;
 		}
 		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
+		$this->is_prepare_jitms_callback_added = true;
 	}
 
 	/**
@@ -424,5 +428,9 @@ class Manager {
 		}
 
 		return $envelopes;
+	}
+
+	public function is_prepare_jitms_callback_added() {
+		return $this->is_prepare_jitms_callback_added;
 	}
 }

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -28,7 +28,8 @@ class Manager {
 		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 			return false;
 		}
-		return add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
+		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
+		return true;
 	}
 
 	/**

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -16,18 +16,25 @@ class Manager {
 
 	const PACKAGE_VERSION = '1.0';
 
-	private $is_prepare_jitms_callback_added;
-
 	/**
 	 * Jetpack_JITM constructor.
 	 */
 	public function __construct() {
+	}
+
+	public function register() {
+		/**
+		 * Filter to turn off all just in time messages
+		 *
+		 * @since 3.7.0
+		 * @since 5.4.0 Correct docblock to reflect default arg value
+		 *
+		 * @param bool false Whether to show just in time messages.
+		 */
 		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
-			$this->is_prepare_jitms_callback_added = false;
 			return false;
 		}
-		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
-		$this->is_prepare_jitms_callback_added = true;
+		return add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
 	}
 
 	/**

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -50,6 +50,10 @@ class Manager {
 	 * Jetpack_JITM constructor.
 	 */
 	public function __construct() {
+		if ( ! class_exists( '\Jetpack' ) ) {
+			// Package tests run in isolation, so provide /Jetpack until it is a proper package
+			require_once dirname( __FILE__ ) . '/../../../class.jetpack.php';
+		}
 		if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
 			return;
 		}

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -16,12 +16,6 @@ class Manager {
 
 	const PACKAGE_VERSION = '1.0';
 
-	/**
-	 * Jetpack_JITM constructor.
-	 */
-	public function __construct() {
-	}
-
 	public function register() {
 		/**
 		 * Filter to turn off all just in time messages
@@ -435,9 +429,5 @@ class Manager {
 		}
 
 		return $envelopes;
-	}
-
-	public function is_prepare_jitms_callback_added() {
-		return $this->is_prepare_jitms_callback_added;
 	}
 }

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -26,7 +26,7 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, false ),
 		) );
 
-		$this->assertFalse( Jetpack_JITM::init() );
+		$this->assertFalse( new Jetpack_JITM() );
 
 		$this->clear_mock_filters();
 	}
@@ -36,7 +36,7 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, true ),
 		) );
 
-		$this->assertTrue( ! ! Jetpack_JITM::init() );
+		$this->assertTrue( ! ! new Jetpack_JITM() );
 
 		$this->clear_mock_filters();
 	}

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -27,7 +27,7 @@ class Test_Jetpack_JITM extends TestCase {
 		) );
 
 		$jitm = new Jetpack_JITM();
-		$this->assertFalse( $jitm->is_prepare_jitms_callback_added() );
+		$this->assertFalse( $jitm->register() );
 
 		$this->clear_mock_filters();
 	}
@@ -38,7 +38,7 @@ class Test_Jetpack_JITM extends TestCase {
 		) );
 
 		$jitm = new Jetpack_JITM();
-		$this->assertTrue( $jitm->is_prepare_jitms_callback_added() );
+		$this->assertTrue( $jitm->register() );
 
 		$this->clear_mock_filters();
 	}

--- a/packages/jitm/tests/php/test_Manager.php
+++ b/packages/jitm/tests/php/test_Manager.php
@@ -26,7 +26,8 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, false ),
 		) );
 
-		$this->assertFalse( new Jetpack_JITM() );
+		$jitm = new Jetpack_JITM();
+		$this->assertFalse( $jitm->is_prepare_jitms_callback_added() );
 
 		$this->clear_mock_filters();
 	}
@@ -36,7 +37,8 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, true ),
 		) );
 
-		$this->assertTrue( ! ! new Jetpack_JITM() );
+		$jitm = new Jetpack_JITM();
+		$this->assertTrue( $jitm->is_prepare_jitms_callback_added() );
 
 		$this->clear_mock_filters();
 	}


### PR DESCRIPTION
Reverting part of Jitm package to use \Jetapck since functions not yet available in Connection package.

Previous PR: #12516

Testing instructions:

Apply D29283-code to your WPCOM sandbox to ensure there is always a JITM waiting for you. Confirm that you see the Jitm when you visit the list of plugins (you should see a JITM that says "Hi").

Update the return value of `is_active()` in class.jetpack.php (line 1564) so that it always returns false. This will cause the `jetpack_just_in_time_messages` filter to return false,
```		
dd_filter( 'jetpack_just_in_time_msgs', function( $display ) {
			if ( ! \Jetpack::is_active() || \Jetpack::is_development_mode() ) {
				return false;
			}
            return true;
		}, 9 );
```
When you reload the page, the JITM will not appear until you remove the return statement from is_active().


