### PR TITLE
Media: Square and Circle gallery images squashed

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
@@ -86,9 +86,16 @@
 
 .tiled-gallery.type-circle .tiled-gallery-item img {
 	border-radius: 50% !important; /* Ensure that circles are displayed in themes that add border-radius to all images as a default */
+	object-fit: cover;
 }
 .tiled-gallery.type-circle .tiled-gallery-caption {
 	display: none;
 	opacity: 0;
 }
 
+
+/* =Square Layout
+-------------------------------------------------------------- */
+.tiled-gallery.type-square .tiled-gallery-item img {
+	object-fit: cover;
+}


### PR DESCRIPTION
Fixes #1526

This patch fixes images getting squashed/skewed in Square and Circle Tiled Gallery as described in 7861-wpcom.

This bug currently only appears when **Classic Editor** is used to create Square or Circle Tiled Gallery on **Simple sites**.

It does not appear in Jetpack site donpark.wpsandbox.me with latest Jetpack. I don't see an equivalent fix in Jetpack so it's not clear why the same issue does not appear there.

This commit was generated from D28285-code.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
