### PR TITLE
Recurring Payments: Widget

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -20,6 +20,7 @@ module.exports = [
 	'modules/sitemaps/sitemaps.php',
 	'modules/theme-tools/social-menu/',
 	'modules/verification-tools.php',
+	'modules/widgets/recurring-payments.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'packages',
 ];

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -134,6 +134,7 @@ class Jetpack_Plan {
 		if ( in_array( $plan['product_slug'], $personal_plans, true ) ) {
 			// special support value, not a module but a separate plugin.
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$plan['class'] = 'personal';
 		}
 
@@ -149,6 +150,7 @@ class Jetpack_Plan {
 		if ( in_array( $plan['product_slug'], $premium_plans, true ) ) {
 			$supports[]    = 'akismet';
 			$supports[]    = 'simple-payments';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';
 			$plan['class'] = 'premium';
@@ -170,6 +172,7 @@ class Jetpack_Plan {
 		if ( in_array( $plan['product_slug'], $business_plans, true ) ) {
 			$supports[]    = 'akismet';
 			$supports[]    = 'simple-payments';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';
 			$plan['class'] = 'business';

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -180,6 +180,24 @@ class Jetpack_Memberships {
 		return $map['meta'];
 	}
 	/**
+	 * Transform WP CPT post into array representing a memberships product.
+	 *
+	 * @param WP_Post $product_post - CPT representing the product.
+	 * @return array
+	 */
+	public static function product_post_to_array( $product_post ) {
+		$data    = array();
+		$mapping = self::get_plan_property_mapping();
+		foreach ( $mapping as $key => $map ) {
+			$data[ $key ] = get_post_meta( $product_post->ID, $map['meta'], true );
+		}
+		$data['title']       = $product_post->post_title;
+		$data['description'] = $product_post->post_content;
+		$data['id']          = $product_post->ID;
+		return $data;
+	}
+
+	/**
 	 * Callback that parses the membership purchase shortcode.
 	 *
 	 * @param array $attrs - attributes in the shortcode. `id` here is the CPT id of the plan.

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -52,7 +52,6 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 			);
 		}
 
-
 		private function get_first_product() {
 			$product_posts = get_posts(
 				array(
@@ -79,7 +78,7 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 		function widget( $args, $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 			$plan = Jetpack_Memberships::product_post_to_array( $instance['product_post_id'] );
-			if( ! $plan ) {
+			if ( ! $plan ) {
 				return;
 			}
 
@@ -117,32 +116,6 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 			return ! empty( $new_instance[ $field ] )
 				? sanitize_text_field( $new_instance[ $field ] )
 				: $old_instance[ $field ];
-		}
-
-		/**
-		 * Record a Track event and bump a MC stat.
-		 *
-		 * @param string $stat_name
-		 * @param string $event_action
-		 * @param array $event_properties
-		 */
-		private function record_event( $stat_name, $event_action, $event_properties = array() ) {
-			$current_user = wp_get_current_user();
-
-			// `bumps_stats_extra` only exists on .com
-			if ( function_exists( 'bump_stats_extras' ) ) {
-				require_lib( 'tracks/client' );
-				tracks_record_event( $current_user, 'simple_payments_button_' . $event_action, $event_properties );
-				/** This action is documented in modules/widgets/social-media-icons.php */
-				do_action( 'jetpack_bump_stats_extra', 'jetpack-simple_payments', $stat_name );
-				return;
-			}
-
-			jetpack_tracks_record_event( $current_user, 'jetpack_wpa_simple_payments_button_' . $event_action, $event_properties );
-			$jetpack = Jetpack::init();
-			// $jetpack->stat automatically prepends the stat group with 'jetpack-'
-			$jetpack->stat( 'simple_payments', $stat_name );
-			$jetpack->do_stats( 'server_side' );
 		}
 
 		/**

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Disable direct access/execution to/of the widget code.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
+	/**
+	 * Recurring Payments Button
+	 *
+	 * Display a Recurring Payments Button as a Widget.
+	 */
+	class Jetpack_Recurring_Payments_Widget extends WP_Widget {
+
+		/**
+		 * Constructor.
+		 */
+		function __construct() {
+			parent::__construct(
+				'jetpack_recurring_payments_widget',
+				/** This filter is documented in modules/widgets/facebook-likebox.php */
+				apply_filters( 'jetpack_widget_name', __( 'Recurring Payments', 'jetpack' ) ),
+				array(
+					'classname'                   => 'jetpack-recurring-payments',
+					'description'                 => __( 'Add a Recurring Payments Button as a Widget.', 'jetpack' ),
+					'customize_selective_refresh' => true,
+				)
+			);
+
+			global $pagenow;
+			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
+			}
+		}
+
+		/**
+		 * Return an associative array of default values.
+		 *
+		 * These values are used in new widgets.
+		 *
+		 * @return array Default values for the widget options.
+		 */
+		private function defaults() {
+			$first_product = $this->get_first_product();
+
+			return array(
+				'title'                    => '',
+				'product_post_id'          => $first_product['id'],
+				'text'					=> __( 'Contribution', 'jetpack' ),
+			);
+		}
+
+
+		private function get_first_product() {
+			$product_posts = get_posts(
+				array(
+					'numberposts' => 1,
+					'orderby'     => 'date',
+					'post_type'   => Jetpack_Memberships::$post_type_plan,
+					'post_status' => 'publish',
+				)
+			);
+			if( empty( $product_posts ) ) {
+				return null;
+			}
+			return Jetpack_Memberships::product_post_to_array( $product_posts[0] );
+		}
+
+		/**
+		 * Front-end display of widget.
+		 *
+		 * @see WP_Widget::widget()
+		 *
+		 * @param array $args     Widget arguments.
+		 * @param array $instance Saved values from database.
+		 */
+		function widget( $args, $instance ) {
+			$instance = wp_parse_args( $instance, $this->defaults() );
+			$plan = Jetpack_Memberships::product_post_to_array( $instance['product_post_id'] );
+			if( ! $plan ) {
+				return;
+			}
+
+			echo $args['before_widget'];
+
+			/** This filter is documented in core/src/wp-includes/default-widgets.php */
+			$title = apply_filters( 'widget_title', $instance['title'] );
+			if ( ! empty( $title ) ) {
+				echo $args['before_title'] . $title . $args['after_title'];
+			}
+
+			echo '<div class="jetpack-recurring-payments-content">';
+			echo Jetpack_Memberships::get_instance()->render_button( array(
+				'planId' => $instance['product_post_id'],
+				'submitButtonText' => $instance['text'],
+			) );
+
+
+			echo '</div><!--simple-payments-->';
+
+			echo $args['after_widget'];
+
+			/** This action is already documented in modules/widgets/gravatar-profile.php */
+			do_action( 'jetpack_stats_extra', 'widget_view', 'recurring_payments' );
+		}
+
+		/**
+		 * Gets the latests field value from either the old instance or the new instance.
+		 *
+		 * @param array $mixed Array of values for the new form instance.
+		 * @param array $mixed Array of values for the old form instance.
+		 * @return mixed $mixed Field value.
+		 */
+		private function get_latest_field_value( $new_instance, $old_instance, $field ) {
+			return ! empty( $new_instance[ $field ] )
+				? sanitize_text_field( $new_instance[ $field ] )
+				: $old_instance[ $field ];
+		}
+
+		/**
+		 * Record a Track event and bump a MC stat.
+		 *
+		 * @param string $stat_name
+		 * @param string $event_action
+		 * @param array $event_properties
+		 */
+		private function record_event( $stat_name, $event_action, $event_properties = array() ) {
+			$current_user = wp_get_current_user();
+
+			// `bumps_stats_extra` only exists on .com
+			if ( function_exists( 'bump_stats_extras' ) ) {
+				require_lib( 'tracks/client' );
+				tracks_record_event( $current_user, 'simple_payments_button_' . $event_action, $event_properties );
+				/** This action is documented in modules/widgets/social-media-icons.php */
+				do_action( 'jetpack_bump_stats_extra', 'jetpack-simple_payments', $stat_name );
+				return;
+			}
+
+			jetpack_tracks_record_event( $current_user, 'jetpack_wpa_simple_payments_button_' . $event_action, $event_properties );
+			$jetpack = Jetpack::init();
+			// $jetpack->stat automatically prepends the stat group with 'jetpack-'
+			$jetpack->stat( 'simple_payments', $stat_name );
+			$jetpack->do_stats( 'server_side' );
+		}
+
+		/**
+		 * Sanitize widget form values as they are saved.
+		 *
+		 * @see WP_Widget::update()
+		 *
+		 * @param array $new_instance Values just sent to be saved.
+		 * @param array $old_instance Previously saved values from database.
+		 *
+		 * @return array Updated safe values to be saved.
+		 */
+		function update( $new_instance, $old_instance ) {
+			$defaults = $this->defaults();
+			//do not overrite `product_post_id` for `$new_instance` with the defaults
+			$new_instance = wp_parse_args( $new_instance, array_diff_key( $defaults, array( 'product_post_id' => 0 ) ) );
+			$old_instance = wp_parse_args( $old_instance, $defaults );
+
+			return array(
+				'title'           => $this->get_latest_field_value( $new_instance, $old_instance, 'title' ),
+				'product_post_id' => $this->get_latest_field_value( $new_instance, $old_instance, 'product_post_id' ),
+				'text'     => $this->get_latest_field_value( $new_instance, $old_instance, 'text' ),
+			);
+
+		}
+
+		/**
+		 * Back-end widget form.
+		 *
+		 * @see WP_Widget::form()
+		 *
+		 * @param array $instance Previously saved values from database.
+		 */
+		function form( $instance ) {
+			$product_posts = get_posts(
+				array(
+					'numberposts' => 100,
+					'orderby'     => 'date',
+					'post_type'   => Jetpack_Memberships::$post_type_plan,
+					'post_status' => 'publish',
+				)
+			);
+			$product_posts = array_map( function( $post ) {
+				return Jetpack_Memberships::product_post_to_array( $post );
+			}, $product_posts );
+			require dirname( __FILE__ ) . '/recurring-payments/form.php';
+		}
+	}
+
+	// Register Jetpack_Recurring_Payments_Widget widget.
+	function register_widget_jetpack_recurring_payments() {
+		if ( ! class_exists( 'Jetpack_Memberships' ) ) {
+			return;
+		}
+		register_widget( 'Jetpack_Recurring_Payments_Widget' );
+	}
+	add_action( 'widgets_init', 'register_widget_jetpack_recurring_payments' );
+}

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -161,6 +161,7 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 			$product_posts = array_map( function( $post ) {
 				return Jetpack_Memberships::product_post_to_array( $post );
 			}, $product_posts );
+			$blog_id = Jetpack_Memberships::get_blog_id();
 			require dirname( __FILE__ ) . '/recurring-payments/form.php';
 		}
 	}

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -184,6 +184,9 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 		if ( ! class_exists( 'Jetpack_Memberships' ) ) {
 			return;
 		}
+		if ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'recurring-payments' ) ) {
+			return;
+		}
 		register_widget( 'Jetpack_Recurring_Payments_Widget' );
 	}
 	add_action( 'widgets_init', 'register_widget_jetpack_recurring_payments' );

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -29,10 +29,6 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 				)
 			);
 
-			global $pagenow;
-			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
-			}
 		}
 
 		/**

--- a/modules/widgets/recurring-payments.php
+++ b/modules/widgets/recurring-payments.php
@@ -73,7 +73,11 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 		 */
 		function widget( $args, $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
-			$plan = Jetpack_Memberships::product_post_to_array( $instance['product_post_id'] );
+			$post = get_post( $instance['product_post_id'] );
+			if ( ! $post ) {
+				return;
+			}
+			$plan = Jetpack_Memberships::product_post_to_array( $post );
 			if ( ! $plan ) {
 				return;
 			}
@@ -146,6 +150,7 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 		 * @param array $instance Previously saved values from database.
 		 */
 		function form( $instance ) {
+			$instance = wp_parse_args( $instance, $this->defaults() );
 			$product_posts = get_posts(
 				array(
 					'numberposts' => 100,
@@ -154,6 +159,7 @@ if ( ! class_exists( 'Jetpack_Recurring_Payments_Widget' ) ) {
 					'post_status' => 'publish',
 				)
 			);
+
 			$product_posts = array_map( function( $post ) {
 				return Jetpack_Memberships::product_post_to_array( $post );
 			}, $product_posts );

--- a/modules/widgets/recurring-payments/form.php
+++ b/modules/widgets/recurring-payments/form.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Display the Simple Payments Form.
+ *
+ * @package Jetpack
+ */
+
+?>
+<p>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+		<?php esc_html_e( 'Widget Title', 'jetpack' ); ?>
+	</label>
+	<input
+		type="text"
+		class="widefat jetpack-simple-payments-widget-title"
+		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+		value="<?php echo esc_attr( $instance['title'] ); ?>" />
+</p>
+<p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">
+		<?php esc_html_e( 'Select a Simple Payments Button:', 'jetpack' ); ?>
+	</label>
+	<select
+		class="widefat jetpack-simple-payments-products"
+		id="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'product_post_id' ) ); ?>">
+		<?php foreach ( $product_posts as $product ) { ?>
+			<option value="<?php echo esc_attr( $product['id'] ); ?>" <?php selected( (int) $instance['product_post_id'], $product['id'] ); ?>>
+				<?php printf( '%s %s - %s', $product['currency'], $product['price'], $product['title'] ); ?>
+			</option>
+		<?php } ?>
+	</select>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'text' ) ); ?>">
+		<?php esc_html_e( 'Button Text', 'jetpack' ); ?>
+	</label>
+	<input
+		type="text"
+		class="widefat jetpack-simple-payments-widget-title"
+		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+		value="<?php echo esc_attr( $instance['title'] ); ?>" />
+</p>
+<p class="jetpack-simple-payments-products-warning" <?php if ( ! empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
+	<?php esc_html_e( "Looks like you don't have any products. You can create one using the Add New button below.", 'jetpack' ); ?>
+</p>
+

--- a/modules/widgets/recurring-payments/form.php
+++ b/modules/widgets/recurring-payments/form.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Display the Simple Payments Form.
+ * Display the Recurring Payments widget Form.
  *
  * @package Jetpack
  */
@@ -12,17 +12,17 @@
 	</label>
 	<input
 		type="text"
-		class="widefat jetpack-simple-payments-widget-title"
+		class="widefat jetpack-recurring-payments-widget-title"
 		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
 		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
 		value="<?php echo esc_attr( $instance['title'] ); ?>" />
 </p>
-<p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
+<p class="jetpack-recurring-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">
-		<?php esc_html_e( 'Select a Simple Payments Button:', 'jetpack' ); ?>
+		<?php esc_html_e( 'Select previously created Recurring Payments plan:', 'jetpack' ); ?>
 	</label>
 	<select
-		class="widefat jetpack-simple-payments-products"
+		class="widefat jetpack-recurring-payments-products"
 		id="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>"
 		name="<?php echo esc_attr( $this->get_field_name( 'product_post_id' ) ); ?>">
 		<?php foreach ( $product_posts as $product ) { ?>
@@ -32,16 +32,19 @@
 		<?php } ?>
 	</select>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'text' ) ); ?>">
-		<?php esc_html_e( 'Button Text', 'jetpack' ); ?>
+		<?php esc_html_e( 'Choose a text to display on your button:', 'jetpack' ); ?>
 	</label>
 	<input
 		type="text"
-		class="widefat jetpack-simple-payments-widget-title"
-		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
-		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
-		value="<?php echo esc_attr( $instance['title'] ); ?>" />
+		class="widefat jetpack-recurring-payments-widget-title"
+		id="<?php echo esc_attr( $this->get_field_id( 'text' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_field_name( 'text' ) ); ?>"
+		value="<?php echo esc_attr( $instance['text'] ); ?>" />
 </p>
-<p class="jetpack-simple-payments-products-warning" <?php if ( ! empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
-	<?php esc_html_e( "Looks like you don't have any products. You can create one using the Add New button below.", 'jetpack' ); ?>
+<p class="jetpack-recurring-payments-products-warning">
+	<?php echo wp_kses( sprintf(
+			__( '<a %s>You can configure Recurring Payments, manage and create new plans on WordPress.com</a>', 'jetpack' ),
+			"target='_blank' rel='noopener noreferer' href='https://wordpress.com/earn/payments/$blog_id'"
+	), array( 'a' => array( 'href' => array(), 'target' => array() , 'rel' => array() ) ) ); ?>
 </p>
 

--- a/modules/widgets/recurring-payments/form.php
+++ b/modules/widgets/recurring-payments/form.php
@@ -15,7 +15,7 @@
 		class="widefat jetpack-recurring-payments-widget-title"
 		id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
 		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
-		value="<?php echo esc_attr( $instance['title'] ); ?>" />
+		value="<?php echo esc_attr( isset( $instance['title'] ) ? $instance['title'] : '' ); ?>" />
 </p>
 <p class="jetpack-recurring-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This pull request introduces a widget for Recurring Payments.
The widget will not be considered a primary interface and thus will not allow for adding new products, editing them, etc.
Also, customizer interactivity makes no sense, since you can only choose a different product.

I know work is being done to replace widgets with Gutenberg, but I am sure it will take time.
With the Gutenberg adoption on WPCOM being around 20% , we have lots of customers not being able to use recurring payments.
Also, having a widget is the most requested functionality now. Even few a12s requested it ( @rantoncuadrado @mlaetitia @zandyring @dbspringer  )

![Zrzut ekranu 2019-06-13 o 15 19 18](https://user-images.githubusercontent.com/3775068/59436674-58068300-8df0-11e9-8ff4-8ecf7aff0436.png)
![Zrzut ekranu 2019-06-13 o 15 19 28](https://user-images.githubusercontent.com/3775068/59436677-59d04680-8df0-11e9-88a1-c970bc4f491a.png)


This continues the work from #9802


#### Testing instructions:

* Set up a site and a product like described in #9802
* Enable JP widgets like in https://github.com/Automattic/jetpack/pull/12684#issuecomment-503985921
* Select "Recurring payments" widget
* Publish your widget

#### Proposed changelog entry for your changes:

* Recurring Payments functionality now has a matching widget
