### PR TITLE
Improve AMP support for Photon

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -356,6 +356,20 @@ class Jetpack_AMP_Support {
 	}
 
 	/**
+	 * Tells Jetpack not to enqueue CSS for share buttons.
+	 *
+	 * @param  bool $enqueue Whether or not to enqueue.
+	 * @return bool          Whether or not to enqueue.
+	 */
+	public static function amp_disable_sharedaddy_css( $enqueue ) {
+		if ( self::is_amp_request() ) {
+			$enqueue = false;
+		}
+
+		return $enqueue;
+	}
+
+	/**
 	 * Ensure proper Photon image dimensions for AMP Stories.
 	 *
 	 * @param array $args Array of Photon Arguments.

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -37,6 +37,9 @@ class Jetpack_AMP_Support {
 
 		// Add post template metadata for legacy AMP.
 		add_filter( 'amp_post_template_metadata', array( 'Jetpack_AMP_Support', 'amp_post_template_metadata' ), 10, 2 );
+
+		// Filter photon image args for AMP Stories.
+		add_filter( 'jetpack_photon_post_image_args', array( 'Jetpack_AMP_Support', 'filter_photon_post_image_args_for_stories' ), 10, 2 );
 	}
 
 	/**
@@ -353,17 +356,71 @@ class Jetpack_AMP_Support {
 	}
 
 	/**
-	 * Tells Jetpack not to enqueue CSS for share buttons.
+	 * Ensure proper Photon image dimensions for AMP Stories.
 	 *
-	 * @param  bool $enqueue Whether or not to enqueue.
-	 * @return bool          Whether or not to enqueue.
+	 * @param array $args Array of Photon Arguments.
+	 * @param array $details {
+	 *     Array of image details.
+	 *
+	 *     @type string    $tag            Image tag (Image HTML output).
+	 *     @type string    $src            Image URL.
+	 *     @type string    $src_orig       Original Image URL.
+	 *     @type int|false $width          Image width.
+	 *     @type int|false $height         Image height.
+	 *     @type int|false $width_orig     Original image width before constrained by content_width.
+	 *     @type int|false $height_orig    Original Image height before constrained by content_width.
+	 *     @type string    $transform_orig Original transform before constrained by content_width.
+	 * }
+	 * @return array Args.
 	 */
-	public static function amp_disable_sharedaddy_css( $enqueue ) {
-		if ( self::is_amp_request() ) {
-			$enqueue = false;
+	public static function filter_photon_post_image_args_for_stories( $args, $details ) {
+		if ( ! is_singular( 'amp_story' ) ) {
+			return $args;
 		}
 
-		return $enqueue;
+		// Percentage-based dimensions are not allowed in AMP, so this shouldn't happen, but short-circuit just in case.
+		if ( false !== strpos( $details['width_orig'], '%' ) || false !== strpos( $details['height_orig'], '%' ) ) {
+			return $args;
+		}
+
+		$max_height = 1440; // See image size with the slug \AMP_Story_Post_Type::MAX_IMAGE_SIZE_SLUG.
+		$transform  = $details['transform_orig'];
+		$width      = $details['width_orig'];
+		$height     = $details['height_orig'];
+
+		// If height is available, constrain to $max_height.
+		if ( false !== $height ) {
+			if ( $height > $max_height && false !== $height ) {
+				$width  = ( $max_height * $width ) / $height;
+				$height = $max_height;
+			} elseif ( $height > $max_height ) {
+				$height = $max_height;
+			}
+		}
+
+		/*
+		 * Set a height if none is found.
+		 * If height is set in this manner and height is available, use `fit` instead of `resize` to prevent skewing.
+		 */
+		if ( false === $height ) {
+			$height = $max_height;
+			if ( false !== $width ) {
+				$transform = 'fit';
+			}
+		}
+
+		// Build array of Photon args and expose to filter before passing to Photon URL function.
+		$args = array();
+
+		if ( false !== $width && false !== $height ) {
+			$args[ $transform ] = $width . ',' . $height;
+		} elseif ( false !== $width ) {
+			$args['w'] = $width;
+		} elseif ( false !== $height ) {
+			$args['h'] = $height;
+		}
+
+		return $args;
 	}
 }
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -419,6 +419,10 @@ class Jetpack_Photon {
 						list( $width, $height ) = Jetpack_Photon::parse_dimensions_from_filename( $src );
 					}
 
+					$width_orig     = $width;
+					$height_orig    = $height;
+					$transform_orig = $transform;
+
 					// If width is available, constrain to $content_width
 					if ( false !== $width && false === strpos( $width, '%' ) && is_numeric( $content_width ) ) {
 						if ( $width > $content_width && false !== $height && false === strpos( $height, '%' ) ) {
@@ -468,16 +472,19 @@ class Jetpack_Photon {
 					 *
 					 * @param array $args Array of Photon Arguments.
 					 * @param array $args {
-					 * 	 Array of image details.
+					 *     Array of image details.
 					 *
-					 * 	 @type $tag Image tag (Image HTML output).
-					 * 	 @type $src Image URL.
-					 * 	 @type $src_orig Original Image URL.
-					 * 	 @type $width Image width.
-					 * 	 @type $height Image height.
+					 *     @type string    $tag            Image tag (Image HTML output).
+					 *     @type string    $src            Image URL.
+					 *     @type string    $src_orig       Original Image URL.
+					 *     @type int|false $width          Image width.
+					 *     @type int|false $height         Image height.
+					 *     @type int|false $width_orig     Original image width before constrained by content_width.
+					 *     @type int|false $height_orig    Original Image height before constrained by content_width.
+					 *     @type string    $transform_orig Original transform before constrained by content_width.
 					 * }
 					 */
-					$args = apply_filters( 'jetpack_photon_post_image_args', $args, compact( 'tag', 'src', 'src_orig', 'width', 'height' ) );
+					$args = apply_filters( 'jetpack_photon_post_image_args', $args, compact( 'tag', 'src', 'src_orig', 'width', 'height', 'width_orig', 'height_orig', 'transform_orig' ) );
 
 					$photon_url = jetpack_photon_url( $src, $args );
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -239,7 +239,7 @@ class Jetpack_Photon {
 	public static function parse_images_from_html( $content ) {
 		$images = array();
 
-		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]*?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
+		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><(?:img|amp-img|amp-anim)[^>]*?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
 			foreach ( $images as $key => $unused ) {
 				// Simplify the output as much as possible, mostly for confirming test results.
 				if ( is_numeric( $key ) && $key > 0 )

--- a/class.photon.php
+++ b/class.photon.php
@@ -471,7 +471,7 @@ class Jetpack_Photon {
 					 * @since 2.0.0
 					 *
 					 * @param array $args Array of Photon Arguments.
-					 * @param array $args {
+					 * @param array $details {
 					 *     Array of image details.
 					 *
 					 *     @type string    $tag            Image tag (Image HTML output).
@@ -481,10 +481,11 @@ class Jetpack_Photon {
 					 *     @type int|false $height         Image height.
 					 *     @type int|false $width_orig     Original image width before constrained by content_width.
 					 *     @type int|false $height_orig    Original Image height before constrained by content_width.
+					 *     @type string    $transform      Transform.
 					 *     @type string    $transform_orig Original transform before constrained by content_width.
 					 * }
 					 */
-					$args = apply_filters( 'jetpack_photon_post_image_args', $args, compact( 'tag', 'src', 'src_orig', 'width', 'height', 'width_orig', 'height_orig', 'transform_orig' ) );
+					$args = apply_filters( 'jetpack_photon_post_image_args', $args, compact( 'tag', 'src', 'src_orig', 'width', 'height', 'width_orig', 'height_orig', 'transform', 'transform_orig' ) );
 
 					$photon_url = jetpack_photon_url( $src, $args );
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -543,7 +543,7 @@ class Jetpack_Photon {
 						}
 
 						// Tag an image for dimension checking
-						if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+						if ( ! self::is_amp_endpoint() ) {
 							$new_tag = preg_replace( '#(\s?/)?>(\s*</a>)?$#i', ' data-recalc-dims="1"\1>\2', $new_tag );
 						}
 
@@ -1190,7 +1190,7 @@ class Jetpack_Photon {
 	 * @return null
 	 */
 	public function action_wp_enqueue_scripts() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( self::is_amp_endpoint() ) {
 			return;
 		}
 		wp_enqueue_script(
@@ -1272,5 +1272,17 @@ class Jetpack_Photon {
 	 */
 	public function _override_image_downsize_in_rest_edit_context() {
 		return true;
+	}
+
+	/**
+	 * Return whether the current page is AMP.
+	 *
+	 * This is only present for the sake of WordPress.com where the Jetpack_AMP_Support
+	 * class does not yet exist. This mehod may only be called at the wp action or later.
+	 *
+	 * @return bool Whether AMP page.
+	 */
+	private static function is_amp_endpoint() {
+		return class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
 	}
 }

--- a/class.photon.php
+++ b/class.photon.php
@@ -536,7 +536,9 @@ class Jetpack_Photon {
 						}
 
 						// Tag an image for dimension checking
-						$new_tag = preg_replace( '#(\s?/)?>(\s*</a>)?$#i', ' data-recalc-dims="1"\1>\2', $new_tag );
+						if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+							$new_tag = preg_replace( '#(\s?/)?>(\s*</a>)?$#i', ' data-recalc-dims="1"\1>\2', $new_tag );
+						}
 
 						// Replace original tag with modified version
 						$content = str_replace( $tag, $new_tag, $content );

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -905,12 +905,15 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	 * @covers Jetpack_Photon::filter_the_content
 	 * @dataProvider photon_attributes_when_amp_response
 	 * @since 7.6.0
+	 *
+	 * @param string $sample_html Sample HTML.
+	 * @param string $photon_src  Photon URL suffix (after the subdomain).
 	 */
 	public function test_photon_filter_the_content_for_amp_responses( $sample_html, $photon_src ) {
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
-		$this->assertSame( $photon_src, html_entity_decode( $attributes['src']['value'] ) );
+		$this->assertStringEndsWith( $photon_src, html_entity_decode( $attributes['src']['value'] ) );
 		$this->assertArrayHasKey( 'width', $attributes );
 		$this->assertArrayHasKey( 'height', $attributes );
 		$this->assertNotContains( 'data-recalc-dims', $filtered_content );
@@ -925,11 +928,11 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		return array(
 			'amp-img' => array(
 				'<amp-img class="aligncenter wp-image-6372" title="Tube Bomber salmon dry fly" alt="Tube Bomber salmon dry fly" src="http://www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg" width="102" height="61"></amp-img>',
-				'https://i1.wp.com/www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg?resize=102%2C61',
+				'.wp.com/www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg?resize=102%2C61',
 			),
 			'amp-anim' => array(
 				'<amp-anim alt="LOL" src="https://example.com/lol.gif" width="32" height="32"></amp-anim>',
-				'https://i0.wp.com/example.com/lol.gif?resize=32%2C32&ssl=1',
+				'.wp.com/example.com/lol.gif?resize=32%2C32&ssl=1',
 			),
 		);
 	}
@@ -961,7 +964,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$filtered_content = apply_filters( 'the_content', $content, $post->ID );
 
 		$this->assertContains(
-			'https://i0.wp.com/example.com/wp-content/uploads/2019/06/huge.jpg?h=1440&#038;ssl=1',
+			'.wp.com/example.com/wp-content/uploads/2019/06/huge.jpg?h=1440&#038;ssl=1',
 			$filtered_content
 		);
 

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -804,6 +804,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 
 		$this->assertArrayNotHasKey( 'width', $attributes );
 		$this->assertArrayNotHasKey( 'height', $attributes );
+		$this->assertContains( 'data-recalc-dims', $filtered_content );
 	}
 
 	/**
@@ -815,9 +816,9 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	public function test_photon_filter_the_content_width_height_attributes_when_image_args_filtered( $filter_callback, $has_attributes, $width, $height ) {
 		list( $sample_html ) = $this->get_photon_sample_content( 'a-tags-without-images.html' );
 
-		add_filter( 'jetpack_photon_post_image_args', array( $this, $filter_callback ) );
+		add_filter( 'jetpack_photon_post_image_args', $filter_callback, 10, 2 );
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
-		remove_filter( 'jetpack_photon_post_image_args', array( $this, $filter_callback ) );
+		remove_filter( 'jetpack_photon_post_image_args', $filter_callback, 10, 2 );
 
 		$first_line = strtok( $filtered_content, "\n" ); // Should contain an image tag on the first line
 		$attributes = wp_kses_hair( $first_line, wp_allowed_protocols() );
@@ -836,27 +837,62 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	}
 
 	public function photon_attributes_when_filtered_data_provider() {
+		$that = $this; // For sake of PHP 5.3.
+
+		$assert_details = function ( $details ) use ( $that ) {
+			$that->assertInternalType( 'array', $details );
+			$that->assertArrayHasKey( 'tag', $details );
+			$that->assertArrayHasKey( 'src', $details );
+			$that->assertArrayHasKey( 'src_orig', $details );
+			$that->assertArrayHasKey( 'width', $details );
+			$that->assertArrayHasKey( 'width_orig', $details );
+			$that->assertArrayHasKey( 'height', $details );
+			$that->assertArrayHasKey( 'height_orig', $details );
+			$that->assertArrayHasKey( 'transform', $details );
+			$that->assertArrayHasKey( 'transform_orig', $details );
+		};
+
 		return array(
 			'photon_post_image_args_force_resize' => array(
-				'photon_post_image_args_force_resize',
+				function( $args, $details ) use ( $assert_details ) {
+					$assert_details( $details );
+					return array(
+						'resize' => '300,250'
+					);
+				},
 				true,
 				300,
 				250
 			),
 			'photon_post_image_args_force_fit' => array(
-				'photon_post_image_args_force_fit',
+				function ( $args, $details ) use ( $assert_details ) {
+					$assert_details( $details );
+					return array(
+						'fit' => '600,600'
+					);
+				},
 				true,
 				600,
 				600
 			),
 			'photon_post_image_args_force_lb' => array(
-				'photon_post_image_args_force_lb',
+				function ( $args, $details ) use ( $assert_details ) {
+					$assert_details( $details );
+					return array(
+						'lb' => '800,100,000000'
+					);
+				},
 				true,
 				800,
 				100
 			),
 			'photon_post_image_args_force_width_only' => array(
-				'photon_post_image_args_force_width_only',
+				function ( $args, $details ) use ( $assert_details ) {
+					$assert_details( $details );
+					return array(
+						'w' => '104'
+					);
+				},
 				false,
 				false,
 				false
@@ -864,28 +900,72 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		);
 	}
 
-	public function photon_post_image_args_force_resize() {
+	/**
+	 * @author westonruter
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @dataProvider photon_attributes_when_amp_response
+	 * @since 7.6.0
+	 */
+	public function test_photon_filter_the_content_for_amp_responses( $sample_html, $photon_src ) {
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$attributes = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$this->assertSame( $photon_src, html_entity_decode( $attributes['src']['value'] ) );
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertArrayHasKey( 'height', $attributes );
+		$this->assertNotContains( 'data-recalc-dims', $filtered_content );
+	}
+
+	/**
+	 * Data provider for testing AMP responses.
+	 *
+	 * @return array
+	 */
+	public function photon_attributes_when_amp_response() {
 		return array(
-			'resize' => '300,250'
+			'amp-img' => array(
+				'<amp-img class="aligncenter wp-image-6372" title="Tube Bomber salmon dry fly" alt="Tube Bomber salmon dry fly" src="http://www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg" width="102" height="61"></amp-img>',
+				'https://i1.wp.com/www.fishmadman.com/pages/wp-content/uploads/2012/02/Rav-fra-2004-2009-11-1024x611.jpg?resize=102%2C61',
+			),
+			'amp-anim' => array(
+				'<amp-anim alt="LOL" src="https://example.com/lol.gif" width="32" height="32"></amp-anim>',
+				'https://i0.wp.com/example.com/lol.gif?resize=32%2C32&ssl=1',
+			),
 		);
 	}
 
-	public function photon_post_image_args_force_fit() {
-		return array(
-			'fit' => '600,600'
-		);
-	}
+	/**
+	 * @author westonruter
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @covers Jetpack_AMP_Support::filter_photon_post_image_args_for_stories
+	 * @since 7.6.0
+	 */
+	public function test_photon_filter_the_content_for_amp_story() {
+		$post_type = 'amp_story';
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		register_post_type( $post_type, array( 'public' => true ) );
+		Jetpack_AMP_Support::init();
+		$post = $this->factory()->post->create_and_get( compact( 'post_type' ) );
+		$this->go_to( get_permalink( $post ) );
+		$this->assertTrue( is_singular( $post_type ) );
 
-	public function photon_post_image_args_force_lb() {
-		return array(
-			'lb' => '800,100,000000'
+		$content = implode(
+			"\n",
+			array(
+				'<!-- wp:amp/amp-story-page {"mediaId":2414,"mediaType":"image","focalPoint":{"x":0.4900990099009901,"y":0.5131578947368421}} -->',
+				'<amp-story-page style="background-color:#ffffff" id="a6c81a13-14a0-464b-88fa-9612e86bacf7" class="wp-block-amp-amp-story-page"><amp-story-grid-layer template="fill"><amp-img layout="fill" src="https://example.com/wp-content/uploads/2019/06/huge.jpg" style="object-position:49.00990099009901% 51.31578947368421%"></amp-img></amp-story-grid-layer><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page>',
+				'<!-- /wp:amp/amp-story-page -->',
+			)
 		);
-	}
 
-	public function photon_post_image_args_force_width_only() {
-		return array(
-			'w' => '104'
+		$filtered_content = apply_filters( 'the_content', $content, $post->ID );
+
+		$this->assertContains(
+			'https://i0.wp.com/example.com/wp-content/uploads/2019/06/huge.jpg?h=1440&#038;ssl=1',
+			$filtered_content
 		);
+
+		unregister_post_type( $post_type );
 	}
 
 	/**


### PR DESCRIPTION
In testing a site using the [AMP plugin](https://wordpress.org/plugins/amp/) in Standard/Transitional mode and in AMP Stories, I noticed a couple issues where Photon could better support AMP.

# Proposed Changes

## Support photonification of `amp-img` like `img`

I noticed that an `<amp-img>` put directly into `post_content` does not get processed by Photon. This isn't particularly surprising since it would be looking for `<img>` not `<amp-img>` (or `<amp-anim>`). To fix this, the regex in `\Jetpack_Photon::parse_images_from_html()` just needs to be updated like so:

```diff
- (?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]*?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?
+ (?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><(?:img|amp-img|amp-anim)[^>]*?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?
```

Given `post_content` (e.g. a Custom HTML block) containing:

```html
<amp-img src="https://example.com/wp-content/uploads/2019/06/downasaur-150x150.jpg" alt="" class="wp-image-9451" width="100" height=100></amp-img>
```

Before, with no change because Photon didn't see it:

```html
<amp-img src="https://example.com/wp-content/uploads/2019/06/downasaur-150x150.jpg" alt="" class="wp-image-9451" width="100" height="100"></amp-img>
```

After, with image being replaced with Photon CDN as expected:

```html
<amp-img src="https://i2.wp.com/example.com/wp-content/uploads/2019/06/downasaur.jpg?resize=100%2C100&amp;ssl=1" alt="" class="wp-image-9451" width="100" height="100"></amp-img>
```

## Remove unnecessary `data-recalc-dims=1`

Additionally I noticed that Photon was adding the `data-recalc-dims=1` attribute to images, but this is irrelevant in AMP since the `devicepx` JS is not loaded. So I'm not omitting this in AMP.

## Prevent constraining to `content_width` in Stories

Originally reported in https://github.com/ampproject/amp-wp/issues/2595.

The AMP Stories experience (`amp_story` plugin) intends to constrain the _height_ of images to be 1440px, given the vertical resolution of mobile devices. This turned out to fail to work as expected when Photon supplied, since it constrains based on the theme's `content_width`.

For example, when setting the background image for a story page when a theme has a `640` content width, the generated markup with Photon is:

```html
<amp-img layout="fill" src="https://i2.wp.com/example.com/wp-content/uploads/2019/06/downasaur.jpg?w=640&amp;ssl=1" class="amp-wp-6ed12b8"></amp-img>
```

The `w=640` is the problem here. What is actually desired is `h=1440`.

In order to accomplish this, this PR adds a `jetpack_photon_post_image_args` filter which runs when on a singular `amp_story` post to override the args to be appropriate for the format.

In order to achieve this, additional context params needed to be passed to `jetpack_photon_post_image_args` in order to basically re-factor the following logic using a fixed height of 1440px instead of the `content_width`:

https://github.com/Automattic/jetpack/blob/596bdd6f1b2979217b3ef1179ef28c083d47c9a6/class.photon.php#L422-L458

When this change is paired with support for photonizing `<amp-img>` in `post_content` (which the `amp_story` post type does), the result is a user can successfully upload new large images and have them appear with the expected 1440px height as opposed to the full size or a `content_width`-constrained size.

# Testing instructions:

0. Upload a large image to the media library (do this first before the following).
1. Activate photon module
2. Install and activate AMP v1.2 and enable the Stories experience.
3. Upload another large image.
4. Create a new story and select the first uploaded image as a page background,  then add another page and use the second image as its background.
5. Confirm that both story pages have images that include `h=1440`.

# Proposed changelog entry for your changes:

* Improve AMP support in Photon, including handling of `<amp-img>` and `<amp-anim>` in `post_content` and ensuring proper height-constrained images are used in AMP Stories. Adds additional context to `jetpack_photon_post_image_args` filter, and remove AMP-unnecessary `data-recalc-dims` attribute.
