### PR TITLE
Jetpack anti-spam. Consistent naming throughout

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -35,11 +35,11 @@ class DashAkismet extends Component {
 
 	getContent() {
 		const akismetData = this.props.akismetData;
-		const labelName = __( 'Spam Protection' );
+		const labelName = __( 'Jetpack Anti-spam' );
 
 		const support = {
 			text: __(
-				'Akismet checks your comments and contact form submissions against our global database of spam.'
+				'Jetpack Anti-spam powered by Akismet. Comments and contact form submissions are checked against our global database of spam.'
 			),
 			link: 'https://akismet.com/',
 			privacyLink: 'https://automattic.com/privacy/',
@@ -122,7 +122,7 @@ class DashAkismet extends Component {
 				>
 					<p className="jp-dash-item__description">
 						{ __(
-							'Whoops! Your Akismet key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.',
+							'Whoops! Your Jetpack Anti-spam (powered by Akismet) key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.',
 							{
 								components: {
 									akismetSettings: (

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -130,7 +130,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Spam filtering', { context: 'Settings header' } ) }
+					header={ __( 'Jetpack Anti-spam', { context: 'Settings header' } ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'wordpress_api_key' ) }
 					feature={ FEATURE_SPAM_AKISMET_PLUS }
 				>


### PR DESCRIPTION
Consistent naming of the spam feature. Jetpack anti-spam.

Fixes #12486 

![Screenshot 2019-06-20 at 15 40 34](https://user-images.githubusercontent.com/411945/59857897-ca87dd80-9371-11e9-8536-895ec26338b2.png)
![Screenshot 2019-06-20 at 15 40 45](https://user-images.githubusercontent.com/411945/59857899-ca87dd80-9371-11e9-8d99-a02a74ee15f2.png)

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/dashboard and wp-admin/admin.php?page=jetpack#/settings
* Check for consistent naming of Jetpack Anti-spam

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
