### PR TITLE
DNA: Legacy Compat class.jetpack-options.php

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Deprecated since 7.5 – Jetpack_Options are autoloaded from packages/options/legacy/class.jetpack-options.php
+ */
+_deprecated_file( basename( __FILE__ ), 'jetpack-7.5', 'packages/options/legacy/class.jetpack-options.php' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -93,6 +93,9 @@
 		<testsuite name="geo-location">
 			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
 		</testsuite>
+		<testsuite name="deprecation">
+			<file>tests/php/test_deprecation.php</file>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -1,0 +1,44 @@
+<?php
+
+class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
+
+	private $errors;
+
+	public function errorHandler( $errno, $errstr, $errfile, $errline, $errcontext ) {
+		$this->errors[] = compact( "errno", "errstr", "errfile",
+			"errline", "errcontext" );
+	}
+
+	private function set_error_handler() {
+		$this->errors = array();
+		set_error_handler( array( $this, "errorHandler" ) );
+	}
+
+	public function assertDeprecatedFileError( $deprecated, $replacement, $errno ) {
+		foreach ( $this->errors as $error ) {
+			if ( $error['errno'] === $errno ) {
+				if ( $error['errcontext']['file'] === $deprecated && $error['errcontext']['replacement'] === $replacement ) {
+					self::assertTrue( true );
+
+					return;
+				}
+			}
+
+		}
+		$this->fail( "Error for $deprecated not found" );
+	}
+
+	function test_require_old_jetpack_options() {
+		$this->set_error_handler();
+		require_once JETPACK__PLUGIN_DIR . '/class.jetpack-options.php';
+
+		$this->assertDeprecatedFileError( 'class.jetpack-options.php', 'packages/options/legacy/class.jetpack-options.php',
+			E_USER_NOTICE );
+		restore_error_handler();
+	}
+
+	function test_jetpack_options__get_option() {
+		$this->assertTrue( method_exists( 'Jetpack_Options', 'get_option' ) );
+	}
+
+}


### PR DESCRIPTION
Adds back `class.jetpack-options.php` in order fatals on third parties still requiring the old file.

## Fixes
https://github.com/Automattic/jetpack/issues/12849
https://github.com/Automattic/jetpack/issues/12850

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
See: https://github.com/Automattic/jetpack/pull/12857

#### Testing instructions:

* Run tests `yarn docker:phpunit --testsuite=deprecation `
* require_once JETPACK__PLUGIN_DIR . '/class.jetpack-options.php'; from outside tests
* check that you get a notice if `WP_DEBUG` is set to `true`.
* check that you don't get any notices errors when `WP_DEBUG` is set to `false`.
