### PR TITLE
Avoid running these functions on commit

### DIFF
--- a/packages/compat/functions.php
+++ b/packages/compat/functions.php
@@ -4,6 +4,10 @@
  * TODO: Legacy global scope functions here
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 add_action( 'plugins_loaded', 'jetpack_compat_require_defined_functions' );
 
 function jetpack_compat_require_defined_functions() {


### PR DESCRIPTION
While trying to commit, I started getting this error

```
Fatal error: Uncaught Error: Call to undefined function add_action() in /Users/aldion/Sites/jetpack/packages/compat/functions.php:7
Stack trace:
#0 /Users/aldion/Sites/jetpack/vendor/composer/autoload_real.php(66): require()
#1 /Users/aldion/Sites/jetpack/vendor/composer/autoload_real.php(56): composerRequiree13ef0d812da0cb7b74bcb3dd6467eb1('009de6aaa0d497e...', '/Users/aldion/S...')
#2 /Users/aldion/Sites/jetpack/vendor/autoload.php(7): ComposerAutoloaderInite13ef0d812da0cb7b74bcb3dd6467eb1::getLoader()
#3 /Users/aldion/Sites/jetpack/vendor/squizlabs/php_codesniffer/autoload.php(79): include('/Users/aldion/S...')
#4 [internal function]: PHP_CodeSniffer\Autoload::load('PHP_CodeSniffer...')
#5 /Users/aldion/Sites/jetpack/vendor/squizlabs/php_codesniffer/bin/phpcs(17): spl_autoload_call('PHP_CodeSniffer...')
#6 {main}
```

And it was because the code in `packages/compat/functions.php` was being run, although this code is only meant to be run during WP execution.
This PR seeks to solve this by only running the code when WordPress is running.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add a check for a constant defined during WP execution. If the condition is not met, exit without running the code in this file

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to commit something.
* Ensure you don't have fatal errors.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
