### PR TITLE
Jetpack DNA: Move WooCommerce Sync Module from Legacy to psr-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-actions.php
+++ b/packages/sync/legacy/class.jetpack-sync-actions.php
@@ -327,7 +327,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function add_woocommerce_sync_module( $sync_modules ) {
-		$sync_modules[] = 'Jetpack_Sync_Module_WooCommerce';
+		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
 		return $sync_modules;
 	}
 

--- a/packages/sync/src/modules/WooCommerce.php
+++ b/packages/sync/src/modules/WooCommerce.php
@@ -1,6 +1,8 @@
 <?php
 
-class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
+namespace Automattic\Jetpack\Sync\Modules;
+
+class WooCommerce extends \Jetpack_Sync_Module {
 
 	private $order_item_meta_whitelist = array(
 		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-product-store.php#L20


### PR DESCRIPTION
This PR moves the WooCommerce sync module from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.