### PR TITLE
Sync: Decouple is_active, is_dev_mode and is_staging methods

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7113,4 +7113,23 @@ p {
 		}
 		return true;
 	}
+
+	/**
+	 * Initialize and hook up external filters and actions that Sync needs.
+	 *
+	 * @since 7.5.0
+	 *
+	 * @static
+	 * @access public
+	 */
+	public static function initialize_sync() {
+		// Let Sync know if the site is in development mode.
+		add_filter( 'jetpack_sync_is_development_mode', array( 'Jetpack', 'is_development_mode' ) );
+
+		// Let Sync know if this is a staging site.
+		add_filter( 'jetpack_sync_is_staging_site', array( 'Jetpack', 'is_staging_site' ) );
+
+		// Let Sync know if Jetpack is active.
+		add_filter( 'jetpack_sync_jetpack_is_active', array( 'Jetpack', 'is_active' ) );
+	}
 }

--- a/jetpack.php
+++ b/jetpack.php
@@ -235,6 +235,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php'          );
 
+Jetpack::initialize_sync();
 Jetpack_Sync_Main::init();
 
 if ( is_admin() ) {

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -107,13 +107,13 @@ class Jetpack_Sync_Actions {
 		if ( ! Jetpack_Sync_Settings::is_sync_enabled() ) {
 			return false;
 		}
-		if ( Jetpack::is_development_mode() ) {
+		if ( apply_filters( 'jetpack_sync_is_development_mode', false ) ) {
 			return false;
 		}
-		if ( Jetpack::is_staging_site() ) {
+		if ( apply_filters( 'jetpack_sync_is_staging_site', false ) ) {
 			return false;
 		}
-		if ( ! Jetpack::is_active() ) {
+		if ( ! apply_filters( 'jetpack_sync_jetpack_is_active', false ) ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;
 			}

--- a/packages/sync/legacy/class.jetpack-sync-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-users.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Users {
 	static $user_roles = array();
 
 	static function init() {
-		if ( Jetpack::is_active() ) {
+		if ( apply_filters( 'jetpack_sync_jetpack_is_active', false ) ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,5 +1,6 @@
 <?php
 
+Jetpack::initialize_sync();
 Jetpack_Sync_Main::init();
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';


### PR DESCRIPTION
This PR starts decoupling the sync package from external classes by using filters and actions. This is a step towards allowing easier testing and independent packaging of the Sync package.

I'd like to get some feedback on this approach - if it's feasible, we could use it for decoupling the rest of sync and other big packages from the core Jetpack plugin.

**Question:** Should these 3 methods be part of the connection package @zinigor @mdawaffe?

#### Changes proposed in this Pull Request:
* Introduce new filters instead of several methods:
  * `Jetpack::is_active()`
  * `Jetpack::is_development_mode()`
  * `Jetpack::is_staging_site()`
* Introduce a method for initialyzing Sync in the main Jetpack class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:

* Checkout this branch.
* Smoke test incremental and full sync and verify everything works like it did before.

#### Proposed changelog entry for your changes:
* Sync: Decouple is_active, is_dev_mode and is_staging methods
