### PR TITLE
Jetpack DNA: Register Jetpack autoloader in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -18,6 +18,7 @@ if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
 }
 
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
+require $jetpack_autoloader;
 
 Jetpack_Options::delete_all_known_options();
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,6 +17,8 @@ if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
 	define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
 }
 
+$jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
+
 Jetpack_Options::delete_all_known_options();
 
 // Delete all legacy options

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,8 +17,7 @@ if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
 	define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
 }
 
-$jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
-require $jetpack_autoloader;
+require JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
 
 Jetpack_Options::delete_all_known_options();
 


### PR DESCRIPTION
Register Jetpack autoloader in uninstall.php so it can find the requested classes.

Fixes

[02-Jul-2019 22:04:38 UTC] PHP Fatal error:  Uncaught Error: Class 'Jetpack_Options' not found in /srv/users/user0c495719/apps/user0c495719/public/wp-content/plugins/jetpack/uninstall.php:20
Stack trace:
#0 /srv/users/user0c495719/apps/user0c495719/public/wp-admin/includes/plugin.php(1192): include()
#1 /srv/users/user0c495719/apps/user0c495719/public/wp-admin/includes/plugin.php(934): uninstall_plugin('jetpack/jetpack...')
#2 /srv/users/user0c495719/apps/user0c495719/public/wp-admin/includes/ajax-actions.php(4309): delete_plugins(Array)
#3 /srv/users/user0c495719/apps/user0c495719/public/wp-includes/class-wp-hook.php(286): wp_ajax_delete_plugin('')
#4 /srv/users/user0c495719/apps/user0c495719/public/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#5 /srv/users/user0c495719/apps/user0c495719/public/wp-includes/plugin.php(465): WP_Hook->do_action(Array)
#6 /srv/users/user0c495719/apps/user0c495719/public/wp-admin/admin-ajax.php(173): do_action('wp_ajax_delete-...')
#7 {main}
  thrown in /srv/users/user0c495719/apps/user0c495719/public/wp-content/plugins/jetpack/uninstall.php on line 20

#### Testing instructions:

* install this branch
* uninstall this branch :)
