### PR TITLE
Jetpack DNA: Fix errors and finish Status package README

### DIFF
--- a/packages/status/README.md
+++ b/packages/status/README.md
@@ -15,7 +15,7 @@ $status = new Status();
 $is_development_mode = $status->is_development_mode();
 ```
 
-Find out whether this is a system with a multiple networks:
+Find out whether this is a system with multiple networks:
 
 ```php
 use Automattic\Jetpack\Status;

--- a/packages/status/README.md
+++ b/packages/status/README.md
@@ -11,5 +11,15 @@ Find out whether the site is in development mode:
 ```php
 use Automattic\Jetpack\Status;
 
-$is_development_mode = Status::is_development_mode();
+$status = new Status();
+$is_development_mode = $status->is_development_mode();
+```
+
+Find out whether this is a system with a multiple networks:
+
+```php
+use Automattic\Jetpack\Status;
+
+$status = new Status();
+$is_multi_network = $status->is_multi_network();
 ```


### PR DESCRIPTION
This PR fixes an error in the README of the Status package, and adds another example of a method we recently added, but we forgot to document.

#### Changes proposed in this Pull Request:
* Fix example of `Status::is_development_mode()` to be called non-statically.
* Add an example for `Status::is_multi_network()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA.

#### Testing instructions:
* No testing needed, just take a look and verify README is sane.

#### Proposed changelog entry for your changes:
* Docs: Fix example of `Status::is_development_mode()` to be called non-statically.
* Docs: Add an example for `Status::is_multi_network()`.
