### PR TITLE
Disable instagram tests for now

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,7 +41,6 @@
 		</testsuite>
 		<testsuite name="shortcodes">
 			<directory prefix="test" suffix=".php">tests/php/modules/shortcodes</directory>
-			<exclude>tests/php/modules/shortcodes/test-class.instagram.php</exclude>
 		</testsuite>
 		<testsuite name="widgets">
 			<directory prefix="test_" suffix=".php">tests/php/modules/widgets</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,6 +41,7 @@
 		</testsuite>
 		<testsuite name="shortcodes">
 			<directory prefix="test" suffix=".php">tests/php/modules/shortcodes</directory>
+			<exclude>tests/php/modules/shortcodes/test-class.instagram.php</exclude>
 		</testsuite>
 		<testsuite name="widgets">
 			<directory prefix="test_" suffix=".php">tests/php/modules/widgets</directory>

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -121,8 +121,12 @@ BODY;
 
 	/**
 	 * @covers ::jetpack_instagram_handler
+	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_image_url_with_embed() {
+		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped('must be revisited.');
+		}
 		global $post;
 
 		$instagram_url = 'https://www.instagram.com/p/BnMO9vRleEx/';
@@ -142,8 +146,12 @@ BODY;
 
 	/**
 	 * @covers ::jetpack_instagram_handler
+	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_video_url_with_embed() {
+		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped('must be revisited.');
+		}
 		global $post;
 
 		$instagram_url = 'https://www.instagram.com/tv/BkQjCfsBIzi/';
@@ -163,8 +171,12 @@ BODY;
 
 	/**
 	 * @covers ::jetpack_instagram_handler
+	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_profile_image_url_with_embed() {
+		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped('must be revisited.');
+		}
 		global $post;
 
 		$instagram_username      = 'jeherve';
@@ -187,8 +199,12 @@ BODY;
 
 	/**
 	 * @covers ::jetpack_instagram_handler
+	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_profile_video_url_with_embed() {
+		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped('must be revisited.');
+		}
 		global $post;
 
 		$instagram_username      = 'instagram';

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -124,8 +124,8 @@ BODY;
 	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_image_url_with_embed() {
-		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
-			$this->markTestSkipped('must be revisited.');
+		if ( 'master' === getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped( 'must be revisited.' );
 		}
 		global $post;
 
@@ -149,8 +149,8 @@ BODY;
 	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_video_url_with_embed() {
-		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
-			$this->markTestSkipped('must be revisited.');
+		if ( 'master' === getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped( 'must be revisited.' );
 		}
 		global $post;
 
@@ -174,8 +174,8 @@ BODY;
 	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_profile_image_url_with_embed() {
-		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
-			$this->markTestSkipped('must be revisited.');
+		if ( 'master' === getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped( 'must be revisited.' );
 		}
 		global $post;
 
@@ -202,8 +202,8 @@ BODY;
 	 * @todo Enable this test on WP master https://github.com/Automattic/jetpack/issues/12918
 	 */
 	public function test_instagram_replace_profile_video_url_with_embed() {
-		if ( 'master'===getenv( 'WP_BRANCH' ) ) {
-			$this->markTestSkipped('must be revisited.');
+		if ( 'master' === getenv( 'WP_BRANCH' ) ) {
+			$this->markTestSkipped( 'must be revisited.' );
 		}
 		global $post;
 


### PR DESCRIPTION
`test-class.instagram.php` tests are failing against WP master. Disabling them for now, to unblock folks, since the failure seems like related to the core changes.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* disable instagram tests


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure that Travis is happy
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
