### PR TITLE
Sync: Fix constants usage in posts sync module

### DIFF
--- a/packages/sync/src/modules/Posts.php
+++ b/packages/sync/src/modules/Posts.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 class Posts extends \Jetpack_Sync_Module {
 
@@ -320,7 +320,7 @@ class Posts extends \Jetpack_Sync_Module {
 			false;
 
 		$state = array(
-			'is_auto_save'                 => (bool) Constants::get_constant( 'DOING_AUTOSAVE' ),
+			'is_auto_save'                 => (bool) Jetpack_Constants::get_constant( 'DOING_AUTOSAVE' ),
 			'previous_status'              => $previous_status,
 			'just_published'               => $just_published,
 			'is_gutenberg_meta_box_update' => $this->is_gutenberg_meta_box_update(),


### PR DESCRIPTION
When we were PSR-4-ing the sync modules, we forgot to alias `Automattic\Jetpack\Constants` in the posts sync module. This is necessary, because `Constants` already exists in the sync modules namespace.

#### Changes proposed in this Pull Request:
* Sync: Fix constants usage in posts sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project - p1HpG7-70O-p2

#### Testing instructions:
* Verify sync still works.
* Verify CI is green.

#### Proposed changelog entry for your changes:
* Sync: Fix constants usage in posts sync module
