### PR TITLE
Sync: ensure we can calculate a histogram for terms

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -90,7 +90,6 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		}
 		$histogram = $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
 
-		l( $histogram );
 
 		return array( 'histogram' => $histogram, 'type' => $store->get_checksum_type() );
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -90,7 +90,6 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		}
 		$histogram = $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
 
-
 		return array( 'histogram' => $histogram, 'type' => $store->get_checksum_type() );
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -90,6 +90,8 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 		}
 		$histogram = $store->checksum_histogram( $args['object_type'], $args['buckets'], $args['start_id'], $args['end_id'], $columns, $args['strip_non_ascii'], $args['shared_salt'] );
 
+		l( $histogram );
+
 		return array( 'histogram' => $histogram, 'type' => $store->get_checksum_type() );
 	}
 }

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -361,7 +361,6 @@ class Defaults {
 		'term_id',
 		'name',
 		'slug',
-		'term_group',
 	);
 
 	static $default_multisite_callable_whitelist = array(

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -357,6 +357,13 @@ class Defaults {
 		'option_value',
 	);
 
+	static $default_term_checksum_columns = array(
+		'term_id',
+		'name',
+		'slug',
+		'term_group',
+	);
+
 	static $default_multisite_callable_whitelist = array(
 		'network_name'                        => array( 'Jetpack', 'network_name' ),
 		'network_allow_new_registrations'     => array( 'Jetpack', 'network_allow_new_registrations' ),

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -698,7 +698,7 @@ class Replicastore implements Replicastore_Interface {
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
 				break;
-			case "terms":
+			case 'terms':
 				$object_table = $wpdb->terms;
 				$object_count = $this->term_count();
 				$id_field     = 'term_id';

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -647,10 +647,29 @@ class Replicastore implements Replicastore_Interface {
 		);
 	}
 
+	function get_columns_for_object_type( $object_type ) {
+		switch( $object_type ) {
+			case "post_meta":
+				return Defaults::$default_post_meta_checksum_columns;
+			case "comments":
+				return Defaults::$default_comment_checksum_columns;
+			case "comment_meta":
+				return Defaults::$default_post_meta_checksum_columns;
+			case "terms":
+				return Defaults::$default_term_checksum_columns;
+			default:
+				return Defaults::$default_post_checksum_columns;
+		}
+	}
+
 	function checksum_histogram( $object_type, $buckets, $start_id = null, $end_id = null, $columns = null, $strip_non_ascii = true, $salt = '' ) {
 		global $wpdb;
 
 		$wpdb->queries = array();
+
+		if ( empty( $columns ) ) {
+			$columns = $this->get_columns_for_object_type( $object_type );
+		}
 
 		switch ( $object_type ) {
 			case 'posts':
@@ -658,46 +677,30 @@ class Replicastore implements Replicastore_Interface {
 				$object_table = $wpdb->posts;
 				$id_field     = 'ID';
 				$where_sql    = Settings::get_blacklisted_post_types_sql();
-				if ( empty( $columns ) ) {
-					$columns = Defaults::$default_post_checksum_columns;
-				}
 				break;
 			case 'post_meta':
 				$object_table = $wpdb->postmeta;
 				$where_sql    = Settings::get_whitelisted_post_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
-
-				if ( empty( $columns ) ) {
-					$columns = Defaults::$default_post_meta_checksum_columns;
-				}
 				break;
 			case 'comments':
 				$object_count = $this->comment_count( null, $start_id, $end_id );
 				$object_table = $wpdb->comments;
 				$id_field     = 'comment_ID';
 				$where_sql    = Settings::get_comments_filter_sql();
-				if ( empty( $columns ) ) {
-					$columns = Defaults::$default_comment_checksum_columns;
-				}
 				break;
 			case 'comment_meta':
 				$object_table = $wpdb->commentmeta;
 				$where_sql    = Settings::get_whitelisted_comment_meta_sql();
 				$object_count = $this->meta_count( $object_table, $where_sql, $start_id, $end_id );
 				$id_field     = 'meta_id';
-				if ( empty( $columns ) ) {
-					$columns = Defaults::$default_post_meta_checksum_columns;
-				}
 				break;
 			case "terms":
 				$object_table = $wpdb->terms;
 				$object_count = $this->term_count();
 				$id_field     = 'term_id';
-				$where_sql    = '';
-				if ( empty( $columns ) ) {
-					$columns  = Jetpack_Sync_Defaults::$default_term_checksum_column;
-				}
+				$where_sql    = '1=1';
 				break;
 			default:
 				return false;

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -7,7 +7,7 @@ namespace Automattic\Jetpack\Sync;
  * This is useful to compare values in the local WP DB to values in the synced replica store
  */
 class Replicastore implements Replicastore_Interface {
-	
+
 	public function reset() {
 		global $wpdb;
 
@@ -36,6 +36,11 @@ class Replicastore implements Replicastore_Interface {
 
 	function full_sync_end( $checksum ) {
 		// noop right now
+	}
+
+	public function term_count() {
+		global $wpdb;
+		return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->terms" );
 	}
 
 	public function post_count( $status = null, $min_id = null, $max_id = null ) {
@@ -683,6 +688,15 @@ class Replicastore implements Replicastore_Interface {
 				$id_field     = 'meta_id';
 				if ( empty( $columns ) ) {
 					$columns = Defaults::$default_post_meta_checksum_columns;
+				}
+				break;
+			case "terms":
+				$object_table = $wpdb->terms;
+				$object_count = $this->term_count();
+				$id_field     = 'term_id';
+				$where_sql    = '';
+				if ( empty( $columns ) ) {
+					$columns  = Jetpack_Sync_Defaults::$default_term_checksum_column;
 				}
 				break;
 			default:

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -649,6 +649,8 @@ class Replicastore implements Replicastore_Interface {
 
 	function get_columns_for_object_type( $object_type ) {
 		switch( $object_type ) {
+			case "posts":
+				return Defaults::$default_post_checksum_columns;
 			case "post_meta":
 				return Defaults::$default_post_meta_checksum_columns;
 			case "comments":
@@ -658,7 +660,7 @@ class Replicastore implements Replicastore_Interface {
 			case "terms":
 				return Defaults::$default_term_checksum_columns;
 			default:
-				return Defaults::$default_post_checksum_columns;
+				return false;
 		}
 	}
 

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -647,17 +647,17 @@ class Replicastore implements Replicastore_Interface {
 		);
 	}
 
-	function get_columns_for_object_type( $object_type ) {
+	function get_checksum_columns_for_object_type( $object_type ) {
 		switch( $object_type ) {
-			case "posts":
+			case 'posts':
 				return Defaults::$default_post_checksum_columns;
-			case "post_meta":
+			case 'post_meta':
 				return Defaults::$default_post_meta_checksum_columns;
-			case "comments":
+			case 'comments':
 				return Defaults::$default_comment_checksum_columns;
-			case "comment_meta":
+			case 'comment_meta':
 				return Defaults::$default_post_meta_checksum_columns;
-			case "terms":
+			case 'terms':
 				return Defaults::$default_term_checksum_columns;
 			default:
 				return false;
@@ -670,7 +670,7 @@ class Replicastore implements Replicastore_Interface {
 		$wpdb->queries = array();
 
 		if ( empty( $columns ) ) {
-			$columns = $this->get_columns_for_object_type( $object_type );
+			$columns = $this->get_checksum_columns_for_object_type( $object_type );
 		}
 
 		switch ( $object_type ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue where we cannot validate a site whose terms are out of sync

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensure sync histogram endpoint can calculate a checksum for terms

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Ip7rcWF-12N-p2

#### Testing instructions:
* requires an upstream patch D30065-code to test

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
