### PR TITLE
Discussion: Copy improvements to comment card

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -99,7 +99,7 @@ class CommentsComponent extends React.Component {
 						</ModuleToggle>
 						<FormFieldset>
 							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
+								<span className="jp-form-label-wide">{ __( 'Comment form introduction' ) }</span>
 								<TextInput
 									name={ 'highlander_comment_form_prompt' }
 									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
@@ -112,7 +112,7 @@ class CommentsComponent extends React.Component {
 								/>
 							</FormLabel>
 							<span className="jp-form-setting-explanation">
-								{ __( 'A few catchy words to motivate your readers to comment.' ) }
+								{ __( 'A few catchy words to motivate your visitors to comment.' ) }
 							</span>
 							<FormLabel>
 								<span className="jp-form-label-wide">{ __( 'Color scheme' ) }</span>

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Comments
- * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
+ * Module Description: Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -24,7 +24,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment.', 'Module Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -24,7 +24,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment', 'Module Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(


### PR DESCRIPTION
Update copy on comments card. Google+ no longer exists:

> Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment.

Fixes #12619 

See original issue for before and after comparison.

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/discussion
* Verify copy changes are correct

#### Proposed changelog entry for your changes:
* None
