### PR TITLE
Jetpack DNA: avoid Fatals when logging in via SSO

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
+
 include_once( 'class.jetpack-admin-page.php' );
 include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
+
 /**
  * Client = Plugin
  * Client Server = API Methods the Plugin must respond to

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
+
 /**
  * Disable direct access and execution.
  */

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
+
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' );
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' );
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -14,6 +14,8 @@
  * @package Jetpack
  */
 
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
+
 if ( defined( 'STATS_VERSION' ) ) {
 	return;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This fixes fatals when one tries to access the SSO log in page.

Related: #12596

#### Testing instructions:

* Before this patch: enable the SSO module, log out of your site, and try to log back in using SSO:
```
PHP Fatal error:  Uncaught Error: Class 'JetpackTracking' not found in /var/www/html/wp-content/plugins/jetpack/modules/sso.php:366
```
* After this patch, the error should be gone.

#### Proposed changelog entry for your changes:

* None
