### PR TITLE
Connection: Use package for is_user_connected

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1699,12 +1699,7 @@ class Jetpack {
 	 * Is a given user (or the current user if none is specified) linked to a WordPress.com user?
 	 */
 	public static function is_user_connected( $user_id = false ) {
-		$user_id = false === $user_id ? get_current_user_id() : absint( $user_id );
-		if ( ! $user_id ) {
-			return false;
-		}
-
-		return (bool) Jetpack_Data::get_access_token( $user_id );
+		return self::connection()->is_user_connected( $user_id );
 	}
 
 	/**


### PR DESCRIPTION
This PR updates the `Jetpack::is_user_connected` method to use the connection package. 

A next logical step would be to actually get rid of `Jetpack::is_user_connected` completely and use the connection manager method directly, but to do that first, we need to make sure that we have a proper way to access and manage the single instance of the connection manager.

#### Changes proposed in this Pull Request:
* Update the `Jetpack::is_user_connected` method to use the connection package. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout this branch.
* Enable `WP_DEBUG_LOG`
* Go to the Jetpack dashboard `/wp-admin/admin.php?page=jetpack#/dashboard`
* Open the browser console.
* Type `window.Initial_State.userData.currentUser.isConnected`
* Verify it corresponds to the current state of the connection of the currently logged in user (`true` or `false`).
* Verify your `debug.log` is empty.

#### Proposed changelog entry for your changes:
* Update the `Jetpack::is_user_connected` method to use the connection package. 
