### PR TITLE
Bring .com masterbar tooltip to Jetpack

### DIFF
--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -31,6 +31,9 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						disableInDevMode
 						module={ { module: 'masterbar' } }
 						support={ {
+							text: __(
+								'Adds a toolbar with links to all your sites, notifications, your WordPress.com profile, and the Reader.'
+							),
 							link: 'https://jetpack.com/support/masterbar/',
 						} }
 					>


### PR DESCRIPTION
Before:

![Screenshot 2019-06-25 at 12 04 09](https://user-images.githubusercontent.com/411945/60093873-70f12b80-9742-11e9-8fa2-f55235b18c61.png)


After:

![Screenshot 2019-06-25 at 12 09 03](https://user-images.githubusercontent.com/411945/60093861-69ca1d80-9742-11e9-83c3-1d16e08237e1.png)

.com:

![Screenshot 2019-06-25 at 12 09 10](https://user-images.githubusercontent.com/411945/60093848-60d94c00-9742-11e9-9f00-d7fdfcba7039.png)

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify tooltip matches Calypso / .com for the toolbar setting

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
