### PR TITLE
Unit Tests: No longer require PHP >= 5.6 for some suites

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 			<file>tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
-			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test" suffix=".php">tests/php/core-api</directory>
+			<directory prefix="test" suffix=".php">tests/php/core-api</directory>
 		</testsuite>
 		<testsuite name="media">
 			<directory prefix="test" suffix=".php">tests/php/media</directory>
@@ -91,7 +91,7 @@
 			<directory prefix="test" suffix=".php">tests/php/modules/search</directory>
 		</testsuite>
 		<testsuite name="geo-location">
-			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
+			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
 		</testsuite>
 	</testsuites>
 	<groups>


### PR DESCRIPTION
We were running some unit test suites only on PHP >= 5.6 before, but now that 5.6 is the oldest version that we run, this limitation will no longer be necessary. This PR removes that limitation

#### Changes proposed in this Pull Request:
* Remove the PHP >= 5.6 limitation that was enabled for for some of the test suites

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
* Verify that CI is green.

#### Proposed changelog entry for your changes:
* Unit Tests: No longer require PHP >= 5.6 for some suites
