### PR TITLE
Add JetpackBanner to Backups card in At-a-Glance

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -40,6 +40,7 @@ const renderCard = props => (
 		className={ props.className }
 		status={ props.status }
 		pro={ true }
+		overrideContent={ props.overrideContent }
 	>
 		<p className="jp-dash-item__description">{ props.content }</p>
 	</DashItem>
@@ -231,13 +232,13 @@ class DashBackups extends Component {
 	}
 }
 
-export default connect( ( state, { source } ) => {
+export default connect( state => {
 	return {
 		vaultPressData: getVaultPressData( state ),
 		sitePlan: getSitePlan( state ),
 		isDevMode: isDevMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		showBackups: showBackups( state ),
-		upgradeUrl: getUpgradeUrl( state, source ),
+		upgradeUrl: getUpgradeUrl( state, 'aag-backups' ),
 	};
 } )( DashBackups );

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -140,7 +140,7 @@ class DashBackups extends Component {
 						eventFeature="backups"
 						path="dashboard"
 						plan={ PLAN_JETPACK_PREMIUM }
-						icon="lock"
+						icon="history"
 					/>
 				),
 			} );

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -7,18 +7,19 @@ import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
 import { get, isEmpty, noop } from 'lodash';
+import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import JetpackBanner from 'components/jetpack-banner';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
-import UpgradeLink from 'components/upgrade-link';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
-import { showBackups } from 'state/initial-state';
+import { getUpgradeUrl, showBackups } from 'state/initial-state';
 
 /**
  * Displays a card for Backups based on the props given.
@@ -55,6 +56,7 @@ class DashBackups extends Component {
 		sitePlan: PropTypes.object.isRequired,
 		isDevMode: PropTypes.bool.isRequired,
 		isVaultPressInstalled: PropTypes.bool.isRequired,
+		upgradeUrl: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -126,13 +128,19 @@ class DashBackups extends Component {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
-				content: __(
-					'To automatically back up your entire site, please {{a}}upgrade your account{{/a}}.',
-					{
-						components: {
-							a: <UpgradeLink source="aag-backups" target="at-a-glance" feature="backups" />,
-						},
-					}
+				overrideContent: (
+					<JetpackBanner
+						callToAction={ __( 'Upgrade' ) }
+						title={ __(
+							'Never worry about losing your site – automatic backups keep your content safe.'
+						) }
+						disableHref="false"
+						href={ this.props.upgradeUrl }
+						eventFeature="backups"
+						path="dashboard"
+						plan={ PLAN_JETPACK_PREMIUM }
+						icon="lock"
+					/>
 				),
 			} );
 		}
@@ -223,12 +231,13 @@ class DashBackups extends Component {
 	}
 }
 
-export default connect( state => {
+export default connect( ( state, { source } ) => {
 	return {
 		vaultPressData: getVaultPressData( state ),
 		sitePlan: getSitePlan( state ),
 		isDevMode: isDevMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		showBackups: showBackups( state ),
+		upgradeUrl: getUpgradeUrl( state, source ),
 	};
 } )( DashBackups );


### PR DESCRIPTION
Similar to what https://github.com/Automattic/jetpack/pull/12600 did for the Scan card, this adds a JetpackBanner to the Backups card on the At-a-Glance page.

Fixes #12565 

#### Changes proposed in this Pull Request:
* Updates the Backups card on the At-a-Glance page to use the JetpackBanner component.

Before:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/42627630/60044488-198e8500-9688-11e9-8363-8106945be9a3.png">

After:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/42627630/60044527-2f03af00-9688-11e9-89a9-51f94107233f.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the At a Glance Tuneup project

#### Testing instructions:
* Go to the At-a-Glance page on a Jetpack Free plan.
* Verify that a JetpackBanner is prompting an upgrade on the backups card.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Changes to upgrade messaging on the Backups card.
