### PR TITLE
VideoPress: make sure Poster images never have extra params.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -114,6 +114,16 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		|| $image_url_parts['host'] === jetpack_photon_parse_url( $custom_photon_url, PHP_URL_HOST )
 		|| $is_wpcom_image
 	) {
+		/*
+		 * VideoPress Poster images should only keep one param, ssl.
+		 */
+		if (
+			is_array( $args )
+			&& 'videos.files.wordpress.com' === strtolower( $image_url_parts['host'] )
+		) {
+			$args = array_intersect_key( array( 'ssl' => 1 ), $args );
+		}
+
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );
 	}


### PR DESCRIPTION
Fixes #12755 

#### Changes proposed in this Pull Request:

VideoPress Poster images are hosted on WordPress.com, using wpcom' custom image processing feature.
As such, a VideoPress poster image does not support extra parameters that may be added by Photon, such as `quality` or `strip`. We now remove any extra parameters, and only keep ssl.

#### Testing instructions:

* Start from a Jetpack using a Premium plan, where the VideoPress module is active.
* Upload a video, and let it be fully processed by VideoPress. You can do so in https://wordpress.com/media/
* Once the video has fully processed, you should see a thumbnail for the video on that same Calypso page.
* Add the following snippet to your site:
```php
add_filter('jetpack_photon_pre_args', 'jetpackme_custom_photon_compression' );
function jetpackme_custom_photon_compression( $args ) {
	$args['quality'] = 80;
	$args['strip'] = 'all';
	return $args;
}

```
* Refresh the Calypso page, and notice that the thumbnails now disappear.
* Apply this PR.
* Watch as the thumbnails appear again.

**Before**

![image](https://user-images.githubusercontent.com/426388/59772036-4ff48a80-92ab-11e9-9847-b13468952308.png)

**After**

![image](https://user-images.githubusercontent.com/426388/59772045-5420a800-92ab-11e9-9aae-b29beadcd90c.png)


#### Proposed changelog entry for your changes:

* Jetpack Videos: ensure that Video Poster images are always displayed properly.
