### PR TITLE
Connection package: Implement is_active method

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -51,7 +51,7 @@ class Manager implements Manager_Interface {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		return false;
+		return (bool) $this->get_access_token( self::JETPACK_MASTER_USER );
 	}
 
 	/**

--- a/packages/connection/tests/php/Manager.php
+++ b/packages/connection/tests/php/Manager.php
@@ -2,14 +2,47 @@
 
 namespace Automattic\Jetpack\Connection;
 
-use phpmock\functions\FunctionProvider;
-use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
 
 class ManagerTest extends TestCase {
+	public function setUp() {
+		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+		                      ->setMethods( [ 'get_access_token' ] )
+		                      ->getMock();
+	}
+
+	public function tearDown() {
+		unset( $this->manager );
+	}
 
 	function test_class_implements_interface() {
 		$manager = new Manager();
 		$this->assertInstanceOf( 'Automattic\Jetpack\Connection\Manager_Interface', $manager );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 */
+	public function test_is_active_when_connected() {
+		$access_token = (object) [
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		];
+		$this->manager->expects( $this->once() )
+		              ->method( 'get_access_token' )
+		              ->will( $this->returnValue( $access_token ) );
+
+		$this->assertTrue( $this->manager->is_active() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 */
+	public function test_is_active_when_not_connected() {
+		$this->manager->expects( $this->once() )
+		              ->method( 'get_access_token' )
+		              ->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $this->manager->is_active() );
 	}
 }


### PR DESCRIPTION
This PR implements the `is_active()` method in the connection package, which is essentially a port of `Jetpack::is_active()`. Also, adds a couple of tests for it.

#### Changes proposed in this Pull Request:
* Implement `Automattic\Jetpack\Connection\Manager::is_active`
* Add tests for `Automattic\Jetpack\Connection\Manager::is_active`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Verify tests pass.

#### Proposed changelog entry for your changes:
* Implement `Automattic\Jetpack\Connection\Manager::is_active`
