### PR TITLE
Writing: Update .com toolbar copy and move down page

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -84,9 +84,6 @@ export class Writing extends React.Component {
 					className="jp-settings-description"
 				/>
 				{ this.props.isModuleFound( 'carousel' ) && <WritingMedia { ...commonProps } /> }
-				{ this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
-					<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
-				) }
 				{ showComposing && (
 					<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } />
 				) }
@@ -102,6 +99,9 @@ export class Writing extends React.Component {
 						isLinked={ this.props.isLinked }
 						userCanManageModules={ this.props.userCanManageModules }
 					/>
+				) }
+				{ this.props.isModuleFound( 'masterbar' ) && ! this.props.masterbarIsAlwaysActive && (
+					<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
 				) }
 				{ ! showComposing && ! showPostByEmail && (
 					<Card>

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -36,11 +36,10 @@ export const Masterbar = withModuleSettingsFormHelpers(
 					>
 						<p>
 							{ __(
-								'The WordPress.com toolbar replaces the default WordPress ' +
-									'admin toolbar and streamlines your WordPress experience. ' +
-									'It offers one-click access to manage all your sites, ' +
-									'update your WordPress.com profile, view notifications, ' +
-									'and catch up on the sites you follow in the Reader.'
+								'The WordPress.com toolbar replaces the default WordPress admin toolbar. ' +
+									'It offers one-click access to notifcations, your WordPress.com ' +
+									'profile and your other Jetpack and WordPress.com websites. ' +
+									'You can also catch up on the sites you follow in the Reader.'
 							) }
 						</p>
 						<ModuleToggle


### PR DESCRIPTION
Update copy for .com toolbar and move down the page

> The WordPress.com toolbar replaces the default WordPress admin toolbar. It offers one-click access to notifcations, your WordPress.com profile and your other Jetpack and WordPress.com websites. You can also catch up on the sites you follow in the Reader.

Fixes #12613 

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/writing
* Verify copy is OK on the .com toolbar setting and that it is now at the bottom of the page

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
