### PR TITLE
Stats settings: verbiage enhancements

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -200,7 +200,9 @@ class SiteStatsComponent extends React.Component {
 								onChange={ this.handleStatsOptionToggle( 'admin_bar' ) }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Put a chart showing 48 hours of views in the admin bar' ) }
+									{ __(
+										'Include a small chart in your admin bar with a 48-hour traffic snapshot'
+									) }
 								</span>
 							</CompactFormToggle>
 							<CompactFormToggle

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2033,7 +2033,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 			// Stats
 			'admin_bar' => array(
-				'description'       => esc_html__( 'Put a chart showing 48 hours of views in the admin bar.', 'jetpack' ),
+				'description'       => esc_html__( 'Include a small chart in your admin bar with a 48-hour traffic snapshot.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',


### PR DESCRIPTION
#9745 described a number of enhancements, some of which had already been implemented. We also superseded some of the changes in: #12779 

This brings the final change from that issue into play:

![Screenshot 2019-06-21 at 15 36 46](https://user-images.githubusercontent.com/411945/59930228-64b35880-943a-11e9-9588-08b7f9ca4088.png)

Fixes #9745

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/settings?term=stats
* Check the copy on the site stats card

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
