### PR TITLE
Sync: Migrate `Jetpack::is_active` to `Connection_Manager::is_active`

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -553,6 +553,7 @@ class Jetpack {
 		} );
 
 		$this->connection_manager = new Connection_Manager( );
+		Jetpack_Sync_Main::init()->set_connection_manager( $this->connection_manager );
 
 		/**
 		 * Prepare Gutenberg Editor functionality

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -347,6 +347,11 @@ class Jetpack {
 	protected $connection_manager;
 
 	/**
+	 * @var \Jetpack_Sync_Main
+	 */
+	protected $sync_main;
+
+	/**
 	 * @var string Transient key used to prevent multiple simultaneous plugin upgrades
 	 */
 	public static $plugin_upgrade_lock_key = 'jetpack_upgrade_lock';
@@ -553,7 +558,7 @@ class Jetpack {
 		} );
 
 		$this->connection_manager = new Connection_Manager( );
-		Jetpack_Sync_Main::init()->set_connection_manager( $this->connection_manager );
+		$this->sync_main = new Jetpack_Sync_Main( $this->connection_manager );
 
 		/**
 		 * Prepare Gutenberg Editor functionality

--- a/jetpack.php
+++ b/jetpack.php
@@ -235,8 +235,6 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php'          );
 
-Jetpack_Sync_Main::init();
-
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php' );

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -4,6 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev"
 	},
@@ -11,5 +12,13 @@
 		"classmap": [
 			"/legacy"
 		]
-	}
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 
 /**
@@ -113,7 +114,9 @@ class Jetpack_Sync_Actions {
 		if ( Jetpack::is_staging_site() ) {
 			return false;
 		}
-		if ( ! Jetpack::is_active() ) {
+
+		$connection_manager = new Connection_Manager();
+		if ( ! $connection_manager->is_active() ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;
 			}

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -15,7 +15,7 @@ class Jetpack_Sync_Actions {
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME  = 'jetpack_sync_interval';
 	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * MINUTE_IN_SECONDS;
 
-	static function init() {
+	public function __construct( Connection_Manager $connection ) {
 		// everything below this point should only happen if we're a valid sync site
 		if ( ! self::sync_allowed() ) {
 			return;
@@ -30,7 +30,7 @@ class Jetpack_Sync_Actions {
 		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 
 		// Sync connected user role changes to .com
-		Jetpack_Sync_Users::init();
+		new Jetpack_Sync_Users( $connection );
 
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -115,7 +115,7 @@ class Jetpack_Sync_Actions {
 			return false;
 		}
 
-		$connection_manager = new Connection_Manager();
+		$connection_manager = Jetpack_Sync_Main::init()->get_connection_manager();
 		if ( ! $connection_manager->is_active() ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;

--- a/packages/sync/legacy/class.jetpack-sync-listener.php
+++ b/packages/sync/legacy/class.jetpack-sync-listener.php
@@ -25,7 +25,6 @@ class Jetpack_Sync_Listener {
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	protected function __construct() {
-		Jetpack_Sync_Main::init();
 		$this->set_defaults();
 		$this->init();
 	}

--- a/packages/sync/legacy/class.jetpack-sync-main.php
+++ b/packages/sync/legacy/class.jetpack-sync-main.php
@@ -5,14 +5,48 @@
  * @package jetpack-sync
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 /**
  * Jetpack Sync main class.
  */
 class Jetpack_Sync_Main {
 	/**
-	 * Initialize the main sync actions.
+	 * Holds the singleton instance of this class.
+	 *
+	 * @var Jetpack_Sync_Main
+	 */
+	private static $instance;
+
+	/**
+	 * The connection manager object.
+	 *
+	 * @var Connection_Manager
+	 */
+	private $connection_manager;
+
+	/**
+	 * Singleton initializator.
+	 *
+	 * @static
+	 * @access public
+	 *
+	 * @return Jetpack_Sync_Main The singleton instance of this class.
 	 */
 	public static function init() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor. Initializes the main sync hooks.
+	 *
+	 * @access private
+	 */
+	private function __construct() {
 		// Check for WooCommerce support.
 		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
 
@@ -28,5 +62,23 @@ class Jetpack_Sync_Main {
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ), 10, 2 );
 		add_action( 'jetpack_user_authorized', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 0 );
+	}
+
+	/**
+	 * Set the connection manager object.
+	 *
+	 * @param Connection_Manager $connection_manager The connection manager object.
+	 */
+	public function set_connection_manager( Connection_Manager $connection_manager ) {
+		$this->connection_manager = $connection_manager;
+	}
+
+	/**
+	 * Set the connection manager object.
+	 *
+	 * @return Connection_Manager $connection_manager The connection manager object.
+	 */
+	public function get_connection_manager() {
+		return $this->connection_manager;
 	}
 }

--- a/packages/sync/legacy/class.jetpack-sync-main.php
+++ b/packages/sync/legacy/class.jetpack-sync-main.php
@@ -11,12 +11,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
  * Jetpack Sync main class.
  */
 class Jetpack_Sync_Main {
-	/**
-	 * Holds the singleton instance of this class.
-	 *
-	 * @var Jetpack_Sync_Main
-	 */
-	private static $instance;
 
 	/**
 	 * The connection manager object.
@@ -26,27 +20,13 @@ class Jetpack_Sync_Main {
 	private $connection_manager;
 
 	/**
-	 * Singleton initializator.
-	 *
-	 * @static
-	 * @access public
-	 *
-	 * @return Jetpack_Sync_Main The singleton instance of this class.
-	 */
-	public static function init() {
-		if ( ! self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
 	 * Constructor. Initializes the main sync hooks.
 	 *
 	 * @access private
 	 */
-	private function __construct() {
+	public function __construct( Connection_Manager $connection ) {
+		$this->connection_manager = $connection;
+
 		// Check for WooCommerce support.
 		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
 
@@ -57,20 +37,15 @@ class Jetpack_Sync_Main {
 		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
 		 * with a high priority or sites that use alternate cron.
 		 */
-		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+		add_action( 'plugins_loaded', array( $this, 'initialize_actions' ), 90 );
 
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ), 10, 2 );
 		add_action( 'jetpack_user_authorized', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 0 );
 	}
 
-	/**
-	 * Set the connection manager object.
-	 *
-	 * @param Connection_Manager $connection_manager The connection manager object.
-	 */
-	public function set_connection_manager( Connection_Manager $connection_manager ) {
-		$this->connection_manager = $connection_manager;
+	public function initialize_actions() {
+		new Jetpack_Sync_Actions( $this->connection_manager );
 	}
 
 	/**

--- a/packages/sync/legacy/class.jetpack-sync-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-users.php
@@ -10,9 +10,8 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 class Jetpack_Sync_Users {
 	static $user_roles = array();
 
-	static function init() {
-		$connection_manager = Jetpack_Sync_Main::init()->get_connection_manager();
-		if ( $connection_manager->is_active() ) {
+	public function __construct( Connection_Manager $connection ) {
+		if ( $connection->is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}

--- a/packages/sync/legacy/class.jetpack-sync-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-users.php
@@ -11,7 +11,7 @@ class Jetpack_Sync_Users {
 	static $user_roles = array();
 
 	static function init() {
-		$connection_manager = new Connection_Manager();
+		$connection_manager = Jetpack_Sync_Main::init()->get_connection_manager();
 		if ( $connection_manager->is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );

--- a/packages/sync/legacy/class.jetpack-sync-users.php
+++ b/packages/sync/legacy/class.jetpack-sync-users.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 /**
  * Class Jetpack_Sync_Users
  *
@@ -9,7 +11,8 @@ class Jetpack_Sync_Users {
 	static $user_roles = array();
 
 	static function init() {
-		if ( Jetpack::is_active() ) {
+		$connection_manager = new Connection_Manager();
+		if ( $connection_manager->is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,7 +1,5 @@
 <?php
 
-Jetpack_Sync_Main::init();
-
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 
 require_once $sync_server_dir . 'class.jetpack-sync-test-replicastore.php';


### PR DESCRIPTION
This PR updates `Jetpack::is_active` to `Connection_Manager::is_active` in the sync package. The idea is that we'd like to decouple the packages from the plugin, so that's a small step towards that.

#### Changes proposed in this Pull Request:
* Port `Jetpack_Sync_Main` to a singleton as a main sync entry point.
* Add the `connection` package as a dependency to the `sync` package.
* Implement dependency injection of connection manager inside the sync main instance.
* Migrate `Jetpack::is_active` to `Connection_Manager::is_active` in the Sync package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* Smoke test sync (full and incremental)
* Verify tests pass.

#### Proposed changelog entry for your changes:
* Migrate `Jetpack::is_active` to `Connection_Manager::is_active` in the Sync package.