### PR TITLE
Sync: PSR-4 the sync queue, queue buffer and utils.

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -4,6 +4,7 @@ WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Queue;
 
 /**
  * Control your local Jetpack installation.
@@ -1035,7 +1036,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch( $action ) {
 			case 'peek':
-				$queue = new Jetpack_Sync_Queue( $mapped_queue_name );
+				$queue = new Queue( $mapped_queue_name );
 				$items = $queue->peek( 100 );
 
 				if ( empty( $items ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Queue;
+use Automattic\Jetpack\Sync\Queue_Buffer;
 use Automattic\Jetpack\Sync\Sender;
 
 // POST /sites/%s/sync
@@ -162,7 +164,7 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 		}
 
 		$sender = Sender::get_instance();
-		$response = $sender->do_sync_for_queue( new Jetpack_Sync_Queue( $args['queue'] ) );
+		$response = $sender->do_sync_for_queue( new Queue( $args['queue'] ) );
 
 		return array(
 			'response' => $response
@@ -183,7 +185,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			return new WP_Error( 'invalid_number_of_items', 'Number of items needs to be an integer that is larger than 0 and less then 100', 400 );
 		}
 
-		$queue = new Jetpack_Sync_Queue( $queue_name );
+		$queue = new Queue( $queue_name );
 
 		if ( 0 === $queue->size() ) {
 			return new WP_Error( 'queue_size', 'The queue is empty and there is nothing to send', 400 );
@@ -265,8 +267,8 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		$request_body ['buffer_id'] = preg_replace( '/[^A-Za-z0-9]/', '', $request_body['buffer_id'] );
 		$request_body['item_ids'] = array_filter( array_map( array( 'Jetpack_JSON_API_Sync_Close_Endpoint', 'sanitize_item_ids' ), $request_body['item_ids'] ) );
 
-		$buffer = new Jetpack_Sync_Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
-		$queue = new Jetpack_Sync_Queue( $queue_name );
+		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
+		$queue = new Queue( $queue_name );
 
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
@@ -301,7 +303,7 @@ class Jetpack_JSON_API_Sync_Unlock_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
 		}
 
-		$queue = new Jetpack_Sync_Queue( $args['queue'] );
+		$queue = new Queue( $args['queue'] );
 
 		// False means that there was no lock to delete.
 		$response = $queue->unlock();

--- a/packages/sync/legacy/class.jetpack-sync-module-full-sync.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-full-sync.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Queue;
 
 /**
  * This class does a full resync of the database by
@@ -125,7 +126,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		// if full sync queue is full, don't enqueue more items
 		$max_queue_size_full_sync = Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
-		$full_sync_queue          = new Jetpack_Sync_Queue( 'full_sync' );
+		$full_sync_queue          = new Queue( 'full_sync' );
 
 		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();
 

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Automattic\Jetpack\Sync;
+use Automattic\Jetpack\Sync\Queue;
 
 /**
  * This class monitors actions and logs them to the queue to be sent
@@ -311,8 +312,8 @@ class Listener {
 	}
 
 	function set_defaults() {
-		$this->sync_queue      = new \Jetpack_Sync_Queue( 'sync' );
-		$this->full_sync_queue = new \Jetpack_Sync_Queue( 'full_sync' );
+		$this->sync_queue      = new Queue( 'sync' );
+		$this->full_sync_queue = new Queue( 'full_sync' );
 		$this->set_queue_size_limit( \Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
 		$this->set_queue_lag_limit( \Jetpack_Sync_Settings::get_setting( 'max_queue_lag' ) );
 	}

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -417,7 +417,7 @@ class Queue {
 	}
 
 	private function validate_checkout( $buffer ) {
-		if ( ! $buffer instanceof Automattic\Jetpack\Sync\Queue_Buffer ) {
+		if ( ! $buffer instanceof Queue_Buffer ) {
 			return new \WP_Error( 'not_a_buffer', 'You must checkin an instance of Automattic\\Jetpack\\Sync\\Queue_Buffer' );
 		}
 

--- a/packages/sync/src/Queue_Buffer.php
+++ b/packages/sync/src/Queue_Buffer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Automattic\Jetpack\Sync;
+
+/**
+ * A buffer of items from the queue that can be checked out
+ */
+class Queue_Buffer {
+	public $id;
+	public $items_with_ids;
+
+	public function __construct( $id, $items_with_ids ) {
+		$this->id             = $id;
+		$this->items_with_ids = $items_with_ids;
+	}
+
+	public function get_items() {
+		return array_combine( $this->get_item_ids(), $this->get_item_values() );
+	}
+
+	public function get_item_values() {
+		return Utils::get_item_values( $this->items_with_ids );
+	}
+
+	public function get_item_ids() {
+		return Utils::get_item_ids( $this->items_with_ids );
+	}
+}

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -367,8 +367,8 @@ class Sender {
 
 
 	function set_defaults() {
-		$this->sync_queue      = new \Jetpack_Sync_Queue( 'sync' );
-		$this->full_sync_queue = new \Jetpack_Sync_Queue( 'full_sync' );
+		$this->sync_queue      = new Queue( 'sync' );
+		$this->full_sync_queue = new Queue( 'full_sync' );
 		$this->set_codec();
 
 		// saved settings

--- a/packages/sync/src/Utils.php
+++ b/packages/sync/src/Utils.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Automattic\Jetpack\Sync;
+
+class Utils {
+
+	static function get_item_values( $items ) {
+		return array_map( array( __CLASS__, 'get_item_value' ), $items );
+	}
+
+	static function get_item_ids( $items ) {
+		return array_map( array( __CLASS__, 'get_item_id' ), $items );
+	}
+
+	private static function get_item_value( $item ) {
+		return $item->value;
+	}
+
+	private static function get_item_id( $item ) {
+		return $item->id;
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -1,5 +1,8 @@
 <?php
 
+use Automattic\Jetpack\Sync\Queue;
+use Automattic\Jetpack\Sync\Queue_Buffer;
+
 class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 
 	private $queue;
@@ -7,7 +10,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->queue = new Jetpack_Sync_Queue( 'my_queue' );
+		$this->queue = new Queue( 'my_queue' );
 	}
 
 	function test_add_queue_items() {
@@ -48,8 +51,8 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	}
 
 	function test_queue_lag() {
-		/* @var $queue Jetpack_Sync_Queue|\PHPUnit\Framework\MockObject\MockObject */
-		$queue = $this->getMockBuilder( 'Jetpack_Sync_Queue' )
+		/* @var $queue Automattic\Jetpack\Sync\Queue|\PHPUnit\Framework\MockObject\MockObject */
+		$queue = $this->getMockBuilder( 'Automattic\\Jetpack\\Sync\\Queue' )
 			->setMethods( array( 'generate_option_name_timestamp' ) )
 			->setConstructorArgs( array( 'my_queue' ) )
 			->getMock();
@@ -162,7 +165,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	}
 
 	function test_checkout_enforced_across_multiple_instances() {
-		$other_queue = new Jetpack_Sync_Queue( $this->queue->id, 2 );
+		$other_queue = new Queue( $this->queue->id, 2 );
 
 		$this->queue->add_all( array( 1, 2, 3, 4, 5 ) );
 
@@ -177,7 +180,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	}
 
 	function test_checkin_non_checked_out_buffer_raises_error() {
-		$buffer   = new Jetpack_Sync_Queue_Buffer( uniqid(), array() );
+		$buffer   = new Queue_Buffer( uniqid(), array() );
 		$response = $this->queue->checkin( $buffer );
 
 		$this->assertEquals( 'buffer_not_checked_out', $response->get_error_code() );
@@ -185,7 +188,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 
 	function test_checkin_wrong_buffer_raises_error() {
 		$this->queue->add_all( array( 1, 2, 3, 4 ) );
-		$buffer       = new Jetpack_Sync_Queue_Buffer( uniqid(), array() );
+		$buffer       = new Queue_Buffer( uniqid(), array() );
 		$other_buffer = $this->queue->checkout( 5 );
 
 		$response = $this->queue->checkin( $buffer );
@@ -256,7 +259,7 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 	}
 
 	function test_queue_is_persisted() {
-		$other_queue = new Jetpack_Sync_Queue( $this->queue->id );
+		$other_queue = new Queue( $this->queue->id );
 
 		$this->queue->add( 'foo' );
 		$this->assertEquals( array( 'foo' ), $other_queue->checkout( 5 )->get_item_values() );


### PR DESCRIPTION
In #12712 and all the related PRs we are making an effort to namespace all the sync modules. We also  started namespacing the rest of the Sync core, see #12751. 

This PR adds a namespace to the sync queue, queue buffer and utils and that way autoload them with PSR-4.

Changes might look a little more than usual, but that's just because previously those 3 classes were in a single file, and now they're in three separate files (to be PSR-4 compliant).

#### Changes proposed in this Pull Request:
* Sync: Namespace the sync queue, queue buffer and utils and autoload them with PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Namespace the sync queue, queue buffer and utils and autoload them with PSR-4.
