### PR TITLE
Sync: PSR-4 the Callables sync module

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Modules {
 
 	private static $default_sync_modules = array(
 		'Jetpack_Sync_Module_Constants',
-		'Jetpack_Sync_Module_Callables',
+		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
 		'Jetpack_Sync_Module_Options',
 		'Jetpack_Sync_Module_Network_Options',
 		'Jetpack_Sync_Module_Terms',

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Callables extends \Jetpack_Sync_Module {
 	const CALLABLES_CHECKSUM_OPTION_NAME = 'jetpack_callables_sync_checksum';
 	const CALLABLES_AWAIT_TRANSIENT_NAME = 'jetpack_sync_callables_await';
 
@@ -12,9 +14,9 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function set_defaults() {
 		if ( is_multisite() ) {
-			$this->callable_whitelist = array_merge( Jetpack_Sync_Defaults::get_callable_whitelist(), Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
+			$this->callable_whitelist = array_merge( \Jetpack_Sync_Defaults::get_callable_whitelist(), \Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
 		} else {
-			$this->callable_whitelist = Jetpack_Sync_Defaults::get_callable_whitelist();
+			$this->callable_whitelist = \Jetpack_Sync_Defaults::get_callable_whitelist();
 		}
 	}
 
@@ -63,7 +65,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 		$url_callables = array( 'home_url', 'site_url', 'main_network_site_url' );
 		foreach ( $url_callables as $callable ) {
-			delete_option( Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable );
+			delete_option( \Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable );
 		}
 	}
 
@@ -78,7 +80,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function get_all_callables() {
 		// get_all_callables should run as the master user always.
 		$current_user_id = get_current_user_id();
-		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
+		wp_set_current_user( \Jetpack_Options::get_option( 'master_user' ) );
 		$callables = array_combine(
 			array_keys( $this->get_callable_whitelist() ),
 			array_map( array( $this, 'get_callable' ), array_values( $this->get_callable_whitelist() ) )
@@ -125,7 +127,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function set_plugin_action_links() {
 		if (
-			! class_exists( 'DOMDocument' ) ||
+			! class_exists( '\DOMDocument' ) ||
 			! function_exists( 'libxml_use_internal_errors' ) ||
 			! function_exists( 'mb_convert_encoding' )
 		) {
@@ -140,7 +142,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		if ( ! empty( $plugins_lock ) && ( isset( $current_screeen->id ) && $current_screeen->id !== 'plugins' ) ) {
 			return;
 		}
-		$plugins = array_keys( Jetpack_Sync_Functions::get_plugins() );
+		$plugins = array_keys( \Jetpack_Sync_Functions::get_plugins() );
 		foreach ( $plugins as $plugin_file ) {
 			/**
 			 *  Plugins often like to unset things but things break if they are not able to.
@@ -159,7 +161,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			$action_links           = array_filter( $action_links );
 			$formatted_action_links = null;
 			if ( ! empty( $action_links ) && count( $action_links ) > 0 ) {
-				$dom_doc = new DOMDocument();
+				$dom_doc = new \DOMDocument();
 				foreach ( $action_links as $action_link ) {
 					// The @ is not enough to suppress errors when dealing with libxml,
 					// we have to tell it directly how we want to handle errors.
@@ -201,7 +203,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			'home_url',
 			'site_url',
 		);
-		if ( in_array( $name, $idc_override_callables ) && Jetpack_Options::get_option( 'migrate_for_idc' ) ) {
+		if ( in_array( $name, $idc_override_callables ) && \Jetpack_Options::get_option( 'migrate_for_idc' ) ) {
 			return true;
 		}
 
@@ -210,7 +212,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function maybe_sync_callables() {
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
-			if ( ! is_admin() || Jetpack_Sync_Settings::is_doing_cron() ) {
+			if ( ! is_admin() || \Jetpack_Sync_Settings::is_doing_cron() ) {
 				return;
 			}
 
@@ -219,7 +221,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 		}
 
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
+		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), \Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
 
 		$callables = $this->get_all_callables();
 
@@ -227,7 +229,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$callable_checksums = (array) Jetpack_Options::get_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
+		$callable_checksums = (array) \Jetpack_Options::get_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 		$has_changed        = false;
 		// only send the callables that have changed
 		foreach ( $callables as $name => $value ) {
@@ -250,7 +252,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 		}
 		if ( $has_changed ) {
-			Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+			\Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
 		}
 
 	}
@@ -262,7 +264,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			foreach ( $callables as $name => $value ) {
 				$callables_checksums[ $name ] = $this->get_check_sum( $value );
 			}
-			Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callables_checksums );
+			\Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callables_checksums );
 			return $callables;
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules\Callables;
+
 Jetpack_Sync_Main::init();
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
@@ -61,12 +63,12 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 		// don't sync callables or constants every time - slows down tests
-		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
 		set_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
 	}
 
 	protected function resetCallableAndConstantTimeouts() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );	
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules\Callables;
 
 require_once 'test_class.jetpack-sync-base.php';
 
@@ -141,8 +142,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_white_listed_callables_doesnt_get_synced_twice() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Callables::CALLABLES_CHECKSUM_OPTION_NAME );
 		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
 		$this->sender->do_sync();
 
@@ -151,7 +152,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->server_replica_storage->reset();
 
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		$this->sender->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
@@ -250,8 +251,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_home_site_urls_synced_while_migrate_for_idc_set() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Callables::CALLABLES_CHECKSUM_OPTION_NAME );
 
 		$home_option    = get_option( 'home' );
 		$siteurl_option = get_option( 'siteurl' );
@@ -266,7 +267,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		// Second, let's make sure that values don't get synced again if the migrate_for_idc option is not set
 		$this->server_replica_storage->reset();
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		$this->sender->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'home_url' ) );
@@ -277,7 +278,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Options::update_option( 'migrate_for_idc', true );
 
 		$this->server_replica_storage->reset();
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		$this->sender->do_sync();
 
 		$this->assertEquals( $home_option,  $this->server_replica_storage->get_callable( 'home_url' ) );
@@ -412,8 +413,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of
 		// switching back and forth, so we force the domain to be the one in the siteurl option
 		$this->setSyncClientDefaults();
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Callables::CALLABLES_CHECKSUM_OPTION_NAME );
 
 		$original_site_url = site_url();
 
@@ -424,8 +425,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		add_filter( 'site_url', array( $this, 'add_www_subdomain_to_siteurl' ) );
 
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Callables::CALLABLES_CHECKSUM_OPTION_NAME );
 		$this->sender->do_sync();
 
 		$this->assertEquals( $original_site_url, $this->server_replica_storage->get_callable( 'site_url' ) );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules\Callables;
+
 class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	protected $action_ran;
 	protected $action_codec;
@@ -349,7 +351,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 	function test_limits_execution_time_of_do_sync() {
 		// disable sync callables
-		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
 		$this->sender->do_sync();
 
 		$this->assertEquals( 0, $this->sender->get_sync_queue()->size() );


### PR DESCRIPTION
This PR updates the Callables sync module to be loaded via PSR-4.

#### Changes proposed in this Pull Request:
* Update the Callables module 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Play with the site, trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: PSR-4 the Callables sync module
