### PR TITLE
Traffic: Shortlinks copy change

### DIFF
--- a/_inc/client/traffic/shortlinks.jsx
+++ b/_inc/client/traffic/shortlinks.jsx
@@ -39,7 +39,7 @@ class Shortlinks extends Component {
 						toggling={ this.props.isSavingAnyOption( 'shortlinks' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
-						{ __( 'Create short and simple links for all posts and pages' ) }
+						{ __( 'Generate shortened URLs for simpler sharing.' ) }
 					</ModuleToggle>
 				</SettingsGroup>
 			</SettingsCard>


### PR DESCRIPTION
Update copy for shortlinks setting

> Generate shortened URLs for simpler sharing.

Fixes #12622 

Before and after screenshots in issue

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/traffic
* Verify copy has changed

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
