### PR TITLE
SSO: use login when it's a noun vs. log in when it's a verb.

### DIFF
--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -59,7 +59,7 @@ export const SSO = withModuleSettingsFormHelpers(
 					{ ...this.props }
 					hideButton
 					module="sso"
-					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }
+					header={ __( 'WordPress.com login', { context: 'Settings header' } ) }
 				>
 					<SettingsGroup
 						hasChild
@@ -74,7 +74,7 @@ export const SSO = withModuleSettingsFormHelpers(
 					>
 						<p>
 							{ __(
-								'Add an extra layer of security to your website by enabling WordPress.com log in and secure ' +
+								'Add an extra layer of security to your website by enabling WordPress.com login and secure ' +
 									'authentication. If you have multiple sites with this option enabled, you will be able to log in to every ' +
 									'one of them with the same credentials.'
 							) }

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -59,7 +59,7 @@ export const SSO = withModuleSettingsFormHelpers(
 					{ ...this.props }
 					hideButton
 					module="sso"
-					header={ __( 'WordPress.com login', { context: 'Settings header' } ) }
+					header={ __( 'WordPress.com login', { context: 'Settings header, noun.' } ) }
 				>
 					<SettingsGroup
 						hasChild


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* WordPress login if it’s a noun vs log in if it’s a verb — highlighted below

![image](https://user-images.githubusercontent.com/426388/60003464-0de09580-966b-11e9-8c5d-74c5394e1c99.png)

#### Testing instructions:

* Go to Jetpack > Settings > Security
* Verify copy

#### Proposed changelog entry for your changes:

* None
