### PR TITLE
Add class const support to the analyzer

### DIFF
--- a/packages/analyzer/src/Declarations.php
+++ b/packages/analyzer/src/Declarations.php
@@ -109,6 +109,11 @@ class Declarations extends PersistentList {
 						$this->add( new Declarations\Class_Property( $file, $line, $class_name, $name, $static ) );
 						break;
 
+					case 'class_const':
+						echo "Loading class const declaration\n";
+						$this->add( new Declarations\Class_Const( $file, $line, $class_name, $name ) );
+						break;
+
 					case 'method':
 						$params      = json_decode( $params_json );
 						$declaration = new Declarations\Class_Method( $file, $line, $class_name, $name, $static );

--- a/packages/analyzer/src/Declarations.php
+++ b/packages/analyzer/src/Declarations.php
@@ -110,7 +110,6 @@ class Declarations extends PersistentList {
 						break;
 
 					case 'class_const':
-						echo "Loading class const declaration\n";
 						$this->add( new Declarations\Class_Const( $file, $line, $class_name, $name ) );
 						break;
 

--- a/packages/analyzer/src/Declarations/Class_Const.php
+++ b/packages/analyzer/src/Declarations/Class_Const.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Declarations;
+
+/**
+ * We only log public class variables
+ */
+class Class_Const extends Declaration {
+	public $class_name;
+	public $const_name;
+
+	function __construct( $path, $line, $class_name, $const_name ) {
+		$this->class_name = $class_name;
+		$this->const_name = $const_name;
+		parent::__construct( $path, $line );
+	}
+
+	function to_csv_array() {
+		return array(
+			$this->type(),
+			$this->path,
+			$this->line,
+			$this->class_name,
+			$this->const_name,
+			'',
+			''
+		);
+	}
+
+	function type() {
+		return 'class_const';
+	}
+
+	function display_name() {
+		return $this->class_name . '::' . $this->const_name;
+	}
+}

--- a/packages/analyzer/src/Declarations/Visitor.php
+++ b/packages/analyzer/src/Declarations/Visitor.php
@@ -31,6 +31,13 @@ class Visitor extends NodeVisitorAbstract {
 			return;
 		}
 
+		if ( $node instanceof Node\Stmt\ClassConst && $node->isPublic() ) {
+			foreach( $node->consts as $const ) {
+				$this->declarations->add( new Class_Const( $this->current_relative_path, $node->getLine(), $this->current_class, $const->name->name ) );
+			}
+			return;
+		}
+
 		if ( $node instanceof Node\Stmt\ClassMethod && $node->isPublic() ) {
 			// ClassMethods are also listed inside interfaces, which means current_class is null
 			// so we ignore these

--- a/packages/analyzer/src/Differences.php
+++ b/packages/analyzer/src/Differences.php
@@ -54,13 +54,16 @@ class Differences extends PersistentList {
 
 			// do not add warnings for $moved_with_empty_file
 			if ( $matched && $moved_with_empty_file ) {
-				echo "Declaration " . $prev_declaration->display_name() . " moved from " . $prev_declaration->path . " to " . $new_declaration->path . " with matching empty file at original location\n";
+				// echo "Declaration " . $prev_declaration->display_name() . " moved from " . $prev_declaration->path . " to " . $new_declaration->path . " with matching empty file at original location\n";
 			}
 
 			if ( $matched && $moved ) {
 				switch ( $prev_declaration->type() ) {
 					case 'class':
 						$this->add( new Differences\Class_Moved( $prev_declaration, $new_declaration ) );
+						break;
+					case 'class_const':
+						$this->add( new Differences\Class_Const_Moved( $prev_declaration, $new_declaration ) );
 						break;
 					case 'method':
 						$this->add( new Differences\Class_Method_Moved( $prev_declaration, $new_declaration ) );
@@ -81,6 +84,9 @@ class Differences extends PersistentList {
 				switch ( $prev_declaration->type() ) {
 					case 'class':
 						$this->add( new Differences\Class_Missing( $prev_declaration ) );
+						break;
+					case 'class_const':
+						$this->add( new Differences\Class_Const_Missing( $prev_declaration ) );
 						break;
 					case 'method':
 						$this->add( new Differences\Class_Method_Missing( $prev_declaration ) );

--- a/packages/analyzer/src/Differences/Class_Const_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Const_Missing.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Differences;
+
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
+use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
+
+class Class_Const_Missing extends PersistentListItem implements Invocation_Warner {
+	public $declaration;
+
+	function __construct( $declaration ) {
+		$this->declaration = $declaration;
+	}
+
+	function to_csv_array() {
+		return array(
+			$this->type(),
+			$this->declaration->path,
+			$this->declaration->line,
+			$this->declaration->display_name(),
+		);
+	}
+
+	public function type() {
+		return 'class_const_missing';
+	}
+
+	public function find_invocation_warnings( $invocation, $warnings ) {
+		if ( $invocation instanceof Static_Const ) {
+			if ( $invocation->class_name === $this->declaration->class_name
+				&& $invocation->const_name === $this->declaration->const_name) {
+				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class constant ' . $this->declaration->display_name() . ' is missing', $this->declaration ) );
+			}
+		}
+	}
+}

--- a/packages/analyzer/src/Differences/Class_Const_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Const_Moved.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Differences;
+
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
+use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
+
+class Class_Const_Moved extends PersistentListItem implements Invocation_Warner {
+	public $old_declaration;
+	public $new_declaration;
+
+	function __construct( $old_declaration, $new_declaration ) {
+		$this->old_declaration = $old_declaration;
+		$this->new_declaration = $new_declaration;
+	}
+
+	function to_csv_array() {
+		return array(
+			$this->type(),
+			$this->old_declaration->path,
+			$this->old_declaration->line,
+			$this->old_declaration->display_name(),
+		);
+	}
+
+	public function type() {
+		return 'property_moved';
+	}
+
+	public function find_invocation_warnings( $invocation, $warnings ) {
+		if ( $invocation instanceof Static_Const ) {
+			// check if it's using this missing property
+			if ( $invocation->class_name === $this->old_declaration->class_name
+				&& $invocation->const_name === $this->old_declaration->const_name ) {
+				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class const ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );
+			}
+		}
+	}
+}

--- a/packages/analyzer/src/Invocations.php
+++ b/packages/analyzer/src/Invocations.php
@@ -33,7 +33,7 @@ class Invocations extends PersistentList {
 		} elseif ( is_file( $root ) ) {
 			return $this->scan_file( $this->slashit( dirname( $root ) ), $root );
 		} else {
-			throw new \Exception( 'input_error', "Expected $root to be a file or directory" );
+			throw new \Exception( "Expected $root to be a file or directory" );
 		}
 	}
 

--- a/packages/analyzer/src/Invocations/Static_Const.php
+++ b/packages/analyzer/src/Invocations/Static_Const.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Invocations;
+
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+
+/**
+ * Instantiation of a class
+ *
+ * TODO: detect dynamic instantiations like `$shape = new $class_name( $this->images )`
+ */
+class Static_Const extends PersistentListItem {
+	public $path;
+	public $line;
+	public $class_name;
+	public $const_name;
+
+	public function __construct( $path, $line, $class_name, $const_name ) {
+		$this->path = $path;
+		$this->line = $line;
+		$this->class_name = $class_name;
+		$this->const_name = $const_name;
+	}
+
+	public function to_csv_array() {
+		return array(
+			$this->type(),
+			$this->path,
+			$this->line,
+			$this->class_name,
+			$this->const_name
+		);
+	}
+
+	function type() {
+		return 'class_const';
+	}
+
+	function display_name() {
+		return $this->class_name . '::' . $this->const_name;
+	}
+}

--- a/packages/analyzer/src/Invocations/Visitor.php
+++ b/packages/analyzer/src/Invocations/Visitor.php
@@ -37,6 +37,10 @@ class Visitor extends NodeVisitorAbstract {
 			}
 
 			$this->invocations->add( new Function_Call( $this->file_path, $node->getLine(), $function_name ) );
+		} elseif ( $node instanceof Node\Expr\ClassConstFetch ) {
+			$this->invocations->add(
+				new Static_Const( $this->file_path, $node->getLine(), $this->node_to_class_name( $node->class ), $node->name->name )
+			);
 		} else {
 			// print_r( $node );
 		}


### PR DESCRIPTION
Like it says.

```
*** Generate warnings for my library
class_const_missing,utils.php,46,"Class constant \Jetpack_Client::WPCOM_JSON_API_VERSION is missing","\Jetpack_Client::WPCOM_JSON_API_VERSION"

*** Summary of issues
class_const_missing,class.jetpack-client.php,4,\Jetpack_Client::WPCOM_JSON_API_VERSION,1
```