### PR TITLE
Docker: Add yarn command for updating Core unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"docker:tail": "yarn docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\"",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
 		"docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
+		"docker:update-core-unit-tests": "yarn docker:compose exec wordpress svn up /tmp/wordpress-develop/tests/phpunit/data/ /tmp/wordpress-develop/tests/phpunit/includes",
 		"lint": "gulp jshint && eslint --ext .js --ext .jsx ./*.js _inc/client extensions -c .eslintrc.js",
 		"php:compatibility": "composer php:compatibility",
 		"php:lint": "composer php:lint",


### PR DESCRIPTION
Introduces yarn script `yarn docker:update-core-unit-tests`.

Fixes problems when core's code in the container is not the latest and something needs it to be.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduced `yarn docker:update-core-unit-tests` which runs `svn up` on the container directories used for running Jetpack's unit tests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Adds a handy command

#### Testing instructions:

1. On you local copy of Jetpack, make sure the Docker service is running as well as the Jetpack docker containers.
2. Run `yarn docker:update-core-unit-tests`
3. Expect to see something like:
  ```
Updating '/tmp/wordpress-develop/tests/phpunit/data':

Fetching external item into '/tmp/wordpress-develop/tests/phpunit/data/plugins/wordpress-importer':
External at revision 2117724.

At revision 45598.
Updating '/tmp/wordpress-develop/tests/phpunit/includes':
At revision 45598.
Summary of updates:
  Updated '/tmp/wordpress-develop/tests/phpunit/data' to r45598.
  Updated '/tmp/wordpress-develop/tests/phpunit/includes' to r45598.
✨  Done in 12.91s.
  ```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed