### PR TITLE
Sync: Fix PHPCS errors in Stats module

### DIFF
--- a/packages/sync/src/modules/Stats.php
+++ b/packages/sync/src/modules/Stats.php
@@ -1,29 +1,65 @@
 <?php
+/**
+ * Stats sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+/**
+ * Class to handle sync for stats.
+ */
 class Stats extends Module {
-
-	function name() {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function name() {
 		return 'stats';
 	}
 
-	function init_listeners( $callback ) {
+	/**
+	 * Initialize stats action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callback Action handler callable.
+	 */
+	public function init_listeners( $callback ) {
 		add_action( 'jetpack_heartbeat', array( $this, 'sync_site_stats' ), 20 );
 		add_action( 'jetpack_sync_heartbeat_stats', $callback );
 	}
-	/*
+
+	/**
 	 * This namespaces the action that we sync.
 	 * So that we can differentiate it from future actions.
+	 *
+	 * @access public
 	 */
 	public function sync_site_stats() {
 		do_action( 'jetpack_sync_heartbeat_stats' );
 	}
 
+	/**
+	 * Initialize the module in the sender.
+	 *
+	 * @access public
+	 */
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_heartbeat_stats', array( $this, 'add_stats' ) );
 	}
 
+	/**
+	 * Retrieve the stats data for the site.
+	 *
+	 * @access public
+	 *
+	 * @return array Stats data.
+	 */
 	public function add_stats() {
 		return array( \Jetpack::get_stat_data( false, false ) );
 	}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Stats sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Stats sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Stats sync module
