### PR TITLE
Sync: Fix PHPCS errors in Menus module

### DIFF
--- a/packages/sync/src/modules/Menus.php
+++ b/packages/sync/src/modules/Menus.php
@@ -1,14 +1,43 @@
 <?php
+/**
+ * Menus sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+/**
+ * Class to handle sync for menus.
+ */
 class Menus extends Module {
+	/**
+	 * Navigation menu items that were added but not synced yet.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
 	private $nav_items_just_added = array();
 
-	function name() {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function name() {
 		return 'menus';
 	}
 
+	/**
+	 * Initialize menus action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		add_action( 'wp_create_nav_menu', $callable, 10, 2 );
 		add_action( 'wp_update_nav_menu', array( $this, 'update_nav_menu' ), 10, 2 );
@@ -22,6 +51,14 @@ class Menus extends Module {
 		add_action( 'delete_nav_menu', $callable, 10, 3 );
 	}
 
+	/**
+	 * Nav menu update handler.
+	 *
+	 * @access public
+	 *
+	 * @param int   $menu_id ID of the menu.
+	 * @param array $menu_data An array of menu data.
+	 */
 	public function update_nav_menu( $menu_id, $menu_data = array() ) {
 		if ( empty( $menu_data ) ) {
 			return;
@@ -31,12 +68,21 @@ class Menus extends Module {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param int $menu_id, the id of the menu
-		 * @param object $menu_data
+		 * @param int   $menu_id ID of the menu.
+		 * @param array $menu_data An array of menu data.
 		 */
 		do_action( 'jetpack_sync_updated_nav_menu', $menu_id, $menu_data );
 	}
 
+	/**
+	 * Nav menu item addition handler.
+	 *
+	 * @access public
+	 *
+	 * @param int   $menu_id       ID of the menu.
+	 * @param int   $nav_item_id   ID of the new menu item.
+	 * @param array $nav_item_args Arguments used to add the menu item.
+	 */
 	public function update_nav_menu_add_item( $menu_id, $nav_item_id, $nav_item_args ) {
 		$menu_data                    = wp_get_nav_menu_object( $menu_id );
 		$this->nav_items_just_added[] = $nav_item_id;
@@ -45,16 +91,25 @@ class Menus extends Module {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param int $menu_id, the id of the menu
-		 * @param object $menu_data
-		 * @param int $nav_item_id
-		 * @param int $nav_item_args
+		 * @param int   $menu_id       ID of the menu.
+		 * @param array $menu_data     An array of menu data.
+		 * @param int   $nav_item_id   ID of the new menu item.
+		 * @param array $nav_item_args Arguments used to add the menu item.
 		 */
 		do_action( 'jetpack_sync_updated_nav_menu_add_item', $menu_id, $menu_data, $nav_item_id, $nav_item_args );
 	}
 
+	/**
+	 * Nav menu item update handler.
+	 *
+	 * @access public
+	 *
+	 * @param int   $menu_id       ID of the menu.
+	 * @param int   $nav_item_id   ID of the new menu item.
+	 * @param array $nav_item_args Arguments used to update the menu item.
+	 */
 	public function update_nav_menu_update_item( $menu_id, $nav_item_id, $nav_item_args ) {
-		if ( in_array( $nav_item_id, $this->nav_items_just_added ) ) {
+		if ( in_array( $nav_item_id, $this->nav_items_just_added, true ) ) {
 			return;
 		}
 		$menu_data = wp_get_nav_menu_object( $menu_id );
@@ -63,14 +118,22 @@ class Menus extends Module {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param int $menu_id, the id of the menu
-		 * @param object $menu_data
-		 * @param int $nav_item_id
-		 * @param int $nav_item_args
+		 * @param int   $menu_id       ID of the menu.
+		 * @param array $menu_data     An array of menu data.
+		 * @param int   $nav_item_id   ID of the new menu item.
+		 * @param array $nav_item_args Arguments used to update the menu item.
 		 */
 		do_action( 'jetpack_sync_updated_nav_menu_update_item', $menu_id, $menu_data, $nav_item_id, $nav_item_args );
 	}
 
+	/**
+	 * Remove menu items that have already been saved from the "just added" list.
+	 *
+	 * @access public
+	 *
+	 * @param int      $nav_item_id ID of the new menu item.
+	 * @param \WP_Post $post_after  Nav menu item post object after the update.
+	 */
 	public function remove_just_added_menu_item( $nav_item_id, $post_after ) {
 		if ( 'nav_menu_item' !== $post_after->post_type ) {
 			return;


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Menus sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Menus sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Menus sync module
