### PR TITLE
Autoloader: Ignore XMLRPC_Connector if called too early

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -80,6 +80,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\JITM',
 						'Automattic\Jetpack\Connection\Manager',
 						'Automattic\Jetpack\Connection\Manager_Interface',
+						'Automattic\Jetpack\Connection\XMLRPC_Connector',
 						'Jetpack_Options',
 						'Jetpack_Signature',
 						'Jetpack_Sync_Main',


### PR DESCRIPTION
Currently, we're getting a notice when attempting to connect:

```
PHP Notice:  Automattic\Jetpack\Connection\XMLRPC_Connector was called <strong>incorrectly</strong>.
Not all plugins have loaded yet but we requested the class  Automattic\Jetpack\Connection\XMLRPC_Connector Please see
<a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a>
for more information.
(This message was added in version 9999999-dev.) in /var/www/html/wp-includes/functions.php
on line 4773
```

That's because we missed to ignore the `Automattic\Jetpack\Connection\XMLRPC_Connector` class from being reported as a too early called one in our autoloader. 

This PR fixes that by adding that class to the ignore list.

#### Changes proposed in this Pull Request:
* Autoloader: Ignore Automattic\Jetpack\Connection\XMLRPC_Connector if called too early

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* Run `composer install` or `composer dump-autoload` in the root of Jetpack.
* Expose the site publicly (using ngrok or something).
* Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
* Connect the site.
* Verify there are no more of these notices.

#### Proposed changelog entry for your changes:
* Autoloader: Ignore Automattic\Jetpack\Connection\XMLRPC_Connector if called too early