### PR TITLE
Add autoloader package to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor/phpcompatibility
 vendor/sirbrillig
 vendor/squizlabs
 vendor/wp-coding-standards
+vendor/automattic/jetpack-autoloader
 /wpcom-test-backup/
 /.vscode/
 


### PR DESCRIPTION
Follow-up from #12777

#### Changes proposed in this Pull Request:

* That package does not need to be committed, just like it gets ignored for SVN since #12777.
* This is especially useful on release branches.

#### Testing instructions:

* It's hard to test outside of a release branch I think, because outside of release branches the whole `/vendor/automattic/` directory is .gitignored. That is not the case on release branches though.

#### Proposed changelog entry for your changes:

* None
