### PR TITLE
Jetpack DNA: Move Sync Updates Module from Legacy to PSR-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -20,7 +20,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Import',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Comments',
-		'Jetpack_Sync_Module_Updates',
+		'Automattic\\Jetpack\\Sync\\Modules\\Updates',
 		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
 		'Automattic\\Jetpack\\Sync\\Modules\\Meta',
 		'Jetpack_Sync_Module_Plugins',

--- a/packages/sync/src/modules/Updates.php
+++ b/packages/sync/src/modules/Updates.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace Automattic\Jetpack\Sync\Modules;
+
 use Automattic\Jetpack\Constants;
 
-class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
+class Updates extends \Jetpack_Sync_Module {
 
 	const UPDATES_CHECKSUM_OPTION_NAME = 'jetpack_updates_sync_checksum';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR moves the sync updates module from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.