### PR TITLE
Simplify stats graph to use <img> tag

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -900,7 +900,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	if ( Jetpack_AMP_Support::is_amp_request() ) {
 		$menu['title'] = "<amp-img src='$img_src_2x' width=112 height=24 layout=fixed alt='$alt' title='$title'></amp-img>";
 	} else {
-		$menu['title'] = "<div><script type='text/javascript'>var src;if(typeof(window.devicePixelRatio)=='undefined'||window.devicePixelRatio<2){src='$img_src';}else{src='$img_src_2x';}document.write('<img src=\''+src+'\' alt=\'$alt\' title=\'$title\' />');</script></div>";
+		$menu['title'] = "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'>";
 	}
 
 	$wp_admin_bar->add_menu( $menu );

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -900,7 +900,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	if ( Jetpack_AMP_Support::is_amp_request() ) {
 		$menu['title'] = "<amp-img src='$img_src_2x' width=112 height=24 layout=fixed alt='$alt' title='$title'></amp-img>";
 	} else {
-		$menu['title'] = "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'>";
+		$menu['title'] = "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>";
 	}
 
 	$wp_admin_bar->add_menu( $menu );


### PR DESCRIPTION
Rewrite `stats_admin_bar_menu()` to use `<img>` tag instead of `document.write`. Eliminates blocking JavaScript.

Fixes #12944

#### Testing instructions:
* log in (and view admin bar)

#### Proposed changelog entry for your changes:
* no changelog
