### PR TITLE
My Plan: fix button that activates VideoPress

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -26,6 +26,8 @@ import {
 	isActivatingModule,
 	getModuleOverride,
 } from 'state/modules';
+import { updateSettings } from 'state/settings/actions';
+import { getSetting, isUpdatingSetting } from 'state/settings/reducer';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import { showBackups } from 'state/initial-state';
 
@@ -66,7 +68,7 @@ class MyPlanBody extends React.Component {
 	};
 
 	activateVideoPress = () => {
-		this.props.activateModule( 'videopress' );
+		this.props.activateFeature( 'videopress' );
 		this.trackPlansClick( 'activate_videopress' );
 	};
 
@@ -271,7 +273,7 @@ class MyPlanBody extends React.Component {
 										<p>
 											{ __( 'High-speed, high-definition video hosting with no third-party ads.' ) }
 										</p>
-										{ this.props.isModuleActivated( 'videopress' ) ? (
+										{ this.props.getFeatureState( 'videopress' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'upload_videos' ) }
 												href={ this.props.siteAdminUrl + 'upload.php' }
@@ -281,7 +283,7 @@ class MyPlanBody extends React.Component {
 										) : (
 											<Button
 												onClick={ this.activateVideoPress }
-												disabled={ this.props.isActivatingModule( 'videopress' ) }
+												disabled={ this.props.isActivatingFeature( 'videopress' ) }
 											>
 												{ __( 'Activate video hosting' ) }
 											</Button>
@@ -756,6 +758,8 @@ export default connect(
 			isActivatingModule: module_slug => isActivatingModule( state, module_slug ),
 			getModuleOverride: module_slug => getModuleOverride( state, module_slug ),
 			showBackups: showBackups( state ),
+			getFeatureState: feature => getSetting( state, feature ),
+			isActivatingFeature: feature => isUpdatingSetting( state, feature ),
 		};
 	},
 	dispatch => {
@@ -764,6 +768,7 @@ export default connect(
 			activateModule: slug => {
 				return dispatch( activateModule( slug ) );
 			},
+			activateFeature: feature => dispatch( updateSettings( { [ feature ]: true } ) ),
 		};
 	}
 )( MyPlanBody );


### PR DESCRIPTION
This fixes #12192 an issue where the button that activates VideoPress in My Plan tab, wasn't correctly activating the VideoPress module. This was made evident when going to Settings > Performance > Media: the toggle wasn't turned on.

<img width="530" alt="Captura de Pantalla 2019-07-02 a la(s) 19 41 41" src="https://user-images.githubusercontent.com/1041600/60551361-81387600-9d01-11e9-8d4d-a7b0b4b442fe.png">

#### Changes proposed in this Pull Request:
* uses the methods to update settings used in the Settings tab

#### Testing instructions:
* Ensure your Jetpack site has at least a Premium plan
* in the WP Admin, go to Jetpack > Dashboard > My Plan
* scroll down to the button to activate VideoPress
* click on it. Make sure it's gray and disabled while it's activating VideoPress
    <img width="348" alt="Captura de Pantalla 2019-07-02 a la(s) 20 06 21" src="https://user-images.githubusercontent.com/1041600/60552386-f78aa780-9d04-11e9-8b1a-bdcb39815928.png">
* go to Settings > Performance > Media. Make sure the toggle is on.
    <img width="461" alt="Captura de Pantalla 2019-07-02 a la(s) 20 08 58" src="https://user-images.githubusercontent.com/1041600/60552461-52bc9a00-9d05-11e9-8e0b-3d7bf7952155.png">
* now jump to Calypso: https://wordpress.com/settings/performance/YOURSITE and ensure the toggle is on in the Media card
    <img width="384" alt="Captura de Pantalla 2019-07-02 a la(s) 20 07 21" src="https://user-images.githubusercontent.com/1041600/60552422-23a62880-9d05-11e9-978a-8a5c088dd7a4.png">


#### Proposed changelog entry for your changes:
* Fixes button that activates VideoPress (available in Premium or superior plans) in the My Plan tab.
