### PR TITLE
Add JetpackBanner to Akismet card in At-a-Glance

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -66,7 +66,7 @@ class DashAkismet extends Component {
 			privacyLink: 'https://automattic.com/privacy/',
 		};
 
-		if ( akismetData === 'N/A' ) {
+		if ( 'N/A' === akismetData ) {
 			return (
 				<DashItem label={ labelName } module="akismet" support={ support } pro={ true }>
 					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
@@ -76,7 +76,7 @@ class DashAkismet extends Component {
 
 		const hasSitePlan = false !== this.props.sitePlan;
 
-		if ( akismetData === 'not_installed' ) {
+		if ( 'not_installed' === akismetData ) {
 			return (
 				<DashItem
 					label={ labelName }
@@ -104,7 +104,7 @@ class DashAkismet extends Component {
 			);
 		}
 
-		if ( akismetData === 'not_active' ) {
+		if ( 'not_active' === akismetData ) {
 			return (
 				<DashItem
 					label={ labelName }
@@ -132,7 +132,7 @@ class DashAkismet extends Component {
 			);
 		}
 
-		if ( akismetData === 'invalid_key' ) {
+		if ( 'invalid_key' === akismetData ) {
 			return (
 				<DashItem
 					label={ labelName }

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -137,7 +137,7 @@ class DashAkismet extends Component {
 						eventFeature="akismet"
 						path="dashboard"
 						plan={ PLAN_JETPACK_PREMIUM }
-						icon="lock"
+						icon="flag"
 					/>
 				) : null;
 

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
-import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import { PLAN_JETPACK_PREMIUM, getPlanClass } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -105,20 +105,41 @@ class DashAkismet extends Component {
 		}
 
 		if ( akismetData === 'not_active' ) {
-			const activateContent = (
-				<JetpackBanner
-					callToAction={ __( 'Activate' ) }
-					title={ __(
-						'Automatically clear spam from your comments and forms so you can get back to your business.'
-					) }
-					disableHref="false"
-					href={ this.props.upgradeUrl }
-					eventFeature="akismet"
-					path="dashboard"
-					plan={ PLAN_JETPACK_PREMIUM }
-					icon="lock"
-				/>
-			);
+			const planClass = getPlanClass( this.props.sitePlan.product_slug );
+
+			const activateContent =
+				'is-free-plan' === planClass ? null : (
+					<p className="jp-dash-item__description">
+						{ __( 'For state-of-the-art spam defense, please {{a}}activate Akismet{{/a}}.', {
+							components: {
+								a: (
+									<a
+										href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl }
+										onClick={ this.trackActivateClick }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</p>
+				);
+
+			const upgradeContent =
+				'is-free-plan' === planClass ? (
+					<JetpackBanner
+						callToAction={ __( 'Activate' ) }
+						title={ __(
+							'Automatically clear spam from your comments and forms so you can get back to your business.'
+						) }
+						disableHref="false"
+						href={ this.props.upgradeUrl }
+						eventFeature="akismet"
+						path="dashboard"
+						plan={ PLAN_JETPACK_PREMIUM }
+						icon="lock"
+					/>
+				) : null;
 
 			return (
 				<DashItem
@@ -128,8 +149,10 @@ class DashAkismet extends Component {
 					status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
 					className="jp-dash-item__is-inactive"
 					pro={ true }
-					overrideContent={ activateContent }
-				/>
+					overrideContent={ upgradeContent }
+				>
+					{ activateContent }
+				</DashItem>
 			);
 		}
 

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
-import { PLAN_JETPACK_PREMIUM, getPlanClass } from 'lib/plans/constants';
+import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -105,10 +105,15 @@ class DashAkismet extends Component {
 		}
 
 		if ( akismetData === 'not_active' ) {
-			const planClass = getPlanClass( this.props.sitePlan.product_slug );
-
-			const activateContent =
-				'is-free-plan' === planClass ? null : (
+			return (
+				<DashItem
+					label={ labelName }
+					module="akismet"
+					support={ support }
+					status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
+					className="jp-dash-item__is-inactive"
+					pro={ true }
+				>
 					<p className="jp-dash-item__description">
 						{ __( 'For state-of-the-art spam defense, please {{a}}activate Akismet{{/a}}.', {
 							components: {
@@ -123,35 +128,6 @@ class DashAkismet extends Component {
 							},
 						} ) }
 					</p>
-				);
-
-			const upgradeContent =
-				'is-free-plan' === planClass ? (
-					<JetpackBanner
-						callToAction={ __( 'Upgrade' ) }
-						title={ __(
-							'Automatically clear spam from your comments and forms so you can get back to your business.'
-						) }
-						disableHref="false"
-						href={ this.props.upgradeUrl }
-						eventFeature="akismet"
-						path="dashboard"
-						plan={ PLAN_JETPACK_PREMIUM }
-						icon="flag"
-					/>
-				) : null;
-
-			return (
-				<DashItem
-					label={ labelName }
-					module="akismet"
-					support={ support }
-					status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
-					className="jp-dash-item__is-inactive"
-					pro={ true }
-					overrideContent={ upgradeContent }
-				>
-					{ activateContent }
 				</DashItem>
 			);
 		}
@@ -163,23 +139,22 @@ class DashAkismet extends Component {
 					module="akismet"
 					support={ support }
 					className="jp-dash-item__is-inactive"
-					status="is-warning"
-					statusText={ __( 'Invalid key' ) }
 					pro={ true }
-				>
-					<p className="jp-dash-item__description">
-						{ __(
-							'Whoops! Your Jetpack Anti-spam (powered by Akismet) key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.',
-							{
-								components: {
-									akismetSettings: (
-										<a href={ `${ this.props.siteAdminUrl }admin.php?page=akismet-key-config` } />
-									),
-								},
-							}
-						) }
-					</p>
-				</DashItem>
+					overrideContent={
+						<JetpackBanner
+							callToAction={ __( 'Upgrade' ) }
+							title={ __(
+								'Automatically clear spam from your comments and forms so you can get back to your business.'
+							) }
+							disableHref="false"
+							href={ this.props.upgradeUrl }
+							eventFeature="akismet"
+							path="dashboard"
+							plan={ PLAN_JETPACK_PREMIUM }
+							icon="flag"
+						/>
+					}
+				/>
 			);
 		}
 

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -128,7 +128,7 @@ class DashAkismet extends Component {
 			const upgradeContent =
 				'is-free-plan' === planClass ? (
 					<JetpackBanner
-						callToAction={ __( 'Activate' ) }
+						callToAction={ __( 'Upgrade' ) }
 						title={ __(
 							'Automatically clear spam from your comments and forms so you can get back to your business.'
 						) }

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
+import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -16,6 +17,8 @@ import QueryAkismetData from 'components/data/query-akismet-data';
 import { getAkismetData } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
 import { isDevMode } from 'state/connection';
+import { getUpgradeUrl } from 'state/initial-state';
+import JetpackBanner from 'components/jetpack-banner';
 
 class DashAkismet extends Component {
 	static propTypes = {
@@ -25,6 +28,7 @@ class DashAkismet extends Component {
 		// Connected props
 		akismetData: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ).isRequired,
 		isDevMode: PropTypes.bool.isRequired,
+		upgradeUrl: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -101,6 +105,21 @@ class DashAkismet extends Component {
 		}
 
 		if ( akismetData === 'not_active' ) {
+			const activateContent = (
+				<JetpackBanner
+					callToAction={ __( 'Activate' ) }
+					title={ __(
+						'Automatically clear spam from your comments and forms so you can get back to your business.'
+					) }
+					disableHref="false"
+					href={ this.props.upgradeUrl }
+					eventFeature="akismet"
+					path="dashboard"
+					plan={ PLAN_JETPACK_PREMIUM }
+					icon="lock"
+				/>
+			);
+
 			return (
 				<DashItem
 					label={ labelName }
@@ -109,22 +128,8 @@ class DashAkismet extends Component {
 					status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
 					className="jp-dash-item__is-inactive"
 					pro={ true }
-				>
-					<p className="jp-dash-item__description">
-						{ __( 'For state-of-the-art spam defense, please {{a}}activate Akismet{{/a}}.', {
-							components: {
-								a: (
-									<a
-										href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl }
-										onClick={ this.trackActivateClick }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						} ) }
-					</p>
-				</DashItem>
+					overrideContent={ activateContent }
+				/>
 			);
 		}
 
@@ -198,4 +203,5 @@ export default connect( state => ( {
 	akismetData: getAkismetData( state ),
 	sitePlan: getSitePlan( state ),
 	isDevMode: isDevMode( state ),
+	upgradeUrl: getUpgradeUrl( state, 'aag-akismet' ),
 } ) )( DashAkismet );

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -122,12 +122,7 @@ class ProStatus extends React.Component {
 				} );
 				break;
 			case 'invalid_key':
-				status = 'is-warning';
-				action = __( 'Invalid key', {
-					context: 'Short warning message about an invalid key being used for Akismet.',
-				} );
-				actionUrl = this.props.siteAdminUrl + 'admin.php?page=akismet-key-config';
-				break;
+				return;
 			case 'rewind_connected':
 				const rewindMessage = this.getRewindMessage();
 				return (


### PR DESCRIPTION
Similar to what https://github.com/Automattic/jetpack/pull/12600 did for the Scan card, this adds a JetpackBanner to the Akismet card on the At-a-Glance page.

Fixes #12566

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the Akismet card on the At-a-Glance page to use the JetpackBanner component.

Before:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/42627630/60044585-4e9ad780-9688-11e9-9b70-e2e4a9653a87.png">

After:
<img width="411" alt="image" src="https://user-images.githubusercontent.com/42627630/60044714-9ae61780-9688-11e9-8c50-3a6432ce9301.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the At a Glance Tuneup project

#### Testing instructions:
* Go to the At-a-Glance page on a Jetpack Free plan.
* Verify that a JetpackBanner is prompting activation on the Akismet card.
* Go to the At-a-Glance page on a Jetpack paid plan without Akismet activated.
* Verify that a link prompting the user to activate is displayed.


#### Proposed changelog entry for your changes:
* Changes to upgrade messaging on the Akismet card.
