### PR TITLE
Fix/autoplay vimeo embeds

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -6,6 +6,8 @@
  * [vimeo 141358]
  * [vimeo http://vimeo.com/141358]
  * [vimeo 141358 h=500&w=350]
+ * [vimeo 141358 muted=1&autoplay=1]
+ * [vimeo 18427511 background=1&muted=1&autoplay=1]
  * [vimeo id=141358 width=350 height=500]
  *
  * <iframe src="http://player.vimeo.com/video/18427511" width="400" height="225" frameborder="0"></iframe><p><a href="http://vimeo.com/18427511">Eskmo 'We Got More' (Official Video)</a> from <a href="http://vimeo.com/ninjatune">Ninja Tune</a> on <a href="http://vimeo.com">Vimeo</a>.</p>

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -50,11 +50,13 @@ function vimeo_shortcode( $atts ) {
 		'intval',
 		shortcode_atts(
 			array(
-				'id'       => 0,
-				'width'    => 0,
-				'height'   => 0,
-				'autoplay' => 0,
-				'loop'     => 0,
+				'id'         => 0,
+				'width'      => 0,
+				'height'     => 0,
+				'autoplay'   => 0,
+				'loop'       => 0,
+				'background' => 0,
+				'muted'      => 0,
 			),
 			$atts
 		)
@@ -147,6 +149,22 @@ function vimeo_shortcode( $atts ) {
 		|| in_array( 'loop', $atts, true )              // Catch the argument passed without a value.
 	) {
 		$url = add_query_arg( 'loop', 1, $url );
+	}
+
+	if (
+		isset( $args['background'] ) && '1' === $args['background'] // Parsed from the embedded URL.
+		|| $attr['background']                                    // Parsed from shortcode arguments.
+		|| in_array( 'background', $atts )                        // Catch the argument passed without a value.
+	) {
+		$url = add_query_arg( 'background', 1, $url );
+	}
+
+	if (
+		isset( $args['muted'] ) && '1' === $args['muted'] // Parsed from the embedded URL.
+		|| $attr['muted']                                    // Parsed from shortcode arguments.
+		|| in_array( 'muted', $atts )                        // Catch the argument passed without a value.
+	) {
+		$url = add_query_arg( 'muted', 1, $url );
 	}
 
 	$html = sprintf(

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -7,7 +7,7 @@
  * [vimeo http://vimeo.com/141358]
  * [vimeo 141358 h=500&w=350]
  * [vimeo 141358 muted=1&autoplay=1]
- * [vimeo 18427511 background=1&muted=1&autoplay=1]
+ * [vimeo 18427511 background=1]
  * [vimeo id=141358 width=350 height=500]
  *
  * <iframe src="http://player.vimeo.com/video/18427511" width="400" height="225" frameborder="0"></iframe><p><a href="http://vimeo.com/18427511">Eskmo 'We Got More' (Official Video)</a> from <a href="http://vimeo.com/ninjatune">Ninja Tune</a> on <a href="http://vimeo.com">Vimeo</a>.</p>


### PR DESCRIPTION
Provide additional attributes to [support background and muted autoplay for Vimeo embeds that support that customization](https://bit.ly/2F4BSYg).

#### Changes proposed in this Pull Request:

This PR adds functionality to the Vimeo embed shortcode feature — specifically adds support for `muted` and `background` attributes for muted playback, and chromeless playback (for video embeds that support that customization).

#### Testing instructions:
Try any of the shortcodes below:
* `[vimeo 141358 muted=1&autoplay=1]` | autoplay & muted playback
* `[vimeo 18427511 background=1]` | autoplay & muted playback on a chromeless player

#### Proposed changelog entry for your changes:

* Add `background` attribute for Vimeo embeds that support them.

#### Notes
This is my first PR here! As far as I could tell, this doesn't close any existing issues. Can someone add the WIP label to this PR for me? 😄 
