### PR TITLE
Tests: Run PHP lint once per PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - WP_TRAVISCI=phpunit
   # Run phpunit in Travis matrix for these combinations
   matrix:
-  - WP_MODE=single WP_BRANCH=master   SCOPE=full
+  - WP_MODE=single WP_BRANCH=master   SCOPE=full PHP_LINT=1
   - WP_MODE=single WP_BRANCH=latest   SCOPE=full
   - WP_MODE=single WP_BRANCH=previous SCOPE=full
   - WP_MODE=multi  WP_BRANCH=master   SCOPE=full

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -8,6 +8,10 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 	 * @group lint
 	 */
 	public function test_php_lint() {
+		if ( ! getenv( 'PHP_LINT' ) ) {
+			$this->markTestSkipped( 'We only need to run PHP lint tests once for each PHP version.' );
+		}
+
 		$exclude_paths = array(
 			'./docker',
 			'./tools',


### PR DESCRIPTION
The PHP lint test often takes over 10 seconds to complete in CI. While it's useful, we only need to run it once per PHP version, so that's what this PR aims. By doing this, some jobs should run between 10s and 15s quicker, which will result in slightly faster builds.

#### Changes proposed in this Pull Request:
* Run PHP lint once per PHP version

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Observe the Travis CI build and its jobs and verify this works well:
  * Build matrix should have one job per PHP version with `PHP_LINT` enabled.
  * Look at the phpunit reports for slow tests at the end and confirm `WP_Test_Jetpack_PHP_Lint:test_php_lint` is/isn't there:
    * Jobs with `PHP_LINT=1` include the lint test `WP_Test_Jetpack_PHP_Lint:test_php_lint`
    * Jobs without `PHP_LINT=1` don't include the lint test `WP_Test_Jetpack_PHP_Lint:test_php_lint`

#### Proposed changelog entry for your changes:
* Run PHP lint once per PHP version
