### PR TITLE
Jetpack DNA: Move Sync Import Module from Legacy to psr-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -17,7 +17,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Menus',
 		'Jetpack_Sync_Module_Users',
 		'Jetpack_Sync_Module_Posts',
-		'Jetpack_Sync_Module_Import',
+		'Automattic\\Jetpack\\Sync\\Modules\\Import',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Updates',

--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -158,7 +158,7 @@ class Import extends \Jetpack_Sync_Module {
 			// Check if the class extends WP_Importer.
 			if ( class_exists( $class_name, false ) ) {
 				$parents = class_parents( $class_name, false );
-				if ( $parents && in_array( '\WP_Importer', $parents, true ) ) {
+				if ( $parents && in_array( 'WP_Importer', $parents, true ) ) {
 					return $class_name;
 				}
 			}

--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -124,7 +124,7 @@ class Import extends \Jetpack_Sync_Module {
 	 */
 	private static function get_calling_importer_class() {
 		// If WP_Importer doesn't exist, neither will any importer that extends it.
-		if ( ! class_exists( '\WP_Importer', false ) ) {
+		if ( ! class_exists( 'WP_Importer', false ) ) {
 			return 'unknown';
 		}
 

--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Import extends \Jetpack_Sync_Module {
 
 	/**
 	 * Tracks which actions have already been synced for the import
@@ -71,7 +73,7 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 		}
 
 		// Get $importer from known_importers.
-		$known_importers = Jetpack_Sync_Settings::get_setting( 'known_importers' );
+		$known_importers = \Jetpack_Sync_Settings::get_setting( 'known_importers' );
 		if ( isset( $known_importers[ $importer ] ) ) {
 			$importer = $known_importers[ $importer ];
 		}
@@ -122,7 +124,7 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 	 */
 	private static function get_calling_importer_class() {
 		// If WP_Importer doesn't exist, neither will any importer that extends it.
-		if ( ! class_exists( 'WP_Importer', false ) ) {
+		if ( ! class_exists( '\WP_Importer', false ) ) {
 			return 'unknown';
 		}
 
@@ -156,7 +158,7 @@ class Jetpack_Sync_Module_Import extends Jetpack_Sync_Module {
 			// Check if the class extends WP_Importer.
 			if ( class_exists( $class_name, false ) ) {
 				$parents = class_parents( $class_name, false );
-				if ( $parents && in_array( 'WP_Importer', $parents, true ) ) {
+				if ( $parents && in_array( '\WP_Importer', $parents, true ) ) {
 					return $class_name;
 				}
 			}

--- a/tests/php/sync/test_class.jetpack-sync-import.php
+++ b/tests/php/sync/test_class.jetpack-sync-import.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules\Import;
+
 /**
  * Testing Import Syncing Events
  */

--- a/tests/php/sync/test_class.jetpack-sync-import.php
+++ b/tests/php/sync/test_class.jetpack-sync-import.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Sync\Modules\Import;
-
 /**
  * Testing Import Syncing Events
  */


### PR DESCRIPTION
This PR moves the sync import module from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.