### PR TITLE
Mobile: Hide edit post link in content

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -717,7 +717,7 @@ class Jetpack {
 			jetpack_require_lib( 'functions.wp-notify' );
 		}
 
-        // Hide edit post link if mobile app.
+		// Hide edit post link if mobile app.
 		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
 			add_filter( 'edit_post_link', '__return_empty_string' );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -717,6 +717,11 @@ class Jetpack {
 			jetpack_require_lib( 'functions.wp-notify' );
 		}
 
+        // Hide edit post link if mobile app.
+		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
+			add_filter( 'edit_post_link', '__return_empty_string' );
+		}
+
 		// Update the Jetpack plan from API on heartbeats
 		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_from_wpcom' ) );
 

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -350,11 +350,6 @@ function jetpack_mobile_customizer_controls( $wp_customize ) {
 
 add_action( 'jetpack_custom_css_customizer_controls', 'jetpack_mobile_customizer_controls' );
 
-// Hide edit post link if mobile app.
-if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
-	add_filter( 'edit_post_link', '__return_empty_string' );
-}
-
 function jetpack_mobile_save_css_settings() {
 	update_option( 'wp_mobile_custom_css', isset( $_POST['mobile_css'] ) && ! empty( $_POST['mobile_css'] ) );
 }

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -350,19 +350,10 @@ function jetpack_mobile_customizer_controls( $wp_customize ) {
 
 add_action( 'jetpack_custom_css_customizer_controls', 'jetpack_mobile_customizer_controls' );
 
-/**
- * Process edit post link tags for mobile apps.
- *
- * @param $link
- */
-function jetpack_mobile_app_edit_post_link( $link ) {
-	// If WordPress mobile apps, then hide edit links to avoid confusion/conflict.
-	if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
-		return '';
-	}
-	return $link;
+// Hide edit post link if mobile app.
+if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
+	add_filter( 'edit_post_link', '__return_empty_string' );
 }
-add_filter( 'edit_post_link', 'jetpack_mobile_app_edit_post_link', 20 );
 
 function jetpack_mobile_save_css_settings() {
 	update_option( 'wp_mobile_custom_css', isset( $_POST['mobile_css'] ) && ! empty( $_POST['mobile_css'] ) );

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -350,6 +350,20 @@ function jetpack_mobile_customizer_controls( $wp_customize ) {
 
 add_action( 'jetpack_custom_css_customizer_controls', 'jetpack_mobile_customizer_controls' );
 
+/**
+ * Process edit post link tags for mobile apps.
+ *
+ * @param $link
+ */
+function jetpack_mobile_app_edit_post_link( $link ) {
+	// If WordPress mobile apps, then hide edit links to avoid confusion/conflict.
+	if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
+		return '';
+	}
+	return $link;
+}
+add_filter( 'edit_post_link', 'jetpack_mobile_app_edit_post_link', 20 );
+
 function jetpack_mobile_save_css_settings() {
 	update_option( 'wp_mobile_custom_css', isset( $_POST['mobile_css'] ) && ! empty( $_POST['mobile_css'] ) );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds an `edit_post_link` filter to return empty string if request is from an WordPress mobile app.

<!--- Explain what functional changes your PR includes -->

Hides edit post link in post content if client is a WordPress mobile app.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No. This is a manual sync PR for D29686-code.

See trac link in the patch for more detail on the issue this PR and the mentioned patch addresses.

#### Testing instructions:

1. Use a browser that lets you change User-Agent easily. Chrome, for example, has User agent settings under Three Dot menu > More tools > Network conditions.
2. View a post you have edit permission to using Chrome browser with default User-Agent.
3. Verify that Edit link is displayed.

<img width="772" alt="screenshot_726" src="https://user-images.githubusercontent.com/127594/60194410-25945700-97ee-11e9-9d93-6c51ba85701c.png">

4. Add wp-iphone/1.0 or wp-android to User-Agent string and refresh the page.

<img width="773" alt="screenshot_725" src="https://user-images.githubusercontent.com/127594/60194427-2b8a3800-97ee-11e9-98ad-b9b0a94e0334.png">

5. Verify that Edit link is no longer displayed.

#### Proposed changelog entry for your changes:

Hide edit post link in post content if client is a WordPress mobile app.
