### PR TITLE
Fix the missing constant and the method prototype.

### DIFF
--- a/packages/compat/legacy/class.jetpack-client.php
+++ b/packages/compat/legacy/class.jetpack-client.php
@@ -18,6 +18,13 @@ use Automattic\Jetpack\Connection\Client;
 class Jetpack_Client {
 
 	/**
+	 * Jetpack API version.
+	 *
+	 * @deprecated use Automattic\Jetpack\Connection\Client::WPCOM_JSON_API_VERSION
+	 */
+	const WPCOM_JSON_API_VERSION = '1.1';
+
+	/**
 	 * Perform remote request.
 	 *
 	 * @deprecated use Automattic\Jetpack\Connection\Client::remote_request
@@ -45,7 +52,13 @@ class Jetpack_Client {
 	 *
 	 * @return Array|WP_Error
 	 */
-	public static function wpcom_json_api_request_as_blog( $path, $version, $args, $body, $base_api_path ) {
+	public static function wpcom_json_api_request_as_blog(
+		$path,
+		$version = self::WPCOM_JSON_API_VERSION,
+		$args = array(),
+		$body = null,
+		$base_api_path = 'rest'
+	) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Connection\Client' );
 		return Client::wpcom_json_api_request_as_blog( $path, $version, $args, $body, $base_api_path );
 	}


### PR DESCRIPTION
Before the method prototype had a minimum of one argument, now it requires all five. This is not backwards compatible, so the prototype needs to be exactly the same as the stubbed method.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the Atomic fatal error on plugin uploads.

#### Changes proposed in this Pull Request:
* Adds the missing constant.
* Makes the method prototype the same as the original method.

#### Testing instructions:
* With wpcomsh enabled, try to upload a plugin to your site.
* See the fatal error.
* With this PR try again.
* See no fatals, but a notice if you're running a site with WP_DEBUG enabled.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A