### PR TITLE
Fix/9754 seo verbiage copy sprint

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -168,7 +168,7 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Give your search ranking a boost with SEO tools in Jetpack Premium or Professional.'
+							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium.'
 						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -168,7 +168,7 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium.'
+							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium or Professional.'
 						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -168,7 +168,7 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium.'
+							'Give your search ranking a boost with SEO tools in Jetpack Premium or Professional.'
 						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -246,13 +246,6 @@ export const SettingsCard = props => {
 				break;
 
 			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
-				if ( 'is-business-plan' !== planClass && 'is-premium-plan' !== planClass ) {
-					return false;
-				}
-
-				break;
-
-			case FEATURE_SEO_TOOLS_JETPACK:
 				if ( 'is-business-plan' !== planClass && 'is-premium-plan' !== planClass ) {
 					return false;
 				}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -150,7 +150,9 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.' ) }
+						title={ __(
+							'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.'
+						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
@@ -165,7 +167,9 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Help your content get found and shared with SEO tools.' ) }
+						title={ __(
+							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium.'
+						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -39,7 +39,7 @@ class SeoComponent extends React.Component {
 				>
 					<span>
 						{ __(
-							"Jetpack SEO tools will give you live previews of what your site homepage and posts look like in popular search engines. Reorder items such as 'Site Name’' and 'Tagline' without having to touch any code.",
+							"Take control of the way search engines represent your site. With Jetpack's SEO tools you can preview how your content will look on popular search engines and change items like your site name and tagline without having to touch code.",
 							{
 								components: {
 									a: <a href="https://jetpack.com/support/seo-tools/" />,

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -39,7 +39,7 @@ class SeoComponent extends React.Component {
 				>
 					<span>
 						{ __(
-							"You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
+							"Jetpack SEO tools will give you live previews of what your site homepage and posts look like in popular search engines. Reorder items such as 'Site Name’' and 'Tagline' without having to touch any code.",
 							{
 								components: {
 									a: <a href="https://jetpack.com/support/seo-tools/" />,

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -5,14 +5,17 @@ import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { FEATURE_SEO_TOOLS_JETPACK } from 'lib/plans/constants';
+import { FEATURE_SEO_TOOLS_JETPACK, getPlanClass } from 'lib/plans/constants';
+
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { getSitePlan } from 'state/site';
 
 class SeoComponent extends React.Component {
 	trackConfigureClick = () => {
@@ -20,6 +23,7 @@ class SeoComponent extends React.Component {
 	};
 
 	render() {
+		const planClass = getPlanClass( this.props.sitePlan.product_slug );
 		return (
 			<SettingsCard
 				{ ...this.props }
@@ -39,28 +43,28 @@ class SeoComponent extends React.Component {
 				>
 					<span>
 						{ __(
-							"Take control of the way search engines represent your site. With Jetpack's SEO tools you can preview how your content will look on popular search engines and change items like your site name and tagline without having to touch code.",
-							{
-								components: {
-									a: <a href="https://jetpack.com/support/seo-tools/" />,
-								},
-							}
+							'Take control of the way search engines represent your site. With Jetpack’s SEO tools you can preview how your content will look on popular search engines and change items like your site name and tagline in seconds.'
 						) }
 					</span>
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						onClick={ this.trackConfigureClick }
-						href={ this.props.configureUrl }
-					>
-						{ __( 'Configure your SEO settings' ) }
-					</Card>
-				) }
+				{ ! this.props.isUnavailableInDevMode( 'seo-tools' ) &&
+					( 'is-business-plan' === planClass || 'is-premium-plan' === planClass ) && (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackConfigureClick }
+							href={ this.props.configureUrl }
+						>
+							{ __( 'Customize your SEO settings' ) }
+						</Card>
+					) }
 			</SettingsCard>
 		);
 	}
 }
 
-export const SEO = withModuleSettingsFormHelpers( SeoComponent );
+export const SEO = connect( state => {
+	return {
+		sitePlan: getSitePlan( state ),
+	};
+} )( withModuleSettingsFormHelpers( SeoComponent ) );


### PR DESCRIPTION
Updating copy on the SEO banner as well as changing the copy on the feature description for upgraded users. 


Partially Fixes #9754 

#### Changes proposed in this Pull Request:
* updated copy on SEO banner
* updated feature description for upgraded users

![before-after1](https://user-images.githubusercontent.com/49159284/59883207-edb68b00-9379-11e9-8921-a1af52b8e0aa.png)
![copy2-updated](https://user-images.githubusercontent.com/49159284/59883467-cdd39700-937a-11e9-9a42-1db8905566dd.png)

### Changes still needed (need dev help)
We want to show this paragraph to non-upraded users as well as upgraded.
```"Jetpack SEO tools will give you live previews of what your site homepage and posts look like in popular search engines. Reorder items such as 'Site Name’' and 'Tagline' without having to touch any code."```

I found where to change it in the current code, but not how to make it show for all users

![still-needs-to-happen](https://user-images.githubusercontent.com/49159284/59883477-d5933b80-937a-11e9-9308-377d6798ba82.png)



#### Testing instructions:
* Go to /wp-admin/admin.php?page=jetpack#/traffic
* View as non-upgraded
* View as upgraded

#### Proposed changelog entry for your changes:

*none

@scottsweb 