### PR TITLE
Ads: Update earnings link to daily earnings.

### DIFF
--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -80,7 +80,7 @@ export class Traffic extends React.Component {
 				{ foundAds && (
 					<Ads
 						{ ...commonProps }
-						configureUrl={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl }
+						configureUrl={ 'https://wordpress.com/stats/ads/day/' + this.props.siteRawUrl }
 					/>
 				) }
 				{ foundRelated && (


### PR DESCRIPTION
Update earnings link on Ads module to the new daily earnings page in Stats.

<img width="445" alt="Screen Shot 2019-06-11 at 4 34 00 PM" src="https://user-images.githubusercontent.com/273708/59313651-c0295d80-8c66-11e9-9284-560b479c3a8d.png">

<img width="1415" alt="Screen Shot 2019-06-11 at 4 33 41 PM" src="https://user-images.githubusercontent.com/273708/59313658-c3bce480-8c66-11e9-803c-9eaa5e5c77ec.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updated `View Your Earnings` link to daily stats.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updated `View Your Earnings` link.

#### Testing instructions:
* Build branch `yarn build`
* Activate Jetpack Ads module in Settings -> Traffic
* View your earnings link should go to https://wordpress.com/stats/ads/day/<site>

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Updated earnings link to new daily stats page.