### PR TITLE
Free plan header upgrade link

### DIFF
--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -14,6 +14,7 @@ import ChecklistProgress from './checklist-progress-card';
 import { getPlanClass } from 'lib/plans/constants';
 import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
 import { imagePath } from 'constants/urls';
+import UpgradeLink from 'components/upgrade-link';
 
 class MyPlanHeader extends React.Component {
 	trackLearnMore = () => {
@@ -53,7 +54,14 @@ class MyPlanHeader extends React.Component {
 								{ __( 'Your plan: Jetpack Free' ) }
 							</h3>
 							<p className="jp-landing__plan-features-text">
-								{ __( 'Get started with hassle-free design, stats, and performance tools.' ) }
+								{ __(
+									'Worried about security? Get backups, automated security fixes and more: {{a}}Upgrade now{{/a}}',
+									{
+										components: {
+											a: <UpgradeLink source="myplan-header-free-plan-text-link" />
+										}
+									}
+								) }
 							</p>
 							<ChecklistCta onClick={ this.trackChecklistCtaClick } siteSlug={ siteSlug } />
 						</div>


### PR DESCRIPTION
On the free plan we should explain the benefits of an upgrade on the My plan screen. Please check that the CTA is implemented correctly.

Fixes #12586

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/admin.php?page=jetpack#/my-plan on a free plan
* Click the text 'upgrade now' link at the top of the page

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
