### PR TITLE
Jetpack DNA: Move Jetpack Sync Users from Legacy to psr-4

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\Connection\REST_Connector as REST_Connector;
 use Automattic\Jetpack\Connection\XMLRPC_Connector as XMLRPC_Connector;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Sender;
+use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Tracking;
 
 /*
@@ -1812,8 +1813,8 @@ class Jetpack {
 	 * Synchronize connected user role changes
 	 */
 	function user_role_change( $user_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-4.2', 'Jetpack_Sync_Users::user_role_change()' );
-		Jetpack_Sync_Users::user_role_change( $user_id );
+		_deprecated_function( __METHOD__, 'jetpack-4.2', 'Users::user_role_change()' );
+		Users::user_role_change( $user_id );
 	}
 
 	/**

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Users;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -31,7 +32,7 @@ class Actions {
 		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 
 		// Sync connected user role changes to .com
-		\Jetpack_Sync_Users::init();
+		Users::init();
 
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );

--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -1,15 +1,17 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 /**
- * Class Jetpack_Sync_Users
+ * Class Users
  *
  * Responsible for syncing user data changes.
  */
-class Jetpack_Sync_Users {
+class Users {
 	static $user_roles = array();
 
 	static function init() {
-		if ( Jetpack::is_active() ) {
+		if ( \Jetpack::is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
@@ -19,7 +21,7 @@ class Jetpack_Sync_Users {
 	 * Synchronize connected user role changes
 	 */
 	static function user_role_change( $user_id ) {
-		if ( Jetpack::is_user_connected( $user_id ) ) {
+		if ( \Jetpack::is_user_connected( $user_id ) ) {
 			self::update_role_on_com( $user_id );
 			// try to choose a new master if we're demoting the current one
 			self::maybe_demote_master_user( $user_id );
@@ -33,7 +35,7 @@ class Jetpack_Sync_Users {
 
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $user_id );
-		$role = Jetpack::translate_current_user_to_role();
+		$role = \Jetpack::translate_current_user_to_role();
 		wp_set_current_user( $current_user_id );
 		$user_roles[ $user_id ] = $role;
 
@@ -41,19 +43,19 @@ class Jetpack_Sync_Users {
 	}
 
 	static function get_signed_role( $user_id ) {
-		return Jetpack::sign_role( self::get_role( $user_id ), $user_id );
+		return \Jetpack::sign_role( self::get_role( $user_id ), $user_id );
 	}
 
 	static function update_role_on_com( $user_id ) {
 		$signed_role = self::get_signed_role( $user_id );
-		Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
+		\Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
 	}
 
 	static function maybe_demote_master_user( $user_id ) {
-		$master_user_id = Jetpack_Options::get_option( 'master_user' );
+		$master_user_id = \Jetpack_Options::get_option( 'master_user' );
 		$role           = self::get_role( $user_id );
 		if ( $user_id == $master_user_id && 'administrator' != $role ) {
-			$query      = new WP_User_Query(
+			$query      = new \WP_User_Query(
 				array(
 					'fields'  => array( 'id' ),
 					'role'    => 'administrator',
@@ -64,14 +66,14 @@ class Jetpack_Sync_Users {
 			$new_master = false;
 			foreach ( $query->results as $result ) {
 				$found_user_id = absint( $result->id );
-				if ( $found_user_id && Jetpack::is_user_connected( $found_user_id ) ) {
+				if ( $found_user_id && \Jetpack::is_user_connected( $found_user_id ) ) {
 					$new_master = $found_user_id;
 					break;
 				}
 			}
 
 			if ( $new_master ) {
-				Jetpack_Options::update_option( 'master_user', $new_master );
+				\Jetpack_Options::update_option( 'master_user', $new_master );
 			}
 			// else disconnect..?
 		}

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Users;
 
 /**
  * Testing CRUD on Users
@@ -519,17 +520,17 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		) );
 
 		// maybe
-		Jetpack_Sync_Users::maybe_demote_master_user( $current_master_id );
+		Users::maybe_demote_master_user( $current_master_id );
 		$this->assertEquals( $new_master_id, Jetpack_Options::get_option( 'master_user' ) );
 
 		// don't demote user that if the user is still an admin.
-		Jetpack_Sync_Users::maybe_demote_master_user( $new_master_id );
+		Users::maybe_demote_master_user( $new_master_id );
 		$this->assertEquals( 'administrator', $new_master->roles[0] );
 		$this->assertEquals( $new_master_id, Jetpack_Options::get_option( 'master_user' ), 'Do not demote the master user if the user is still an admin' );
 
 		$new_master->set_role( 'author' );
 		// don't demote user if the user one the only admin that is connected.
-		Jetpack_Sync_Users::maybe_demote_master_user( $new_master_id );
+		Users::maybe_demote_master_user( $new_master_id );
 		$this->assertEquals( $new_master_id, Jetpack_Options::get_option( 'master_user' ), 'Do not demote user if the user is the only connected user.' );
 	}
 


### PR DESCRIPTION
This PR moves Jetpack Sync Users from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.