### PR TITLE
Contact info widget: ensure the map response has results 

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -209,13 +209,12 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 				$json_obj = json_decode( $json );
 
-				if ( 'ZERO_RESULTS' == $json_obj->status ) {
+				if ( 'ZERO_RESULTS' == $json_obj->status || empty( $json_obj->results ) ) {
 					// The address supplied does not have a matching lat / lon.
 					// No map is available.
 					$instance['lat'] = '0';
 					$instance['lon'] = '0';
 				} else {
-
 					$loc = $json_obj->results[0]->geometry->location;
 
 					$lat = floatval( $loc->lat );


### PR DESCRIPTION
This fixes #12913 by checking not only that the status is correct, but also if the response has results before attempting to use their geometric data.

May be superseeded by #12474

#### Changes proposed in this Pull Request:
* check that the array of results is not empty

#### Testing instructions:
* Go to `/wp-admin/widgets.php`
* Add a Contact info widget to the footer
* ensure there are no notices in `wp-content/debug.log`
* alternatively check the JS console. This was also causing errors visible in the ajax response.

#### Proposed changelog entry for your changes:
* Not needed.
