### PR TITLE
IDC: use correct namespace when calling Jetpack Logo

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -1,7 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 
 /**
  * This class will handle everything involved with fixing an Identity Crisis.


### PR DESCRIPTION
Fixes #12936

#### Changes proposed in this Pull Request:

* Make sure we use the correct namespace when calling Jetpack Logo.

#### Testing instructions:

* Start from a site currently experiencing an IDC. You can fake this by modifying `check_identity_crisis` to always return `true`.
* Open the dashboard while logged in as an admin and an editor, view the notice.
* See no fatal error in your logs.

#### Proposed changelog entry for your changes:

* Logos: avoid Fatal errors when calling the Jetpack logo in admin notices.
