### PR TITLE
DNA: Add legacy class.jetpack-sync-settings.php

### DIFF
--- a/packages/compat/legacy/class.jetpack-sync-settings.php
+++ b/packages/compat/legacy/class.jetpack-sync-settings.php
@@ -10,7 +10,7 @@ class Jetpack_Sync_Settings extends Automattic\Jetpack\Sync\Settings {
 	public function __callStatic( $method, $args ) {
 		if ( method_exists( parent, $method ) ) {
 			_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-			call_user_func_array( [ parent, $method ], $args );
+			return call_user_func_array( [ parent, $method ], $args );
 		}
 		throw new Exception( "Method doesn't exist" );
 	}

--- a/packages/compat/legacy/class.jetpack-sync-settings.php
+++ b/packages/compat/legacy/class.jetpack-sync-settings.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Class Jetpack_Sync_Settings
+ *
+ * @deprecated Use Automattic\Jetpack\Sync\Settings
+ */
+class Jetpack_Sync_Settings extends Automattic\Jetpack\Sync\Settings {
+
+	public function __callStatic( $method, $args ) {
+		if ( method_exists( parent, $method ) ) {
+			_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
+			call_user_func_array( [ parent, $method ], $args );
+		}
+		throw new Exception( "Method doesn't exist" );
+	}
+
+}

--- a/packages/compat/legacy/class.jetpack-sync-settings.php
+++ b/packages/compat/legacy/class.jetpack-sync-settings.php
@@ -1,18 +1,17 @@
 <?php
 
+use Automattic\Jetpack\Sync\Settings;
+
 /**
  * Class Jetpack_Sync_Settings
  *
  * @deprecated Use Automattic\Jetpack\Sync\Settings
  */
-class Jetpack_Sync_Settings extends Automattic\Jetpack\Sync\Settings {
+class Jetpack_Sync_Settings {
 
-	public function __callStatic( $method, $args ) {
-		if ( method_exists( parent, $method ) ) {
-			_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-			return call_user_func_array( [ parent, $method ], $args );
-		}
-		throw new Exception( "Method doesn't exist" );
+	static function is_syncing() {
+		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
+		return Settings::is_syncing();
 	}
 
 }

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -58,7 +58,13 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 		return array(
 			array( 'Jetpack_Options', 'get_option' ),
 			array( 'Jetpack_Client', 'remote_request' ),
+			array( 'Jetpack_Tracks_Client', 'get_connected_user_tracks_identity' ),
 			array( 'Jetpack_Sync_Settings', 'is_syncing' ),
+// TODO
+//			array( 'Jetpack_Tracks_Client', 'get_connected_user_tracks_identity' ),
+//			array( 'JetpackTracking', 'record_user_event' ),
+//			array( 'Jetpack_Options', 'get_option_and_ensure_autoload' ),
+//			array( 'Jetpack_Client', 'wpcom_json_api_request_as_blog' ),
 		);
 	}
 

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -58,6 +58,7 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 		return array(
 			array( 'Jetpack_Options', 'get_option' ),
 			array( 'Jetpack_Client', 'remote_request' ),
+			array( 'Jetpack_Sync_Settings', 'is_syncing' ),
 		);
 	}
 


### PR DESCRIPTION
Adds backwards compatibility for `Jetpack_Sync` class

## Fixes
https://github.com/Automattic/jetpack/issues/12864

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
See: https://github.com/Automattic/jetpack/pull/12857

#### Testing instructions:

* Run tests `yarn docker:phpunit --testsuite=deprecation `
