### PR TITLE
Fixed a typo in the mobile magic links modal

### DIFF
--- a/_inc/client/components/mobile-magic-link/index.jsx
+++ b/_inc/client/components/mobile-magic-link/index.jsx
@@ -52,7 +52,7 @@ export class MobileMagicLink extends React.Component {
 					<h2>{ __( 'Email me a link to log in to the app' ) }</h2>
 					<h4>
 						{ __(
-							"Easily log in to the WordPress.com app by clicking the link we'll send to the email address on your account."
+							"Easily log in to the WordPress app by clicking the link we'll send to the email address on your account."
 						) }
 					</h4>
 					<div className="mobile-magic-link__modal-actions">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

As per @aerych's request (p1562687926006700-slack-CJRJ3KMEC), this PR fixes a typo in the mobile magic links modal.

Changes the modal text from:

> Easily log in to the WordPress.com app by clicking the link we'll send to the email address on your account.

To:

> Easily log in to the WordPress app by clicking the link we'll send to the email address on your account.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix typo in mobile magic links modal.
