### PR TITLE
AMP Compatibility: Remove social share CSS

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -24,6 +24,7 @@ class Jetpack_AMP_Support {
 
 		// Sharing.
 		add_filter( 'jetpack_sharing_display_markup', array( 'Jetpack_AMP_Support', 'render_sharing_html' ), 10, 2 );
+		add_filter( 'sharing_enqueue_scripts', array( 'Jetpack_AMP_Support', 'amp_disable_sharedaddy_css' ) );
 
 		// enforce freedom mode for videopress.
 		add_filter( 'videopress_shortcode_options', array( 'Jetpack_AMP_Support', 'videopress_enable_freedom_mode' ) );
@@ -350,9 +351,22 @@ class Jetpack_AMP_Support {
 
 		return $markup;
 	}
+
+	/**
+	 * Tells Jetpack not to enqueue CSS for share buttons.
+	 *
+	 * @param  bool $enqueue Whether or not to enqueue.
+	 * @return bool          Whether or not to enqueue.
+	 */
+	public static function amp_disable_sharedaddy_css( $enqueue ) {
+		if ( self::is_amp_request() ) {
+			$enqueue = false;
+		}
+
+		return $enqueue;
+	}
 }
 
 add_action( 'init', array( 'Jetpack_AMP_Support', 'init' ), 1 );
 
 add_action( 'admin_init', array( 'Jetpack_AMP_Support', 'admin_init' ), 1 );
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The CSS for the share icons triggers a "illegal_css_at_rule" AMP validation error because of the use of '-moz-document'. Given AMP uses the `amp-social-share` component, this CSS isn't needed at all. This change tells Jetpack not to enqueue the CSS at all when an AMP page is being viewed.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This builds upon existing AMP compatibility fixes.

#### Testing instructions:

1. Enable the AMP plugin in Transitional mode
1. Enable social sharing icons in Jetpack
1. View a post, and observe the `illegal_css_at_rule` validation error
1. Apply the PR, and refresh the post to see the validation passes

#### Proposed changelog entry for your changes:
* AMP compatibility fix for sharing button CSS
