### PR TITLE
Upgrade Nudge: Autosave upon Upgrade Button click

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -66,8 +66,8 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch, { planPathSlug, postId, postType } ) => ( {
-		autosaveAndRedirectToUpgrade: () => {
-			dispatch( 'core/editor' ).autosave();
+		autosaveAndRedirectToUpgrade: async () => {
+			await dispatch( 'core/editor' ).autosave();
 			window.location.href = getUpgradeUrl( { planPathSlug, postId, postType } );
 		},
 	} ) ),

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, startsWith } from 'lodash';
+import { compact, get, startsWith } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
@@ -56,10 +56,18 @@ export default compose( [
 		const postId = select( 'core/editor' ).getCurrentPostId();
 		const postType = select( 'core/editor' ).getCurrentPostType();
 
+		// The editor for CPTs has an `edit/` route fragment prefixed
+		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
+
 		const upgradeUrl = addQueryArgs(
 			`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
 			{
-				redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
+				redirect_to: compact( [
+					postTypeEditorRoutePrefix,
+					postType,
+					getSiteFragment(),
+					postId,
+				] ).join( '/' ),
 			}
 		);
 

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -18,16 +18,16 @@ import './store';
 
 import './style.scss';
 
+const getUpgradeUrl = ( { planPathSlug, postId, postType } ) =>
+	addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+		redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
+	} );
+
 const UpgradeNudge = ( { autosave, planName, planPathSlug, postId, postType } ) => (
 	<Warning
 		actions={ [
 			<Button
-				href={ addQueryArgs(
-					`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
-					{
-						redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
-					}
-				) }
+				href={ getUpgradeUrl( { planPathSlug, postId, postType } ) }
 				onClick={ autosave }
 				target="_top"
 				isDefault

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -18,11 +18,6 @@ import './store';
 
 import './style.scss';
 
-const getUpgradeUrl = ( { planPathSlug, postId, postType } ) =>
-	addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
-		redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
-	} );
-
 const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 	<Warning
 		actions={ [
@@ -58,18 +53,26 @@ export default compose( [
 			? planSlug.substr( 'jetpack_'.length )
 			: get( plan, [ 'path_slug' ] );
 
+		const postId = select( 'core/editor' ).getCurrentPostId();
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		const upgradeUrl = addQueryArgs(
+			`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
+			{
+				redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
+			}
+		);
+
 		return {
 			planName: get( plan, [ 'product_name_short' ] ),
-			planPathSlug,
-			postId: select( 'core/editor' ).getCurrentPostId(),
-			postType: select( 'core/editor' ).getCurrentPostType(),
+			upgradeUrl,
 		};
 	} ),
-	withDispatch( ( dispatch, { planPathSlug, postId, postType } ) => ( {
+	withDispatch( ( dispatch, { upgradeUrl } ) => ( {
 		autosaveAndRedirectToUpgrade: async () => {
 			await dispatch( 'core/editor' ).autosave();
 			// Using window.top to escape from the editor iframe on WordPress.com
-			window.top.location.href = getUpgradeUrl( { planPathSlug, postId, postType } );
+			window.top.location.href = upgradeUrl;
 		},
 	} ) ),
 ] )( UpgradeNudge );

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -23,15 +23,10 @@ const getUpgradeUrl = ( { planPathSlug, postId, postType } ) =>
 		redirect_to: `/${ postType }/${ getSiteFragment() }/${ postId }`,
 	} );
 
-const UpgradeNudge = ( { autosave, planName, planPathSlug, postId, postType } ) => (
+const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 	<Warning
 		actions={ [
-			<Button
-				href={ getUpgradeUrl( { planPathSlug, postId, postType } ) }
-				onClick={ autosave }
-				target="_top"
-				isDefault
-			>
+			<Button onClick={ autosaveAndRedirectToUpgrade } target="_top" isDefault>
 				{ __( 'Upgrade', 'jetpack' ) }
 			</Button>,
 		] }
@@ -70,7 +65,10 @@ export default compose( [
 			postType: select( 'core/editor' ).getCurrentPostType(),
 		};
 	} ),
-	withDispatch( dispatch => ( {
-		autosave: () => dispatch( 'core/editor' ).autosave(),
+	withDispatch( ( dispatch, { planPathSlug, postId, postType } ) => ( {
+		autosaveAndRedirectToUpgrade: () => {
+			dispatch( 'core/editor' ).autosave();
+			window.location.href = getUpgradeUrl( { planPathSlug, postId, postType } );
+		},
 	} ) ),
 ] )( UpgradeNudge );

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -62,12 +62,9 @@ export default compose( [
 		const upgradeUrl = addQueryArgs(
 			`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
 			{
-				redirect_to: compact( [
-					postTypeEditorRoutePrefix,
-					postType,
-					getSiteFragment(),
-					postId,
-				] ).join( '/' ),
+				redirect_to:
+					'/' +
+					compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
 			}
 		);
 

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -68,7 +68,8 @@ export default compose( [
 	withDispatch( ( dispatch, { planPathSlug, postId, postType } ) => ( {
 		autosaveAndRedirectToUpgrade: async () => {
 			await dispatch( 'core/editor' ).autosave();
-			window.location.href = getUpgradeUrl( { planPathSlug, postId, postType } );
+			// Using window.top to escape from the editor iframe on WordPress.com
+			window.top.location.href = getUpgradeUrl( { planPathSlug, postId, postType } );
 		},
 	} ) ),
 ] )( UpgradeNudge );


### PR DESCRIPTION
Fixes #12976

#### Changes proposed in this Pull Request:

Upgrade Nudge: Autosave upon Upgrade Button click

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Adds autosave to the Paid Blocks' Upgrade Nudge CTA

#### Testing instructions:

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Now add the following line to any file in `docker/mu-plugins`, e.g. a newly created `0-blocks-upgrade.php` (needs to start with `<?php`): `define ( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Simple Payments' block
- It should come with an Upgrade Nudge on top of it.
- Click the 'Upgrade' button. Verify that you're not prompted to save the current post: Instead, you should see an 'Autosaving' message (next to the 'Preview') button before being redirected to checkout.

#### Proposed changelog entry for your changes:

(Covered by whatever we add for #12823)
