### PR TITLE
Related posts settings: verbiage enhancements

### DIFF
--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -63,12 +63,19 @@ class RelatedPostsComponent extends React.Component {
 					disableInDevMode
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
+						text: __(
+							'The related posts feature scans all of your posts’ contents, ' +
+								'analyzes it, and then displays contextual posts your ' +
+								'visitors might be interested in reading. Related posts are ' +
+								'shown at the bottom of each post.'
+						),
 						link: 'https://jetpack.com/support/related-posts/',
 					} }
 				>
-					<p className="jp-form-setting-explanation">
+					<p>
 						{ __(
-							"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
+							'Keep your visitors engaged with related content at the bottom of each post. ' +
+								"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
 							{
 								components: {
 									a: (

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -64,7 +64,7 @@ class RelatedPostsComponent extends React.Component {
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
 						text: __(
-							'The related posts feature scans all of your posts’ contents, ' +
+							'The related posts feature scans all of your posts’ content, ' +
 								'analyzes it, and then displays contextual posts your ' +
 								'visitors might be interested in reading. Related posts are ' +
 								'shown at the bottom of each post.'

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -64,10 +64,8 @@ class RelatedPostsComponent extends React.Component {
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
 						text: __(
-							'The related posts feature scans all of your posts’ content, ' +
-								'analyzes it, and then displays contextual posts your ' +
-								'visitors might be interested in reading. Related posts are ' +
-								'shown at the bottom of each post.'
+							'The feature helps visitors find more of your content by ' +
+								'displaying related posts at the bottom of each post.'
 						),
 						link: 'https://jetpack.com/support/related-posts/',
 					} }


### PR DESCRIPTION
Further refinements to the related posts settings. Introduces a tooltip with more information and a brief overview of the feature benefit:

Fixes #9751

**Before:**

![Screenshot 2019-06-20 at 12 51 24](https://user-images.githubusercontent.com/411945/59847431-5a219200-935a-11e9-8895-981dcb1efd8d.png)

**After:**

![Screenshot 2019-06-20 at 12 49 09](https://user-images.githubusercontent.com/411945/59847446-63126380-935a-11e9-93f9-382943357591.png)

![Screenshot 2019-06-20 at 12 49 16](https://user-images.githubusercontent.com/411945/59847529-aa005900-935a-11e9-92ce-3d4ae98e2175.png)

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/settings?term=related
* Check the copy and tooltip text is as expected. 

#### Proposed changelog entry for your changes:
* None
