### PR TITLE
Fix calypsoify feedback menu for Atomic and Jetpack sites

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -229,7 +229,7 @@ class Jetpack_Calypsoify {
 	public function add_custom_menus() {
 		global $menu, $submenu;
 
-		if ( 'feedback' === $_GET['post_type'] ) {
+		if ( isset($_GET['post_type']) && 'feedback' === $_GET['post_type'] ) {
 			// there is currently no gridicon for feedback, so using dashicon.
 			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', 'dashicons-feedback', 1 );
 			remove_menu_page( 'options-general.php' );
@@ -281,7 +281,7 @@ class Jetpack_Calypsoify {
 	}
 
 	public function insert_sidebar_html() { 
-		$heading = ( 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
+		$heading = ( isset($_GET['post_type']) && 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
 		?>
 		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -38,7 +38,9 @@ class Jetpack_Calypsoify {
 		if ( $this->is_calypsoify_enabled ) {
 			add_action( 'admin_init', array( $this, 'setup_admin' ), 6 );
 			add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
-			add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
+			if ( $_GET[ 'post_type' ] != 'feedback' ) {
+				add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
+			}
 		}
 
 		// Make this always available -- in case calypsoify gets toggled off.
@@ -202,10 +204,14 @@ class Jetpack_Calypsoify {
 	}
 
 	public function remove_core_menus() {
+		if ( $_GET[ 'post_type' ] != 'feedback' ) {
+			remove_menu_page( 'edit.php?post_type=feedback' );
+		} else {
+			remove_menu_page( 'options-general.php' );
+		}
 		remove_menu_page( 'index.php' );
 		remove_menu_page( 'jetpack' );
 		remove_menu_page( 'edit.php' );
-		remove_menu_page( 'edit.php?post_type=feedback' );
 		remove_menu_page( 'upload.php' );
 		remove_menu_page( 'edit.php?post_type=page' );
 		remove_menu_page( 'edit-comments.php' );
@@ -274,13 +280,15 @@ class Jetpack_Calypsoify {
 		);
 	}
 
-	public function insert_sidebar_html() { ?>
+	public function insert_sidebar_html() { 
+		$heading = ( $_GET[ 'post_type' ] == 'feedback' ) ? 'Feedback' : 'Plugins';
+		?>
 		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
 
 			<ul>
 				<li id="calypso-sitename"><?php bloginfo( 'name' ); ?></li>
-				<li id="calypso-plugins"><?php esc_html_e( 'Plugins' ); ?></li>
+				<li id="calypso-plugins"><?php esc_html_e( $heading ); ?></li>
 			</ul>
 		</a>
 		<?php

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -229,7 +229,7 @@ class Jetpack_Calypsoify {
 	public function add_custom_menus() {
 		global $menu, $submenu;
 
-		if ( isset($_GET['post_type']) && 'feedback' === $_GET['post_type'] ) {
+		if ( isset( $_GET['post_type'] ) && 'feedback' === $_GET['post_type'] ) {
 			// there is currently no gridicon for feedback, so using dashicon.
 			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', 'dashicons-feedback', 1 );
 			remove_menu_page( 'options-general.php' );

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -240,7 +240,7 @@ class Jetpack_Calypsoify {
 			if ( empty( $submenu['options-general.php'] ) ) {
 				remove_menu_page( 'options-general.php' );
 			} else {
-			    // Rename and make sure the plugin settings menu is always last.
+				// Rename and make sure the plugin settings menu is always last.
 				// Sneaky plugins seem to override this otherwise.
 				// Settings is always key 80.
 				$menu[80][0]                            = __( 'Plugin Settings', 'jetpack' );

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -38,9 +38,7 @@ class Jetpack_Calypsoify {
 		if ( $this->is_calypsoify_enabled ) {
 			add_action( 'admin_init', array( $this, 'setup_admin' ), 6 );
 			add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 100 );
-			if ( $_GET[ 'post_type' ] != 'feedback' ) {
-				add_action( 'admin_menu', array( $this, 'add_plugin_menus' ), 101 );
-			}
+			add_action( 'admin_menu', array( $this, 'add_custom_menus' ), 101 );
 		}
 
 		// Make this always available -- in case calypsoify gets toggled off.
@@ -204,11 +202,8 @@ class Jetpack_Calypsoify {
 	}
 
 	public function remove_core_menus() {
-		if ( $_GET[ 'post_type' ] != 'feedback' ) {
-			remove_menu_page( 'edit.php?post_type=feedback' );
-		} else {
-			remove_menu_page( 'options-general.php' );
-		}
+		remove_menu_page( 'edit.php?post_type=feedback' );
+		remove_menu_page( 'options-general.php' );
 		remove_menu_page( 'index.php' );
 		remove_menu_page( 'jetpack' );
 		remove_menu_page( 'edit.php' );
@@ -232,21 +227,25 @@ class Jetpack_Calypsoify {
 		remove_submenu_page( 'options-general.php', 'sharing' );
 	}
 
-	public function add_plugin_menus() {
+	public function add_custom_menus() {
 		global $menu, $submenu;
 
-		add_menu_page( __( 'Manage Plugins', 'jetpack' ), __( 'Manage Plugins', 'jetpack' ), 'activate_plugins', 'plugins.php', '', $this->installed_plugins_icon(), 1 );
-
-		// // Count the settings page submenus, if it's zero then don't show this.
-		if ( empty( $submenu['options-general.php'] ) ) {
-			remove_menu_page( 'options-general.php' );
+		if ( $_GET[ 'post_type' ] == 'feedback' ) {
+			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', $this->feedback_icon(), 1 );
+			remove_submenu_page( 'edit.php?post_type=feedback', 'feedback-export');
 		} else {
-			// Rename and make sure the plugin settings menu is always last.
-			// Sneaky plugins seem to override this otherwise.
-			// Settings is always key 80.
-			$menu[80][0]                            = __( 'Plugin Settings', 'jetpack' );
-			$menu[ max( array_keys( $menu ) ) + 1 ] = $menu[80];
-			unset( $menu[80] );
+			add_menu_page( __( 'Manage Plugins', 'jetpack' ), __( 'Manage Plugins', 'jetpack' ), 'activate_plugins', 'plugins.php', '', $this->installed_plugins_icon(), 1 );
+			// Count the settings page submenus, if it's zero then don't show this.
+			if ( empty( $submenu['options-general.php'] ) ) {
+				remove_menu_page( 'options-general.php' );
+			} else {
+			    // Rename and make sure the plugin settings menu is always last.
+				// Sneaky plugins seem to override this otherwise.
+				// Settings is always key 80.
+				$menu[80][0]                            = __( 'Plugin Settings', 'jetpack' );
+				$menu[ max( array_keys( $menu ) ) + 1 ] = $menu[80];
+				unset( $menu[80] );
+			}
 		}
 	}
 
@@ -313,6 +312,12 @@ class Jetpack_Calypsoify {
 
 	private function installed_plugins_icon() {
 		$svg = '<svg class="gridicon gridicons-plugins" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 24"><g><path d="M16 8V3c0-.552-.448-1-1-1s-1 .448-1 1v5h-4V3c0-.552-.448-1-1-1s-1 .448-1 1v5H5v4c0 2.79 1.637 5.193 4 6.317V22h6v-3.683c2.363-1.124 4-3.527 4-6.317V8h-3z" fill="black"></path></g></svg>';
+
+		return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+	}
+
+	private function feedback_icon() {
+		$svg = '<svg class="gridicon gridicons-feedback" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M2 2h16c.55 0 1 .45 1 1v14c0 .55-.45 1-1 1H2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm15 14V7H3v9h14zM4 8v1h3V8H4zm4 0v3h8V8H8zm-4 4v1h3v-1H4zm4 0v3h8v-3H8z"/></g></svg>';
 
 		return 'data:image/svg+xml;base64,' . base64_encode( $svg );
 	}

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -231,7 +231,8 @@ class Jetpack_Calypsoify {
 		global $menu, $submenu;
 
 		if ( $_GET[ 'post_type' ] == 'feedback' ) {
-			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', $this->feedback_icon(), 1 );
+			// there is currently no gridicon for feeback, so using dashicon
+			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', 'dashicons-feedback', 1 );
 			remove_submenu_page( 'edit.php?post_type=feedback', 'feedback-export');
 		} else {
 			add_menu_page( __( 'Manage Plugins', 'jetpack' ), __( 'Manage Plugins', 'jetpack' ), 'activate_plugins', 'plugins.php', '', $this->installed_plugins_icon(), 1 );
@@ -312,12 +313,6 @@ class Jetpack_Calypsoify {
 
 	private function installed_plugins_icon() {
 		$svg = '<svg class="gridicon gridicons-plugins" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 24"><g><path d="M16 8V3c0-.552-.448-1-1-1s-1 .448-1 1v5h-4V3c0-.552-.448-1-1-1s-1 .448-1 1v5H5v4c0 2.79 1.637 5.193 4 6.317V22h6v-3.683c2.363-1.124 4-3.527 4-6.317V8h-3z" fill="black"></path></g></svg>';
-
-		return 'data:image/svg+xml;base64,' . base64_encode( $svg );
-	}
-
-	private function feedback_icon() {
-		$svg = '<svg class="gridicon gridicons-feedback" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M2 2h16c.55 0 1 .45 1 1v14c0 .55-.45 1-1 1H2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm15 14V7H3v9h14zM4 8v1h3V8H4zm4 0v3h8V8H8zm-4 4v1h3v-1H4zm4 0v3h8v-3H8z"/></g></svg>';
 
 		return 'data:image/svg+xml;base64,' . base64_encode( $svg );
 	}

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -229,8 +229,8 @@ class Jetpack_Calypsoify {
 	public function add_custom_menus() {
 		global $menu, $submenu;
 
-		if ( $_GET[ 'post_type' ] == 'feedback' ) {
-			// there is currently no gridicon for feeback, so using dashicon
+		if ( 'feedback' === $_GET['post_type'] ) {
+			// there is currently no gridicon for feedback, so using dashicon.
 			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', 'dashicons-feedback', 1 );
 			remove_menu_page( 'options-general.php' );
 			remove_submenu_page( 'edit.php?post_type=feedback', 'feedback-export' );
@@ -281,14 +281,14 @@ class Jetpack_Calypsoify {
 	}
 
 	public function insert_sidebar_html() { 
-		$heading = ( $_GET[ 'post_type' ] == 'feedback' ) ? 'Feedback' : 'Plugins';
+		$heading = ( 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
 		?>
 		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
 
 			<ul>
 				<li id="calypso-sitename"><?php bloginfo( 'name' ); ?></li>
-				<li id="calypso-plugins"><?php esc_html_e( $heading ); ?></li>
+				<li id="calypso-plugins"><?php echo esc_html( $heading ); ?></li>
 			</ul>
 		</a>
 		<?php

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -281,7 +281,7 @@ class Jetpack_Calypsoify {
 	}
 
 	public function insert_sidebar_html() { 
-		$heading = ( isset($_GET['post_type']) && 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
+		$heading = ( isset( $_GET['post_type'] ) && 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
 		?>
 		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -203,7 +203,6 @@ class Jetpack_Calypsoify {
 
 	public function remove_core_menus() {
 		remove_menu_page( 'edit.php?post_type=feedback' );
-		remove_menu_page( 'options-general.php' );
 		remove_menu_page( 'index.php' );
 		remove_menu_page( 'jetpack' );
 		remove_menu_page( 'edit.php' );
@@ -233,7 +232,8 @@ class Jetpack_Calypsoify {
 		if ( $_GET[ 'post_type' ] == 'feedback' ) {
 			// there is currently no gridicon for feeback, so using dashicon
 			add_menu_page( __( 'Feedback', 'jetpack' ), __( 'Feedback', 'jetpack' ), 'edit_pages', 'edit.php?post_type=feedback', '', 'dashicons-feedback', 1 );
-			remove_submenu_page( 'edit.php?post_type=feedback', 'feedback-export');
+			remove_menu_page( 'options-general.php' );
+			remove_submenu_page( 'edit.php?post_type=feedback', 'feedback-export' );
 		} else {
 			add_menu_page( __( 'Manage Plugins', 'jetpack' ), __( 'Manage Plugins', 'jetpack' ), 'activate_plugins', 'plugins.php', '', $this->installed_plugins_icon(), 1 );
 			// Count the settings page submenus, if it's zero then don't show this.

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -144,8 +144,13 @@ body,
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg,
-#toplevel_page_plugin-install div.wp-menu-image.svg {
+#toplevel_page_plugin-install div.wp-menu-image.svg,
+#toplevel_page_edit-post_type-feedback div.wp-menu-image.svg {
 	background-size: 24px auto;
+}
+
+#toplevel_page_edit-post_type-feedback div.wp-menu-image {
+	height: 40px;
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg {

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -144,13 +144,8 @@ body,
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg,
-#toplevel_page_plugin-install div.wp-menu-image.svg,
-#toplevel_page_edit-post_type-feedback div.wp-menu-image.svg {
+#toplevel_page_plugin-install div.wp-menu-image.svg {
 	background-size: 24px auto;
-}
-
-#toplevel_page_edit-post_type-feedback div.wp-menu-image {
-	height: 40px;
 }
 
 #toplevel_page_plugins div.wp-menu-image.svg {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Previously, users were able to manage feedbacks within Calypso, we were not redirecting them to a Calypsoified WP Admin page.

But we realized the way users could manage feedback in Calypso was not ideal. Users would likely want to read submitted feedback instead of creating new one. WP Admin was already providing that behavior, so we removed the feedback logic from Calypso and started redirecting users to the Calypsoified WP Admin Feedback section: https://github.com/Automattic/wp-calypso/pull/30799

That turned into a new problem: Calypsoify was assuming that the only Calypsoified section a user could access was Plugins. This caused that a user accessing the Calypsoified WP Admin Feedback section would see a Plugins header in the menu https://github.com/Automattic/wp-calypso/issues/33829

We fixed that for simple sites D24873-code, but we forgot about Jetpack and Atomic sites, which is what we're trying to fix now on this PR.

#### Testing instructions:

* In a Jetpack, or Atomic site open `/wp-admin/edit.php?post_type=feedback&calypsoify=1` and the left menu will display as below with incorrect Plugins menu:

<img width="275" alt="broken" src="https://user-images.githubusercontent.com/3629020/59571202-8ccb5080-90f6-11e9-9190-79c4ea9ae570.png">

* With this patch applied the left menu should display correctly as below:

<img width="276" alt="fixed" src="https://user-images.githubusercontent.com/3629020/59571215-a7052e80-90f6-11e9-9988-09bbfdd05c0f.png">

#### Proposed changelog entry for your changes:
N/A
