### PR TITLE
Sync: allow terms module to return term by id

### DIFF
--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -702,7 +702,7 @@ class Replicastore implements Replicastore_Interface {
 				$object_table = $wpdb->terms;
 				$object_count = $this->term_count();
 				$id_field     = 'term_id';
-				$where_sql    = Settings::get_blacklisted_taxonomies_sql();
+				$where_sql    = '1=1';
 				break;
 			default:
 				return false;

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -12,9 +12,18 @@ class Terms extends Module {
 		return 'terms';
 	}
 
+	/**
+	 * Allows WordPress.com servers to retrieve a term object via the sync API.
+	 *
+	 * @param string $object_type The type of object.
+	 * @param int $id The id of the object.
+	 *
+	 * @return bool|\WP_Term
+	 */
 	public function get_object_by_id( $object_type, $id ) {
-		if ( $object_type === 'term' && $term = get_term( intval( $id ) ) ) {
-			return $term;
+		if ( $object_type === 'term' ) {
+			$term = get_term( intval( $id ) );
+			return $term ? $term : false;
 		}
 
 		return false;

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -12,6 +12,14 @@ class Terms extends Module {
 		return 'terms';
 	}
 
+	public function get_object_by_id( $object_type, $id ) {
+		if ( $object_type === 'term' && $term = get_term( intval( $id ) ) ) {
+			return $term;
+		}
+
+		return false;
+	}
+
 	function init_listeners( $callable ) {
 		add_action( 'created_term', array( $this, 'save_term_handler' ), 10, 3 );
 		add_action( 'edited_term', array( $this, 'save_term_handler' ), 10, 3 );

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -23,7 +23,7 @@ class Terms extends Module {
 	public function get_object_by_id( $object_type, $id ) {
 		if ( $object_type === 'term' ) {
 			$term = get_term( intval( $id ) );
-			return $term ? $term : false;
+			return ( $term && ! is_wp_error( $term ) ) ? $term : false;
 		}
 
 		return false;

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -154,7 +154,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		// first, show that term is being synced
-		$this->assertTrue( !! $this->server_replica_storage->get_term( 'filter_me', $term_id ) );
+		$this->assertTrue( ! ! $this->server_replica_storage->get_term( 'filter_me', $term_id ) );
 
 		Settings::update_settings( array( 'taxonomies_blacklist' => array( 'filter_me' ) ) );
 
@@ -172,6 +172,21 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		foreach ( Defaults::$blacklisted_taxonomies as $hardcoded_blacklist_taxonomy ) {
 			$this->assertTrue( in_array( $hardcoded_blacklist_taxonomy, $setting, true ) );
 		}
+	}
+
+	function test_returns_term_object_by_id() {
+		$term_sync_module = Modules::get_module( 'terms' );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_term' );
+		$synced_term = $event->args[0];
+
+		$codec = $this->sender->get_codec();
+
+		$retrieved_term = $codec->decode( $codec->encode(
+			$term_sync_module->get_object_by_id( 'term', $synced_term->term_id )
+		) );
+
+		$this->assertEquals( $synced_term, $retrieved_term );
 	}
 
 	function get_terms() {

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -154,7 +154,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		// first, show that term is being synced
-		$this->assertTrue( ! ! $this->server_replica_storage->get_term( 'filter_me', $term_id ) );
+		$this->assertTrue( !! $this->server_replica_storage->get_term( 'filter_me', $term_id ) );
 
 		Settings::update_settings( array( 'taxonomies_blacklist' => array( 'filter_me' ) ) );
 

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -180,6 +180,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_term' );
 		$synced_term = $event->args[0];
 
+		// Grab the codec - we need to simulate the stripping of types that comes with encoding/decoding.
 		$codec = $this->sender->get_codec();
 
 		$retrieved_term = $codec->decode( $codec->encode(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes no known issues. Part of an effort to fix out-of-sync terms.

#### Changes proposed in this Pull Request:
* The terms sync module will now return a term object given an id

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* see: Ip7rcWF-12N-p2

#### Testing instructions:
- In progress, will require an upstream patch to test.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
