### PR TITLE
Security: replace log into with log in to

### DIFF
--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -75,7 +75,7 @@ export const SSO = withModuleSettingsFormHelpers(
 						<p>
 							{ __(
 								'Add an extra layer of security to your website by enabling WordPress.com log in and secure ' +
-									'authentication. If you have multiple sites with this option enabled, you will be able to log into every ' +
+									'authentication. If you have multiple sites with this option enabled, you will be able to log in to every ' +
 									'one of them with the same credentials.'
 							) }
 						</p>

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -183,7 +183,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'sso' => array(
 				'name' => _x( 'Secure Sign On', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow users to log into this site using WordPress.com accounts', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow users to log in to this site using WordPress.com accounts', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' ),
 			),
 


### PR DESCRIPTION
Replace `log into` with `log in to`

Fixes #12611 

Please see the issue for before and after screenshots

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/security
* Verify the correct terms are used on the Security -> SSO card

#### Proposed changelog entry for your changes:
* None
