### PR TITLE
Admin: fix console warning due to undefined props

### DIFF
--- a/_inc/client/components/upgrade-link/README.md
+++ b/_inc/client/components/upgrade-link/README.md
@@ -20,7 +20,7 @@ class UpgradeTest extends Component {
 				source="aag-backups"
 				target="at-a-glance"
 				feature="backups"
-			>
+			/>
 		);
 	}
 	

--- a/_inc/client/components/upgrade-link/README.md
+++ b/_inc/client/components/upgrade-link/README.md
@@ -15,7 +15,13 @@ import UpgradeLink from 'components/upgrade-link';
 class UpgradeTest extends Component {
 
 	render() {
-		return <UpgradeLink source="aag-backups">;
+		return (
+			<UpgradeLink
+				source="aag-backups"
+				target="at-a-glance"
+				feature="backups"
+			>
+		);
 	}
 	
 }
@@ -31,5 +37,23 @@ The following props can be passed to the UpgradeLink component:
 	<tr><td>Required</td><td>Yes</td></tr>
 </table>
 
-Pass a string describing the context where this link was found and clicked.
+Pass a string describing the local context (like a card) where this link was found and clicked.
+
+### `target`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+Pass a string pointing the view (like a tab) where this link was found and clicked.
+
+### `target`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Pass a string with the name of the feature related to this upgrade link.
 

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -27,11 +27,13 @@ class UpgradeLink extends PureComponent {
 	trackClick = () => {
 		const { target, feature } = this.props;
 
-		if ( target && feature ) {
+		if ( target ) {
+			const featureProp = feature ? { feature } : {};
+
 			analytics.tracks.recordJetpackClick( {
 				type: 'upgrade-link',
 				target,
-				feature,
+				...featureProp,
 			} );
 		}
 	};

--- a/_inc/client/components/upgrade-link/index.jsx
+++ b/_inc/client/components/upgrade-link/index.jsx
@@ -18,7 +18,7 @@ class UpgradeLink extends PureComponent {
 	static propTypes = {
 		source: PropTypes.string.isRequired,
 		target: PropTypes.string.isRequired,
-		feature: PropTypes.string.isRequired,
+		feature: PropTypes.string,
 
 		// Connected
 		upgradeUrl: PropTypes.string.isRequired,

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -58,7 +58,9 @@ class MyPlanHeader extends React.Component {
 									'Worried about security? Get backups, automated security fixes and more: {{a}}Upgrade now{{/a}}',
 									{
 										components: {
-											a: <UpgradeLink source="myplan-header-free-plan-text-link" />,
+											a: (
+												<UpgradeLink source="myplan-header-free-plan-text-link" target="my-plan" />
+											),
 										},
 									}
 								) }


### PR DESCRIPTION
This PR fixes and issue where warnings for undefined `target` and `feature` props were displayed due to a UpgradeLink instantiation missing them in `MyPlanHeader` component.

<img width="825" alt="Captura de Pantalla 2019-07-01 a la(s) 17 03 56" src="https://user-images.githubusercontent.com/1041600/60466022-e4a2a500-9c28-11e9-88d6-0e8d980d5e55.png">

These new properties were introduced recently in

https://github.com/Automattic/jetpack/pull/12690/commits/3d7293a191cb9fd26d8c196f7d8ce2406ff962d1#diff-5ac0a748276b8ad17152af0e79609789R20

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add missing `target` prop to `UpgradeLink` instance
* set `feature` to be not required because the `UpgradeLink` in this case doesn't refer to a feature but to the whole plan
* updates Readme to introduce the new properties introduced in #12690 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Jetpack dashboard in a connected site. I happened to find this while testing 7.5 in a free plan site
* open the browser's Console
* Click My Plan tab
* ensure there's no warning on the Console

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not necessary since it was introduced in the same release cycle
