### PR TITLE
Sharing: Sharing copy changes

### DIFF
--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -57,7 +57,9 @@ class Sharing extends Component {
 					title={
 						this.props.searchTerm
 							? __( 'Sharing' )
-							: __( 'Share your content on social media and increase audience engagement.' )
+							: __(
+									'Share your content to social media, reaching new audiences and increasing engagement.'
+							  )
 					}
 					className="jp-settings-description"
 				/>

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -95,7 +95,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-							{ __( 'Add sharing buttons to your posts' ) }
+							{ __( 'Add sharing buttons to your posts and pages' ) }
 						</ModuleToggle>
 					</SettingsGroup>
 					{ isActive && configCard() }

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -7,7 +7,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' 
 
 /**
  * Module Name: Secure Sign On
- * Module Description: Allow users to log into this site using WordPress.com accounts
+ * Module Description: Allow users to log in to this site using WordPress.com accounts
  * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
  * Recommendation Order: 5


### PR DESCRIPTION
Update copy on the sharing screen (title and setting).

Also fixes a mismatch between the module header used for SSO and what we have in the compiled lang file.

Fixes #12617 

See original issue for before and after screenshots.

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/sharing
* Verify copy changes

#### Proposed changelog entry for your changes:
* None
