### PR TITLE
Sync: Fix PHPCS errors in Protect module

### DIFF
--- a/packages/sync/src/modules/Protect.php
+++ b/packages/sync/src/modules/Protect.php
@@ -1,24 +1,50 @@
 <?php
+/**
+ * Protect sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 /**
- * logs bruteprotect failed logins via sync
+ * Class to handle sync for Protect.
+ * Logs BruteProtect failed logins via sync.
  */
 class Protect extends Module {
-
-	function name() {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function name() {
 		return 'protect';
 	}
 
-	function init_listeners( $callback ) {
+	/**
+	 * Initialize Protect action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callback Action handler callable.
+	 */
+	public function init_listeners( $callback ) {
 		add_action( 'jpp_log_failed_attempt', array( $this, 'maybe_log_failed_login_attempt' ) );
 		add_action( 'jetpack_valid_failed_login_attempt', $callback );
 	}
 
-	function maybe_log_failed_login_attempt( $failed_attempt ) {
+	/**
+	 * Maybe log a failed login attempt.
+	 *
+	 * @access public
+	 *
+	 * @param array $failed_attempt Failed attempt data.
+	 */
+	public function maybe_log_failed_login_attempt( $failed_attempt ) {
 		$protect = \Jetpack_Protect_Module::instance();
 		if ( $protect->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Protect sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Protect sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Protect sync module
