### PR TITLE
Clone the image along with event handlers for Lazy Load

### DIFF
--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -107,7 +107,7 @@ var jetpackLazyImagesModule = function( $ ) {
 
 		srcset = theImage.attr( 'data-lazy-srcset' );
 		sizes = theImage.attr( 'data-lazy-sizes' );
-		theClone = theImage.clone();
+		theClone = theImage.clone(true);
 
 		// Remove lazy attributes from the clone.
 		theClone.removeAttr( 'data-lazy-srcset' ),


### PR DESCRIPTION
By creating the image clone with "clone(true)" instead of "clone()", the event handlers are copied along (see the [jQuery clone()](https://api.jquery.com/clone/) function), so an event like "mouseenter" or "click" attached to the original image will also work on the clone.

This is a patch to the [#12640 issue](https://github.com/Automattic/jetpack/issues/12640).

#### Testing instructions:

When adding the following code to the website:
```
jQuery('img.my-img').on('mouseenter', function() {
   console.log('do something on mouseenter over the image');
});
```
it worked with the Lazy Load feature disabled and failed if enabled. After applying the patch the Lazy Load will not remove anymore the event handlers added to images.

#### Proposed changelog entry for your changes:
* Lazy Load: allow adding event handlers to images
