### PR TITLE
DNA: Jetpack_Sync_Modules stub methods

### DIFF
--- a/packages/compat/legacy/class.jetpack-sync-modules.php
+++ b/packages/compat/legacy/class.jetpack-sync-modules.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Class Jetpack_Sync_Modules
+ *
+ * @deprecated Use Automattic\Jetpack\Sync\Modules
+ */
+class Jetpack_Sync_Modules {
+	static function get_module( $module_name ) {
+		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Modules' );
+
+		return Modules::get_module( $module_name );
+	}
+}

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Deprecated since 7.5 – Jetpack_Options are autoloaded from packages/compat/legacy/class.jetpack-sync-modules.php
+ */
+_deprecated_file( basename( __FILE__ ), 'jetpack-7.5', 'packages/compat/legacy/class.jetpack-sync-modules.php' );

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -1,5 +1,5 @@
 <?php
 /**
- * Deprecated since 7.5 – Jetpack_Options are autoloaded from packages/compat/legacy/class.jetpack-sync-modules.php
+ * Deprecated since 7.5 – Jetpack_Sync_Modules are autoloaded from packages/compat/legacy/class.jetpack-sync-modules.php
  */
 _deprecated_file( basename( __FILE__ ), 'jetpack-7.5', 'packages/compat/legacy/class.jetpack-sync-modules.php' );

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -89,6 +89,12 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 				'packages/connection/src/Client.php',
 				E_USER_NOTICE,
 			),
+			// this relies on test fixes already ported to branch list-of-deprecated-methods
+			// array(
+			// 	'sync/class.jetpack-sync-modules.php',
+			// 	'packages/compat/legacy/class.jetpack-sync-modules.php',
+			// 	E_USER_NOTICE,
+			// ),
 		);
 	}
 

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -73,6 +73,7 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 			array( 'Jetpack_Sync_Actions', 'initialize_listener' ),
 			array( 'Jetpack_Sync_Actions', 'initialize_sender' ),
 //			array( 'JetpackTracking', 'record_user_event' ),
+			array( 'Jetpack_Sync_Modules', 'get_module' ),
 		);
 	}
 


### PR DESCRIPTION
Adds stubs for `Jetpack_Sync_Modules::get_module( $name )` method

Part of #12874

Testing instructions:
Run tests yarn docker:phpunit --testsuite=deprecation

To test:

```php
add_action( 'plugins_loaded', function() {
	// Should not fatal
	require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-modules.php';
	var_dump( Jetpack_Sync_Modules::get_module( 'posts' ), 1 );
});
```