### PR TITLE
Added a currentVersion prop to the Tracks event for the JetpackBanner

### DIFF
--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, size } from 'lodash';
 
@@ -15,6 +16,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import PlanIcon from 'components/plans/plan-icon';
+import { getCurrentVersion } from 'state/initial-state';
 
 import './style.scss';
 
@@ -22,6 +24,7 @@ class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.string,
 		className: PropTypes.string,
+		currentVersion: PropTypes.string.isRequired,
 		description: PropTypes.node,
 		eventFeature: PropTypes.string,
 		feature: PropTypes.string, // PropTypes.oneOf( getValidFeatureKeys() ),
@@ -54,7 +57,7 @@ class Banner extends Component {
 	handleClick = () => {
 		this.props.onClick();
 
-		const { eventFeature, path } = this.props;
+		const { eventFeature, path, currentVersion } = this.props;
 		if ( eventFeature || path ) {
 			const eventFeatureProp = eventFeature ? { feature: eventFeature } : {};
 			const pathProp = path ? { path } : {};
@@ -62,6 +65,7 @@ class Banner extends Component {
 			const eventProps = {
 				target: 'banner',
 				type: 'upgrade',
+				currentVersion,
 				...eventFeatureProp,
 				...pathProp,
 			};
@@ -151,4 +155,6 @@ class Banner extends Component {
 	}
 }
 
-export default Banner;
+export default connect( state => ( {
+	currentVersion: getCurrentVersion( state ),
+} ) )( Banner );

--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -65,7 +65,7 @@ class Banner extends Component {
 			const eventProps = {
 				target: 'banner',
 				type: 'upgrade',
-				currentVersion,
+				current_version: currentVersion,
 				...eventFeatureProp,
 				...pathProp,
 			};

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -24,6 +24,7 @@ import {
 	getApiRootUrl,
 	userCanManageModules,
 	userCanConnectSite,
+	getCurrentVersion,
 	getTracksUserData,
 } from 'state/initial-state';
 import { areThereUnsavedSettings, clearUnsavedSettingsFlag } from 'state/settings';
@@ -59,7 +60,10 @@ class Main extends React.Component {
 
 		// Track initial page view
 		this.props.isSiteConnected &&
-			analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: this.props.route.path } );
+			analytics.tracks.recordEvent( 'jetpack_wpa_page_view', {
+				path: this.props.route.path,
+				current_version: this.props.currentVersion,
+			} );
 	}
 
 	componentDidMount() {
@@ -138,7 +142,10 @@ class Main extends React.Component {
 		// Track page view on change only
 		prevProps.route.path !== this.props.route.path &&
 			this.props.isSiteConnected &&
-			analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: this.props.route.path } );
+			analytics.tracks.recordEvent( 'jetpack_wpa_page_view', {
+				path: this.props.route.path,
+				current_version: this.props.currentVersion,
+			} );
 
 		// Not taking into account development mode here because changing the connection
 		// status without reloading is possible only by disconnecting a live site not
@@ -294,6 +301,7 @@ export default connect(
 			userCanConnectSite: userCanConnectSite( state ),
 			isSiteConnected: isSiteConnected( state ),
 			rewindStatus: getRewindStatus( state ),
+			currentVersion: getCurrentVersion( state ),
 		};
 	},
 	dispatch => ( {


### PR DESCRIPTION
The Tracks event for the `JetpackBanner` was not logging the version, making it hard to know which version of the client was sending users to the redirect links. This adds a `currentVersion` prop to fix that.

#### Changes proposed in this Pull Request:
* Adds a `currentVersion` prop to the `JetpackBanner` Tracks event.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the At-a-Glance update project.

#### Testing instructions:
* Go to the At-a-Glance dashboard on a Jetpack free plan.
* Enter `localStorage.setItem('debug', 'dops:analytics')` in the console and refresh the page in order to see Tracks events.
* Set the console to preserve log.
* Click the Upgrade button on the Scan card.
* In the console, verify that a `jetpack_wpa_click` event was fired with a `currentVersion` prop correctly set.

#### Proposed changelog entry for your changes:
* None needed.
