### PR TITLE
General: Add DreamPress staging site URL pattern

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5992,14 +5992,15 @@ p {
 			'urls' => array(
 				'#\.staging\.wpengine\.com$#i', // WP Engine
 				'#\.staging\.kinsta\.com$#i',   // Kinsta.com
-				),
+				'#\.stage\.site$#i'             // DreamPress
+			),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',      // WP Engine
 				'KINSTA_DEV_ENV',       // Kinsta.com
 				'WPSTAGECOACH_STAGING', // WP Stagecoach
 				'JETPACK_STAGING_MODE', // Generic
-				)
-			);
+			)
+		);
 		/**
 		 * Filters the flags of known staging sites.
 		 *

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -129,6 +129,35 @@ EXPECTED;
 	public function pre_test_is_staging_site_will_report_staging_for_wpengine_sites_by_url(){
 		return 'http://bjk.staging.wpengine.com';
 	}
+
+	/**
+	 * @dataProvider get_is_staging_site_known_hosting_providers_data
+	 */
+	public function test_is_staging_site_for_known_hosting_providers( $site_url ) {
+		$original_site_url = get_option( 'siteurl' );
+		update_option( 'siteurl', $site_url );
+		$result = MockJetpack::is_staging_site();
+		update_option( 'siteurl', $original_site_url );
+		$this->assertTrue(
+			$result,
+			sprintf( 'Expected %s to return true for `is_staging_site()', $site_url )
+		);
+	}
+
+	public function get_is_staging_site_known_hosting_providers_data() {
+		return array(
+			'wpengine' => array(
+				'http://bjk.staging.wpengine.com',
+			),
+			'kinsta' => array(
+				'http://test.staging.kinsta.com',
+			),
+			'dreampress' => array(
+				'http://ebinnion.stage.site',
+			),
+		);
+	}
+
 	/*
 	 * @author tonykova
 	 * @covers Jetpack::implode_frontend_css


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add support for DreamPress's new staging site functionality

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Adds DreamPress staging URL support to existing `Jetpack:is_staging_site()` method

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure unit tests pass

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds staging detection for DreamPress staging site
