### PR TITLE
Renovate: Disable not scheduled PR updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
 	"prHourlyLimit": 1,
 	"supportPolicy": [ "lts_latest" ],
 	"timezone": "UTC",
-	"schedule": [ "every weekend" ]
+	"schedule": [ "every weekend" ],
+	"updateNotScheduled": false
 }


### PR DESCRIPTION
The follow-up to #12650 which added scheduled PR creations, but it does not affect existing PR updates. This PR addresses that

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just hope it will work
* maybe check the docs: https://renovatebot.com/docs/configuration-options/#updatenotscheduled

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
