### PR TITLE
Sync: Fix PHPCS errors in Attachments sync module

### DIFF
--- a/packages/sync/src/modules/Attachments.php
+++ b/packages/sync/src/modules/Attachments.php
@@ -1,12 +1,34 @@
 <?php
+/**
+ * Attachments sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+/**
+ * Class to handle sync for attachments.
+ */
 class Attachments extends Module {
-	function name() {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function name() {
 		return 'attachments';
 	}
 
+	/**
+	 * Initialize attachment action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		add_action( 'add_attachment', array( $this, 'process_add' ) );
 		add_action( 'attachment_updated', array( $this, 'process_update' ), 10, 3 );
@@ -15,29 +37,45 @@ class Attachments extends Module {
 		add_action( 'jetpack_sync_save_attach_attachment', $callable, 10, 2 );
 	}
 
-	function process_add( $attachment_id ) {
+	/**
+	 * Handle the creation of a new attachment.
+	 *
+	 * @access public
+	 *
+	 * @param int $attachment_id ID of the attachment.
+	 */
+	public function process_add( $attachment_id ) {
 		$attachment = get_post( $attachment_id );
 		/**
 		 * Fires when the client needs to sync an new attachment
 		 *
 		 * @since 4.2.0
 		 *
-		 * @param int The attachment ID
-		 * @param object The attachment
+		 * @param int      Attachment ID.
+		 * @param \WP_Post Attachment post object.
 		 */
 		do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment );
 	}
 
-	function process_update( $attachment_id, $attachment_after, $attachment_before ) {
-		// Check whether attachment was added to a post for the first time
+	/**
+	 * Handle updating an existing attachment.
+	 *
+	 * @access public
+	 *
+	 * @param int      $attachment_id     Attachment ID.
+	 * @param \WP_Post $attachment_after  Attachment post object before the update.
+	 * @param \WP_Post $attachment_before Attachment post object after the update.
+	 */
+	public function process_update( $attachment_id, $attachment_after, $attachment_before ) {
+		// Check whether attachment was added to a post for the first time.
 		if ( 0 === $attachment_before->post_parent && 0 !== $attachment_after->post_parent ) {
 			/**
 			 * Fires when an existing attachment is added to a post for the first time
 			 *
 			 * @since 6.6.0
 			 *
-			 * @param int The attachment ID
-			 * @param object The attachment
+			 * @param int      $attachment_id     Attachment ID.
+			 * @param \WP_Post $attachment_after  Attachment post object after the update.
 			 */
 			do_action( 'jetpack_sync_save_attach_attachment', $attachment_id, $attachment_after );
 		} else {
@@ -46,8 +84,8 @@ class Attachments extends Module {
 			 *
 			 * @since 4.9.0
 			 *
-			 * @param int The attachment ID
-			 * @param object The attachment
+			 * @param int      $attachment_id     Attachment ID.
+			 * @param \WP_Post $attachment_after  Attachment post object after the update.
 			 *
 			 * Previously this action was synced using jetpack_sync_save_add_attachment action.
 			 */


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the attachments sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Attachments sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Attachments sync module
