### PR TITLE
Jetpack DNA: Move Full Sync Module from Legacy to PSR-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -24,8 +24,8 @@ class Jetpack_Sync_Modules {
 		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
 		'Automattic\\Jetpack\\Sync\\Modules\\Meta',
 		'Jetpack_Sync_Module_Plugins',
-		'Jetpack_Sync_Module_Full_Sync',
 		'Automattic\\Jetpack\\Sync\\Modules\\Stats',
+		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
 	);
 
 	private static $initialized_modules = null;

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -394,7 +394,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 
 		$this->delete_enqueue_status();
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent" );
 			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent_total" );
 		}

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Automattic\Jetpack\Sync\Modules;
+
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Queue;
 
@@ -15,7 +17,7 @@ use Automattic\Jetpack\Sync\Queue;
  * - we fire a trigger for the entire array which the Automattic\Jetpack\Sync\Listener then serializes and queues.
  */
 
-class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
+class Full_Sync extends \Jetpack_Sync_Module {
 	const STATUS_OPTION_PREFIX = 'jetpack_sync_full_';
 	const FULL_SYNC_TIMEOUT    = 3600;
 
@@ -61,13 +63,13 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( ! is_array( $module_configs ) ) {
 			$module_configs = array();
 			$include_empty  = true;
-			foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+			foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 				$module_configs[ $module->name() ] = true;
 			}
 		}
 
 		// set default configuration, calculate totals, and save configuration if totals > 0
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name   = $module->name();
 			$module_config = isset( $module_configs[ $module_name ] ) ? $module_configs[ $module_name ] : false;
 
@@ -133,7 +135,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( $available_queue_slots <= 0 ) {
 			return;
 		} else {
-			$remaining_items_to_enqueue = min( Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
+			$remaining_items_to_enqueue = min( \Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
 		}
 
 		if ( ! $configs ) {
@@ -144,7 +146,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 
 			// skip module if not configured for this sync or module is done
@@ -205,13 +207,13 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			case 'posts':
 				$table     = $wpdb->posts;
 				$id        = 'ID';
-				$where_sql = Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+				$where_sql = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
 
 				break;
 			case 'comments':
 				$table     = $wpdb->comments;
 				$id        = 'comment_ID';
-				$where_sql = Jetpack_Sync_Settings::get_comments_filter_sql();
+				$where_sql = \Jetpack_Sync_Settings::get_comments_filter_sql();
 				break;
 		}
 		$results = $wpdb->get_results( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table} WHERE {$where_sql}" );
@@ -250,7 +252,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$this->update_status_option( 'send_started', time() );
 		}
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_actions     = $module->get_full_sync_actions();
 			$status_option_name = "{$module->name()}_sent";
 			$total_option_name  = "{$status_option_name}_total";
@@ -352,7 +354,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		$enqueue_status = $this->get_enqueue_status();
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
 			$name = $module->name();
 
 			if ( ! isset( $enqueue_status[ $name ] ) ) {
@@ -384,17 +386,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	public function clear_status() {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		Jetpack_Options::delete_raw_option( "{$prefix}_started" );
-		Jetpack_Options::delete_raw_option( "{$prefix}_params" );
-		Jetpack_Options::delete_raw_option( "{$prefix}_queue_finished" );
-		Jetpack_Options::delete_raw_option( "{$prefix}_send_started" );
-		Jetpack_Options::delete_raw_option( "{$prefix}_finished" );
+		\Jetpack_Options::delete_raw_option( "{$prefix}_started" );
+		\Jetpack_Options::delete_raw_option( "{$prefix}_params" );
+		\Jetpack_Options::delete_raw_option( "{$prefix}_queue_finished" );
+		\Jetpack_Options::delete_raw_option( "{$prefix}_send_started" );
+		\Jetpack_Options::delete_raw_option( "{$prefix}_finished" );
 
 		$this->delete_enqueue_status();
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent" );
-			Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent_total" );
+			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent" );
+			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent_total" );
 		}
 	}
 
@@ -407,37 +409,37 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function get_status_option( $name, $default = null ) {
-		$value = Jetpack_Options::get_raw_option( self::STATUS_OPTION_PREFIX . "_$name", $default );
+		$value = \Jetpack_Options::get_raw_option( self::STATUS_OPTION_PREFIX . "_$name", $default );
 
 		return is_numeric( $value ) ? intval( $value ) : $value;
 	}
 
 	private function update_status_option( $name, $value, $autoload = false ) {
-		Jetpack_Options::update_raw_option( self::STATUS_OPTION_PREFIX . "_$name", $value, $autoload );
+		\Jetpack_Options::update_raw_option( self::STATUS_OPTION_PREFIX . "_$name", $value, $autoload );
 	}
 
 	private function set_enqueue_status( $new_status ) {
-		Jetpack_Options::update_raw_option( 'jetpack_sync_full_enqueue_status', $new_status );
+		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_enqueue_status', $new_status );
 	}
 
 	private function delete_enqueue_status() {
-		return Jetpack_Options::delete_raw_option( 'jetpack_sync_full_enqueue_status' );
+		return \Jetpack_Options::delete_raw_option( 'jetpack_sync_full_enqueue_status' );
 	}
 
 	private function get_enqueue_status() {
-		return Jetpack_Options::get_raw_option( 'jetpack_sync_full_enqueue_status' );
+		return \Jetpack_Options::get_raw_option( 'jetpack_sync_full_enqueue_status' );
 	}
 
 	private function set_config( $config ) {
-		Jetpack_Options::update_raw_option( 'jetpack_sync_full_config', $config );
+		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_config', $config );
 	}
 
 	private function delete_config() {
-		return Jetpack_Options::delete_raw_option( 'jetpack_sync_full_config' );
+		return \Jetpack_Options::delete_raw_option( 'jetpack_sync_full_config' );
 	}
 
 	private function get_config() {
-		return Jetpack_Options::get_raw_option( 'jetpack_sync_full_config' );
+		return \Jetpack_Options::get_raw_option( 'jetpack_sync_full_config' );
 	}
 
 	private function write_option( $name, $value ) {

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -127,7 +127,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 		}
 
 		// if full sync queue is full, don't enqueue more items
-		$max_queue_size_full_sync = Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
+		$max_queue_size_full_sync = \Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
 		$full_sync_queue          = new Queue( 'full_sync' );
 
 		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules\Full_Sync;
+
 function jetpack_foo_full_sync_callable() {
 	return 'the value';
 }
@@ -125,7 +127,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->started_sync_count );
 
 		// fake the last sync being over an hour ago
-		$prefix = Jetpack_Sync_Module_Full_Sync::STATUS_OPTION_PREFIX;
+		$prefix = Full_Sync::STATUS_OPTION_PREFIX;
 		update_option( "{$prefix}_started", time() - 3700 );
 
 		$this->full_sync->start();


### PR DESCRIPTION
This PR moves the full sync module from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.