### PR TITLE
DNA: Auto extend PSR-4 autoloaded classes with legacy class names, if exists

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -107,6 +107,15 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 			if ( file_exists( $jetpack_packages_classes[ $class_name ]['path'] ) ) {
 				require_once $jetpack_packages_classes[ $class_name ]['path'];
 
+				// Extend autoloaded class with legacy class, if it exists.
+				if ( class_exists( $class_name ) && method_exists( $class_name, 'getLegacyName' ) ) {
+					eval( 'class ' . $class_name::getLegacyName() . ' extends ' . $class_name . '{}' );
+
+					if ( class_exists( $class_name::getLegacyName() ) ) {
+						echo $class_name::getLegacyName() . "exists!\n<br>";
+					}
+				}
+
 				return true;
 			}
 		}

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -499,4 +499,8 @@ class Actions {
 			)
 		);
 	}
+
+	static function getLegacyName() {
+		return 'Jetpack_Sync_Actions';
+	}
 }


### PR DESCRIPTION
If a a PSR-4 autoloaded class has a static `getLegacyName()` method, declare a class with the legacy name that extends the PSR-4 autoloaded class.

To test, `rm -rf vendor`, `composer install`

I purposely left echo statements in it so you can see it works.