### PR TITLE
Sync: PSR-4 the sync listener

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -3,6 +3,7 @@
 WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Sync\Listener;
 
 /**
  * Control your local Jetpack installation.
@@ -863,7 +864,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 				/* translators: %s is the site URL */
 				WP_CLI::log( sprintf( __( 'Sync Disabled on %s. Use `wp jetpack sync enable` to enable syncing again.', 'jetpack' ), get_site_url() ) );
-				$listener = Jetpack_Sync_Listener::get_instance();
+				$listener = Listener::get_instance();
 				if ( empty( $assoc_args['queue'] ) ) {
 					$listener->get_sync_queue()->reset();
 					$listener->get_full_sync_queue()->reset();

--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Sender;
 
 /**
@@ -309,7 +310,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function initialize_listener() {
-		self::$listener = Jetpack_Sync_Listener::get_instance();
+		self::$listener = Listener::get_instance();
 	}
 
 	static function initialize_sender() {

--- a/packages/sync/legacy/class.jetpack-sync-module-full-sync.php
+++ b/packages/sync/legacy/class.jetpack-sync-module-full-sync.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Listener;
+
 /**
  * This class does a full resync of the database by
  * enqueuing an outbound action for every single object
@@ -9,7 +11,7 @@
  * - we fire an action called jetpack_full_sync_start so that WPCOM can erase the contents of the cached database
  * - for each object type, we page through the object IDs and enqueue them by firing some monitored actions
  * - we load the full objects for those IDs in chunks of Jetpack_Sync_Module::ARRAY_CHUNK_SIZE (to reduce the number of MySQL calls)
- * - we fire a trigger for the entire array which the Jetpack_Sync_Listener then serializes and queues.
+ * - we fire a trigger for the entire array which the Automattic\Jetpack\Sync\Listener then serializes and queues.
  */
 
 class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
@@ -399,7 +401,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->clear_status();
 		$this->delete_config();
 
-		$listener = Jetpack_Sync_Listener::get_instance();
+		$listener = Listener::get_instance();
 		$listener->get_full_sync_queue()->reset();
 	}
 

--- a/packages/sync/legacy/class.jetpack-sync-settings.php
+++ b/packages/sync/legacy/class.jetpack-sync-settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Listener;
+
 class Jetpack_Sync_Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
 
@@ -124,7 +126,7 @@ class Jetpack_Sync_Settings {
 
 			// if we set the disabled option to true, clear the queues
 			if ( ( 'disable' === $setting || 'network_disable' === $setting ) && ! ! $value ) {
-				$listener = Jetpack_Sync_Listener::get_instance();
+				$listener = Listener::get_instance();
 				$listener->get_sync_queue()->reset();
 				$listener->get_full_sync_queue()->reset();
 			}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Modules\Callables;
+use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 
@@ -32,7 +33,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	public function setUp() {
 
 		$_SERVER['HTTP_USER_AGENT'] = 'Jetpack Unit Tests';
-		$this->listener = Jetpack_Sync_Listener::get_instance();
+		$this->listener = Listener::get_instance();
 		$this->sender   = Sender::get_instance();
 
 		parent::setUp();


### PR DESCRIPTION
In #12712 and all the related PRs we are making an effort to namespace all the sync modules. We also need to start namespacing the rest of the Sync core, see #12751. 

This PR adds a namespace to the sync listener and that way autoload it with PSR-4.

#### Changes proposed in this Pull Request:
* Sync: Namespace the sync listener and autoload it with PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Namespace the sync listener and load it with PSR-4
