### PR TITLE
Plans: Always overwrite jetpack_active_plan option when updating from /site response

### DIFF
--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -44,13 +44,6 @@ class Jetpack_Plan {
 			return false;
 		}
 
-		$current_plan = get_option( self::PLAN_OPTION, array() );
-
-		// If the plans don't differ, then there's nothing to do.
-		if ( ! empty( $current_plan ) && $current_plan['product_slug'] === $results['plan']['product_slug'] ) {
-			return false;
-		}
-
 		// Store the new plan in an option and return true if updated.
 		$result = update_option( self::PLAN_OPTION, $results['plan'], true );
 		if ( ! $result ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Active features of plans can change over time as well as due to external events. In particular this is used for approving sites for Jetpack Ads. Currently the `jetpack_active_plan` option is only updated in cases where the plan changes. This update removes the plan change check forcing it to always update.

#### Testing instructions:

* Create test site with Free or Personal plan
* Visit Settings -> Traffic, note Ads module is unavailable
* Sticker test site with `wordads-free-access` sticker
* Visit Settings-> Traffic, note Ads module is available

#### Proposed changelog entry for your changes:
No changelog needed.
