### PR TITLE
Fix prepare-commit-msg hook when file is missing

### DIFF
--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -3,9 +3,7 @@ const fs = require( 'fs' );
 
 fs.readFile( '.git/last-commit-date', ( err, data ) => {
 	if ( err ) {
-		console.log( err );
 		console.log( 'skipping prepare-commit-msg hook' );
-
 		return;
 	}
 	const commitDate = data.toString();

--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -1,13 +1,17 @@
 /* eslint-disable no-console */
 const fs = require( 'fs' );
 
-const file = fs.readFileSync( '.git/last-commit-date' );
-const commitDate = file.toString();
+fs.readFile( '.git/last-commit-date', ( err, data ) => {
+	if ( err ) {
+		console.log( err );
+	}
+	const commitDate = data.toString();
 
-if ( Date.now() - commitDate > 2000 /* 2sec*/ ) {
-	console.log( 'WARNING: git pre-commit was hook skipped!' );
-	const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' );
-	const newCommitMsg = '[not verified] ' + commitMsg.toString();
+	if ( Date.now() - commitDate > 2000 /* 2sec*/ ) {
+		console.log( 'WARNING: git pre-commit hook was skipped!' );
+		const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' );
+		const newCommitMsg = '[not verified] ' + commitMsg.toString();
 
-	fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
-}
+		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
+	}
+} );

--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -4,6 +4,9 @@ const fs = require( 'fs' );
 fs.readFile( '.git/last-commit-date', ( err, data ) => {
 	if ( err ) {
 		console.log( err );
+		console.log( 'skipping prepare-commit-msg hook' );
+
+		return;
 	}
 	const commitDate = data.toString();
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -15,12 +15,12 @@ if ( pr.body.length < 10 ) {
 }
 
 // Keep track of commits which skipped pre-commit hook
-const commitMessages = danger.git.commits.map( commit => commit.message );
-commitMessages.forEach( message => {
-	if ( message.includes( '[not verified]' ) ) {
-		warn( '`pre-commit` hook was skipped for one or more commits' );
-	}
-} );
+const notVerifiedCommits = danger.git.commits.filter( commit =>
+	commit.message.includes( '[not verified]' )
+);
+if ( notVerifiedCommits.length > 0 ) {
+	warn( '`pre-commit` hook was skipped for one or more commits' );
+}
 
 // Use labels please!
 const ghLabels = github.issue.labels;

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Jetpack
 
+aa
+
 [![License](https://poser.pugx.org/automattic/jetpack/license.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
 [![Code Climate](https://codeclimate.com/github/Automattic/jetpack/badges/gpa.svg)](https://codeclimate.com/github/Automattic/jetpack)
 [![Build Status](https://travis-ci.org/Automattic/jetpack.svg?branch=master)](https://travis-ci.org/Automattic/jetpack)

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 # Jetpack
 
-aa
-
 [![License](https://poser.pugx.org/automattic/jetpack/license.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
 [![Code Climate](https://codeclimate.com/github/Automattic/jetpack/badges/gpa.svg)](https://codeclimate.com/github/Automattic/jetpack)
 [![Build Status](https://travis-ci.org/Automattic/jetpack.svg?branch=master)](https://travis-ci.org/Automattic/jetpack)


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix prepare-commit-msg hook when `.git/last-commit-date` file is missing
* update danger to warn only once about not verified commits

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this branch
* remove `.git/last-commit-date` file
* try to commit with `--no-verify`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
