### PR TITLE
Set the scan upgrade source to aag-scan

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -261,7 +261,7 @@ class DashScan extends Component {
 	}
 }
 
-export default connect( ( state, { source } ) => {
+export default connect( state => {
 	return {
 		vaultPressData: getVaultPressData( state ),
 		scanThreats: getVaultPressScanThreatCount( state ),
@@ -270,6 +270,6 @@ export default connect( ( state, { source } ) => {
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		fetchingSiteData: isFetchingSiteData( state ),
 		showBackups: showBackups( state ),
-		upgradeUrl: getUpgradeUrl( state, source ),
+		upgradeUrl: getUpgradeUrl( state, 'aag-scan' ),
 	};
 } )( DashScan );


### PR DESCRIPTION
The Jetpack redirect link for the Scan upgrade did not have the source parameter correctly set. This PR correctly sets the source parameter.

#### Changes proposed in this Pull Request:
* Updates 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes the upgrade link added in https://github.com/Automattic/jetpack/pull/12600.

#### Testing instructions:
* Go to At a Glance after connecting Jetpack on a Free plan
* See the JetpackBanner prompting an upgrade in the Security Scanning card
* Click the upgrade and verify that you are redirected to a security upgrade landing page

#### Proposed changelog entry for your changes:
* No changelog entry needed
