### PR TITLE
Add JetpackBanner to Search card in At-a-Glance 

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import { noop } from 'lodash';
+import { getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -13,10 +14,11 @@ import { noop } from 'lodash';
 import analytics from 'lib/analytics';
 import DashItem from 'components/dash-item';
 import Card from 'components/card';
+import JetpackBanner from 'components/jetpack-banner';
 import { isModuleFound } from 'state/search';
 import { isDevMode } from 'state/connection';
 import { getSitePlan } from 'state/site';
-import { getPlanClass } from 'lib/plans/constants';
+import { getUpgradeUrl } from 'state/initial-state';
 
 /**
  * Displays a card for Search based on the props given.
@@ -38,6 +40,7 @@ const renderCard = props => (
 		status={ props.status }
 		isModule={ props.pro_inactive }
 		pro={ true }
+		overrideContent={ props.overrideContent }
 	>
 		<p className="jp-dash-item__description">{ props.content }</p>
 	</DashItem>
@@ -83,20 +86,19 @@ class DashSearch extends Component {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
 				pro_inactive: true,
-				content: __(
-					'Replace the built-in search with a fast, scalable, customizable, and highly-relevant search {{a}}hosted in the WordPress.com cloud{{/a}}.',
-					{
-						components: {
-							a: (
-								<a
-									href={ 'https://jetpack.com/features/design/elasticsearch-powered-search/' }
-									onClick={ this.trackSearchLink }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
+				overrideContent: (
+					<JetpackBanner
+						callToAction={ __( 'Upgrade' ) }
+						title={ __(
+							"Replace your site's basic search with customizable search that helps visitors find answers faster."
+						) }
+						disableHref="false"
+						href={ this.props.upgradeUrl }
+						eventFeature="search"
+						path="dashboard"
+						plan={ PLAN_JETPACK_PREMIUM }
+						icon="search"
+					/>
 				),
 			} );
 		}
@@ -152,5 +154,6 @@ export default connect( state => {
 		foundSearch: isModuleFound( state, 'search' ),
 		planClass: getPlanClass( getSitePlan( state ).product_slug ),
 		isDevMode: isDevMode( state ),
+		upgradeUrl: getUpgradeUrl( state, 'aag-search' ),
 	};
 } )( DashSearch );


### PR DESCRIPTION
Similar to what https://github.com/Automattic/jetpack/pull/12600 did for the Scan card, this adds a JetpackBanner to the Search card on the At-a-Glance page.

Fixes #12567

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the Search card on the At-a-Glance page to use the JetpackBanner component.

Before:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/42627630/60045564-c964f200-968a-11e9-9a36-0ef54c19fcef.png">

After:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/42627630/60046295-a63b4200-968c-11e9-8652-a7612fe0de2b.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the At a Glance Tuneup project.

#### Testing instructions:
* Go to the At-a-Glance page on a Jetpack Free plan.
* Verify that a JetpackBanner is prompting an upgrade on the search card.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Changes to upgrade messaging on the Search card.
