### PR TITLE
Connection: Remove token from error message when we detect the token is malformed

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -594,7 +594,7 @@ class Manager implements Manager_Interface {
 			}
 			$user_token_chunks = explode( '.', $user_tokens[ $user_id ] );
 			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
-				return $suppress_errors ? false : new \WP_Error( 'token_malformed', sprintf( 'Token \'%s\' for user %d is malformed', $user_tokens[ $user_id ], $user_id ) );
+				return $suppress_errors ? false : new \WP_Error( 'token_malformed', sprintf( 'Token for user %d is malformed', $user_id ) );
 			}
 			if ( $user_token_chunks[2] !== (string) $user_id ) {
 				return $suppress_errors ? false : new \WP_Error( 'user_id_mismatch', sprintf( 'Requesting user_id %d does not match token user_id %d', $user_id, $user_token_chunks[2] ) );


### PR DESCRIPTION
We don't need to put the "malformed" token in the WP_Error message as there's not much we can do with it anyways.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the token from the generated string that ends up being the Error message we pass to the `jetpack_verify_signature_error` action

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Removes a feature-like thing.

#### Testing instructions:

Confirm the change makes sense

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
