### PR TITLE
At a Glance - update DashItem card titles

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -52,7 +52,7 @@ class DashAkismet extends Component {
 
 	getContent() {
 		const akismetData = this.props.akismetData;
-		const labelName = __( 'Jetpack Anti-spam' );
+		const labelName = __( 'Anti-spam' );
 
 		const support = {
 			text: __(

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -28,7 +28,7 @@ import { showBackups } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Jetpack Backup' ) }
+		label={ __( 'Backups' ) }
 		module={ props.feature || 'backups' }
 		support={ {
 			text: __(

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -28,7 +28,7 @@ import { showBackups } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Backups' ) }
+		label={ __( 'Backup' ) }
 		module={ props.feature || 'backups' }
 		support={ {
 			text: __(

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -28,7 +28,7 @@ import { showBackups } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Backups' ) }
+		label={ __( 'Jetpack Backup' ) }
 		module={ props.feature || 'backups' }
 		support={ {
 			text: __(

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -30,7 +30,7 @@ class DashMonitor extends Component {
 	};
 
 	getContent() {
-		const labelName = __( 'Downtime monitoring' );
+		const labelName = __( 'Downtime monitor' );
 
 		const support = {
 			text: __(

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -36,7 +36,7 @@ class DashProtect extends Component {
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return (
 					<DashItem
-						label="Jetpack Protect"
+						label="Protect"
 						module="protect"
 						support={ support }
 						status="is-working"
@@ -54,7 +54,7 @@ class DashProtect extends Component {
 				);
 			}
 			return (
-				<DashItem label="Jetpack Protect" module="protect" support={ support } status="is-working">
+				<DashItem label="Protect" module="protect" support={ support } status="is-working">
 					<h2 className="jp-dash-item__count">{ numberFormat( protectCount ) }</h2>
 					<p className="jp-dash-item__description">
 						{ __( 'Total malicious attacks blocked on your site.' ) }
@@ -65,7 +65,7 @@ class DashProtect extends Component {
 
 		return (
 			<DashItem
-				label="Jetpack Protect"
+				label="Protect"
 				module="protect"
 				support={ support }
 				className="jp-dash-item__is-inactive"

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -25,6 +25,7 @@ class DashProtect extends Component {
 	activateProtect = () => this.props.updateOptions( { protect: true } );
 
 	getContent() {
+		const labelName = __( 'Protect' );
 		const support = {
 			text: __( 'Protects your site from traditional and distributed brute force login attacks.' ),
 			link: 'https://jetpack.com/support/protect/',
@@ -36,7 +37,7 @@ class DashProtect extends Component {
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return (
 					<DashItem
-						label="Protect"
+						label={ labelName }
 						module="protect"
 						support={ support }
 						status="is-working"
@@ -54,7 +55,7 @@ class DashProtect extends Component {
 				);
 			}
 			return (
-				<DashItem label="Protect" module="protect" support={ support } status="is-working">
+				<DashItem label={ labelName } module="protect" support={ support } status="is-working">
 					<h2 className="jp-dash-item__count">{ numberFormat( protectCount ) }</h2>
 					<p className="jp-dash-item__description">
 						{ __( 'Total malicious attacks blocked on your site.' ) }
@@ -65,7 +66,7 @@ class DashProtect extends Component {
 
 		return (
 			<DashItem
-				label="Protect"
+				label={ labelName }
 				module="protect"
 				support={ support }
 				className="jp-dash-item__is-inactive"

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -54,7 +54,7 @@ class DashProtect extends Component {
 				);
 			}
 			return (
-				<DashItem label="Protect" module="protect" support={ support } status="is-working">
+				<DashItem label="Jetpack Protect" module="protect" support={ support } status="is-working">
 					<h2 className="jp-dash-item__count">{ numberFormat( protectCount ) }</h2>
 					<p className="jp-dash-item__description">
 						{ __( 'Total malicious attacks blocked on your site.' ) }
@@ -65,7 +65,7 @@ class DashProtect extends Component {
 
 		return (
 			<DashItem
-				label="Protect"
+				label="Jetpack Protect"
 				module="protect"
 				support={ support }
 				className="jp-dash-item__is-inactive"

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -36,7 +36,7 @@ class DashProtect extends Component {
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return (
 					<DashItem
-						label="Protect"
+						label="Jetpack Protect"
 						module="protect"
 						support={ support }
 						status="is-working"

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -29,7 +29,7 @@ import JetpackBanner from 'components/jetpack-banner';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Jetpack Scan' ) }
+		label={ __( 'Scan' ) }
 		module={ props.feature || 'scan' }
 		support={ {
 			text: __(

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -29,7 +29,7 @@ import JetpackBanner from 'components/jetpack-banner';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Security Scanning' ) }
+		label={ __( 'Jetpack Scan' ) }
 		module={ props.feature || 'scan' }
 		support={ {
 			text: __(


### PR DESCRIPTION
The card titles were inconsistent. I changed them to just be the title (without the `Jetpack ` prefix.

One section I did not change was Search. I feel Search needs something else with it to make it more obvious it's not just a regular old search. It currently reads "Jetpack Search."

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates card titles to be consistent

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Just copy changes

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Go to the Jetpack Dashboard
* Review the labels of each DashItem

#### Before
![image](https://user-images.githubusercontent.com/1123119/60033596-b8ea5280-965d-11e9-863e-268a051e1801.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/60035363-83476880-9661-11e9-86c8-439d7c29867f.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed.
