### PR TITLE
Release script: update list of files that ship with each release

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -33,7 +33,9 @@ vendor/wp-coding-standards
 vendor/automattic/jetpack-autoloader
 vendor/automattic/**/tests/
 vendor/automattic/**/README.md
+vendor/automattic/**/phpunit.xml
 vendor/automattic/**/phpunit.xml.dist
+vendor/automattic/**/composer.json
 composer.lock
 package.json
 gulpfile.js

--- a/.svnignore
+++ b/.svnignore
@@ -31,6 +31,9 @@ vendor/sirbrillig
 vendor/squizlabs
 vendor/wp-coding-standards
 vendor/automattic/jetpack-autoloader
+vendor/automattic/**/tests/
+vendor/automattic/**/README.md
+vendor/automattic/**/phpunit.xml.dist
 composer.lock
 package.json
 gulpfile.js

--- a/.svnignore
+++ b/.svnignore
@@ -19,8 +19,10 @@ renovate.json
 bin/phpcs-whitelist.js
 bin/pre-commit-hook.js
 bin/release-package.php
+css/*.css.map
 docs
 tests
+scss
 tools
 vendor/bin
 vendor/dealerdirect

--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -1,4 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# This script requires Bash 4+, since we want a version of Bash that supports globstar.
+if [ -z "${BASH_VERSINFO}" ] || [ -z "${BASH_VERSINFO[0]}" ] || [ ${BASH_VERSINFO[0]} -lt 4 ]; then
+	echo "This script requires Bash version >= 4."
+	read -p "Do you want to install it on your system with Homebrew? [y/N]" -n 1 -r
+	if [[ $REPLY != "y" && $REPLY != "Y" ]]; then
+		exit 1;
+	else
+		brew install bash 2>/dev/null
+		echo "Done!"
+	fi
+fi
 
 if [ $# -eq 0 ]; then
 	echo 'Usage: `./deploy-to-svn.sh <tag | HEAD>`'
@@ -69,6 +81,7 @@ echo "Done!"
 
 echo "Purging paths included in .svnignore"
 # check .svnignore
+shopt -s globstar # Support globs.
 for file in $( cat "$JETPACK_GIT_DIR/.svnignore" 2>/dev/null ); do
 	rm -rf $JETPACK_SVN_DIR/trunk/$file
 done


### PR DESCRIPTION
Fixes #12808

#### Changes proposed in this Pull Request:

- [x] - Make sure the release script can process globs in `.svnignore`
- [x] - Do not ship the scss directory
- [x] - Do not ship the Unit Tests, Unit Test config files, and readme files that ship with each package in `vendor/automattic`.
- [x] - Do not ship any `css/*.css.map` files.

--------

Once we take care of that first item, the following existing rules from the `.svnignore` file will be respected:
```
extensions/**/*.css
extensions/**/*.gif
extensions/**/*.jpeg
extensions/**/*.jpg
extensions/**/*.js
extensions/**/*.json
extensions/**/*.jsx
extensions/**/*.md
extensions/**/*.png
extensions/**/*.sass
extensions/**/*.scss
extensions/**/*.svg
```
As a result, we will not be shipping any more unbuilt block files with the plugin. We should make sure this is okay, and won't cause any issues with block translations: p1561379577167900-slack-jetpack-crew

--------

The easiest way to handle that first item seems to be to rely on recent versions of Bash (not shipped by default with Mac OS), that support globstar. Since there are only a handful of us pushing releases out, I think it's not too bad of a thing to require. I opted to suggest an installation via Homebrew when one does not run an up to date version of Bash since Mac OS is the majority around these parts. @zinigor I realize this excludes you. :( What do you think about this?

#### Testing instructions:

* On this branch, run `yarn build-production`
* Run `curl -O https://gist.githubusercontent.com/jeherve/2692e31475aa339233f98387b743208c/raw/eddd55b9a6ea3626cc1442e4d4ee9b37354f7448/12832.diff && git apply 12832.diff`
* Run `./tools/12832.sh`
* Run `cd /tmp/12832`
* Check that all files are there in the `vendor/automattic/` directory, except for test files.

#### Proposed changelog entry for your changes:

* None
