### PR TITLE
Jetpack DNA: Move Jetpack Sync Settings from Legacy to psr-4

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Queue;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Control your local Jetpack installation.
@@ -832,7 +833,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				break;
 			case 'settings':
 				WP_CLI::log( __( 'Sync Settings:', 'jetpack' ) );
-				foreach( Jetpack_Sync_Settings::get_settings() as $setting => $item ) {
+				foreach( Settings::get_settings() as $setting => $item ) {
 					$settings[]  = array(
 						'setting' => $setting,
 						'value' => is_scalar( $item ) ? $item : json_encode( $item )
@@ -841,18 +842,18 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI\Utils\format_items( 'table', $settings, array( 'setting', 'value' ) );
 
 			case 'disable':
-				// Don't set it via the Jetpack_Sync_Settings since that also resets the queues.
+				// Don't set it via the Settings since that also resets the queues.
 				update_option( 'jetpack_sync_settings_disable', 1 );
 				/* translators: %s is the site URL */
 				WP_CLI::log( sprintf( __( 'Sync Disabled on %s', 'jetpack' ), get_site_url() ) );
 				break;
 			case 'enable':
-				Jetpack_Sync_Settings::update_settings( array( 'disable' => 0 ) );
+				Settings::update_settings( array( 'disable' => 0 ) );
 				/* translators: %s is the site URL */
 				WP_CLI::log( sprintf( __( 'Sync Enabled on %s', 'jetpack' ), get_site_url() ) );
 				break;
 			case 'reset':
-				// Don't set it via the Jetpack_Sync_Settings since that also resets the queues.
+				// Don't set it via the Settings since that also resets the queues.
 				update_option( 'jetpack_sync_settings_disable', 1 );
 
 				/* translators: %s is the site URL */
@@ -887,7 +888,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				break;
 			case 'start':
 				if ( ! Actions::sync_allowed() ) {
-					if( ! Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
+					if( ! Settings::get_setting( 'disable' ) ) {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. It is currently disabled. Run `wp jetpack sync enable` to enable it.', 'jetpack' ) );
 						return;
 					}
@@ -906,11 +907,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 				}
 				// Get the original settings so that we can restore them later
-				$original_settings = Jetpack_Sync_Settings::get_settings();
+				$original_settings = Settings::get_settings();
 
 				// Initialize sync settigns so we can sync as quickly as possible
 				$sync_settings = wp_parse_args(
-					array_intersect_key( $assoc_args, Jetpack_Sync_Settings::$valid_settings ),
+					array_intersect_key( $assoc_args, Settings::$valid_settings ),
 					array(
 						'sync_wait_time' => 0,
 						'enqueue_wait_time' => 0,
@@ -918,7 +919,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 						'max_queue_size_full_sync' => 100000
 					)
 				);
-				Jetpack_Sync_Settings::update_settings( $sync_settings );
+				Settings::update_settings( $sync_settings );
 
 				// Convert comma-delimited string of modules to an array
 				if ( ! empty( $assoc_args['modules'] ) ) {
@@ -959,7 +960,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				} else {
 
 					// Reset sync settings to original.
-					Jetpack_Sync_Settings::update_settings( $original_settings );
+					Settings::update_settings( $original_settings );
 
 					if ( $modules ) {
 						/* translators: %s is a comma separated list of Jetpack modules */
@@ -990,7 +991,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				} while ( $result && ! is_wp_error( $result ) );
 
 				// Reset sync settings to original.
-				Jetpack_Sync_Settings::update_settings( $original_settings );
+				Settings::update_settings( $original_settings );
 
 				WP_CLI::success( __( 'Finished syncing to WordPress.com', 'jetpack' ) );
 				break;

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Queue_Buffer;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
+use Automattic\Jetpack\Sync\Settings;
 
 // POST /sites/%s/sync
 class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
@@ -98,7 +99,7 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 	protected function result() {
 		$args = $this->input();
 
-		$sync_settings = Jetpack_Sync_Settings::get_settings();
+		$sync_settings = Settings::get_settings();
 
 		foreach ( $args as $key => $value ) {
 			if ( $value !== false ) {
@@ -115,10 +116,10 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 			}
 		}
 
-		Jetpack_Sync_Settings::update_settings( $sync_settings );
+		Settings::update_settings( $sync_settings );
 
 		// re-fetch so we see what's really being stored
-		return Jetpack_Sync_Settings::get_settings();
+		return Settings::get_settings();
 	}
 }
 
@@ -126,7 +127,7 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
 
-		return Jetpack_Sync_Settings::get_settings();
+		return Settings::get_settings();
 	}
 }
 
@@ -146,9 +147,9 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 
 		$codec = Sender::get_instance()->get_codec();
 
-		Jetpack_Sync_Settings::set_is_syncing( true );
+		Settings::set_is_syncing( true );
 		$objects = $codec->encode( $sync_module->get_objects_by_id( $object_type, $object_ids ) );
-		Jetpack_Sync_Settings::set_is_syncing( false );
+		Settings::set_is_syncing( false );
 
 		return array(
 			'objects' => $objects,
@@ -215,9 +216,9 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
 		}
 
-		Jetpack_Sync_Settings::set_is_syncing( true );
+		Settings::set_is_syncing( true );
 		list( $items_to_send, $skipped_items_ids, $items ) = $sender->get_items_to_send( $buffer, $args['encode'] );
-		Jetpack_Sync_Settings::set_is_syncing( false );
+		Settings::set_is_syncing( false );
 
 		return array(
 			'buffer_id'      => $buffer->id,

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -10,6 +10,8 @@ Version: 2.4
 License: GPLv2 or later
 */
 
+use Automattic\Jetpack\Sync\Settings;
+
 define( 'GRUNION_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GRUNION_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -1935,7 +1937,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML for the concat form.
 	 */
 	static function parse( $attributes, $content ) {
-		if ( Jetpack_Sync_Settings::is_syncing() ) {
+		if ( Settings::is_syncing() ) {
 			return '';
 		}
 		// Create a new Grunion_Contact_Form object (this class)

--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Settings;
+
 class Jetpack_Likes_Settings {
 	function __construct() {
 		$this->in_jetpack = ! ( defined( 'IS_WPCOM' ) && IS_WPCOM );
@@ -269,7 +271,7 @@ class Jetpack_Likes_Settings {
 	 * similar logic and filters apply here, too.
 	 */
 	function is_likes_visible() {
-		if ( Jetpack_Sync_Settings::is_syncing() ) {
+		if ( Settings::is_syncing() ) {
 			return false;
 		}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Sync\Settings;
+
 class Jetpack_RelatedPosts {
 	const VERSION   = '20190204';
 	const SHORTCODE = 'jetpack-related-posts';
@@ -197,7 +200,7 @@ class Jetpack_RelatedPosts {
 	 * @returns string
 	 */
 	public function get_target_html() {
-		if ( Jetpack_Sync_Settings::is_syncing() ) {
+		if ( Settings::is_syncing() ) {
 			return '';
 		}
 
@@ -231,7 +234,7 @@ EOT;
 	 * @returns string
 	 */
 	public function get_target_html_unsupported() {
-		if ( Jetpack_Sync_Settings::is_syncing() ) {
+		if ( Settings::is_syncing() ) {
 			return '';
 		}
 		return "\n\n<!-- Jetpack Related Posts is not supported in this context. -->\n\n";

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Settings;
+
 include_once dirname( __FILE__ ) . '/sharing-sources.php';
 
 define( 'WP_SHARING_PLUGIN_VERSION', JETPACK__VERSION );
@@ -669,7 +671,7 @@ add_action( 'template_redirect', 'sharing_process_requests', 9 );
 function sharing_display( $text = '', $echo = false ) {
 	global $post, $wp_current_filter;
 
-	if ( Jetpack_Sync_Settings::is_syncing() ) {
+	if ( Settings::is_syncing() ) {
 		return $text;
 	}
 

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -106,7 +106,8 @@ class Actions {
 		if ( defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
 			return true;
 		}
-		if ( ! \Jetpack_Sync_Settings::is_sync_enabled() ) {
+
+		if ( ! Settings::is_sync_enabled() ) {
 			return false;
 		}
 		if ( \Jetpack::is_development_mode() ) {
@@ -125,11 +126,11 @@ class Actions {
 	}
 
 	static function sync_via_cron_allowed() {
-		return ( \Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
+		return ( Settings::get_setting( 'sync_via_cron' ) );
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
-		if ( in_array( $post->post_type, \Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
+		if ( in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
 
@@ -137,7 +138,7 @@ class Actions {
 	}
 
 	static function set_is_importing_true() {
-		\Jetpack_Sync_Settings::set_importing( true );
+		Settings::set_importing( true );
 	}
 
 	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
@@ -163,7 +164,7 @@ class Actions {
 			$query_args['migrate_for_idc'] = true;
 		}
 
-		$query_args['timeout'] = \Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
+		$query_args['timeout'] = Settings::is_doing_cron() ? 30 : 15;
 
 		/**
 		 * Filters query parameters appended to the Sync request URL sent to WordPress.com.
@@ -290,7 +291,7 @@ class Actions {
 
 		self::initialize_sender();
 
-		$time_limit = \Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+		$time_limit = Settings::get_setting( 'cron_sync_time_limit' );
 		$start_time = time();
 
 		do {
@@ -438,7 +439,7 @@ class Actions {
 		$is_new_sync_upgrade = version_compare( $old_version, '4.2', '>=' );
 		if ( ! empty( $old_version ) && $is_new_sync_upgrade && version_compare( $old_version, '4.5', '<' ) ) {
 			self::clear_sync_cron_jobs();
-			\Jetpack_Sync_Settings::update_settings(
+			Settings::update_settings(
 				array(
 					'render_filtered_content' => Defaults::$default_render_filtered_content,
 				)

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -235,7 +235,7 @@ class Listener {
 					$args,
 					get_current_user_id(),
 					microtime( true ),
-					\Settings::is_importing(),
+					Settings::is_importing(),
 					$this->get_actor( $current_filter, $args ),
 				)
 			);
@@ -246,7 +246,7 @@ class Listener {
 					$args,
 					get_current_user_id(),
 					microtime( true ),
-					\Settings::is_importing(),
+					Settings::is_importing(),
 				)
 			);
 		}

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -84,7 +84,7 @@ class Listener {
 	// prevent adding items to the queue if it hasn't sent an item for 15 mins
 	// AND the queue is over 1000 items long (by default)
 	function can_add_to_queue( $queue ) {
-		if ( ! \Jetpack_Sync_Settings::is_sync_enabled() ) {
+		if ( ! Settings::is_sync_enabled() ) {
 			return false;
 		}
 
@@ -140,7 +140,7 @@ class Listener {
 		$data_to_enqueue = array();
 		$user_id         = get_current_user_id();
 		$currtime        = microtime( true );
-		$is_importing    = \Jetpack_Sync_Settings::is_importing();
+		$is_importing    = Settings::is_importing();
 
 		foreach ( $args_array as $args ) {
 			$previous_end = isset( $args['previous_end'] ) ? $args['previous_end'] : null;
@@ -179,7 +179,7 @@ class Listener {
 
 	function enqueue_action( $current_filter, $args, $queue ) {
 		// don't enqueue an action during the outbound http request - this prevents recursion
-		if ( \Jetpack_Sync_Settings::is_sending() ) {
+		if ( Settings::is_sending() ) {
 			return;
 		}
 
@@ -235,7 +235,7 @@ class Listener {
 					$args,
 					get_current_user_id(),
 					microtime( true ),
-					\Jetpack_Sync_Settings::is_importing(),
+					\Settings::is_importing(),
 					$this->get_actor( $current_filter, $args ),
 				)
 			);
@@ -246,7 +246,7 @@ class Listener {
 					$args,
 					get_current_user_id(),
 					microtime( true ),
-					\Jetpack_Sync_Settings::is_importing(),
+					\Settings::is_importing(),
 				)
 			);
 		}
@@ -313,8 +313,8 @@ class Listener {
 	function set_defaults() {
 		$this->sync_queue      = new Queue( 'sync' );
 		$this->full_sync_queue = new Queue( 'full_sync' );
-		$this->set_queue_size_limit( \Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
-		$this->set_queue_lag_limit( \Jetpack_Sync_Settings::get_setting( 'max_queue_lag' ) );
+		$this->set_queue_size_limit( Settings::get_setting( 'max_queue_size' ) );
+		$this->set_queue_lag_limit( Settings::get_setting( 'max_queue_lag' ) );
 	}
 
 	function get_request_url() {

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\Jetpack\Sync;
 
-use Automattic\Jetpack\Constants;
-
 /**
  * An implementation of Replicastore Interface which returns data stored in a WordPress.org DB.
  * This is useful to compare values in the local WP DB to values in the synced replica store
@@ -655,14 +653,14 @@ class Replicastore implements Replicastore_Interface {
 				$object_count = $this->post_count( null, $start_id, $end_id );
 				$object_table = $wpdb->posts;
 				$id_field     = 'ID';
-				$where_sql    = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+				$where_sql    = Settings::get_blacklisted_post_types_sql();
 				if ( empty( $columns ) ) {
 					$columns = Defaults::$default_post_checksum_columns;
 				}
 				break;
 			case 'post_meta':
 				$object_table = $wpdb->postmeta;
-				$where_sql    = \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql();
+				$where_sql    = Settings::get_whitelisted_post_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 
@@ -674,14 +672,14 @@ class Replicastore implements Replicastore_Interface {
 				$object_count = $this->comment_count( null, $start_id, $end_id );
 				$object_table = $wpdb->comments;
 				$id_field     = 'comment_ID';
-				$where_sql    = \Jetpack_Sync_Settings::get_comments_filter_sql();
+				$where_sql    = Settings::get_comments_filter_sql();
 				if ( empty( $columns ) ) {
 					$columns = Defaults::$default_comment_checksum_columns;
 				}
 				break;
 			case 'comment_meta':
 				$object_table = $wpdb->commentmeta;
-				$where_sql    = \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql();
+				$where_sql    = Settings::get_whitelisted_comment_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 				if ( empty( $columns ) ) {

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -7,8 +7,7 @@ namespace Automattic\Jetpack\Sync;
  * This is useful to compare values in the local WP DB to values in the synced replica store
  */
 class Replicastore implements Replicastore_Interface {
-
-
+	
 	public function reset() {
 		global $wpdb;
 
@@ -147,12 +146,12 @@ class Replicastore implements Replicastore_Interface {
 
 	public function posts_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->posts, Defaults::$default_post_checksum_columns, 'ID', \Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->posts, Defaults::$default_post_checksum_columns, 'ID', Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
 	}
 
 	public function post_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->postmeta, Defaults::$default_post_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->postmeta, Defaults::$default_post_meta_checksum_columns, 'meta_id', Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
 	}
 
 	public function comment_count( $status = null, $min_id = null, $max_id = null ) {
@@ -282,12 +281,12 @@ class Replicastore implements Replicastore_Interface {
 
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->comments, Defaults::$default_comment_checksum_columns, 'comment_ID', \Jetpack_Sync_Settings::get_comments_filter_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->comments, Defaults::$default_comment_checksum_columns, 'comment_ID', Settings::get_comments_filter_sql(), $min_id, $max_id );
 	}
 
 	public function comment_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->commentmeta, Defaults::$default_comment_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->commentmeta, Defaults::$default_comment_meta_checksum_columns, 'meta_id', Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
 	}
 
 	public function options_checksum() {

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -3,8 +3,6 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Sync\Modules;
-use Automattic\Jetpack\Sync\Defaults;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -118,11 +116,11 @@ class Sender {
 
 		$start_time = microtime( true );
 
-		\Jetpack_Sync_Settings::set_is_syncing( true );
+		Settings::set_is_syncing( true );
 
 		$sync_result = $this->do_sync_for_queue( $queue );
 
-		\Jetpack_Sync_Settings::set_is_syncing( false );
+		Settings::set_is_syncing( false );
 
 		$exceeded_sync_wait_threshold = ( microtime( true ) - $start_time ) > (float) $this->get_sync_wait_threshold();
 
@@ -239,9 +237,9 @@ class Sender {
 			 * @param double $time The current time
 			 * @param string $queue The queue used to send ('sync' or 'full_sync')
 			 */
-			\Jetpack_Sync_Settings::set_is_sending( true );
+			Settings::set_is_sending( true );
 			$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id, $checkout_duration, $preprocess_duration );
-			\Jetpack_Sync_Settings::set_is_sending( false );
+			Settings::set_is_sending( false );
 		} else {
 			$processed_item_ids = $skipped_items_ids;
 			$skipped_items_ids  = array();
@@ -374,8 +372,8 @@ class Sender {
 		$this->set_codec();
 
 		// saved settings
-		\Jetpack_Sync_Settings::set_importing( null );
-		$settings = \Jetpack_Sync_Settings::get_settings();
+		Settings::set_importing( null );
+		$settings = Settings::get_settings();
 		$this->set_dequeue_max_bytes( $settings['dequeue_max_bytes'] );
 		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );
 		$this->set_upload_max_rows( $settings['upload_max_rows'] );
@@ -397,7 +395,7 @@ class Sender {
 			delete_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name );
 		}
 
-		\Jetpack_Sync_Settings::reset_data();
+		Settings::reset_data();
 	}
 
 	function uninstall() {

--- a/packages/sync/src/Settings.php
+++ b/packages/sync/src/Settings.php
@@ -1,9 +1,8 @@
 <?php
 
-use Automattic\Jetpack\Sync\Listener;
-use Automattic\Jetpack\Sync\Defaults;
+namespace Automattic\Jetpack\Sync;
 
-class Jetpack_Sync_Settings {
+class Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
 
 	static $valid_settings = array(

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Settings;
 
 class Callables extends \Jetpack_Sync_Module {
 	const CALLABLES_CHECKSUM_OPTION_NAME = 'jetpack_callables_sync_checksum';
@@ -215,7 +216,7 @@ class Callables extends \Jetpack_Sync_Module {
 
 	public function maybe_sync_callables() {
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
-			if ( ! is_admin() || \Jetpack_Sync_Settings::is_doing_cron() ) {
+			if ( ! is_admin() || Settings::is_doing_cron() ) {
 				return;
 			}
 

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Settings;
+
 class Comments extends \Jetpack_Sync_Module {
 
 	public function name() {
@@ -171,7 +173,7 @@ class Comments extends \Jetpack_Sync_Module {
 
 	// Comment Meta
 	function is_whitelisted_comment_meta( $meta_key ) {
-		return in_array( $meta_key, \Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) );
+		return in_array( $meta_key, Settings::get_setting( 'comment_meta_whitelist' ) );
 	}
 
 	function filter_meta( $args ) {
@@ -191,7 +193,7 @@ class Comments extends \Jetpack_Sync_Module {
 
 		return array(
 			$comments,
-			$this->get_metadata( $comment_ids, 'comment', \Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' ) ),
+			$this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
 			$previous_interval_end,
 		);
 	}

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * This class does a full resync of the database by
@@ -128,7 +129,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 		}
 
 		// if full sync queue is full, don't enqueue more items
-		$max_queue_size_full_sync = \Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
+		$max_queue_size_full_sync = Settings::get_setting( 'max_queue_size_full_sync' );
 		$full_sync_queue          = new Queue( 'full_sync' );
 
 		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();
@@ -136,7 +137,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 		if ( $available_queue_slots <= 0 ) {
 			return;
 		} else {
-			$remaining_items_to_enqueue = min( \Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
+			$remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
 		}
 
 		if ( ! $configs ) {
@@ -208,13 +209,13 @@ class Full_Sync extends \Jetpack_Sync_Module {
 			case 'posts':
 				$table     = $wpdb->posts;
 				$id        = 'ID';
-				$where_sql = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+				$where_sql = Settings::get_blacklisted_post_types_sql();
 
 				break;
 			case 'comments':
 				$table     = $wpdb->comments;
 				$id        = 'comment_ID';
-				$where_sql = \Jetpack_Sync_Settings::get_comments_filter_sql();
+				$where_sql = Settings::get_comments_filter_sql();
 				break;
 		}
 		$results = $wpdb->get_results( "SELECT MAX({$id}) as max, MIN({$id}) as min, COUNT({$id}) as count FROM {$table} WHERE {$where_sql}" );

--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Settings;
+
 class Import extends \Jetpack_Sync_Module {
 
 	/**
@@ -73,7 +75,7 @@ class Import extends \Jetpack_Sync_Module {
 		}
 
 		// Get $importer from known_importers.
-		$known_importers = \Jetpack_Sync_Settings::get_setting( 'known_importers' );
+		$known_importers = Settings::get_setting( 'known_importers' );
 		if ( isset( $known_importers[ $importer ] ) ) {
 			$importer = $known_importers[ $importer ];
 		}

--- a/packages/sync/src/modules/Posts.php
+++ b/packages/sync/src/modules/Posts.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Sync\Settings;
 
 class Posts extends \Jetpack_Sync_Module {
 
@@ -94,7 +95,7 @@ class Posts extends \Jetpack_Sync_Module {
 	}
 
 	private function get_where_sql( $config ) {
-		$where_sql = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+		$where_sql = Settings::get_blacklisted_post_types_sql();
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
@@ -123,7 +124,7 @@ class Posts extends \Jetpack_Sync_Module {
 	function filter_blacklisted_post_types( $args ) {
 		$post = $args[1];
 
-		if ( in_array( $post->post_type, \Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
+		if ( in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
 
@@ -141,13 +142,13 @@ class Posts extends \Jetpack_Sync_Module {
 
 	function is_whitelisted_post_meta( $meta_key ) {
 		// _wpas_skip_ is used by publicize
-		return in_array( $meta_key, \Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' ) ) || wp_startswith( $meta_key, '_wpas_skip_' );
+		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ) ) || wp_startswith( $meta_key, '_wpas_skip_' );
 	}
 
 	function is_post_type_allowed( $post_id ) {
 		$post = get_post( intval( $post_id ) );
 		if ( $post->post_type ) {
-			return ! in_array( $post->post_type, \Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) );
+			return ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ) );
 		}
 		return false;
 	}
@@ -221,7 +222,7 @@ class Posts extends \Jetpack_Sync_Module {
 		}
 
 		/** This filter is already documented in core. wp-includes/post-template.php */
-		if ( \Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public ) {
+		if ( Settings::get_setting( 'render_filtered_content' ) && $post_type->public ) {
 			global $shortcode_tags;
 			/**
 			 * Filter prevents some shortcodes from expanding.
@@ -425,7 +426,7 @@ class Posts extends \Jetpack_Sync_Module {
 
 		return array(
 			$posts,
-			$this->get_metadata( $post_ids, 'post', \Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' ) ),
+			$this->get_metadata( $post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) ),
 			$this->get_term_relationships( $post_ids ),
 			$previous_interval_end,
 		);

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,11 +1,13 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Modules\WP_Super_Cache;
 use Automattic\Jetpack\Sync\Sender;
-use Automattic\Jetpack\Sync\Functions;
+use Automattic\Jetpack\Sync\Settings;
+
 
 require_once 'test_class.jetpack-sync-base.php';
 
@@ -445,12 +447,12 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		set_current_screen( 'post-user' );
 
 		// admin but in cron (for some reason)
-		Jetpack_Sync_Settings::set_doing_cron( true );
+		Settings::set_doing_cron( true );
 
 		$this->sender->do_sync();
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'site_url' ) );
 
-		Jetpack_Sync_Settings::set_doing_cron( false );
+		Settings::set_doing_cron( false );
 		$this->sender->do_sync();
 		$this->assertEquals( site_url(), $this->server_replica_storage->get_callable( 'site_url' ) );
 	}
@@ -864,7 +866,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 	function test_force_sync_callabled_on_plugin_update() {
 		// fake the cron so that we really prevent the callables from being called
-		Jetpack_Sync_Settings::$is_doing_cron = true;
+		Settings::$is_doing_cron = true;
 
 		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable_random' ) );
 		$this->sender->do_sync();
@@ -890,7 +892,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 		$synced_value3 = $this->server_replica_storage->get_callable( 'jetpack_foo' );
-		Jetpack_Sync_Settings::$is_doing_cron = false;
+		Settings::$is_doing_cron = false;
 		$this->assertNotEmpty( $synced_value3, 'value is empty!' );
 
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Full_Sync;
+use Automattic\Jetpack\Sync\Settings;
 
 function jetpack_foo_full_sync_callable() {
 	return 'the value';
@@ -183,7 +184,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->server_replica_storage->reset();
 		$this->sender->reset_data();
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
@@ -236,7 +237,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_terms_with_previous_interval_end() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+		Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		for ( $i = 0; $i < 25; $i += 1 ) {
 			wp_insert_term( 'term' . $i, 'post_tag' );
@@ -306,7 +307,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_previous_interval_end_for_users() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+		Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		for ( $i = 0; $i < 45; $i += 1 ) {
 			$user_ids[] = $this->factory->user->create();
@@ -351,7 +352,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( intval( $previous_interval_end ), $last_user->ID );
 
-		Jetpack_Sync_Settings::reset_data();
+		Settings::reset_data();
 		$this->full_sync->reset_data();
 
 	}
@@ -587,7 +588,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_post_meta() {
 		$post_id = $this->factory->post->create();
 
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'test_meta_key', 'test_meta_array' ) ) );
+		Settings::update_settings( array( 'post_meta_whitelist' => array( 'test_meta_key', 'test_meta_array' ) ) );
 
 		add_post_meta( $post_id, 'test_meta_key', 'foo' );
 		add_post_meta( $post_id, 'test_meta_array', array( 'foo', 'bar' ) );
@@ -613,8 +614,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_doesnt_sends_forbiden_private_or_public_post_meta() {
 		$post_id = $this->factory->post->create();
 
-		$meta_module = Modules::get_module( "meta" );
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'a_public_meta' ) ) );
+		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
+		Settings::update_settings( array( 'post_meta_whitelist' => array( 'a_public_meta' ) ) );
 
 		// forbidden private meta
 		add_post_meta( $post_id, '_test_meta_key', 'foo1' );
@@ -674,7 +675,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$comment_ids = $this->factory->comment->create_post_comments( $post_id );
 		$comment_id  = $comment_ids[0];
 
-		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( 'test_meta_key' ) ) );
+		Settings::update_settings( array( 'comment_meta_whitelist' => array( 'test_meta_key' ) ) );
 
 		add_comment_meta( $comment_id, 'test_meta_key', 'foo' );
 
@@ -1366,7 +1367,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_enqueues_limited_number_of_items() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_enqueue_full_sync' => 2 ) );
+		Settings::update_settings( array( 'max_enqueue_full_sync' => 2 ) );
 
 		global $wpdb;
 
@@ -1403,7 +1404,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_stops_enqueuing_at_max_queue_size() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 2, 'max_enqueue_full_sync' => 10 ) );
+		Settings::update_settings( array( 'max_queue_size_full_sync' => 2, 'max_enqueue_full_sync' => 10 ) );
 
 		// this should become three items
 		$synced_post_ids = $this->factory->post->create_many( 25 );
@@ -1440,7 +1441,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_previous_interval_end_on_posts() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+		Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		$this->factory->post->create_many( 25 );
 
@@ -1481,7 +1482,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_previous_interval_end_on_comments() {
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
+		Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 		$this->post_id = $this->factory->post->create();
 		for( $i = 0; $i < 25; $i++ ) {
 			$this->factory->comment->create_post_comments( $this->post_id );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -614,7 +614,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_doesnt_sends_forbiden_private_or_public_post_meta() {
 		$post_id = $this->factory->post->create();
 
-		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
+		$meta_module = Modules::get_module( "meta" );
 		Settings::update_settings( array( 'post_meta_whitelist' => array( 'a_public_meta' ) ) );
 
 		// forbidden private meta

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Settings;
 
 class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_sending_empties_queue() {
@@ -108,9 +109,9 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_do_not_load_sender_if_is_cron_and_cron_sync_disabled() {
 		Constants::set_constant( 'DOING_CRON', true );
-		$settings = Jetpack_Sync_Settings::get_settings();
+		$settings = Settings::get_settings();
 		$settings['sync_via_cron'] = 0;
-		Jetpack_Sync_Settings::update_settings( $settings );
+		Settings::update_settings( $settings );
 		Actions::$sender = null;
 
 		Actions::add_sender_shutdown();
@@ -118,7 +119,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNull( Actions::$sender );
 
 		Constants::clear_constants();
-		Jetpack_Sync_Settings::reset_data();
+		Settings::reset_data();
 	}
 
 	function test_cleanup_cron_jobs_with_non_staggered_start() {
@@ -151,15 +152,15 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_settings_updates_on_upgrade() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
-		Jetpack_Sync_Settings::get_settings();
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::get_settings();
 
-		$this->assertEquals( 1, Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) );
+		$this->assertEquals( 1, Settings::get_setting( 'render_filtered_content' ) );
 
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', '4.5', '4.3' );
 
-		$this->assertEquals( 0, Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) );
+		$this->assertEquals( 0, Settings::get_setting( 'render_filtered_content' ) );
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Settings;
 
 class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	function test_never_queues_if_development() {
@@ -42,10 +43,10 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Defaults::$default_max_queue_lag, $this->listener->get_queue_lag_limit() );
 
 		// set max queue size to 2 items
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size' => 2 ) );
+		Settings::update_settings( array( 'max_queue_size' => 2 ) );
 
 		// set max queue age to 3 seconds
-		Jetpack_Sync_Settings::update_settings( array( 'max_queue_lag' => 3 ) );
+		Settings::update_settings( array( 'max_queue_lag' => 3 ) );
 
 		$this->listener->set_defaults(); // should pick up new queue size limit
 
@@ -184,7 +185,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_does_set_silent_flag_true_while_importing() {
-		Jetpack_Sync_Settings::set_importing( true );
+		Settings::set_importing( true );
 
 		$this->factory->post->create();
 

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\Sync\Defaults;
  */
 
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Settings;
 
 require_jetpack_file( 'modules/contact-form/grunion-contact-form.php' );
 
@@ -21,7 +22,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 
 		// create a post
 		$this->meta_module = Modules::get_module( "meta" );
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'foobar' ) ) );
+		Settings::update_settings( array( 'post_meta_whitelist' => array( 'foobar' ) ) );
 		$this->post_id = $this->factory->post->create();
 		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 		$this->sender->do_sync();
@@ -107,7 +108,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( '_private_meta' ) ) );
+		Settings::update_settings( array( 'post_meta_whitelist' => array( '_private_meta' ) ) );
 
 		add_post_meta( $this->post_id, '_private_meta', 'boo' );
 
@@ -124,7 +125,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'comment', $comment_ids[0], '_private_meta', true ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( '_private_meta' ) ) );
+		Settings::update_settings( array( 'comment_meta_whitelist' => array( '_private_meta' ) ) );
 
 		add_comment_meta( $comment_ids[0], '_private_meta', 'boo' );
 		$this->sender->do_sync();
@@ -133,7 +134,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_whitelisted_post_meta() {
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array() ) );
+		Settings::update_settings( array( 'post_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
 		$white_listed_post_meta = Defaults::$post_meta_whitelist;
@@ -148,7 +149,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		foreach ( $white_listed_post_meta as $meta_key ) {
 			$this->assertOptionIsSynced( $meta_key, 'foo', 'post', $this->post_id );
 		}
-		$whitelist = Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' );
+		$whitelist = Settings::get_setting( 'post_meta_whitelist' );
 
 		$whitelist_and_option_keys_difference = array_diff( $whitelist, $white_listed_post_meta );
 		// Are we testing all the options
@@ -159,7 +160,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_whitelisted_comment_meta() {
-		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array() ) );
+		Settings::update_settings( array( 'comment_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
 		$white_listed_comment_meta = Defaults::$comment_meta_whitelist;
@@ -176,7 +177,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		foreach ( $white_listed_comment_meta as $meta_key ) {
 			$this->assertOptionIsSynced( $meta_key, 'foo', 'comment', $comment_ids[0] );
 		}
-		$whitelist = Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' );
+		$whitelist = Settings::get_setting( 'comment_meta_whitelist' );
 
 		$whitelist_and_option_keys_difference = array_diff( $whitelist, $white_listed_comment_meta );
 		// Are we testing all the options

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,8 +1,10 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Testing CRUD on Posts
@@ -405,7 +407,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_filtered_content_was_filtered() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
 		$this->post->post_content = "[foo]";
 
@@ -418,7 +420,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_disabled_post_filtered_content() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 0 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 0 ) );
 
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
 		$this->post->post_content = "[foo]";
@@ -430,11 +432,11 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $post_on_server->post_content, '[foo]' );
 		$this->assertTrue( empty( $post_on_server->post_content_filtered ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 	}
 
 	function test_sync_post_filtered_excerpt_was_filtered() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
 		$this->post->post_excerpt = "[foo]";
@@ -449,7 +451,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_filter_do_not_expand_jetpack_shortcodes() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		add_filter( 'jetpack_sync_do_not_expand_shortcodes', array( $this, 'do_not_expand_shortcode' ) );
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
@@ -650,7 +652,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		// first, show that post is being synced
 		$this->assertTrue( !! $this->server_replica_storage->get_post( $post_id ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'post_types_blacklist' => array( 'filter_me' ) ) );
+		Settings::update_settings( array( 'post_types_blacklist' => array( 'filter_me' ) ) );
 
 		$post_id = $this->factory->post->create( array( 'post_type' => 'filter_me' ) );
 
@@ -659,7 +661,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 
 		// also assert that the post types blacklist still contains the hard-coded values
-		$setting = Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' );
+		$setting = Settings::get_setting( 'post_types_blacklist' );
 
 		$this->assertTrue( in_array( 'filter_me', $setting ) );
 
@@ -674,7 +676,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'post_types_blacklist' => array( 'dont_publicize_me' ) ) );
+		Settings::update_settings( array( 'post_types_blacklist' => array( 'dont_publicize_me' ) ) );
 
 		$this->assertFalse( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
 
@@ -705,7 +707,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_remove_contact_form_shortcode_from_filtered_content() {
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/contact-form/grunion-contact-form.php';
 
@@ -726,7 +728,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	function test_remove_likes_from_filtered_content() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		// initial sync sets the screen to 'sync', then `is_admin` returns `true`
 		set_current_screen( 'front' );
@@ -753,7 +755,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	function test_remove_sharedaddy_from_filtered_content() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php';
@@ -784,7 +786,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	function test_remove_related_posts_from_filtered_content() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/related-posts.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/related-posts/jetpack-related-posts.php';
@@ -807,7 +809,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	function test_remove_related_posts_shortcode_from_filtered_content() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/related-posts.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/related-posts/jetpack-related-posts.php';
@@ -896,7 +898,7 @@ POST_CONTENT;
 
 	function test_that_we_apply_the_right_filters_to_post_content_and_excerpt() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		add_filter( 'the_content', array( $this, 'the_content_filter' ), 1000 );
 		add_filter( 'the_excerpt', array( $this, 'the_excerpt_filter' ), 1000 );
@@ -944,7 +946,7 @@ POST_CONTENT;
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
 		// this only applies to rendered content, which is off by default
-		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
 		$content =
 			'Check out this cool video:

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -1,8 +1,10 @@
 <?php
 
+use Automattic\Jetpack\Sync\Settings;
+
 class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 	function test_can_write_settings() {
-		$settings = Jetpack_Sync_Settings::get_settings();
+		$settings = Settings::get_settings();
 
 		foreach (
 			array(
@@ -20,9 +22,9 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		}
 
 		$settings['dequeue_max_bytes'] = 50;
-		Jetpack_Sync_Settings::update_settings( $settings );
+		Settings::update_settings( $settings );
 
-		$updated_settings = Jetpack_Sync_Settings::get_settings();
+		$updated_settings = Settings::get_settings();
 
 		$this->assertSame( 50, $updated_settings['dequeue_max_bytes'] );
 	}
@@ -34,9 +36,9 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		$this->assertTrue( $this->listener->get_sync_queue()->size() > 0 );
 
-		Jetpack_Sync_Settings::update_settings( array( 'disable' => 1 ) );
+		Settings::update_settings( array( 'disable' => 1 ) );
 
-		$this->assertFalse( Jetpack_Sync_Settings::is_sync_enabled() );
+		$this->assertFalse( Settings::is_sync_enabled() );
 
 		// generating posts should no longer affect queue size
 		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
@@ -47,8 +49,8 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'disable' => 0 ) );
-		$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
+		Settings::update_settings( array( 'disable' => 0 ) );
+		$this->assertTrue( Settings::is_sync_enabled() );
 	}
 
 	function test_settings_disable_network_enqueue_and_clears_queue() {
@@ -62,7 +64,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		$this->assertTrue( $this->listener->get_sync_queue()->has_any_items() );
 
-		Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
+		Settings::update_settings( array( 'network_disable' => 1 ) );
 
 		// generating posts should no longer affect queue size
 		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
@@ -73,21 +75,21 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 0 ) );
+		Settings::update_settings( array( 'network_disable' => 0 ) );
 	}
 
 	function test_setting_network_option_on_single_site_does_not_work() {
 		if ( is_multisite() ) {
-			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
-			$this->assertEquals( 1, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
-			$this->assertFalse( Jetpack_Sync_Settings::is_sync_enabled() );
-			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 0 ) ); // reset things
-			$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
+			Settings::update_settings( array( 'network_disable' => 1 ) );
+			$this->assertEquals( 1, Settings::get_setting( 'network_disable' ) );
+			$this->assertFalse( Settings::is_sync_enabled() );
+			Settings::update_settings( array( 'network_disable' => 0 ) ); // reset things
+			$this->assertTrue( Settings::is_sync_enabled() );
 		} else {
-			Jetpack_Sync_Settings::update_settings( array( 'network_disable' => 1 ) );
+			Settings::update_settings( array( 'network_disable' => 1 ) );
 			// Notice that the value is unchanged
-			$this->assertEquals( 0, Jetpack_Sync_Settings::get_setting( 'network_disable' ) );
-			$this->assertTrue( Jetpack_Sync_Settings::is_sync_enabled() );
+			$this->assertEquals( 0, Settings::get_setting( 'network_disable' ) );
+			$this->assertTrue( Settings::is_sync_enabled() );
 		}
 	}
 


### PR DESCRIPTION
This PR moves the Jetpack Sync Settings from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.