### PR TITLE
Sync: Use Status::is_development_mode() instead of the Jetpack one

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -169,6 +169,36 @@
             "description": "A wrapper for defining constants in a more testable way."
         },
         {
+            "name": "automattic/jetpack-status",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "./packages/status",
+                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
+                "shasum": null
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
+        },
+        {
             "name": "automattic/jetpack-jitm",
             "version": "dev-add/jetpack-compat-package",
             "dist": {
@@ -697,6 +727,7 @@
         "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-constants": 20,
+        "automattic/jetpack-status": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-sync": 20,

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev"
+		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"autoload": {
 		"psr-4": {

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -110,12 +111,16 @@ class Actions {
 		if ( ! Settings::is_sync_enabled() ) {
 			return false;
 		}
-		if ( \Jetpack::is_development_mode() ) {
+
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			return false;
 		}
+
 		if ( \Jetpack::is_staging_site() ) {
 			return false;
 		}
+
 		if ( ! \Jetpack::is_active() ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;


### PR DESCRIPTION
This PR updates the Sync package to now rely on the Status package, and use `Status::is_development_mode()` as a step towards decoupling the Sync package from the Jetpack core.

#### Changes proposed in this Pull Request:
* Add Status package as a dependency of the Sync package.
* Use `Status::in_development_mode` instead of `Jetpack::in_development_mode`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of the Jetpack DNA project.

#### Testing instructions:

* Checkout the branch.
* Enable WP_DEBUG_LOG.
* Smoke test the site in wp-admin and the frontend.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Sync: Use Status::is_development_mode() instead of the Jetpack one