### PR TITLE
Sync Package: Moves the Protect sync module

### DIFF
--- a/packages/sync/src/Modules.php
+++ b/packages/sync/src/Modules.php
@@ -20,7 +20,7 @@ class Modules {
 		'Automattic\\Jetpack\\Sync\\Modules\\Users',
 		'Automattic\\Jetpack\\Sync\\Modules\\Import',
 		'Automattic\\Jetpack\\Sync\\Modules\\Posts',
-		'Jetpack_Sync_Module_Protect',
+		'Automattic\\Jetpack\\Sync\\Modules\\Protect',
 		'Automattic\\Jetpack\\Sync\\Modules\\Comments',
 		'Automattic\\Jetpack\\Sync\\Modules\\Updates',
 		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',

--- a/packages/sync/src/modules/Protect.php
+++ b/packages/sync/src/modules/Protect.php
@@ -1,11 +1,15 @@
 <?php
 
+namespace Automattic\Jetpack\Sync\Modules;
+
 use Automattic\Jetpack\Constants;
 
 /**
- * logs bruteprotect failed logins via sync
+ * Logs valid failed login attempts via sync.
+ * A failed attempt is considered valid if it comes from a trusted IP address.
+ * Failed attempts from unknown IP addresses do not trigger sync actions.
  */
-class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
+class Protect extends \Jetpack_Sync_Module {
 
 	function name() {
 		return 'protect';
@@ -17,7 +21,7 @@ class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 	}
 
 	function maybe_log_failed_login_attempt( $failed_attempt ) {
-		$protect = Jetpack_Protect_Module::instance();
+		$protect = \Jetpack_Protect_Module::instance();
 		if ( $protect->has_login_ability() && ! Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}

--- a/packages/sync/src/modules/Protect.php
+++ b/packages/sync/src/modules/Protect.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 /**
  * Logs valid failed login attempts via sync.
@@ -22,7 +22,7 @@ class Protect extends \Jetpack_Sync_Module {
 
 	function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = \Jetpack_Protect_Module::instance();
-		if ( $protect->has_login_ability() && ! Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( $protect->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}


### PR DESCRIPTION
We are trying to move away from class mapped packages, and unspool all of the dependencies within a package.

So let's do this!

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #12712

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR should have no functional changes. The Protect sync module should function exactly the same as before.

Note, the Protect module will need its own package, but we'll handle that in an other PR.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This modifies an existing part of Jetpack.

#### Testing instructions:

* Try this branch out on a Jurassic.ninja site or on your docker testing site.
* Connect the site and activate the recommended features.
* Point your testing site to your .com sandbox to observe sync actions in real time.
* Log out of your testing site, and login with a incorrect username / password
* Do you see the sync action for `jetpack_valid_failed_login_attempt`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
