### PR TITLE
Travis CI: give names to Node.js based jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,15 @@ env:
 matrix:
   include:
   - if: branch !~ /(^branch-.*-built)/
+    name: "JavaScript & CSS lint"
     language: node_js
     env: WP_TRAVISCI="yarn lint"
   - if: branch !~ /(^branch-.*-built)/
+    name: "Danger CI, test dashboard & extensions"
     language: node_js
     env: WP_TRAVISCI="yarn test-dangerci-and-adminpage-and-extensions"
   - if: branch !~ /(^branch-.*-built)/
+    name: "Build dashboard & extensions"
     language: node_js
     env: WP_TRAVISCI="yarn build"
   - php: "7.3"


### PR DESCRIPTION
Give names to Node.js based jobs in Travis CI.

Just makes it easier for newcomers to Jetpack to see what exactly is failing.

I was actually hoping to still see the constants (`WP_TRAVIS_CI=...`) just to make it easier for folks developing this file, I'm not sure if this tradeoff between "more clarity for devs" vs "less clarity for Travis maintainers" is good. It's a quick look at Travis config to see which is what command tho, so might be non-issue. Thoughts?

https://docs.travis-ci.com/user/customizing-the-build/#naming-jobs-within-matrices

#### Before

<img width="907" alt="image" src="https://user-images.githubusercontent.com/87168/59342615-c70daa00-8d12-11e9-83d7-de253af544db.png">

#### After

<img width="895" alt="image" src="https://user-images.githubusercontent.com/87168/59342623-cbd25e00-8d12-11e9-9190-f243ad9f4051.png">



#### Changes proposed in this Pull Request:
* Add `name` to `includes` jobs in matrix

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

#### Testing instructions:
See Travis