### PR TITLE
Upgrade Nudge: Fix Styling by using `@wordpress/editor`'s `Warning` component

### DIFF
--- a/extensions/shared/styles/gutenberg-variables.scss
+++ b/extensions/shared/styles/gutenberg-variables.scss
@@ -6,10 +6,11 @@
  * https://github.com/WordPress/gutenberg/blob/df6a17c8eb07e1355527b01e99ee22cf4c2338d7/assets/stylesheets/_variables.scss
  */
 
-$default-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$default-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+	'Helvetica Neue', sans-serif;
 $default-font-size: 13px;
 $default-line-height: 1.4;
-$editor-font: "Noto Serif", serif;
+$editor-font: 'Noto Serif', serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $text-editor-font-size: 14px;
@@ -23,3 +24,6 @@ $break-small: 600px;
 
 // Block UI
 $border-width: 1px;
+
+// Blocks
+$block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.

--- a/extensions/shared/styles/gutenberg-variables.scss
+++ b/extensions/shared/styles/gutenberg-variables.scss
@@ -20,3 +20,6 @@ $break-xlarge: 1080px;
 //$break-large: 960px; // admin sidebar auto folds
 //$break-medium: 782px; // editor sidebar auto folds
 $break-small: 600px;
+
+// Block UI
+$border-width: 1px;

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -43,7 +43,7 @@ const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
 					} ) }
 				</span>
 				<span className="jetpack-upgrade-nudge__message">
-					{ __( 'To make this block visible on your site', 'jetpack' ) }
+					{ __( 'The block will be hidden from your visitors until you upgrade.', 'jetpack' ) }
 				</span>
 			</div>
 		</div>

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import Gridicon from 'gridicons';
+import { Warning } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -17,33 +17,33 @@ import './store';
 import './style.scss';
 
 const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
-	<div className="block-editor-warning">
-		<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
-		<div className="block-editor-warning__message">
-			<span className="jetpack-upgrade-nudge__title">
-				{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
-					planName,
-				} ) }
-			</span>
-			<span className="jetpack-upgrade-nudge__message">
-				{ __( 'To make this block visible on your site', 'jetpack' ) }
-			</span>
-		</div>
-		<Button
-			className="jetpack-upgrade-nudge__button"
-			href={ addQueryArgs(
-				`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
-				{
-					redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
-				}
-			) }
-			target="_top"
-			isDefault
-		>
-			{ __( 'Upgrade', 'jetpack' ) }
-		</Button>
-	</div>
+	<Warning
+		actions={ [
+			<Button
+				href={ addQueryArgs(
+					`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
+					{
+						redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
+					}
+				) }
+				target="_top"
+				isDefault
+			>
+				{ __( 'Upgrade', 'jetpack' ) }
+			</Button>,
+		] }
+	>
+		<span className="jetpack-upgrade-nudge__title">
+			{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
+				planName,
+			} ) }
+		</span>
+		<span className="jetpack-upgrade-nudge__message">
+			{ __( 'To make this block visible on your site', 'jetpack' ) }
+		</span>
+	</Warning>
 );
+
 export default withSelect( ( select, { plan: planSlug } ) => {
 	const plan = select( 'wordpress-com/plans' ).getPlan( planSlug );
 

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -34,16 +34,18 @@ const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
 			</Button>,
 		] }
 	>
-		<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
-		<div>
-			<span className="jetpack-upgrade-nudge__title">
-				{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
-					planName,
-				} ) }
-			</span>
-			<span className="jetpack-upgrade-nudge__message">
-				{ __( 'To make this block visible on your site', 'jetpack' ) }
-			</span>
+		<div className="jetpack-upgrade-nudge__info">
+			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
+			<div>
+				<span className="jetpack-upgrade-nudge__title">
+					{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
+						planName,
+					} ) }
+				</span>
+				<span className="jetpack-upgrade-nudge__message">
+					{ __( 'To make this block visible on your site', 'jetpack' ) }
+				</span>
+			</div>
 		</div>
 	</Warning>
 );

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -39,12 +39,12 @@ const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
 			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
 			<div>
 				<span className="jetpack-upgrade-nudge__title">
-					{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
+					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {
 						planName,
 					} ) }
 				</span>
 				<span className="jetpack-upgrade-nudge__message">
-					{ __( 'The block will be hidden from your visitors until you upgrade.', 'jetpack' ) }
+					{ __( 'It will be hidden from site visitors until you upgrade.', 'jetpack' ) }
 				</span>
 			</div>
 		</div>

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -17,9 +17,9 @@ import './store';
 import './style.scss';
 
 const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
-	<div className="jetpack-upgrade-nudge">
+	<div className="block-editor-warning">
 		<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
-		<div className="jetpack-upgrade-nudge__info">
+		<div className="block-editor-warning__message">
 			<span className="jetpack-upgrade-nudge__title">
 				{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
 					planName,

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -33,14 +34,17 @@ const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
 			</Button>,
 		] }
 	>
-		<span className="jetpack-upgrade-nudge__title">
-			{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
-				planName,
-			} ) }
-		</span>
-		<span className="jetpack-upgrade-nudge__message">
-			{ __( 'To make this block visible on your site', 'jetpack' ) }
-		</span>
+		<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
+		<div>
+			<span className="jetpack-upgrade-nudge__title">
+				{ sprintf( __( 'Upgrade to %(planName)s', 'jetpack' ), {
+					planName,
+				} ) }
+			</span>
+			<span className="jetpack-upgrade-nudge__message">
+				{ __( 'To make this block visible on your site', 'jetpack' ) }
+			</span>
+		</div>
 	</Warning>
 );
 

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -33,6 +33,7 @@ const UpgradeNudge = ( { planName, planPathSlug, postId, postType } ) => (
 				{ __( 'Upgrade', 'jetpack' ) }
 			</Button>,
 		] }
+		className="jetpack-upgrade-nudge"
 	>
 		<div className="jetpack-upgrade-nudge__info">
 			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -13,14 +13,15 @@
 	}
 
 	.jetpack-upgrade-nudge__icon {
+		align-self: center;
 		background: var( --color-plan-premium );
 		border-radius: 50%;
 		box-sizing: content-box;
-		margin-right: 16px;
 		color: var( --color-white );
-		padding: 6px;
-		align-self: center;
 		fill: var( --color-white );
+		flex-shrink: 0;
+		margin-right: 16px;
+		padding: 6px;
 	}
 
 	.jetpack-upgrade-nudge__info {

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -16,7 +16,6 @@
 		color: var( --color-white );
 		padding: 6px;
 		align-self: center;
-		flex: 0 0 auto;
 		fill: var( --color-white );
 	}
 

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -1,7 +1,11 @@
+@import '../styles/gutenberg-variables.scss';
+
 .jetpack-upgrade-nudge {
 	border-left: 3px solid var( --color-plan-premium );
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
 	display: flex;
+	font-family: $default-font;
+	line-height: $default-line-height;
 	margin: 0 -1px 1em 0;
 	padding: 12px 16px;
 	text-align: left;

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -8,6 +8,10 @@
 		margin: 1em 0;
 	}
 
+	.editor-warning__actions {
+		line-height: 1;
+	}
+
 	.jetpack-upgrade-nudge__icon {
 		background: var( --color-plan-premium );
 		border-radius: 50%;

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -2,6 +2,13 @@
 	margin-bottom: 0;
 }
 
+.jetpack-upgrade-nudge {
+	// Override `.editor-styles-wrapper p` style overrides on WordPress.com
+	.editor-warning__message {
+		margin: 1em 0;
+	}
+}
+
 .jetpack-upgrade-nudge__icon {
 	background: var( --color-plan-premium );
 	border-radius: 50%;

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -10,6 +10,11 @@
 	fill: var( --color-white );
 }
 
+.jetpack-upgrade-nudge__info {
+	display: flex;
+	flex-direction: row;
+}
+
 .jetpack-upgrade-nudge__title {
 	font-size: 14px;
 }

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -1,17 +1,3 @@
-@import '../styles/gutenberg-variables.scss';
-
-.jetpack-upgrade-nudge {
-	border-left: 3px solid var( --color-plan-premium );
-	box-shadow: 0 0 0 1px var( --color-border-subtle );
-	display: flex;
-	font-family: $default-font;
-	line-height: $default-line-height;
-	margin: 0 -1px 1em 0;
-	padding: 12px 16px;
-	text-align: left;
-	width: 100%;
-}
-
 .jetpack-upgrade-nudge__icon {
 	background: var( --color-plan-premium );
 	border-radius: 50%;
@@ -30,7 +16,6 @@
 
 .jetpack-upgrade-nudge__message {
 	color: var( --color-text-subtle );
-	font-size: 12px;
 	display: block;
 }
 

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -1,3 +1,7 @@
+.jetpack-upgrade-nudge.block-editor-warning {
+	margin-bottom: 0;
+}
+
 .jetpack-upgrade-nudge__icon {
 	background: var( --color-plan-premium );
 	border-radius: 50%;

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -18,7 +18,3 @@
 	color: var( --color-text-subtle );
 	display: block;
 }
-
-.jetpack-upgrade-nudge__button {
-	margin-left: auto;
-}

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -1,36 +1,36 @@
-.jetpack-upgrade-nudge.block-editor-warning {
-	margin-bottom: 0;
-}
-
 .jetpack-upgrade-nudge {
+	&.block-editor-warning {
+		margin-bottom: 0;
+	}
+
 	// Override `.editor-styles-wrapper p` style overrides on WordPress.com
 	.editor-warning__message {
 		margin: 1em 0;
 	}
-}
 
-.jetpack-upgrade-nudge__icon {
-	background: var( --color-plan-premium );
-	border-radius: 50%;
-	box-sizing: content-box;
-	margin-right: 16px;
-	color: var( --color-white );
-	padding: 6px;
-	align-self: center;
-	flex: 0 0 auto;
-	fill: var( --color-white );
-}
+	.jetpack-upgrade-nudge__icon {
+		background: var( --color-plan-premium );
+		border-radius: 50%;
+		box-sizing: content-box;
+		margin-right: 16px;
+		color: var( --color-white );
+		padding: 6px;
+		align-self: center;
+		flex: 0 0 auto;
+		fill: var( --color-white );
+	}
 
-.jetpack-upgrade-nudge__info {
-	display: flex;
-	flex-direction: row;
-}
+	.jetpack-upgrade-nudge__info {
+		display: flex;
+		flex-direction: row;
+	}
 
-.jetpack-upgrade-nudge__title {
-	font-size: 14px;
-}
+	.jetpack-upgrade-nudge__title {
+		font-size: 14px;
+	}
 
-.jetpack-upgrade-nudge__message {
-	color: var( --color-text-subtle );
-	display: block;
+	.jetpack-upgrade-nudge__message {
+		color: var( --color-text-subtle );
+		display: block;
+	}
 }

--- a/extensions/shared/wrap-paid-block/index.jsx
+++ b/extensions/shared/wrap-paid-block/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -14,7 +15,11 @@ export default ( { requiredPlan } ) =>
 	createHigherOrderComponent(
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
-			<div className="jetpack-paid-block__wrapper">
+			<div
+				className={ classNames( 'jetpack-paid-block__wrapper', {
+					'is-selected': props.isSelected,
+				} ) }
+			>
 				<UpgradeNudge plan={ requiredPlan } />
 				<WrappedComponent { ...props } />
 			</div>

--- a/extensions/shared/wrap-paid-block/index.jsx
+++ b/extensions/shared/wrap-paid-block/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -9,14 +8,16 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import UpgradeNudge from '../upgrade-nudge';
 
+import './style.scss';
+
 export default ( { requiredPlan } ) =>
 	createHigherOrderComponent(
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
-			<Fragment>
+			<div className="jetpack-paid-block__wrapper">
 				<UpgradeNudge plan={ requiredPlan } />
 				<WrappedComponent { ...props } />
-			</Fragment>
+			</div>
 		),
 		'wrapPaidBlock'
 	);

--- a/extensions/shared/wrap-paid-block/index.jsx
+++ b/extensions/shared/wrap-paid-block/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-
+import { Fragment } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -9,18 +9,14 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import UpgradeNudge from '../upgrade-nudge';
 
-import './style.scss';
-
 export default ( { requiredPlan } ) =>
 	createHigherOrderComponent(
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
-			<div className="jetpack-paid-block__wrapper">
+			<Fragment>
 				<UpgradeNudge plan={ requiredPlan } />
-				<div className="jetpack-paid-block__disabled">
-					<WrappedComponent { ...props } />
-				</div>
-			</div>
+				<WrappedComponent { ...props } />
+			</Fragment>
 		),
 		'wrapPaidBlock'
 	);

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -5,6 +5,6 @@
 	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
 	margin-left: -14px;
 	margin-right: -14px;
-	padding-left: 14px;
-	padding-right: 14px;
+	padding-left: calc( 14px - #{$border-width} );
+	padding-right: calc( 14px - #{$border-width} );
 }

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -3,8 +3,8 @@
 
 .block-editor-block-list__block:not( .is-selected ) .jetpack-paid-block__wrapper {
 	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
-	margin-left: -14px;
-	margin-right: -14px;
-	padding-left: calc( 14px - #{$border-width} );
-	padding-right: calc( 14px - #{$border-width} );
+	margin-left: -#{$block-padding};
+	margin-right: -#{$block-padding};
+	padding-left: calc( #{$block-padding} - #{$border-width} );
+	padding-right: calc( #{$block-padding} - #{$border-width} );
 }

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -1,7 +1,0 @@
-.jetpack-paid-block__wrapper {
-	border: 1px solid var( --color-border-subtle );
-}
-
-.jetpack-paid-block__disabled {
-	padding: 10px;
-}

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -3,6 +3,5 @@
 }
 
 .jetpack-paid-block__disabled {
-	opacity: 0.5;
 	padding: 10px;
 }

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -3,10 +3,8 @@
 
 .block-editor-block-list__block:not( .is-selected ) .jetpack-paid-block__wrapper {
 	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
-	margin-bottom: -14px;
 	margin-left: -14px;
 	margin-right: -14px;
-	padding-bottom: 14px;
 	padding-left: 14px;
 	padding-right: 14px;
 }

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -1,7 +1,7 @@
 @import '../styles/gutenberg-colors.scss';
 @import '../styles/gutenberg-variables.scss';
 
-.jetpack-paid-block__wrapper {
+.block-editor-block-list__block:not( .is-selected ) .jetpack-paid-block__wrapper {
 	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
 	margin-bottom: -14px;
 	margin-left: -14px;

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -1,7 +1,9 @@
 @import '../styles/gutenberg-colors.scss';
 @import '../styles/gutenberg-variables.scss';
 
-.block-editor-block-list__block:not( .is-selected ) .jetpack-paid-block__wrapper {
+// The block gets a border from Gutenberg if it is selected,
+// so we only add ours if it isn't.
+.jetpack-paid-block__wrapper:not( .is-selected ) {
 	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
 	margin-left: -#{$block-padding};
 	margin-right: -#{$block-padding};

--- a/extensions/shared/wrap-paid-block/style.scss
+++ b/extensions/shared/wrap-paid-block/style.scss
@@ -1,0 +1,12 @@
+@import '../styles/gutenberg-colors.scss';
+@import '../styles/gutenberg-variables.scss';
+
+.jetpack-paid-block__wrapper {
+	border: $border-width solid $light-gray-500; // To reflect the `Warning` component from `@wordpress/editor`
+	margin-bottom: -14px;
+	margin-left: -14px;
+	margin-right: -14px;
+	padding-bottom: 14px;
+	padding-left: 14px;
+	padding-right: 14px;
+}


### PR DESCRIPTION
Fixes #12946

#### Changes proposed in this Pull Request:

* Upgrade Nudge: Fix Styling by using `@wordpress/editor`'s [`Warning`](https://github.com/WordPress/gutenberg/blob/21e2dce2b287347e21c3e0618bc8fa8c0c1ef5ca/packages/block-editor/src/components/warning/index.js) component 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fix styling of the recently introduced Upgrade Nudge

#### Screenshots

![image](https://user-images.githubusercontent.com/96308/60708281-87139e80-9f2f-11e9-8302-be57580e76a4.png)

![image](https://user-images.githubusercontent.com/96308/60708307-9266ca00-9f2f-11e9-85f9-e01bd14b8a2d.png)

#### Testing instructions:

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Now add the following line to any file in `docker/mu-plugins`, e.g. a newly created `0-blocks-upgrade.php` (needs to start with `<?php`): `define ( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Simple Payments' block
- It should come with an Upgrade Nudge on top of it, which should look as depicted in the screenshots.

#### Proposed changelog entry for your changes:

(Covered by whatever we add for #12823)