### PR TITLE
Status: Port Jetpack::is_multi_network() and add tests

### DIFF
--- a/packages/status/src/Status.php
+++ b/packages/status/src/Status.php
@@ -41,4 +41,27 @@ class Status {
 
 		return $development_mode;
 	}
+
+	/**
+	 * Whether this is a system with a multiple networks.
+	 * Implemented since there is no core is_multi_network function.
+	 * Right now there is no way to tell which network is the dominant network on the system.
+	 *
+	 * @return boolean
+	 */
+	public function is_multi_network() {
+		global $wpdb;
+
+		// if we don't have a multi site setup no need to do any more
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		$num_sites = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->site}" );
+		if ( $num_sites > 1 ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -112,6 +112,51 @@ class Test_Status extends TestCase {
 	}
 
 	/**
+	 * @covers Automattic\Jetpack\Status::is_multi_network
+	 */
+	public function test_is_multi_network_not_multisite() {
+		$this->mock_function( 'is_multisite', false );
+
+		$this->assertFalse( $this->status->is_multi_network() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Status::is_multi_network
+	 */
+	public function test_is_multi_network_when_single_network() {
+		global $wpdb;
+		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
+		             ->setMockClassName( 'wpdb' )
+		             ->setMethods( array( 'get_var' ) )
+		             ->getMock();
+		$wpdb->method( 'get_var' )
+		     ->willReturn( 1 );
+		$this->mock_function( 'is_multisite', true );
+
+		$this->assertFalse( $this->status->is_multi_network() );
+
+		unset( $wpdb );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Status::is_multi_network
+	 */
+	public function test_is_multi_network_when_multiple_networks() {
+		global $wpdb;
+		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
+		             ->setMockClassName( 'wpdb' )
+		             ->setMethods( array( 'get_var' ) )
+		             ->getMock();
+		$wpdb->method( 'get_var' )
+		     ->willReturn( 2 );
+		$this->mock_function( 'is_multisite', true );
+
+		$this->assertTrue( $this->status->is_multi_network() );
+
+		unset( $wpdb );
+	}
+
+	/**
 	 * Mock a global function with particular arguments and make it return a certain value.
 	 *
 	 * @param string $function_name Name of the function.

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -225,12 +225,15 @@ class Test_Status extends TestCase {
 	 */
 	protected function mock_wpdb_get_var( $return_value = null ) {
 		global $wpdb;
+
 		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
 		             ->setMockClassName( 'wpdb' )
 		             ->setMethods( array( 'get_var' ) )
 		             ->getMock();
 		$wpdb->method( 'get_var' )
 		     ->willReturn( $return_value );
+
+		$wpdb->site = 'wp_site';
 	}
 
 	/**

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -124,36 +124,24 @@ class Test_Status extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_multi_network
 	 */
 	public function test_is_multi_network_when_single_network() {
-		global $wpdb;
-		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
-		             ->setMockClassName( 'wpdb' )
-		             ->setMethods( array( 'get_var' ) )
-		             ->getMock();
-		$wpdb->method( 'get_var' )
-		     ->willReturn( 1 );
+		$this->mock_wpdb_get_var( 1 );
 		$this->mock_function( 'is_multisite', true );
 
 		$this->assertFalse( $this->status->is_multi_network() );
 
-		unset( $wpdb );
+		$this->clean_mock_wpdb_get_var();
 	}
 
 	/**
 	 * @covers Automattic\Jetpack\Status::is_multi_network
 	 */
 	public function test_is_multi_network_when_multiple_networks() {
-		global $wpdb;
-		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
-		             ->setMockClassName( 'wpdb' )
-		             ->setMethods( array( 'get_var' ) )
-		             ->getMock();
-		$wpdb->method( 'get_var' )
-		     ->willReturn( 2 );
+		$this->mock_wpdb_get_var( 2 );
 		$this->mock_function( 'is_multisite', true );
 
 		$this->assertTrue( $this->status->is_multi_network() );
 
-		unset( $wpdb );
+		$this->clean_mock_wpdb_get_var();
 	}
 
 	/**
@@ -227,5 +215,29 @@ class Test_Status extends TestCase {
 				return $return_value;
 			} );
 		return $builder->build()->enable();
+	}
+
+	/**
+	 * Mock $wpdb->get_var() and make it return a certain value.
+	 *
+	 * @param mixed  $return_value  Return value of the function.
+	 * @return PHPUnit\Framework\MockObject\MockObject The mock object.
+	 */
+	protected function mock_wpdb_get_var( $return_value = null ) {
+		global $wpdb;
+		$wpdb = $this->getMockBuilder( 'Mock_wpdb' )
+		             ->setMockClassName( 'wpdb' )
+		             ->setMethods( array( 'get_var' ) )
+		             ->getMock();
+		$wpdb->method( 'get_var' )
+		     ->willReturn( $return_value );
+	}
+
+	/**
+	 * Clean up the existing $wpdb->get_var() mock.
+	 */
+	protected function clean_mock_wpdb_get_var() {
+		global $wpdb;
+		unset( $wpdb );
 	}
 }


### PR DESCRIPTION
This PR ports the `Jetpack::is_multi_network()` method to the Status package and adds some tests. This method is used in the Sync package, so this is a small step towards decoupling sync from the Jetpack core.

#### Changes proposed in this Pull Request:
* Port `Jetpack::is_multi_network()` to the status package.
* Add tests for `Status::is_multi_network()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of Jetpack DNA.

#### Testing instructions:

* Go to the status package directory: `cd packages/status`
* Install and run tests `composer phpunit` and verify they pass.
* See CI and verify that that tests pass.

#### Proposed changelog entry for your changes:
* Port `Jetpack::is_multi_network()` to the Status package and add tests
