### PR TITLE
General: Start sending ABSPATH when registering

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5066,7 +5066,8 @@ p {
 				'_ui'             => $tracks_identity['_ui'],
 				'_ut'             => $tracks_identity['_ut'],
 				'site_created'    => Jetpack::get_assumed_site_creation_date(),
-				'jetpack_version' => JETPACK__VERSION
+				'jetpack_version' => JETPACK__VERSION,
+				'ABSPATH'         => defined( 'ABSPATH' ) ? ABSPATH : '',
 			),
 			'headers' => array(
 				'Accept' => 'application/json',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Start ending the value of the `ABSPATH` constant when registering a site. This will be used to support setting SSH credentials by hosting partners.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is adding new data to an existing flow. See D29544-code where the work is taking place on adding the ability for hosting partners to set SSH credentials.

#### Testing instructions:

- Checkout D29670-code patch on WPCOM
- Launch JN site with Jetpack Beta and `update/abspath-with-register` branch via special ops
- Sandbox WPCOM from Jetpack site by going to **Settings > Jetpack Constants** and entering and updating `JETPACK__SANDBOX_DOMAIN`
- Click "Set Up Jetpack" button in Jetpack wp-admin to begin connection process
- Do not authorize connection on WordPress.com, which will result in the site being registered, but not fully connected, thus no syncing
- Go to https://jetpack.com/support/debug?url=YOUR_JN_URL_HERE
- Ensure that `ABSPATH` constant is set in constants list

#### Proposed changelog entry for your changes:

* Begin sending `ABSPATH` constant value when registering a site to support setting SSH credentials for Jetpack Backup.
