### PR TITLE
Build: don't remove Composer lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"watch": "yarn install-if-deps-outdated && ./node_modules/.bin/gulp watch",
 		"clean": "yarn clean-client && yarn clean-extensions && yarn clean-composer",
 		"clean-client": "rm -rf _inc/build/ css/",
-		"clean-composer": "rm -rf composer.lock vendor/",
+		"clean-composer": "rm -rf vendor/",
 		"clean-extensions": "rm -rf _inc/blocks/ ",
 		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files",
 		"distclean": "rm -rf node_modules && yarn clean",


### PR DESCRIPTION
The Composer lockfile is effectively useless if it's removed just before Composer installer runs, hence not providing a "locked", repeatable state for the install.

Currently, I get unwanted changes to this file if I run `yarn build` (in non-master branch). :-(

Convo p1560890905209800-slack-jetpack-dna

#### Changes proposed in this Pull Request:
* Don't remove `composer.lock` in cleanup command

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 

#### Testing instructions:
- Run `yarn distclean` and `yarn build`
- Does everything work just fine? No surprise changes in Composer lockfile?

#### Proposed changelog entry for your changes:
-
