### PR TITLE
E2E tests: add simple payment test

### DIFF
--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -34,8 +34,13 @@ export async function connectThroughWPAdminIfNeeded( {
 	plan = 'pro',
 } = {} ) {
 	await ( await HomePage.visit( page ) ).setSandboxModeForPayments( cookie );
+	console.log( await page.cookies() );
 	await ( await WPLoginPage.visit( page ) ).login();
 	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
+	console.log( await page.cookies() );
+	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, '.ngrok.io' );
+	console.log( await page.cookies() );
+
 	await ( await Sidebar.init( page ) ).selectJetpack();
 
 	const jetpackPage = await JetpackPage.init( page );
@@ -71,7 +76,7 @@ export async function connectThroughWPAdminIfNeeded( {
 
 	console.log( await page.cookies() );
 
-	// await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
+	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
 	// console.log( '2' );
 	// console.log( await page.cookies() );
 

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -67,6 +67,7 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
+	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, '.eu.ngrok.io' );
 
 	if ( await jetpackPage.isPlan( plan ) ) {
 		console.log( 'Can see activated plan' );

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -24,6 +24,7 @@ import { takeScreenshot } from '../reporters/screenshot';
 
 const cookie = config.get( 'storeSandboxCookieValue' );
 const cardCredentials = config.get( 'testCardCredentials' );
+const siteUrl = new URL( process.env.WP_BASE_URL ).host;
 
 /**
  * Connects your site to WPCOM as `wpcomUser`, buys a Professional plan via sandbox cookie
@@ -34,13 +35,8 @@ export async function connectThroughWPAdminIfNeeded( {
 	plan = 'pro',
 } = {} ) {
 	await ( await HomePage.visit( page ) ).setSandboxModeForPayments( cookie );
-	console.log( await page.cookies() );
 	await ( await WPLoginPage.visit( page ) ).login();
-	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
-	console.log( await page.cookies() );
-	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, '.ngrok.io' );
-	console.log( await page.cookies() );
-
+	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
 	await ( await Sidebar.init( page ) ).selectJetpack();
 
 	const jetpackPage = await JetpackPage.init( page );
@@ -73,18 +69,11 @@ export async function connectThroughWPAdminIfNeeded( {
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
 	console.log( '1' );
-
 	console.log( await page.cookies() );
 
-	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
-	// console.log( '2' );
-	// console.log( await page.cookies() );
-
-	// await page.waitFor( 5000 );
-	// await page.reload();
-
-	// console.log( '3' );
-	// console.log( await page.cookies() );
+	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
+	console.log( '2' );
+	console.log( await page.cookies() );
 
 	await jetpackPage.isPlan( plan );
 	const filePath = await takeScreenshot( 'whatever', 'name' );

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -66,5 +66,5 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
-	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
+	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
 }

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -35,7 +35,7 @@ export async function connectThroughWPAdminIfNeeded( {
 } = {} ) {
 	await ( await HomePage.visit( page ) ).setSandboxModeForPayments( cookie );
 	await ( await WPLoginPage.visit( page ) ).login();
-	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, '.eu.ngrok.io' );
+	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
 	await ( await Sidebar.init( page ) ).selectJetpack();
 
 	const jetpackPage = await JetpackPage.init( page );
@@ -71,28 +71,17 @@ export async function connectThroughWPAdminIfNeeded( {
 
 	console.log( await page.cookies() );
 
-	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, '.eu.ngrok.io' );
-	console.log( '2' );
-	console.log( await page.cookies() );
+	// await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, 'ngrok.io' );
+	// console.log( '2' );
+	// console.log( await page.cookies() );
 
-	await page.waitFor( 5000 );
-	await page.reload();
+	// await page.waitFor( 5000 );
+	// await page.reload();
 
-	console.log( '3' );
-	console.log( await page.cookies() );
+	// console.log( '3' );
+	// console.log( await page.cookies() );
 
-	const list = await page.evaluate( () =>
-		wp.data
-			.select( 'core/blocks' )
-			.getBlockTypes()
-			.filter( b => b.category === 'jetpack' )
-	);
-	console.log( JSON.stringify( list ) );
-
-	if ( await jetpackPage.isPlan( plan ) ) {
-		console.log( 'Can see activated plan' );
-		return true;
-	}
+	await jetpackPage.isPlan( plan );
 	const filePath = await takeScreenshot( 'whatever', 'name' );
 	await sendFailedTestScreenshotToSlack( filePath );
 }

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -19,6 +19,8 @@ import WPLoginPage from '../pages/wp-admin/login';
 import CheckoutPage from '../pages/wpcom/checkout';
 import ThankYouPage from '../pages/wpcom/thank-you';
 import MyPlanPage from '../pages/wpcom/my-plan';
+import { sendFailedTestScreenshotToSlack } from '../reporters/slack';
+import { takeScreenshot } from '../reporters/screenshot';
 
 const cookie = config.get( 'storeSandboxCookieValue' );
 const cardCredentials = config.get( 'testCardCredentials' );
@@ -65,4 +67,11 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
+
+	if ( await jetpackPage.isPlan( plan ) ) {
+		console.log( 'Can see activated plan' );
+		return true;
+	}
+	const filePath = await takeScreenshot( 'whatever', 'name' );
+	await sendFailedTestScreenshotToSlack( filePath );
 }

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -19,8 +19,6 @@ import WPLoginPage from '../pages/wp-admin/login';
 import CheckoutPage from '../pages/wpcom/checkout';
 import ThankYouPage from '../pages/wpcom/thank-you';
 import MyPlanPage from '../pages/wpcom/my-plan';
-import { sendFailedTestScreenshotToSlack } from '../reporters/slack';
-import { takeScreenshot } from '../reporters/screenshot';
 
 const cookie = config.get( 'storeSandboxCookieValue' );
 const cardCredentials = config.get( 'testCardCredentials' );
@@ -68,14 +66,4 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
-	console.log( '1' );
-	console.log( await page.cookies() );
-
-	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
-	console.log( '2' );
-	console.log( await page.cookies() );
-
-	await jetpackPage.isPlan( plan );
-	const filePath = await takeScreenshot( 'whatever', 'name' );
-	await sendFailedTestScreenshotToSlack( filePath );
 }

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -67,7 +67,27 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
+	console.log( '1' );
+
+	console.log( await page.cookies() );
+
 	await ( await JetpackPage.init( page ) ).setSandboxModeForPayments( cookie, '.eu.ngrok.io' );
+	console.log( '2' );
+	console.log( await page.cookies() );
+
+	await page.waitFor( 5000 );
+	await page.reload();
+
+	console.log( '3' );
+	console.log( await page.cookies() );
+
+	const list = await page.evaluate( () =>
+		wp.data
+			.select( 'core/blocks' )
+			.getBlockTypes()
+			.filter( b => b.category === 'jetpack' )
+	);
+	console.log( JSON.stringify( list ) );
 
 	if ( await jetpackPage.isPlan( plan ) ) {
 		console.log( 'Can see activated plan' );

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -66,4 +66,5 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	await ( await JetpackPage.init( page ) ).waitForPage();
+	await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, siteUrl );
 }

--- a/tests/e2e/lib/page-helper.js
+++ b/tests/e2e/lib/page-helper.js
@@ -24,15 +24,21 @@ export async function waitForSelector(
 	options = { timeout: 30000, logHTML: true }
 ) {
 	let el;
+	const startTime = new Date();
 	try {
 		el = await page.waitForSelector( selector, options );
-		console.log( `Found element by locator: ${ selector }` );
+		const secondsPassed = ( new Date() - startTime ) / 1000;
+		console.log( `Found element by locator: ${ selector }. Waited for: ${ secondsPassed } sec` );
 		return el;
 	} catch ( e ) {
 		if ( options.logHTML && process.env.PUPPETEER_HEADLESS !== 'false' ) {
 			const bodyHTML = await this.page.evaluate( () => document.body.innerHTML );
 			console.log( bodyHTML );
 		}
+		const secondsPassed = ( new Date() - startTime ) / 1000;
+		console.log(
+			`Failed to locate an element by locator: ${ selector }. Waited for: ${ secondsPassed } sec`
+		);
 		throw e;
 	}
 }
@@ -59,7 +65,7 @@ export async function waitAndClick( page, selector, options = { visible: true } 
  */
 export async function waitAndType( page, selector, value, options = { visible: true } ) {
 	const el = await waitForSelector( page, selector, options );
-	await el.focus( selector );
+	await page.focus( selector );
 	await pressKeyWithModifier( 'primary', 'a' );
 	// await el.click( { clickCount: 3 } );
 	await page.waitFor( 300 );

--- a/tests/e2e/lib/pages/blocks/simple-payments.js
+++ b/tests/e2e/lib/pages/blocks/simple-payments.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import { waitAndType, waitAndClick, waitForSelector } from '../../page-helper';
+
+export default class SimplePaymentBlock {
+	constructor( block, page ) {
+		this.blockName = SimplePaymentBlock.name();
+		this.block = block;
+		this.page = page;
+		this.blockSelector = '#block-' + block.clientId;
+	}
+
+	static name() {
+		return 'Simple Payments';
+	}
+
+	async fillDetails( {
+		title = `SP test ${ new Date() }`,
+		description = 'random product description',
+		price = '23.42',
+		// isMultiple = false,
+		email = 'test@example.com',
+	} = {} ) {
+		const titleSelector = this.getSelector( '.simple-payments__field-title' );
+		const descriptionSelector = this.getSelector( '.simple-payments__field-content' );
+		// const currencySelector = this.getSelector( '.simple-payments__field-currency' );
+		const priceSelector = this.getSelector( '.simple-payments__field-price' );
+		// const multipleProductButton = this.getSelector( '.simple-payments__field-multiple' );
+		const emailSelector = this.getSelector( '.simple-payments__field-email' );
+		// const mediaUploadSelector = this.getSelector( '.components-form-file-upload input' );
+
+		await waitAndClick( this.page, titleSelector );
+		await waitAndType( this.page, titleSelector, title );
+
+		await waitAndClick( this.page, descriptionSelector );
+		await waitAndType( this.page, descriptionSelector, description );
+
+		await waitAndClick( this.page, priceSelector );
+		await waitAndType( this.page, priceSelector, price );
+
+		await waitAndClick( this.page, emailSelector );
+		await waitAndType( this.page, emailSelector, email );
+	}
+
+	getSelector( selector ) {
+		return `${ this.blockSelector } ${ selector }`;
+	}
+
+	/**
+	 * Checks whether block is rendered on frontend
+	 * @param {Page} page Puppeteer page instance
+	 */
+	static async isRendered( page ) {
+		const containerSelector = '.jetpack-simple-payments-product';
+
+		await waitForSelector( page, containerSelector );
+	}
+}

--- a/tests/e2e/lib/pages/postFrontend.js
+++ b/tests/e2e/lib/pages/postFrontend.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import Page from './page';
+
+export default class PostFrontendPage extends Page {
+	constructor( page ) {
+		const expectedSelector = '#main article.post';
+		super( page, { expectedSelector } );
+	}
+
+	/**
+	 * Checks whether specific block is rendered on frontend. All the custom logic is defined in block's `isRendered` static method
+	 * @param {Class} BlockClass Block class that has a static `isRendered` method
+	 */
+	async isRenderedBlockPresent( BlockClass ) {
+		return await BlockClass.isRendered( this.page );
+	}
+}

--- a/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import Page from '../page';
+/**
+ * WordPress dependencies
+ */
+import { insertBlock, getAllBlocks } from '@wordpress/e2e-test-utils';
+import { waitAndClick, waitForSelector } from '../../page-helper';
+
+export default class BlockEditorPage extends Page {
+	constructor( page ) {
+		const expectedSelector = '.block-editor';
+		super( page, { expectedSelector } );
+	}
+
+	async insertBlock( blockName ) {
+		await insertBlock( blockName );
+		const blockInfo = await this.getInsertedBlock();
+		console.log( blockInfo );
+		return blockInfo;
+	}
+
+	async getInsertedBlock() {
+		const blocks = await getAllBlocks();
+		return blocks[ blocks.length - 1 ];
+	}
+
+	async publishPost() {
+		await waitAndClick( this.page, '.editor-post-publish-panel__toggle' );
+
+		// Disable reason: Wait for the animation to complete, since otherwise the
+		// click attempt may occur at the wrong point.
+		// Also, for some reason post-publish bar wont show up it we click to fast :/
+		await page.waitFor( 5000 );
+
+		await waitAndClick( this.page, '.editor-post-publish-button' );
+		return await waitForSelector( this.page, '.post-publish-panel__postpublish-buttons a' );
+	}
+
+	async viewPost() {
+		await waitForSelector( this.page, '.post-publish-panel__postpublish-buttons a' );
+		await waitAndClick( this.page, '.post-publish-panel__postpublish-buttons a' );
+	}
+
+	async focus() {
+		await this.page.focus( this.expectedSelector );
+	}
+}

--- a/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -45,5 +45,6 @@ export default class BlockEditorPage extends Page {
 
 	async focus() {
 		await this.page.focus( this.expectedSelector );
+		await waitAndClick( this.page, '.editor-post-title__input' );
 	}
 }

--- a/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -26,17 +26,17 @@ export default class JetpackPage extends Page {
 
 	async isPremium() {
 		const premiumPlanImage = ".jp-landing__plan-card-img img[src*='premium']";
-		return await isEventuallyVisible( this.page, premiumPlanImage, 10000 );
+		return await isEventuallyVisible( this.page, premiumPlanImage, 20000 );
 	}
 
 	async isProfessional() {
 		const proPlanImage = ".jp-landing__plan-card-img img[src*='business']";
-		return await isEventuallyVisible( this.page, proPlanImage, 10000 );
+		return await isEventuallyVisible( this.page, proPlanImage, 20000 );
 	}
 
 	async isConnected() {
 		const connectionInfo = '.jp-connection-settings__info';
-		return await isEventuallyVisible( this.page, connectionInfo, 10000 );
+		return await isEventuallyVisible( this.page, connectionInfo, 20000 );
 	}
 
 	async isPlan( plan ) {

--- a/tests/e2e/lib/pages/wp-admin/sidebar.js
+++ b/tests/e2e/lib/pages/wp-admin/sidebar.js
@@ -15,10 +15,14 @@ export default class Sidebar extends Page {
 		const menuItemSelector =
 			'#toplevel_page_jetpack a[href$="jetpack#/dashboard"], #toplevel_page_jetpack a[href$="jetpack"]';
 
-		return await Promise.all( [
-			this.page.waitForNavigation( { waitFor: 'networkidle2' } ),
-			this._selectMenuItem( jetpackMenuSelector, menuItemSelector ),
-		] );
+		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+	}
+
+	async selectNewPost() {
+		const postsSelector = '#menu-posts';
+		const itemSelector = '#menu-posts a[href*="post-new"]';
+
+		return await this._selectMenuItem( postsSelector, itemSelector );
 	}
 
 	async _selectMenuItem( menuSelector, menuItemSelector ) {

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -3,6 +3,11 @@
  */
 import { setBrowserViewport } from '@wordpress/e2e-test-utils';
 /**
+ * Internal dependencies
+ */
+import { connectThroughWPAdminIfNeeded } from './flows/jetpack-connect';
+import { enablePageDialogAccept } from '@wordpress/e2e-test-utils/build/enable-page-dialog-accept';
+/**
  * Environment variables
  */
 const { PUPPETEER_TIMEOUT, E2E_DEBUG } = process.env;
@@ -24,6 +29,11 @@ async function setupBrowser() {
 // each other's side-effects.
 beforeAll( async () => {
 	await setupBrowser();
+
+	// Handles not saved changed dialog in block editor
+	await enablePageDialogAccept();
+
+	await connectThroughWPAdminIfNeeded();
 } );
 
 afterEach( async () => {

--- a/tests/e2e/specs/dummy.test.js
+++ b/tests/e2e/specs/dummy.test.js
@@ -25,6 +25,6 @@ describe( 'First test suite', () => {
 		await blockEditor.viewPost();
 
 		const frontend = await PostFrontendPage.init( page );
-		frontend.isRenderedBlockPresent( SimplePaymentBlock );
+		await frontend.isRenderedBlockPresent( SimplePaymentBlock );
 	} );
 } );

--- a/tests/e2e/specs/dummy.test.js
+++ b/tests/e2e/specs/dummy.test.js
@@ -1,10 +1,30 @@
 /**
+ * WordPress dependencies
+ */
+import { createNewPost } from '@wordpress/e2e-test-utils/build/create-new-post';
+/**
  * Internal dependencies
  */
-import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
+import BlockEditorPage from '../lib/pages/wp-admin/block-editor';
+import SimplePaymentBlock from '../lib/pages/blocks/simple-payments';
+import PostFrontendPage from '../lib/pages/postFrontend';
 
-describe( 'First test', () => {
-	it( 'Can go through the whole Jetpack connect process', async () => {
-		await connectThroughWPAdminIfNeeded();
+describe( 'First test suite', () => {
+	it( 'Can publish a post with a Simple Payments block', async () => {
+		await createNewPost();
+
+		const blockEditor = await BlockEditorPage.init( page );
+		const blockInfo = await blockEditor.insertBlock( SimplePaymentBlock.name() );
+
+		const spBlock = new SimplePaymentBlock( blockInfo, page );
+		await spBlock.fillDetails();
+
+		await blockEditor.focus();
+
+		await blockEditor.publishPost();
+		await blockEditor.viewPost();
+
+		const frontend = await PostFrontendPage.init( page );
+		frontend.isRenderedBlockPresent( SimplePaymentBlock );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds Simple Payment e2e test

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.
Internal ref: p9dueE-Ju-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the Travis CI e2e job
* Try running these tests locally:
  - Follow these instructions to decrypt config file: [master/tests/e2e/README.md#test-configuration ](https://github.com/Automattic/jetpack/blob/master/tests/e2e/README.md#test-configuration ) 
  - You can use your local install or a JN site for this. 
  - The test expects `wordpress` to be your site's login/password, but you can override these by `WP_PASSWORD` & `WP_USERNAME` env variables.
  - run `WP_BASE_URL="YOUR_SITE_URL" yarn test-e2e`

The test itself should work for both already connected sites with a purchased plan, and for newly created, not connected sites. 


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/a
