### PR TITLE
Security: Downtime monitoring copy

### DIFF
--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -49,7 +49,9 @@ export const Monitor = withModuleSettingsFormHelpers(
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Receive notifications when your site goes offline.' ) }
+								{ __(
+									"Get alerts if your site goes offline. We’ll let you know when it's back up, too."
+								) }
 							</span>
 						</ModuleToggle>
 					</SettingsGroup>

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -50,7 +50,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 						>
 							<span className="jp-form-toggle-explanation">
 								{ __(
-									"Get alerts if your site goes offline. We’ll let you know when it's back up, too."
+									'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.'
 								) }
 							</span>
 						</ModuleToggle>

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -49,7 +49,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( "Monitor your site's downtime" ) }
+								{ __( 'Receive notifications when your site goes offline.' ) }
 							</span>
 						</ModuleToggle>
 					</SettingsGroup>


### PR DESCRIPTION
Update copy on downtime monitoring card:

> Receive notifications when your site goes offline.

Fixes #12588 

Please see the issue for a before and after

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/security
* Check the copy on the downtime monitoring card

#### Proposed changelog entry for your changes:
* None
