### PR TITLE
Sync: Migrate to use is_active() from the connection package

### DIFF
--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -4,6 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 
@@ -121,7 +122,8 @@ class Actions {
 			return false;
 		}
 
-		if ( ! \Jetpack::is_active() ) {
+		$connection = new Jetpack_Connection();
+		if ( ! $connection->is_active() ) {
 			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
 				return false;
 			}

--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Roles;
 
 /**
@@ -13,7 +14,8 @@ class Users {
 	static $user_roles = array();
 
 	static function init() {
-		if ( \Jetpack::is_active() ) {
+		$connection = new Jetpack_Connection();
+		if ( $connection->is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}


### PR DESCRIPTION
This PR updates the sync package to use the `is_active()` method from the connection package instead of `Jetpack::is_active()`, in an effort to decouple sync from the Jetpack core. It also adds the connection package as a formal dependency of the sync package.

#### Changes proposed in this Pull Request:
Sync: Migrate to use `is_active()` from the connection package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:

* Checkout the branch.
* Enable WP_DEBUG_LOG.
* Smoke test the site in wp-admin and the frontend.
* Trigger an incremental sync.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
Sync: Migrate to use is_active() from the connection package.
