### PR TITLE
Docker: Remove Gutenberg and debugger plugins from the install script

### DIFF
--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -25,11 +25,6 @@ wp --allow-root option update blog_public 0
 # https://wordpress.org/plugins/query-monitor/
 wp --allow-root plugin install query-monitor --activate
 
-# Install Gutenberg and Gutenberg debugger
-# https://wordpress.org/plugins/gutenberg/
-# https://wordpress.org/plugins/g-debugger/
-wp --allow-root plugin install g-debugger gutenberg
-
 # Activate Jetpack
 wp --allow-root plugin activate jetpack
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Since Gutenberg is part of WordPress core, the Gutenberg plugin and its debugger is no longer needed in the Docker build script. 

#### Testing instructions:
* Uninstall your WordPress site using the following command:
```
yarn docker:uninstall
```
* Go to: `docker/wordpress/wp-content/plugins` and remove `gutenberg` and `g-debugger`.
* Run the site install script again using the following command:
```
yarn docker:install
```
* Confirm that Gutenberg and G Debugger plugins are not installed on your site.

#### Proposed changelog entry for your changes:
* Remove Gutenberg and debugger plugins from the Docker install script.
