### PR TITLE
Tests: Cleanup any obsolete PHP 5.2 remnants

### DIFF
--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -59,7 +59,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author roccotripaldi
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_token_or_signature() {
 		global $wp_version;
@@ -78,7 +77,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_token() {
 		$_GET['signature'] = 'invalid';
@@ -91,7 +89,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_signature() {
 		$_GET['token'] = 'invalid';
@@ -104,7 +101,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author roccotripaldi
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_invalid_token() {
 		$_GET['token'] = 'invalid';
@@ -118,7 +114,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_bad_nonce() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -139,7 +134,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_authentication_fail_bad_signature() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -157,7 +151,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_get_authentication_success() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -187,7 +180,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_authentication_fail_bad_signature() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -207,7 +199,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_authentication_fail_bad_body_hash() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -238,7 +229,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	/**
 	 * @author jnylen0
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
@@ -278,7 +268,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_urlencoded_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
@@ -321,7 +310,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @covers Jetpack->wp_rest_authenticate
-	 * @requires PHP 5.2
 	 */
 	public function test_jetpack_rest_api_post_multipart_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'multipart/form-data; boundary=------------------------test';

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -14,7 +14,6 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 	/**
 	 * @author zinigor
 	 * @covers Jetpack_Core_API_Module_Activate_Endpoint
-	 * @requires PHP 5.2
 	 * @dataProvider api_routes
 	 */
 	public function test_register_routes( $route_string = false, $method = false, $classname = false ) {

--- a/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -12,7 +12,6 @@ class WP_Test_Jetpack_Core_Api_Xmlrpc_Consumer_Endpoint extends WP_UnitTestCase 
 	/**
 	 * @author zinigor
 	 * @covers Jetpack_Core_XMLRPC_Consumer_Endpoint
-	 * @requires PHP 5.2
 	 * @dataProvider true_false_provider
 	 */
 	public function test_Jetpack_Core_API_XMLRPC_Consumer_Endpoint_privacy_check( $query_success, $result ) {

--- a/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
@@ -24,12 +24,6 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 
 		parent::setUp();
 
-		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
-			// Loading the API breaks in 5.2.x due to `const` declarations, and
-			// this will still happen even though all tests are skipped (why?)
-			return;
-		}
-
 		$this->set_globals();
 	}
 
@@ -55,7 +49,6 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
-	 * @requires PHP 5.3
 	 */
 	public function test_get_term_feed_url_pretty_permalinks() {
 		global $blog_id;
@@ -86,7 +79,6 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	 * @author nylen
 	 * @covers WPCOM_JSON_API_Get_Taxonomy_Endpoint
 	 * @group json-api
-	 * @requires PHP 5.3
 	 */
 	public function test_get_term_feed_url_ugly_permalinks() {
 		global $blog_id;

--- a/tests/php/json-api/test-class.json-api-plugins-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-plugins-endpoints.php
@@ -18,12 +18,6 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 
 		parent::setUp();
 
-		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
-			// Loading the API breaks in 5.2.x due to `const` declarations, and
-			// this will still happen even though all tests are skipped (why?)
-			return;
-		}
-
 		$this->set_globals();
 
 		// Force direct method. Running the upgrade via PHPUnit can't detect the correct filesystem method.
@@ -34,7 +28,6 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 	 * @author lezama
 	 * @covers Jetpack_JSON_API_Plugins_Modify_Endpoint
 	 * @group external-http
-	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
 		$endpoint = new Jetpack_JSON_API_Plugins_Modify_Endpoint( array(
@@ -103,7 +96,6 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 	 * @author tonykova
 	 * @covers Jetpack_API_Plugins_Install_Endpoint
 	 * @group external-http
-	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {
 		if ( is_multisite() ) {

--- a/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/tests/php/media/test-class.jetpack-media-extractor.php
@@ -377,7 +377,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Media_Meta_Extractor::extract
-	 * @todo This test is failing in 5.2 and 5.3 for unknown reasons. Figure it out.
+	 * @todo This test is failing in 5.3 for unknown reasons. Figure it out.
 	 * @since 3.2
 	 * @requires PHP 5.4.0
 	 */

--- a/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
+++ b/tests/php/sync/anonymous_function_test_for_register_post_types_callback_error.php
@@ -1,9 +1,0 @@
-<?php
-
-/**
- * This code is used by the test test_register_post_types_callback_error() present in the file tests/php/sync/test_class.jetpack-sync-callables.php
- * This test attempts to sync an anonymous callable but anonymous functions are not present in PHP 5.2 which we still support.
- * So, this file is conditionally included by that test if being run on PHP >=5.4
- */
-register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
-

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -642,12 +642,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_register_post_types_callback_error() {
-		if ( version_compare(PHP_VERSION, '5.4', '<' ) ) {
-			$this->markTestSkipped( 'Callbacks are only available in PHP 5.4 and greater' );
-			return;
-		}
-		// This file needs to be included conditionally so PHP 5.2 does not error due to static analysis of this file.
-		require_once dirname( __FILE__ ) . '/anonymous_function_test_for_register_post_types_callback_error.php';
+		register_post_type( 'testing', array( 'register_meta_box_cb' => function() {} ) );
 		$this->sender->do_sync();
 
 		$post_types =  $this->server_replica_storage->get_callable( 'post_types' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1089,10 +1089,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
-		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
-			$this->markTestSkipped( 'This test fails in PHP 5.2.' );
-		}
-
 		$post_id = $this->factory->post->create();
 		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id_2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
@@ -1223,10 +1219,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_status_with_a_small_queue() {
-		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
-			$this->markTestSkipped( 'This test fails in PHP 5.2.' );
-		}
-
 		$this->sender->set_dequeue_max_bytes( 750 ); // process 0.00075MB of items at a time
 
 		$this->create_dummy_data_and_empty_the_queue();

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -15,9 +15,6 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		parent::setUp();
 
 		require ABSPATH . 'wp-includes/version.php';
-		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
-			$this->markTestIncomplete( "Right now this doesn't work on PHP 5.2" );
-		}
 
 		if (
 			version_compare( $wp_version, '4.9.0', '<' )
@@ -101,7 +98,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		 * in WP Plugin_Upgrader->update() doesn't fire the upgrader_process_complete action
 		 * when it encounters an error so right now we do not have a way to hook into why a plugin failed.
 		 */
-		$this->markTestIncomplete( "Right now this doesn't work on PHP 5.2" );
+		$this->markTestIncomplete( "Right now this doesn't work." );
 
 		$this->server_event_storage->reset();
 		$plugin_defaults = array(

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -16,10 +16,6 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_installing_and_removing_plugin_is_synced() {
-		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
-			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");
-		}
-
 		$this->resetCallableAndConstantTimeouts();
 		$this->sender->do_sync();
 		$this->server_event_storage->reset();

--- a/tests/php/sync/test_interface.jetpack-sync-codec.php
+++ b/tests/php/sync/test_interface.jetpack-sync-codec.php
@@ -2,8 +2,6 @@
 
 /*
  * Tests all known implementations of the codec
- *
- * @requires PHP 5.3
  */
 
 class WP_Test_Jetpack_Sync_Codec_Interface extends PHPUnit_Framework_TestCase {
@@ -12,7 +10,6 @@ class WP_Test_Jetpack_Sync_Codec_Interface extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider codec_provider
-	 * @requires PHP 5.3
 	 */
 	public function test_sync_codec_encodes_objects( $codec ) {
 		$object = (object) array(
@@ -27,7 +24,6 @@ class WP_Test_Jetpack_Sync_Codec_Interface extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider codec_provider
-	 * @requires PHP 5.3
 	 */
 	public function test_sync_codec_does_not_explode_on_circular_reference( $codec ) {
 		$object_a = new stdClass();
@@ -42,7 +38,6 @@ class WP_Test_Jetpack_Sync_Codec_Interface extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider codec_provider
-	 * @requires PHP 5.3
 	 */
 	public function test_codec_does_not_modify_original_object( $codec ) {
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -11,8 +11,6 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 
 /*
  * Tests all known implementations of the replicastore
- *
- * @requires PHP 5.3
  */
 
 class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
@@ -36,13 +34,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		parent::setUp();
-
-		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
-			$this->markTestSkipped(
-				'PHP 5.2 and below does not support ReflectionProperty to the extent that we need.'
-			);
-			return;
-		}
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			switch_to_blog( self::$token->blog_id );
@@ -69,7 +60,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Test that the checksum values between implementations are the same
-	 * @requires PHP 5.3
 	 */
 	function test_all_checksums_match() {
 		$post           = self::$factory->post( 5 );
@@ -161,7 +151,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_checksum_with_id_range( $store ) {
 		$post           = self::$factory->post( 5 );
@@ -213,7 +202,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_does_not_checksum_spam_comments( $store ) {
 		$comment        = self::$factory->comment( 3, 1 );
@@ -233,7 +221,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_strips_non_ascii_chars_for_checksum( $store ) {
 		$utf8_post = self::$factory->post( 1, array( 'post_content' => 'Panamá' ) );
@@ -262,7 +249,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_checksum_histogram( $store ) {
 
@@ -334,7 +320,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_checksum_posts_return_different_values_on_enej_case( $store ) {
 		$store->reset();
@@ -359,7 +344,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_histogram_accepts_columns( $store ) {
 		for ( $i = 1; $i <= 20; $i += 1 ) {
@@ -379,7 +363,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_histogram_detects_missing_columns( $store ) {
 		global $wpdb;
@@ -410,7 +393,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_upsert_post( $store ) {
 		$this->assertEquals( 0, $store->post_count() );
@@ -440,7 +422,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_get_posts( $store ) {
 		$store->upsert_post( self::$factory->post( 1, array( 'post_status' => 'draft' ) ) );
@@ -465,7 +446,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_checksum_posts( $store ) {
 		$before_checksum = $store->posts_checksum();
@@ -483,7 +463,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_upsert_comment( $store ) {
 		$this->assertEquals( 0, $store->comment_count() );
@@ -511,7 +490,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_checksum_comments( $store ) {
 		$before_checksum = $store->comments_checksum();
@@ -525,7 +503,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_get_comments( $store ) {
 		$post_id = 1;
@@ -548,7 +525,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_update_option( $store ) {
 		$option_name  = 'blogdescription';
@@ -561,7 +537,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_delete_option( $store ) {
 		$option_name  = 'test_replicastore_' . rand();
@@ -575,7 +550,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_set_theme_support( $store ) {
 
@@ -685,7 +659,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_reset_preserves_internal_keys( $store ) {
 		if ( $store instanceof Jetpack_Sync_Test_Replicastore ) {
@@ -709,7 +682,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_update_meta( $store ) {
 		$store->upsert_post( self::$factory->post( 1 ) );
@@ -725,7 +697,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_update_meta_array( $store ) {
 		$meta_array = array( 'trees' => 'green', 'ocean' => 'blue' );
@@ -772,7 +743,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_set_constant( $store ) {
 		$this->assertNull( $store->get_constant( 'FOO' ) );
@@ -788,7 +758,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_set_updates( $store ) {
 		$this->assertNull( $store->get_updates( 'core' ) );
@@ -804,7 +773,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_set_callables( $store ) {
 		if ( $store instanceof Replicastore ) {
@@ -824,7 +792,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_set_site_options( $store ) {
 		$this->assertFalse( $store->get_site_option( 'foo' ), 'Site option Not empty.' );
@@ -836,7 +803,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_delete_site_option( $store ) {
 		$store->update_site_option( 'to_delete', 'me' );
@@ -854,7 +820,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_update_users( $store ) {
 		if ( $store instanceof Replicastore ) {
@@ -896,7 +861,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_get_allowed_mime_types( $store ) {
 		if ( $store instanceof Replicastore ) {
@@ -917,7 +881,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	public function test_replica_update_terms( $store ) {
 		$taxonomy = 'test_shadow_taxonomy_term';
@@ -944,7 +907,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_delete_terms( $store ) {
 		$taxonomy = 'test_shadow_taxonomy_term';
@@ -969,7 +931,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_update_post_terms( $store ) {
 		$taxonomy = 'test_shadow_taxonomy_term';
@@ -1003,7 +964,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 	function test_replica_delete_post_terms( $store ) {
 		$this->markTestIncomplete( 'contains SQL' );

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * The tests require PHP 5.3 :( The feature does not.
- *
- * @requires PHP 5.3
- */
 class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	protected static $test_image;
 
@@ -12,12 +7,6 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 
 	public function setUp() {
 		parent::setUp();
-
-		// The version of PHPUnit we're using on TravisCI doesn't support @requires
-		// Skip manually.
-		if ( version_compare( phpversion(), '5.3', '<' ) ) {
-			$this->markTestSkipped( 'Testing the Jetpack_Photon singleton requires PHP 5.3' );
-		}
 
 		// Preserving global variables
 		global $content_width;
@@ -33,11 +22,6 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	}
 
 	public function tearDown() {
-		// ::tearDown runs even if the test is skipped.
-		if ( version_compare( phpversion(), '5.3', '<' ) ) {
-			return parent::tearDown();
-		}
-
 		// Restoring global variables
 		global $content_width;
 		$content_width = $this->_globals['content_width'];


### PR DESCRIPTION
This PR removes any PHP 5.2 remnants from our tests.

#### Changes proposed in this Pull Request:
Tests: Cleanup any obsolete PHP 5.2 remnants

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No, this is purely a janitorial/cleanup PR.

#### Testing instructions:
* Make sure all tests pass on CI.

#### Proposed changelog entry for your changes:
Tests: Cleanup any obsolete PHP 5.2 remnants
