### PR TITLE
Discussion: Subscriptions copy change

### DIFF
--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -118,7 +118,7 @@ class SubscriptionsComponent extends React.Component {
 								onChange={ this.handleSubscribeToBlogToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Show a "follow blog" option in the comment form' ) }
+									{ __( 'Enable the “subscribe to site” option on your comment form' ) }
 								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
@@ -131,7 +131,7 @@ class SubscriptionsComponent extends React.Component {
 								onChange={ this.handleSubscribeToCommentToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Show a "follow comments" option in the comment form' ) }
+									{ __( 'Enable the “subscribe to comments” option on your comment form' ) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -194,7 +194,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'subscriptions' => array(
 				'name' => _x( 'Subscriptions', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow users to subscribe to your posts and comments and receive notifications via email', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Let visitors to subscribe to new posts and comments via email', 'Module Description', 'jetpack' ),
 			),
 
 			'tiled-gallery' => array(

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Subscriptions
- * Module Description: Allow users to subscribe to your posts and comments and receive notifications via email
+ * Module Description: Let visitors to subscribe to new posts and comments via email
  * Sort Order: 9
  * Recommendation Order: 8
  * First Introduced: 1.2


### PR DESCRIPTION
Adjust copy on subscriptions module description and settings:

> Let visitors to subscribe to new posts and comments via email.

> Enable the “subscribe to site” option on your comment form.

> Enable the “subscribe to comments” option on your comment form.

Fixes #12621

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/discussion
* Verify changes to subscriptions card

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
