### PR TITLE
Ads Ads.txt: Add "Check here for more details" link

### DIFF
--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -206,11 +206,19 @@ export const Ads = withModuleSettingsFormHelpers(
 								<p>
 									{ isAdsActive &&
 										__(
-											'Jetpack automatically generates a custom {{link}}ads.txt{{/link}} tailored for your site. ' +
-												'If you need to add additional entries for other networks please add them in the space below, one per line.',
+											'Jetpack automatically generates a custom {{link1}}ads.txt{{/link1}} tailored for your site. ' +
+												'If you need to add additional entries for other networks please add them in the space below, one per line. ' +
+												'{{link2}}Check here for more details{{/link2}}.',
 											{
 												components: {
-													link: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
+													link1: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
+													link2: (
+														<a
+															href="https://jetpack.com/2018/11/09/how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt/"
+															target="_blank"
+															rel="noopener noreferrer"
+														/>
+													),
 												},
 											}
 										) }


### PR DESCRIPTION
Adding a link to a little more helpful info re: ads.txt and custom entries. Links to:

https://jetpack.com/2018/11/09/how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt/

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added link with more details about custom ads.txt entries

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds link to additional details.

#### Testing instructions:
* Build branch `yarn build`
* Activate Jetpack Ads module in Settings -> Traffic
* You should see "Check here for more details." link.

<img width="1055" alt="Screen Shot 2019-06-11 at 2 37 01 PM" src="https://user-images.githubusercontent.com/273708/59308636-67ea5f80-8c56-11e9-9715-baf35d52f604.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Additional details for custom ads.txt entries.
