### PR TITLE
Sync: Fix PHPCS errors in Import module

### DIFF
--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -172,7 +172,7 @@ class Import extends Module {
 	 */
 	private static function get_calling_importer_class() {
 		// If WP_Importer doesn't exist, neither will any importer that extends it.
-		if ( ! class_exists( '\\WP_Importer', false ) ) {
+		if ( ! class_exists( 'WP_Importer', false ) ) {
 			return 'unknown';
 		}
 
@@ -206,7 +206,7 @@ class Import extends Module {
 			// Check if the class extends WP_Importer.
 			if ( class_exists( $class_name, false ) ) {
 				$parents = class_parents( $class_name, false );
-				if ( $parents && in_array( '\\WP_Importer', $parents, true ) ) {
+				if ( $parents && in_array( 'WP_Importer', $parents, true ) ) {
 					return $class_name;
 				}
 			}

--- a/packages/sync/src/modules/Import.php
+++ b/packages/sync/src/modules/Import.php
@@ -1,14 +1,22 @@
 <?php
+/**
+ * Import sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Settings;
 
+/**
+ * Class to handle sync for imports.
+ */
 class Import extends Module {
 
 	/**
 	 * Tracks which actions have already been synced for the import
-	 * to prevent the same event from being triggered a second time
+	 * to prevent the same event from being triggered a second time.
 	 *
 	 * @var array
 	 */
@@ -32,10 +40,24 @@ class Import extends Module {
 		'import_end'   => 'jetpack_sync_import_end',
 	);
 
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'import';
 	}
 
+	/**
+	 * Initialize imports action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		add_action( 'export_wp', $callable );
 		add_action( 'jetpack_sync_import_start', $callable, 10, 2 );
@@ -51,10 +73,23 @@ class Import extends Module {
 		add_action( 'import_end', array( $this, 'sync_import_action' ) );
 	}
 
+	/**
+	 * Set module defaults.
+	 * Define an empty list of synced actions for us to fill later.
+	 *
+	 * @access public
+	 */
 	public function set_defaults() {
 		$this->synced_actions = array();
 	}
 
+	/**
+	 * Generic handler for import actions.
+	 *
+	 * @access public
+	 *
+	 * @param string $importer Either a string reported by the importer, the class name of the importer, or 'unknown'.
+	 */
 	public function sync_import_action( $importer ) {
 		$import_action = current_filter();
 		// Map action to event name.
@@ -113,6 +148,14 @@ class Import extends Module {
 		}
 	}
 
+	/**
+	 * Retrieve the name of the importer.
+	 *
+	 * @access private
+	 *
+	 * @param string $importer Either a string reported by the importer, the class name of the importer, or 'unknown'.
+	 * @return string Name of the importer, or "Unknown Importer" if importer is unknown.
+	 */
 	private function get_importer_name( $importer ) {
 		$importers = get_importers();
 		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
@@ -122,11 +165,14 @@ class Import extends Module {
 	 * Determine the class that extends `WP_Importer` which is responsible for
 	 * the current action. Designed to be used within an action handler.
 	 *
-	 * @return string  The name of the calling class, or 'unknown'.
+	 * @access private
+	 * @static
+	 *
+	 * @return string The name of the calling class, or 'unknown'.
 	 */
 	private static function get_calling_importer_class() {
 		// If WP_Importer doesn't exist, neither will any importer that extends it.
-		if ( ! class_exists( 'WP_Importer', false ) ) {
+		if ( ! class_exists( '\\WP_Importer', false ) ) {
 			return 'unknown';
 		}
 
@@ -160,7 +206,7 @@ class Import extends Module {
 			// Check if the class extends WP_Importer.
 			if ( class_exists( $class_name, false ) ) {
 				$parents = class_parents( $class_name, false );
-				if ( $parents && in_array( 'WP_Importer', $parents, true ) ) {
+				if ( $parents && in_array( '\\WP_Importer', $parents, true ) ) {
 					return $class_name;
 				}
 			}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Import sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Import sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Import sync module
