### PR TITLE
Remove e2e test code that purchases the Jetpack plan twice in a row

### DIFF
--- a/tests/e2e/lib/pages/wpcom/checkout.js
+++ b/tests/e2e/lib/pages/wpcom/checkout.js
@@ -43,10 +43,8 @@ export default class CheckoutPage extends Page {
 
 	async waitForPaymentProcessing() {
 		const progressBarSelector = '.checkout__credit-card-payment-box-progress-bar';
-		if ( await isEventuallyVisible( this.page, progressBarSelector ) ) {
-			// Wait for the progress bar to finish.
-			await waitForSelector( this.page, progressBarSelector, { hidden: true, timeout: 3 * 30000 } );
-		}
+		await waitForSelector( this.page, progressBarSelector );
+		await waitForSelector( this.page, progressBarSelector, { hidden: true, timeout: 3 * 30000 } );
 	}
 
 	async waitToDisappear() {

--- a/tests/e2e/lib/pages/wpcom/checkout.js
+++ b/tests/e2e/lib/pages/wpcom/checkout.js
@@ -42,15 +42,10 @@ export default class CheckoutPage extends Page {
 	}
 
 	async waitForPaymentProcessing() {
-		const paymentButtonSelector = '.credit-card-payment-box button.is-primary:not([disabled])';
 		const progressBarSelector = '.checkout__credit-card-payment-box-progress-bar';
-		await waitForSelector( this.page, progressBarSelector, { hidden: true, timeout: 3 * 30000 } );
-		// For some reason first purchase attempt fails quite often. Going to try for a second time.
-		if ( ! this.paymentFailed && this.page.$( paymentButtonSelector ) ) {
-			this.paymentFailed = true;
-			// eslint-disable-next-line no-console
-			console.log( 'First payment attempt failed. Trying one more time!' );
-			return this.submitPaymentDetails();
+		if ( await isEventuallyVisible( this.page, progressBarSelector ) ) {
+			// Wait for the progress bar to finish.
+			await waitForSelector( this.page, progressBarSelector, { hidden: true, timeout: 3 * 30000 } );
 		}
 	}
 


### PR DESCRIPTION
The e2e tests currently submit the checkout form to purchase a plan, then submit it again because it appears not to succeed (there is a 500 error).  In reality, though, examination of server-side records shows that the first payment attempt does succeed (despite the 500 error) and the second payment attempt therefore triggers a renewal.  This is leading to some complications in the test data server-side.

I've fixed the underlying issue on the server that was causing the 500 errors (it was limited to the test environment only): D29974-code

Consequently, it should be possible to remove the workaround in the tests completely. This pull request does that.  It also makes sure we wait for the progress bar on the checkout form to appear before waiting for it to complete and disappear (I'm not sure how much it matters, but it looks to me like the old code is at risk of failing via a race condition if it detects the "disappearance" of the progress bar before it even appears on the screen.)

See also: pNPgK-4C2-p2

#### Testing instructions:

Run the e2e tests and see if they pass :) Note: I haven't tested this at all myself, since I'm not familiar with the test setup.  Just putting it up here for review to try to help out.

#### Proposed changelog entry for your changes:
* Remove e2e test code that purchases the Jetpack plan twice in a row
