### PR TITLE
Sync: PSR-4 the Attachments sync module

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "b6c34729a2a37b5a485add5d357ff018654e3e35",
+                "reference": "7feb756c23c7c54941fbd9620a22407fbaa59028",
                 "shasum": null
             },
             "require": {
@@ -207,7 +207,10 @@
             "autoload": {
                 "classmap": [
                     "/legacy"
-                ]
+                ],
+                "psr-4": {
+                    "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
+                }
             },
             "license": [
                 "GPL-2.0-or-later"

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -10,6 +10,9 @@
 	"autoload": {
 		"classmap": [
 			"/legacy"
-		]
+		],
+		"psr-4": {
+			"Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
+		}
 	}
 }

--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -21,7 +21,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Updates',
-		'Jetpack_Sync_Module_Attachments',
+		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
 		'Jetpack_Sync_Module_Meta',
 		'Jetpack_Sync_Module_Plugins',
 		'Jetpack_Sync_Module_Full_Sync',

--- a/packages/sync/src/modules/Attachments.php
+++ b/packages/sync/src/modules/Attachments.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Attachments extends \Jetpack_Sync_Module {
 	function name() {
 		return 'attachments';
 	}


### PR DESCRIPTION
This PR allows for sync modules to be loadable via PSR-4, and updates the Attachments sync module to be loaded via PSR-4.

#### Changes proposed in this Pull Request:
* Make the sync package modules directory compatible with PSR-4
* Update the Attachments module 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: PSR-4 the Attachments sync module
