### PR TITLE
Packages: Fix relative path in tracking package

### DIFF
--- a/packages/tracking/src/Manager.php
+++ b/packages/tracking/src/Manager.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\Jetpack\Tracking;
 
-require_once( dirname( __FILE__ ) . '/../../../_inc/lib/tracks/client.php' );
+require_once dirname( dirname( dirname( __DIR__ ) ) ) . '/_inc/lib/tracks/client.php';
 
 class Manager {
 	static $product_name = 'jetpack';
@@ -16,20 +16,24 @@ class Manager {
 		}
 
 		// For tracking stuff via js/ajax
-		add_action( 'admin_enqueue_scripts',     array( __CLASS__, 'enqueue_tracks_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_tracks_scripts' ) );
 
-		add_action( 'jetpack_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
-		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
-		add_action( 'jetpack_user_authorized',   array( __CLASS__, 'track_user_linked' ) );
-		add_action( 'wp_login_failed',           array( __CLASS__, 'track_failed_login_attempts' ) );
+		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activate_module' ), 1, 1 );
+		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivate_module' ), 1, 1 );
+		add_action( 'jetpack_user_authorized', array( __CLASS__, 'track_user_linked' ) );
+		add_action( 'wp_login_failed', array( __CLASS__, 'track_failed_login_attempts' ) );
 	}
 
 	static function enqueue_tracks_scripts() {
 		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
-		wp_localize_script( 'jptracks', 'jpTracksAJAX', array(
-			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-			'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
-		) );
+		wp_localize_script(
+			'jptracks',
+			'jpTracksAJAX',
+			array(
+				'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+				'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
+			)
+		);
 	}
 
 	/* User has linked their account */
@@ -63,11 +67,17 @@ class Manager {
 
 	/* Failed login attempts */
 	static function track_failed_login_attempts( $login ) {
-		require_once( JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php' );
-		self::record_user_event( 'failed_login', array( 'origin_ip' => jetpack_protect_get_ip(), 'login' => $login ) );
+		require_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
+		self::record_user_event(
+			'failed_login',
+			array(
+				'origin_ip' => jetpack_protect_get_ip(),
+				'login'     => $login,
+			)
+		);
 	}
 
-	static function record_user_event( $event_type, $data= array(), $user = null ) {
+	static function record_user_event( $event_type, $data = array(), $user = null ) {
 
 		if ( ! $user ) {
 			$user = wp_get_current_user();
@@ -91,4 +101,4 @@ class Manager {
 	}
 }
 
-add_action( 'init',  array( 'JetpackTracking', 'track_jetpack_usage' ) );
+add_action( 'init', array( 'JetpackTracking', 'track_jetpack_usage' ) );


### PR DESCRIPTION
This PR fixes the following error that's thrown when attempting to connect a site:

```
Warning: require_once(.../wp-content/plugins/jetpack-dev/vendor/automattic/jetpack-tracking/src/../../../_inc/lib/tracks/client.php): failed to open stream: No such file or directory in .../wp-content/plugins/jetpack-dev/vendor/automattic/jetpack-tracking/src/Manager.php on line 8
```

It also applies some PHPCS fixes.

#### Changes proposed in this Pull Request:
* Fix the relative require path and make it absolute.
* Several PHPCS fixer automated fixes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout branch.
* Disconnect the site.
* Attempt to connect, starting from wp-admin.
* Verify you can connect.

#### Proposed changelog entry for your changes:
* Fix relative path in tracking package 

#### Note

Ideally, the fix should be to actually have all the tracking client files in the package, but that's material for another PR.
