### PR TITLE
Jetpack DNA: Move Jetpack Sync Defaults from Legacy to psr-4

### DIFF
--- a/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
+++ b/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected $needed_capabilities = 'manage_options';
@@ -32,7 +34,7 @@ class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
 		 * @param array The default list of site options.
 		 * @param bool Is the option a site option.
 		 */
-		if ( ! in_array( $this->option_name, apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist, $this->site_option ) ) ) {
+		if ( ! in_array( $this->option_name, apply_filters( 'jetpack_options_whitelist', Defaults::$default_options_whitelist, $this->site_option ) ) ) {
 			return new WP_Error( 'option_name_not_in_whitelist', __( 'You must specify a whitelisted option_name', 'jetpack' ) );
 		}
 		return true;

--- a/packages/sync/legacy/class.jetpack-sync-settings.php
+++ b/packages/sync/legacy/class.jetpack-sync-settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Defaults;
 
 class Jetpack_Sync_Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
@@ -60,7 +61,7 @@ class Jetpack_Sync_Settings {
 				$value = get_site_option( self::SETTINGS_OPTION_PREFIX . $setting );
 			} else {
 				// On single sites just return the default setting
-				$value                            = Jetpack_Sync_Defaults::get_default_setting( $setting );
+				$value                            = Defaults::get_default_setting( $setting );
 				self::$settings_cache[ $setting ] = $value;
 				return $value;
 			}
@@ -69,7 +70,7 @@ class Jetpack_Sync_Settings {
 		}
 
 		if ( false === $value ) { // no default value is set.
-			$value = Jetpack_Sync_Defaults::get_default_setting( $setting );
+			$value = Defaults::get_default_setting( $setting );
 			if ( self::is_network_setting( $setting ) ) {
 				update_site_option( self::SETTINGS_OPTION_PREFIX . $setting, $value );
 			} else {
@@ -84,16 +85,16 @@ class Jetpack_Sync_Settings {
 		$default_array_value = null;
 		switch ( $setting ) {
 			case 'post_types_blacklist':
-				$default_array_value = Jetpack_Sync_Defaults::$blacklisted_post_types;
+				$default_array_value = Defaults::$blacklisted_post_types;
 				break;
 			case 'post_meta_whitelist':
-				$default_array_value = Jetpack_Sync_Defaults::get_post_meta_whitelist();
+				$default_array_value = Defaults::get_post_meta_whitelist();
 				break;
 			case 'comment_meta_whitelist':
-				$default_array_value = Jetpack_Sync_Defaults::get_comment_meta_whitelist();
+				$default_array_value = Defaults::get_comment_meta_whitelist();
 				break;
 			case 'known_importers':
-				$default_array_value = Jetpack_Sync_Defaults::get_known_importers();
+				$default_array_value = Defaults::get_known_importers();
 				break;
 		}
 

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -440,7 +440,7 @@ class Actions {
 			self::clear_sync_cron_jobs();
 			\Jetpack_Sync_Settings::update_settings(
 				array(
-					'render_filtered_content' => \Jetpack_Sync_Defaults::$default_render_filtered_content,
+					'render_filtered_content' => Defaults::$default_render_filtered_content,
 				)
 			);
 		}

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Automattic\Jetpack\Sync;
+
 require_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php';
 
 use Automattic\Jetpack\Sync\Functions;
@@ -6,7 +9,7 @@ use Automattic\Jetpack\Sync\Functions;
 /**
  * Just some defaults that we share with the server
  */
-class Jetpack_Sync_Defaults {
+class Defaults {
 
 	static $default_options_whitelist = array(
 		'stylesheet',
@@ -564,7 +567,7 @@ class Jetpack_Sync_Defaults {
 
 	static function get_default_setting( $setting ) {
 		$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes
-		return Jetpack_Sync_Defaults::$$default_name;
+		return self::$$default_name;
 	}
 
 	static $default_network_options_whitelist = array(

--- a/packages/sync/src/Functions.php
+++ b/packages/sync/src/Functions.php
@@ -3,7 +3,6 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
-
 /*
  * Utility functions to generate data synced to wpcom
  */
@@ -85,7 +84,7 @@ class Functions {
 	public static function sanitize_post_type( $post_type ) {
 		// Lets clone the post type object instead of modifing the global one.
 		$sanitized_post_type = array();
-		foreach ( \Jetpack_Sync_Defaults::$default_post_type_attributes as $attribute_key => $default_value ) {
+		foreach ( Defaults::$default_post_type_attributes as $attribute_key => $default_value ) {
 			if ( isset( $post_type->{ $attribute_key } ) ) {
 				$sanitized_post_type[ $attribute_key ] = $post_type->{ $attribute_key };
 			}

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 /**
  * A persistent queue that can be flushed in increments of N items,
  * and which blocks reads until checked-out buffers are checked in or
@@ -347,7 +349,7 @@ class Queue {
 	private function set_checkout_id( $checkout_id ) {
 		global $wpdb;
 
-		$expires     = time() + \Jetpack_Sync_Defaults::$default_sync_queue_lock_timeout;
+		$expires     = time() + Defaults::$default_sync_queue_lock_timeout;
 		$updated_num = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s",

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * An implementation of Replicastore Interface which returns data stored in a WordPress.org DB.
  * This is useful to compare values in the local WP DB to values in the synced replica store
@@ -147,12 +149,12 @@ class Replicastore implements Replicastore_Interface {
 
 	public function posts_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->posts, \Jetpack_Sync_Defaults::$default_post_checksum_columns, 'ID', \Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->posts, Defaults::$default_post_checksum_columns, 'ID', \Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
 	}
 
 	public function post_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->postmeta, \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->postmeta, Defaults::$default_post_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
 	}
 
 	public function comment_count( $status = null, $min_id = null, $max_id = null ) {
@@ -282,21 +284,20 @@ class Replicastore implements Replicastore_Interface {
 
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->comments, \Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', \Jetpack_Sync_Settings::get_comments_filter_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->comments, Defaults::$default_comment_checksum_columns, 'comment_ID', \Jetpack_Sync_Settings::get_comments_filter_sql(), $min_id, $max_id );
 	}
 
 	public function comment_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->commentmeta, \Jetpack_Sync_Defaults::$default_comment_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->commentmeta, Defaults::$default_comment_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
 	}
 
 	public function options_checksum() {
 		global $wpdb;
-
-		$options_whitelist = "'" . implode( "', '", \Jetpack_Sync_Defaults::$default_options_whitelist ) . "'";
+		$options_whitelist = "'" . implode( "', '", Defaults::$default_options_whitelist ) . "'";
 		$where_sql         = "option_name IN ( $options_whitelist )";
 
-		return $this->table_checksum( $wpdb->options, \Jetpack_Sync_Defaults::$default_option_checksum_columns, null, $where_sql, null, null );
+		return $this->table_checksum( $wpdb->options, Defaults::$default_option_checksum_columns, null, $where_sql, null, null );
 	}
 
 
@@ -656,7 +657,7 @@ class Replicastore implements Replicastore_Interface {
 				$id_field     = 'ID';
 				$where_sql    = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
 				if ( empty( $columns ) ) {
-					$columns = \Jetpack_Sync_Defaults::$default_post_checksum_columns;
+					$columns = Defaults::$default_post_checksum_columns;
 				}
 				break;
 			case 'post_meta':
@@ -666,7 +667,7 @@ class Replicastore implements Replicastore_Interface {
 				$id_field     = 'meta_id';
 
 				if ( empty( $columns ) ) {
-					$columns = \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
+					$columns = Defaults::$default_post_meta_checksum_columns;
 				}
 				break;
 			case 'comments':
@@ -675,7 +676,7 @@ class Replicastore implements Replicastore_Interface {
 				$id_field     = 'comment_ID';
 				$where_sql    = \Jetpack_Sync_Settings::get_comments_filter_sql();
 				if ( empty( $columns ) ) {
-					$columns = \Jetpack_Sync_Defaults::$default_comment_checksum_columns;
+					$columns = Defaults::$default_comment_checksum_columns;
 				}
 				break;
 			case 'comment_meta':
@@ -684,7 +685,7 @@ class Replicastore implements Replicastore_Interface {
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 				if ( empty( $columns ) ) {
-					$columns = \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
+					$columns = Defaults::$default_post_meta_checksum_columns;
 				}
 				break;
 			default:

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Defaults;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -381,7 +382,7 @@ class Sender {
 		$this->set_sync_wait_time( $settings['sync_wait_time'] );
 		$this->set_enqueue_wait_time( $settings['enqueue_wait_time'] );
 		$this->set_sync_wait_threshold( $settings['sync_wait_threshold'] );
-		$this->set_max_dequeue_time( \Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+		$this->set_max_dequeue_time( Defaults::get_max_sync_execution_time() );
 	}
 
 	function reset_data() {

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Functions;
+use Automattic\Jetpack\Sync\Defaults;
 
 class Callables extends \Jetpack_Sync_Module {
 	const CALLABLES_CHECKSUM_OPTION_NAME = 'jetpack_callables_sync_checksum';
@@ -16,9 +17,9 @@ class Callables extends \Jetpack_Sync_Module {
 
 	public function set_defaults() {
 		if ( is_multisite() ) {
-			$this->callable_whitelist = array_merge( \Jetpack_Sync_Defaults::get_callable_whitelist(), \Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
+			$this->callable_whitelist = array_merge( Defaults::get_callable_whitelist(), Defaults::get_multisite_callable_whitelist() );
 		} else {
-			$this->callable_whitelist = \Jetpack_Sync_Defaults::get_callable_whitelist();
+			$this->callable_whitelist = Defaults::get_callable_whitelist();
 		}
 	}
 
@@ -223,7 +224,7 @@ class Callables extends \Jetpack_Sync_Module {
 			}
 		}
 
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), \Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
+		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Defaults::$default_sync_callables_wait_time );
 
 		$callables = $this->get_all_callables();
 

--- a/packages/sync/src/modules/Constants.php
+++ b/packages/sync/src/modules/Constants.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class Constants extends \Jetpack_Sync_Module {
 	const CONSTANTS_CHECKSUM_OPTION_NAME = 'jetpack_constants_sync_checksum';
 	const CONSTANTS_AWAIT_TRANSIENT_NAME = 'jetpack_sync_constants_await';
@@ -35,7 +37,7 @@ class Constants extends \Jetpack_Sync_Module {
 	}
 
 	function get_constants_whitelist() {
-		return \Jetpack_Sync_Defaults::get_constants_whitelist();
+		return Defaults::get_constants_whitelist();
 	}
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -65,7 +67,7 @@ class Constants extends \Jetpack_Sync_Module {
 			return;
 		}
 
-		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), \Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
+		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), Defaults::$default_sync_constants_wait_time );
 
 		$constants = $this->get_all_constants();
 		if ( empty( $constants ) ) {

--- a/packages/sync/src/modules/Network_Options.php
+++ b/packages/sync/src/modules/Network_Options.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class Network_Options extends \Jetpack_Sync_Module {
 	private $network_options_whitelist;
 
@@ -45,7 +47,7 @@ class Network_Options extends \Jetpack_Sync_Module {
 	}
 
 	public function set_defaults() {
-		$this->network_options_whitelist = \Jetpack_Sync_Defaults::$default_network_options_whitelist;
+		$this->network_options_whitelist = Defaults::$default_network_options_whitelist;
 	}
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {

--- a/packages/sync/src/modules/Options.php
+++ b/packages/sync/src/modules/Options.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class Options extends \Jetpack_Sync_Module {
 	private $options_whitelist, $options_contentless;
 
@@ -94,7 +96,7 @@ class Options extends \Jetpack_Sync_Module {
 	}
 
 	function update_options_whitelist() {
-		$this->options_whitelist = \Jetpack_Sync_Defaults::get_options_whitelist();
+		$this->options_whitelist = Defaults::get_options_whitelist();
 	}
 
 	function set_options_whitelist( $options ) {
@@ -106,7 +108,7 @@ class Options extends \Jetpack_Sync_Module {
 	}
 
 	function update_options_contentless() {
-		$this->options_contentless = \Jetpack_Sync_Defaults::get_options_contentless();
+		$this->options_contentless = Defaults::get_options_contentless();
 	}
 
 	function get_options_contentless() {

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class Terms extends \Jetpack_Sync_Module {
 	private $taxonomy_whitelist;
 
@@ -95,7 +97,7 @@ class Terms extends \Jetpack_Sync_Module {
 	}
 
 	function set_defaults() {
-		$this->taxonomy_whitelist = \Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
+		$this->taxonomy_whitelist = Defaults::$default_taxonomy_whitelist;
 	}
 
 	public function expand_term_taxonomy_id( $args ) {

--- a/packages/sync/src/modules/Themes.php
+++ b/packages/sync/src/modules/Themes.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class Themes extends \Jetpack_Sync_Module {
 	function name() {
 		return 'themes';
@@ -364,7 +366,7 @@ class Themes extends \Jetpack_Sync_Module {
 
 		/**
 		 * Fires when the client needs to sync theme support info
-		 * Only sends theme support attributes whitelisted in Jetpack_Sync_Defaults::$default_theme_support_whitelist
+		 * Only sends theme support attributes whitelisted in Defaults::$default_theme_support_whitelist
 		 *
 		 * @since 4.2.0
 		 *
@@ -580,7 +582,7 @@ class Themes extends \Jetpack_Sync_Module {
 		if ( $theme === null ) {
 			$theme = wp_get_theme();
 
-			foreach ( \Jetpack_Sync_Defaults::$default_theme_support_whitelist as $theme_feature ) {
+			foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
 				$has_support = current_theme_supports( $theme_feature );
 				if ( $has_support ) {
 					$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];

--- a/packages/sync/src/modules/Users.php
+++ b/packages/sync/src/modules/Users.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Sync\Defaults;
 
 class Users extends \Jetpack_Sync_Module {
 	const MAX_INITIAL_SYNC_USERS = 100;
@@ -121,7 +122,7 @@ class Users extends \Jetpack_Sync_Module {
 		if ( is_wp_error( $user ) ) {
 			return $user_capabilities;
 		}
-		foreach ( \Jetpack_Sync_Defaults::get_capabilities_whitelist() as $capability ) {
+		foreach ( Defaults::get_capabilities_whitelist() as $capability ) {
 			if ( $user_has_capabilities = user_can( $user, $capability ) ) {
 				$user_capabilities[ $capability ] = true;
 			}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Replicastore_Interface;
+use Automattic\Jetpack\Sync\Defaults;
 
 /**
  * A simple in-memory implementation of iJetpack_Sync_Replicastore
@@ -74,7 +75,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 	}
 
 	function posts_checksum( $min_id = null, $max_id = null ) {
-		return $this->calculate_checksum( $this->posts[ get_current_blog_id() ], 'ID', $min_id, $max_id, Jetpack_Sync_Defaults::$default_post_checksum_columns );
+		return $this->calculate_checksum( $this->posts[ get_current_blog_id() ], 'ID', $min_id, $max_id, Defaults::$default_post_checksum_columns );
 	}
 
 	function post_meta_checksum( $min_id = null, $max_id = null ) {
@@ -120,7 +121,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 	}
 
 	function comments_checksum( $min_id = null, $max_id = null ) {
-		return $this->calculate_checksum( array_filter( $this->comments[ get_current_blog_id() ], array( $this, 'is_not_spam' ) ), 'comment_ID', $min_id, $max_id, Jetpack_Sync_Defaults::$default_comment_checksum_columns );
+		return $this->calculate_checksum( array_filter( $this->comments[ get_current_blog_id() ], array( $this, 'is_not_spam' ) ), 'comment_ID', $min_id, $max_id, Defaults::$default_comment_checksum_columns );
 	}
 
 	function comment_meta_checksum( $min_id = null, $max_id = null ) {
@@ -204,7 +205,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 	}
 
 	function options_checksum() {
-		return strtoupper( dechex( array_reduce( Jetpack_Sync_Defaults::$default_options_whitelist, array( $this, 'option_checksum' ), 0 ) ) );
+		return strtoupper( dechex( array_reduce( Defaults::$default_options_whitelist, array( $this, 'option_checksum' ), 0 ) ) );
 	}
 
 	private function option_checksum( $carry, $option_name ) {
@@ -610,7 +611,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 				$get_function  = 'get_post';
 
 				if ( empty( $fields ) ) {
-					$fields = Jetpack_Sync_Defaults::$default_post_checksum_columns;
+					$fields = Defaults::$default_post_checksum_columns;
 				}
 
 				break;
@@ -621,7 +622,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 				$get_function = 'get_post_meta_by_id';
 
 				if ( empty( $fields ) ) {
-					$fields = Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
+					$fields = Defaults::$default_post_meta_checksum_columns;
 				}
 				break;
 			case 'comments':
@@ -631,7 +632,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 				$get_function = 'get_comment';
 
 				if ( empty( $fields ) ) {
-					$fields = Jetpack_Sync_Defaults::$default_comment_checksum_columns;
+					$fields = Defaults::$default_comment_checksum_columns;
 				}
 				break;
 			case 'comment_meta':
@@ -641,7 +642,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 				$get_function = 'get_comment_meta_by_id';
 
 				if ( empty( $fields ) ) {
-					$fields = Jetpack_Sync_Defaults::$default_comment_meta_checksum_columns;
+					$fields = Defaults::$default_comment_meta_checksum_columns;
 				}
 				break;
 			default:

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Modules\Constants;
 
 /**
@@ -42,7 +43,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 		$this->constant_module->set_defaults(); // use the default constants
 		$this->sender->do_sync();
 
-		foreach ( Jetpack_Sync_Defaults::$default_constants_whitelist as $constant ) {
+		foreach ( Defaults::$default_constants_whitelist as $constant ) {
 			try {
 				$value = constant( $constant );
 				$this->assertEquals( $value, $this->server_replica_storage->get_constant( $constant ) );
@@ -54,7 +55,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 		$this->server_replica_storage->reset();
 		$this->sender->do_sync();
 
-		foreach ( Jetpack_Sync_Defaults::$default_constants_whitelist as $constant ) {
+		foreach ( Defaults::$default_constants_whitelist as $constant ) {
 			$this->assertEquals( null, $this->server_replica_storage->get_constant( $constant ) );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-defaults.php
+++ b/tests/php/sync/test_class.jetpack-sync-defaults.php
@@ -1,6 +1,9 @@
 <?php
+
+use Automattic\Jetpack\Sync\Defaults;
+
 /**
- * Testing WP_Test_Jetpack_Sync_Defaults class
+ * Testing WP_Test_Defaults class
  */
 class WP_Test_Jetpack_Sync_Defaults extends WP_Test_Jetpack_Sync_Base {
 	private $jp_option = 'example_jp_option_name_here';
@@ -23,16 +26,16 @@ class WP_Test_Jetpack_Sync_Defaults extends WP_Test_Jetpack_Sync_Base {
 
 	function test_is_whitelisted_option() {
 		// A default option.
-		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( 'blogname' ) );
+		$this->assertTrue( Defaults::is_whitelisted_option( 'blogname' ) );
 
 		// A custom JP option, registered with the `jetpack_options_whitelist` filter.
-		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( $this->jp_option ) );
+		$this->assertTrue( Defaults::is_whitelisted_option( $this->jp_option ) );
 
 		// A custom JP sync option, registered with the `jetpack_sync_options_whitelist` filter.
-		$this->assertTrue( Jetpack_Sync_Defaults::is_whitelisted_option( $this->jp_sync_option ) );
+		$this->assertTrue( Defaults::is_whitelisted_option( $this->jp_sync_option ) );
 
 		// An unknown option.
-		$this->assertFalse( Jetpack_Sync_Defaults::is_whitelisted_option( 'some_unknown_option' ) );
+		$this->assertFalse( Defaults::is_whitelisted_option( 'some_unknown_option' ) );
 	}
 
 	public function add_to_options_whitelist( $whitelist ) {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Defaults;
+
 class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	function test_never_queues_if_development() {
 		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
@@ -36,8 +38,8 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->listener->get_sync_queue()->reset();
 
 		// first, let's try overriding the default queue limit
-		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_size, $this->listener->get_queue_size_limit() );
-		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_lag, $this->listener->get_queue_lag_limit() );
+		$this->assertEquals( Defaults::$default_max_queue_size, $this->listener->get_queue_size_limit() );
+		$this->assertEquals( Defaults::$default_max_queue_lag, $this->listener->get_queue_lag_limit() );
 
 		// set max queue size to 2 items
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size' => 2 ) );

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Defaults;
+
 /**
  * Testing CRUD on Meta
  */
@@ -134,7 +136,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_post_meta = Jetpack_Sync_Defaults::$post_meta_whitelist;
+		$white_listed_post_meta = Defaults::$post_meta_whitelist;
 
 		// update all the opyions.
 		foreach ( $white_listed_post_meta as $meta_key ) {
@@ -160,7 +162,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_comment_meta = Jetpack_Sync_Defaults::$comment_meta_whitelist;
+		$white_listed_comment_meta = Defaults::$comment_meta_whitelist;
 
 		$comment_ids = $this->factory->comment->create_post_comments( $this->post_id );
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Defaults;
 
 /**
  * Testing CRUD on Posts
@@ -662,7 +663,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertTrue( in_array( 'filter_me', $setting ) );
 
-		foreach( Jetpack_Sync_Defaults::$blacklisted_post_types as $hardcoded_blacklist_post_type ) {
+		foreach( Defaults::$blacklisted_post_types as $hardcoded_blacklist_post_type ) {
 			$this->assertTrue( in_array( $hardcoded_blacklist_post_type, $setting ) );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Modules\Callables;
 
 class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
@@ -338,16 +339,16 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		// test with strings, non-strings, 0 and null
 
 		ini_set( 'max_execution_time', '30' );
-		$this->assertEquals( 10, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+		$this->assertEquals( 10, Defaults::get_max_sync_execution_time() );
 
 		ini_set( 'max_execution_time', 65 );
-		$this->assertEquals( 21, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+		$this->assertEquals( 21, Defaults::get_max_sync_execution_time() );
 
 		ini_set( 'max_execution_time', '0' );
-		$this->assertEquals( 20, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+		$this->assertEquals( 20, Defaults::get_max_sync_execution_time() );
 
 		ini_set( 'max_execution_time', null );
-		$this->assertEquals( 20, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+		$this->assertEquals( 20, Defaults::get_max_sync_execution_time() );
 	}
 
 	function test_limits_execution_time_of_do_sync() {


### PR DESCRIPTION
This PR moves Jetpack Sync Defaults from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.