### PR TITLE
Plans: Copy improvements to marketing cards on plans page

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -206,7 +206,7 @@ class MyPlanBody extends React.Component {
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Built-in Performance' ) }
+									{ __( 'Optimized performance' ) }
 								</h3>
 								<p>
 									{ __(
@@ -572,7 +572,7 @@ class MyPlanBody extends React.Component {
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Built-in Performance' ) }
+									{ __( 'Optimized performance' ) }
 								</h3>
 								<p>
 									{ __(

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -547,7 +547,7 @@ class MyPlanBody extends React.Component {
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Always-on Security' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Always-on security' ) }</h3>
 								<p>
 									{ __(
 										'Prevent login attacks, and get instant notifications when there’s an issue with your site.'
@@ -651,7 +651,7 @@ class MyPlanBody extends React.Component {
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Site Activity' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Site activity' ) }</h3>
 								<p>
 									{ __(
 										'View a chronological list of all the changes and updates to your site in an organized, readable way.'

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -680,14 +680,14 @@ class MyPlanBody extends React.Component {
 								</h3>
 								<p>
 									{ __(
-										'Need help? Search our support site to find out about your site, your account, and how to make the most of WordPress.'
+										'Need help? Learn about getting started, customizing your site, using advanced code snippets and more.'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_support_documentation' ) }
 									href="https://jetpack.com/support/"
 								>
-									{ __( 'Support documentation' ) }
+									{ __( 'Search support docs' ) }
 								</Button>
 							</div>
 						</div>

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -635,7 +635,7 @@ class MyPlanBody extends React.Component {
 									onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
 									href={ 'https://wordpress.com/marketing/connections/' + this.props.siteRawUrl }
 								>
-									{ __( 'Start publicizing now' ) }
+									{ __( 'Start sharing' ) }
 								</Button>
 							</div>
 						</div>

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -680,7 +680,7 @@ class MyPlanBody extends React.Component {
 								</h3>
 								<p>
 									{ __(
-										'Need help? Learn about getting started, customizing your site, using advanced code snippets and more.'
+										'Need help? Learn about getting started, customizing your site, using advanced code snippets, and more.'
 									) }
 								</p>
 								<Button

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -695,18 +695,21 @@ class MyPlanBody extends React.Component {
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Jetpack offers so much more' ) }
+									{ __( 'Take your site to the next level!' ) }
 								</h3>
-								<p>
-									{ __(
-										'Get peace of mind of automated backups and priority support, reach a wider audience by using advanced SEO tools, monetize your site by running ads, and customize your site with any of our 200+ premium themes.'
-									) }
-								</p>
+								<ul className="jp-landing__plan-features-list">
+									<li>{ __( 'Get peace of mind with automated backups.' ) }</li>
+									<li>{ __( 'Resolve issues quickly with priority support.' ) }</li>
+									<li>{ __( 'Expand your audience with pro SEO tools.' ) }</li>
+									<li>{ __( 'Customize your social posting schedule.' ) }</li>
+									<li>{ __( 'Monetize your site by running high quality ads.' ) }</li>
+								</ul>
 								<Button
+									className="is-primary"
 									onClick={ this.handleButtonClickForTracking( 'free_explore_jetpack_plans' ) }
 									href={ '#/plans' }
 								>
-									{ __( 'Explore Jetpack plans' ) }
+									{ __( 'Upgrade Jetpack now' ) }
 								</Button>
 							</div>
 						</div>

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -50,7 +50,7 @@ class MyPlanHeader extends React.Component {
 						</div>
 						<div className="jp-landing__plan-card-current">
 							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Welcome to Jetpack Free' ) }
+								{ __( 'Your plan: Jetpack Free' ) }
 							</h3>
 							<p className="jp-landing__plan-features-text">
 								{ __( 'Get started with hassle-free design, stats, and performance tools.' ) }
@@ -73,7 +73,7 @@ class MyPlanHeader extends React.Component {
 						</div>
 						<div className="jp-landing__plan-card-current">
 							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Welcome to Jetpack Personal' ) }
+								{ __( 'Your plan: Jetpack Personal' ) }
 							</h3>
 							{ this.props.showBackups ? (
 								<p className="jp-landing__plan-features-text">
@@ -102,7 +102,7 @@ class MyPlanHeader extends React.Component {
 						</div>
 						<div className="jp-landing__plan-card-current">
 							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Welcome to Jetpack Premium' ) }
+								{ __( 'Your plan: Jetpack Premium' ) }
 							</h3>
 							<p className="jp-landing__plan-features-text">
 								{ __(
@@ -127,7 +127,7 @@ class MyPlanHeader extends React.Component {
 						</div>
 						<div className="jp-landing__plan-card-current">
 							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Welcome to Jetpack Professional' ) }
+								{ __( 'Your plan: Jetpack Professional' ) }
 							</h3>
 							<p className="jp-landing__plan-features-text">
 								{ __(

--- a/_inc/client/my-plan/style.scss
+++ b/_inc/client/my-plan/style.scss
@@ -59,6 +59,10 @@
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 
+	&:last-child {
+		max-width: 100%;
+	}
+
 	.is-loading & {
 		width: 49.5%;
 	}
@@ -79,6 +83,11 @@
 	@include breakpoint( "<480px" ) {
 		padding: rem( 16px );
 	}
+}
+
+.jp-landing__plan-features-list {
+	list-style: initial;
+	margin-left: rem( 16px );
 }
 
 .jp-landing__plan-features-img {


### PR DESCRIPTION
This PR bundles together a number of copy fixes on the plans page, improving copy and the clarity of our calls to action. 

Fixes https://github.com/Automattic/jetpack/issues/12721
Fixes https://github.com/Automattic/jetpack/issues/12716
Fixes https://github.com/Automattic/jetpack/issues/12592
Fixes https://github.com/Automattic/jetpack/issues/12587
Fixes https://github.com/Automattic/jetpack/issues/12614

Each issue has a before and after screenshot. The biggest change is on the upgrade card:

![Screenshot 2019-06-19 at 12 45 37](https://user-images.githubusercontent.com/411945/59762885-2bd78000-9290-11e9-8dd8-150288c6cce3.png)

#### Testing instructions:
* Go to My plan wp-admin/admin.php?page=jetpack#/my-plan
* Check copy for consistency and spelling
* Focus on the upgrade card (screenshot above)
* Focus on calls to action
* Ensure all headings use sentence case

#### Proposed changelog entry for your changes:
* None
