### PR TITLE
Amin Page: Rename Tracks event prop for akismet feature to be anti-spam for activation and installation buttons

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -42,7 +42,7 @@ class DashAkismet extends Component {
 		analytics.tracks.recordJetpackClick( {
 			type: 'install-link',
 			target: 'at-a-glance',
-			feature: 'akismet',
+			feature: 'anti-spam',
 		} );
 	}
 
@@ -50,7 +50,7 @@ class DashAkismet extends Component {
 		analytics.tracks.recordJetpackClick( {
 			type: 'activate-link',
 			target: 'at-a-glance',
-			feature: 'akismet',
+			feature: 'anti-spam',
 		} );
 	}
 


### PR DESCRIPTION
As  noted in https://github.com/Automattic/jetpack/pull/12690#discussion-diff-295801645R48 we should call this feature `anti-spam` .

See for example: https://github.com/Automattic/jetpack/blob/5729f3aebe6d2969af629e2777cac8854e08cf20/_inc/client/security/antispam.jsx#L76 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Just updates some tracking event properties. 

#### Testing instructions:

* Confirm the change makes sense

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
