### PR TITLE
Added a stringify function to avoid unneeded recursion when scanning code.

### DIFF
--- a/packages/analyzer/src/PersistentList.php
+++ b/packages/analyzer/src/PersistentList.php
@@ -32,7 +32,13 @@ class PersistentList {
 	/**
 	 * Saves the items to a file and returns the file contents
 	 */
-	public function save( $file_path ) {
+	public function save( $file_path, $allow_empty = true ) {
+
+		// Not saving empty files if empty files are not allowed to be saved
+		if ( ! $allow_empty && empty( $this->items ) ) {
+			return '';
+		}
+
 		$handle = fopen( $file_path, 'w+' );
 		foreach ( $this->items as $item ) {
 			fputcsv( $handle, $item->to_csv_array() );


### PR DESCRIPTION
When an invocation is complex enough, it will go further than our logic in the analyzer, but we don't need to follow the properties or class names based on other variables - we still won't find out whether the class or property was moved in Jetpack without runtime analysis. Therefore we replace these instances with just a node's class name for want of a better string.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Fixes analyzer fatal errors on scanning various codebases.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added a stopgap stringifier function that will let us avoid unnecessary recursion.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the Jetpack DNA effort.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
This change was prompted by scanning the entire WordPress repository using [the slurper plugin](https://github.com/markjaquith/WordPress-Plugin-Directory-Slurper), but you can see the fatals by scanning any code that uses the following code invocations: `new $this->class_name()`, `new $variable[ $class_name_index ]`, etc.
* Try scanning code that fails with missing property errors.
* Try scanning it with this fix, see that there's no failures anymore.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
