### PR TITLE
Fix a typo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Lazy Load: allow adding event handlers to images.
 * Recurring Payments Block: improve the display of the block in the editor.
 * WordAds: update link to daily earnings stats on WordPress.com.
-* WordAds: provide dditional details for custom ads.txt entries in the Jetpack dashboard.
+* WordAds: provide additional details for custom ads.txt entries in the Jetpack dashboard.
 * WordPress.com Toolbar: add colors to Recovery Mode button.
 
 **Improved compatibility**


### PR DESCRIPTION
Fix a typo I found when translating the plugin to pt-BR.
