### PR TITLE
Jetpack DNA: Update sync to use the Roles package

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,12 @@
     "packages": [
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
-                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9"
+                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -40,11 +41,12 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
-                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb"
+                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb",
+                "shasum": null
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -74,11 +76,12 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
-                "reference": "cd47566548267b29b0df1574a7c6be67de9c5cc9"
+                "reference": "cd47566548267b29b0df1574a7c6be67de9c5cc9",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -106,11 +109,12 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "0a0e293d73c17d59376590d56e5667b169d26877"
+                "reference": "0a0e293d73c17d59376590d56e5667b169d26877",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -142,11 +146,12 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95",
+                "shasum": null
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -169,42 +174,13 @@
             "description": "A wrapper for defining constants in a more testable way."
         },
         {
-            "name": "automattic/jetpack-status",
-            "version": "dev-master",
-            "dist": {
-                "type": "path",
-                "url": "./packages/status",
-                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
-                "shasum": null
-            },
-            "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
-        },
-        {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca"
+                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -238,11 +214,12 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
+                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -267,11 +244,12 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
-                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f"
+                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -292,16 +270,79 @@
             "description": "A wrapper for wp-options to manage specific Jetpack options."
         },
         {
+            "name": "automattic/jetpack-roles",
+            "version": "dev-update/sync-use-roles-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/roles",
+                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7",
+                "shasum": null
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities."
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "dev-update/sync-use-roles-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/status",
+                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
+                "shasum": null
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
+        },
+        {
             "name": "automattic/jetpack-sync",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "b0d6e62ff20115d1ef5575ff46940fcbdb4bd2b0"
+                "reference": "1d7998577b452db00de2a4aabd693379bae0a065",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev"
             },
             "type": "library",
             "autoload": {
@@ -317,11 +358,12 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-add/jetpack-compat-package",
+            "version": "dev-update/sync-use-roles-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
-                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85"
+                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-options": "@dev"
@@ -420,16 +462,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.1.1",
+            "version": "9.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +485,7 @@
                 "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -474,7 +516,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-30T23:16:27+00:00"
+            "time": "2019-06-27T19:58:56+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -679,12 +721,12 @@
             "version": "2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908",
                 "shasum": ""
             },
@@ -727,7 +769,6 @@
         "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-constants": 20,
-        "automattic/jetpack-status": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-sync": 20,

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-status": "@dev"
 	},
 	"autoload": {

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -14,5 +14,13 @@
 			"Automattic\\Jetpack\\Sync\\": "src/",
 			"Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
 		}
-	}
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Roles;
+
 /**
  * This class monitors actions and logs them to the queue to be sent
  */
@@ -267,7 +269,8 @@ class Listener {
 			$user = wp_get_current_user();
 		}
 
-		$translated_role = \Jetpack::translate_user_to_role( $user );
+		$roles           = new Roles();
+		$translated_role = $roles->translate_user_to_role( $user );
 
 		$actor = array(
 			'wpcom_user_id'    => null,

--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Roles;
+
 /**
  * Class Users
  *
@@ -35,7 +37,8 @@ class Users {
 
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $user_id );
-		$role = \Jetpack::translate_current_user_to_role();
+		$roles = new Roles();
+		$role  = $roles->translate_current_user_to_role();
 		wp_set_current_user( $current_user_id );
 		$user_roles[ $user_id ] = $role;
 

--- a/packages/sync/src/modules/Posts.php
+++ b/packages/sync/src/modules/Posts.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Settings;
 
 class Posts extends Module {
@@ -358,12 +359,14 @@ class Posts extends Module {
 
 		$author_user_object = get_user_by( 'id', $post->post_author );
 		if ( $author_user_object ) {
+			$roles = new Roles();
+
 			$post_flags['author'] = array(
 				'id'              => $post->post_author,
 				'wpcom_user_id'   => get_user_meta( $post->post_author, 'wpcom_user_id', true ),
 				'display_name'    => $author_user_object->display_name,
 				'email'           => $author_user_object->user_email,
-				'translated_role' => \Jetpack::translate_user_to_role( $author_user_object ),
+				'translated_role' => $roles->translate_user_to_role( $author_user_object ),
 			);
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Settings;
 
@@ -90,13 +91,14 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$current_user  = wp_get_current_user();
 
+		$roles = new Roles();
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
 			'display_name'     => $current_user->display_name,
 			'user_email'       => $current_user->user_email,
 			'user_roles'       => $current_user->roles,
-			'translated_role'  => Jetpack::translate_current_user_to_role(),
+			'translated_role'  => $roles->translate_current_user_to_role(),
 			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
 			'is_wp_admin'      => is_admin(),
 			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,
@@ -123,13 +125,14 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$current_user = wp_get_current_user();
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 
+		$roles = new Roles();
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
 			'display_name'     => $current_user->display_name,
 			'user_email'       => $current_user->user_email,
 			'user_roles'       => $current_user->roles,
-			'translated_role'  => Jetpack::translate_current_user_to_role(),
+			'translated_role'  => $roles->translate_current_user_to_role(),
 			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
 			'is_wp_admin'      => is_admin(),
 			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,
@@ -160,13 +163,14 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		wp_signon( array( 'user_login' => $current_user->data->user_login, 'user_password' => 'password' ) );
 		remove_filter( 'jetpack_sync_actor_user_data', '__return_false' );
 
+		$roles = new Roles();
 		$example_actor = array(
 			'wpcom_user_id'    => null,
 			'external_user_id' => $current_user->ID,
 			'display_name'     => $current_user->display_name,
 			'user_email'       => $current_user->user_email,
 			'user_roles'       => $current_user->roles,
-			'translated_role'  => Jetpack::translate_current_user_to_role(),
+			'translated_role'  => $roles->translate_current_user_to_role(),
 			'is_cron'          => defined( 'DOING_CRON' ) ? DOING_CRON : false,
 			'is_wp_admin'      => is_admin(),
 			'is_rest'          => defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false,

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1,7 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
-
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Settings;
@@ -1044,7 +1044,8 @@ That was a cool video.';
 		$this->assertEquals( $author->display_name, $event->args[1]['author']['display_name'] ); // since 5.4 ?
 		$this->assertEquals( $author->ID, $event->args[1]['author']['id'] ); // since 5.4 ?
 		$this->assertEquals( $author->user_email, $event->args[1]['author']['email'] ); // since 5.4 ?
-		$this->assertEquals( Jetpack::translate_user_to_role( $author ), $event->args[1]['author']['translated_role'] ); // since 5.4 ?
+		$roles = new Roles();
+		$this->assertEquals( $roles->translate_user_to_role( $author ), $event->args[1]['author']['translated_role'] ); // since 5.4 ?
 		$this->assertTrue( isset( $event->args[1]['author']['wpcom_user_id'] ) );
 	}
 


### PR DESCRIPTION
In #12953 we introduced a Roles package. This PR updates the sync package to use methods from that package instead of the Jetpack class methods, in an effort to decouple sync from the Jetpack core.

#### Changes proposed in this Pull Request:
* Jetpack DNA: Update sync to use the Roles package

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:

* Checkout the branch.
* Enable WP_DEBUG_LOG.
* Smoke test the site in wp-admin and the frontend.
* Trigger an incremental sync.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
* Jetpack DNA: Update sync to use the Roles package
