### PR TITLE
Sync: Fix PHPCS errors in Network Options module

### DIFF
--- a/packages/sync/src/modules/Network_Options.php
+++ b/packages/sync/src/modules/Network_Options.php
@@ -1,22 +1,51 @@
 <?php
+/**
+ * Network Options sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Defaults;
 
+/**
+ * Class to handle sync for network options.
+ */
 class Network_Options extends Module {
+	/**
+	 * Whitelist for network options we want to sync.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
 	private $network_options_whitelist;
 
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'network_options';
 	}
 
+	/**
+	 * Initialize network options action listeners when on multisite.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		if ( ! is_multisite() ) {
 			return;
 		}
 
-		// multi site network options
+		// Multi site network options.
 		add_action( 'add_site_option', $callable, 10, 2 );
 		add_action( 'update_site_option', $callable, 10, 3 );
 		add_action( 'delete_site_option', $callable, 10, 1 );
@@ -27,16 +56,28 @@ class Network_Options extends Module {
 		add_filter( 'jetpack_sync_before_enqueue_update_site_option', $whitelist_network_option_handler );
 	}
 
+	/**
+	 * Initialize network options action listeners for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_network_options', $callable );
 	}
 
+	/**
+	 * Initialize the module in the sender.
+	 *
+	 * @access public
+	 */
 	public function init_before_send() {
 		if ( ! is_multisite() ) {
 			return;
 		}
 
-		// full sync
+		// Full sync.
 		add_filter(
 			'jetpack_sync_before_send_jetpack_full_sync_network_options',
 			array(
@@ -46,11 +87,27 @@ class Network_Options extends Module {
 		);
 	}
 
+	/**
+	 * Set module defaults.
+	 * Define the network options whitelist based on the default one.
+	 *
+	 * @access public
+	 */
 	public function set_defaults() {
 		$this->network_options_whitelist = Defaults::$default_network_options_whitelist;
 	}
 
-	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+	/**
+	 * Enqueue the network options actions for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param array   $config               Full sync configuration for this sync module.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue.
+	 * @param boolean $state                True if full sync has finished enqueueing this module, false otherwise.
+	 * @return array Number of actions enqueued, and next module state.
+	 */
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! is_multisite() ) {
 			return array( null, true );
 		}
@@ -64,11 +121,19 @@ class Network_Options extends Module {
 		 */
 		do_action( 'jetpack_full_sync_network_options', true );
 
-		// The number of actions enqueued, and next module state (true == done)
+		// The number of actions enqueued, and next module state (true == done).
 		return array( 1, true );
 	}
 
-	function estimate_full_sync_actions( $config ) {
+	/**
+	 * Retrieve an estimated number of actions that will be enqueued.
+	 *
+	 * @access public
+	 *
+	 * @param array $config Full sync configuration for this sync module.
+	 * @return array Number of items yet to be enqueued.
+	 */
+	public function estimate_full_sync_actions( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! is_multisite() ) {
 			return null;
 		}
@@ -76,11 +141,25 @@ class Network_Options extends Module {
 		return 1;
 	}
 
-	function get_full_sync_actions() {
+	/**
+	 * Retrieve the actions that will be sent for this module during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return array Full sync actions of this module.
+	 */
+	public function get_full_sync_actions() {
 		return array( 'jetpack_full_sync_network_options' );
 	}
 
-	function get_all_network_options() {
+	/**
+	 * Retrieve all network options as per the current network options whitelist.
+	 *
+	 * @access public
+	 *
+	 * @return array All network options.
+	 */
+	public function get_all_network_options() {
 		$options = array();
 		foreach ( $this->network_options_whitelist as $option ) {
 			$options[ $option ] = get_site_option( $option );
@@ -89,16 +168,37 @@ class Network_Options extends Module {
 		return $options;
 	}
 
-	function set_network_options_whitelist( $options ) {
+	/**
+	 * Set the network options whitelist.
+	 *
+	 * @access public
+	 *
+	 * @param array $options The new network options whitelist.
+	 */
+	public function set_network_options_whitelist( $options ) {
 		$this->network_options_whitelist = $options;
 	}
 
-	function get_network_options_whitelist() {
+	/**
+	 * Get the network options whitelist.
+	 *
+	 * @access public
+	 *
+	 * @return array The network options whitelist.
+	 */
+	public function get_network_options_whitelist() {
 		return $this->network_options_whitelist;
 	}
 
-	// reject non-whitelisted network options
-	function whitelist_network_options( $args ) {
+	/**
+	 * Reject non-whitelisted network options.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array|false $args The hook parameters, false if not a whitelisted network option.
+	 */
+	public function whitelist_network_options( $args ) {
 		if ( ! $this->is_whitelisted_network_option( $args[0] ) ) {
 			return false;
 		}
@@ -106,10 +206,26 @@ class Network_Options extends Module {
 		return $args;
 	}
 
-	function is_whitelisted_network_option( $option ) {
-		return is_multisite() && in_array( $option, $this->network_options_whitelist );
+	/**
+	 * Whether the option is a whitelisted network option in a multisite system.
+	 *
+	 * @access public
+	 *
+	 * @param string $option Option name.
+	 * @return boolean True if this is a whitelisted network option.
+	 */
+	public function is_whitelisted_network_option( $option ) {
+		return is_multisite() && in_array( $option, $this->network_options_whitelist, true );
 	}
 
+	/**
+	 * Expand the network options within a hook before they are serialized and sent to the server.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array $args The hook parameters.
+	 */
 	public function expand_network_options( $args ) {
 		if ( $args[0] ) {
 			return $this->get_all_network_options();


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Network Options sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Network Options sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Network Options sync module
