### PR TITLE
Merges connection "Connectors" work into the master branch.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -90,12 +90,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'callback' => __CLASS__ . '::delete_jitm_message'
 		) );
 
-		// Register a site
-		register_rest_route( 'jetpack/v4', '/verify_registration', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::verify_registration',
-		) );
-
 		// Authorize a remote user
 		register_rest_route( 'jetpack/v4', '/remote_authorize', array(
 			'methods' => WP_REST_Server::EDITABLE,
@@ -519,28 +513,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		return $jitm->dismiss( $request['id'], $request['feature_class'] );
 	}
-
-	/**
-	 * Handles verification that a site is registered
-	 *
-	 * @since 5.4.0
-	 *
-	 * @param WP_REST_Request $request The request sent to the WP REST API.
-	 *
-	 * @return array|wp-error
-	 */
-	public static function verify_registration( $request ) {
-		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
-		$xmlrpc_server = new Jetpack_XMLRPC_Server();
-		$result = $xmlrpc_server->verify_registration( array( $request['secret_1'], $request['state'] ) );
-
-		if ( is_a( $result, 'IXR_Error' ) ) {
-			$result = new WP_Error( $result->code, $result->message );
-		}
-
-		return $result;
-	}
-
 
 	/**
 	 * Checks if this site has been verified using a service - only 'google' supported at present - and a specfic

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -75,7 +75,6 @@ class Jetpack_XMLRPC_Server {
 	 */
 	function bootstrap_xmlrpc_methods() {
 		return array(
-			'jetpack.verifyRegistration' => array( $this, 'verify_registration' ),
 			'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ),
 			'jetpack.remoteRegister' => array( $this, 'remote_register' ),
 		);
@@ -395,14 +394,6 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		return $error;
-	}
-
-	/**
-	* Verifies that Jetpack.WordPress.com received a registration request from this site
-	*/
-	function verify_registration( $data ) {
-		// failure modes will be recorded in tracks in the verify_action method
-		return $this->verify_action( array( 'register', $data[0], $data[1] ) );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -26,6 +26,8 @@ jetpack_do_activate (bool)
 */
 
 use \Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use \Automattic\Jetpack\Connection\XMLRPC_Connector as XMLRPC_Connector;
+use \Automattic\Jetpack\Connection\REST_Connector as REST_Connector;
 use \Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 
 require_once( JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php' );
@@ -599,6 +601,8 @@ class Jetpack {
 					add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'authorize_xmlrpc_methods' ) );
 				}
 			} else {
+				new XMLRPC_Connector( $this->connection_manager );
+
 				// The bootstrap API methods.
 				add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'bootstrap_xmlrpc_methods' ) );
 				$signed = $this->verify_xml_rpc_signature();
@@ -623,6 +627,8 @@ class Jetpack {
 			if ( Jetpack::is_active() ) {
 				add_action( 'login_form_jetpack_json_api_authorization', array( &$this, 'login_form_json_api_authorization' ) );
 				add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );
+			} else {
+				add_action( 'rest_api_init', array( $this, 'initialize_rest_api_registration_connector' ) );
 			}
 		}
 
@@ -728,6 +734,10 @@ class Jetpack {
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
 		}
+	}
+
+	function initialize_rest_api_registration_connector() {
+		new REST_Connector( $this->connection_manager );
 	}
 
 	/**

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Connection\Manager_Interface;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Tracking\Manager as JetpackTracking;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
@@ -229,9 +230,122 @@ class Manager implements Manager_Interface {
 	/**
 	 * Responds to a WordPress.com call to register the current site.
 	 * Should be changed to protected.
+	 *
+	 * @param array $registration_data Array of [ secret_1, user_id ].
 	 */
-	public function handle_registration() {
+	public function handle_registration( array $registration_data ) {
+		list( $registration_secret_1, $registration_user_id ) = $registration_data;
+		if ( empty( $registration_user_id ) ) {
+			return new \WP_Error( 'registration_state_invalid', __( 'Invalid Registration State', 'jetpack' ), 400 );
+		}
 
+		return $this->verify_secrets( 'register', $registration_secret_1, (int) $registration_user_id );
+	}
+
+	/**
+	 * Verify a Previously Generated Secret.
+	 *
+	 * @param string $action   The type of secret to verify.
+	 * @param string $secret_1 The secret string to compare to what is stored.
+	 * @param int    $user_id  The user ID of the owner of the secret.
+	 */
+	protected function verify_secrets( $action, $secret_1, $user_id ) {
+		$allowed_actions = array( 'register', 'authorize', 'publicize' );
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return new \WP_Error( 'unknown_verification_action', 'Unknown Verification Action', 400 );
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		JetpackTracking::record_user_event( "jpc_verify_{$action}_begin", array(), $user );
+
+		$return_error = function( \WP_Error $error ) use ( $action, $user ) {
+			JetpackTracking::record_user_event(
+				"jpc_verify_{$action}_fail",
+				array(
+					'error_code'    => $error->get_error_code(),
+					'error_message' => $error->get_error_message(),
+				),
+				$user
+			);
+
+			return $error;
+		};
+
+		$stored_secrets = $this->get_secrets( $action, $user_id );
+		$this->delete_secrets( $action, $user_id );
+
+		if ( empty( $secret_1 ) ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secret_1_missing',
+					/* translators: "%s" is the name of a paramter. It can be either "secret_1" or "state". */
+					sprintf( __( 'The required "%s" parameter is missing.', 'jetpack' ), 'secret_1' ),
+					400
+				)
+			);
+		} elseif ( ! is_string( $secret_1 ) ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secret_1_malformed',
+					/* translators: "%s" is the name of a paramter. It can be either "secret_1" or "state". */
+					sprintf( __( 'The required "%s" parameter is malformed.', 'jetpack' ), 'secret_1' ),
+					400
+				)
+			);
+		} elseif ( empty( $user_id ) ) {
+			// $user_id is passed around during registration as "state".
+			return $return_error(
+				new \WP_Error(
+					'state_missing',
+					/* translators: "%s" is the name of a paramter. It can be either "secret_1" or "state". */
+					sprintf( __( 'The required "%s" parameter is missing.', 'jetpack' ), 'state' ),
+					400
+				)
+			);
+		} elseif ( ! ctype_digit( (string) $user_id ) ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secret_1_malformed',
+					/* translators: "%s" is the name of a paramter. It can be either "secret_1" or "state". */
+					sprintf( __( 'The required "%s" parameter is malformed.', 'jetpack' ), 'state' ),
+					400
+				)
+			);
+		}
+
+		if ( ! $stored_secrets ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secrets_missing',
+					__( 'Verification secrets not found', 'jetpack' ),
+					400
+				)
+			);
+		} elseif ( is_wp_error( $stored_secrets ) ) {
+			$stored_secrets->add_data( 400 );
+			return $return_error( $stored_secrets );
+		} elseif ( empty( $stored_secrets['secret_1'] ) || empty( $stored_secrets['secret_2'] ) || empty( $stored_secrets['exp'] ) ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secrets_incomplete',
+					__( 'Verification secrets are incomplete', 'jetpack' ),
+					400
+				)
+			);
+		} elseif ( ! hash_equals( $secret_1, $stored_secrets['secret_1'] ) ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secrets_mismatch',
+					__( 'Secret mismatch', 'jetpack' ),
+					400
+				)
+			);
+		}
+
+		JetpackTracking::record_user_event( "jpc_verify_{$action}_success", array(), $user );
+
+		return $stored_secrets['secret_2'];
 	}
 
 	/**
@@ -267,11 +381,13 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
-	 * @param $text
+	 * The Base64 Encoding of the SHA1 Hash of the Input.
+	 *
+	 * @param string $text The string to hash.
 	 * @return string
 	 */
-	function sha1_base64( $text ) {
-		return base64_encode( sha1( $text, true ) );
+	public function sha1_base64( $text ) {
+		return base64_encode( sha1( $text, true ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	/**
@@ -285,7 +401,7 @@ class Manager implements Manager_Interface {
 
 		// If it's empty, just fail out.
 		if ( ! $domain ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'fail_domain_empty',
 				/* translators: %1$s is a domain name. */
 				sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', 'jetpack' ), $domain )
@@ -317,7 +433,7 @@ class Manager implements Manager_Interface {
 			'build.wordpress-develop.test', // VVV pattern.
 		);
 		if ( in_array( $domain, $forbidden_domains, true ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'fail_domain_forbidden',
 				sprintf(
 					/* translators: %1$s is a domain name. */
@@ -332,7 +448,7 @@ class Manager implements Manager_Interface {
 
 		// No .test or .local domains.
 		if ( preg_match( '#\.(test|local)$#i', $domain ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'fail_domain_tld',
 				sprintf(
 					/* translators: %1$s is a domain name. */
@@ -347,7 +463,7 @@ class Manager implements Manager_Interface {
 
 		// No WPCOM subdomains.
 		if ( preg_match( '#\.WordPress\.com$#i', $domain ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'fail_subdomain_wpcom',
 				sprintf(
 					/* translators: %1$s is a domain name. */
@@ -434,7 +550,7 @@ class Manager implements Manager_Interface {
 			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
 				return false;
 			}
-			if ( $user_id != $user_token_chunks[2] ) {
+			if ( $user_token_chunks[2] !== (string) $user_id ) {
 				return false;
 			}
 			$possible_normal_tokens[] = "{$user_token_chunks[0]}.{$user_token_chunks[1]}";

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -112,8 +112,10 @@ interface Manager_Interface {
 	/**
 	 * Responds to a WordPress.com call to register the current site.
 	 * Should be changed to protected.
+	 *
+	 * @param array $registration_data Array of [ secret_1, user_id ].
 	 */
-	public function handle_registration();
+	public function handle_registration( array $registration_data );
 
 	/**
 	 * Responds to a WordPress.com call to authorize the current user.

--- a/packages/connection/src/REST_Connector.php
+++ b/packages/connection/src/REST_Connector.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Sets up the Connection REST API endpoints.
+ *
+ * @package jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * Registers the REST routes for Connections.
+ */
+class REST_Connector {
+	/**
+	 * The Connection Manager.
+	 *
+	 * @var Manager
+	 */
+	private $connection;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Manager $connection The Connection Manager.
+	 */
+	public function __construct( Manager $connection ) {
+		$this->connection = $connection;
+
+		// Register a site.
+		register_rest_route(
+			'jetpack/v4',
+			'/verify_registration',
+			array(
+				'methods'  => \WP_REST_Server::EDITABLE,
+				'callback' => array( $this, 'verify_registration' ),
+			)
+		);
+	}
+
+	/**
+	 * Handles verification that a site is registered.
+	 *
+	 * @since 5.4.0
+	 *
+	 * @param \WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return string|WP_Error
+	 */
+	public function verify_registration( \WP_REST_Request $request ) {
+		$registration_data = array( $request['secret_1'], $request['state'] );
+
+		return $this->connection->handle_registration( $registration_data );
+	}
+}

--- a/packages/connection/src/XMLRPC_Connector.php
+++ b/packages/connection/src/XMLRPC_Connector.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Sets up the Connection XML-RPC methods.
+ *
+ * @package jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * Registers the XML-RPC methods for Connections.
+ */
+class XMLRPC_Connector {
+	/**
+	 * The Connection Manager.
+	 *
+	 * @var Manager
+	 */
+	private $connection;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Manager $connection The Connection Manager.
+	 */
+	public function __construct( Manager $connection ) {
+		$this->connection = $connection;
+
+		add_filter( 'xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
+	}
+
+	/**
+	 * Attached to the `xmlrpc_methods` filter.
+	 *
+	 * @param array $methods The already registered XML-RPC methods.
+	 * @return array
+	 */
+	public function xmlrpc_methods( $methods ) {
+		return array_merge(
+			$methods,
+			array(
+				'jetpack.verifyRegistration' => array( $this, 'verify_registration' ),
+			)
+		);
+	}
+
+	/**
+	 * Handles verification that a site is registered.
+	 *
+	 * @param array $registration_data The data sent by the XML-RPC client:
+	 *                                 [ $secret_1, $user_id ].
+	 *
+	 * @return string|IXR_Error
+	 */
+	public function verify_registration( $registration_data ) {
+		return $this->output( $this->connection->handle_registration( $registration_data ) );
+	}
+
+	/**
+	 * Normalizes output for XML-RPC.
+	 *
+	 * @param mixed $data The data to output.
+	 */
+	private function output( $data ) {
+		if ( is_wp_error( $data ) ) {
+			$code = $data->get_error_data();
+			if ( ! $code ) {
+				$code = -10520;
+			}
+
+			return new \IXR_Error(
+				$code,
+				sprintf( 'Jetpack: [%s] %s', $data->get_error_code(), $data->get_error_message() )
+			);
+		}
+
+		return $data;
+	}
+}


### PR DESCRIPTION
The connectors work should have been merged into `master` instead of the feature branch, so this PR brings the changes into `master`. The original PR is #12630.

> Pull the site registration API methods/endpoints out into their own connector classes: one for XML-RPC, one for REST.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds connectors as separate classes for connection purposes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure you can connect/disconnect your Jetpack site using this version.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A