### PR TITLE
Git hooks: Mark commits that skipped a pre-commit hook

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -68,7 +68,6 @@ function checkFileAgainstDirtyList( file ) {
 
 /**
  * Captures a pre-commit date to be used later in prepare-commit-msg.js hook to figure out whether pre-commit was executed
- *
  */
 function capturePreCommitDate() {
 	if ( exitCode === 0 ) {

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -7,6 +7,7 @@ const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
 const whitelist = require( './phpcs-whitelist' );
+const fs = require( 'fs' );
 let exitCode = 0;
 
 /**
@@ -63,6 +64,16 @@ const phpcsFiles = phpFiles.filter( phpcsFilesToFilter );
  */
 function checkFileAgainstDirtyList( file ) {
 	return -1 === dirtyFiles.indexOf( file );
+}
+
+/**
+ * Captures a pre-commit date to be used later in prepare-commit-msg.js hook to figure out whether pre-commit was executed
+ *
+ */
+function capturePreCommitDate() {
+	if ( exitCode === 0 ) {
+		fs.writeFileSync( '.git/last-commit-date', Date.now() );
+	}
 }
 
 dirtyFiles.forEach( file =>
@@ -152,5 +163,7 @@ if ( phpcsResult && phpcsResult.status ) {
 	);
 	exitCode = 1;
 }
+
+capturePreCommitDate();
 
 process.exit( exitCode );

--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-console */
+const fs = require( 'fs' );
+
+const file = fs.readFileSync( '.git/last-commit-date' );
+const commitDate = file.toString();
+
+if ( Date.now() - commitDate > 2000 /* 2sec*/ ) {
+	console.log( 'WARNING: git pre-commit was hook skipped!' );
+	const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' );
+	const newCommitMsg = '[not verified] ' + commitMsg.toString();
+
+	fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
+}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -16,9 +16,11 @@ if ( pr.body.length < 10 ) {
 
 // Keep track of commits which skipped pre-commit hook
 const commitMessages = danger.git.commits.map( commit => commit.message );
-if ( commitMessages.includes( '[not verified]' ) ) {
-	warn( '`pre-commit` hook was skipped for one or more commits' );
-}
+commitMessages.forEach( message => {
+	if ( message.includes( '[not verified]' ) ) {
+		warn( '`pre-commit` hook was skipped for one or more commits' );
+	}
+} );
 
 // Use labels please!
 const ghLabels = github.issue.labels;

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -14,6 +14,12 @@ if ( pr.body.length < 10 ) {
 	warn( 'Please include a description of your PR changes.' );
 }
 
+// Keep track of commits which skipped pre-commit hook
+const commitMessages = danger.git.commits.map( commit => commit.message );
+if ( commitMessages.includes( '[not verified]' ) ) {
+	warn( '`pre-commit` hook was skipped for one or more commits' );
+}
+
 // Use labels please!
 const ghLabels = github.issue.labels;
 if ( ! ghLabels.find( l => l.name.toLowerCase().includes( '[status]' ) ) ) {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
 		"gulp-sftp": "0.1.5",
 		"husky": "2.3.0",
 		"jest": "24.7.1",
-		"jest-circus": "24.8.0",
 		"jest-puppeteer": "4.1.1",
 		"lodash": "4.17.11",
 		"mocha": "6.1.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "node bin/pre-commit-hook.js"
+			"pre-commit": "node bin/pre-commit-hook.js",
+			"prepare-commit-msg": "node bin/prepare-commit-msg.js"
 		}
 	},
 	"dependencies": {
@@ -178,6 +179,7 @@
 		"gulp-sftp": "0.1.5",
 		"husky": "2.3.0",
 		"jest": "24.7.1",
+		"jest-circus": "24.8.0",
 		"jest-puppeteer": "4.1.1",
 		"lodash": "4.17.11",
 		"mocha": "6.1.4",


### PR DESCRIPTION
We kinda rely on pre-commit hooks to make sure committed code is backward compatible (via `php:compatibility` script). This PR helps to mark commits which skipped pre-commit hooks via `--no-verify` flag. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* mark commits which skipped pre-commit hook

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* checkout this branch
* commit any change with `-n`/`--no-verify` flag (`git commit -m 'message' -n`)
* check git log and make sure your commit message starts with `[not verified]`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
