### PR TITLE
Add Tracks events to at-a-glance page

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -34,13 +34,6 @@ class DashAkismet extends Component {
 		isDevMode: '',
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.trackInstallClick = this.trackInstallClick.bind( this );
-		this.trackActivateClick = this.trackActivateClick.bind( this );
-	}
-
 	trackInstallClick() {
 		analytics.tracks.recordJetpackClick( {
 			type: 'install-link',

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -9,6 +9,7 @@ import { numberFormat, translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import QueryAkismetData from 'components/data/query-akismet-data';
@@ -32,6 +33,29 @@ class DashAkismet extends Component {
 		akismetData: 'N/A',
 		isDevMode: '',
 	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.trackInstallClick = this.trackInstallClick.bind( this );
+		this.trackActivateClick = this.trackActivateClick.bind( this );
+	}
+
+	trackInstallClick() {
+		analytics.tracks.recordJetpackClick( {
+			type: 'install-link',
+			target: 'at-a-glance',
+			feature: 'akismet',
+		} );
+	}
+
+	trackActivateClick() {
+		analytics.tracks.recordJetpackClick( {
+			type: 'activate-link',
+			target: 'at-a-glance',
+			feature: 'akismet',
+		} );
+	}
 
 	getContent() {
 		const akismetData = this.props.akismetData;
@@ -71,6 +95,7 @@ class DashAkismet extends Component {
 								a: (
 									<a
 										href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl }
+										onClick={ this.trackInstallClick }
 										target="_blank"
 										rel="noopener noreferrer"
 									/>
@@ -98,6 +123,7 @@ class DashAkismet extends Component {
 								a: (
 									<a
 										href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl }
+										onClick={ this.trackActivateClick }
 										target="_blank"
 										rel="noopener noreferrer"
 									/>

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -130,7 +130,7 @@ class DashBackups extends Component {
 					'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.',
 					{
 						components: {
-							a: <UpgradeLink source="aag-backups" />,
+							a: <UpgradeLink source="aag-backups" target="at-a-glance" feature="backups" />,
 						},
 					}
 				),

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -12,6 +12,7 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import QueryPluginUpdates from 'components/data/query-plugin-updates';
@@ -25,6 +26,20 @@ class DashPluginUpdates extends Component {
 		siteAdminUrl: PropTypes.string.isRequired,
 		pluginUpdates: PropTypes.any.isRequired,
 	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.trackManagePlugins = this.trackManagePlugins.bind( this );
+	}
+
+	trackManagePlugins() {
+		analytics.tracks.recordJetpackClick( {
+			type: 'link',
+			target: 'at-a-glance',
+			feature: 'manage-plugins',
+		} );
+	}
 
 	getContent() {
 		const labelName = __( 'Plugin Updates' );
@@ -86,6 +101,7 @@ class DashPluginUpdates extends Component {
 					className="jp-dash-item__manage-in-wpcom"
 					compact
 					href={ managePluginsUrl }
+					onClick={ this.trackManagePlugins }
 					target="_blank"
 				>
 					{ __( 'Manage your plugins' ) }

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -27,12 +27,6 @@ class DashPluginUpdates extends Component {
 		pluginUpdates: PropTypes.any.isRequired,
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.trackManagePlugins = this.trackManagePlugins.bind( this );
-	}
-
 	trackManagePlugins() {
 		analytics.tracks.recordJetpackClick( {
 			type: 'link',

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -161,7 +161,7 @@ class DashScan extends Component {
 								'For automated, comprehensive scanning of security threats, please {{a}}upgrade your account{{/a}}.',
 								{
 									components: {
-										a: <UpgradeLink source="aag-scan" />,
+										a: <UpgradeLink source="aag-scan" target="at-a-glance" feature="scan" />,
 									},
 								}
 						  ) }

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -56,12 +56,6 @@ class DashSearch extends Component {
 		isDevMode: false,
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.trackSearchLink = this.trackSearchLink.bind( this );
-	}
-
 	trackSearchLink() {
 		analytics.tracks.recordJetpackClick( {
 			type: 'upgrade-link',

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -10,6 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import DashItem from 'components/dash-item';
 import Card from 'components/card';
 import { isModuleFound } from 'state/search';
@@ -55,6 +56,20 @@ class DashSearch extends Component {
 		isDevMode: false,
 	};
 
+	constructor() {
+		super( ...arguments );
+
+		this.trackSearchLink = this.trackSearchLink.bind( this );
+	}
+
+	trackSearchLink() {
+		analytics.tracks.recordJetpackClick( {
+			type: 'upgrade-link',
+			target: 'at-a-glance',
+			feature: 'search',
+		} );
+	}
+
 	activateSearch = () => this.props.updateOptions( { search: true } );
 
 	render() {
@@ -81,6 +96,7 @@ class DashSearch extends Component {
 							a: (
 								<a
 									href={ 'https://jetpack.com/features/design/elasticsearch-powered-search/' }
+									onClick={ this.trackSearchLink }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/_inc/client/components/card/index.jsx
+++ b/_inc/client/components/card/index.jsx
@@ -67,6 +67,7 @@ class Card extends React.Component {
 		style: PropTypes.object,
 		className: PropTypes.string,
 		href: PropTypes.string,
+		onClick: PropTypes.func,
 		title: PropTypes.string,
 		tagName: PropTypes.string,
 		target: PropTypes.string,
@@ -78,6 +79,7 @@ class Card extends React.Component {
 		iconColor: '#787878',
 		className: '',
 		tagName: 'div',
+		onClick: () => {},
 	};
 
 	render() {

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -24,13 +24,7 @@ class UpgradeLink extends PureComponent {
 		upgradeUrl: PropTypes.string.isRequired,
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.trackClick = this.trackClick.bind( this );
-	}
-
-	trackClick() {
+	trackClick = () => {
 		const { target, feature } = this.props;
 
 		if ( target && feature ) {
@@ -40,7 +34,7 @@ class UpgradeLink extends PureComponent {
 				feature,
 			} );
 		}
-	}
+	};
 
 	render() {
 		return (

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { getUpgradeUrl } from 'state/initial-state';
 
 /**
@@ -16,14 +17,39 @@ import { getUpgradeUrl } from 'state/initial-state';
 class UpgradeLink extends PureComponent {
 	static propTypes = {
 		source: PropTypes.string.isRequired,
+		target: PropTypes.string.isRequired,
+		feature: PropTypes.string.isRequired,
 
 		// Connected
 		upgradeUrl: PropTypes.string.isRequired,
 	};
 
+	constructor() {
+		super( ...arguments );
+
+		this.trackClick = this.trackClick.bind( this );
+	}
+
+	trackClick() {
+		const { target, feature } = this.props;
+
+		if ( target && feature ) {
+			analytics.tracks.recordJetpackClick( {
+				type: 'upgrade-link',
+				target,
+				feature,
+			} );
+		}
+	}
+
 	render() {
 		return (
-			<a href={ this.props.upgradeUrl } target="_blank" rel="noopener noreferrer">
+			<a
+				href={ this.props.upgradeUrl }
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ this.trackClick }
+			>
 				{ this.props.children }
 			</a>
 		);

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -247,7 +247,7 @@ class ProStatus extends React.Component {
 
 				case 'search':
 					if ( hasFree || hasPersonal || hasPremium ) {
-						return this.getProActions( 'pro' );
+						return this.getProActions( 'pro', 'search' );
 					}
 					return '';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
A Tracks events audit of the At A Glance page found several links and buttons that are missing Tracks events. This PR adds the missing Tracks events. See panfyZ-26-p2 for the4 full list.

#### Testing instructions:
1. To ensure that you can see Tracks events, enter `localStorage.setItem('debug', 'dops:analytics')` in the browser console and refresh the page.
2. Configure the browser console such that it does not clear between page loads. In Chrome this is the "preserve log" option. Some of the links navigate the page, so you will need the full console log to verify the Tracks events.
2. Visit the at-a-glance page by going to Jetpack > Dashboard > At a Glance.
3. On each of the Security, Backups, Spam, Manage Your Plugins, and Search sections click the blue hyperlink. Look in the console and verify that a Tracks event with the correct `type`, `target`, and `feature` prop was fired.
4. On the Search section, click the Upgrade button. Look in the console and verify that a Tracks event with the correct `feature` prop was fired.

#### Proposed changelog entry for your changes:
No changelog entry needed.
