### PR TITLE
Sync Package: Moves the Plugins sync module

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -23,7 +23,7 @@ class Jetpack_Sync_Modules {
 		'Automattic\\Jetpack\\Sync\\Modules\\Updates',
 		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
 		'Automattic\\Jetpack\\Sync\\Modules\\Meta',
-		'Jetpack_Sync_Module_Plugins',
+		'Automattic\\Jetpack\\Sync\\Modules\\Plugins',
 		'Automattic\\Jetpack\\Sync\\Modules\\Stats',
 		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
 	);

--- a/packages/sync/src/modules/Plugins.php
+++ b/packages/sync/src/modules/Plugins.php
@@ -1,8 +1,8 @@
 <?php
-
+namespace Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Constants;
 
-class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
+class Plugins extends \Jetpack_Sync_Module {
 
 	private $action_handler;
 	private $plugin_info = array();
@@ -162,8 +162,8 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 	public function check_plugin_edit() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
-			! isset( $_POST['newcontent'] ) ||
-			! isset( $_POST['plugin'] )
+		     ! isset( $_POST['newcontent'] ) ||
+		     ! isset( $_POST['plugin'] )
 		) {
 			return;
 		}

--- a/packages/sync/src/modules/Plugins.php
+++ b/packages/sync/src/modules/Plugins.php
@@ -1,6 +1,6 @@
 <?php
 namespace Automattic\Jetpack\Sync\Modules;
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 class Plugins extends \Jetpack_Sync_Module {
 
@@ -67,7 +67,7 @@ class Plugins extends \Jetpack_Sync_Module {
 		switch ( $details['action'] ) {
 			case 'update':
 				$state  = array(
-					'is_autoupdate' => Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
+					'is_autoupdate' => Jetpack_Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
 				);
 				$errors = $this->get_errors( $upgrader->skin );
 				if ( $errors ) {


### PR DESCRIPTION
We are trying to move away from class mapped packages, and unspool all of the dependencies within a package.

So let's do this!

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #12712

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR should have no functional changes. The Plugins sync module should function exactly the same as before.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This modifies an existing part of Jetpack.

#### Testing instructions:

* Try this branch out on a Jurassic.ninja site or on your docker testing site.
* Connect the site and activate the recommended features.
* Point your testing site to your .com sandbox to observe sync actions in real time.
* Try a full sync and ensure there are no php errors in your site's error logs
* Try some plugin actions, install, activate, deactivate, etc, and ensure you observe the corresponding sync actions on your .com sandbox.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
