### PR TITLE
Travis CI: Run packages CI tests in same job as core tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ env:
   - WP_TRAVISCI=phpunit
   # Run phpunit in Travis matrix for these combinations
   matrix:
-  - WP_MODE=single WP_BRANCH=master   SCOPE=full PHP_LINT=1
-  - WP_MODE=single WP_BRANCH=latest   SCOPE=full
-  - WP_MODE=single WP_BRANCH=previous SCOPE=full
-  - WP_MODE=multi  WP_BRANCH=master   SCOPE=full
-  - SCOPE=packages
+  - WP_MODE=single WP_BRANCH=master PHP_LINT=1
+  - WP_MODE=single WP_BRANCH=latest
+  - WP_MODE=single WP_BRANCH=previous
+  - WP_MODE=multi  WP_BRANCH=master
 
 # Define a matrix of additional build configurations
 # The versions listed above will automatically create our first configuration,

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -14,11 +14,6 @@ elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
 	composer global require "phpunit/phpunit=4.8.*" --no-suggest
 fi
 
-# If testing packages we don't need a developer WordPress checkout
-if [ "$SCOPE" == "packages" ]; then
-	exit 0;
-fi
-
 mysql -e "set global wait_timeout = 3600;"
 
 # Prepare a developer checkout of WordPress


### PR DESCRIPTION
This should free up a few containers that can be used by other PRs/jobs

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved Packages tests into old, "core" unit-test jobs

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check Travis, make sure both package tests & jetpack unit tests still runs
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
