### PR TITLE
Traffic: Google Analytics settings copy

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -150,7 +150,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Integrate easily with Google Analytics.' ) }
+						title={ __( 'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.' ) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -39,18 +39,16 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 							link: 'https://jetpack.com/support/google-analytics/',
 						} }
 					>
-						<p>
-							{ __(
-								'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
-									' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
-									'normally show slightly different totals for your visits, views, etc.',
-								{
-									components: {
-										a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />,
-									},
-								}
-							) }
-						</p>
+						{ __(
+							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
+								' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
+								'normally show slightly different totals for your visits, views, etc.',
+							{
+								components: {
+									a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />,
+								},
+							}
+						) }
 					</SettingsGroup>
 					{ ! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
 						<Card


### PR DESCRIPTION
Update the call to action for upgrades in the analytic card. Also remote the paragraphs for better spacing.  

Fixes #9755 

See original issue for before and after. 

There was an original request in the issue to change the settings string too, we haven't introduced the concept of a WordPress.com dashboard anywhere else and I think the future of how this works is still up for debate.

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/traffic
* Verify call to action on the free plan

#### Proposed changelog entry for your changes:
* None
