### PR TITLE
Sync: Fix PHPCS errors in Utils

### DIFF
--- a/packages/sync/src/Utils.php
+++ b/packages/sync/src/Utils.php
@@ -1,21 +1,64 @@
 <?php
+/**
+ * Sync utils.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
+/**
+ * Class for sync utilities.
+ */
 class Utils {
-
-	static function get_item_values( $items ) {
+	/**
+	 * Retrieve the values of sync items.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param array $items Array of sync items.
+	 * @return array Array of sync item values.
+	 */
+	public static function get_item_values( $items ) {
 		return array_map( array( __CLASS__, 'get_item_value' ), $items );
 	}
 
-	static function get_item_ids( $items ) {
+	/**
+	 * Retrieve the IDs of sync items.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param array $items Array of sync items.
+	 * @return array Array of sync item IDs.
+	 */
+	public static function get_item_ids( $items ) {
 		return array_map( array( __CLASS__, 'get_item_id' ), $items );
 	}
 
+	/**
+	 * Get the value of a sync item.
+	 *
+	 * @access private
+	 * @static
+	 *
+	 * @param array $item Sync item.
+	 * @return mixed Sync item value.
+	 */
 	private static function get_item_value( $item ) {
 		return $item->value;
 	}
 
+	/**
+	 * Get the ID of a sync item.
+	 *
+	 * @access private
+	 * @static
+	 *
+	 * @param array $item Sync item.
+	 * @return int Sync item ID.
+	 */
 	private static function get_item_id( $item ) {
 		return $item->id;
 	}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Utils class.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Utils class

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Not necessary, we're only adding some inline documentation.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Utils class
