### PR TITLE
Admin Page: do not disable Widget Visibility and Widgets toggles

### DIFF
--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -16,7 +16,6 @@ import { ModuleToggle } from 'components/module-toggle';
 
 class Widgets extends Component {
 	render() {
-		const isLinked = this.props.isLinked;
 		const foundWidgets = this.props.isModuleFound( 'widgets' );
 		const foundWidgetVisibility = this.props.isModuleFound( 'widget-visibility' );
 
@@ -41,7 +40,6 @@ class Widgets extends Component {
 					>
 						<ModuleToggle
 							slug="widgets"
-							disabled={ ! isLinked }
 							activated={ this.props.widgetsActive }
 							toggling={ this.props.isSavingAnyOption( 'widgets' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -64,7 +62,6 @@ class Widgets extends Component {
 					>
 						<ModuleToggle
 							slug="widget-visibility"
-							disabled={ ! isLinked }
 							activated={ this.props.widgetVisibilityActive }
 							toggling={ this.props.isSavingAnyOption( 'widget-visibility' ) }
 							toggleModule={ this.props.toggleModuleNow }


### PR DESCRIPTION
Follow-up from #12090

#### Changes proposed in this Pull Request:

The 2 modules are available in development mode as well (they do not rely on a connection to WordPress.com), so we should not block access to them.

**Before**

![image](https://user-images.githubusercontent.com/426388/59877665-aabedc80-93a6-11e9-8b2b-59933977effd.png)


**After**

![image](https://user-images.githubusercontent.com/426388/59877669-ae526380-93a6-11e9-882b-6604f440b80f.png)


#### Testing instructions:

* Start with a site that is brand new, and where you have enabled [dev mode](https://jetpack.com/support/development-mode)
* Go to Jetpack > Settings
* Search for `widgets`
* You should then be able to activate and deactivate the 2 Widget modules.

#### Proposed changelog entry for your changes:

* Admin Page: do not disable Widget Visibility and Widgets toggles in Development mode.
