### PR TITLE
Don't exit if ABSPATH is not defined

### DIFF
--- a/packages/compat/functions.php
+++ b/packages/compat/functions.php
@@ -1,15 +1,25 @@
 <?php
-
 /**
- * TODO: Legacy global scope functions here
+ * Legacy global scope functions.
+ *
+ * @package global-functions
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	return;
+}
+
+// Add here, after the condition above, any code that should only run when WordPress is running.
+// Autoload will load everything even when PHPCS is running and we don't want to run these
+// in such case because they will fatal, for example, due to 'add_action' being undefined.
+
+/**
+ * Load necessary functions.
+ */
+function jetpack_compat_require_defined_functions() {
+	jetpack_require_lib( 'tracks/client' );
 }
 
 add_action( 'plugins_loaded', 'jetpack_compat_require_defined_functions' );
 
-function jetpack_compat_require_defined_functions() {
-	jetpack_require_lib( 'tracks/client' );
-}
+


### PR DESCRIPTION
Work in the opposite way: if it's defined, run the code. This avoid exiting when PHPCS is running.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Put functions that only have to run in WP environment inside the condition

#### Testing instructions:
* Make sure PHPCS is running again.
* If you have PhpStorm setup with PHPCS, as soon as you apply this change, PHPCS will start working again.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
