### PR TITLE
Moves multisite builds to master branch piggyback-mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ env:
   - WP_TRAVISCI=phpunit
   # Run phpunit in Travis matrix for these combinations
   matrix:
-  - WP_MODE=single WP_BRANCH=master PHP_LINT=1
-  - WP_MODE=single WP_BRANCH=latest
-  - WP_MODE=single WP_BRANCH=previous
-  - WP_MODE=multi  WP_BRANCH=master
+  - WP_BRANCH=master PHP_LINT=1
+  - WP_BRANCH=latest
+  - WP_BRANCH=previous
 
 # Define a matrix of additional build configurations
 # The versions listed above will automatically create our first configuration,

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -36,15 +36,16 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
 	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"
-	echo " - WordPress mode: $WP_MODE"
 	echo " - WordPress branch: $WP_BRANCH"
+	if [ "$WP_BRANCH" == "master" ]; then
+		echo " - Because WordPress is in master branch, will also attempt to test multisite."
+	fi
 
 	# WP_BRANCH = master | latest | previous
 	cd "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG"
 
-	# WP_MODE = single | multi
-	if [ "$WP_MODE" == "multi" ]; then
-		# Test multi WP
+	if [ "$WP_BRANCH" == "master" ]; then
+		# Test multi WP in addition to single, but only in master branch mode.
 		if WP_MULTISITE=1 $WP_TRAVISCI -c tests/php.multisite.xml; then
 			# Everything is fine
 			:
@@ -52,15 +53,16 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 			exit 1
 		fi
 		:
-	else
-		# Test single WP
-		if $WP_TRAVISCI; then
-			# Everything is fine
-			:
-		else
-			exit 1
-		fi
 	fi
+
+	# Test single WP
+	if $WP_TRAVISCI; then
+		# Everything is fine
+		:
+	else
+		exit 1
+	fi
+
 else
 	# Run linter/tests
 	if $WP_TRAVISCI; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -25,7 +25,11 @@ echo "Travis CI command: $WP_TRAVISCI"
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
-	run_packages_tests
+	# Run package tests only for the latest WordPress branch, because the
+	# tests are independent of the version.
+	if [ "latest" == "$WP_BRANCH" ]; then
+		run_packages_tests
+	fi
 
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -37,7 +41,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	echo "Running \`$WP_TRAVISCI\` with:"
 	echo " - $(phpunit --version)"
 	echo " - WordPress branch: $WP_BRANCH"
-	if [ "$WP_BRANCH" == "master" ]; then
+	if [ "master" == "$WP_BRANCH" ]; then
 		echo " - Because WordPress is in master branch, will also attempt to test multisite."
 	fi
 


### PR DESCRIPTION
Before we've had multisite builds running separately, which was causing some overhead when creating build containers. This attempts to use the same code twice by running the multisite suite before the single site one, reducing the matrix by four containers.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes a problem with too many build containers blocking other builds.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved multisite builds into master builds.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a janitorial fix.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure Travis builds pass.
* Open any `WP_BRANCH=master` build and see that there are two sets of tests - multisite and single site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
