### PR TITLE
 Carousel: Add Pointer Cursor to Gallery

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -1,3 +1,7 @@
+[data-carousel-extra] {
+	cursor: pointer; /* adds a cursor when the carousel takes effect */
+}
+
 .jp-carousel-wrap * {
 	line-height:inherit; /* prevent declarations of line-height in the universal selector */
 }

--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -1,5 +1,5 @@
 [data-carousel-extra] {
-	cursor: pointer; /* adds a cursor when the carousel takes effect */
+	cursor: pointer; /* adds a cursor when the carousel takes effect - restarting tests */
 }
 
 .jp-carousel-wrap * {

--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -1,5 +1,5 @@
 [data-carousel-extra] {
-	cursor: pointer; /* adds a cursor when the carousel takes effect - restarting tests */
+	cursor: pointer; /* adds a cursor when the carousel takes effect */
 }
 
 .jp-carousel-wrap * {

--- a/modules/carousel/rtl/jetpack-carousel-rtl.css
+++ b/modules/carousel/rtl/jetpack-carousel-rtl.css
@@ -1,5 +1,9 @@
 /* This file was automatically generated on Jul 30 2015 22:37:09 */
 
+[data-carousel-extra] {
+	cursor: pointer; /* adds a cursor when the carousel takes effect */
+}
+
 .jp-carousel-wrap * {
 	line-height:inherit; /* prevent declarations of line-height in the universal selector */
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12330

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a cursor to whenever a user hovers over an image which when clicked will open the Carousel

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Improves the existing Carousel

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the carousel feature, verify that when hovering over a gallery, a pointer cursor will appear
* When the carousel feature is disable, verify that this style of a pointer cursor is not taking effect 
* Verify that the selector of `[data-carousel-extra]` is ideal to use (I feel it's the best solution)

![ezgif-3-0622488aeeb5](https://user-images.githubusercontent.com/43215253/60767730-8572e380-a0b3-11e9-90f7-f99fe8e2dcdf.gif)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Carousel: use a pointer cursor when hovering over galleries that utilise the Carousel feature.
