### PR TITLE
WIP: DNA: Warn when using Jetpack Packages before `plugins_loaded`

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -83,7 +83,8 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Jetpack_Options',
 						'Jetpack_Sync_Main',
 						'Automattic\Jetpack\Constants',
-					)
+					),
+					true
 				);
 				if ( ! $ignore && function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
 					_doing_it_wrong(

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -93,8 +93,8 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 
 				return true;
 			}
-			return false;
 		}
+		return false;
 	}
 
 	// Add the jetpack autoloader.

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -77,7 +77,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 				$ignore = in_array(
 					$class_name,
 					array(
-						'Automattic\Jetpack\JITM\Manager',
+						'Automattic\Jetpack\JITM',
 						'Automattic\Jetpack\Connection\Manager',
 						'Automattic\Jetpack\Connection\Manager_Interface',
 						'Jetpack_Options',

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -73,7 +73,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 
 		if ( isset( $jetpack_packages_classes[ $class_name ] ) ) {
 
-			if ( defined( WP_DEBUG ) && WP_DEBUG ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				if ( function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
 					_doing_it_wrong(
 						esc_html( $class_name ),
@@ -93,6 +93,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 
 				return true;
 			}
+			return false;
 		}
 	}
 

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -72,9 +72,20 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 		global $jetpack_packages_classes;
 
 		if ( isset( $jetpack_packages_classes[ $class_name ] ) ) {
-
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				if ( function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
+				// TODO ideally we shouldn't skip any of these, see: https://github.com/Automattic/jetpack/pull/12646
+				$ignore = in_array(
+					$class_name,
+					array(
+						'Automattic\Jetpack\JITM\Manager',
+						'Automattic\Jetpack\Connection\Manager',
+						'Automattic\Jetpack\Connection\Manager_Interface',
+						'Jetpack_Options',
+						'Jetpack_Sync_Main',
+						'Automattic\Jetpack\Constants',
+					)
+				);
+				if ( ! $ignore && function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
 					_doing_it_wrong(
 						esc_html( $class_name ),
 						sprintf(
@@ -94,6 +105,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 				return true;
 			}
 		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Waiting for `plugins_loaded` is the right thing to do if we want the site to always load the latest available version of a JP Package.
As Today Jetpack does a lot of invocations before `plugins_loaded`, throwing Notices when `defined( 'WP_DEBUG' ) && WP_DEBUG` for the following classes:

```
Automattic\Jetpack\Connection\Manager
Automattic\Jetpack\Connection\Manager_Interface
Jetpack_Options
Jetpack_Sync_Main
Automattic\Jetpack\Constants
```

Open questions:

- why would we want to do anything before `plugins_loaded`?
- either do it after `plugins_loaded` or live with the first found version of a class?
- HOW SHOULD WE MOVE FORWARD?

**Testing Instructions**
* run `composer dump-autoload` to generate a new `autoload_packages.php`
* make sure `WP_DEBUG` is set to true
* after loading the site confirm there are no warnings in the frontend or in the logs
* comment one of the classes in the '$ignore` array
* after loading the site confirm there are warnings in the frontend or in the logs