### PR TITLE
Discussion: Title copy change

### DIFF
--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -61,7 +61,7 @@ export class Discussion extends React.Component {
 						this.props.searchTerm
 							? __( 'Discussion' )
 							: __(
-									'Open your site to comments and invite subscribers to get alerts about your latest work.'
+									'Manage advanced comment settings and grow your audience with email subscriptions.'
 							  )
 					}
 					className="jp-settings-description"


### PR DESCRIPTION
Update title in discussions section:

> Manage advanced comment settings and grow your audience with email subscriptions.

Fixes #12618 

See original issue for screenshots.

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/discussion
* Verify title is correctly updated and spelt

#### Proposed changelog entry for your changes:
* None
