### PR TITLE
Sync: Fix PHPCS errors in Updates module

### DIFF
--- a/packages/sync/src/modules/Updates.php
+++ b/packages/sync/src/modules/Updates.php
@@ -34,7 +34,7 @@ class Updates extends Module {
 	 *
 	 * @access private
 	 *
-	 * @var string
+	 * @var array
 	 */
 	private $updates = array();
 

--- a/packages/sync/src/modules/Updates.php
+++ b/packages/sync/src/modules/Updates.php
@@ -1,24 +1,70 @@
 <?php
+/**
+ * Updates sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 
+/**
+ * Class to handle sync for updates.
+ */
 class Updates extends Module {
-
+	/**
+	 * Name of the updates checksum option.
+	 *
+	 * @var string
+	 */
 	const UPDATES_CHECKSUM_OPTION_NAME = 'jetpack_updates_sync_checksum';
 
+	/**
+	 * WordPress Version.
+	 *
+	 * @access private
+	 *
+	 * @var string
+	 */
 	private $old_wp_version = null;
-	private $updates        = array();
 
+	/**
+	 * The current updates.
+	 *
+	 * @access private
+	 *
+	 * @var string
+	 */
+	private $updates = array();
+
+	/**
+	 * Set module defaults.
+	 *
+	 * @access public
+	 */
 	public function set_defaults() {
 		$this->updates = array();
 	}
 
-	function name() {
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function name() {
 		return 'updates';
 	}
 
+	/**
+	 * Initialize updates action listeners.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_listeners( $callable ) {
 		global $wp_version;
 		$this->old_wp_version = $wp_version;
@@ -56,7 +102,7 @@ class Updates extends Module {
 			add_action( 'jetpack_sync_core_update_network', $callable, 10, 3 );
 		}
 
-		// Send data when update completes
+		// Send data when update completes.
 		add_action( '_core_updated_successfully', array( $this, 'update_core' ) );
 		add_action( 'jetpack_sync_core_reinstalled_successfully', $callable );
 		add_action( 'jetpack_sync_core_autoupdated_successfully', $callable, 10, 2 );
@@ -64,15 +110,36 @@ class Updates extends Module {
 
 	}
 
+	/**
+	 * Initialize updates action listeners for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param callable $callable Action handler callable.
+	 */
 	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_updates', $callable );
 	}
 
+	/**
+	 * Initialize the module in the sender.
+	 *
+	 * @access public
+	 */
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_update_themes_change', array( $this, 'expand_themes' ) );
 	}
 
+	/**
+	 * Handle a core network update.
+	 *
+	 * @access public
+	 *
+	 * @param int $wp_db_version     Current version of the WordPress database.
+	 * @param int $old_wp_db_version Old version of the WordPress database.
+	 * @return int Current version of the WordPress database.
+	 */
 	public function update_core_network_event( $wp_db_version, $old_wp_db_version ) {
 		global $wp_version;
 		/**
@@ -88,9 +155,19 @@ class Updates extends Module {
 		return $wp_db_version;
 	}
 
+	/**
+	 * Handle a core update.
+	 *
+	 * @access public
+	 *
+	 * @todo Implement nonce or refactor to use `admin_post_{$action}` hooks instead.
+	 *
+	 * @param string $new_wp_version The new WP core version.
+	 */
 	public function update_core( $new_wp_version ) {
 		global $pagenow;
 
+		// // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['action'] ) && 'do-core-reinstall' === $_GET['action'] ) {
 			/**
 			 * Sync event that fires when core reinstall was successful
@@ -103,10 +180,10 @@ class Updates extends Module {
 			return;
 		}
 
-		// Core was autoudpated
+		// Core was autoupdated.
 		if (
 			'update-core.php' !== $pagenow &&
-			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // wp.com rest api calls should never be marked as a core autoupdate
+			! Jetpack_Constants::is_true( 'REST_API_REQUEST' ) // WP.com rest api calls should never be marked as a core autoupdate.
 		) {
 			/**
 			 * Sync event that fires when core autoupdate was successful
@@ -128,10 +205,17 @@ class Updates extends Module {
 		 * @param string $old_wp_version the previous WordPress version
 		 */
 		do_action( 'jetpack_sync_core_updated_successfully', $new_wp_version, $this->old_wp_version );
-		return;
-
 	}
 
+	/**
+	 * Retrieve the checksum for an update.
+	 *
+	 * @access public
+	 *
+	 * @param object $update    The update object.
+	 * @param string $transient The transient we're retrieving a checksum for.
+	 * @return int The checksum.
+	 */
 	public function get_update_checksum( $update, $transient ) {
 		$updates    = array();
 		$no_updated = array();
@@ -170,7 +254,7 @@ class Updates extends Module {
 			case 'update_core':
 				if ( ! empty( $update->updates ) && is_array( $update->updates ) ) {
 					foreach ( $update->updates as $response ) {
-						if ( ! empty( $response->response ) && $response->response === 'latest' ) {
+						if ( ! empty( $response->response ) && 'latest' === $response->response ) {
 							continue;
 						}
 						if ( ! empty( $response->response ) && isset( $response->packages->full ) ) {
@@ -195,6 +279,15 @@ class Updates extends Module {
 		return $this->get_check_sum( array( $no_updated, $updates ) );
 	}
 
+	/**
+	 * Validate a change coming from an update before sending for sync.
+	 *
+	 * @access public
+	 *
+	 * @param mixed  $value      Site transient value.
+	 * @param int    $expiration Time until transient expiration in seconds.
+	 * @param string $transient  Transient name.
+	 */
 	public function validate_update_change( $value, $expiration, $transient ) {
 		$new_checksum = $this->get_update_checksum( $value, $transient );
 
@@ -213,17 +306,17 @@ class Updates extends Module {
 		update_option( self::UPDATES_CHECKSUM_OPTION_NAME, $checksums );
 		if ( 'update_core' === $transient ) {
 			/**
-			 * jetpack_update_core_change
+			 * Trigger a change to core update that we want to sync.
 			 *
 			 * @since 5.1.0
 			 *
-			 * @param array containing info that tells us what needs updating
+			 * @param array $value Contains info that tells us what needs updating.
 			 */
 			do_action( 'jetpack_update_core_change', $value );
 			return;
 		}
 		if ( empty( $this->updates ) ) {
-			// lets add the shutdown method once and only when the updates move from empty to filled with something
+			// Lets add the shutdown method once and only when the updates move from empty to filled with something.
 			add_action( 'shutdown', array( $this, 'sync_last_event' ), 9 );
 		}
 		if ( ! isset( $this->updates[ $transient ] ) ) {
@@ -232,24 +325,41 @@ class Updates extends Module {
 		$this->updates[ $transient ][] = $value;
 	}
 
+	/**
+	 * Sync the last update only.
+	 *
+	 * @access public
+	 */
 	public function sync_last_event() {
 		foreach ( $this->updates as $transient => $values ) {
-			$value = end( $values ); // only send over the last value
+			$value = end( $values ); // Only send over the last value.
 			/**
-			 * jetpack_{$transient}_change
-			 * jetpack_update_plugins_change
-			 * jetpack_update_themes_change
+			 * Trigger a change to a specific update that we want to sync.
+			 * Triggers one of the following actions:
+			 * - jetpack_{$transient}_change
+			 * - jetpack_update_plugins_change
+			 * - jetpack_update_themes_change
 			 *
 			 * @since 5.1.0
 			 *
-			 * @param array containing info that tells us what needs updating
+			 * @param array $value Contains info that tells us what needs updating.
 			 */
 			do_action( "jetpack_{$transient}_change", $value );
 		}
 
 	}
 
-	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+	/**
+	 * Enqueue the updates actions for full sync.
+	 *
+	 * @access public
+	 *
+	 * @param array   $config               Full sync configuration for this sync module.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue.
+	 * @param boolean $state                True if full sync has finished enqueueing this module, false otherwise.
+	 * @return array Number of actions enqueued, and next module state.
+	 */
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		/**
 		 * Tells the client to sync all updates to the server
 		 *
@@ -259,18 +369,40 @@ class Updates extends Module {
 		 */
 		do_action( 'jetpack_full_sync_updates', true );
 
-		// The number of actions enqueued, and next module state (true == done)
+		// The number of actions enqueued, and next module state (true == done).
 		return array( 1, true );
 	}
 
-	public function estimate_full_sync_actions( $config ) {
+	/**
+	 * Retrieve an estimated number of actions that will be enqueued.
+	 *
+	 * @access public
+	 *
+	 * @param array $config Full sync configuration for this sync module.
+	 * @return array Number of items yet to be enqueued.
+	 */
+	public function estimate_full_sync_actions( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return 1;
 	}
 
-	function get_full_sync_actions() {
+	/**
+	 * Retrieve the actions that will be sent for this module during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return array Full sync actions of this module.
+	 */
+	public function get_full_sync_actions() {
 		return array( 'jetpack_full_sync_updates' );
 	}
 
+	/**
+	 * Retrieve all updates that we're interested in.
+	 *
+	 * @access public
+	 *
+	 * @return array All updates.
+	 */
 	public function get_all_updates() {
 		return array(
 			'core'    => get_site_transient( 'update_core' ),
@@ -279,8 +411,15 @@ class Updates extends Module {
 		);
 	}
 
-	// removes unnecessary keys from synced updates data
-	function filter_update_keys( $args ) {
+	/**
+	 * Remove unnecessary keys from synced updates data.
+	 *
+	 * @access public
+	 *
+	 * @param array $args Hook arguments.
+	 * @return array $args Hook arguments.
+	 */
+	public function filter_update_keys( $args ) {
 		$updates = $args[0];
 
 		if ( isset( $updates->no_update ) ) {
@@ -290,12 +429,28 @@ class Updates extends Module {
 		return $args;
 	}
 
-	function filter_upgrader_process_complete( $args ) {
+	/**
+	 * Filter out upgrader object from the completed upgrader action args.
+	 *
+	 * @access public
+	 *
+	 * @param array $args Hook arguments.
+	 * @return array $args Filtered hook arguments.
+	 */
+	public function filter_upgrader_process_complete( $args ) {
 		array_shift( $args );
 
 		return $args;
 	}
 
+	/**
+	 * Expand the updates within a hook before they are serialized and sent to the server.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array $args The hook parameters.
+	 */
 	public function expand_updates( $args ) {
 		if ( $args[0] ) {
 			return $this->get_all_updates();
@@ -304,11 +459,20 @@ class Updates extends Module {
 		return $args;
 	}
 
+	/**
+	 * Expand the themes within a hook before they are serialized and sent to the server.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array $args The hook parameters.
+	 */
 	public function expand_themes( $args ) {
 		if ( ! isset( $args[0], $args[0]->response ) ) {
 			return $args;
 		}
 		if ( ! is_array( $args[0]->response ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( 'Warning: Not an Array as expected but -> ' . wp_json_encode( $args[0]->response ) . ' instead', E_USER_WARNING );
 			return $args;
 		}
@@ -319,6 +483,13 @@ class Updates extends Module {
 		return $args;
 	}
 
+	/**
+	 * Perform module cleanup.
+	 * Deletes any transients and options that this module uses.
+	 * Usually triggered when uninstalling the plugin.
+	 *
+	 * @access public
+	 */
 	public function reset_data() {
 		delete_option( self::UPDATES_CHECKSUM_OPTION_NAME );
 	}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Updates sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Updates sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Updates sync module
