### PR TITLE
Sync: PSR-4 the Terms sync module

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -12,7 +12,7 @@ class Jetpack_Sync_Modules {
 		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
 		'Jetpack_Sync_Module_Options',
 		'Jetpack_Sync_Module_Network_Options',
-		'Jetpack_Sync_Module_Terms',
+		'Automattic\\Jetpack\\Sync\\Modules\\Terms',
 		'Jetpack_Sync_Module_Themes',
 		'Jetpack_Sync_Module_Menus',
 		'Jetpack_Sync_Module_Users',

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Terms extends \Jetpack_Sync_Module {
 	private $taxonomy_whitelist;
 
 	function name() {
@@ -58,8 +60,8 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	}
 
 	function save_term_handler( $term_id, $tt_id, $taxonomy ) {
-		if ( class_exists( 'WP_Term' ) ) {
-			$term_object = WP_Term::get_instance( $term_id, $taxonomy );
+		if ( class_exists( '\\WP_Term' ) ) {
+			$term_object = \WP_Term::get_instance( $term_id, $taxonomy );
 		} else {
 			$term_object = get_term_by( 'id', $term_id, $taxonomy );
 		}
@@ -93,7 +95,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	}
 
 	function set_defaults() {
-		$this->taxonomy_whitelist = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
+		$this->taxonomy_whitelist = \Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
 	}
 
 	public function expand_term_taxonomy_id( $args ) {


### PR DESCRIPTION
This PR updates the Terms sync module to be loaded via PSR-4. 

#### Changes proposed in this Pull Request:
* Update the Terms module to PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: PSR-4 the Terms sync module
