### PR TITLE
oEmbeds: add support for Song.link

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1809,6 +1809,7 @@ class Jetpack {
 		wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
 		wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
 		wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
+		wp_oembed_add_provider( 'https://song.link/*', 'https://song.link/oembed', false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9973

#### Changes proposed in this Pull Request:

* oEmbeds: add support for Song.link

**Related WordPress.com change**: D30137-code

#### Testing instructions:

1. Add the following link to a new post: https://song.link/i/1126437693
2. You should see an embed appear, with no errors.

#### Proposed changelog entry for your changes:

* oEmbeds: add support for Song.link
