### PR TITLE
Jetpack DNA: Port Jetpack::is_single_user_site and add tests

### DIFF
--- a/packages/status/README.md
+++ b/packages/status/README.md
@@ -23,3 +23,12 @@ use Automattic\Jetpack\Status;
 $status = new Status();
 $is_multi_network = $status->is_multi_network();
 ```
+
+Find out whether this site is a single user site:
+
+```php
+use Automattic\Jetpack\Status;
+
+$status = new Status();
+$is_single_user_site = $status->is_single_user_site();
+```

--- a/packages/status/src/Status.php
+++ b/packages/status/src/Status.php
@@ -52,7 +52,7 @@ class Status {
 	public function is_multi_network() {
 		global $wpdb;
 
-		// if we don't have a multi site setup no need to do any more
+		// If we don't have a multi site setup no need to do any more.
 		if ( ! is_multisite() ) {
 			return false;
 		}
@@ -63,5 +63,21 @@ class Status {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether the current site is single user site.
+	 *
+	 * @return bool
+	 */
+	public function is_single_user_site() {
+		global $wpdb;
+
+		$some_users = get_transient( 'jetpack_is_single_user' );
+		if ( false === $some_users ) {
+			$some_users = $wpdb->get_var( "SELECT COUNT(*) FROM (SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->prefix}capabilities' LIMIT 2) AS someusers" );
+			set_transient( 'jetpack_is_single_user', (int) $some_users, 12 * HOUR_IN_SECONDS );
+		}
+		return 1 === (int) $some_users;
 	}
 }

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -281,7 +281,9 @@ class Test_Status extends TestCase {
 		$wpdb->method( 'get_var' )
 		     ->willReturn( $return_value );
 
-		$wpdb->site = 'wp_site';
+		$wpdb->prefix   = 'wp_';
+		$wpdb->site     = 'wp_site';
+		$wpdb->usermeta = 'wp_usermeta';
 	}
 
 	/**

--- a/packages/status/tests/php/test_Status.php
+++ b/packages/status/tests/php/test_Status.php
@@ -16,6 +16,15 @@ class Test_Status extends TestCase {
 	private $site_url = 'https://yourjetpack.blog';
 
 	/**
+	 * Setup before running any of the tests.
+	 */
+	public static function setUpBeforeClass() {
+		if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+			define( 'HOUR_IN_SECONDS', 60 * 60 );
+		}
+	}
+
+	/**
 	 * Test setup.
 	 */
 	public function setUp() {
@@ -143,6 +152,45 @@ class Test_Status extends TestCase {
 
 		$this->clean_mock_wpdb_get_var();
 	}
+
+	/**
+	 * @covers Automattic\Jetpack\Status::is_single_user_site
+	 */
+	public function test_is_single_user_site_with_transient() {
+		$this->mock_wpdb_get_var( 3 );
+		$this->mock_function( 'get_transient', '1' );
+
+		$this->assertTrue( $this->status->is_single_user_site() );
+
+		$this->clean_mock_wpdb_get_var();
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Status::is_single_user_site
+	 */
+	public function test_is_single_user_site_with_one_user() {
+		$this->mock_wpdb_get_var( 1 );
+		$this->mock_function( 'get_transient', false );
+		$this->mock_function( 'set_transient' );
+
+		$this->assertTrue( $this->status->is_single_user_site() );
+
+		$this->clean_mock_wpdb_get_var();
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Status::is_single_user_site
+	 */
+	public function test_is_single_user_site_with_multiple_users() {
+		$this->mock_wpdb_get_var( 3 );
+		$this->mock_function( 'get_transient', false );
+		$this->mock_function( 'set_transient' );
+
+		$this->assertFalse( $this->status->is_single_user_site() );
+
+		$this->clean_mock_wpdb_get_var();
+	}
+
 
 	/**
 	 * Mock a global function with particular arguments and make it return a certain value.


### PR DESCRIPTION
This PR ports the `Jetpack::is_single_user_site()` method to the Status package and adds some tests. This method is used in the Sync package, so this is a small step towards decoupling sync from the Jetpack core.

#### Changes proposed in this Pull Request:
* Port `Jetpack::is_single_user_site()` to the status package.
* Add tests for `Status::is_single_user_site()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Part of Jetpack DNA.

#### Testing instructions:

* Go to the status package directory: `cd packages/status`
* Install and run tests `composer phpunit` and verify they pass.
* See CI and verify that that tests pass.

#### Proposed changelog entry for your changes:
* Port `Jetpack::is_single_user_site()` to the Status package and add tests
