### PR TITLE
Sync: PSR-4 the sync actions

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -1,6 +1,7 @@
 <?php //phpcs:ignore
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Sync\Actions;
 
 class Jetpack_Provision { //phpcs:ignore
 
@@ -37,9 +38,9 @@ class Jetpack_Provision { //phpcs:ignore
 
 		// If Jetpack is currently connected, and is not in Safe Mode already, kick off a sync of the current
 		// functions/callables so that we can test if this site is in IDC.
-		if ( Jetpack::is_active() && ! Jetpack::validate_sync_error_idc_option() && Jetpack_Sync_Actions::sync_allowed() ) {
-			Jetpack_Sync_Actions::do_full_sync( array( 'functions' => true ) );
-			Jetpack_Sync_Actions::$sender->do_full_sync();
+		if ( Jetpack::is_active() && ! Jetpack::validate_sync_error_idc_option() && Actions::sync_allowed() ) {
+			Actions::do_full_sync( array( 'functions' => true ) );
+			Actions::$sender->do_full_sync();
 		}
 
 		if ( Jetpack::validate_sync_error_idc_option() ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -3,6 +3,7 @@
 WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Queue;
 
@@ -818,7 +819,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'status':
-				$status = Jetpack_Sync_Actions::get_sync_status();
+				$status = Actions::get_sync_status();
 				$collection = array();
 				foreach ( $status as $key => $item ) {
 					$collection[]  = array(
@@ -885,7 +886,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 				break;
 			case 'start':
-				if ( ! Jetpack_Sync_Actions::sync_allowed() ) {
+				if ( ! Actions::sync_allowed() ) {
 					if( ! Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. It is currently disabled. Run `wp jetpack sync enable` to enable it.', 'jetpack' ) );
 						return;
@@ -948,7 +949,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				}
 
 				// Kick off a full sync
-				if ( Jetpack_Sync_Actions::do_full_sync( $modules ) ) {
+				if ( Actions::do_full_sync( $modules ) ) {
 					if ( $modules ) {
 						/* translators: %s is a comma separated list of Jetpack modules */
 						WP_CLI::log( sprintf( __( 'Initialized a new full sync with modules: %s', 'jetpack' ), join( ', ', array_keys( $modules ) ) ) );
@@ -971,7 +972,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				// Keep sending to WPCOM until there's nothing to send
 				$i = 1;
 				do {
-					$result = Jetpack_Sync_Actions::$sender->do_full_sync();
+					$result = Actions::$sender->do_full_sync();
 					if ( is_wp_error( $result ) ) {
 						$queue_empty_error = ( 'empty_queue_full_sync' == $result->get_error_code() );
 						if ( ! $queue_empty_error || ( $queue_empty_error && ( 1 == $i ) ) ) {
@@ -1010,7 +1011,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * @synopsis <incremental|full_sync> <peek>
 	 */
 	public function sync_queue( $args, $assoc_args ) {
-		if ( ! Jetpack_Sync_Actions::sync_allowed() ) {
+		if ( ! Actions::sync_allowed() ) {
 			WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site.', 'jetpack' ) );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Queue_Buffer;
 use Automattic\Jetpack\Sync\Sender;
@@ -36,7 +37,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		if ( empty( $modules ) ) {
 			$modules = null;
 		}
-		return array( 'scheduled' => Jetpack_Sync_Actions::do_full_sync( $modules ) );
+		return array( 'scheduled' => Actions::do_full_sync( $modules ) );
 	}
 
 	protected function validate_queue( $query ) {
@@ -56,7 +57,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 	protected function result() {
 		$args   = $this->query_args();
 		$fields = isset( $args['fields'] ) ? $args['fields'] : array();
-		return Jetpack_Sync_Actions::get_sync_status( $fields );
+		return Actions::get_sync_status( $fields );
 	}
 }
 

--- a/packages/sync/legacy/class.jetpack-sync-main.php
+++ b/packages/sync/legacy/class.jetpack-sync-main.php
@@ -14,19 +14,19 @@ class Jetpack_Sync_Main {
 	 */
 	public static function init() {
 		// Check for WooCommerce support.
-		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
+		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'initialize_woocommerce' ), 5 );
 
 		// Check for WP Super Cache.
-		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_wp_super_cache' ), 5 );
+		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'initialize_wp_super_cache' ), 5 );
 
 		/*
 		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
 		 * with a high priority or sites that use alternate cron.
 		 */
-		add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'init' ), 90 );
 
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
-		add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ), 10, 2 );
-		add_action( 'jetpack_user_authorized', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 0 );
+		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
+		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 	}
 }

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -324,7 +324,7 @@ class Actions {
 		if ( false === class_exists( 'WooCommerce' ) ) {
 			return;
 		}
-		add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_woocommerce_sync_module' ) );
+		add_filter( 'jetpack_sync_modules', array( __CLASS__, 'add_woocommerce_sync_module' ) );
 	}
 
 	static function add_woocommerce_sync_module( $sync_modules ) {
@@ -336,7 +336,7 @@ class Actions {
 		if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 			return;
 		}
-		add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_wp_super_cache_sync_module' ) );
+		add_filter( 'jetpack_sync_modules', array( __CLASS__, 'add_wp_super_cache_sync_module' ) );
 	}
 
 	static function add_wp_super_cache_sync_module( $sync_modules ) {
@@ -440,7 +440,7 @@ class Actions {
 			self::clear_sync_cron_jobs();
 			\Jetpack_Sync_Settings::update_settings(
 				array(
-					'render_filtered_content' => Jetpack_Sync_Defaults::$default_render_filtered_content,
+					'render_filtered_content' => \Jetpack_Sync_Defaults::$default_render_filtered_content,
 				)
 			);
 		}

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -1,8 +1,8 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Sync\Listener;
-use Automattic\Jetpack\Sync\Sender;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -10,7 +10,7 @@ use Automattic\Jetpack\Sync\Sender;
  *
  * It also binds the action to send data to WPCOM to Jetpack's XMLRPC client object.
  */
-class Jetpack_Sync_Actions {
+class Actions {
 	static $sender                         = null;
 	static $listener                       = null;
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME  = 'jetpack_sync_interval';
@@ -31,7 +31,7 @@ class Jetpack_Sync_Actions {
 		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 
 		// Sync connected user role changes to .com
-		Jetpack_Sync_Users::init();
+		\Jetpack_Sync_Users::init();
 
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
@@ -106,16 +106,16 @@ class Jetpack_Sync_Actions {
 		if ( defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
 			return true;
 		}
-		if ( ! Jetpack_Sync_Settings::is_sync_enabled() ) {
+		if ( ! \Jetpack_Sync_Settings::is_sync_enabled() ) {
 			return false;
 		}
-		if ( Jetpack::is_development_mode() ) {
+		if ( \Jetpack::is_development_mode() ) {
 			return false;
 		}
-		if ( Jetpack::is_staging_site() ) {
+		if ( \Jetpack::is_staging_site() ) {
 			return false;
 		}
-		if ( ! Jetpack::is_active() ) {
+		if ( ! \Jetpack::is_active() ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;
 			}
@@ -125,11 +125,11 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function sync_via_cron_allowed() {
-		return ( Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
+		return ( \Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
-		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
+		if ( in_array( $post->post_type, \Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
 
@@ -137,33 +137,33 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function set_is_importing_true() {
-		Jetpack_Sync_Settings::set_importing( true );
+		\Jetpack_Sync_Settings::set_importing( true );
 	}
 
 	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
-		Jetpack::load_xml_rpc_client();
+		\Jetpack::load_xml_rpc_client();
 
 		$query_args = array(
 			'sync'      => '1',             // add an extra parameter to the URL so we can tell it's a sync action
 			'codec'     => $codec_name,     // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
 			'queue'     => $queue_id,       // sync or full_sync
-			'home'      => Jetpack_Sync_Functions::home_url(),  // Send home url option to check for Identity Crisis server-side
-			'siteurl'   => Jetpack_Sync_Functions::site_url(),  // Send siteurl option to check for Identity Crisis server-side
+			'home'      => \Jetpack_Sync_Functions::home_url(),  // Send home url option to check for Identity Crisis server-side
+			'siteurl'   => \Jetpack_Sync_Functions::site_url(),  // Send siteurl option to check for Identity Crisis server-side
 			'cd'        => sprintf( '%.4f', $checkout_duration ),   // Time spent retrieving queue items from the DB
 			'pd'        => sprintf( '%.4f', $preprocess_duration ), // Time spent converting queue items into data to send
 		);
 
 		// Has the site opted in to IDC mitigation?
-		if ( Jetpack::sync_idc_optin() ) {
+		if ( \Jetpack::sync_idc_optin() ) {
 			$query_args['idc'] = true;
 		}
 
-		if ( Jetpack_Options::get_option( 'migrate_for_idc', false ) ) {
+		if ( \Jetpack_Options::get_option( 'migrate_for_idc', false ) ) {
 			$query_args['migrate_for_idc'] = true;
 		}
 
-		$query_args['timeout'] = Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
+		$query_args['timeout'] = \Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
 
 		/**
 		 * Filters query parameters appended to the Sync request URL sent to WordPress.com.
@@ -174,9 +174,9 @@ class Jetpack_Sync_Actions {
 		 */
 		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
 
-		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );
+		$url = add_query_arg( $query_args, \Jetpack::xmlrpc_api_url() );
 
-		$rpc = new Jetpack_IXR_Client(
+		$rpc = new \Jetpack_IXR_Client(
 			array(
 				'url'     => $url,
 				'user_id' => JETPACK_MASTER_USER,
@@ -202,13 +202,13 @@ class Jetpack_Sync_Actions {
 			);
 
 			if ( in_array( $error_code, $allowed_idc_error_codes ) ) {
-				Jetpack_Options::update_option(
+				\Jetpack_Options::update_option(
 					'sync_error_idc',
-					Jetpack::get_sync_error_idc_option( $response )
+					\Jetpack::get_sync_error_idc_option( $response )
 				);
 			}
 
-			return new WP_Error(
+			return new \WP_Error(
 				'sync_error_idc',
 				esc_html__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis', 'jetpack' )
 			);
@@ -242,7 +242,7 @@ class Jetpack_Sync_Actions {
 			return false;
 		}
 
-		$full_sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$full_sync_module = \Jetpack_Sync_Modules::get_module( 'full-sync' );
 
 		if ( ! $full_sync_module ) {
 			return false;
@@ -290,7 +290,7 @@ class Jetpack_Sync_Actions {
 
 		self::initialize_sender();
 
-		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+		$time_limit = \Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
 		$start_time = time();
 
 		do {
@@ -438,7 +438,7 @@ class Jetpack_Sync_Actions {
 		$is_new_sync_upgrade = version_compare( $old_version, '4.2', '>=' );
 		if ( ! empty( $old_version ) && $is_new_sync_upgrade && version_compare( $old_version, '4.5', '<' ) ) {
 			self::clear_sync_cron_jobs();
-			Jetpack_Sync_Settings::update_settings(
+			\Jetpack_Sync_Settings::update_settings(
 				array(
 					'render_filtered_content' => Jetpack_Sync_Defaults::$default_render_filtered_content,
 				)
@@ -455,7 +455,7 @@ class Jetpack_Sync_Actions {
 	static function get_sync_status( $fields = null ) {
 		self::initialize_sender();
 
-		$sync_module     = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sync_module     = \Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$queue           = self::$sender->get_sync_queue();
 		$full_queue      = self::$sender->get_full_sync_queue();
 		$cron_timestamps = array_keys( _get_cron_array() );
@@ -464,7 +464,7 @@ class Jetpack_Sync_Actions {
 		$checksums = array();
 
 		if ( ! empty( $fields ) ) {
-			$store         = new Jetpack_Sync_WP_Replicastore();
+			$store         = new \Jetpack_Sync_WP_Replicastore();
 			$fields_params = array_map( 'trim', explode( ',', $fields ) );
 
 			if ( in_array( 'posts_checksum', $fields_params, true ) ) {

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Automattic\Jetpack\Sync;
-use Automattic\Jetpack\Sync\Queue;
 
 /**
  * This class monitors actions and logs them to the queue to be sent
@@ -253,10 +252,10 @@ class Listener {
 		}
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible
-		if ( ! \Jetpack_Sync_Actions::$sender ) {
+		if ( ! Actions::$sender ) {
 			add_filter( 'jetpack_sync_sender_should_load', '__return_true' );
 			if ( did_action( 'init' ) ) {
-				\Jetpack_Sync_Actions::add_sender_shutdown();
+				Actions::add_sender_shutdown();
 			}
 		}
 	}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -56,7 +56,7 @@ if ( '1' != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 
 if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 	/**
-	 * "Mocking" function so that it exists and Jetpack_Sync_Actions will load Automattic\Jetpack\Sync\Modules\WP_Super_Cache
+	 * "Mocking" function so that it exists and Automattic\Jetpack\Sync\Actions will load Automattic\Jetpack\Sync\Modules\WP_Super_Cache
 	 */
 	function wp_cache_is_enabled() {
 

--- a/tests/php/sync/test_class.jetpack-sync-actions.php
+++ b/tests/php/sync/test_class.jetpack-sync-actions.php
@@ -1,14 +1,16 @@
 <?php
 
+use Automattic\Jetpack\Sync\Actions;
+
 class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 	function test_get_sync_status() {
-		$no_checksum = Jetpack_Sync_Actions::get_sync_status();
+		$no_checksum = Actions::get_sync_status();
 		$this->assertArrayNotHasKey( 'posts_checksum', $no_checksum );
 		$this->assertArrayNotHasKey( 'comments_checksum', $no_checksum );
 		$this->assertArrayNotHasKey( 'post_meta_checksum', $no_checksum );
 		$this->assertArrayNotHasKey( 'comment_meta_checksum', $no_checksum );
 
-		$kitchen_sink_checksum = Jetpack_Sync_Actions::get_sync_status(
+		$kitchen_sink_checksum = Actions::get_sync_status(
 			'posts_checksum,comments_checksum,post_meta_checksum,comment_meta_checksum'
 		);
 		$this->assertArrayHasKey( 'posts_checksum', $kitchen_sink_checksum );
@@ -16,13 +18,13 @@ class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'post_meta_checksum', $kitchen_sink_checksum );
 		$this->assertArrayHasKey( 'comment_meta_checksum', $kitchen_sink_checksum );
 
-		$posts = Jetpack_Sync_Actions::get_sync_status( 'posts_checksum' );
+		$posts = Actions::get_sync_status( 'posts_checksum' );
 		$this->assertArrayHasKey( 'posts_checksum', $posts );
 		$this->assertArrayNotHasKey( 'comments_checksum', $posts );
 		$this->assertArrayNotHasKey( 'post_meta_checksum', $posts );
 		$this->assertArrayNotHasKey( 'comment_meta_checksum', $posts );
 
-		$comments = Jetpack_Sync_Actions::get_sync_status(
+		$comments = Actions::get_sync_status(
 			'comments_checksum'
 		);
 		$this->assertArrayNotHasKey( 'posts_checksum', $comments );
@@ -30,7 +32,7 @@ class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'post_meta_checksum', $comments );
 		$this->assertArrayNotHasKey( 'comment_meta_checksum', $comments );
 
-		$post_meta = Jetpack_Sync_Actions::get_sync_status(
+		$post_meta = Actions::get_sync_status(
 			'post_meta_checksum'
 		);
 		$this->assertArrayNotHasKey( 'posts_checksum', $post_meta );
@@ -38,7 +40,7 @@ class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'post_meta_checksum', $post_meta );
 		$this->assertArrayNotHasKey( 'comment_meta_checksum', $post_meta );
 
-		$comment_meta = Jetpack_Sync_Actions::get_sync_status(
+		$comment_meta = Actions::get_sync_status(
 			'comment_meta_checksum'
 		);
 		$this->assertArrayNotHasKey( 'posts_checksum', $comment_meta );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Modules\Full_Sync;
 
 function jetpack_foo_full_sync_callable() {
@@ -1342,7 +1343,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
-		Jetpack_Sync_Actions::do_initial_sync( '4.2', '4.1' );
+		Actions::do_initial_sync( '4.2', '4.1' );
 		$current_user = wp_get_current_user();
 
 		$expected_sync_config = array(

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Actions;
 
 class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_sending_empties_queue() {
@@ -20,7 +21,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_schedules_incremental_sync_cron() {
 		// we need to run this again because cron is cleared between tests
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
+		Actions::init_sync_cron_jobs();
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
 		// we need to check a while in the past because the task got scheduled at
 		// the beginning of the entire test run, not at the beginning of this test :)
@@ -28,43 +29,43 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_default_schedule_incremental_sync_cron() {
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
+		Actions::init_sync_cron_jobs();
+		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_filtered_schedule_incremental_sync_cron_works() {
 		add_filter( 'jetpack_sync_incremental_sync_interval', array( $this, '__return_hourly_schedule' ) );
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
+		Actions::init_sync_cron_jobs();
 		$this->assertEquals( 'hourly', wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_filtered_schedule_incremental_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_incremental_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
+		Actions::init_sync_cron_jobs();
+		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_schedules_full_sync_cron() {
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
+		Actions::init_sync_cron_jobs();
 		$timestamp = wp_next_scheduled( 'jetpack_sync_full_cron' );
 		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
 	}
 
 	function test_default_schedule_full_sync_cron() {
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		Actions::init_sync_cron_jobs();
+		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_filtered_schedule_full_sync_cron_works() {
 		add_filter( 'jetpack_sync_full_sync_interval', array( $this, '__return_hourly_schedule' ) );
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
+		Actions::init_sync_cron_jobs();
 		$this->assertEquals( 'hourly', wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_filtered_schedule_full_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_full_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		Actions::init_sync_cron_jobs();
+		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_starts_full_sync_on_user_authorized() {
@@ -96,12 +97,12 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_loads_sender_if_listener_queues_actions() {
 		remove_all_filters( 'jetpack_sync_sender_should_load' );
-		Jetpack_Sync_Actions::$sender = null;
+		Actions::$sender = null;
 
 		$this->listener->enqueue_action( 'test_action', array( 'test_arg' ), $this->listener->get_sync_queue() );
 
 		$this->assertTrue( !! has_filter( 'jetpack_sync_sender_should_load', '__return_true' ) );
-		$this->assertTrue( Jetpack_Sync_Actions::$sender !== null );
+		$this->assertTrue( Actions::$sender !== null );
 	}
 
 	function test_do_not_load_sender_if_is_cron_and_cron_sync_disabled() {
@@ -109,18 +110,18 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$settings = Jetpack_Sync_Settings::get_settings();
 		$settings['sync_via_cron'] = 0;
 		Jetpack_Sync_Settings::update_settings( $settings );
-		Jetpack_Sync_Actions::$sender = null;
+		Actions::$sender = null;
 
-		Jetpack_Sync_Actions::add_sender_shutdown();
+		Actions::add_sender_shutdown();
 
-		$this->assertNull( Jetpack_Sync_Actions::$sender );
+		$this->assertNull( Actions::$sender );
 
 		Constants::clear_constants();
 		Jetpack_Sync_Settings::reset_data();
 	}
 
 	function test_cleanup_cron_jobs_with_non_staggered_start() {
-		Jetpack_Sync_Actions::init_sync_cron_jobs();
+		Actions::init_sync_cron_jobs();
 
 		$this->assertInternalType( 'integer', wp_next_scheduled( 'jetpack_sync_cron' ) );
 		$this->assertInternalType( 'integer', wp_next_scheduled( 'jetpack_sync_full_cron' ) );
@@ -133,18 +134,18 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_cron_start_time_offset_has_randomness() {
-		Jetpack_Sync_Actions::clear_sync_cron_jobs();
+		Actions::clear_sync_cron_jobs();
 
 		if ( is_multisite() ) {
 			$values = array();
 			for ( $i = 0; $i < 10; $i++ ) {
-				$values[] = Jetpack_Sync_Actions::get_start_time_offset();
+				$values[] = Actions::get_start_time_offset();
 			}
 
 			$this->assertGreaterThan( 1, array_unique( $values ) );
 
 		} else {
-			$this->assertEquals( 0, Jetpack_Sync_Actions::get_start_time_offset() );
+			$this->assertEquals( 0, Actions::get_start_time_offset() );
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -59,7 +59,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		// Priority is set earlier now plugins_loaded but we plugins should still be able to set whitelist_filters by
 		// using the plugins_loaded action.
 
-		$this->assertEquals( 90, has_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ) ) );
+		$this->assertEquals( 90, has_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'init' ) ) );
 	}
 
 	public function test_sync_default_options() {


### PR DESCRIPTION
In #12712 and all the related PRs we are making an effort to namespace all the sync modules. We also need to start namespacing the rest of the Sync core, see #12751. 

This PR adds a namespace to the sync actions class and that way autoload it with PSR-4.

#### Changes proposed in this Pull Request:
* Sync: Namespace the sync actions class and autoload it with PSR-4.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Checkout the branch.
* Enable `WP_DEBUG_LOG`.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Namespace the sync actions class and load it with PSR-4
