### PR TITLE
Jetpack DNA: Move Jetpack_Sync_Main from Legacy to psr-4

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -233,7 +233,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php'          );
 
-Jetpack_Sync_Main::init();
+\Automattic\Jetpack\Sync\Main::init();
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -83,7 +83,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Connection\XMLRPC_Connector',
 						'Jetpack_Options',
 						'Jetpack_Signature',
-						'Jetpack_Sync_Main',
+						'Automattic\Jetpack\Sync\Main',
 						'Automattic\Jetpack\Constants',
 						'Automattic\Jetpack\Tracking',
 						'Automattic\Jetpack\Plugin\Tracking',

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -27,7 +27,7 @@ class Listener {
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	protected function __construct() {
-		\Jetpack_Sync_Main::init();
+		Main::init();
 		$this->set_defaults();
 		$this->init();
 	}

--- a/packages/sync/src/Main.php
+++ b/packages/sync/src/Main.php
@@ -5,10 +5,12 @@
  * @package jetpack-sync
  */
 
+namespace Automattic\Jetpack\Sync;
+
 /**
  * Jetpack Sync main class.
  */
-class Jetpack_Sync_Main {
+class Main {
 	/**
 	 * Initialize the main sync actions.
 	 */

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -3,13 +3,14 @@
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Main;
 use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 use Automattic\Jetpack\Sync\Modules\Posts;
 
-Jetpack_Sync_Main::init();
+Main::init();
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 


### PR DESCRIPTION
This PR moves the Jetpack_Sync_Main from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.