### PR TITLE
Sync: Fix PHPCS errors in WP Super Cache module

### DIFF
--- a/packages/sync/src/modules/WP_Super_Cache.php
+++ b/packages/sync/src/modules/WP_Super_Cache.php
@@ -1,15 +1,35 @@
 <?php
+/**
+ * WP_Super_Cache sync module.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+/**
+ * Class to handle sync for WP_Super_Cache.
+ */
 class WP_Super_Cache extends Module {
-
+	/**
+	 * Constructor.
+	 *
+	 * @todo Should we refactor this to use $this->set_defaults() instead?
+	 */
 	public function __construct() {
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_wp_super_cache_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'add_wp_super_cache_callable_whitelist' ), 10 );
 	}
 
-	static $wp_super_cache_constants = array(
+	/**
+	 * Whitelist for constants we are interested to sync.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @var array
+	 */
+	public static $wp_super_cache_constants = array(
 		'WPLOCKDOWN',
 		'WPSC_DISABLE_COMPRESSION',
 		'WPSC_DISABLE_LOCKING',
@@ -17,14 +37,57 @@ class WP_Super_Cache extends Module {
 		'ADVANCEDCACHEPROBLEM',
 	);
 
-	static $wp_super_cache_callables = array(
+	/**
+	 * Container for the whitelist for WP_Super_Cache callables we are interested to sync.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @var array
+	 */
+	public static $wp_super_cache_callables = array(
 		'wp_super_cache_globals' => array( __CLASS__, 'get_wp_super_cache_globals' ),
 	);
 
+	/**
+	 * Sync module name.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'wp-super-cache';
 	}
 
+	/**
+	 * Retrieve all WP_Super_Cache callables we are interested to sync.
+	 *
+	 * @access public
+	 *
+	 * @global $wp_cache_mod_rewrite;
+	 * @global $cache_enabled;
+	 * @global $super_cache_enabled;
+	 * @global $ossdlcdn;
+	 * @global $cache_rebuild_files;
+	 * @global $wp_cache_mobile;
+	 * @global $wp_super_cache_late_init;
+	 * @global $wp_cache_anon_only;
+	 * @global $wp_cache_not_logged_in;
+	 * @global $wp_cache_clear_on_post_edit;
+	 * @global $wp_cache_mobile_enabled;
+	 * @global $wp_super_cache_debug;
+	 * @global $cache_max_time;
+	 * @global $wp_cache_refresh_single_only;
+	 * @global $wp_cache_mfunc_enabled;
+	 * @global $wp_supercache_304;
+	 * @global $wp_cache_no_cache_for_get;
+	 * @global $wp_cache_mutex_disabled;
+	 * @global $cache_jetpack;
+	 * @global $cache_domain_mapping;
+	 *
+	 * @return array All WP_Super_Cache callables.
+	 */
 	public static function get_wp_super_cache_globals() {
 		global $wp_cache_mod_rewrite;
 		global $cache_enabled;
@@ -71,10 +134,22 @@ class WP_Super_Cache extends Module {
 		);
 	}
 
+	/**
+	 * Add WP_Super_Cache constants to the constants whitelist.
+	 *
+	 * @param array $list Existing constants whitelist.
+	 * @return array Updated constants whitelist.
+	 */
 	public function add_wp_super_cache_constants_whitelist( $list ) {
 		return array_merge( $list, self::$wp_super_cache_constants );
 	}
 
+	/**
+	 * Add WP_Super_Cache callables to the callables whitelist.
+	 *
+	 * @param array $list Existing callables whitelist.
+	 * @return array Updated callables whitelist.
+	 */
 	public function add_wp_super_cache_callable_whitelist( $list ) {
 		return array_merge( $list, self::$wp_super_cache_callables );
 	}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the WP Super Cache sync module.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in WP Super Cache sync module

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in WP Super Cache sync module
