### PR TITLE
Connection Manager: Prevent notice on empty Jetpack blog token

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -606,16 +606,15 @@ class Manager implements Manager_Interface {
 				$possible_normal_tokens[] = $stored_blog_token;
 			}
 
-			$defined_tokens = Constants::is_defined( 'JETPACK_BLOG_TOKEN' ) &&
-							  Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) != ''
-				? explode( ',', Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
-				: array();
+			$defined_tokens_string = Constants::get_constant( 'JETPACK_BLOG_TOKEN' );
 
-			foreach ( $defined_tokens as $defined_token ) {
-				if ( ';' === $defined_token[0] ) {
-					$possible_special_tokens[] = $defined_token;
-				} else {
-					$possible_normal_tokens[] = $defined_token;
+			if ( $defined_tokens_string ) {
+				foreach ( $defined_tokens_string as $defined_token ) {
+					if ( ';' === $defined_token[0] ) {
+						$possible_special_tokens[] = $defined_token;
+					} else {
+						$possible_normal_tokens[] = $defined_token;
+					}
 				}
 			}
 		}

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -610,7 +610,6 @@ class Manager implements Manager_Interface {
 
 			if ( $defined_tokens_string ) {
 				$defined_tokens = explode( ',', $defined_tokens_string );
-
 				foreach ( $defined_tokens as $defined_token ) {
 					if ( ';' === $defined_token[0] ) {
 						$possible_special_tokens[] = $defined_token;

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -606,7 +606,8 @@ class Manager implements Manager_Interface {
 				$possible_normal_tokens[] = $stored_blog_token;
 			}
 
-			$defined_tokens = Constants::is_defined( 'JETPACK_BLOG_TOKEN' )
+			$defined_tokens = Constants::is_defined( 'JETPACK_BLOG_TOKEN' ) &&
+							  Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) != ''
 				? explode( ',', Constants::get_constant( 'JETPACK_BLOG_TOKEN' ) )
 				: array();
 

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -609,7 +609,9 @@ class Manager implements Manager_Interface {
 			$defined_tokens_string = Constants::get_constant( 'JETPACK_BLOG_TOKEN' );
 
 			if ( $defined_tokens_string ) {
-				foreach ( $defined_tokens_string as $defined_token ) {
+				$defined_tokens = explode( ',', $defined_tokens_string );
+
+				foreach ( $defined_tokens as $defined_token ) {
 					if ( ';' === $defined_token[0] ) {
 						$possible_special_tokens[] = $defined_token;
 					} else {

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -220,4 +220,12 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 		$this->assertFalse( $token );
 	}
+
+	public function test_get_access_token_with_empty_constant_does_not_generate_notice() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', '' );
+
+		$token = $this->connection->get_access_token();
+
+		$this->assertEquals( self::STORED, $token->secret );
+	}
 }


### PR DESCRIPTION
This PR prevents a notice when the Jetpack blog token is empty.

Testing instructions:
Before applying this patch, add `define( 'JETPACK_BLOG_TOKEN', '' );` to wp-config.php and ensure Jetpack Comments are enabled. You should receive a notice similar to the following:

```
[03-Jul-2019 20:24:09 UTC] PHP Notice:  Uninitialized string offset: 0 in /var/www/html/wp-content/plugins/jetpack/packages/connection/src/Manager.php on line 615
[03-Jul-2019 20:24:09 UTC] PHP Stack trace:
[03-Jul-2019 20:24:09 UTC] PHP   1. {main}() /var/www/html/index.php:0
[03-Jul-2019 20:24:09 UTC] PHP   2. require() /var/www/html/index.php:17
[03-Jul-2019 20:24:09 UTC] PHP   3. require_once() /var/www/html/wp-blog-header.php:19
[03-Jul-2019 20:24:09 UTC] PHP   4. include() /var/www/html/wp-includes/template-loader.php:78
[03-Jul-2019 20:24:09 UTC] PHP   5. comments_template() /var/www/html/wp-content/themes/twentysixteen/single.php:24
[03-Jul-2019 20:24:09 UTC] PHP   6. require() /var/www/html/wp-includes/comment-template.php:1510
[03-Jul-2019 20:24:09 UTC] PHP   7. comment_form() /var/www/html/wp-content/themes/twentysixteen/comments.php:77
[03-Jul-2019 20:24:09 UTC] PHP   8. do_action() /var/www/html/wp-includes/comment-template.php:2558
[03-Jul-2019 20:24:09 UTC] PHP   9. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:465
[03-Jul-2019 20:24:09 UTC] PHP  10. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:310
[03-Jul-2019 20:24:09 UTC] PHP  11. Jetpack_Comments->comment_form_after() /var/www/html/wp-includes/class-wp-hook.php:286
[03-Jul-2019 20:24:09 UTC] PHP  12. Jetpack_Data::get_access_token() /var/www/html/wp-content/plugins/jetpack/modules/comments/comments.php:280
[03-Jul-2019 20:24:09 UTC] PHP  13. Automattic\Jetpack\Connection\Manager->get_access_token() /var/www/html/wp-content/plugins/jetpack/class.jetpack-data.php:11
```

Once this patch is applied, the notice should go away.

