### PR TITLE
PHPCS: Bumping the minimum version for phpcs to 5.6

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
 	<config name="minimum_supported_wp_version" value="5.1" />
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="PHPCompatibilityWP"/>
 	<rule ref="WordPress-Core" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Fixes an issue where the linter reports PHP issues on versions 5.3 and up.
I'd expect to only see issues on 5.6 and up.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes minimum version of phpcs to 5.6

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances our existing linter.

#### Testing instructions:

* Make a change to `packages/sync/modules.php` and try to commit
* Ensure you get no php errors for version 5.5 ( you would before this change )

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
