### PR TITLE
Jetpack DNA: Move Jetpack Sync Simple Codec from Legacy to psr-4

### DIFF
--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -3,7 +3,6 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Sync\JSON_Deflate_Array_Codec;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -303,7 +302,7 @@ class Sender {
 		if ( function_exists( 'gzinflate' ) ) {
 			$this->codec = new JSON_Deflate_Array_Codec();
 		} else {
-			$this->codec = new \Jetpack_Sync_Simple_Codec();
+			$this->codec = new Simple_Codec();
 		}
 	}
 

--- a/packages/sync/src/Simple_Codec.php
+++ b/packages/sync/src/Simple_Codec.php
@@ -1,12 +1,12 @@
 <?php
 
-use Automattic\Jetpack\Sync\JSON_Deflate_Array_Codec;
+namespace Automattic\Jetpack\Sync;
 
 /**
  * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
  * algorithm to compress objects serialized using json_encode
  */
-class Jetpack_Sync_Simple_Codec extends JSON_Deflate_Array_Codec {
+class Simple_Codec extends JSON_Deflate_Array_Codec {
 	const CODEC_NAME = 'simple';
 
 	public function name() {


### PR DESCRIPTION
This PR moves Jetpack Sync Simple Codec from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.