### PR TITLE
Traffic: Link related posts hint to related documentation

### DIFF
--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -67,7 +67,20 @@ class RelatedPostsComponent extends React.Component {
 					} }
 				>
 					<p className="jp-form-setting-explanation">
-						{ __( "These settings won't apply to related posts added using the block editor." ) }
+						{ __(
+							"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
+							{
+								components: {
+									a: (
+										<a
+											href="https://jetpack.com/support/jetpack-blocks/related-posts-block/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
 					</p>
 					<ModuleToggle
 						slug="related-posts"


### PR DESCRIPTION
Link the "These settings won't apply to related posts added using the block editor." text to the related documentation, providing more context around the block and block editor.

Fixes #12713 

See the issue for before and after screenshots.


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to admin.php?page=jetpack#/traffic
* Check the link in the related posts card

