### PR TITLE
Writing: Update copy for post duplicate feature

### DIFF
--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Module Name: Copy Post
- * Module Description: Copy an existing post's content into a new draft post
- * Jumpstart Description: Copy an existing post's content into a new draft post
+ * Module Description: Enable the option copy entire posts and pages, including tags and settings
+ * Jumpstart Description: Enable the option copy entire posts and pages, including tags and settings
  * Sort Order: 15
  * First Introduced: 7.0
  * Requires Connection: No

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Beautiful Math
- * Module Description: Use the LaTeX markup language to write mathematical equations and formulas.
+ * Module Description: Use the LaTeX markup language to write mathematical equations and formulas
  * Sort Order: 12
  * First Introduced: 1.1
  * Requires Connection: No

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -34,8 +34,8 @@ function jetpack_get_module_i18n( $key ) {
 
 			'copy-post' => array(
 				'name' => _x( 'Copy Post', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Copy an existing post\'s content into a new draft post', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Copy an existing post\'s content into a new draft post', 'Jumpstart Description', 'jetpack' ),
+				'description' => _x( 'Enable the option copy entire posts and pages, including tags and settings', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Enable the option copy entire posts and pages, including tags and settings', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'custom-content-types' => array(
@@ -75,7 +75,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'latex' => array(
 				'name' => _x( 'Beautiful Math', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Use the LaTeX markup language to write mathematical equations and formulas.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Use the LaTeX markup language to write mathematical equations and formulas', 'Module Description', 'jetpack' ),
 			),
 
 			'lazy-images' => array(


### PR DESCRIPTION
Explain that the duplicate post option is a feature to be enabled:

> Enable the option copy entire posts and pages, including tags and settings

Fixes #12607 

See original issue for screenshots


#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/writing
* Check the copy of the duplicate posts feature (composing card)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
