### PR TITLE
Packages: Cleanup the constants package a bit

### DIFF
--- a/packages/constants/tests/php/test_Constants.php
+++ b/packages/constants/tests/php/test_Constants.php
@@ -3,7 +3,7 @@
 use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\TestCase;
 
-class Test_Manager extends TestCase {
+class Test_Constants extends TestCase {
 	public function setUp() {
 		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			define( 'JETPACK__VERSION', '7.5' );

--- a/packages/constants/tests/php/test_Constants.php
+++ b/packages/constants/tests/php/test_Constants.php
@@ -15,49 +15,70 @@ class Test_Constants extends TestCase {
 		Constants::$set_constants = array();
 	}
 
-	// Constants::is_defined()
-
+	/**
+	 * @covers Automattic\Jetpack\Constants::is_defined
+	 */
 	function test_jetpack_constants_is_defined_when_constant_set_via_class() {
 		Constants::set_constant( 'TEST', 'hello' );
 		$this->assertTrue( Constants::is_defined( 'TEST' ) );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::is_defined
+	 */
 	function test_jetpack_constants_is_defined_false_when_constant_not_set() {
 		$this->assertFalse( Constants::is_defined( 'UNDEFINED' ) );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::is_defined
+	 */
 	function test_jetpack_constants_is_defined_true_when_set_with_define() {
 		$this->assertTrue( Constants::is_defined( 'JETPACK__VERSION' ) );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::is_defined
+	 */
 	function test_jetpack_constants_is_defined_when_constant_set_to_null() {
 		Constants::set_constant( 'TEST', null );
 		$this->assertTrue( Constants::is_defined( 'TEST' ) );
 	}
 
-	// Constants::get_constant()
-
+	/**
+	 * @covers Automattic\Jetpack\Constants::get_constant
+	 */
 	function test_jetpack_constants_default_to_constant() {
 		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::get_constant
+	 */
 	function test_jetpack_constants_get_constant_null_when_not_set() {
 		$this->assertNull( Constants::get_constant( 'UNDEFINED' ) );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::get_constant
+	 */
 	function test_jetpack_constants_can_override_previously_defined_constant() {
 		$test_version = '1.0.0';
 		Constants::set_constant( 'JETPACK__VERSION', $test_version );
 		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::get_constant
+	 */
 	function test_jetpack_constants_override_to_null_gets_null() {
 		Constants::set_constant( 'JETPACK__VERSION', null );
 		$this->assertNull( Constants::get_constant( 'JETPACK__VERSION' ) );
 	}
 
-	// Constants::set_constant()
-
+	/**
+	 * @covers Automattic\Jetpack\Constants::set_constant
+	 */
 	function test_jetpack_constants_set_constants_adds_to_set_constants_array() {
 		$key = 'TEST';
 		Constants::set_constant( $key, '1' );
@@ -65,16 +86,18 @@ class Test_Constants extends TestCase {
 		$this->assertEquals( '1', Constants::$set_constants[ $key ] );
 	}
 
-	// Constants::clear_constants()
-
+	/**
+	 * @covers Automattic\Jetpack\Constants::clear_constants
+	 */
 	function test_jetpack_constants_can_clear_all_constants() {
 		Constants::set_constant( 'JETPACK__VERSION', '1.0.0' );
 		Constants::clear_constants();
 		$this->assertEmpty( Constants::$set_constants );
 	}
 
-	// Constants::clear_single_constant()
-
+	/**
+	 * @covers Automattic\Jetpack\Constants::clear_single_constant
+	 */
 	function test_jetpack_constants_can_clear_single_constant() {
 		Constants::set_constant( 'FIRST', '1' );
 		Constants::set_constant( 'SECOND', '2' );
@@ -87,6 +110,9 @@ class Test_Constants extends TestCase {
 		$this->assertContains( 'SECOND', array_keys( Constants::$set_constants ) );
 	}
 
+	/**
+	 * @covers Automattic\Jetpack\Constants::clear_single_constant
+	 */
 	function test_jetpack_constants_can_clear_single_constant_when_null() {
 		Constants::set_constant( 'TEST', null );
 		$this->assertCount( 1, Constants::$set_constants );
@@ -96,7 +122,9 @@ class Test_Constants extends TestCase {
 		$this->assertEmpty( Constants::$set_constants );
 	}
 
-	// Jetpack_Constant::is_true
+	/**
+	 * @covers Automattic\Jetpack\Constants::is_true
+	 */
 	function test_jetpack_constants_is_true_method() {
 		$this->assertFalse( Constants::is_true( 'FOO' ), 'unset constant returns true' );
 		Constants::set_constant( 'FOO', false );


### PR DESCRIPTION
This PR performs a couple of minor cleanups to the `jetpack-constants` package.

#### Changes proposed in this Pull Request:
* Rename the tests file from `test_Manager.php` to `test_Constants.php`.
* Use the `@covers` annotation.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Verify tests still pass (CI should be enough)

#### Proposed changelog entry for your changes:
* Cleanup the constants package
