### PR TITLE
Add terms to return value in existing Post backup endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
@@ -17,14 +17,22 @@ class Jetpack_JSON_API_Get_Post_Backup_Endpoint extends Jetpack_JSON_API_Endpoin
 	}
 
 	protected function result() {
+		global $wpdb;
+
 		$post = get_post( $this->post_id );
 		if ( empty( $post ) ) {
 			return new WP_Error( 'post_not_found', __( 'Post not found', 'jetpack' ), 404 );
 		}
 
+		// Fetch terms associated with this post object
+		$terms = $wpdb->get_results( $wpdb->prepare(
+			"SELECT term_taxonomy_id, term_order FROM {$wpdb->term_relationships} WHERE object_id = %d;", $post->ID
+		) );
+
 		return array(
-			'post' => (array)$post,
-			'meta' => get_post_meta( $post->ID ),
+			'post'  => (array)$post,
+			'meta'  => get_post_meta( $post->ID ),
+			'terms' => (array)$terms,
 		);
 	}
 

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1061,8 +1061,9 @@ new Jetpack_JSON_API_Get_Post_Backup_Endpoint( array(
 		'$post' => '(int) The post ID',
 	),
 	'response_format' => array(
-		'post' => '(array) Post table row',
-		'meta' => '(array) Associative array of key/value postmeta data',
+		'post'  => '(array) Post table row',
+		'meta'  => '(array) Associative array of key/value postmeta data',
+		'terms' => '(array) List of terms attached to the post object',
 	),
 	'example_request_data' => array(
 		'headers' => array(


### PR DESCRIPTION
When fetching a post object backup, include linked terms via the term_relationships table. 

#### Changes proposed in this Pull Request:
This PR adds a `terms` key to the result of the Post Backup API endpoint, which includes a summary of the linked term relationships associated with the requested Post Object. 

Reference: pa0RFL-jR-p2

#### Testing instructions:
Execute the post backup endpoint via the wpcom API, and verify that the resultant output includes associated term relationships. 

See pa0RFL-jR-p2 for more details. 

#### Proposed changelog entry for your changes:
* Include updates to term relationships when backing up Post object changes.
