### PR TITLE
Sync: PSR-4 the Codec interface

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-json-deflate-array-codec.php
+++ b/packages/sync/legacy/class.jetpack-sync-json-deflate-array-codec.php
@@ -1,10 +1,12 @@
 <?php
 
+use Automattic\Jetpack\Sync\Codec_Interface;
+
 /**
- * An implementation of iJetpack_Sync_Codec that uses gzip's DEFLATE
+ * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
  * algorithm to compress objects serialized using json_encode
  */
-class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
+class Jetpack_Sync_JSON_Deflate_Array_Codec implements Codec_Interface {
 	const CODEC_NAME = 'deflate-json-array';
 
 	public function name() {

--- a/packages/sync/legacy/class.jetpack-sync-simple-codec.php
+++ b/packages/sync/legacy/class.jetpack-sync-simple-codec.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * An implementation of iJetpack_Sync_Codec that uses gzip's DEFLATE
+ * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
  * algorithm to compress objects serialized using json_encode
  */
 class Jetpack_Sync_Simple_Codec extends Jetpack_Sync_JSON_Deflate_Array_Codec {

--- a/packages/sync/src/Codec_Interface.php
+++ b/packages/sync/src/Codec_Interface.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 /**
  * Very simple interface for encoding and decoding input
  * This is used to provide compression and serialization to messages
  **/
-interface iJetpack_Sync_Codec {
+interface Codec_Interface {
 	// we send this with the payload so we can select the appropriate decoder at the other end
 	public function name();
 

--- a/packages/sync/src/Server.php
+++ b/packages/sync/src/Server.php
@@ -17,7 +17,7 @@ class Server {
 		$this->codec = new \Jetpack_Sync_JSON_Deflate_Array_Codec();
 	}
 
-	function set_codec( \iJetpack_Sync_Codec $codec ) {
+	function set_codec( Codec_Interface $codec ) {
 		$this->codec = $codec;
 	}
 

--- a/tests/php/sync/test_interface.jetpack-sync-codec.php
+++ b/tests/php/sync/test_interface.jetpack-sync-codec.php
@@ -6,7 +6,7 @@
  * @requires PHP 5.3
  */
 
-class WP_Test_iJetpack_Sync_Codec extends PHPUnit_Framework_TestCase {
+class WP_Test_Jetpack_Sync_Codec_Interface extends PHPUnit_Framework_TestCase {
 
 	static $all_codecs;
 
@@ -73,11 +73,11 @@ class WP_Test_iJetpack_Sync_Codec extends PHPUnit_Framework_TestCase {
 
 	public function codec_provider( $name ) {
 		if ( ! self::$all_codecs ) {
-			// detect classes that implement iJetpack_Sync_Codec
+			// detect classes that implement Automattic\Jetpack\Sync\Codec_Interface
 			self::$all_codecs = array();
 
 			foreach ( get_declared_classes() as $className ) {
-				if ( in_array( 'iJetpack_Sync_Codec', class_implements( $className ) ) ) {
+				if ( in_array( 'Automattic\\Jetpack\\Sync\\Codec_Interface', class_implements( $className ) ) ) {
 					self::$all_codecs[] = $className;
 				}
 			}


### PR DESCRIPTION
In #12712 and all the related PRs we are making an effort to namespace all the sync modules. We also  started namespacing the rest of the Sync core, see #12751. 

This PR adds a namespace to the sync codec interface and that way autoload it with PSR-4.

#### Changes proposed in this Pull Request:
* Sync: Namespace the sync codec interface and autoload it with PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Namespace the sync codec interface and autoload it with PSR-4.
