### PR TITLE
Blocks: Always return a site slug from getSiteFragment()

### DIFF
--- a/extensions/shared/get-site-fragment.js
+++ b/extensions/shared/get-site-fragment.js
@@ -1,14 +1,9 @@
 /**
- * Returns the site fragment in the environment we're running Gutenberg in.
+ * Returns the site fragment (slug) in the environment we're running Gutenberg in.
  *
- * @returns {?Number|String} Site fragment (ID or slug); null for WP.org wp-admin.
+ * @returns {?String} Site fragment (slug)
  */
 export default function getSiteFragment() {
-	// WP.com wp-admin exposes the site ID in window._currentSiteId
-	if ( window && window._currentSiteId ) {
-		return window._currentSiteId;
-	}
-
 	// Gutenberg in Jetpack adds a site fragment in the initial state
 	if (
 		window &&


### PR DESCRIPTION
The rationale for this change is explained in D29733-code #598003:

> I noticed one bug here: The 'Upgrade' button link doesn't work from within the Simple Site wp-admin editor: It points to e.g. https://wordpress.com/plans/84306531?feature=simple-payments&plan=value_bundle, i.e. uses a site ID (`84306531` in this example) rather than a site slug.
> 
> This is due to how the `getSiteFragment` helper is [implemented](https://github.com/Automattic/jetpack/blob/c285c1598571804977659579d389405a10e38e3b/extensions/shared/get-site-fragment.js#L7-L10). In other words, that function is too loosely typed, somewhat unpredictably returning either a `siteId` or a `siteSlug`.
> 
> For our purposes, we might be able to simply drop that part of the function, since the [code below](https://github.com/Automattic/jetpack/blob/c285c1598571804977659579d389405a10e38e3b/extensions/shared/get-site-fragment.js#L12-L19) that part of the function relies on `window.Jetpack_Editor_Initial_State.siteFragment` instead, which is also present on WP.com.
>
> _However_, things are probably not as simple: I'm afraid that `getSiteFragment` is also used by other consumers -- specifically by consumers that might live outside of the editor, i.e. in wp-admin more generally, where `window.Jetpack_Editor_Initial_State` isn't available. 
> 
> If this is the case, the correct fix will be to split the helper into two, more strictly typed ones (`getSiteId` and `getSiteSlug`, probably).

I've started this PR as an RFC. Is it safe to make this change? I've grepped `getSiteFragment` across the JP codebase, and the places we're using it seem to work with a site slug -- all of them are within an editor context.

(It's possible that things were trickier when we still had to take Gutenlypso into account.)

Some relevant past PRs: #11347 https://github.com/Automattic/wp-calypso/pull/30705/files#r256485143

#### Changes proposed in this Pull Request:

* Blocks: Always return a site slug from getSiteFragment()

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Changes an existing helper function

#### Testing instructions:

Verify that any code relying on `getSiteFragment` still works, both on JP, and for the WP.com counterpart of this PR: For now, that's really just Publicize (mind https://github.com/Automattic/wp-calypso/issues/34236 though!)

#### Proposed changelog entry for your changes:

Blocks: Always return a site slug from getSiteFragment()