### PR TITLE
Contact Form AMP Support

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3366,8 +3366,19 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	function render_date_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+
 		$field = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required );
+
+		/* For AMP requests, use amp-date-picker element: https://amp.dev/documentation/components/amp-date-picker */
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			return sprintf(
+				'<%1$s mode="overlay" layout="container" type="single" input-selector="[name=%2$s]">%3$s</%1$s>',
+				'amp-date-picker',
+				esc_attr( $id ),
+				$field
+			);
+		}
 
 		wp_enqueue_script(
 			'grunion-frontend',


### PR DESCRIPTION
The Contact Form block's date picker enqueues several scripts, which causes the block to break in AMP environments. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR uses the `amp-date-picker` element (https://amp.dev/documentation/components/amp-date-picker) making the Contact Form block fully AMP compatible.

#### Testing instructions:
* Spin up a new Jurassic Ninja instance using this URL: https://jurassic.ninja/create/?jetpack-beta&branch=add/amp-contact-form
* Connect Jetpack
* Install and activate the AMP plugin: https://wordpress.org/plugins/amp/. 
* Go to the AMP settings page (`/wp-admin/admin.php?page=amp-options`) and switch mode to *Transitional*.
* Create a new post and insert the Form block, and set it up to send to an email you receive.
* Add a Date Picker form element to the form.
* Publish or preview the post, and submit the form.
* Switch to AMP version (either use admin nav to toggle or simply add `?amp` to the end of the URL). 
* Submit the form.
* Verify that form submission works correctly in AMP and non-AMP environments, and that date picker value is included in both. 
* Observe the date picker UI looks different in AMP version:

<img width="1554" alt="Screen Shot 2019-07-08 at 8 30 48 AM" src="https://user-images.githubusercontent.com/1477002/60810910-1dc4a300-a15c-11e9-8737-259b5cf339ff.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Contact Form block AMP compatibility.
