### PR TITLE
Premium block flows: add tracks event

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -607,6 +607,7 @@ class Jetpack_Gutenberg {
 				'available_blocks' => self::get_availability(),
 				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
 				'siteFragment'     => $site_fragment,
+				'tracksUserData'   => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			)
 		);
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -600,6 +600,16 @@ class Jetpack_Gutenberg {
 			plugins_url( $blocks_dir . '/', JETPACK__PLUGIN_FILE )
 		);
 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$user_data = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+		} else {
+			$user      = wp_get_current_user();
+			$user_data = array(
+				'userid'   => $user->ID,
+				'username' => $user->user_login,
+			);
+		}
+
 		wp_localize_script(
 			'jetpack-blocks-editor',
 			'Jetpack_Editor_Initial_State',
@@ -607,7 +617,8 @@ class Jetpack_Gutenberg {
 				'available_blocks' => self::get_availability(),
 				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
 				'siteFragment'     => $site_fragment,
-				'tracksUserData'   => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
+				'tracksUserData'   => $user_data,
+				'wpcomBlogId'      => Jetpack_Options::get_option( 'id', 0 ),
 			)
 		);
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -601,13 +601,13 @@ class Jetpack_Gutenberg {
 		);
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$user_data = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
-		} else {
 			$user      = wp_get_current_user();
 			$user_data = array(
 				'userid'   => $user->ID,
 				'username' => $user->user_login,
 			);
+		} else {
+			$user_data = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
 		}
 
 		wp_localize_script(

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -606,8 +606,10 @@ class Jetpack_Gutenberg {
 				'userid'   => $user->ID,
 				'username' => $user->user_login,
 			);
+			$blog_id   = get_current_blog_id();
 		} else {
 			$user_data = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+			$blog_id   = Jetpack_Options::get_option( 'id', 0 );
 		}
 
 		wp_localize_script(
@@ -618,7 +620,7 @@ class Jetpack_Gutenberg {
 				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
 				'siteFragment'     => $site_fragment,
 				'tracksUserData'   => $user_data,
-				'wpcomBlogId'      => Jetpack_Options::get_option( 'id', 0 ),
+				'wpcomBlogId'      => $blog_id,
 			)
 		);
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -555,6 +555,11 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
+		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.
+		if ( ! Jetpack::is_development_mode() && Jetpack::is_active() ) {
+			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+		}
+
 		$rtl        = is_rtl() ? '.rtl' : '';
 		$beta       = Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ? '-beta' : '';
 		$blocks_dir = self::get_blocks_directory();

--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -9,8 +9,11 @@ import analytics from '../_inc/client/lib/analytics';
 if (
 	typeof window === 'object' &&
 	typeof window.Jetpack_Editor_Initial_State === 'object' &&
-	typeof window.Jetpack_Editor_Initial_State.tracksUserData === 'object'
+	typeof window.Jetpack_Editor_Initial_State.tracksUserData === 'object' &&
+	typeof window.Jetpack_Editor_Initial_State.wpcomBlogId !== 'undefined'
 ) {
-	const { userid, username, blogid: blog_id } = window.Jetpack_Editor_Initial_State.tracksUserData;
-	analytics.initialize( userid, username, { blog_id } );
+	const { userid, username } = window.Jetpack_Editor_Initial_State.tracksUserData;
+	analytics.initialize( userid, username, {
+		blog_id: window.Jetpack_Editor_Initial_State.wpcomBlogId,
+	} );
 }

--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -3,3 +3,14 @@
  */
 import './shared/public-path';
 import './shared/block-category';
+import analytics from '../_inc/client/lib/analytics';
+
+// @TODO Please make a shared analytics solution and remove this!
+if (
+	typeof window === 'object' &&
+	typeof window.Jetpack_Editor_Initial_State === 'object' &&
+	typeof window.Jetpack_Editor_Initial_State.tracksUserData === 'object'
+) {
+	const { userid, username, blogid: blog_id } = window.Jetpack_Editor_Initial_State.tracksUserData;
+	analytics.initialize( userid, username, { blog_id } );
+}

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { compact, get, startsWith } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
+import { compact, get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import analytics from '../../../_inc/client/lib/analytics';
 import getSiteFragment from '../get-site-fragment';
 import './store';
 
@@ -70,11 +71,13 @@ export default compose( [
 
 		return {
 			planName: get( plan, [ 'product_name_short' ] ),
+			planPathSlug,
 			upgradeUrl,
 		};
 	} ),
-	withDispatch( ( dispatch, { upgradeUrl } ) => ( {
+	withDispatch( ( dispatch, { planPathSlug, upgradeUrl } ) => ( {
 		autosaveAndRedirectToUpgrade: async () => {
+			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', { planPathSlug } );
 			await dispatch( 'core/editor' ).autosave();
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = upgradeUrl;

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -75,9 +75,9 @@ export default compose( [
 			upgradeUrl,
 		};
 	} ),
-	withDispatch( ( dispatch, { planPathSlug, upgradeUrl } ) => ( {
+	withDispatch( ( dispatch, { plan: plan_slug, upgradeUrl } ) => ( {
 		autosaveAndRedirectToUpgrade: async () => {
-			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', { planPathSlug } );
+			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', { plan_slug } );
 			await dispatch( 'core/editor' ).autosave();
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = upgradeUrl;

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -71,7 +71,6 @@ export default compose( [
 
 		return {
 			planName: get( plan, [ 'product_name_short' ] ),
-			planPathSlug,
 			upgradeUrl,
 		};
 	} ),

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -74,9 +74,12 @@ export default compose( [
 			upgradeUrl,
 		};
 	} ),
-	withDispatch( ( dispatch, { plan: plan_slug, upgradeUrl } ) => ( {
+	withDispatch( ( dispatch, { blockName, plan, upgradeUrl } ) => ( {
 		autosaveAndRedirectToUpgrade: async () => {
-			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', { plan_slug } );
+			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+				plan,
+				source: blockName,
+			} );
 			await dispatch( 'core/editor' ).autosave();
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = upgradeUrl;

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -78,7 +78,7 @@ export default compose( [
 		autosaveAndRedirectToUpgrade: async () => {
 			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 				plan,
-				source: blockName,
+				block: blockName,
 			} );
 			await dispatch( 'core/editor' ).autosave();
 			// Using window.top to escape from the editor iframe on WordPress.com

--- a/extensions/shared/wrap-paid-block.jsx
+++ b/extensions/shared/wrap-paid-block.jsx
@@ -14,7 +14,7 @@ export default ( { requiredPlan } ) =>
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
 			<Fragment>
-				<UpgradeNudge plan={ requiredPlan } />
+				<UpgradeNudge plan={ requiredPlan } blockName={ props.name } />
 				<WrappedComponent { ...props } />
 			</Fragment>
 		),


### PR DESCRIPTION
Adds tracks event to premium block flows for "upgrade" button:

<img width="640" alt="premium-block-nudge" src="https://user-images.githubusercontent.com/87168/61024179-78a50700-a3b5-11e9-8ab5-f6766848af7e.png">


Resolves https://github.com/Automattic/jetpack/issues/12964

- Might still need a better event name `jetpack_editor_block_upgrade_click` (PCYsg-4S2-p2)
- Should I use [`recordJetpackClick()`](https://github.com/Automattic/jetpack/blob/3c16fe75b1461b2370d9a2fc22e619b3af36345f/_inc/client/lib/analytics/index.js#L137-L141) instead?
- Importing the lib — what do you think is the best approach?
  - I could either move the lib somewhere more obviously shared
  - Import it using `../../../` chain
  - Use this resolution helper in Webpack config (leaning towards this)

#### Changes proposed in this Pull Request:
*


#### Testing instructions:
- Have a Jetpack site with a free plan
- Enable `define ( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );` in your configs
- Insert simple payments block in the block editor
- In the browser developer console, enable "preserve log" from settings and run `localStorage.setItem('debug', '*');`
- Press "upgrade" button. You should see the event pop up in the console before being redirected .com

#### Proposed changelog entry for your changes:
N/A
