### PR TITLE
Mailchimp Block: AMP Support

### DIFF
--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -79,6 +79,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	<div class="<?php echo esc_attr( $classes ); ?>" data-blog-id="<?php echo esc_attr( $blog_id ); ?>">
 		<div class="components-placeholder">
 			<form
+				aria-describedby="wp-block-jetpack-mailchimp_consent-text"
 				<?php if ( $is_amp_request ) : ?>
 					action-xhr="<?php echo esc_url( $amp_form_action ); ?>"
 					method="post"
@@ -106,33 +107,35 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 				<p id="wp-block-jetpack-mailchimp_consent-text" name="wp-block-jetpack-mailchimp_consent-text">
 					<?php echo wp_kses_post( $values['consentText'] ); ?>
 				</p>
+
+				<?php if ( $is_amp_request ) : ?>
+
+					<div submit-success>
+						<template type="amp-mustache">
+							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success wp-block-jetpack-mailchimp__is-amp">
+								<?php echo esc_html( $values['successLabel'] ); ?>
+							</div>
+						</template>
+					</div>
+					<div submit-error>
+						<template type="amp-mustache">
+							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error wp-block-jetpack-mailchimp__is-amp">
+								<?php echo esc_html( $values['errorLabel'] ); ?>
+							</div>
+						</template>
+					</div>
+					<div submitting>
+						<template type="amp-mustache">
+							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing wp-block-jetpack-mailchimp__is-amp" role="status">
+								<?php echo esc_html( $values['processingLabel'] ); ?>
+							</div>
+						</template>
+					</div>
+
+				<?php endif; ?>
+
 			</form>
-
-			<?php if ( $is_amp_request ) : ?>
-
-				<div submit-success>
-					<template type="amp-mustache">
-						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success wp-block-jetpack-mailchimp__is-amp">
-							<?php echo esc_html( $values['successLabel'] ); ?>
-						</div>
-					</template>
-				</div>
-				<div submit-error>
-					<template type="amp-mustache>
-						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error wp-block-jetpack-mailchimp__is-amp">
-							<?php echo esc_html( $values['errorLabel'] ); ?>
-						</div>
-					</template>
-				</div>
-				<div submitting>
-					<template type="amp-mustache">
-						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing" role="status">
-							<?php echo esc_html( $values['processingLabel'] ); ?>
-						</div>
-					</template>
-				</div>
-
-			<?php else : ?>
+			<?php if ( ! $is_amp_request ) : ?>
 
 				<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing" role="status">
 					<?php echo esc_html( $values['processingLabel'] ); ?>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -102,7 +102,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						<?php echo wp_kses_post( $values['submitButtonText'] ); ?>
 					</button>
 				</p>
-				<p id="wp-block-jetpack-mailchimp_consent-text" name="wp-block-jetpack-mailchimp_consent-text">
+				<p id="wp-block-jetpack-mailchimp_consent-text">
 					<?php echo wp_kses_post( $values['consentText'] ); ?>
 				</p>
 

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -94,9 +94,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						required
 						title="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
 						type="email"
-						<?php if ( $is_amp_request ) : ?>
 						name="email"
-						<?php endif; ?>
 					/>
 				</p>
 				<p>

--- a/extensions/blocks/mailchimp/view.scss
+++ b/extensions/blocks/mailchimp/view.scss
@@ -29,6 +29,9 @@
 			background-color: var( --color-success );
 			color: $white;
 		}
+		&.wp-block-jetpack-mailchimp__is-amp {
+			display: block;
+		}
 	}
 
 }

--- a/extensions/blocks/mailchimp/view.scss
+++ b/extensions/blocks/mailchimp/view.scss
@@ -1,7 +1,6 @@
 @import '../../shared/styles/gutenberg-colors.scss';
 
 .wp-block-jetpack-mailchimp {
-
 	&.is-processing {
 		form {
 			display: none;
@@ -22,16 +21,27 @@
 		}
 
 		&.wp-block-jetpack-mailchimp_processing {
-			background-color: rgba( 0, 0, 0, 0.025 ); // This would be "dark-opacity-light-50" which doesn't exist in Gutenberg
+			background-color: rgba(
+				0,
+				0,
+				0,
+				0.025
+			); // This would be "dark-opacity-light-50" which doesn't exist in Gutenberg
 		}
 
 		&.wp-block-jetpack-mailchimp_success {
 			background-color: var( --color-success );
 			color: $white;
 		}
-		&.wp-block-jetpack-mailchimp__is-amp {
-			display: block;
-		}
+	}
+	/* AMP Related classes */
+	.wp-block-jetpack-mailchimp_notification.wp-block-jetpack-mailchimp__is-amp {
+		display: block;
+	}
+	form.amp-form-submitting > p,
+	form.amp-form-submit-success > p,
+	form.amp-form-submit-error > p {
+		display: none;
 	}
 
 }


### PR DESCRIPTION
This PR introduces AMP support for the Mailchimp block. The functionality of the block should be identical in AMP and non-AMP pages. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Discussion of Jetpack AMP compatibility here: p1HpG7-6nB-p2 

#### Testing instructions:

- Apply D29462-code to sandbox. 
- Install AMP plugin (https://wordpress.org/plugins/amp/) on local testing instance, enable AMP, set to Transitional mode.
- Add Mailchimp block to a post (you'll need to link to a Mailchimp account to test).
- Publish the post and view. In non-AMP mode, try adding various emails, and verify that they are added to your Mailchimp list.
- Switch the page to AMP mode, and try the same. The results should be exactly the same. 