### PR TITLE
Jetpack DNA: Move Sync Constants Module from Legacy to PSR-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-modules.php
+++ b/packages/sync/legacy/class.jetpack-sync-modules.php
@@ -8,7 +8,7 @@
 class Jetpack_Sync_Modules {
 
 	private static $default_sync_modules = array(
-		'Jetpack_Sync_Module_Constants',
+		'Automattic\\Jetpack\\Sync\\Modules\\Constants',
 		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
 		'Automattic\\Jetpack\\Sync\\Modules\\Network_Options',
 		'Automattic\\Jetpack\\Sync\\Modules\\Options',

--- a/packages/sync/src/modules/Constants.php
+++ b/packages/sync/src/modules/Constants.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class Constants extends \Jetpack_Sync_Module {
 	const CONSTANTS_CHECKSUM_OPTION_NAME = 'jetpack_constants_sync_checksum';
 	const CONSTANTS_AWAIT_TRANSIENT_NAME = 'jetpack_sync_constants_await';
 
@@ -33,7 +35,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 	}
 
 	function get_constants_whitelist() {
-		return Jetpack_Sync_Defaults::get_constants_whitelist();
+		return \Jetpack_Sync_Defaults::get_constants_whitelist();
 	}
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -63,7 +65,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 			return;
 		}
 
-		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
+		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), \Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
 
 		$constants = $this->get_all_constants();
 		if ( empty( $constants ) ) {

--- a/packages/sync/src/modules/Updates.php
+++ b/packages/sync/src/modules/Updates.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 class Updates extends \Jetpack_Sync_Module {
 
@@ -106,7 +106,7 @@ class Updates extends \Jetpack_Sync_Module {
 		// Core was autoudpated
 		if (
 			'update-core.php' !== $pagenow &&
-			! Constants::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
+			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
 		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful

--- a/packages/sync/src/modules/Users.php
+++ b/packages/sync/src/modules/Users.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 class Users extends \Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;
@@ -250,7 +250,7 @@ class Users extends \Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
+		if ( Jetpack_Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**
@@ -271,7 +271,7 @@ class Users extends \Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
+		if ( Jetpack_Constants::is_true( 'JETPACK_INVITE_ACCEPTED' ) ) {
 			$this->add_flags( $user_id, array( 'invitation_accepted' => true ) );
 		}
 		/**

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -2,7 +2,7 @@
 
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
-use Automattic\Jetpack\Sync\Modules\Constants as Constants_Sync_Module; // as because conflict with Constants used in children
+use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 
@@ -68,12 +68,12 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 		// don't sync callables or constants every time - slows down tests
 		set_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
-		set_transient( Constants_Sync_Module::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
 	}
 
 	protected function resetCallableAndConstantTimeouts() {
 		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_transient( Constants_Sync_Module::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 
@@ -67,12 +68,12 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 		// don't sync callables or constants every time - slows down tests
 		set_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
-		set_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
 	}
 
 	protected function resetCallableAndConstantTimeouts() {
 		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );	
+		delete_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -2,7 +2,7 @@
 
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
-use Automattic\Jetpack\Sync\Modules\Constants;
+use Automattic\Jetpack\Sync\Modules\Constants as Constants_Sync_Module; // as because conflict with Constants used in children
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 
@@ -68,12 +68,12 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 		// don't sync callables or constants every time - slows down tests
 		set_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
-		set_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Constants_Sync_Module::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
 	}
 
 	protected function resetCallableAndConstantTimeouts() {
 		delete_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Constants_Sync_Module::CONSTANTS_AWAIT_TRANSIENT_NAME );
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules\Constants;
+
 /**
  * Testing CRUD on Constants
  */

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -69,7 +69,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 
 		$this->server_replica_storage->reset();
 
-		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
 		$this->sender->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_ABC' ) );


### PR DESCRIPTION
This PR moves the sync constants module from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.