### PR TITLE
Sync Package: Moves the Options sync module 

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -10,8 +10,8 @@ class Jetpack_Sync_Modules {
 	private static $default_sync_modules = array(
 		'Jetpack_Sync_Module_Constants',
 		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
-		'Jetpack_Sync_Module_Options',
 		'Jetpack_Sync_Module_Network_Options',
+		'Automattic\\Jetpack\\Sync\\Modules\\Options',
 		'Automattic\\Jetpack\\Sync\\Modules\\Terms',
 		'Jetpack_Sync_Module_Themes',
 		'Jetpack_Sync_Module_Menus',

--- a/packages/sync/src/modules/Options.php
+++ b/packages/sync/src/modules/Options.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Options extends \Jetpack_Sync_Module {
 	private $options_whitelist, $options_contentless;
 
 	public function name() {
@@ -92,7 +94,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	}
 
 	function update_options_whitelist() {
-		$this->options_whitelist = Jetpack_Sync_Defaults::get_options_whitelist();
+		$this->options_whitelist = \Jetpack_Sync_Defaults::get_options_whitelist();
 	}
 
 	function set_options_whitelist( $options ) {
@@ -104,7 +106,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	}
 
 	function update_options_contentless() {
-		$this->options_contentless = Jetpack_Sync_Defaults::get_options_contentless();
+		$this->options_contentless = \Jetpack_Sync_Defaults::get_options_contentless();
 	}
 
 	function get_options_contentless() {
@@ -157,9 +159,9 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		// If there's a core icon, maybe update the option.  If not, fall back to Jetpack's.
 		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
 			// This is the option that is synced with dotcom
-			Jetpack_Options::update_option( 'site_icon_url', $url );
+			\Jetpack_Options::update_option( 'site_icon_url', $url );
 		} elseif ( empty( $url ) ) {
-			Jetpack_Options::delete_option( 'site_icon_url' );
+			\Jetpack_Options::delete_option( 'site_icon_url' );
 		}
 	}
 


### PR DESCRIPTION
We are trying to move away from class mapped packages, and unspool all of the dependencies within a package.

So let's do this!

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #12712

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR should have no functional changes. The Options sync module should function exactly the same as before.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This modifies an existing part of Jetpack.

#### Testing instructions:

* Try this branch out on a Jurassic.ninja site or on your docker testing site.
* Connect the site and activate the recommended features.
* Point your testing site to your .com sandbox to observe sync actions in real time.
* Try a full sync and ensure there are no php errors in your site's error logs
* Try updating some options, such as blog description and stuff. Ensure you see the expected sync actions in the pipeline.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
