### PR TITLE
WordAds Block: AMP Support

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -496,6 +496,15 @@ HTML;
 		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
 			$loc_id = self::$ad_location_ids[ $location ];
 		}
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			$site_id = $this->params->blog_id;
+			return <<<HTML
+			<amp-ad width="$width" height="$height"
+			    type="pubmine"
+			    data-siteid="$site_id">
+			</amp-ad>
+HTML;
+		}
 
 		return <<<HTML
 		<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -232,7 +232,7 @@ class WordAds {
 		}
 
 		if ( $this->option( 'enable_header_ad', true ) ) {
-			if ( $this->is_amp() ) {
+			if ( self::is_amp() ) {
 				add_filter( 'the_content', array( $this, 'insert_header_ad_amp' ) );
 			} else {
 				switch ( get_stylesheet() ) {
@@ -426,7 +426,7 @@ HTML;
 
 		$ad_type = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
 		echo $this->get_ad( 'top', $ad_type );
-		if ( ! $this->is_amp() ) {
+		if ( ! self::is_amp() ) {
 			echo <<<HTML
 		<script type="text/javascript">
 			jQuery('.wpcnt-header').insertBefore('$selector');

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -72,7 +72,7 @@ class WordAds {
 	 * Checks for AMP support and returns true iff active & AMP request
 	 * @return boolean True if supported AMP request
 	 *
-	 * @since 4.5.0
+	 * @since 7.5.0
 	 */
 	public static function is_amp() {
 		return class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -61,6 +61,23 @@ class WordAds {
 		'inline-plugin' => 320,
 	);
 
+	/**
+	 * Counter to enable unique, sequential section IDs for all amp-ad units
+	 *
+	 * @var int
+	 */
+	public static $amp_section_id = 0;
+
+	/**
+	 * Increment the AMP section ID and return the value
+	 *
+	 * @return int
+	 */
+	public static function get_amp_section_id() {
+		self::$amp_section_id++;
+		return self::$amp_section_id;
+	}
+
 	public static $SOLO_UNIT_CSS = 'float:left;margin-right:5px;margin-top:0px;';
 
 	/**
@@ -481,7 +498,8 @@ HTML;
 	 *
 	 * @since 5.7
 	 */
-	function get_ad_snippet( $section_id, $height, $width, $location = '', $css = '' ) {
+	public function get_ad_snippet( $section_id, $height, $width, $location = '', $css = '' ) {
+
 		$this->ads[] = array(
 			'location' => $location,
 			'width'    => $width,
@@ -497,11 +515,13 @@ HTML;
 			$loc_id = self::$ad_location_ids[ $location ];
 		}
 		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			$amp_section_id = self::get_amp_section_id();
 			$site_id = $this->params->blog_id;
 			return <<<HTML
 			<amp-ad width="$width" height="$height"
 			    type="pubmine"
-			    data-siteid="$site_id">
+			    data-siteid="$site_id"
+			    data-section="$amp_section_id">
 			</amp-ad>
 HTML;
 		}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -515,6 +515,7 @@ HTML;
 		);
 
 		if ( self::is_amp() ) {
+			$height += 15; // this will ensure enough padding for "Report this ad"
 			$amp_section_id = self::get_amp_section_id();
 			$site_id = $this->params->blog_id;
 			return <<<HTML

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -69,6 +69,16 @@ class WordAds {
 	public static $amp_section_id = 1;
 
 	/**
+	 * Checks for AMP support and returns true iff active & AMP request
+	 * @return boolean True if supported AMP request
+	 *
+	 * @since 4.5.0
+	 */
+	public static function is_amp() {
+		return class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+	}
+
+	/**
 	 * Increment the AMP section ID and return the value
 	 *
 	 * @return int
@@ -498,22 +508,13 @@ HTML;
 	 * @since 5.7
 	 */
 	public function get_ad_snippet( $section_id, $height, $width, $location = '', $css = '' ) {
-
 		$this->ads[] = array(
 			'location' => $location,
 			'width'    => $width,
 			'height'   => $height,
 		);
-		$ad_number   = count( $this->ads ) . '-' . uniqid();
 
-		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
-		$css = esc_attr( $css );
-
-		$loc_id = 100;
-		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
-			$loc_id = self::$ad_location_ids[ $location ];
-		}
-		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		if ( self::is_amp() ) {
 			$amp_section_id = self::get_amp_section_id();
 			$site_id = $this->params->blog_id;
 			return <<<HTML
@@ -523,6 +524,15 @@ HTML;
 			    data-section="$amp_section_id">
 			</amp-ad>
 HTML;
+		}
+
+		$ad_number = count( $this->ads ) . '-' . uniqid();
+		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
+		$css = esc_attr( $css );
+
+		$loc_id = 100;
+		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
+			$loc_id = self::$ad_location_ids[ $location ];
 		}
 
 		return <<<HTML

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -515,9 +515,10 @@ HTML;
 		);
 
 		if ( self::is_amp() ) {
-			$height += 15; // this will ensure enough padding for "Report this ad"
-			$amp_section_id = self::get_amp_section_id();
-			$site_id = $this->params->blog_id;
+			$height         = esc_attr( $height + 15 ); // this will ensure enough padding for "Report this ad"
+			$width          = esc_attr( $width );
+			$amp_section_id = esc_attr( self::get_amp_section_id() );
+			$site_id        = esc_attr( $this->params->blog_id );
 			return <<<HTML
 			<amp-ad width="$width" height="$height"
 			    type="pubmine"

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -445,6 +445,9 @@ HTML;
 	public function insert_header_ad_amp( $content ) {
 
 		$ad_type = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
+		if ( 'house' === $ad_type ) {
+			return $content;
+		}
 		return $this->get_ad( 'top', $ad_type ) . $content;
 
 	}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -66,7 +66,7 @@ class WordAds {
 	 *
 	 * @var int
 	 */
-	public static $amp_section_id = 0;
+	public static $amp_section_id = 1;
 
 	/**
 	 * Increment the AMP section ID and return the value
@@ -74,8 +74,7 @@ class WordAds {
 	 * @return int
 	 */
 	public static function get_amp_section_id() {
-		self::$amp_section_id++;
-		return self::$amp_section_id;
+		return self::$amp_section_id++;
 	}
 
 	public static $SOLO_UNIT_CSS = 'float:left;margin-right:5px;margin-top:0px;';

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -232,15 +232,19 @@ class WordAds {
 		}
 
 		if ( $this->option( 'enable_header_ad', true ) ) {
-			switch ( get_stylesheet() ) {
-				case 'twentyseventeen':
-				case 'twentyfifteen':
-				case 'twentyfourteen':
-					add_action( 'wp_footer', array( $this, 'insert_header_ad_special' ) );
-					break;
-				default:
-					add_action( 'wp_head', array( $this, 'insert_header_ad' ), 100 );
-					break;
+			if ( $this->is_amp() ) {
+				add_filter( 'the_content', array( $this, 'insert_header_ad_amp' ) );
+			} else {
+				switch ( get_stylesheet() ) {
+					case 'twentyseventeen':
+					case 'twentyfifteen':
+					case 'twentyfourteen':
+						add_action( 'wp_footer', array( $this, 'insert_header_ad_special' ) );
+						break;
+					default:
+						add_action( 'wp_head', array( $this, 'insert_header_ad' ), 100 );
+						break;
+				}
 			}
 		}
 	}
@@ -422,11 +426,27 @@ HTML;
 
 		$ad_type = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
 		echo $this->get_ad( 'top', $ad_type );
-		echo <<<HTML
+		if ( ! $this->is_amp() ) {
+			echo <<<HTML
 		<script type="text/javascript">
 			jQuery('.wpcnt-header').insertBefore('$selector');
 		</script>
 HTML;
+		}
+	}
+
+	/**
+	 * Header unit for AMP
+	 *
+	 * @param string $content Content of the page.
+	 *
+	 * @since 7.5.0
+	 */
+	public function insert_header_ad_amp( $content ) {
+
+		$ad_type = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
+		return $this->get_ad( 'top', $ad_type ) . $content;
+
 	}
 
 	/**

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -132,7 +132,7 @@ class WordAds {
 	 * @since 4.5.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'init' ) );
+		add_action( 'wp', array( $this, 'init' ) );
 	}
 
 	/**

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -448,7 +448,7 @@ HTML;
 		if ( 'house' === $ad_type ) {
 			return $content;
 		}
-		return $this->get_ad( 'top', $ad_type ) . $content;
+		return $this->get_ad( 'top_amp', $ad_type ) . $content;
 
 	}
 
@@ -505,6 +505,11 @@ HTML;
 			} elseif ( 'inline' === $spot ) {
 				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '5';
 				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
+			} elseif ( 'top_amp' === $spot ) {
+				// 320x50 unit which can safely be inserted below title, above content in a variety of themes.
+				$width   = 320;
+				$height  = 50;
+				$snippet = $this->get_ad_snippet( null, $height, $width );
 			}
 		} elseif ( 'house' == $type ) {
 			$leaderboard = 'top' == $spot && ! $this->params->mobile_device;

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -133,6 +133,7 @@ class WordAds {
 	 */
 	function __construct() {
 		add_action( 'wp', array( $this, 'init' ) );
+		add_action( 'rest_api_init', array( $this, 'init' ) );
 	}
 
 	/**

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -269,6 +269,9 @@ class WordAds {
 	 * @return [type] [description]
 	 */
 	function insert_head_meta() {
+		if ( self::is_amp() ) {
+			return;
+		}
 		$themename = esc_js( get_stylesheet() );
 		$pagetype  = intval( $this->params->get_page_type_ipw() );
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
@@ -291,6 +294,9 @@ HTML;
 	 * @since 4.5.0
 	 */
 	function insert_head_iponweb() {
+		if ( self::is_amp() ) {
+			return;
+		}
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
 		echo <<<HTML
 		<link rel='dns-prefetch' href='//s.pubmine.com' />


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR brings AMP compatibility to the Jetpack Ads block. 

A couple of gotchas:

1) ~The `Additional ad placements->Top of each page` option will lead to AMP incompatibility in TwentySeventeen, TwentyFifteen, and TwentyFourteen. This is due to https://github.com/Automattic/jetpack/blob/master/modules/wordads/wordads.php#L400-L402. I plan to address this in a separate PR since this doesn't directly relate to the block.~
2) AMP ads will be blocked if `Settings->Reading->Search Engine Visibility->Discourage search engines from indexing this site` is checked. 
3) Make sure you have no ad blockers enabled (I fell for this one more than once :-) )

#### Testing instructions:

- Spin up a Jurassic Ninja instance with this link: ~https://jurassic.ninja/create/?branch=add/amp-ads-support~ http://jurassic.ninja/create/?jetpack-beta&branch=add/amp-ads-support
- Connect Jetpack, and upgrade to Premium.
- Navigate to `/wp-admin/admin.php?page=jetpack#/traffic`.
- Enable Ads. Switch off `Additional ad placements->Top of each page` (see note above)
- Install and activate the AMP plugin: https://wordpress.org/plugins/amp/
- Go to AMP settings and switch to **Transitional** mode.
- Create a post, add Ads block, publish the post.
- View published post, in both AMP and non-AMP environments. You should see roughly identical output in both.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* AMP compatibility for the Jetpack Ads block.
