### PR TITLE
Hosting Partners: Provisioning script can now send SSH credentials.

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -17,7 +17,12 @@ usage () {
 	[--force_connect=1] \
 	[--force_register=1] \
 	[--allow-root] \
-	[--partner-tracking-id=1]'
+	[--partner-tracking-id=1] \
+	[--ssh-host=example.com] \
+	[--ssh-user=user_name] \
+	[--ssh-pass=user_pass] \
+	[--ssh-private-key=private_key] \
+	[--ssh-port=22] '
 }
 
 # Note: this script should always be designed to keep wp-cli OPTIONAL
@@ -81,6 +86,26 @@ for i in "$@"; do
 			;;
 		--partner-tracking-id=* )
 			PROVISION_REQUEST_URL="$PROVISION_REQUEST_URL?partner-tracking-id=${i#*=}"
+			shift
+			;;
+		--ssh-host=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_host=${i#*=}"
+			shift
+			;;
+		--ssh-user=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_user=${i#*=}"
+			shift
+			;;
+		--ssh-pass=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_pass=${i#*=}"
+			shift
+			;;
+		--ssh-private-key=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_private_key=${i#*=}"
+			shift
+			;;
+		--ssh-port=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_port=${i#*=}"
 			shift
 			;;
 		--allow-root )

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -21,7 +21,7 @@ usage () {
 	[--ssh-host=example.com] \
 	[--ssh-user=user_name] \
 	[--ssh-pass=user_pass] \
-	[--ssh-private-key=private_key] \
+	[--ssh-private-key=/path/to/private_key] \
 	[--ssh-port=22] '
 }
 
@@ -101,7 +101,7 @@ for i in "$@"; do
 			shift
 			;;
 		--ssh-private-key=* )
-			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_private_key=${i#*=}"
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_private_key=<${i#*=}"
 			shift
 			;;
 		--ssh-port=* )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The `partner-provision.sh` script is basically a client that calls the Jetpack Start API `/provision` endpoint. While D29544-code updates this endpoint to accept SSH credentials, this PR updates the shell script that calls that endpoint.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This updates an existing feature. Previously the provisioning script could not send SSH credentials. This PR allows it to do so thus making setting up VaultPress / Rewind easier for hosting partners.

For more info, see parMIr-cg-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Create a new Jurassic Ninja site and take note of its SSH access credentials.
2) Grab a hosting partner id and secret (Team Catalyst can provide you with one).
3) Checkout this branch.
4) Run the following command, replacing the strings in *CAPS* with your own

```bash
./bin/partner-provision.sh \
--partner_id=PARTNER_ID \
--partner_secret=PARTNER_SECRET \
--user=1 \
--plan=premium \
--url=JURASSIC_NINJA_URL \
--ssh-host=JURASSIC_NINJA_HOST \
--ssh-user=JURASSIC_NINJA_SSH_USER \
--ssh-pass=JURASSIC_NINJA_SSH_PASSWORD
```

The output of this command should be a JSON object. Make sure `ssh_set` is `true` and `ssh_error` is an empty string.

Note: For prettier JSON output, you can pipe the output of this command to [jq](https://stedolan.github.io/jq/).



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add ability to send SSH credentials via `bin/partner-provision.sh`.
