### PR TITLE
Remove Composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 		"issues": "https://github.com/Automattic/jetpack/issues"
 	},
 	"require": {
-		"composer/installers": "1.6.0",
 		"ext-openssl": "*",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-options": "@dev",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Those were already removed in #12479, but were added back by mistake in #1239

#### Testing instructions:

* Not much really. Try `yarn build`, and make sure Jetpack still loads.

#### Proposed changelog entry for your changes:

* None
