### PR TITLE
Sync: PSR-4 the sync server

### DIFF
--- a/packages/sync/src/Server.php
+++ b/packages/sync/src/Server.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 /**
  * Simple version of a Jetpack Sync Server - just receives arrays of events and
  * issues them locally with the 'jetpack_sync_remote_action' action.
  */
-class Jetpack_Sync_Server {
+class Server {
 	private $codec;
 	const MAX_TIME_PER_REQUEST_IN_SECONDS = 15;
 	const BLOG_LOCK_TRANSIENT_PREFIX      = 'jp_sync_req_lock_';
@@ -12,10 +14,10 @@ class Jetpack_Sync_Server {
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	function __construct() {
-		$this->codec = new Jetpack_Sync_JSON_Deflate_Array_Codec();
+		$this->codec = new \Jetpack_Sync_JSON_Deflate_Array_Codec();
 	}
 
-	function set_codec( iJetpack_Sync_Codec $codec ) {
+	function set_codec( \iJetpack_Sync_Codec $codec ) {
 		$this->codec = $codec;
 	}
 
@@ -41,7 +43,7 @@ class Jetpack_Sync_Server {
 	function receive( $data, $token = null, $sent_timestamp = null, $queue_id = null ) {
 		$start_time = microtime( true );
 		if ( ! is_array( $data ) ) {
-			return new WP_Error( 'action_decoder_error', 'Events must be an array' );
+			return new \WP_Error( 'action_decoder_error', 'Events must be an array' );
 		}
 
 		if ( $token && ! $this->attempt_request_lock( $token->blog_id ) ) {
@@ -54,7 +56,7 @@ class Jetpack_Sync_Server {
 			 */
 			do_action( 'jetpack_sync_multi_request_fail', $token );
 
-			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
+			return new \WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
 		}
 
 		$events           = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Sender;
+use Automattic\Jetpack\Sync\Server;
 
 Jetpack_Sync_Main::init();
 
@@ -38,7 +39,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		$this->setSyncClientDefaults();
 
-		$this->server = new Jetpack_Sync_Server();
+		$this->server = new Server();
 
 		// bind the sender to the server
 		remove_all_filters( 'jetpack_sync_send_data' );


### PR DESCRIPTION
In #12712 and all the related PRs we are making an effort to namespace all the sync modules. We also need to start namespacing the rest of the Sync core, see #12751. 

This PR adds a namespace to the sync server and that way autoload it with PSR-4.

#### Changes proposed in this Pull Request:
* Sync: Namespace the sync server and autoload it with PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Namespace the sync server and load it with PSR-4
