### PR TITLE
Jetpack DNA: Move Jetpack Sync WP Replicastore from Legacy to psr-4

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Queue_Buffer;
+use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 
 // POST /sites/%s/sync
@@ -64,7 +65,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 // GET /sites/%s/data-check
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		$store = new Jetpack_Sync_WP_Replicastore();
+		$store = new Replicastore();
 		return $store->checksum_all();
 	}
 }
@@ -80,7 +81,7 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 			$columns = null; // go with defaults
 		}
 
-		$store = new Jetpack_Sync_WP_Replicastore();
+		$store = new Replicastore();
 
 		if ( ! isset( $args['strip_non_ascii'] ) ) {
 			$args['strip_non_ascii'] = true;

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -464,7 +464,7 @@ class Actions {
 		$checksums = array();
 
 		if ( ! empty( $fields ) ) {
-			$store         = new \Jetpack_Sync_WP_Replicastore();
+			$store         = new Replicastore();
 			$fields_params = array_map( 'trim', explode( ',', $fields ) );
 
 			if ( in_array( 'posts_checksum', $fields_params, true ) ) {

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -85,7 +85,7 @@ class Replicastore implements Replicastore_Interface {
 		global $wpdb;
 
 		// reject the post if it's not a WP_Post
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return;
 		}
 

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace Automattic\Jetpack\Sync;
+
 /**
- * An implementation of iJetpack_Sync_Replicastore which returns data stored in a WordPress.org DB.
+ * An implementation of Replicastore Interface which returns data stored in a WordPress.org DB.
  * This is useful to compare values in the local WP DB to values in the synced replica store
  */
-class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
+class Replicastore implements Replicastore_Interface {
 
 
 	public function reset() {
@@ -145,12 +147,12 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 
 	public function posts_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->posts, Jetpack_Sync_Defaults::$default_post_checksum_columns, 'ID', Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->posts, \Jetpack_Sync_Defaults::$default_post_checksum_columns, 'ID', \Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
 	}
 
 	public function post_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->postmeta, Jetpack_Sync_Defaults::$default_post_meta_checksum_columns, 'meta_id', Jetpack_Sync_Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->postmeta, \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql(), $min_id, $max_id );
 	}
 
 	public function comment_count( $status = null, $min_id = null, $max_id = null ) {
@@ -209,7 +211,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function get_comment( $id ) {
-		return WP_Comment::get_instance( $id );
+		return \WP_Comment::get_instance( $id );
 	}
 
 	public function upsert_comment( $comment ) {
@@ -280,21 +282,21 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->comments, Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', Jetpack_Sync_Settings::get_comments_filter_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->comments, \Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', \Jetpack_Sync_Settings::get_comments_filter_sql(), $min_id, $max_id );
 	}
 
 	public function comment_meta_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->commentmeta, Jetpack_Sync_Defaults::$default_comment_meta_checksum_columns, 'meta_id', Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->commentmeta, \Jetpack_Sync_Defaults::$default_comment_meta_checksum_columns, 'meta_id', \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql(), $min_id, $max_id );
 	}
 
 	public function options_checksum() {
 		global $wpdb;
 
-		$options_whitelist = "'" . implode( "', '", Jetpack_Sync_Defaults::$default_options_whitelist ) . "'";
+		$options_whitelist = "'" . implode( "', '", \Jetpack_Sync_Defaults::$default_options_whitelist ) . "'";
 		$where_sql         = "option_name IN ( $options_whitelist )";
 
-		return $this->table_checksum( $wpdb->options, Jetpack_Sync_Defaults::$default_option_checksum_columns, null, $where_sql, null, null );
+		return $this->table_checksum( $wpdb->options, \Jetpack_Sync_Defaults::$default_option_checksum_columns, null, $where_sql, null, null );
 	}
 
 
@@ -492,7 +494,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 			$taxonomies = $this->get_callable( 'taxonomies' );
 			if ( ! isset( $taxonomies[ $taxonomy ] ) ) {
 				// doesn't exist, or somehow hasn't been synced
-				return new WP_Error( 'invalid_taxonomy', "The taxonomy '$taxonomy' doesn't exist" );
+				return new \WP_Error( 'invalid_taxonomy', "The taxonomy '$taxonomy' doesn't exist" );
 			}
 			$t = $taxonomies[ $taxonomy ];
 
@@ -603,7 +605,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function get_user( $user_id ) {
-		return WP_User::get_instance( $user_id );
+		return \WP_User::get_instance( $user_id );
 	}
 
 	public function upsert_user( $user ) {
@@ -652,14 +654,14 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				$object_count = $this->post_count( null, $start_id, $end_id );
 				$object_table = $wpdb->posts;
 				$id_field     = 'ID';
-				$where_sql    = Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
+				$where_sql    = \Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
 				if ( empty( $columns ) ) {
-					$columns = Jetpack_Sync_Defaults::$default_post_checksum_columns;
+					$columns = \Jetpack_Sync_Defaults::$default_post_checksum_columns;
 				}
 				break;
 			case 'post_meta':
 				$object_table = $wpdb->postmeta;
-				$where_sql    = Jetpack_Sync_Settings::get_whitelisted_post_meta_sql();
+				$where_sql    = \Jetpack_Sync_Settings::get_whitelisted_post_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 
@@ -671,18 +673,18 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 				$object_count = $this->comment_count( null, $start_id, $end_id );
 				$object_table = $wpdb->comments;
 				$id_field     = 'comment_ID';
-				$where_sql    = Jetpack_Sync_Settings::get_comments_filter_sql();
+				$where_sql    = \Jetpack_Sync_Settings::get_comments_filter_sql();
 				if ( empty( $columns ) ) {
-					$columns = Jetpack_Sync_Defaults::$default_comment_checksum_columns;
+					$columns = \Jetpack_Sync_Defaults::$default_comment_checksum_columns;
 				}
 				break;
 			case 'comment_meta':
 				$object_table = $wpdb->commentmeta;
-				$where_sql    = Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql();
+				$where_sql    = \Jetpack_Sync_Settings::get_whitelisted_comment_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 				if ( empty( $columns ) ) {
-					$columns = Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
+					$columns = \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
 				}
 				break;
 			default:
@@ -776,7 +778,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 ENDSQL;
 		$result = $wpdb->get_var( $wpdb->prepare( $query, $salt ) );
 		if ( $wpdb->last_error ) {
-			return new WP_Error( 'database_error', $wpdb->last_error );
+			return new \WP_Error( 'database_error', $wpdb->last_error );
 		}
 
 		return $result;
@@ -812,6 +814,6 @@ ENDSQL;
 	private function invalid_call() {
 		$backtrace = debug_backtrace();
 		$caller    = $backtrace[1]['function'];
-		throw new Exception( "This function $caller is not supported on the WP Replicastore" );
+		throw new \Exception( "This function $caller is not supported on the WP Replicastore" );
 	}
 }

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -666,7 +666,7 @@ class Replicastore implements Replicastore_Interface {
 				$id_field     = 'meta_id';
 
 				if ( empty( $columns ) ) {
-					$columns = Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
+					$columns = \Jetpack_Sync_Defaults::$default_post_meta_checksum_columns;
 				}
 				break;
 			case 'comments':

--- a/packages/sync/src/Replicastore_Interface.php
+++ b/packages/sync/src/Replicastore_Interface.php
@@ -6,12 +6,14 @@
  * To run tests: phpunit --testsuite sync --filter New_Sync
  */
 
+namespace Automattic\Jetpack\Sync;
+
 /**
  * A high-level interface for objects that store synced WordPress data
  * Useful for ensuring that different storage mechanisms implement the
  * required semantics for storing all the data that we sync
  */
-interface iJetpack_Sync_Replicastore {
+interface Replicastore_Interface {
 	// remove all data
 	public function reset();
 

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -307,7 +307,7 @@ class Sender {
 	}
 
 	function send_checksum() {
-		$store = new \Jetpack_Sync_WP_Replicastore();
+		$store = new Replicastore();
 		do_action( 'jetpack_sync_checksum', $store->checksum_all() );
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Replicastore_Interface;
+
 /**
  * Translates incoming actions from the Jetpack site into mutations on core types
  * In other words: this tries to keep a local datastore in sync with the remote one
@@ -7,7 +9,7 @@
 class Jetpack_Sync_Server_Replicator {
 	private $store;
 
-	function __construct( iJetpack_Sync_Replicastore $store ) {
+	function __construct( Replicastore_Interface $store ) {
 		$this->store = $store;
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -1,10 +1,12 @@
 <?php
 
+use Automattic\Jetpack\Sync\Replicastore_Interface;
+
 /**
  * A simple in-memory implementation of iJetpack_Sync_Replicastore
  * used for development and testing
  */
-class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
+class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 
 	private $posts;
 	private $post_status;

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules\Constants;
+use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 use Automattic\Jetpack\Sync\Modules\Posts;
@@ -83,7 +84,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	}
 
 	protected function assertDataIsSynced() {
-		$local  = new Jetpack_Sync_WP_Replicastore();
+		$local  = new Replicastore();
 		$remote = $this->server_replica_storage;
 
 		// Also pass the posts though the same filter other wise they woun't match any more.

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -80,7 +80,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
 		foreach ( get_declared_classes() as $className ) {
-			if ( in_array( 'iJetpack_Sync_Replicastore', class_implements( $className ) ) ) {
+			if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore', class_implements( $className ) ) ) {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {
@@ -1050,7 +1050,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 			self::$all_replicastores = array();
 
 			foreach ( get_declared_classes() as $className ) {
-				if ( in_array( 'iJetpack_Sync_Replicastore', class_implements( $className ) ) ) {
+				if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore_Interface', class_implements( $className ) ) ) {
 					self::$all_replicastores[] = $className;
 				}
 			}

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -80,7 +80,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
 		foreach ( get_declared_classes() as $className ) {
-			if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore', class_implements( $className ) ) ) {
+			if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore_Interface', class_implements( $className ) ) ) {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -80,7 +80,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
 		foreach ( get_declared_classes() as $className ) {
-			if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore_Interface', class_implements( $className ) ) ) {
+			if ( in_array( 'Automattic\Jetpack\Sync\Replicastore_Interface', class_implements( $className ) ) ) {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {
@@ -107,6 +107,8 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		// ensure the checksums are the same
 		$checksums = array_map( array( $this, 'get_all_checksums' ), $all_replicastores );
+
+		var_dump($checksums);
 
 		// for helpful debug output in case they don't match
 		$labelled_checksums = array_combine( array_map( 'get_class', $all_replicastores ), $checksums );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Sync\Replicastore;
+
 if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	require_once ABSPATH . 'wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-test-object-factory.php';
 } else {
@@ -500,7 +502,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		unset( $retrieved_comment->comment_date );
 		unset( $retrieved_comment->comment_date_gmt );
 
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+		if ( $store instanceof Replicastore ) {
 			$this->markTestIncomplete( "The WP replicastore doesn't support setting comments post_fields" );
 		}
 
@@ -577,7 +579,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 */
 	function test_replica_set_theme_support( $store ) {
 
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+		if ( $store instanceof Replicastore ) {
 			$this->markTestIncomplete( "The WP replicastore doesn't support setting theme options directly" );
 		}
 
@@ -805,7 +807,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 * @requires PHP 5.3
 	 */
 	function test_replica_set_callables( $store ) {
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+		if ( $store instanceof Replicastore ) {
 			$this->markTestIncomplete( "The WP replicastore doesn't support setting callables directly" );
 		}
 
@@ -855,7 +857,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 * @requires PHP 5.3
 	 */
 	function test_replica_update_users( $store ) {
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+		if ( $store instanceof Replicastore ) {
 			$this->markTestIncomplete( "The WP replicastore doesn't support setting users" );
 		}
 
@@ -897,7 +899,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 * @requires PHP 5.3
 	 */
 	function test_replica_get_allowed_mime_types( $store ) {
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+		if ( $store instanceof Replicastore ) {
 			$this->markTestIncomplete( "The WP replicastore doesn't support setting users" );
 		}
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -80,7 +80,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
 		foreach ( get_declared_classes() as $className ) {
-			if ( in_array( 'Automattic\Jetpack\Sync\Replicastore_Interface', class_implements( $className ) ) ) {
+			if ( in_array( 'Automattic\\Jetpack\\Sync\\Replicastore_Interface', class_implements( $className ) ) ) {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {
@@ -107,8 +107,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		// ensure the checksums are the same
 		$checksums = array_map( array( $this, 'get_all_checksums' ), $all_replicastores );
-
-		var_dump($checksums);
 
 		// for helpful debug output in case they don't match
 		$labelled_checksums = array_combine( array_map( 'get_class', $all_replicastores ), $checksums );


### PR DESCRIPTION
This PR moves Jetpack Sync WP Replicastore from legacy to PSR-4.

No new tests should be needed because this is a refactor, so existing tests should catch any regressions.