### PR TITLE
Sync: Fix PHPCS errors in base module

### DIFF
--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -1,59 +1,175 @@
 <?php
+/**
+ * A base abstraction of a sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Listener;
 
 /**
- * Basic methods implemented by Jetpack Sync extensions
+ * Basic methods implemented by Jetpack Sync extensions.
+ *
+ * @abstract
  */
 abstract class Module {
+	/**
+	 * Number of items per chunk when grouping objects for performance reasons.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
 	const ARRAY_CHUNK_SIZE = 10;
 
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	abstract public function name();
 
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+	/**
+	 * Retrieve a sync object by its ID.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Type of the sync object.
+	 * @param int    $id          ID of the sync object.
+	 * @return mixed Object, or false if the object is invalid.
+	 */
 	public function get_object_by_id( $object_type, $id ) {
 		return false;
 	}
 
-	// override these to set up listeners and set/reset data/defaults
+	/**
+	 * Initialize callables action listeners.
+	 * Override these to set up listeners and set/reset data/defaults.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 	}
 
+	/**
+	 * Initialize module action listeners for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_full_sync_listeners( $callable ) {
 	}
 
+	/**
+	 * Initialize the module in the sender.
+	 *
+	 * @access public
+	 */
 	public function init_before_send() {
 	}
 
+	/**
+	 * Set module defaults.
+	 *
+	 * @access public
+	 */
 	public function set_defaults() {
 	}
 
+	/**
+	 * Perform module cleanup.
+	 * Usually triggered when uninstalling the plugin.
+	 *
+	 * @access public
+	 */
 	public function reset_data() {
 	}
 
+	/**
+	 * Enqueue the module actions for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param array   $config               Full sync configuration for this sync module.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue.
+	 * @param boolean $state                True if full sync has finished enqueueing this module, false otherwise.
+	 * @return array Number of actions enqueued, and next module state.
+	 */
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
-		// in subclasses, return the number of actions enqueued, and next module state (true == done)
+		// In subclasses, return the number of actions enqueued, and next module state (true == done).
 		return array( null, true );
 	}
 
+	/**
+	 * Retrieve an estimated number of actions that will be enqueued.
+	 *
+	 * @access public
+	 *
+	 * @param array $config Full sync configuration for this sync module.
+	 * @return array Number of items yet to be enqueued.
+	 */
 	public function estimate_full_sync_actions( $config ) {
-		// in subclasses, return the number of items yet to be enqueued
+		// In subclasses, return the number of items yet to be enqueued.
 		return null;
 	}
 
+	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+	/**
+	 * Retrieve the actions that will be sent for this module during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return array Full sync actions of this module.
+	 */
 	public function get_full_sync_actions() {
 		return array();
 	}
 
+	/**
+	 * Get the number of actions that we care about.
+	 *
+	 * @access protected
+	 *
+	 * @param array $action_names     Action names we're interested in.
+	 * @param array $actions_to_count Unfiltered list of actions we want to count.
+	 * @return array Number of actions that we're interested in.
+	 */
 	protected function count_actions( $action_names, $actions_to_count ) {
 		return count( array_intersect( $action_names, $actions_to_count ) );
 	}
 
+	/**
+	 * Calculate the checksum of one or more values.
+	 *
+	 * @access protected
+	 *
+	 * @param mixed $values Values to calculate checksum for.
+	 * @return int The checksum.
+	 */
 	protected function get_check_sum( $values ) {
 		return crc32( wp_json_encode( jetpack_json_wrap( $values ) ) );
 	}
 
+	/**
+	 * Whether a particular checksum in a set of checksums is valid.
+	 *
+	 * @access protected
+	 *
+	 * @param array  $sums_to_check Array of checksums.
+	 * @param string $name          Name of the checksum.
+	 * @param int    $new_sum       Checksum to compare against.
+	 * @return boolean Whether the checksum is valid.
+	 */
 	protected function still_valid_checksum( $sums_to_check, $name, $new_sum ) {
 		if ( isset( $sums_to_check[ $name ] ) && $sums_to_check[ $name ] === $new_sum ) {
 			return true;
@@ -62,6 +178,19 @@ abstract class Module {
 		return false;
 	}
 
+	/**
+	 * Enqueue all items of a sync type as an action.
+	 *
+	 * @access protected
+	 *
+	 * @param string  $action_name          Name of the action.
+	 * @param string  $table_name           Name of the database table.
+	 * @param string  $id_field             Name of the ID field in the database.
+	 * @param string  $where_sql            The SQL WHERE clause to filter to the desired items.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue in the same time.
+	 * @param boolean $state                Whether enqueueing has finished.
+	 * @return array Array, containing the number of chunks and TRUE, indicating enqueueing has finished.
+	 */
 	protected function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql, $max_items_to_enqueue, $state ) {
 		global $wpdb;
 
@@ -75,12 +204,13 @@ abstract class Module {
 		$previous_interval_end = $state ? $state : '~0';
 		$listener              = Listener::get_instance();
 
-		// count down from max_id to min_id so we get newest posts/comments/etc first
+		// Count down from max_id to min_id so we get newest posts/comments/etc first.
+		// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} < {$previous_interval_end} ORDER BY {$id_field} DESC LIMIT {$items_per_page}" ) ) {
-			// Request posts in groups of N for efficiency
+			// Request posts in groups of N for efficiency.
 			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
 
-			// if we hit our row limit, process and return
+			// If we hit our row limit, process and return.
 			if ( $chunk_count + count( $chunked_ids ) >= $max_items_to_enqueue ) {
 				$remaining_items_count                      = $max_items_to_enqueue - $chunk_count;
 				$remaining_items                            = array_slice( $chunked_ids, 0, $remaining_items_count );
@@ -95,26 +225,48 @@ abstract class Module {
 			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids_with_previous_end );
 
 			$chunk_count += count( $chunked_ids );
-			$page        += 1;
-			// $ids are ordered in descending order
+			$page++;
+			// The $ids are ordered in descending order.
 			$previous_interval_end = end( $ids );
 		}
 
 		return array( $chunk_count, true );
 	}
 
+	/**
+	 * Retrieve chunk IDs with previous interval end.
+	 *
+	 * @access private
+	 *
+	 * @param array $chunks                All remaining items.
+	 * @param int   $previous_interval_end The last item from the previous interval.
+	 * @return array Chunk IDs with the previous interval end.
+	 */
 	private function get_chunks_with_preceding_end( $chunks, $previous_interval_end ) {
+		$chunks_with_ends = array();
 		foreach ( $chunks as $chunk ) {
 			$chunks_with_ends[] = array(
 				'ids'          => $chunk,
 				'previous_end' => $previous_interval_end,
 			);
-			// Chunks are ordered in descending order
+			// Chunks are ordered in descending order.
 			$previous_interval_end = end( $chunk );
 		}
 		return $chunks_with_ends;
 	}
 
+	/**
+	 * Get metadata of a particular object type within the designated meta key whitelist.
+	 *
+	 * @access protected
+	 *
+	 * @todo Refactor to use $wpdb->prepare() on the SQL query.
+	 *
+	 * @param array  $ids                Object IDs.
+	 * @param string $meta_type          Meta type.
+	 * @param array  $meta_key_whitelist Meta key whitelist.
+	 * @return array Unserialized meta values.
+	 */
 	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist ) {
 		global $wpdb;
 		$table = _get_meta_table( $meta_type );
@@ -128,36 +280,82 @@ abstract class Module {
 		return array_map(
 			array( $this, 'unserialize_meta' ),
 			$wpdb->get_results(
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 				"SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )' .
 				" AND meta_key IN ( $private_meta_whitelist_sql ) ",
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 				OBJECT
 			)
 		);
 	}
 
+	/**
+	 * Initialize listeners for the particular meta type.
+	 *
+	 * @access public
+	 *
+	 * @param string   $meta_type Meta type.
+	 * @param callable $callable  Action handler callable.
+	 */
 	public function init_listeners_for_meta_type( $meta_type, $callable ) {
 		add_action( "added_{$meta_type}_meta", $callable, 10, 4 );
 		add_action( "updated_{$meta_type}_meta", $callable, 10, 4 );
 		add_action( "deleted_{$meta_type}_meta", $callable, 10, 4 );
 	}
 
+	/**
+	 * Initialize meta whitelist handler for the particular meta type.
+	 *
+	 * @access public
+	 *
+	 * @param string   $meta_type         Meta type.
+	 * @param callable $whitelist_handler Action handler callable.
+	 */
 	public function init_meta_whitelist_handler( $meta_type, $whitelist_handler ) {
 		add_filter( "jetpack_sync_before_enqueue_added_{$meta_type}_meta", $whitelist_handler );
 		add_filter( "jetpack_sync_before_enqueue_updated_{$meta_type}_meta", $whitelist_handler );
 		add_filter( "jetpack_sync_before_enqueue_deleted_{$meta_type}_meta", $whitelist_handler );
 	}
 
+	/**
+	 * Retrieve the term relationships for the specified object IDs.
+	 *
+	 * @access protected
+	 *
+	 * @todo This feels too specific to be in the abstract sync Module class. Move it?
+	 *
+	 * @param array $ids Object IDs.
+	 * @return array Term relationships - object ID and term taxonomy ID pairs.
+	 */
 	protected function get_term_relationships( $ids ) {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )', OBJECT );
 	}
 
+	/**
+	 * Unserialize the value of a meta object, if necessary.
+	 *
+	 * @access public
+	 *
+	 * @param object $meta Meta object.
+	 * @return object Meta object with possibly unserialized value.
+	 */
 	public function unserialize_meta( $meta ) {
 		$meta->meta_value = maybe_unserialize( $meta->meta_value );
 		return $meta;
 	}
 
+	/**
+	 * Retrieve a set of objects by their IDs.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param array  $ids         Object IDs.
+	 * @return array Array of objects.
+	 */
 	public function get_objects_by_id( $object_type, $ids ) {
 		if ( empty( $ids ) || empty( $object_type ) ) {
 			return array();


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the base sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in base sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in base sync module
