### PR TITLE
Sync: Fix PHPCS errors in Callables sync module

### DIFF
--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Callables sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
@@ -6,16 +11,50 @@ use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Settings;
 
+/**
+ * Class to handle sync for callables.
+ */
 class Callables extends Module {
+	/**
+	 * Name of the callables checksum option.
+	 *
+	 * @var string
+	 */
 	const CALLABLES_CHECKSUM_OPTION_NAME = 'jetpack_callables_sync_checksum';
+
+	/**
+	 * Name of the transient for locking callables.
+	 *
+	 * @var string
+	 */
 	const CALLABLES_AWAIT_TRANSIENT_NAME = 'jetpack_sync_callables_await';
 
+	/**
+	 * Whitelist for callables we want to sync.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
 	private $callable_whitelist;
 
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'functions';
 	}
 
+	/**
+	 * Set module defaults.
+	 * Define the callable whitelist based on whether this is a single site or a multisite installation.
+	 *
+	 * @access public
+	 */
 	public function set_defaults() {
 		if ( is_multisite() ) {
 			$this->callable_whitelist = array_merge( Defaults::get_callable_whitelist(), Defaults::get_multisite_callable_whitelist() );
@@ -24,9 +63,16 @@ class Callables extends Module {
 		}
 	}
 
+	/**
+	 * Initialize callables action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
-		add_action( 'current_screen', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late
+		add_action( 'current_screen', array( $this, 'set_plugin_action_links' ), 9999 ); // Should happen very late.
 
 		// For some options, we should always send the change right away!
 		$always_send_updates_to_these_options = array(
@@ -52,17 +98,36 @@ class Callables extends Module {
 		add_action( 'update_option_active_plugins', array( $this, 'unlock_plugin_action_link_and_callables' ) );
 	}
 
+	/**
+	 * Initialize callables action listeners for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_callables', $callable );
 	}
 
+	/**
+	 * Initialize the module in the sender.
+	 *
+	 * @access public
+	 */
 	public function init_before_send() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_sync_callables' ) );
 
-		// full sync
+		// Full sync.
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_callables', array( $this, 'expand_callables' ) );
 	}
 
+	/**
+	 * Perform module cleanup.
+	 * Deletes any transients and options that this module uses.
+	 * Usually triggered when uninstalling the plugin.
+	 *
+	 * @access public
+	 */
 	public function reset_data() {
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
@@ -73,14 +138,35 @@ class Callables extends Module {
 		}
 	}
 
-	function set_callable_whitelist( $callables ) {
+	/**
+	 * Set the callable whitelist.
+	 *
+	 * @access public
+	 *
+	 * @param array $callables The new callables whitelist.
+	 */
+	public function set_callable_whitelist( $callables ) {
 		$this->callable_whitelist = $callables;
 	}
 
-	function get_callable_whitelist() {
+	/**
+	 * Get the callable whitelist.
+	 *
+	 * @access public
+	 *
+	 * @return array The callables whitelist.
+	 */
+	public function get_callable_whitelist() {
 		return $this->callable_whitelist;
 	}
 
+	/**
+	 * Retrieve all callables as per the current callables whitelist.
+	 *
+	 * @access public
+	 *
+	 * @return array All callables.
+	 */
 	public function get_all_callables() {
 		// get_all_callables should run as the master user always.
 		$current_user_id = get_current_user_id();
@@ -93,11 +179,30 @@ class Callables extends Module {
 		return $callables;
 	}
 
+	/**
+	 * Invoke a particular callable.
+	 * Used as a wrapper to standartize invocation.
+	 *
+	 * @access private
+	 *
+	 * @param callable $callable Callable to invoke.
+	 * @return mixed Return value of the callable.
+	 */
 	private function get_callable( $callable ) {
 		return call_user_func( $callable );
 	}
 
-	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+	/**
+	 * Enqueue the callable actions for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param array   $config               Full sync configuration for this sync module.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue.
+	 * @param boolean $state                True if full sync has finished enqueueing this module, false otherwise.
+	 * @return array Number of actions enqueued, and next module state.
+	 */
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		/**
 		 * Tells the client to sync all callables to the server
 		 *
@@ -107,28 +212,62 @@ class Callables extends Module {
 		 */
 		do_action( 'jetpack_full_sync_callables', true );
 
-		// The number of actions enqueued, and next module state (true == done)
+		// The number of actions enqueued, and next module state (true == done).
 		return array( 1, true );
 	}
 
-	public function estimate_full_sync_actions( $config ) {
+	/**
+	 * Retrieve an estimated number of actions that will be enqueued.
+	 *
+	 * @access public
+	 *
+	 * @param array $config Full sync configuration for this sync module.
+	 * @return array Number of items yet to be enqueued.
+	 */
+	public function estimate_full_sync_actions( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return 1;
 	}
 
+	/**
+	 * Retrieve the actions that will be sent for this module during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return array Full sync actions of this module.
+	 */
 	public function get_full_sync_actions() {
 		return array( 'jetpack_full_sync_callables' );
 	}
 
+	/**
+	 * Unlock callables so they would be available for syncing again.
+	 *
+	 * @access public
+	 */
 	public function unlock_sync_callable() {
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
 	}
 
+	/**
+	 * Unlock callables and plugin action links.
+	 *
+	 * @access public
+	 */
 	public function unlock_plugin_action_link_and_callables() {
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_transient( 'jetpack_plugin_api_action_links_refresh' );
 		add_filter( 'jetpack_check_and_send_callables', '__return_true' );
 	}
 
+	/**
+	 * Parse and store the plugin action links if on the plugins page.
+	 *
+	 * @uses \DOMDocument
+	 * @uses libxml_use_internal_errors
+	 * @uses mb_convert_encoding
+	 *
+	 * @access public
+	 */
 	public function set_plugin_action_links() {
 		if (
 			! class_exists( '\DOMDocument' ) ||
@@ -143,7 +282,7 @@ class Callables extends Module {
 		$plugins_action_links = array();
 		// Is the transient lock in place?
 		$plugins_lock = get_transient( 'jetpack_plugin_api_action_links_refresh', false );
-		if ( ! empty( $plugins_lock ) && ( isset( $current_screeen->id ) && $current_screeen->id !== 'plugins' ) ) {
+		if ( ! empty( $plugins_lock ) && ( isset( $current_screeen->id ) && 'plugins' !== $current_screeen->id ) ) {
 			return;
 		}
 		$plugins = array_keys( Functions::get_plugins() );
@@ -174,20 +313,22 @@ class Callables extends Module {
 					libxml_use_internal_errors( false );
 
 					$link_elements = $dom_doc->getElementsByTagName( 'a' );
-					if ( $link_elements->length == 0 ) {
+					if ( 0 === $link_elements->length ) {
 						continue;
 					}
 
 					$link_element = $link_elements->item( 0 );
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
 						$link_url = trim( $link_element->getAttribute( 'href' ) );
 
-						// Add the full admin path to the url if the plugin did not provide it
+						// Add the full admin path to the url if the plugin did not provide it.
 						$link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
 						if ( empty( $link_url_scheme ) ) {
 							$link_url = admin_url( $link_url );
 						}
 
+						// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						$formatted_action_links[ $link_element->nodeValue ] = $link_url;
 					}
 				}
@@ -196,24 +337,39 @@ class Callables extends Module {
 				$plugins_action_links[ $plugin_file ] = $formatted_action_links;
 			}
 		}
-		// Cache things for a long time
+		// Cache things for a long time.
 		set_transient( 'jetpack_plugin_api_action_links_refresh', time(), DAY_IN_SECONDS );
 		update_option( 'jetpack_plugin_api_action_links', $plugins_action_links );
 	}
 
+	/**
+	 * Whether a certain callable should be sent.
+	 *
+	 * @access public
+	 *
+	 * @param array  $callable_checksums Callable checksums.
+	 * @param string $name               Name of the callable.
+	 * @param string $checksum           A checksum of the callable.
+	 * @return boolean Whether to send the callable.
+	 */
 	public function should_send_callable( $callable_checksums, $name, $checksum ) {
 		$idc_override_callables = array(
 			'main_network_site',
 			'home_url',
 			'site_url',
 		);
-		if ( in_array( $name, $idc_override_callables ) && \Jetpack_Options::get_option( 'migrate_for_idc' ) ) {
+		if ( in_array( $name, $idc_override_callables, true ) && \Jetpack_Options::get_option( 'migrate_for_idc' ) ) {
 			return true;
 		}
 
 		return ! $this->still_valid_checksum( $callable_checksums, $name, $checksum );
 	}
 
+	/**
+	 * Sync the callables if we're supposed to.
+	 *
+	 * @access public
+	 */
 	public function maybe_sync_callables() {
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
 			if ( ! is_admin() || Settings::is_doing_cron() ) {
@@ -235,10 +391,10 @@ class Callables extends Module {
 
 		$callable_checksums = (array) \Jetpack_Options::get_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 		$has_changed        = false;
-		// only send the callables that have changed
+		// Only send the callables that have changed.
 		foreach ( $callables as $name => $value ) {
 			$checksum = $this->get_check_sum( $value );
-			// explicitly not using Identical comparison as get_option returns a string
+			// Explicitly not using Identical comparison as get_option returns a string.
 			if ( ! is_null( $value ) && $this->should_send_callable( $callable_checksums, $name, $checksum ) ) {
 				/**
 				 * Tells the client to sync a callable (aka function) to the server
@@ -261,6 +417,14 @@ class Callables extends Module {
 
 	}
 
+	/**
+	 * Expand the callables within a hook before they are serialized and sent to the server.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array $args The hook parameters.
+	 */
 	public function expand_callables( $args ) {
 		if ( $args[0] ) {
 			$callables           = $this->get_all_callables();


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Callables sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Callables sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Callables sync module
