### PR TITLE
Sync Package: Moves the Network Options sync module

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -10,7 +10,7 @@ class Jetpack_Sync_Modules {
 	private static $default_sync_modules = array(
 		'Jetpack_Sync_Module_Constants',
 		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
-		'Jetpack_Sync_Module_Network_Options',
+		'Automattic\\Jetpack\\Sync\\Modules\\Network_Options',
 		'Automattic\\Jetpack\\Sync\\Modules\\Options',
 		'Automattic\\Jetpack\\Sync\\Modules\\Terms',
 		'Automattic\\Jetpack\\Sync\\Modules\\Themes',

--- a/packages/sync/src/modules/Network_Options.php
+++ b/packages/sync/src/modules/Network_Options.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Network_Options extends \Jetpack_Sync_Module {
 	private $network_options_whitelist;
 
 	public function name() {
@@ -43,7 +45,7 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 	}
 
 	public function set_defaults() {
-		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
+		$this->network_options_whitelist = \Jetpack_Sync_Defaults::$default_network_options_whitelist;
 	}
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {


### PR DESCRIPTION
We are trying to move away from class mapped packages, and unspool all of the dependencies within a package.

So let's do this!

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #12712

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR should have no functional changes. The Network Options sync modules should function exactly the same as before.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This modifies an existing part of Jetpack.

#### Testing instructions:

* Try this branch out on a Jurassic.ninja multi-site or on your docker testing multi-site.
* Connect the site and activate the recommended features.
* Point your testing site to your .com sandbox to observe sync actions in real time.
* Try a full sync and ensure there are no php errors in your site's error logs
* Try updating network options. Ensure you see the expected sync actions in the pipeline.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
