### PR TITLE
Gutenberg v5.9.x and Contact Form Block Support

### DIFF
--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -69,7 +69,7 @@ export const settings = {
 	},
 
 	edit: JetpackContactForm,
-	save: function() { return ( <InnerBlocks.Content /> ); },
+	save: () => <InnerBlocks.Content />,
 	deprecated: [
 		{
 			attributes: {
@@ -107,7 +107,7 @@ export const settings = {
 				return true;
 			},
 
-			save: function() { return ( <InnerBlocks.Content /> ); },
+			save: () => <InnerBlocks.Content />,
 		},
 	],
 };

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -69,7 +69,7 @@ export const settings = {
 	},
 
 	edit: JetpackContactForm,
-	save: InnerBlocks.Content,
+	save: function() { return ( <InnerBlocks.Content /> ); },
 	deprecated: [
 		{
 			attributes: {
@@ -107,7 +107,7 @@ export const settings = {
 				return true;
 			},
 
-			save: InnerBlocks.Content,
+			save: function() { return ( <InnerBlocks.Content /> ); },
 		},
 	],
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When using Gutenberg v5.9.0, the Jetpack contact form is not available. Existing blocks display the following in the editor:

<img width="801" alt="Screen Shot 2019-06-12 at 3 11 48 PM" src="https://user-images.githubusercontent.com/1270189/59391266-a6e8e580-8d28-11e9-843f-d20081dd70a7.png">

This PR wraps the save functions in a wrapper to satisfy this check: https://github.com/WordPress/gutenberg/pull/14529/files#diff-33e0ac9c44b16a617039a563d4c065f3R108

#### Testing instructions:
- Spin up a test instance with https://jurassic.ninja/create/?jetpack-beta&branch=fix/contact-form-g-5-9
- Activate Contact Form in Jetpack Settings:

<img width="1073" alt="Screen Shot 2019-06-12 at 4 08 35 PM" src="https://user-images.githubusercontent.com/1270189/59392406-64290c80-8d2c-11e9-95ae-81f14c0bbcbe.png">

- Install Gutenberg v5.9.0 and activate
- See if contact form is available in the inserter
- No regressions in behavior
- No error in console about `The "save" property must be a valid function`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog entry needed
