### PR TITLE
Packages: Remove Manager pattern from Asset Tools

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/asset-tools",
-                "reference": "d425ff2ef48f7e4c323507ca583e4065f7f107a6",
+                "reference": "5733de68bc0616f37ed3813b092908767df2cf68",
                 "shasum": null
             },
             "require": {
@@ -21,7 +21,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Automattic\\Jetpack\\Asset_Tools\\": "src/"
+                    "Automattic\\Jetpack\\": "src/"
                 }
             },
             "license": [

--- a/packages/asset-tools/composer.json
+++ b/packages/asset-tools/composer.json
@@ -8,7 +8,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Automattic\\Jetpack\\Asset_Tools\\": "src/"
+			"Automattic\\Jetpack\\": "src/"
 		}
 	},
 	"repositories": [

--- a/packages/asset-tools/src/Asset_Tools.php
+++ b/packages/asset-tools/src/Asset_Tools.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Automattic\Jetpack\Asset_Tools;
+namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 
-class Manager {
+class Asset_Tools {
 	/**
 	 * Given a minified path, and a non-minified path, will return
 	 * a minified or non-minified file URL based on whether SCRIPT_DEBUG is set and truthy.

--- a/packages/jitm/src/Manager.php
+++ b/packages/jitm/src/Manager.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\JITM;
 
-use Automattic\Jetpack\Asset_Tools\Manager as Asset_Manager;
+use Automattic\Jetpack\Asset_Tools;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
@@ -164,7 +164,7 @@ class Manager {
 	 * Function to enqueue jitm css and js
 	 */
 	function jitm_enqueue_files() {
-		$asset_manager = new Asset_Manager();
+		$asset_manager = new Asset_Tools();
 		$min           = ''; // ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_style(
 			'jetpack-jitm-css',


### PR DESCRIPTION
As we've decided to move away from the Manager pattern, this PR removes it from the Asset Tools package.

#### Changes proposed in this Pull Request:
* Remove Manager pattern from the Asset Tools package

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Verify the JITM package still works well.

#### Proposed changelog entry for your changes:
* Remove Manager pattern from Asset Tools
