### PR TITLE
Travis: Run php:compatibility check

### DIFF
--- a/_inc/lib/class.jetpack-automatic-install-skin.php
+++ b/_inc/lib/class.jetpack-automatic-install-skin.php
@@ -86,6 +86,7 @@ class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
 		}
 
 		if ( strpos( $string, '%' ) !== false ) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 			$args = func_get_args();
 			$args = array_splice( $args, 1 );
 			if ( ! empty( $args ) ) {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"phpcompatibility/phpcompatibility-wp": "2.0.0"
 	},
 	"scripts": {
-		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.3-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
+		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
 		"php:lint": "composer install && vendor/bin/phpcs -p -s",
 		"php:autofix": "composer install && vendor/bin/phpcbf",
 		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -23,10 +23,18 @@ function run_packages_tests {
 
 function run_php_compatibility {
 	export PHPCOMP_EXEC="composer php:compatibility ."
+	export PHPCS_CHECK_EXEC="./vendor/bin/phpcs --version | grep -e PHP_CodeSniffer"
 	echo "Running PHP:Compatibility checks:"
 	echo "PHP Compatibility command: \`$PHPCOMP_EXEC\` "
 
-	if $PHPCOMP_EXEC; then
+	if $PHPCS_CHECK_EXEC; then
+		# Everything is fine
+		:
+	else
+		exit 1
+	fi
+
+		if $PHPCOMP_EXEC; then
 		# Everything is fine
 		:
 	else

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -34,7 +34,7 @@ function run_php_compatibility {
 		exit 1
 	fi
 
-		if $PHPCOMP_EXEC; then
+	if $PHPCOMP_EXEC; then
 		# Everything is fine
 		:
 	else

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -21,6 +21,19 @@ function run_packages_tests {
 	done
 }
 
+function run_php_compatibility {
+	export PHPCOMP_EXEC="composer php:compatibility"
+	echo "Running PHP:Compatibility checks:"
+	echo "PHP Compatibility command: \`$PHPCOMP_EXEC\` "
+
+	if $PHPCOMP_EXEC; then
+		# Everything is fine
+		:
+	else
+		exit 1
+	fi
+}
+
 echo "Travis CI command: $WP_TRAVISCI"
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
@@ -30,6 +43,11 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	if [ "latest" == "$WP_BRANCH" ]; then
 		run_packages_tests
 	fi
+
+	if [ "previous" == "$WP_BRANCH" ]; then
+		run_php_compatibility
+	fi
+
 
 	# Run a external-html group tests
 	if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -22,7 +22,7 @@ function run_packages_tests {
 }
 
 function run_php_compatibility {
-	export PHPCOMP_EXEC="composer php:compatibility"
+	export PHPCOMP_EXEC="composer php:compatibility ."
 	echo "Running PHP:Compatibility checks:"
 	echo "PHP Compatibility command: \`$PHPCOMP_EXEC\` "
 


### PR DESCRIPTION
For some reason, we run PHPCS compatibility checks only on pre-commit hooks, which could be ignored. Running them in Travis could help us maintain backward compatibility even better.  

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* run PHPCS compatibility in travis

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much. check "Previous" travis jobs? 
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
