### PR TITLE
CI: Try disabling xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,14 @@ git:
   depth: 1
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - |
+    # Remove Xdebug for a huge performance increase:
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
+  - |
   - export PLUGIN_SLUG=$(basename $(pwd))
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ git:
   depth: 1
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - export PLUGIN_SLUG=$(basename $(pwd))
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,9 @@ before_script:
   - composer install
   - ./tests/setup-travis.sh
 
-script: ./tests/run-travis.sh
+script:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6"  ]]; then phpdbg -qrr phpunit; fi
+  - ./tests/run-travis.sh
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,7 @@ before_script:
   - composer install
   - ./tests/setup-travis.sh
 
-script:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6"  ]]; then phpdbg -qrr phpunit; fi
-  - ./tests/run-travis.sh
+script: ./tests/run-travis.sh
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ matrix:
 
   allow_failures:
     - name: "E2E tests"
+  fast_finish: true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ matrix:
 
 cache:
   directories:
+   - vendor
    - $HOME/.composer/cache/files
    - $HOME/.cache/yarn
    - $HOME/.phpbrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
 cache:
   directories:
    - vendor
-   - $HOME/.composer/cache/files
+   - $HOME/.composer/cache
    - $HOME/.cache/yarn
    - $HOME/.phpbrew
 


### PR DESCRIPTION
In progress.

This PR attempts to remove xdebug in Travis setup as an attempt to make tests run faster.

#### Changes proposed in this Pull Request:
* Disable xdebug in Travis CI setup.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No, this is part of the internal CI tooling.

#### Testing instructions:
* Compare build speeds in Travis CI.

#### Proposed changelog entry for your changes:
* Disable xdebug in Travis configuration
