### PR TITLE
Summarise all code invocation dependencies by file or dependency

### DIFF
--- a/packages/analyzer/scripts/example.php
+++ b/packages/analyzer/scripts/example.php
@@ -51,6 +51,19 @@ $invocations->scan( $external_base_path . '/example-external.php' );
 // $invocations->scan( '/Users/dan/workspace/a8c/some-repo', array( '.git', '.gitmodules', 'assets' ) );
 // $invocations->output();
 
+echo "\n*** List of dependencies\n";
+$dependencies = new Automattic\Jetpack\Analyzer\Dependencies();
+$dependencies->generate( $invocations, $jp74_declarations, $repo_path );
+$dependencies->output();
+
+echo "\n*** Summary of dependencies by declaration\n";
+echo $dependencies->declaration_summary();
+
+echo "\n*** Summary of dependencies by external file\n";
+echo $dependencies->external_file_summary();
+
+
+echo "\n*** List of warnings\n";
 $warnings = new Automattic\Jetpack\Analyzer\Warnings();
 $warnings->generate( $invocations, $differences );
 $warnings->output();

--- a/packages/analyzer/src/Dependencies.php
+++ b/packages/analyzer/src/Dependencies.php
@@ -16,7 +16,6 @@ class Dependencies extends PersistentList {
 		 */
 		foreach( $invocations->get() as $invocation ) {
 			foreach( $declarations->get() as $declaration ) {
-				// $warning = $
 				if ( $invocation->depends_on( $declaration ) ) {
 					$this->add( new Dependencies\Dependency( $invocation, $declaration, $invocation_root ) );
 				}

--- a/packages/analyzer/src/Dependencies.php
+++ b/packages/analyzer/src/Dependencies.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer;
+
+/**
+ * This simply lists dependencies of invocations in Codebase A to declarations in codebase B
+ */
+class Dependencies extends PersistentList {
+	function generate( $invocations, $declarations, $invocation_root = null ) {
+		if ( $invocation_root ) {
+			$invocation_root = $this->slashit( $invocation_root );
+		}
+
+		/**
+		 * Scan every invocation to see if it depends on a Difference
+		 */
+		foreach( $invocations->get() as $invocation ) {
+			foreach( $declarations->get() as $declaration ) {
+				// $warning = $
+				if ( $invocation->depends_on( $declaration ) ) {
+					$this->add( new Dependencies\Dependency( $invocation, $declaration, $invocation_root ) );
+				}
+			}
+		}
+	}
+
+	private function slashit( $path ) {
+		$path .= ( substr( $path, -1 ) == '/' ? '' : '/' );
+		return $path;
+	}
+
+	public function declaration_summary() {
+		if ( $this->count() === 0 ) {
+			return '';
+		}
+
+		// assoc array of issues and counts
+		$summary = array();
+		foreach( $this->get() as $dependency ) {
+			$unique_issue_key = $dependency->declaration->display_name();
+
+			if ( ! isset( $summary[$unique_issue_key] ) ) {
+				$summary[$unique_issue_key] = 0;
+			}
+
+			$summary[$unique_issue_key] += 1;
+		}
+
+		arsort( $summary );
+
+		$summary_string = '';
+		foreach( $summary as $issue => $count ) {
+			$summary_string .= "$issue,$count\n";
+		}
+
+		return $summary_string;
+	}
+
+	public function external_file_summary() {
+		if ( $this->count() === 0 ) {
+			return '';
+		}
+
+		// assoc array of issues and counts
+		$summary = array();
+		foreach( $this->get() as $dependency ) {
+			$unique_issue_key = $dependency->full_path();
+
+			if ( ! isset( $summary[$unique_issue_key] ) ) {
+				$summary[$unique_issue_key] = 0;
+			}
+
+			$summary[$unique_issue_key] += 1;
+		}
+
+		arsort( $summary );
+
+		$summary_string = '';
+		foreach( $summary as $issue => $count ) {
+			$summary_string .= "$issue,$count\n";
+		}
+
+		return $summary_string;
+	}
+}

--- a/packages/analyzer/src/Dependencies.php
+++ b/packages/analyzer/src/Dependencies.php
@@ -3,7 +3,7 @@
 namespace Automattic\Jetpack\Analyzer;
 
 /**
- * This simply lists dependencies of invocations in Codebase A to declarations in codebase B
+ * This collects dependencies of invocations in Codebase A to declarations in codebase B
  */
 class Dependencies extends PersistentList {
 	function generate( $invocations, $declarations, $invocation_root = null ) {
@@ -12,7 +12,7 @@ class Dependencies extends PersistentList {
 		}
 
 		/**
-		 * Scan every invocation to see if it depends on a Difference
+		 * Scan every invocation to see if it depends on a declaration
 		 */
 		foreach( $invocations->get() as $invocation ) {
 			foreach( $declarations->get() as $declaration ) {
@@ -34,7 +34,7 @@ class Dependencies extends PersistentList {
 			return '';
 		}
 
-		// assoc array of issues and counts
+		// assoc array of declarations and counts
 		$summary = array();
 		foreach( $this->get() as $dependency ) {
 			$unique_issue_key = $dependency->declaration->display_name();
@@ -61,7 +61,7 @@ class Dependencies extends PersistentList {
 			return '';
 		}
 
-		// assoc array of issues and counts
+		// assoc array of files and counts
 		$summary = array();
 		foreach( $this->get() as $dependency ) {
 			$unique_issue_key = $dependency->full_path();

--- a/packages/analyzer/src/Dependencies/Dependency.php
+++ b/packages/analyzer/src/Dependencies/Dependency.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Dependencies;
+
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+
+class Dependency extends PersistentListItem {
+	public $invocation;
+	public $declaration;
+	public $invocation_root;
+
+	function __construct( $invocation, $declaration, $invocation_root = null ) {
+		$this->invocation = $invocation;
+		$this->declaration = $declaration;
+		$this->invocation_root = $invocation_root;
+	}
+
+	// /**
+	//  * This key is used to identify unique issues (e.g. Jetpack_Options has moved) across multiple invocations
+	//  */
+	// function unique_issue_key() {
+	// 	return $this->type . ',' . $this->old_declaration->path . ',' . $this->old_declaration->line . ',' . $this->old_declaration->display_name();
+	// }
+
+	function to_csv_array() {
+		return array(
+			'dependency',
+			$this->invocation->path,
+			$this->invocation->line,
+			$this->invocation->display_name(),
+			$this->declaration->display_name(),
+		);
+	}
+
+	function full_path() {
+		return $this->invocation_root ? $this->invocation_root . $this->invocation->path : $this->invocation->path;
+	}
+}

--- a/packages/analyzer/src/Dependencies/Dependency.php
+++ b/packages/analyzer/src/Dependencies/Dependency.php
@@ -15,13 +15,6 @@ class Dependency extends PersistentListItem {
 		$this->invocation_root = $invocation_root;
 	}
 
-	// /**
-	//  * This key is used to identify unique issues (e.g. Jetpack_Options has moved) across multiple invocations
-	//  */
-	// function unique_issue_key() {
-	// 	return $this->type . ',' . $this->old_declaration->path . ',' . $this->old_declaration->line . ',' . $this->old_declaration->display_name();
-	// }
-
 	function to_csv_array() {
 		return array(
 			'dependency',

--- a/packages/analyzer/src/Differences/Class_Method_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Method_Moved.php
@@ -33,13 +33,10 @@ class Class_Method_Moved extends PersistentListItem implements Invocation_Warner
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof Static_Call ) {
-			// check if it's instantiating this missing class
-			if ( $invocation->class_name === $this->old_declaration->class_name
-				&& $invocation->method_name === $this->old_declaration->method_name
-				&& $this->old_declaration->static ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static method ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );
-			}
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static method ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Differences/Class_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Moved.php
@@ -29,12 +29,10 @@ class Class_Moved extends PersistentListItem implements Invocation_Warner {
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof New_ ) {
-			// check if it's instantiating this missing class
-			// echo "Checking " . $invocation->class_name . " matches " . $this->old_declaration->class_name . "\n";
-			if ( $invocation->class_name === $this->old_declaration->class_name ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );
-			}
+		if ( $invocation->depends_on( $this->declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Differences/Class_Property_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Property_Missing.php
@@ -27,13 +27,10 @@ class Class_Property_Missing extends PersistentListItem implements Invocation_Wa
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof Static_Property ) {
-			// check if it's using this missing property
-			if ( $invocation->class_name === $this->declaration->class_name
-				&& $invocation->prop_name === $this->declaration->prop_name
-				&& $this->declaration->static ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static property ' . $this->declaration->display_name() . ' is missing', $this->declaration ) );
-			}
+		if ( $invocation->depends_on( $this->declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static property ' . $this->declaration->display_name() . ' is missing', $this->declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Differences/Class_Property_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Property_Moved.php
@@ -29,13 +29,10 @@ class Class_Property_Moved extends PersistentListItem implements Invocation_Warn
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof Static_Property ) {
-			// check if it's using this missing property
-			if ( $invocation->class_name === $this->old_declaration->class_name
-				&& $invocation->prop_name === $this->old_declaration->prop_name
-				&& $this->old_declaration->static ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static property ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );
-			}
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class static property ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Differences/Function_Missing.php
+++ b/packages/analyzer/src/Differences/Function_Missing.php
@@ -31,11 +31,10 @@ class Function_Missing extends PersistentListItem implements Invocation_Warner {
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof Function_Call ) {
-			// check if it's instantiating this missing class
-			if ( $invocation->func_name === $this->declaration->func_name ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Function ' . $this->declaration->display_name() . ' is missing', $this->declaration ) );
-			}
+		if ( $invocation->depends_on( $this->declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Function ' . $this->declaration->display_name() . ' is missing', $this->declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Differences/Function_Moved.php
+++ b/packages/analyzer/src/Differences/Function_Moved.php
@@ -33,11 +33,10 @@ class Function_Moved extends PersistentListItem implements Invocation_Warner {
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation instanceof Function_Call ) {
-			// check if it's instantiating this missing class
-			if ( $invocation->func_name === $this->old_declaration->func_name ) {
-				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Function ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );
-			}
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Function ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
+			);
 		}
 	}
 }

--- a/packages/analyzer/src/Invocations/Depends_On.php
+++ b/packages/analyzer/src/Invocations/Depends_On.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Automattic\Jetpack\Analyzer\Invocations;
+
+interface Depends_On {
+	public function depends_on( $declaration );
+}

--- a/packages/analyzer/src/Invocations/Function_Call.php
+++ b/packages/analyzer/src/Invocations/Function_Call.php
@@ -3,13 +3,14 @@
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Declarations\Function_;
 
 /**
  * Invocations of a function
  *
  * TODO: detect dynamic invocations like `$function_name( 'hi' )`
  */
-class Function_Call extends PersistentListItem {
+class Function_Call extends PersistentListItem implements Depends_On {
 	public $path;
 	public $line;
 	public $func_name;
@@ -36,5 +37,10 @@ class Function_Call extends PersistentListItem {
 
 	function display_name() {
 		return $this->func_name;
+	}
+
+	function depends_on( $declaration ) {
+		return $declaration instanceof Function_
+			&& $this->func_name === $declaration->func_name;
 	}
 }

--- a/packages/analyzer/src/Invocations/New_.php
+++ b/packages/analyzer/src/Invocations/New_.php
@@ -3,13 +3,14 @@
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Declarations\Class_;
 
 /**
  * Instantiation of a class
  *
  * TODO: detect dynamic instantiations like `$shape = new $class_name( $this->images )`
  */
-class New_ extends PersistentListItem {
+class New_ extends PersistentListItem implements Depends_On {
 	public $path;
 	public $line;
 	public $class_name;
@@ -36,5 +37,10 @@ class New_ extends PersistentListItem {
 
 	function display_name() {
 		return 'new ' . $this->class_name;
+	}
+
+	function depends_on( $declaration ) {
+		return $declaration instanceof Class_
+			&& $this->class_name === $declaration->class_name;
 	}
 }

--- a/packages/analyzer/src/Invocations/Static_Call.php
+++ b/packages/analyzer/src/Invocations/Static_Call.php
@@ -3,13 +3,14 @@
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Declarations\Class_Method;
 
 /**
  * Instantiation of a class
  *
  * TODO: detect dynamic instantiations like `$shape = new $class_name( $this->images )`
  */
-class Static_Call extends PersistentListItem {
+class Static_Call extends PersistentListItem implements Depends_On {
 	public $path;
 	public $line;
 	public $class_name;
@@ -38,5 +39,12 @@ class Static_Call extends PersistentListItem {
 
 	function display_name() {
 		return $this->class_name . '::' . $this->method_name;
+	}
+
+	function depends_on( $declaration ) {
+		return $declaration instanceof Class_Method
+			&& $this->class_name === $declaration->class_name
+			&& $this->method_name === $declaration->method_name
+			&& $declaration->static;
 	}
 }

--- a/packages/analyzer/src/Invocations/Static_Const.php
+++ b/packages/analyzer/src/Invocations/Static_Const.php
@@ -3,13 +3,14 @@
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Declarations\Class_Const;
 
 /**
  * Instantiation of a class
  *
  * TODO: detect dynamic instantiations like `$shape = new $class_name( $this->images )`
  */
-class Static_Const extends PersistentListItem {
+class Static_Const extends PersistentListItem implements Depends_On {
 	public $path;
 	public $line;
 	public $class_name;
@@ -38,5 +39,11 @@ class Static_Const extends PersistentListItem {
 
 	function display_name() {
 		return $this->class_name . '::' . $this->const_name;
+	}
+
+	function depends_on( $declaration ) {
+		return $declaration instanceof Class_Const
+			&& $this->class_name === $declaration->class_name
+			&& $this->const_name === $declaration->const_name;
 	}
 }

--- a/packages/analyzer/src/Invocations/Static_Property.php
+++ b/packages/analyzer/src/Invocations/Static_Property.php
@@ -3,13 +3,14 @@
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Declarations\Class_Property;
 
 /**
  * Instantiation of a class
  *
  * TODO: detect dynamic instantiations like `$shape = new $class_name( $this->images )`
  */
-class Static_Property extends PersistentListItem {
+class Static_Property extends PersistentListItem implements Depends_On {
 	public $path;
 	public $line;
 	public $class_name;
@@ -38,5 +39,12 @@ class Static_Property extends PersistentListItem {
 
 	function display_name() {
 		return $this->class_name . '::$' . $this->prop_name;
+	}
+
+	function depends_on( $declaration ) {
+		return $declaration instanceof Class_Property
+			&& $this->class_name === $declaration->class_name
+			&& $this->prop_name === $declaration->prop_name
+			&& $declaration->static;
 	}
 }


### PR DESCRIPTION
Sometimes it's useful to look for all dependencies between Codebase A and Codebase B. That is, all lines where Codebase **invokes** something that is **declared** in Codebase B.

This can be useful for eyeballing all the ways our code is used in those files, to check for possible incompatibilities.

It adds a new `Dependencies` class and refactors some of the code that looks for incompatibilities (i.e. "invocations that depend on declarations that have changed") so that it can be used to find **all** uses of a declaration.

### Usage

```php
// get the declarations
$jetpack_exclude    = array( '.git', 'vendor', 'tests', 'docker', 'bin', 'scss', 'images', 'docs', 'languages', 'node_modules' );
$jetpack_74_declarations = new Automattic\Jetpack\Analyzer\Declarations();
$jetpack_74_declarations->scan( $jetpack_74_path, $jetpack_exclude );

// get the invocations
$invocations = new Automattic\Jetpack\Analyzer\Invocations();
$invocations->scan( $repo_path, array( '.git', 'node_modules' ) );

// find and print the dependencies
$dependencies = new Automattic\Jetpack\Analyzer\Dependencies();
$dependencies->generate( $invocations, $jetpack_74_declarations, $repo_path );
$dependencies->output();
```

Example full output ( `$dependencies->output();` )

```
dependency,widgets/twitter.php,226,"\Jetpack_Options::get_option","\Jetpack_Options::get_option($name,$default=\false)"
dependency,widgets/twitter.php,230,"\Jetpack_Client::remote_request","\Jetpack_Client::remote_request($args,$body=\null)"
dependency,widgets/instagram/instagram.php,97,"\Jetpack_Options::get_option","\Jetpack_Options::get_option($name,$default=\false)"
dependency,widgets/instagram/instagram.php,148,"\Jetpack_Options::get_option","\Jetpack_Options::get_option($name,$default=\false)"
dependency,widgets/instagram/instagram.php,151,"\Jetpack_Client::remote_request","\Jetpack_Client::remote_request($args,$body=\null)"
```

Example summary by **declaration** ( `echo $dependencies->declaration_summary();` )

```
\Jetpack_Options::get_option($name,$default=\false),16
\Jetpack::is_active(),6
\Jetpack::load_xml_rpc_client(),4
\Jetpack_IXR_Client,3
\Jetpack_Client::WPCOM_JSON_API_VERSION,3
\Jetpack_Client::wpcom_json_api_request_as_blog($path,$version=\Jetpack_Client::WPCOM_JSON_API_VERSION,$args=array(),$body=\null,$base_api_path='rest'),3
wp_startswith($haystack,$needle),3
\Jetpack_Client::remote_request($args,$body=\null),3
\Jetpack_Client::_wp_remote_request($url,$args,$set_fallback=\false),2
wp_endswith($haystack,$needle),2
\Jetpack::activate_module($module,$exit=\true,$redirect=\true),2
```

Example summary by **external file** ( `echo $dependencies->external_file_summary();` )

```
/path/to/repo/repo-a/jetpack-start/provision.php,19
/path/to/repo/repo-b/class.cli-commands.php,9
/path/to/repo/repo-a/jetpack-start/api.php,7
/path/to/repo/repo-a/vaultpress/vaultpress.php,6
/path/to/repo/repo-a/a8c-files.php,5
/path/to/repo/repo-b/boostrap.php,4
```