### PR TITLE
Sharing: avoid displaying empty list items in AMP views

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -338,7 +338,14 @@ class Jetpack_AMP_Support {
 			$sharing_link   .= '></amp-social-share>';
 			$sharing_links[] = $sharing_link;
 		}
-		return preg_replace( '#(?<=<div class="sd-content">).+?(?=</div>)#s', implode( '', $sharing_links ), $markup );
+
+		// Wrap AMP sharing buttons in container.
+		$markup = preg_replace( '#(?<=<div class="sd-content">).+?(?=</div>)#s', implode( '', $sharing_links ), $markup );
+
+		// Remove any lingering share-end list items.
+		$markup = str_replace( '<li class="share-end"></li>', '', $markup );
+
+		return $markup;
 	}
 }
 


### PR DESCRIPTION
Fixes #12639

#### Changes proposed in this Pull Request:

* When you use the AMP plugin and Jetpack's Sharing buttons, Jetpack sets up some custom markup for the AMP buttons. Unfortunately that markup is currently including some empty list items that are hidden with CSS within the regular sharing view, but do not get hidden when using the AMP view.

![image](https://user-images.githubusercontent.com/426388/59423929-65f9db00-8dd3-11e9-8aff-d29c9b13218b.png)

This PR removes those additional list items.

It does not, however, make any changes to the items' style. There are still some issues with styles at the moment, but I can't pinpoint if those come from `modules/theme-tools/compat/twentynineteen.css`, `modules/sharedaddy/sharing.css`, or AMP's own `assets/css/amp-default.css`. Putting up the bat signal on that one to get some help from @Automattic/jetpack-design! 🙏 

#### Testing instructions:

* Start with a site running Twenty Nineteen
* Install the AMP plugin, and in the AMP plugin options select Native.
* Activate Jetpack Sharing buttons, and under Settings > Sharing add a Facebook and a Twitter button. Change the button style to official buttons.
* Visit a post's page.
* See the buttons.

#### Proposed changelog entry for your changes:

* Sharing: avoid displaying extra list items below the sharing buttons when using the AMP plugin.
