### PR TITLE
Compare param signatures more closely, including defaults

### DIFF
--- a/packages/analyzer/src/Declarations/Class_Method.php
+++ b/packages/analyzer/src/Declarations/Class_Method.php
@@ -12,10 +12,10 @@ class Class_Method extends Declaration {
 	public $static;
 
 	function __construct( $path, $line, $class_name, $method_name, $static ) {
-		$this->class_name = $class_name;
+		$this->class_name  = $class_name;
 		$this->method_name = $method_name;
-		$this->params = array();
-		$this->static = $static;
+		$this->params      = array();
+		$this->static      = $static;
 		parent::__construct( $path, $line );
 	}
 
@@ -32,7 +32,7 @@ class Class_Method extends Declaration {
 			$this->class_name,
 			$this->method_name,
 			$this->static,
-			json_encode( $this->params )
+			json_encode( $this->params ),
 		);
 	}
 
@@ -42,6 +42,6 @@ class Class_Method extends Declaration {
 
 	function display_name() {
 		$sep = $this->static ? '::' : '->';
-		return $this->class_name . $sep . $this->method_name . '(' . implode( ', ', array_map( function( $param ) { return '$' . $param->name; }, $this->params ) ) . ')';
+		return $this->class_name . $sep . $this->method_name . '(' . $this->get_params_as_string() . ')';
 	}
 }

--- a/packages/analyzer/src/Declarations/Declaration.php
+++ b/packages/analyzer/src/Declarations/Declaration.php
@@ -35,8 +35,6 @@ abstract class Declaration extends PersistentListItem {
 			',',
 			array_map(
 				function( $param ) {
-					// echo $this->path . ':' . $this->line . ' ' . print_r($param->default,1)."\n";
-					// print_r( $this );
 					if ( ! empty( $param->default ) ) {
 						  return '$' . $param->name . '=' . $param->default;
 					}

--- a/packages/analyzer/src/Declarations/Declaration.php
+++ b/packages/analyzer/src/Declarations/Declaration.php
@@ -28,4 +28,22 @@ abstract class Declaration extends PersistentListItem {
 
 	// e.g. Jetpack::get_file_url_for_environment()
 	abstract function display_name();
+
+	// utility function
+	protected function get_params_as_string() {
+		return implode(
+			',',
+			array_map(
+				function( $param ) {
+					// echo $this->path . ':' . $this->line . ' ' . print_r($param->default,1)."\n";
+					// print_r( $this );
+					if ( ! empty( $param->default ) ) {
+						  return '$' . $param->name . '=' . $param->default;
+					}
+					return '$' . $param->name;
+				},
+				$this->params
+			)
+		);
+	}
 }

--- a/packages/analyzer/src/Declarations/Function_.php
+++ b/packages/analyzer/src/Declarations/Function_.php
@@ -11,7 +11,7 @@ class Function_ extends Declaration {
 
 	function __construct( $path, $line, $func_name ) {
 		$this->func_name = $func_name;
-		$this->params = array();
+		$this->params    = array();
 		parent::__construct( $path, $line );
 	}
 
@@ -28,7 +28,7 @@ class Function_ extends Declaration {
 			'',
 			$this->func_name,
 			'',
-			json_encode( $this->params )
+			json_encode( $this->params ),
 		);
 	}
 
@@ -37,6 +37,6 @@ class Function_ extends Declaration {
 	}
 
 	function display_name() {
-		return $this->func_name . '(' . implode( ', ', array_map( function( $param ) { return '$' . $param->name; }, $this->params ) ) . ')';
+		return $this->func_name . '(' . $this->get_params_as_string() . ')';
 	}
 }

--- a/packages/analyzer/src/Declarations/Visitor.php
+++ b/packages/analyzer/src/Declarations/Visitor.php
@@ -47,7 +47,7 @@ class Visitor extends NodeVisitorAbstract {
 			}
 			$method = new Class_Method( $this->current_relative_path, $node->getLine(), $this->current_class, $node->name->name, $node->isStatic() );
 			foreach ( $node->getParams() as $param ) {
-				$param_default = Utils::get_param_default_as_string( $param->default );
+				$param_default = Utils::get_param_default_as_string( $param->default, $this->current_class );
 				$method->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );
 			}
 			$this->declarations->add( $method );
@@ -57,7 +57,7 @@ class Visitor extends NodeVisitorAbstract {
 		if ( $node instanceof Node\Stmt\Function_ ) {
 			$function = new Function_( $this->current_relative_path, $node->getLine(), $node->name->name );
 			foreach ( $node->getParams() as $param ) {
-				$param_default = Utils::get_param_default_as_string( $param->default );
+				$param_default = Utils::get_param_default_as_string( $param->default, $this->current_class );
 				$function->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );
 			}
 			$this->declarations->add( $function );

--- a/packages/analyzer/src/Declarations/Visitor.php
+++ b/packages/analyzer/src/Declarations/Visitor.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\Analyzer\Declarations;
 
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
+use Automattic\Jetpack\Analyzer\Utils;
 
 class Visitor extends NodeVisitorAbstract {
 	private $current_class;
@@ -12,14 +13,14 @@ class Visitor extends NodeVisitorAbstract {
 
 	public function __construct( $current_relative_path, $declarations ) {
 		$this->current_relative_path = $current_relative_path;
-		$this->declarations = $declarations;
-		$this->current_class = null;
+		$this->declarations          = $declarations;
+		$this->current_class         = null;
 	}
 
 	public function enterNode( Node $node ) {
 
 		if ( $node instanceof Node\Stmt\Class_ ) {
-			$namespaced_name = '\\' . implode( '\\', $node->namespacedName->parts );
+			$namespaced_name     = '\\' . implode( '\\', $node->namespacedName->parts );
 			$this->current_class = $namespaced_name;
 
 			$this->declarations->add( new Class_( $this->current_relative_path, $node->getLine(), $namespaced_name ) );
@@ -39,7 +40,8 @@ class Visitor extends NodeVisitorAbstract {
 			}
 			$method = new Class_Method( $this->current_relative_path, $node->getLine(), $this->current_class, $node->name->name, $node->isStatic() );
 			foreach ( $node->getParams() as $param ) {
-				$method->add_param( $param->var->name, $param->default, $param->type, $param->byRef, $param->variadic );
+				$param_default = Utils::get_param_default_as_string( $param->default );
+				$method->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );
 			}
 			$this->declarations->add( $method );
 			return;
@@ -48,9 +50,10 @@ class Visitor extends NodeVisitorAbstract {
 		if ( $node instanceof Node\Stmt\Function_ ) {
 			$function = new Function_( $this->current_relative_path, $node->getLine(), $node->name->name );
 			foreach ( $node->getParams() as $param ) {
-				$function->add_param( $param->var->name, $param->default, $param->type, $param->byRef, $param->variadic );
+				$param_default = Utils::get_param_default_as_string( $param->default );
+				$function->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );
 			}
-			$this->declarations->add( $function  );
+			$this->declarations->add( $function );
 			return;
 		}
 	}

--- a/packages/analyzer/src/Invocations/Visitor.php
+++ b/packages/analyzer/src/Invocations/Visitor.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
+use Automattic\Jetpack\Analyzer\Utils;
 
 class Visitor extends NodeVisitorAbstract {
 	private $invocations;
@@ -17,21 +18,21 @@ class Visitor extends NodeVisitorAbstract {
 	public function enterNode( Node $node ) {
 		if ( $node instanceof Node\Expr\New_ ) {
 			$this->invocations->add(
-				new New_( $this->file_path, $node->getLine(), $this->node_to_class_name( $node->class ) )
+				new New_( $this->file_path, $node->getLine(), Utils::node_to_class_name( $node->class ) )
 			);
 		} elseif ( $node instanceof Node\Expr\StaticCall ) {
 			// TODO - args
 			$this->invocations->add(
-				new Static_Call( $this->file_path, $node->getLine(), $this->node_to_class_name( $node->class ), $node->name->name )
+				new Static_Call( $this->file_path, $node->getLine(), Utils::node_to_class_name( $node->class ), $node->name->name )
 			);
 		} elseif ( $node instanceof Node\Expr\StaticPropertyFetch ) {
 			$this->invocations->add(
-				new Static_Property( $this->file_path, $node->getLine(), $this->node_to_class_name( $node->class ), $node->name->name )
+				new Static_Property( $this->file_path, $node->getLine(), Utils::node_to_class_name( $node->class ), $node->name->name )
 			);
 		} elseif ( $node instanceof Node\Expr\FuncCall ) {
 			// TODO - args
 			if ( $node->name instanceof Node\Expr\Variable ) {
-				$function_name = '$' . $this->maybe_stringify( $node->name->name );
+				$function_name = '$' . Utils::maybe_stringify( $node->name->name );
 			} else {
 				$function_name = implode( '\\', $node->name->parts );
 			}
@@ -43,53 +44,5 @@ class Visitor extends NodeVisitorAbstract {
 	}
 
 	public function leaveNode( Node $node ) {
-	}
-
-	private function node_to_class_name( $node ) {
-		if ( $node instanceof Node\Expr\Variable
-			|| $node instanceof Node\Stmt\Class_ ) {
-			$class_name = $node->name;
-		} elseif ( $node instanceof Node\Name ) {
-			$class_name = '\\' . implode( '\\', $node->parts );
-		} elseif ( $node instanceof Node\Expr\PropertyFetch ) {
-			$class_name =
-						'$'
-						. $this->maybe_stringify( $node->var->name )
-						. '->' . $this->maybe_stringify( $node->name->name );
-		} elseif ( $node instanceof Node\Expr\ArrayDimFetch ) {
-
-			$class_name =
-						'$'
-						. $this->maybe_stringify( $node->var->name )
-						. '[' . $this->maybe_stringify( $node->dim->value )
-						. ']';
-		} else {
-			if ( method_exists( $node, 'toCodeString' ) ) {
-				$class_name = $node->toCodeString();
-			} else {
-				$class_name = get_class( $node );
-			}
-		}
-
-		return $class_name;
-	}
-
-	private function maybe_stringify( $object ) {
-		$is_stringifiable = (
-			is_string( $object )
-			|| (
-				is_object( $object )
-				&& method_exists( $object, '__toString' )
-			)
-		);
-
-		if ( $is_stringifiable ) {
-			return (string) $object;
-		}
-
-		// Objects that need additional recursion to properly stringify
-		// are of no interest to us because we won't know what classes
-		// or methods they use without runtime analysis.
-		return get_class( $object );
 	}
 }

--- a/packages/analyzer/src/Invocations/Visitor.php
+++ b/packages/analyzer/src/Invocations/Visitor.php
@@ -40,7 +40,7 @@ class Visitor extends NodeVisitorAbstract {
 			$this->invocations->add( new Function_Call( $this->file_path, $node->getLine(), $function_name ) );
 		} elseif ( $node instanceof Node\Expr\ClassConstFetch ) {
 			$this->invocations->add(
-				new Static_Const( $this->file_path, $node->getLine(), $this->node_to_class_name( $node->class ), $node->name->name )
+				new Static_Const( $this->file_path, $node->getLine(), Utils::node_to_class_name( $node->class ), $node->name->name )
 			);
 		} else {
 			// print_r( $node );

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -11,7 +11,7 @@ class Utils {
 	/**
 	 * parses the node used to describe parameter defaults into a string for easy comparison
 	 */
-	static function get_param_default_as_string( $default ) {
+	static function get_param_default_as_string( $default, $current_class ) {
 		if ( $default instanceof Node\Expr\Array_ ) {
 			return 'array()';
 		} elseif ( $default instanceof Node\Expr\ConstFetch ) {
@@ -21,17 +21,17 @@ class Utils {
 		} elseif ( $default instanceof Node\Scalar\String_ ) {
 			return '\'' . $default->value . '\'';
 		} elseif ( $default instanceof Node\Expr\UnaryMinus ) {
-			return '-' . self::get_param_default_as_string( $default->expr );
+			return '-' . self::get_param_default_as_string( $default->expr, $current_class );
 		} elseif ( $default instanceof Node\Expr\UnaryPlus ) {
-			return '+' . self::get_param_default_as_string( $default->expr );
+			return '+' . self::get_param_default_as_string( $default->expr, $current_class );
 		} elseif ( $default instanceof Node\Expr\ClassConstFetch ) {
-			return self::node_to_class_name( $default->class ) . '::' . $default->name->name;
+			return self::node_to_class_name( $default->class, $current_class ) . '::' . $default->name->name;
 		} else {
 			return $default;
 		}
 	}
 
-	static function node_to_class_name( $node ) {
+	static function node_to_class_name( $node, $class_for_self = null ) {
 		if ( $node instanceof Node\Expr\Variable
 			|| $node instanceof Node\Stmt\Class_ ) {
 			$class_name = $node->name;
@@ -55,6 +55,11 @@ class Utils {
 			} else {
 				$class_name = get_class( $node );
 			}
+		}
+
+		if ( $class_name  === '\\self' && ! is_null( $class_for_self ) ) {
+			echo "Substituting $class_name with $class_for_self\n";
+			$class_name = $class_for_self;
 		}
 
 		return $class_name;

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -16,7 +16,7 @@ class Utils {
 			return 'array()';
 		} elseif ( $default instanceof Node\Expr\ConstFetch ) {
 			return $default->name->toCodeString();
-		} elseif ( $default instanceof Node\Scalar\LNumber ) {
+		} elseif ( $default instanceof Node\Scalar\LNumber || $default instanceof Node\Scalar\DNumber ) {
 			return $default->value;
 		} elseif ( $default instanceof Node\Scalar\String_ ) {
 			return '\'' . $default->value . '\'';

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer;
+
+use PhpParser\Node;
+
+/**
+ * Shared code that probably should be a trait
+ */
+class Utils {
+	/**
+	 * parses the node used to describe parameter defaults into a string for easy comparison
+	 */
+	static function get_param_default_as_string( $default ) {
+		if ( $default instanceof Node\Expr\Array_ ) {
+			return 'array()';
+		} elseif ( $default instanceof Node\Expr\ConstFetch ) {
+			return $default->name->toCodeString();
+		} elseif ( $default instanceof Node\Scalar\LNumber ) {
+			return $default->value;
+		} elseif ( $default instanceof Node\Scalar\String_ ) {
+			return '\'' . $default->value . '\'';
+		} elseif ( $default instanceof Node\Expr\UnaryMinus ) {
+			return '-' . self::get_param_default_as_string( $default->expr );
+		} elseif ( $default instanceof Node\Expr\UnaryPlus ) {
+			return '+' . self::get_param_default_as_string( $default->expr );
+		} elseif ( $default instanceof Node\Expr\ClassConstFetch ) {
+			return self::node_to_class_name( $default->class ) . '::' . $default->name->name;
+		} else {
+			return $default;
+		}
+	}
+
+	static function node_to_class_name( $node ) {
+		if ( $node instanceof Node\Expr\Variable
+			|| $node instanceof Node\Stmt\Class_ ) {
+			$class_name = $node->name;
+		} elseif ( $node instanceof Node\Name ) {
+			$class_name = '\\' . implode( '\\', $node->parts );
+		} elseif ( $node instanceof Node\Expr\PropertyFetch ) {
+			$class_name =
+						'$'
+						. self::maybe_stringify( $node->var->name )
+						. '->' . self::maybe_stringify( $node->name->name );
+		} elseif ( $node instanceof Node\Expr\ArrayDimFetch ) {
+
+			$class_name =
+						'$'
+						. self::maybe_stringify( $node->var->name )
+						. '[' . self::maybe_stringify( $node->dim->value )
+						. ']';
+		} else {
+			if ( method_exists( $node, 'toCodeString' ) ) {
+				$class_name = $node->toCodeString();
+			} else {
+				$class_name = get_class( $node );
+			}
+		}
+
+		return $class_name;
+	}
+
+	static function maybe_stringify( $object ) {
+		$is_stringifiable = (
+			is_string( $object )
+			|| (
+				is_object( $object )
+				&& method_exists( $object, '__toString' )
+			)
+		);
+
+		if ( $is_stringifiable ) {
+			return (string) $object;
+		}
+
+		// Objects that need additional recursion to properly stringify
+		// are of no interest to us because we won't know what classes
+		// or methods they use without runtime analysis.
+		return get_class( $object );
+	}
+}

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -58,7 +58,6 @@ class Utils {
 		}
 
 		if ( $class_name  === '\\self' && ! is_null( $class_for_self ) ) {
-			echo "Substituting $class_name with $class_for_self\n";
 			$class_name = $class_for_self;
 		}
 


### PR DESCRIPTION
Some of our compatibility classes / methods were created without correct defaults, which will break any invocations relying on those defaults.

Since our default comparison between functions and class methods just calls `$declaration->display_name()` to make sure it's the same, this PR alters the serialization of params to include a serialized version of the default value.

Doesn't render all defaults but hopefully is a basis for further work. Will explode on unrecognized default value types.

Here's an example of it catching [this case](https://github.com/Automattic/jetpack/pull/12883/files#diff-4cc971fa470c8d9acd5851b284e03d7aR55).

```
method_missing,class.jetpack-client.php,310,\Jetpack_Client::wpcom_json_api_request_as_blog($path,$version=\Jetpack_Client::WPCOM_JSON_API_VERSION,$args=array(),$body=\null,$base_api_path='rest'),3
```
