### PR TITLE
Jetpack DNA: Introduce a Roles package

### DIFF
--- a/packages/roles/README.md
+++ b/packages/roles/README.md
@@ -1,0 +1,35 @@
+# Jetpack Roles
+
+A user roles class for Jetpack.
+
+Contains utilities for translating user roles to capabilities and vice versa.
+
+### Usage
+
+Get the role of the current user:
+
+```php
+use Automattic\Jetpack\Roles;
+
+$roles = new Roles();
+$current_user_role = $roles->translate_current_user_to_role();
+```
+
+Get the role of a particular user:
+
+```php
+use Automattic\Jetpack\Roles;
+
+$roles = new Roles();
+$user  = get_user_by( 'contact@yourjetpack.blog' );
+$user_role = $roles->translate_user_to_role( $user );
+```
+
+Get the capability we require for a role:
+
+```php
+use Automattic\Jetpack\Roles;
+
+$roles = new Roles();
+$capability = $roles->translate_role_to_cap( 'administrator' );
+```

--- a/packages/roles/composer.json
+++ b/packages/roles/composer.json
@@ -1,0 +1,30 @@
+{
+	"name": "automattic/jetpack-roles",
+	"description": "Utilities, related with user roles and capabilities.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"Automattic\\Jetpack\\": "src/"
+		}
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
+}

--- a/packages/roles/phpunit.xml.dist
+++ b/packages/roles/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/roles/src/Roles.php
+++ b/packages/roles/src/Roles.php
@@ -17,11 +17,10 @@ class Roles {
 	 * Map of roles we care about, and their corresponding minimum capabilities.
 	 *
 	 * @access protected
-	 * @static
 	 *
 	 * @var array
 	 */
-	protected static $capability_translations = array(
+	protected $capability_translations = array(
 		'administrator' => 'manage_options',
 		'editor'        => 'edit_others_posts',
 		'author'        => 'publish_posts',
@@ -32,10 +31,12 @@ class Roles {
 	/**
 	 * Get the role of the current user.
 	 *
+	 * @access public
+	 *
 	 * @return string|boolean Current user's role, false if not enough capabilities for any of the roles.
 	 */
 	public function translate_current_user_to_role() {
-		foreach ( self::$capability_translations as $role => $cap ) {
+		foreach ( $this->capability_translations as $role => $cap ) {
 			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
 				return $role;
 			}
@@ -47,11 +48,13 @@ class Roles {
 	/**
 	 * Get the role of a particular user.
 	 *
+	 * @access public
+	 *
 	 * @param \WP_User $user User object.
 	 * @return string|boolean User's role, false if not enough capabilities for any of the roles.
 	 */
 	public function translate_user_to_role( $user ) {
-		foreach ( self::$capability_translations as $role => $cap ) {
+		foreach ( $this->capability_translations as $role => $cap ) {
 			if ( user_can( $user, $role ) || user_can( $user, $cap ) ) {
 				return $role;
 			}
@@ -63,14 +66,16 @@ class Roles {
 	/**
 	 * Get the minimum capability for a role.
 	 *
+	 * @access public
+	 *
 	 * @param string $role Role name.
 	 * @return string|boolean Capability, false if role isn't mapped to any capabilities.
 	 */
 	public function translate_role_to_cap( $role ) {
-		if ( ! isset( self::$capability_translations[ $role ] ) ) {
+		if ( ! isset( $this->capability_translations[ $role ] ) ) {
 			return false;
 		}
 
-		return self::$capability_translations[ $role ];
+		return $this->capability_translations[ $role ];
 	}
 }

--- a/packages/roles/src/Roles.php
+++ b/packages/roles/src/Roles.php
@@ -34,7 +34,7 @@ class Roles {
 	 *
 	 * @return string|boolean Current user's role, false if not enough capabilities for any of the roles.
 	 */
-	public static function translate_current_user_to_role() {
+	public function translate_current_user_to_role() {
 		foreach ( self::$capability_translations as $role => $cap ) {
 			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
 				return $role;
@@ -50,7 +50,7 @@ class Roles {
 	 * @param \WP_User $user User object.
 	 * @return string|boolean User's role, false if not enough capabilities for any of the roles.
 	 */
-	public static function translate_user_to_role( $user ) {
+	public function translate_user_to_role( $user ) {
 		foreach ( self::$capability_translations as $role => $cap ) {
 			if ( user_can( $user, $role ) || user_can( $user, $cap ) ) {
 				return $role;
@@ -66,7 +66,7 @@ class Roles {
 	 * @param string $role Role name.
 	 * @return string|boolean Capability, false if role isn't mapped to any capabilities.
 	 */
-	public static function translate_role_to_cap( $role ) {
+	public function translate_role_to_cap( $role ) {
 		if ( ! isset( self::$capability_translations[ $role ] ) ) {
 			return false;
 		}

--- a/packages/roles/src/Roles.php
+++ b/packages/roles/src/Roles.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * A user roles class for Jetpack.
+ *
+ * @package jetpack-roles
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class Automattic\Jetpack\Roles
+ *
+ * Contains utilities for translating user roles to capabilities and vice versa.
+ */
+class Roles {
+	/**
+	 * Map of roles we care about, and their corresponding minimum capabilities.
+	 *
+	 * @access protected
+	 * @static
+	 *
+	 * @var array
+	 */
+	protected static $capability_translations = array(
+		'administrator' => 'manage_options',
+		'editor'        => 'edit_others_posts',
+		'author'        => 'publish_posts',
+		'contributor'   => 'edit_posts',
+		'subscriber'    => 'read',
+	);
+
+	/**
+	 * Get the role of the current user.
+	 *
+	 * @return string|boolean Current user's role, false if not enough capabilities for any of the roles.
+	 */
+	public static function translate_current_user_to_role() {
+		foreach ( self::$capability_translations as $role => $cap ) {
+			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
+				return $role;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the role of a particular user.
+	 *
+	 * @param \WP_User $user User object.
+	 * @return string|boolean User's role, false if not enough capabilities for any of the roles.
+	 */
+	public static function translate_user_to_role( $user ) {
+		foreach ( self::$capability_translations as $role => $cap ) {
+			if ( user_can( $user, $role ) || user_can( $user, $cap ) ) {
+				return $role;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the minimum capability for a role.
+	 *
+	 * @param string $role Role name.
+	 * @return string|boolean Capability, false if role isn't mapped to any capabilities.
+	 */
+	public static function translate_role_to_cap( $role ) {
+		if ( ! isset( self::$capability_translations[ $role ] ) ) {
+			return false;
+		}
+
+		return self::$capability_translations[ $role ];
+	}
+}

--- a/packages/roles/tests/php/bootstrap.php
+++ b/packages/roles/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/roles/tests/php/test_Roles.php
+++ b/packages/roles/tests/php/test_Roles.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Roles;
+use PHPUnit\Framework\TestCase;
+use phpmock\Mock;
+use phpmock\MockBuilder;
+
+class Test_Roles extends TestCase {
+	/**
+	 * Test setup.
+	 */
+	public function setUp() {
+		$this->roles = new Roles();
+	}
+
+	/**
+	 * Test teardown.
+	 */
+	public function tearDown() {
+		Mock::disableAll();
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_current_user_to_role
+	 */
+	public function test_current_user_to_role_with_role() {
+		$this->mock_function( 'current_user_can', true, 'administrator' );
+		
+		$this->assertEquals( 'administrator', $this->roles->translate_current_user_to_role() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_current_user_to_role
+	 */
+	public function test_current_user_to_role_with_capability() {
+		$this->mock_function( 'current_user_can', true, 'edit_others_posts' );
+		
+		$this->assertEquals( 'editor', $this->roles->translate_current_user_to_role() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_current_user_to_role
+	 */
+	public function test_current_user_to_role_with_no_match() {
+		$this->mock_function( 'current_user_can', false );
+		
+		$this->assertEquals( false, $this->roles->translate_current_user_to_role() );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_user_to_role
+	 */
+	public function test_user_to_role_with_role() {
+		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$this->mock_function( 'user_can', true, $user_mock, 'administrator' );
+		
+		$this->assertEquals( 'administrator', $this->roles->translate_user_to_role( $user_mock ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_user_to_role
+	 */
+	public function test_user_to_role_with_capability() {
+		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$this->mock_function( 'user_can', true, $user_mock, 'edit_others_posts' );
+		
+		$this->assertEquals( 'editor', $this->roles->translate_user_to_role( $user_mock ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_user_to_role
+	 */
+	public function test_user_to_role_with_no_match() {
+		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$this->mock_function( 'user_can', false );
+		
+		$this->assertEquals( false, $this->roles->translate_user_to_role( $user_mock ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_role_to_cap
+	 */
+	public function test_role_to_cap_existing_role() {
+		$this->assertEquals( 'edit_others_posts', $this->roles->translate_role_to_cap( 'editor' ) );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Roles::translate_role_to_cap
+	 */
+	public function test_role_to_cap_non_existing_role() {
+		$this->assertEquals( false, $this->roles->translate_role_to_cap( 'follower' ) );
+	}
+
+	/**
+	 * Mock a global function and make it return a certain value.
+	 * Optionally can limit the mock to invocations with certain arguments.
+	 *
+	 * @param string $function_name Name of the function.
+	 * @param mixed  $return_value  Return value of the function.
+	 * @param mixed  $arg_1_value   Value of the first argument value we expect.
+	 * @param mixed  $arg_2_value   Value of the second argument value we expect.
+	 * @return phpmock\Mock The mock object.
+	 */
+	protected function mock_function( $function_name, $return_value = null, $arg_1_value = null, $arg_2_value = null ) {
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( $function_name )
+			->setFunction( function( $arg_1, $arg_2 = null ) use ( &$return_value, &$arg_1_value, &$arg_2_value ) {
+				// Return the value if we don't care about arguments.
+				if ( is_null( $arg_1 ) && is_null( $arg_2 ) ) {
+					return $return_value;
+				}
+
+				// Return the value if we don't care about the second argument, but the first one matches.
+				if ( is_null( $arg_2 ) && $arg_1_value === $arg_1 ) {
+					return $return_value;
+				}
+
+				// Return the value if both arguments match.
+				if ( $arg_1_value === $arg_1 && $arg_2_value === $arg_2 ) {
+					return $return_value;
+				}
+			} );
+		return $builder->build()->enable();
+	}
+}


### PR DESCRIPTION
Currently, we have several methods for translating user roles to capabilities and vice versa. This PR moves them to a package, because we'll need them to be independent as they're used in the Sync package.

#### Changes proposed in this Pull Request:
* Introduce a new Roles package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA.

#### Testing instructions:
* Checkout this branch.
* Navigate to the Roles package directory `cd packages/roles`.
* Run installation and tests: `composer phpunit`.
* Make sure tests pass.
* Make sure CI is green.

#### Proposed changelog entry for your changes:
* Jetpack DNA: Introduce a Roles package
