### PR TITLE
DNA: make sure that local tags match remote tags in package release

### DIFF
--- a/bin/release-package.php
+++ b/bin/release-package.php
@@ -76,7 +76,7 @@ execute( $command, 'Could not add the new package repository remote.', true, tru
 execute( 'git push package master --force', 'Could not push to the new package repository.', true, true );
 
 // Grab all the existing tags from the package repository.
-execute( 'git fetch --tags', 'Could not fetch the existing tags of the package.', true, true );
+execute( 'git fetch -f --tags', 'Could not fetch the existing tags of the package.', true, true );
 
 // Create the new tag.
 $command = sprintf(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When releasing a new version of a package, one of the steps is to fetch all tags from the Jetpack repo. However, if the tags you have in your local copy don't match the remote tags, you get the following error:
```
From github.com:Automattic/jetpack
 ! [rejected]            7.3.1.1    -> 7.3.1.1  (would clobber existing tag)
```

This error interrupts the release process. To avoid this, let's force fetch tags from the remote copy to avoid mismatchs.

#### Testing instructions:

* Try to release a package as explained in p1HpG7-70B-p2
* See no errors

#### Proposed changelog entry for your changes:

* None
