### PR TITLE
Updating copy (copy sprint 1.0) changing to be clearer

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -174,7 +174,9 @@ class SiteStatsComponent extends React.Component {
 			>
 				<FoldableCard
 					onOpen={ this.trackOpenCard }
-					header={ __( 'Collecting valuable traffic stats and insights' ) }
+					header={ __(
+						'Expand to update settings for how visits are counted and manage who can view this information.'
+					) }
 					clickableHeader={ true }
 					className={ classNames( 'jp-foldable-settings-standalone', {
 						'jp-foldable-settings-disable': unavailableInDevMode,


### PR DESCRIPTION
Updating copy on Traffic section card (per copy sprint. )

Fixes #12715 

#### Changes proposed in this Pull Request:
Update copy 
From: "Collecting valuable traffic & insights"
To: "Expand to update settings for how visits are counted and manage who can view this information."



#### Testing instructions:

1) View /wp-admin/admin.php?page=jetpack#/traffic
2) Scroll down to "site stats" section. Copy is in there
<img width="693" alt="Screenshot 2019-06-20 09 40 41" src="https://user-images.githubusercontent.com/49159284/59857907-81b73100-933f-11e9-9cbd-90c5e71aa28e.png">




#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*none needed i don't think.
