### PR TITLE
Remove promise to reduce hosting costs

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -207,7 +207,7 @@ class Jetpack_Connection_Banner {
 							<p>
 								<?php
 								esc_html_e(
-									'Activate site accelerator tools and watch your page load times and hosting costs drop – we’ll ' .
+									'Activate site accelerator tools and watch your page load times decrease—we’ll ' .
 									'optimize your images and serve them from our own powerful global network of servers, ' .
 									'and speed up your mobile site to reduce bandwidth usage.',
 									'jetpack'
@@ -288,7 +288,7 @@ class Jetpack_Connection_Banner {
 						<div class="jp-connect-full__slide-card">
 							<p><?php
 								esc_html_e(
-									"Activate site accelerator tools and watch your page load times and hosting costs drop—" .
+									"Activate site accelerator tools and watch your page load times decrease—" .
 									"we'll optimize your images and serve them from our own powerful global network of servers, " .
 									"and speed up your mobile site to reduce bandwidth usage.",
 									'jetpack'

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Jetpack is your site's security detail, guarding you against brute-force attacks
 * Fast, priority support from WordPress experts.
 
 = Peak Performance =
-Activate site accelerator tools and watch your page load times and hosting costs drop -- we'll optimize your images and serve them from our own powerful global network, and speed up your mobile site to reduce bandwidth usage (and save money!). Connect Jetpack to take advantage of:
+Activate site accelerator tools and watch your page load times decrease -- we'll optimize your images and serve them from our own powerful global network, and speed up your mobile site to reduce bandwidth usage (and save money!). Connect Jetpack to take advantage of:
 
 * Images and static files, like CSS and JavaScript, served from our servers, not yours.
 * Elasticsearch-powered related content and site search, for relevant results with no drain on your servers.


### PR DESCRIPTION
Our commitment to reducing hosting hosts cannot be proven and few hosts charge this way.

Fixes #12432 

#### Testing instructions:
* Go to wp-admin/admin.php?page=jetpack#/dashboard on a disconnected site
* Verify changes

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
