### PR TITLE
Sharing buttons settings: verbiage enhancement

### DIFF
--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -89,6 +89,11 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							link: 'https://jetpack.com/support/sharing/',
 						} }
 					>
+						<p>
+							{ __(
+								'Sharing buttons are about expanding your reach: when you add them to your content, site visitors can share your posts and pages on social media with a couple of quick clicks.'
+							) }
+						</p>
 						<ModuleToggle
 							slug="sharedaddy"
 							activated={ isActive }

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -83,15 +83,13 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 						disableInDevMode
 						module={ { module: 'sharing' } }
 						support={ {
-							text: __(
-								'Adds sharing buttons to your content so that visitors can share it on social media sites.'
-							),
+							text: __( 'Learn more about how to activate and customize your sharing buttons.' ),
 							link: 'https://jetpack.com/support/sharing/',
 						} }
 					>
 						<p>
 							{ __(
-								'Sharing buttons are about expanding your reach: when you add them to your content, site visitors can share your posts and pages on social media with a couple of quick clicks.'
+								'Add sharing buttons so visitors can share your posts and pages on social media with a couple of quick clicks.'
 							) }
 						</p>
 						<ModuleToggle

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -83,7 +83,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 						disableInDevMode
 						module={ { module: 'sharing' } }
 						support={ {
-							text: __( 'Learn more about how to activate and customize your sharing buttons.' ),
+							text: __( 'You can choose which services appear and customize the buttons.' ),
 							link: 'https://jetpack.com/support/sharing/',
 						} }
 					>


### PR DESCRIPTION
Explain the benefit of sharing buttons as discuss in #9738

> Sharing buttons are about expanding your reach: when you add them to your content, site visitors can share your posts and pages on social media with a couple of quick clicks.

Fixes #9738

See original issue for before and after screenshots

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/sharing
* Check explainer for sharing buttons

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
