### PR TITLE
Slideshow Block: AMP Compatibility

### DIFF
--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -64,16 +64,30 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 		$classes[] = 'wp-block-jetpack-slideshow__autoplay';
 		$classes[] = 'wp-block-jetpack-slideshow__autoplay-playing';
 	}
+	$first_image = wp_get_attachment_metadata( $ids[0] );
+	$width       = $first_image['width'];
+	$height      = $first_image['height'];
+
 	$slides     = array_map(
-		function( $id ) {
+		function( $id ) use ( $width, $height ) {
 			$caption    = wp_get_attachment_caption( $id );
 			$figcaption = $caption ? sprintf(
 				'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
 				wp_kses_post( $caption )
 			) : '';
-			$image      = wp_get_attachment_image( $id, 'large', false, array( 'class' => 'wp-block-jetpack-slideshow_image' ) );
+			$image      = wp_get_attachment_image(
+				$id,
+				[ $width, $height ],
+				false,
+				[
+					'class'      => 'wp-block-jetpack-slideshow_image',
+					'object-fit' => 'contain',
+				]
+			);
 			return sprintf(
-				'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
+				'<div class="wp-block-jetpack-slideshow_slide" width="%s" height="%s"><figure>%s%s</figure></div>',
+				esc_attr( $width ),
+				esc_attr( $height ),
 				$image,
 				$figcaption
 			);
@@ -96,7 +110,9 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 		implode( '', $bullets )
 	);
 	$carousel   = sprintf(
-		'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
+		'<amp-carousel height="%s" width="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
+		esc_attr( $height ),
+		esc_attr( $width ),
 		esc_attr__( 'Next Slide', 'jetpack' ),
 		esc_attr__( 'Previous Slide', 'jetpack' ),
 		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -134,9 +134,10 @@ function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
 	$buttons = array_map(
 		function( $index ) {
 			return sprintf(
-				'<button option="%s" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" %s></button>',
-				esc_attr( $index ),
-				( $index + 1 ),
+				'<button option="%d" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="%s %d" %s></button>',
+				absint( $index ),
+				esc_attr__( 'Go to slide', 'jetpack' ),
+				absint( $index + 1 ),
 				0 === $index ? 'selected' : ''
 			);
 		},

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -74,15 +74,17 @@ function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
 	$first_image = wp_get_attachment_metadata( $ids[0] );
 	$delay       = empty( $attr['delay'] ) ? 3 : absint( $attr['delay'] );
 	$autoplay    = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+	$width       = empty( $first_image['width'] ) ? 800 : $first_image['width'];
+	$height      = empty( $first_image['height'] ) ? 600 : $first_image['height'];
 	return sprintf(
 		'<amp-carousel width="%1$d" height="%2$d" layout="responsive" type="slides" data-next-button-aria-label="%3$s" data-prev-button-aria-label="%4$s" controls loop %5$s id="wp-block-jetpack-slideshow__amp-carousel__%6$s" on="slideChange:wp-block-jetpack-slideshow__amp-pagination__%6$s.toggle(index=event.index, value=true)">%7$s</amp-carousel>',
-		esc_attr( $first_image['width'] ),
-		esc_attr( $first_image['height'] ),
+		esc_attr( $width ),
+		esc_attr( $height ),
 		esc_attr__( 'Next Slide', 'jetpack' ),
 		esc_attr__( 'Previous Slide', 'jetpack' ),
 		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
 		absint( $block_ordinal ),
-		implode( '', jetpack_slideshow_block_slides( $ids, $first_image['width'], $first_image['height'] ) )
+		implode( '', jetpack_slideshow_block_slides( $ids, $width, $height ) )
 	);
 }
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -52,9 +52,9 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 	);
 
 	return sprintf(
-		'<div class="%s" id="wp-block-jetpack-slideshow__%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s%s</div></div>',
+		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',
 		esc_attr( implode( $classes, ' ' ) ),
-		esc_attr( $wp_block_jetpack_slideshow_id ),
+		absint( $wp_block_jetpack_slideshow_id ),
 		jetpack_slideshow_block_amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
 		$autoplay ? jetpack_slideshow_block_autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
 		jetpack_slideshow_block_bullets( $ids, $wp_block_jetpack_slideshow_id )
@@ -72,17 +72,16 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
 	$ids         = empty( $attr['ids'] ) ? array() : $attr['ids'];
 	$first_image = wp_get_attachment_metadata( $ids[0] );
-	$delay       = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+	$delay       = empty( $attr['delay'] ) ? 3 : absint( $attr['delay'] );
 	$autoplay    = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
 	return sprintf(
-		'<amp-carousel width="%s" height="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="wp-block-jetpack-slideshow__amp-carousel__%s" on="slideChange:wp-block-jetpack-slideshow__amp-pagination__%s.toggle(index=event.index, value=true)">%s</amp-carousel>',
+		'<amp-carousel width="%1$d" height="%2$d" layout="responsive" type="slides" data-next-button-aria-label="%3$s" data-prev-button-aria-label="%4$s" controls loop %5$s id="wp-block-jetpack-slideshow__amp-carousel__%6$s" on="slideChange:wp-block-jetpack-slideshow__amp-pagination__%6$s.toggle(index=event.index, value=true)">%7$s</amp-carousel>',
 		esc_attr( $first_image['width'] ),
 		esc_attr( $first_image['height'] ),
 		esc_attr__( 'Next Slide', 'jetpack' ),
 		esc_attr__( 'Previous Slide', 'jetpack' ),
 		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
-		esc_attr( $block_ordinal ),
-		esc_attr( $block_ordinal ),
+		absint( $block_ordinal ),
 		implode( '', jetpack_slideshow_block_slides( $ids, $first_image['width'], $first_image['height'] ) )
 	);
 }
@@ -145,9 +144,8 @@ function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
 	);
 
 	return sprintf(
-		'<amp-selector id="wp-block-jetpack-slideshow__amp-pagination__%s" class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination" on="select:wp-block-jetpack-slideshow__amp-carousel__%s.goToSlide(index=event.targetOption)" layout="container">%s</amp-selector>',
-		esc_attr( $block_ordinal ),
-		esc_attr( $block_ordinal ),
+		'<amp-selector id="wp-block-jetpack-slideshow__amp-pagination__%1$d" class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination" on="select:wp-block-jetpack-slideshow__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container">%2$s</amp-selector>',
+		absint( $block_ordinal ),
 		implode( '', $buttons )
 	);
 }
@@ -161,12 +159,12 @@ function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
  */
 function jetpack_slideshow_block_autoplay_ui( $block_ordinal = 0 ) {
 	$block_id        = sprintf(
-		'wp-block-jetpack-slideshow__%s',
-		intval( $block_ordinal )
+		'wp-block-jetpack-slideshow__%d',
+		absint( $block_ordinal )
 	);
 	$amp_carousel_id = sprintf(
-		'wp-block-jetpack-slideshow__amp-carousel__%s',
-		intval( $block_ordinal )
+		'wp-block-jetpack-slideshow__amp-carousel__%d',
+		absint( $block_ordinal )
 	);
 	$autoplay_pause  = sprintf(
 		'<a aria-label="%s" class="wp-block-jetpack-slideshow_button-pause" role="button" on="tap:%s.toggleAutoplay(toggleOn=false),%s.toggleClass(class=wp-block-jetpack-slideshow__autoplay-playing,force=false)"></a>',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -40,20 +40,30 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 function jetpack_slideshow_block_render_amp( $attr ) {
 	global $wp_block_jetpack_slideshow_id;
 	$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
-	$amp_carousel_id               = sprintf(
+
+	$block_id = sprintf(
 		'wp-block-jetpack-slideshow__%s',
 		intval( $wp_block_jetpack_slideshow_id )
 	);
 
-	$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
-	$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-	$delay      = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
-	$align      = isset( $attr['align'] ) ? $attr['align'] : 'center';
-	$classes    = array(
+	$amp_carousel_id = sprintf(
+		'wp-block-jetpack-slideshow__amp_carousel_%s',
+		intval( $wp_block_jetpack_slideshow_id )
+	);
+
+	$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
+	$autoplay = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+	$delay    = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+	$align    = isset( $attr['align'] ) ? $attr['align'] : 'center';
+	$classes  = array(
 		'wp-block-jetpack-slideshow',
 		'wp-amp-block',
 		'align' . $align,
 	);
+	if ( $autoplay ) {
+		$classes[] = 'wp-block-jetpack-slideshow__autoplay';
+		$classes[] = 'wp-block-jetpack-slideshow__autoplay-playing';
+	}
 	$slides     = array_map(
 		function( $id ) {
 			$caption    = wp_get_attachment_caption( $id );
@@ -94,10 +104,25 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 		implode( '', $slides )
 	);
 
+	$autoplay_pause = sprintf(
+		'<a aria-label="%s" class="wp-block-jetpack-slideshow_button-pause" role="button" on="tap:%s.toggleAutoplay(toggleOn=false),%s.toggleClass(class=wp-block-jetpack-slideshow__autoplay-playing,force=false)"></a>',
+		esc_attr__( 'Pause Slideshow', 'jetpack' ),
+		esc_attr( $amp_carousel_id ),
+		esc_attr( $block_id )
+	);
+	$autoplay_play  = sprintf(
+		'<a aria-label="%s" class="wp-block-jetpack-slideshow_button-play" role="button" on="tap:%s.toggleAutoplay(toggleOn=true),%s.toggleClass(class=wp-block-jetpack-slideshow__autoplay-playing,force=true)"></a>',
+		esc_attr__( 'Play Slideshow', 'jetpack' ),
+		esc_attr( $amp_carousel_id ),
+		esc_attr( $block_id )
+	);
+
 	return sprintf(
-		'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s</div></div>',
+		'<div class="%s" id="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s%s</div></div>',
 		esc_attr( implode( $classes, ' ' ) ),
+		esc_attr( $block_id ),
 		$carousel,
+		$autoplay ? $autoplay_pause . $autoplay_play : '',
 		$pagination
 	);
 }

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -43,17 +43,17 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 
 	$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
 	$autoplay = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-	$classes  = array(
-		'wp-block-jetpack-slideshow',
+
+	$extras  = array(
 		'wp-amp-block',
-		'align' . isset( $attr['align'] ) ? $attr['align'] : 'center',
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay' : null,
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay-playing' : null,
 	);
+	$classes = Jetpack_Gutenberg::block_classes( 'slideshow', $attr, $extras );
 
 	return sprintf(
 		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',
-		esc_attr( implode( $classes, ' ' ) ),
+		esc_attr( $classes ),
 		absint( $wp_block_jetpack_slideshow_id ),
 		jetpack_slideshow_block_amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
 		$autoplay ? jetpack_slideshow_block_autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -47,7 +47,6 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 
 	$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
 	$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-	$autoplay   = false;
 	$delay      = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
 	$align      = isset( $attr['align'] ) ? $attr['align'] : 'center';
 	$classes    = array(

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -135,11 +135,15 @@ function jetpack_slideshow_block_slides( $ids = array(), $width = 400, $height =
 function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
 	$buttons = array_map(
 		function( $index ) {
+			$aria_label = sprintf(
+				/* translators: %d: Slide number. */
+				__( 'Go to slide %d', 'jetpack' ),
+				absint( $index + 1 )
+			);
 			return sprintf(
-				'<button option="%d" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="%s %d" %s></button>',
+				'<button option="%d" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="%s" %s></button>',
 				absint( $index ),
-				esc_attr__( 'Go to slide', 'jetpack' ),
-				absint( $index + 1 ),
+				esc_attr( $aria_label ),
 				0 === $index ? 'selected' : ''
 			);
 		},

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -96,7 +96,7 @@ function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
  *
  * @return array Array of slides markup.
  */
-function jetpack_slideshow_block_slides( $ids = [], $width = 400, $height = 300 ) {
+function jetpack_slideshow_block_slides( $ids = array(), $width = 400, $height = 300 ) {
 	return array_map(
 		function( $id ) use ( $width, $height ) {
 			$caption    = wp_get_attachment_caption( $id );
@@ -106,12 +106,12 @@ function jetpack_slideshow_block_slides( $ids = [], $width = 400, $height = 300 
 			) : '';
 			$image      = wp_get_attachment_image(
 				$id,
-				[ $width, $height ],
+				array( $width, $height ),
 				false,
-				[
+				array(
 					'class'      => 'wp-block-jetpack-slideshow_image',
 					'object-fit' => 'contain',
-				]
+				)
 			);
 			return sprintf(
 				'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
@@ -131,7 +131,7 @@ function jetpack_slideshow_block_slides( $ids = [], $width = 400, $height = 300 
  *
  * @return array Array of bullets markup.
  */
-function jetpack_slideshow_block_bullets( $ids = [], $block_ordinal = 0 ) {
+function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
 	$buttons = array_map(
 		function( $index ) {
 			return sprintf(

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -26,9 +26,9 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	$type = 'slideshow';
 	Jetpack_Gutenberg::load_assets_as_required( $type );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		global $slideshow_id;
-		$slideshow_id    = ( $slideshow_id || 0 ) + 1;
-		$amp_carousel_id = sprintf( 'wp-block-jetpack-slideshow__%s', $slideshow_id );
+		global $wp_block_jetpack_slideshow_id;
+		$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
+		$amp_carousel_id               = sprintf( 'wp-block-jetpack-slideshow__%s', $wp_block_jetpack_slideshow_id );
 
 		$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
 		$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -52,12 +52,12 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 	);
 
 	return sprintf(
-		'<div class="%s" id="wp-block-jetpack-slideshow__%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s<div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination">%s</div></div></div>',
+		'<div class="%s" id="wp-block-jetpack-slideshow__%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s%s</div></div>',
 		esc_attr( implode( $classes, ' ' ) ),
 		esc_attr( $wp_block_jetpack_slideshow_id ),
 		jetpack_slideshow_block_amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
 		$autoplay ? jetpack_slideshow_block_autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
-		implode( '', jetpack_slideshow_block_bullets( $ids, $wp_block_jetpack_slideshow_id ) )
+		jetpack_slideshow_block_bullets( $ids, $wp_block_jetpack_slideshow_id )
 	);
 }
 
@@ -75,12 +75,13 @@ function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
 	$delay       = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
 	$autoplay    = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
 	return sprintf(
-		'<amp-carousel width="%s" height="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="wp-block-jetpack-slideshow__amp_carousel_%s">%s</amp-carousel>',
+		'<amp-carousel width="%s" height="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="wp-block-jetpack-slideshow__amp-carousel__%s" on="slideChange:wp-block-jetpack-slideshow__amp-pagination__%s.toggle(index=event.index, value=true)">%s</amp-carousel>',
 		esc_attr( $first_image['width'] ),
 		esc_attr( $first_image['height'] ),
 		esc_attr__( 'Next Slide', 'jetpack' ),
 		esc_attr__( 'Previous Slide', 'jetpack' ),
 		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
+		esc_attr( $block_ordinal ),
 		esc_attr( $block_ordinal ),
 		implode( '', jetpack_slideshow_block_slides( $ids, $first_image['width'], $first_image['height'] ) )
 	);
@@ -131,20 +132,23 @@ function jetpack_slideshow_block_slides( $ids = [], $width = 400, $height = 300 
  * @return array Array of bullets markup.
  */
 function jetpack_slideshow_block_bullets( $ids = [], $block_ordinal = 0 ) {
-	$amp_carousel_id = sprintf(
-		'wp-block-jetpack-slideshow__amp_carousel_%s',
-		intval( $block_ordinal )
-	);
-	return array_map(
-		function( $index ) use ( $amp_carousel_id ) {
+	$buttons = array_map(
+		function( $index ) {
 			return sprintf(
-				'<button class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" on="tap:%s.goToSlide(index=%s)"></button>',
+				'<button option="%s" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" %s></button>',
+				esc_attr( $index ),
 				( $index + 1 ),
-				esc_attr( $amp_carousel_id ),
-				$index
+				0 === $index ? 'selected' : ''
 			);
 		},
 		array_keys( $ids )
+	);
+
+	return sprintf(
+		'<amp-selector id="wp-block-jetpack-slideshow__amp-pagination__%s" class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination" on="select:wp-block-jetpack-slideshow__amp-carousel__%s.goToSlide(index=event.targetOption)" layout="container">%s</amp-selector>',
+		esc_attr( $block_ordinal ),
+		esc_attr( $block_ordinal ),
+		implode( '', $buttons )
 	);
 }
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -43,36 +43,46 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 
 	$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
 	$autoplay = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-	$delay    = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
-	$align    = isset( $attr['align'] ) ? $attr['align'] : 'center';
 	$classes  = array(
 		'wp-block-jetpack-slideshow',
 		'wp-amp-block',
-		'align' . $align,
+		'align' . isset( $attr['align'] ) ? $attr['align'] : 'center',
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay' : null,
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay-playing' : null,
-	);
-
-	$first_image = wp_get_attachment_metadata( $ids[0] );
-
-	$amp_carousel = sprintf(
-		'<amp-carousel width="%s" height="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="wp-block-jetpack-slideshow__amp_carousel_%s">%s</amp-carousel>',
-		esc_attr( $first_image['width'] ),
-		esc_attr( $first_image['height'] ),
-		esc_attr__( 'Next Slide', 'jetpack' ),
-		esc_attr__( 'Previous Slide', 'jetpack' ),
-		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
-		esc_attr( $wp_block_jetpack_slideshow_id ),
-		implode( '', jetpack_slideshow_block_slides( $ids, $first_image['width'], $first_image['height'] ) )
 	);
 
 	return sprintf(
 		'<div class="%s" id="wp-block-jetpack-slideshow__%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s<div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination">%s</div></div></div>',
 		esc_attr( implode( $classes, ' ' ) ),
 		esc_attr( $wp_block_jetpack_slideshow_id ),
-		$amp_carousel,
+		jetpack_slideshow_block_amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
 		$autoplay ? jetpack_slideshow_block_autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
 		implode( '', jetpack_slideshow_block_bullets( $ids, $wp_block_jetpack_slideshow_id ) )
+	);
+}
+
+/**
+ * Generate amp-carousel markup
+ *
+ * @param array $attr Array of block attributes.
+ * @param int   $block_ordinal The ordinal number of the block, used in unique ID.
+ *
+ * @return string amp-carousel markup.
+ */
+function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
+	$ids         = empty( $attr['ids'] ) ? array() : $attr['ids'];
+	$first_image = wp_get_attachment_metadata( $ids[0] );
+	$delay       = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+	$autoplay    = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+	return sprintf(
+		'<amp-carousel width="%s" height="%s" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="wp-block-jetpack-slideshow__amp_carousel_%s">%s</amp-carousel>',
+		esc_attr( $first_image['width'] ),
+		esc_attr( $first_image['height'] ),
+		esc_attr__( 'Next Slide', 'jetpack' ),
+		esc_attr__( 'Previous Slide', 'jetpack' ),
+		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
+		esc_attr( $block_ordinal ),
+		implode( '', jetpack_slideshow_block_slides( $ids, $first_image['width'], $first_image['height'] ) )
 	);
 }
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -58,21 +58,14 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 	$slides     = array_map(
 		function( $id ) {
 			$caption    = wp_get_attachment_caption( $id );
-			$src        = wp_get_attachment_image_src( $id, 'full' );
 			$figcaption = $caption ? sprintf(
 				'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
 				wp_kses_post( $caption )
 			) : '';
-			$amp_img    = sprintf(
-				'<amp-img src="%s" width="%s" height="%s" alt="%s" class="wp-block-jetpack-slideshow_image" />',
-				esc_url( $src[0] ),
-				esc_attr( $src[1] ),
-				esc_attr( $src[2] ),
-				esc_attr( $caption )
-			);
+			$image      = wp_get_attachment_image( $id, 'large', false, array( 'class' => 'wp-block-jetpack-slideshow_image' ) );
 			return sprintf(
 				'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
-				$amp_img,
+				$image,
 				$figcaption
 			);
 		},

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -88,16 +88,16 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 	);
 	$carousel   = sprintf(
 		'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
-		__( 'Next Slide', 'jetpack' ),
-		__( 'Previous Slide', 'jetpack' ),
-		$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
+		esc_attr__( 'Next Slide', 'jetpack' ),
+		esc_attr__( 'Previous Slide', 'jetpack' ),
+		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
 		esc_attr( $amp_carousel_id ),
 		implode( '', $slides )
 	);
 
 	return sprintf(
 		'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s</div></div>',
-		implode( $classes, ' ' ),
+		esc_attr( implode( $classes, ' ' ) ),
 		$carousel,
 		$pagination
 	);

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -165,7 +165,7 @@ function jetpack_slideshow_block_autoplay_ui( $block_ordinal = 0 ) {
 		intval( $block_ordinal )
 	);
 	$amp_carousel_id = sprintf(
-		'wp-block-jetpack-slideshow__amp_carousel_%s',
+		'wp-block-jetpack-slideshow__amp-carousel__%s',
 		intval( $block_ordinal )
 	);
 	$autoplay_pause  = sprintf(

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -60,7 +60,9 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 			$ids
 		);
 		$carousel = sprintf(
-			'<amp-carousel height="300" width="400" layout="responsive" type="slides" controls loop %s>%s</amp-carousel>',
+			'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s>%s</amp-carousel>',
+			__( 'Next Slide', 'jetpack' ),
+			__( 'Previous Slide', 'jetpack' ),
 			$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
 			implode( '', $slides )
 		);

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -23,79 +23,89 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
-	$type = 'slideshow';
-	Jetpack_Gutenberg::load_assets_as_required( $type );
+	Jetpack_Gutenberg::load_assets_as_required( 'slideshow' );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		global $wp_block_jetpack_slideshow_id;
-		$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
-		$amp_carousel_id               = sprintf(
-			'wp-block-jetpack-slideshow__%s',
-			intval( $wp_block_jetpack_slideshow_id )
-		);
-
-		$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
-		$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-		$autoplay   = false;
-		$delay      = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
-		$align      = isset( $attr['align'] ) ? $attr['align'] : 'center';
-		$classes    = array(
-			'wp-block-jetpack-' . $type,
-			'wp-amp-block',
-			'align' . $align,
-		);
-		$slides     = array_map(
-			function( $id ) {
-				$caption    = wp_get_attachment_caption( $id );
-				$src        = wp_get_attachment_image_src( $id, 'full' );
-				$figcaption = $caption ? sprintf(
-					'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
-					wp_kses_post( $caption )
-				) : '';
-				$amp_img    = sprintf(
-					'<amp-img src="%s" width="%s" height="%s" alt="%s" class="wp-block-jetpack-slideshow_image" />',
-					esc_url( $src[0] ),
-					esc_attr( $src[1] ),
-					esc_attr( $src[2] ),
-					esc_attr( $caption )
-				);
-				return sprintf(
-					'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
-					$amp_img,
-					$figcaption
-				);
-			},
-			$ids
-		);
-		$bullets    = array_map(
-			function( $index ) use ( $amp_carousel_id ) {
-				return sprintf(
-					'<button class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" on="tap:%s.goToSlide(index=%s)"></button>',
-					( $index + 1 ),
-					esc_attr( $amp_carousel_id ),
-					$index
-				);
-			},
-			array_keys( $ids )
-		);
-		$pagination = sprintf(
-			'<div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination">%s</div>',
-			implode( '', $bullets )
-		);
-		$carousel   = sprintf(
-			'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
-			__( 'Next Slide', 'jetpack' ),
-			__( 'Previous Slide', 'jetpack' ),
-			$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
-			esc_attr( $amp_carousel_id ),
-			implode( '', $slides )
-		);
-
-		return sprintf(
-			'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s</div></div>',
-			implode( $classes, ' ' ),
-			$carousel,
-			$pagination
-		);
+		return jetpack_slideshow_block_render_amp( $attr );
 	}
 	return $content;
+}
+
+/**
+ * Render slideshow block for AMP
+ *
+ * @param array $attr Array containing the slideshow block attributes.
+ *
+ * @return string
+ */
+function jetpack_slideshow_block_render_amp( $attr ) {
+	global $wp_block_jetpack_slideshow_id;
+	$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
+	$amp_carousel_id               = sprintf(
+		'wp-block-jetpack-slideshow__%s',
+		intval( $wp_block_jetpack_slideshow_id )
+	);
+
+	$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
+	$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+	$autoplay   = false;
+	$delay      = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+	$align      = isset( $attr['align'] ) ? $attr['align'] : 'center';
+	$classes    = array(
+		'wp-block-jetpack-slideshow',
+		'wp-amp-block',
+		'align' . $align,
+	);
+	$slides     = array_map(
+		function( $id ) {
+			$caption    = wp_get_attachment_caption( $id );
+			$src        = wp_get_attachment_image_src( $id, 'full' );
+			$figcaption = $caption ? sprintf(
+				'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
+				wp_kses_post( $caption )
+			) : '';
+			$amp_img    = sprintf(
+				'<amp-img src="%s" width="%s" height="%s" alt="%s" class="wp-block-jetpack-slideshow_image" />',
+				esc_url( $src[0] ),
+				esc_attr( $src[1] ),
+				esc_attr( $src[2] ),
+				esc_attr( $caption )
+			);
+			return sprintf(
+				'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
+				$amp_img,
+				$figcaption
+			);
+		},
+		$ids
+	);
+	$bullets    = array_map(
+		function( $index ) use ( $amp_carousel_id ) {
+			return sprintf(
+				'<button class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" on="tap:%s.goToSlide(index=%s)"></button>',
+				( $index + 1 ),
+				esc_attr( $amp_carousel_id ),
+				$index
+			);
+		},
+		array_keys( $ids )
+	);
+	$pagination = sprintf(
+		'<div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination">%s</div>',
+		implode( '', $bullets )
+	);
+	$carousel   = sprintf(
+		'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
+		__( 'Next Slide', 'jetpack' ),
+		__( 'Previous Slide', 'jetpack' ),
+		$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
+		esc_attr( $amp_carousel_id ),
+		implode( '', $slides )
+	);
+
+	return sprintf(
+		'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s</div></div>',
+		implode( $classes, ' ' ),
+		$carousel,
+		$pagination
+	);
 }

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -28,7 +28,10 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		global $wp_block_jetpack_slideshow_id;
 		$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
-		$amp_carousel_id               = sprintf( 'wp-block-jetpack-slideshow__%s', $wp_block_jetpack_slideshow_id );
+		$amp_carousel_id               = sprintf(
+			'wp-block-jetpack-slideshow__%s',
+			intval( $wp_block_jetpack_slideshow_id )
+		);
 
 		$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
 		$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
@@ -46,14 +49,14 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 				$src        = wp_get_attachment_image_src( $id, 'full' );
 				$figcaption = $caption ? sprintf(
 					'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
-					$caption
+					wp_kses_post( $caption )
 				) : '';
 				$amp_img    = sprintf(
 					'<amp-img src="%s" width="%s" height="%s" alt="%s" class="wp-block-jetpack-slideshow_image" />',
-					$src[0],
-					$src[1],
-					$src[2],
-					$caption
+					esc_url( $src[0] ),
+					esc_attr( $src[1] ),
+					esc_attr( $src[2] ),
+					esc_attr( $caption )
 				);
 				return sprintf(
 					'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
@@ -68,7 +71,7 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 				return sprintf(
 					'<button class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" on="tap:%s.goToSlide(index=%s)"></button>',
 					( $index + 1 ),
-					$amp_carousel_id,
+					esc_attr( $amp_carousel_id ),
 					$index
 				);
 			},
@@ -83,7 +86,7 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 			__( 'Next Slide', 'jetpack' ),
 			__( 'Previous Slide', 'jetpack' ),
 			$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
-			$amp_carousel_id,
+			esc_attr( $amp_carousel_id ),
 			implode( '', $slides )
 		);
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -38,8 +38,8 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
  * @return string
  */
 function jetpack_slideshow_block_render_amp( $attr ) {
-	global $wp_block_jetpack_slideshow_id;
-	$wp_block_jetpack_slideshow_id = ( $wp_block_jetpack_slideshow_id || 0 ) + 1;
+	static $wp_block_jetpack_slideshow_id = 0;
+	$wp_block_jetpack_slideshow_id++;
 
 	$block_id = sprintf(
 		'wp-block-jetpack-slideshow__%s',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -26,17 +26,21 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 	$type = 'slideshow';
 	Jetpack_Gutenberg::load_assets_as_required( $type );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
-		$autoplay = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
-		$autoplay = false;
-		$delay    = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
-		$align    = isset( $attr['align'] ) ? $attr['align'] : 'center';
-		$classes  = array(
+		global $slideshow_id;
+		$slideshow_id    = ( $slideshow_id || 0 ) + 1;
+		$amp_carousel_id = sprintf( 'wp-block-jetpack-slideshow__%s', $slideshow_id );
+
+		$ids        = empty( $attr['ids'] ) ? array() : $attr['ids'];
+		$autoplay   = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+		$autoplay   = false;
+		$delay      = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+		$align      = isset( $attr['align'] ) ? $attr['align'] : 'center';
+		$classes    = array(
 			'wp-block-jetpack-' . $type,
 			'wp-amp-block',
 			'align' . $align,
 		);
-		$slides   = array_map(
+		$slides     = array_map(
 			function( $id ) {
 				$caption    = wp_get_attachment_caption( $id );
 				$src        = wp_get_attachment_image_src( $id, 'full' );
@@ -59,18 +63,35 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
 			},
 			$ids
 		);
-		$carousel = sprintf(
-			'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s>%s</amp-carousel>',
+		$bullets    = array_map(
+			function( $index ) use ( $amp_carousel_id ) {
+				return sprintf(
+					'<button class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="Go to slide %s" on="tap:%s.goToSlide(index=%s)"></button>',
+					( $index + 1 ),
+					$amp_carousel_id,
+					$index
+				);
+			},
+			array_keys( $ids )
+		);
+		$pagination = sprintf(
+			'<div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination">%s</div>',
+			implode( '', $bullets )
+		);
+		$carousel   = sprintf(
+			'<amp-carousel height="300" width="400" layout="responsive" type="slides" data-next-button-aria-label="%s" data-prev-button-aria-label="%s" controls loop %s id="%s">%s</amp-carousel>',
 			__( 'Next Slide', 'jetpack' ),
 			__( 'Previous Slide', 'jetpack' ),
 			$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
+			$amp_carousel_id,
 			implode( '', $slides )
 		);
 
 		return sprintf(
-			'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s</div></div>',
+			'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s%s</div></div>',
 			implode( $classes, ' ' ),
-			$carousel
+			$carousel,
+			$pagination
 		);
 	}
 	return $content;

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -23,6 +23,53 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_slideshow_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'slideshow' );
+	$type = 'slideshow';
+	Jetpack_Gutenberg::load_assets_as_required( $type );
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
+		$autoplay = empty( $attr['autoplay'] ) ? false : $attr['autoplay'];
+		$autoplay = false;
+		$delay    = empty( $attr['delay'] ) ? 3 : intval( $attr['delay'] );
+		$align    = isset( $attr['align'] ) ? $attr['align'] : 'center';
+		$classes  = array(
+			'wp-block-jetpack-' . $type,
+			'wp-amp-block',
+			'align' . $align,
+		);
+		$slides   = array_map(
+			function( $id ) {
+				$caption    = wp_get_attachment_caption( $id );
+				$src        = wp_get_attachment_image_src( $id, 'full' );
+				$figcaption = $caption ? sprintf(
+					'<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">%s</figcaption>',
+					$caption
+				) : '';
+				$amp_img    = sprintf(
+					'<amp-img src="%s" width="%s" height="%s" alt="%s" class="wp-block-jetpack-slideshow_image" />',
+					$src[0],
+					$src[1],
+					$src[2],
+					$caption
+				);
+				return sprintf(
+					'<div class="wp-block-jetpack-slideshow_slide"><figure>%s%s</figure></div>',
+					$amp_img,
+					$figcaption
+				);
+			},
+			$ids
+		);
+		$carousel = sprintf(
+			'<amp-carousel height="300" width="400" layout="responsive" type="slides" controls loop %s>%s</amp-carousel>',
+			$autoplay ? 'autoplay delay=' . ( $delay * 1000 ) : '',
+			implode( '', $slides )
+		);
+
+		return sprintf(
+			'<div class="%s"><div class="wp-block-jetpack-slideshow_container swiper-container">%s</div></div>',
+			implode( $classes, ' ' ),
+			$carousel
+		);
+	}
 	return $content;
 }

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -10,8 +10,19 @@
 		outline: 0;
 	}
 
-	&.wp-amp-block > .wp-block-jetpack-slideshow_container {
-		opacity: 1;
+	&.wp-amp-block {
+		& > .wp-block-jetpack-slideshow_container {
+			opacity: 1;
+		}
+	}
+	&.wp-amp-block.wp-block-jetpack-slideshow__autoplay {
+		&.wp-block-jetpack-slideshow__autoplay-playing .wp-block-jetpack-slideshow_button-pause,
+		.wp-block-jetpack-slideshow_button-play {
+			display: block;
+		}
+		&.wp-block-jetpack-slideshow__autoplay-playing .wp-block-jetpack-slideshow_button-play {
+			display: none;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_container {
@@ -64,6 +75,7 @@
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next,
 	.wp-block-jetpack-slideshow_button-pause,
+	.wp-block-jetpack-slideshow_button-play,
 	.amp-carousel-button {
 		background-color: rgba( 0, 0, 0, 0.5 );
 		background-position: center;
@@ -110,8 +122,9 @@
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
+	.wp-block-jetpack-slideshow_button-play,
 	.wp-block-jetpack-slideshow_button-pause {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 19h4V5H6v14zm8-14v14h4V5h-4z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E" );
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M6%2019h4V5H6v14zm8-14v14h4V5h-4z'%20fill='white'/%3E%3Cpath%20d='M0%200h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 		display: none;
 		margin-top: 0;
 		position: absolute;
@@ -120,8 +133,9 @@
 		z-index: 1;
 	}
 
+	.wp-block-jetpack-slideshow_button-play,
 	.wp-block-jetpack-slideshow_autoplay-paused .wp-block-jetpack-slideshow_button-pause {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M8 5v14l11-7z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E" );
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M8%205v14l11-7z'%20fill='white'/%3E%3Cpath%20d='M0 0h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 	}
 
 	&[data-autoplay='true'] .wp-block-jetpack-slideshow_button-pause {

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -190,6 +190,17 @@
 	}
 }
 
+.wp-block-jetpack-slideshow_pagination.amp-pagination {
+	text-align: center;
+	.swiper-pagination-bullet {
+		margin: 0 4px;
+		border-radius: 100%;
+		display: inline-block;
+		padding: 0;
+		border: 0;
+	}
+}
+
 @media ( min-width: $break-small ) {
 	.wp-block-jetpack-slideshow {
 		.wp-block-jetpack-slideshow_button-prev,

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -103,7 +103,7 @@
 	.swiper-button-next.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-next,
 	.amp-carousel-button-next {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='%23fff'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
 	&.swiper-container-rtl .swiper-button-next.swiper-button-white,
@@ -111,7 +111,7 @@
 	.swiper-button-prev.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-prev,
 	.amp-carousel-button-prev {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
 	.wp-block-jetpack-slideshow_button-pause {

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -10,6 +10,10 @@
 		outline: 0;
 	}
 
+	&.wp-amp-block > .wp-block-jetpack-slideshow_container {
+		opacity: 1;
+	}
+
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		overflow: hidden;
@@ -55,11 +59,16 @@
 		max-width: 100%;
 		width: auto;
 		object-fit: contain;
+		/* For amp-img */
+		& > * {
+			object-fit: contain;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next,
-	.wp-block-jetpack-slideshow_button-pause {
+	.wp-block-jetpack-slideshow_button-pause,
+	.amp-carousel-button {
 		background-color: rgba( 0, 0, 0, 0.5 );
 		background-position: center;
 		background-repeat: no-repeat;
@@ -92,14 +101,16 @@
 	&.swiper-container-rtl .swiper-button-prev.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
 	.swiper-button-next.swiper-button-white,
-	.wp-block-jetpack-slideshow_button-next {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+	.wp-block-jetpack-slideshow_button-next,
+	.amp-carousel-button-next {
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='%23fff'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
 	&.swiper-container-rtl .swiper-button-next.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-next,
 	.swiper-button-prev.swiper-button-white,
-	.wp-block-jetpack-slideshow_button-prev {
+	.wp-block-jetpack-slideshow_button-prev,
+	.amp-carousel-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -196,6 +196,7 @@
 			}
 		}
 
+		.swiper-pagination-bullet[selected],
 		.swiper-pagination-bullet-active {
 			background-color: currentColor;
 			opacity: 1;

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -101,6 +101,10 @@
 		}
 	}
 
+	.amp-carousel-button {
+		margin: 0;
+	}
+
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next {
 		display: none;

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -59,10 +59,6 @@
 		max-width: 100%;
 		width: auto;
 		object-fit: contain;
-		/* For amp-img */
-		& > * {
-			object-fit: contain;
-		}
 	}
 
 	.wp-block-jetpack-slideshow_button-prev,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR makes the Slideshow block AMP compatible. This is achieved by using the [`amp-carousel`](https://amp.dev/documentation/components/amp-carousel) element instead of [Swiper](https://idangero.us/swiper/) in AMP requests. The functionality is similar although a few features are different and/or lost in the AMP version:

1) No support for Fade transition style in AMP version. Transitions will always be Slides. The `amp-carousel` slide transition is also faster and less graceful than Swiper's.
~2) There is no Autoplay pausing in the AMP version. If Autoplay is enabled it will always be on.~
~3) The pagination bullets don't show "active slide" state in the AMP version. They are functional (clicking will jump the slideshow to the requested slide) but they don't change state to indicate which is current.~
~4) Dynamic height sizing will not occur in the AMP version.~

Update: Autoplay pause/play button support added in https://github.com/Automattic/jetpack/pull/13009/commits/cabea0d9a74b9f3d6003d7df3224a78b966b6f10

Update: Pagination bullets active slide state in https://github.com/Automattic/jetpack/pull/13009/commits/64107c74dab5653099f48d952d7671d2590a2d88

Update: Dynamic height sizing in https://github.com/Automattic/jetpack/pull/13009/commits/3cfa9017b5e166a7c2db9a94426079e76f291fb6.

Part of https://github.com/Automattic/jetpack/issues/9730

#### Testing instructions:
* Spin up a Jurassic Ninja instance with this link: https://jurassic.ninja/create/?jetpack-beta&branch=add/amp-slideshow
* Set up Jetpack.
* Install and activate AMP: https://wordpress.org/plugins/amp/
* In AMP settings, set mode to *Transitional*
* Create a post, insert Slideshow block, add images.
* Publish and view the post, then switch to AMP by interacting with the AMP item in the admin menu, or by simply appending `?amp` to the URL.
* Observe that the slideshow looks and functions like the non-AMP version (taking into account the list of differences above).

#### Other testing scenarios
* Multiple slideshows on one page
* Slideshows with captions
* Captions with HTML tags

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Slideshow block AMP compatibility
