### PR TITLE
Sync: Add WP_DEBUG to the list of constants

### DIFF
--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -206,6 +206,7 @@ class Defaults {
 		'PHP_VERSION',
 		'WP_MEMORY_LIMIT',
 		'WP_MAX_MEMORY_LIMIT',
+		'WP_DEBUG',
 	);
 
 	public static function get_constants_whitelist() {


### PR DESCRIPTION
Start Syncing `WP_DEBUG` value.


#### Changes proposed in this Pull Request:
* Adds `WP_DEBUG` to `$default_constants_whitelist`

#### Testing instructions:
* do a full_sync of your test site
* check that the new constant is being synced
