### PR TITLE
Renovate: Run only on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
 	"extends": [ "config:base" ],
 	"labels": [ "[Type] Janitorial", "[Status] Needs Review" ],
 	"prHourlyLimit": 1,
-	"supportPolicy": [ "lts_latest" ]
+	"supportPolicy": [ "lts_latest" ],
+	"timezone": "UTC",
+	"schedule": [ "every weekend" ]
 }


### PR DESCRIPTION
Sometimes Renovate PRs interfere with some real work, which got blocked. This PR will make renovate to launch any builds on weekends only

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing really :) 


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
