### PR TITLE
Ensure core video block deprecations cannot be overriden

### DIFF
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -109,6 +109,7 @@ const addVideoPressSupport = ( settings, name ) => {
 					save: settings.save,
 					isEligible: attrs => ! attrs.guid,
 				},
+				...( Array.isArray( settings.deprecated ) ? settings.deprecated : [] ),
 			],
 		};
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related https://github.com/Automattic/jetpack/issues/12358
Noticed while working on https://github.com/WordPress/gutenberg/pull/16348

Currently the technique used to extend the video block's behaviour overwrites the core video block's deprecated property:
https://github.com/Automattic/jetpack/blob/4c63a49fc0139c3296248e09ee69dedb537e024f/extensions/blocks/videopress/editor.js#L106-L112

At the moment this doesn't cause any issues since the core video block doesn't have a deprecated property. If one were to be added, the overwriting that jetpack does would cause invalid blocks.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensure any deprecations added in the core video block are kept by spreading them into the deprecated array.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
Testings is a little tricky, but something like this should enable reproduction of the issue:
1. Deactivate Jetpack
2. Add a video block to a new post and save the post
3. Modify the core video block so that it has a deprecation, changing the save function (e.g it doesn't matter what it's changed to, something like `<div>video test</div>` would work
4. Load the post in the editor and ensure there are no validation errors
5. Activate Jetpack
6. Load the post in the editor again

**Expected (this branch)**
No validation errors should be visible.

**Actual (current master)**
Activating Jetpack causes a validation error.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Ensure any deprecations added in the core video block are not overwritten
