### PR TITLE
Upgrade prompt on share page for publicize

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -214,13 +214,10 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SCHEDULE_PUBLICIZE_JETPACK:
-				const isCurrentlyEnabled = props.getSettingCurrentValue( 'publicize' );
-
 				if (
 					'is-premium-plan' === planClass ||
 					'is-business-plan' === planClass ||
-					props.isDevMode ||
-					isCurrentlyEnabled
+					props.isDevMode
 				) {
 					return '';
 				}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -221,7 +221,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						title={ __(
-							'Auto-schedule your social media posts, so they are shared exactly when they should be.'
+							'Upgrade to customize your posting schedule. Your posts will be shared to social media exactly when you want them to be.'
 						) }
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -214,7 +214,11 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SCHEDULE_PUBLICIZE_JETPACK:
-				if ( 'is-premium-plan' === planClass || 'is-business-plan' === planClass ) {
+				if (
+					'is-premium-plan' === planClass ||
+					'is-business-plan' === planClass ||
+					! props.UnavailableInDevMode
+				) {
 					return '';
 				}
 

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -214,10 +214,13 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SCHEDULE_PUBLICIZE_JETPACK:
+				const isCurrentlyEnabled = props.getSettingCurrentValue( 'publicize' );
+
 				if (
 					'is-premium-plan' === planClass ||
 					'is-business-plan' === planClass ||
-					! props.UnavailableInDevMode
+					props.isDevMode ||
+					isCurrentlyEnabled
 				) {
 					return '';
 				}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -23,6 +23,7 @@ import {
 	FEATURE_WORDADS_JETPACK,
 	FEATURE_SPAM_AKISMET_PLUS,
 	FEATURE_SEARCH_JETPACK,
+	FEATURE_SCHEDULE_PUBLICIZE_JETPACK,
 	getPlanClass,
 } from 'lib/plans/constants';
 
@@ -150,7 +151,9 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.' ) }
+						title={ __(
+							'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.'
+						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
@@ -207,6 +210,24 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PERSONAL }
 						feature={ feature }
 						href={ props.spamUpgradeUrl }
+					/>
+				);
+
+			case FEATURE_SCHEDULE_PUBLICIZE_JETPACK:
+				if ( 'is-premium-plan' === planClass || 'is-business-plan' === planClass ) {
+					return '';
+				}
+
+				return (
+					<JetpackBanner
+						title={ __(
+							'Auto-schedule your social media posts, so they are shared exactly when they should be.'
+						) }
+						callToAction={ upgradeLabel }
+						plan={ PLAN_JETPACK_PREMIUM }
+						feature={ feature }
+						onClick={ handleClickForTracking( feature ) }
+						href={ props.publicizeUpgradeUrl }
 					/>
 				);
 
@@ -364,6 +385,7 @@ export default connect( state => {
 		adsUpgradeUrl: getUpgradeUrl( state, 'settings-ads' ),
 		securityProUpgradeUrl: getUpgradeUrl( state, 'settings-security-pro' ),
 		securityPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-security-premium' ),
+		publicizeUpgradeUrl: getUpgradeUrl( state, 'settings-publicize' ),
 		gaUpgradeUrl: getUpgradeUrl( state, 'settings-ga' ),
 		seoUpgradeUrl: getUpgradeUrl( state, 'settings-seo' ),
 		searchUpgradeUrl: getUpgradeUrl( state, 'settings-search' ),

--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -102,6 +102,7 @@ export const FEATURE_SEO_TOOLS_JETPACK = 'seo-tools-jetpack';
 export const FEATURE_WORDADS_JETPACK = 'wordads-jetpack';
 export const FEATURE_GOOGLE_ANALYTICS_JETPACK = 'google-analytics-jetpack';
 export const FEATURE_SEARCH_JETPACK = 'search-jetpack';
+export const FEATURE_SCHEDULE_PUBLICIZE_JETPACK = 'schedule-publicize-jetpack';
 
 export function isMonthly( plan ) {
 	return includes( JETPACK_MONTHLY_PLANS, plan );

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -72,6 +72,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 					feature={ FEATURE_SCHEDULE_PUBLICIZE_JETPACK }
 					module="publicize"
 					hideButton
+					isActive
+					unavailableInDevMode
 				>
 					{ userCanManageModules && (
 						<SettingsGroup

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -72,8 +72,6 @@ export const Publicize = withModuleSettingsFormHelpers(
 					feature={ FEATURE_SCHEDULE_PUBLICIZE_JETPACK }
 					module="publicize"
 					hideButton
-					isActive
-					unavailableInDevMode
 				>
 					{ userCanManageModules && (
 						<SettingsGroup

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -13,6 +13,7 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
+import { FEATURE_SCHEDULE_PUBLICIZE_JETPACK } from 'lib/plans/constants';
 
 export const Publicize = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -68,6 +69,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Publicize connections', { context: 'Settings header' } ) }
+					feature={ FEATURE_SCHEDULE_PUBLICIZE_JETPACK }
 					module="publicize"
 					hideButton
 				>


### PR DESCRIPTION
Currently, there is no upgrade prompt on the Settings > Sharing page. There are some great paid features, like being able to schedule your social media posts that we are not surfacing to users

Only visible to free and personal plans.

![Screenshot 2019-06-21 at 16 06 58](https://user-images.githubusercontent.com/411945/59932215-9e865e00-943e-11e9-8ffc-16244f155aff.png)

Fixes #12594

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/admin.php?page=jetpack#/sharing
* Test the banner on free and personal plans, it should be hidden on others
* Check events are firing

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
