### PR TITLE
Jetpack DNA: Move Jetpack_Sync_JSON_Deflate_Array_Codec from Legacy to psr-4

### DIFF
--- a/packages/sync/legacy/class.jetpack-sync-simple-codec.php
+++ b/packages/sync/legacy/class.jetpack-sync-simple-codec.php
@@ -1,10 +1,12 @@
 <?php
 
+use Automattic\Jetpack\Sync\JSON_Deflate_Array_Codec;
+
 /**
  * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
  * algorithm to compress objects serialized using json_encode
  */
-class Jetpack_Sync_Simple_Codec extends Jetpack_Sync_JSON_Deflate_Array_Codec {
+class Jetpack_Sync_Simple_Codec extends JSON_Deflate_Array_Codec {
 	const CODEC_NAME = 'simple';
 
 	public function name() {

--- a/packages/sync/src/Json_Deflate_Array_Codec.php
+++ b/packages/sync/src/Json_Deflate_Array_Codec.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 use Automattic\Jetpack\Sync\Codec_Interface;
 
 /**
  * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
  * algorithm to compress objects serialized using json_encode
  */
-class Jetpack_Sync_JSON_Deflate_Array_Codec implements Codec_Interface {
+class JSON_Deflate_Array_Codec implements Codec_Interface {
 	const CODEC_NAME = 'deflate-json-array';
 
 	public function name() {

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\JSON_Deflate_Array_Codec;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -300,7 +301,7 @@ class Sender {
 	}
 	function set_codec() {
 		if ( function_exists( 'gzinflate' ) ) {
-			$this->codec = new \Jetpack_Sync_JSON_Deflate_Array_Codec();
+			$this->codec = new JSON_Deflate_Array_Codec();
 		} else {
 			$this->codec = new \Jetpack_Sync_Simple_Codec();
 		}

--- a/packages/sync/src/Server.php
+++ b/packages/sync/src/Server.php
@@ -14,7 +14,7 @@ class Server {
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	function __construct() {
-		$this->codec = new \Jetpack_Sync_JSON_Deflate_Array_Codec();
+		$this->codec = new JSON_Deflate_Array_Codec();
 	}
 
 	function set_codec( Codec_Interface $codec ) {


### PR DESCRIPTION
This PR moves the Jetpack_Sync_JSON_Deflate_Array_Codec from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.