### PR TITLE
Enable related posts for AMP

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1656,7 +1656,9 @@ EOT;
 	 * @return null
 	 */
 	protected function _action_frontend_init_page() {
-		$this->_enqueue_assets( true, true );
+
+		$enqueue_script = ! ( class_exists( 'Jetpack_AMP_Support' ) || Jetpack_AMP_Support::is_amp_request() );
+		$this->_enqueue_assets( $enqueue_script, true );
 		$this->_setup_shortcode();
 
 		add_filter( 'the_content', array( $this, 'filter_add_target_to_dom' ), 40 );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1659,7 +1659,7 @@ EOT;
 	 */
 	protected function _action_frontend_init_page() {
 
-		$enqueue_script = ! ( class_exists( 'Jetpack_AMP_Support' ) || Jetpack_AMP_Support::is_amp_request() );
+		$enqueue_script = ! ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
 		$this->_enqueue_assets( $enqueue_script, true );
 		$this->_setup_shortcode();
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -120,7 +120,7 @@ class Jetpack_RelatedPosts {
 	 */
 	public function action_frontend_init() {
 		// Add a shortcode handler that outputs nothing, this gets overridden later if we can display related content
-		add_shortcode( self::SHORTCODE, array( $this, 'get_target_html_unsupported' ) );
+		add_shortcode( self::SHORTCODE, array( $this, 'get_client_rendered_html_unsupported' ) );
 
 		if ( ! $this->_enabled_for_request() )
 			return;
@@ -176,9 +176,9 @@ class Jetpack_RelatedPosts {
 
 		if ( ! $this->_found_shortcode ) {
 			if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-				$content .= "\n" . $this->get_amp_html();
+				$content .= "\n" . $this->get_server_rendered_html();
 			} else {
-				$content .= "\n" . $this->get_target_html();
+				$content .= "\n" . $this->get_client_rendered_html();
 			}
 		}
 
@@ -187,8 +187,10 @@ class Jetpack_RelatedPosts {
 
 	/**
 	 * Render static markup based on the Gutenberg block code
+	 *
+	 * @return string Rendered related posts HTML.
 	 */
-	function get_amp_html() {
+	function get_server_rendered_html() {
 		$rp_settings = Jetpack_Options::get_option( 'relatedposts', array() );
 		$block_rp_settings = array(
 			'displayThumbnails' => $rp_settings['show_thumbnails'],
@@ -222,7 +224,7 @@ class Jetpack_RelatedPosts {
 	 * @uses esc_html__, apply_filters
 	 * @returns string
 	 */
-	public function get_target_html() {
+	public function get_client_rendered_html() {
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -256,7 +258,7 @@ EOT;
 	 *
 	 * @returns string
 	 */
-	public function get_target_html_unsupported() {
+	public function get_client_rendered_html_unsupported() {
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -1709,7 +1711,7 @@ EOT;
 	protected function _setup_shortcode() {
 		add_filter( 'the_content', array( $this, 'test_for_shortcode' ), 0 );
 
-		add_shortcode( self::SHORTCODE, array( $this, 'get_target_html' ) );
+		add_shortcode( self::SHORTCODE, array( $this, 'get_client_rendered_html' ) );
 	}
 
 	protected function _allow_feature_toggle() {

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -166,7 +166,9 @@ class Jetpack_RelatedPosts {
 	 * Will skip adding the target if the post content contains a Related Posts block.
 	 *
 	 * @filter the_content
-	 * @param string $content
+	 *
+	 * @param string $content Post content.
+	 *
 	 * @returns string
 	 */
 	public function filter_add_target_to_dom( $content ) {
@@ -190,17 +192,19 @@ class Jetpack_RelatedPosts {
 	 *
 	 * @return string Rendered related posts HTML.
 	 */
-	function get_server_rendered_html() {
-		$rp_settings = Jetpack_Options::get_option( 'relatedposts', array() );
+	public function get_server_rendered_html() {
+		$rp_settings       = Jetpack_Options::get_option( 'relatedposts', array() );
 		$block_rp_settings = array(
 			'displayThumbnails' => $rp_settings['show_thumbnails'],
-			'showHeadline' => $rp_settings['show_headline'],
-			'displayDate' => isset( $rp_settings['show_date'] ) ? (bool) $rp_settings['show_date'] : true,
-			'displayContext' => isset( $rp_settings['show_context'] ) && $rp_settings['show_context'],
-			'postLayout' => isset( $rp_settings['layout'] ) ? $rp_settings['layout'] : 'grid',
-			'postsToShow' => isset( $rp_settings['size'] ) ? $rp_settings['size'] : 3,
-			'headline' => apply_filters( 'jetpack_relatedposts_filter_headline', $this->get_headline() )
+			'showHeadline'      => $rp_settings['show_headline'],
+			'displayDate'       => isset( $rp_settings['show_date'] ) ? (bool) $rp_settings['show_date'] : true,
+			'displayContext'    => isset( $rp_settings['show_context'] ) && $rp_settings['show_context'],
+			'postLayout'        => isset( $rp_settings['layout'] ) ? $rp_settings['layout'] : 'grid',
+			'postsToShow'       => isset( $rp_settings['size'] ) ? $rp_settings['size'] : 3,
+			/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
+			'headline'          => apply_filters( 'jetpack_relatedposts_filter_headline', $this->get_headline() ),
 		);
+
 		return $this->render_block( $block_rp_settings );
 	}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -175,7 +175,7 @@ class Jetpack_RelatedPosts {
 		}
 
 		if ( ! $this->_found_shortcode ) {
-			if ( Jetpack_AMP_Support::is_amp_request() ) {
+			if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 				$content .= "\n" . $this->get_amp_html();
 			} else {
 				$content .= "\n" . $this->get_target_html();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #9556

Currently the related posts block is disabled for all AMP requests because they don't support client-side JS. However, the Gutenberg block does server side rendering. This patch reuses the Gutenberg code in kind of a brute-force way to enable Related Posts in AMP.

cc @westonruter @jeffersonrabb 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Enable Related Posts for AMP pages

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds Related Posts support to AMP pages

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the AMP plugin (tested with v1.2)
* Enable Related posts
* View the AMP version of a page by appending ?amp
* Related posts should be displayed
* Try changing some settings (e.g. enable/disable thumbnails, enable/disable heading). Should work similarly to front-end

This is the most minimal, brute-force version I could create. It may create invalid AMP in other ways (e.g. too much CSS). Comments and corrections welcome.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Enable Related Posts for AMP pages
