### PR TITLE
Sync: Fix PHPCS errors in Meta module

### DIFF
--- a/packages/sync/src/modules/Meta.php
+++ b/packages/sync/src/modules/Meta.php
@@ -1,8 +1,23 @@
 <?php
+/**
+ * Meta sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+/**
+ * Class to handle sync for meta.
+ */
 class Meta extends Module {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'meta';
 	}
@@ -15,8 +30,10 @@ class Meta extends Module {
 	 * This seemed to be required since if we have missing meta on WP.com and need to fetch it, we don't know what
 	 * the meta key is, but we do know that we have missing meta for a given post or comment.
 	 *
-	 * @param string $object_type The type of object for which we retrieve meta. Either 'post' or 'comment'
-	 * @param array  $config Must include 'meta_key' and 'ids' keys
+	 * @todo Refactor the $wpdb->prepare call to use placeholders.
+	 *
+	 * @param string $object_type The type of object for which we retrieve meta. Either 'post' or 'comment'.
+	 * @param array  $config      Must include 'meta_key' and 'ids' keys.
 	 *
 	 * @return array
 	 */
@@ -37,10 +54,11 @@ class Meta extends Module {
 		$ids              = $config['ids'];
 		$object_id_column = $object_type . '_id';
 
-		// Sanitize so that the array only has integer values
+		// Sanitize so that the array only has integer values.
 		$ids_string = implode( ', ', array_map( 'intval', $ids ) );
 		$metas      = $wpdb->get_results(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"SELECT * FROM {$table} WHERE {$object_id_column} IN ( {$ids_string} ) AND meta_key = %s",
 				$meta_key
 			)


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Meta sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Meta sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Meta sync module
