### PR TITLE
Packages: Implement Connection_Manager::is_user_connected

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -56,11 +56,16 @@ class Manager implements Manager_Interface {
 	 * Returns true if the user with the specified identifier is connected to
 	 * WordPress.com.
 	 *
-	 * @param Integer $user_id the user identifier.
+	 * @param Integer|Boolean $user_id the user identifier.
 	 * @return Boolean is the user connected?
 	 */
-	public function is_user_connected( $user_id ) {
-		return $user_id;
+	public function is_user_connected( $user_id = false ) {
+		$user_id = false === $user_id ? get_current_user_id() : absint( $user_id );
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		return (bool) $this->get_access_token( $user_id );
 	}
 
 	/**

--- a/packages/connection/tests/php/Manager.php
+++ b/packages/connection/tests/php/Manager.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use phpmock\Mock;
+use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
 
 class ManagerTest extends TestCase {
@@ -13,6 +15,7 @@ class ManagerTest extends TestCase {
 
 	public function tearDown() {
 		unset( $this->manager );
+		Mock::disableAll();
 	}
 
 	function test_class_implements_interface() {
@@ -44,5 +47,84 @@ class ManagerTest extends TestCase {
 		              ->will( $this->returnValue( false ) );
 
 		$this->assertFalse( $this->manager->is_active() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected
+	 */
+	public function test_is_user_connected_with_default_user_id_logged_out() {
+		$this->mock_function( 'get_current_user_id', 0 );
+
+		$this->assertFalse( $this->manager->is_user_connected() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected
+	 */
+	public function test_is_user_connected_with_false_user_id_logged_out() {
+		$this->mock_function( 'get_current_user_id', 0 );
+
+		$this->assertFalse( $this->manager->is_user_connected( false ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected
+	 */
+	public function test_is_user_connected_with_user_id_logged_out_not_connected() {
+		$this->mock_function( 'absint', 1 );
+		$this->manager->expects( $this->once() )
+		              ->method( 'get_access_token' )
+		              ->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $this->manager->is_user_connected( 1 ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected
+	 */
+	public function test_is_user_connected_with_default_user_id_logged_in() {
+		$this->mock_function( 'get_current_user_id', 1 );
+		$access_token = (object) [
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		];
+		$this->manager->expects( $this->once() )
+		              ->method( 'get_access_token' )
+		              ->will( $this->returnValue( $access_token ) );
+
+		$this->assertTrue( $this->manager->is_user_connected() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected
+	 */
+	public function test_is_user_connected_with_user_id_logged_in() {
+		$this->mock_function( 'absint', 1 );
+		$access_token = (object) [
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		];
+		$this->manager->expects( $this->once() )
+		              ->method( 'get_access_token' )
+		              ->will( $this->returnValue( $access_token ) );
+
+		$this->assertTrue( $this->manager->is_user_connected( 1 ) );
+	}
+
+	/**
+	 * Mock a global function and make it return a certain value.
+	 *
+	 * @param string $function_name Name of the function.
+	 * @param mixed  $return_value  Return value of the function.
+	 * @return phpmock\Mock The mock object.
+	 */
+	protected function mock_function( $function_name, $return_value = null ) {
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( $function_name )
+			->setFunction( function() use ( &$return_value ) {
+				return $return_value;
+			} );
+		return $builder->build()->enable();
 	}
 }


### PR DESCRIPTION
This PR implements `Connection_Manager::is_user_connected` and adds several tests for it.

#### Changes proposed in this Pull Request:
* Implement `Connection_Manager::is_user_connected`.
* Add tests for `Connection_Manager::is_user_connected`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* `cd packages/connection`
* `composer phpunit`
* Verify tests pass, and CI is green.

#### Proposed changelog entry for your changes:
* Implement Connection_Manager::is_user_connected
