### PR TITLE
Making the "ask a question" cta a link, so the upgrade cta will have …

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
-import Button from 'components/button';
 import analytics from 'lib/analytics';
 
 /**
@@ -80,7 +79,7 @@ class SupportCard extends React.Component {
 								: __( 'Your paid plan gives you access to prioritized Jetpack support.' ) }
 						</p>
 						<p className="jp-support-card__description">
-							<Button
+							<a
 								onClick={ this.trackAskQuestionClick }
 								href={
 									this.props.isAtomicSite
@@ -89,17 +88,7 @@ class SupportCard extends React.Component {
 								}
 							>
 								{ __( 'Ask a question' ) }
-							</Button>
-							<Button
-								onClick={ this.trackSearchClick }
-								href={
-									this.props.isAtomicSite
-										? 'https://wordpress.com/help/'
-										: 'https://jetpack.com/support/'
-								}
-							>
-								{ __( 'Search our support site' ) }
-							</Button>
+							</a>
 						</p>
 					</div>
 				</Card>


### PR DESCRIPTION
Making the "ask a question" cta a link, so the upgrade cta will have more prominence. Removing the "search our support site" cta as it's duplicative

Fixes #12615 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed the "Ask a question" button to a text link.
* Removed the "Search the help site" button


#### Testing instructions:
1) Visit Jetpack pages
2) Scroll down to the bottom to "We're here to help" module
<img width="683" alt="Screenshot 2019-06-20 11 55 32" src="https://user-images.githubusercontent.com/49159284/59868388-6c99cc80-9356-11e9-9bee-04f27aeed6fb.png">




