### PR TITLE
Autoloader: Ignore Jetpack_Signature if called too early

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -73,7 +73,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 
 		if ( isset( $jetpack_packages_classes[ $class_name ] ) ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// TODO ideally we shouldn't skip any of these, see: https://github.com/Automattic/jetpack/pull/12646
+				// TODO ideally we shouldn't skip any of these, see: https://github.com/Automattic/jetpack/pull/12646.
 				$ignore = in_array(
 					$class_name,
 					array(
@@ -81,6 +81,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Connection\Manager',
 						'Automattic\Jetpack\Connection\Manager_Interface',
 						'Jetpack_Options',
+						'Jetpack_Signature',
 						'Jetpack_Sync_Main',
 						'Automattic\Jetpack\Constants',
 					),


### PR DESCRIPTION
Currently, we're getting a bunch of these notices:

```
PHP Notice:  Jetpack_Signature was called <strong>incorrectly</strong>.
Not all plugins have loaded yet but we requested the class Jetpack_Signature Please see
<a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a>
for more information.
(This message was added in version 0.1.) in /var/www/html/wp-includes/functions.php
on line 4773
```

That's because we missed to ignore the `Jetpack_Signature` class from being reported as a too early called one in our autoloader. 

This PR fixes that by adding that class to the ignore list.

#### Changes proposed in this Pull Request:
* Autoloader: Ignore Jetpack_Signature if called too early

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* Run `composer install` or `composer dump-autoload` in the root of Jetpack.
* Expose the site publicly (using ngrok or something).
* Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
* Make sure site's connected.
* Trigger a full sync.
* Verify there are no more of these notices.

#### Proposed changelog entry for your changes:
* Autoloader: Ignore Jetpack_Signature if called too early