### PR TITLE
General: update PHP requirements to match 7.5.1 release

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -14,7 +14,7 @@
  */
 
 define( 'JETPACK__MINIMUM_WP_VERSION',  '5.1' );
-define( 'JETPACK__MINIMUM_PHP_VERSION', '5.3.2' );
+define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION',             '7.6-alpha' );
 define( 'JETPACK_MASTER_USER',           true );
 define( 'JETPACK__API_VERSION',          1 );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, an
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 7.4.1
 Requires at least: 5.1
-Requires PHP: 5.3
+Requires PHP: 5.6
 Tested up to: 5.2
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This ports part of the changes from 9c6f24355b40b1552a8042978659d7c930a7dac9

The other changes were addressed in #12939 and #12940

#### Testing instructions:

* Not much really. You can try spinning up a site running WordPress 5.1, upload a copy of Jetpack from this branch, and ensure that once activated, the plugin is actually paused.

#### Proposed changelog entry for your changes:

* None