### PR TITLE
Jetpack DNA: Move Jetpack Sync Modules from Legacy to psr-4

### DIFF
--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Sender;
 
 /**
@@ -269,7 +270,7 @@ class Jetpack_Debug_Data {
 		);
 
 		/** Sync Debug Information */
-		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sync_module = Modules::get_module( 'full-sync' );
 		if ( $sync_module ) {
 			$sync_statuses              = $sync_module->get_status();
 			$human_readable_sync_status = array();

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Tracking;
 
@@ -708,7 +709,7 @@ class Jetpack_XMLRPC_Server {
 		// e.g. posts, post, 5
 		list( $module_name, $object_type, $id ) = $args;
 
-		$sync_module = Jetpack_Sync_Modules::get_module( $module_name );
+		$sync_module = Modules::get_module( $module_name );
 		$codec = Sender::get_instance()->get_codec();
 
 		return $codec->encode( $sync_module->get_object_by_id( $object_type, $id ) );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Queue_Buffer;
 use Automattic\Jetpack\Sync\Replicastore;
@@ -136,7 +137,7 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 
 		$module_name = $args['module_name'];
 
-		if ( ! $sync_module = Jetpack_Sync_Modules::get_module( $module_name ) ) {
+		if ( ! $sync_module = Modules::get_module( $module_name ) ) {
 			return new WP_Error( 'invalid_module', 'You specified an invalid sync module' );
 		}
 

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -243,7 +243,7 @@ class Actions {
 			return false;
 		}
 
-		$full_sync_module = \Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$full_sync_module = Modules::get_module( 'full-sync' );
 
 		if ( ! $full_sync_module ) {
 			return false;
@@ -456,7 +456,7 @@ class Actions {
 	static function get_sync_status( $fields = null ) {
 		self::initialize_sender();
 
-		$sync_module     = \Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sync_module     = Modules::get_module( 'full-sync' );
 		$queue           = self::$sender->get_sync_queue();
 		$full_queue      = self::$sender->get_full_sync_queue();
 		$cron_timestamps = array_keys( _get_cron_array() );

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -36,7 +36,7 @@ class Listener {
 		$handler           = array( $this, 'action_handler' );
 		$full_sync_handler = array( $this, 'full_sync_action_handler' );
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module->init_listeners( $handler );
 			$module->init_full_sync_listeners( $full_sync_handler );
 		}

--- a/packages/sync/src/Modules.php
+++ b/packages/sync/src/Modules.php
@@ -5,7 +5,9 @@
  * of sync modules
  */
 
-class Jetpack_Sync_Modules {
+namespace Automattic\Jetpack\Sync;
+
+class Modules {
 
 	private static $default_sync_modules = array(
 		'Automattic\\Jetpack\\Sync\\Modules\\Constants',
@@ -64,9 +66,9 @@ class Jetpack_Sync_Modules {
 		 */
 		$modules = apply_filters( 'jetpack_sync_modules', self::$default_sync_modules );
 
-		$modules = array_map( array( 'Jetpack_Sync_Modules', 'load_module' ), $modules );
+		$modules = array_map( array( 'Automattic\\Jetpack\\Sync\\Modules', 'load_module' ), $modules );
 
-		return array_map( array( 'Jetpack_Sync_Modules', 'set_module_defaults' ), $modules );
+		return array_map( array( 'Automattic\\Jetpack\\Sync\\Modules', 'set_module_defaults' ), $modules );
 	}
 
 	static function load_module( $module_name ) {

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -45,7 +46,7 @@ class Sender {
 	private function init() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module->init_before_send();
 		}
 	}
@@ -78,7 +79,7 @@ class Sender {
 	}
 
 	public function do_full_sync() {
-		if ( ! \Jetpack_Sync_Modules::get_module( 'full-sync' ) ) {
+		if ( ! Modules::get_module( 'full-sync' ) ) {
 			return;
 		}
 		$this->continue_full_sync_enqueue();
@@ -94,7 +95,7 @@ class Sender {
 			return false;
 		}
 
-		\Jetpack_Sync_Modules::get_module( 'full-sync' )->continue_enqueuing();
+		Modules::get_module( 'full-sync' )->continue_enqueuing();
 
 		$this->set_next_sync_time( time() + $this->get_enqueue_wait_time(), 'full-sync-enqueue' );
 	}
@@ -387,7 +388,7 @@ class Sender {
 		$this->reset_sync_queue();
 		$this->reset_full_sync_queue();
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module->reset_data();
 		}
 

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
 
 /**
@@ -63,13 +64,13 @@ class Full_Sync extends \Jetpack_Sync_Module {
 		if ( ! is_array( $module_configs ) ) {
 			$module_configs = array();
 			$include_empty  = true;
-			foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+			foreach ( Modules::get_modules() as $module ) {
 				$module_configs[ $module->name() ] = true;
 			}
 		}
 
 		// set default configuration, calculate totals, and save configuration if totals > 0
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module_name   = $module->name();
 			$module_config = isset( $module_configs[ $module_name ] ) ? $module_configs[ $module_name ] : false;
 
@@ -146,7 +147,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 
 			// skip module if not configured for this sync or module is done
@@ -252,7 +253,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 			$this->update_status_option( 'send_started', time() );
 		}
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module_actions     = $module->get_full_sync_actions();
 			$status_option_name = "{$module->name()}_sent";
 			$total_option_name  = "{$status_option_name}_total";
@@ -354,7 +355,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 
 		$enqueue_status = $this->get_enqueue_status();
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$name = $module->name();
 
 			if ( ! isset( $enqueue_status[ $name ] ) ) {
@@ -394,7 +395,7 @@ class Full_Sync extends \Jetpack_Sync_Module {
 
 		$this->delete_enqueue_status();
 
-		foreach ( \Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent" );
 			\Jetpack_Options::delete_raw_option( "{$prefix}_{$module->name()}_sent_total" );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
@@ -65,7 +66,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 	public function setSyncClientDefaults() {
 		$this->sender->set_defaults();
-		Jetpack_Sync_Modules::set_defaults();
+		Modules::set_defaults();
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 		// don't sync callables or constants every time - slows down tests

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Modules\WP_Super_Cache;
 use Automattic\Jetpack\Sync\Sender;
@@ -25,7 +26,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->resetCallableAndConstantTimeouts();
 
-		$this->callable_module = Jetpack_Sync_Modules::get_module( "functions" );
+		$this->callable_module = Modules::get_module( "functions" );
 		set_current_screen( 'post-user' ); // this only works in is_admin()
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
+
 /**
  * Testing CRUD on Comments
  */
@@ -350,7 +352,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_returns_comment_object_by_id() {
-		$comment_sync_module = Jetpack_Sync_Modules::get_module( "comments" );
+		$comment_sync_module = Modules::get_module( "comments" );
 
 		$comment_id = $this->comment_ids[0];
 		

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Constants;
 
 /**
@@ -14,7 +15,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 
 		$this->resetCallableAndConstantTimeouts();
 
-		$this->constant_module = Jetpack_Sync_Modules::get_module( "constants" );
+		$this->constant_module = Modules::get_module( "constants" );
 	}
 
 	// TODO:

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Full_Sync;
 
 function jetpack_foo_full_sync_callable() {
@@ -19,7 +20,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$this->full_sync = Modules::get_module( 'full-sync' );
 	}
 
 	function test_enqueues_sync_start_action() {
@@ -151,10 +152,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 
-		$options_full_sync_actions = Jetpack_Sync_Modules::get_module( 'options' )->get_full_sync_actions();
+		$options_full_sync_actions = Modules::get_module( 'options' )->get_full_sync_actions();
 		$options_event             = $this->server_event_storage->get_most_recent_event( $options_full_sync_actions[0] );
 
-		$posts_full_sync_actions = Jetpack_Sync_Modules::get_module( 'posts' )->get_full_sync_actions();
+		$posts_full_sync_actions = Modules::get_module( 'posts' )->get_full_sync_actions();
 		$posts_event             = $this->server_event_storage->get_most_recent_event( $posts_full_sync_actions[0] );
 
 		$this->assertTrue( $start_event !== false );
@@ -476,7 +477,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_functions() {
-		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
@@ -491,7 +492,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_functions_inverse() {
-		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
@@ -514,7 +515,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_sends_all_options() {
 		delete_option( 'non_existant' );
-		Jetpack_Sync_Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value', 'non_existant' ) );
+		Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value', 'non_existant' ) );
 		update_option( 'my_option', 'foo' );
 		update_option( 'my_prefix_value', 'bar' );
 		update_option( 'my_non_synced_option', 'baz' );
@@ -554,7 +555,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			$this->markTestSkipped( 'Run it in multi site mode' );
 		}
 
-		Jetpack_Sync_Modules::get_module( "network_options" )->set_network_options_whitelist( array(
+		Modules::get_module( "network_options" )->set_network_options_whitelist( array(
 			'my_option',
 			'my_prefix_value'
 		) );
@@ -612,7 +613,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_doesnt_sends_forbiden_private_or_public_post_meta() {
 		$post_id = $this->factory->post->create();
 
-		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
+		$meta_module = Modules::get_module( "meta" );
 		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'a_public_meta' ) ) );
 
 		// forbidden private meta
@@ -732,7 +733,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function check_for_updates_to_sync() {
-		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module = Modules::get_module( 'updates' );
 		$updates_module->sync_last_event();
 	}
 
@@ -1307,7 +1308,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			$this->factory->comment->create_post_comments( $post_id, 2 );
 		}
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+		foreach ( Modules::get_modules() as $module ) {
 			$module_name            = $module->name();
 			$estimate               = $module->estimate_full_sync_actions( true );
 			list( $actual, $state ) = $module->enqueue_full_sync_actions( true, 100, false );
@@ -1337,7 +1338,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
 		$this->server_replica_storage->reset();
 		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
-		$user_ids = Jetpack_Sync_Modules::get_module( 'users' )->get_initial_sync_user_config();
+		$user_ids = Modules::get_module( 'users' )->get_initial_sync_user_config();
 		$this->assertEquals( 3, count( $user_ids ) );
 		$this->full_sync->start( array( 'users' => 'initial' ) );
 		$this->sender->do_full_sync();

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Sync\Modules;
 
 class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_sending_empties_queue() {
@@ -70,7 +71,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_starts_full_sync_on_user_authorized() {
 		do_action( 'jetpack_user_authorized', 'abcd1234' );
-		$this->assertTrue( Jetpack_Sync_Modules::get_module( 'full-sync' )->is_started() );
+		$this->assertTrue( Modules::get_module( 'full-sync' )->is_started() );
 	}
 
 	function test_sends_updating_jetpack_version_event() {

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -4,6 +4,8 @@
  * Testing CRUD on Meta
  */
 
+use Automattic\Jetpack\Sync\Modules;
+
 require_jetpack_file( 'modules/contact-form/grunion-contact-form.php' );
 
 class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
@@ -16,7 +18,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		parent::setUp();
 
 		// create a post
-		$this->meta_module = Jetpack_Sync_Modules::get_module( "meta" );
+		$this->meta_module = Modules::get_module( "meta" );
 		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'foobar' ) ) );
 		$this->post_id = $this->factory->post->create();
 		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );

--- a/tests/php/sync/test_class.jetpack-sync-network-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-network-options.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
+
 /**
  * Testing CRUD on Network Options
  * use phpunit --testsuite sync  -c tests/php.multisite.xml --filter WP_Test_Jetpack_Sync_Network_Options
@@ -12,7 +14,7 @@ class WP_Test_Jetpack_Sync_Network_Options extends WP_Test_Jetpack_Sync_Base {
 
 		parent::setUp();
 
-		$this->network_options_module = Jetpack_Sync_Modules::get_module( "network_options" );
+		$this->network_options_module = Modules::get_module( "network_options" );
 
 		$this->network_options_module->set_network_options_whitelist( array( 'test_network_option' ) );
 		add_site_option( 'test_network_option', 'foo' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
+
 /**
  * Testing CRUD on Options
  */
@@ -10,7 +12,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
 
-		$this->options_module = Jetpack_Sync_Modules::get_module( "options" );
+		$this->options_module = Modules::get_module( "options" );
 
 		$this->options_module->set_options_whitelist( array( 'test_option' ) );
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing CRUD on Posts
@@ -26,7 +27,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertEquals( $this->post->ID, $event->args[0] );
 
-		$post_sync_module = Jetpack_Sync_Modules::get_module( "posts" );
+		$post_sync_module = Modules::get_module( "posts" );
 
 		$this->post = $post_sync_module->filter_post_content_and_add_links( $this->post );
 		$this->assertEqualsObject( $this->post, $event->args[1] );
@@ -36,7 +37,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		// post stored by server should equal post in client
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 
-		$post_sync_module = Jetpack_Sync_Modules::get_module( "posts" );
+		$post_sync_module = Modules::get_module( "posts" );
 
 		$this->post = $post_sync_module->filter_post_content_and_add_links( $this->post );
 		$this->assertEquals( $this->post, $this->server_replica_storage->get_post( $this->post->ID ) );
@@ -682,7 +683,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_returns_post_object_by_id() {
-		$post_sync_module = Jetpack_Sync_Modules::get_module( "posts" );
+		$post_sync_module = Modules::get_module( "posts" );
 
 		$post_id = $this->factory->post->create();
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Callables;
 
 class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
@@ -264,7 +265,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_reset_module_also_resets_full_sync_lock() {
-		$full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$full_sync = Modules::get_module( 'full-sync' );
 		$full_sync->start();
 		$status = $full_sync->get_status();
 		$this->assertTrue( $full_sync->is_started() );

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing CRUD on Terms
@@ -14,7 +15,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		parent::setUp();
 		$this->sender->reset_data();
 
-		$this->terms_module = Jetpack_Sync_Modules::get_module( "terms" );
+		$this->terms_module = Modules::get_module( "terms" );
 
 		$this->taxonomy = 'genre';
 		register_taxonomy(

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing Updates Sync
@@ -16,7 +17,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function check_for_updates_to_sync() {
-		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module = Modules::get_module( 'updates' );
 		$updates_module->sync_last_event();
 	}
 
@@ -53,7 +54,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		set_site_transient( 'update_plugins', $response );
 
 		//
-		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module = Modules::get_module( 'updates' );
 		$updates_module->sync_last_event();
 		$has_action = has_action( 'shutdown', array( $updates_module, 'sync_last_event' ) );
 		$this->sender->do_sync();
@@ -113,7 +114,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		set_site_transient( 'update_themes', $response );
 
 		//
-		$updates_module = Jetpack_Sync_Modules::get_module( 'updates' );
+		$updates_module = Modules::get_module( 'updates' );
 		$updates_module->sync_last_event();
 
 		$has_action = has_action( 'shutdown', array( $updates_module, 'sync_last_event' ) );
@@ -248,7 +249,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertFalse( $pagenow === 'update-core.php' );
 		Constants::set_constant( 'REST_API_REQUEST', true );
-		Jetpack_Sync_Modules::get_module( "updates" )->update_core( 'new_version' );
+		Modules::get_module( "updates" )->update_core( 'new_version' );
 		$this->sender->do_sync();
 
 		Constants::clear_single_constant( 'REST_API_REQUEST' );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Users;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing CRUD on Users
@@ -33,7 +34,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );
 
-		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
+		$user_sync_module = Modules::get_module( "users" );
 		$synced_user = $event->args[0];
 
 		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
@@ -417,7 +418,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$save_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 		$this->assertFalse( (bool) $save_event );
 
-		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
+		$user_sync_module = Modules::get_module( "users" );
 		$synced_user = $add_event->args[0];
 
 		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
@@ -535,7 +536,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_returns_user_object_by_id() {
-		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
+		$user_sync_module = Modules::get_module( "users" );
 
 		// get the synced object
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );

--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
+
 /**
  * Testing WooCommerce Sync
  */
@@ -61,11 +63,11 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 			return;
 		}
 		parent::setUp();
-		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$this->full_sync = Modules::get_module( 'full-sync' );
 	}
 
 	function test_module_is_enabled() {
-		$this->assertTrue( !! Jetpack_Sync_Modules::get_module( "woocommerce" ) );
+		$this->assertTrue( !! Modules::get_module( "woocommerce" ) );
 	}
 
 	// Incremental sync

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\WP_Super_Cache;
 
 /**
@@ -34,7 +35,7 @@ class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_module_is_enabled() {
-		$this->assertTrue( !! Jetpack_Sync_Modules::get_module( "wp-super-cache" ) );
+		$this->assertTrue( !! Modules::get_module( "wp-super-cache" ) );
 	}
 
 	function test_constants_are_synced() {


### PR DESCRIPTION
This PR moves Jetpack Sync Modules from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.