### PR TITLE
Back compat: File deprecation for class.tracks-client.php

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Deprecated file since 7.5 - Jetpack_Tracks_Client is now autoloaded from 'vendor/automattic/jetpack-tracking/legacy/class.tracks-client.php'
+ */
+_deprecated_file( basename( __FILE__ ), 'jetpack-7.5', 'vendor/automattic/jetpack-tracking/legacy/class.tracks-client.php' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12848, sort of. 

Since this method is already being handled in it's own package's `legacy/`, the class and method are already loaded at the global scope. 

And since there's no psr-4 replacement, there is no actual deprecation of the method to declare. 

#### Testing instructions:
```
add_action( 'plugins_loaded', function() {
	require_once JETPACK__PLUGIN_DIR . '_inc/lib/tracks/class.tracks-client.php';
	var_export( Jetpack_Tracks_Client::get_connected_user_tracks_identity() );
});

```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
NA
