### PR TITLE
Add the missing use declaration to the compat layer file.

### DIFF
--- a/packages/compat/legacy/class.jetpack-sync-actions.php
+++ b/packages/compat/legacy/class.jetpack-sync-actions.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * A compatibility shim for the sync actions class.
+ *
+ * @package jetpack-compat
+ */
+
+use Automattic\Jetpack\Sync\Actions;
 
 /**
  * Class Jetpack_Sync_Actions
@@ -7,166 +14,346 @@
  */
 class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 
-	static function init() {
+	/**
+	 * Initializes the class.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::init
+	 */
+	public static function init() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::init();
 	}
 
-	static function add_sender_shutdown() {
+	/**
+	 * Adds a shutdown sender callback.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::add_sender_shutdown
+	 */
+	public static function add_sender_shutdown() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::add_sender_shutdown();
 	}
 
-	static function should_initialize_sender() {
+	/**
+	 * Returns false or true based on whether this class should initialize the sender
+	 * in current circumstances.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::should_initialize_sender
+	 *
+	 * @return Boolean should the object initialize sender?
+	 */
+	public static function should_initialize_sender() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::should_initialize_sender();
 	}
 
-	static function sync_allowed() {
+	/**
+	 * Returns false or true based on whether sync is allowed.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::sync_allowed
+	 *
+	 * @return Boolean is sync allowed?
+	 */
+	public static function sync_allowed() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::sync_allowed();
 	}
 
-	static function sync_via_cron_allowed() {
+	/**
+	 * Returns false or true based on whether sync via cron is allowed.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::sync_via_cron_allowed
+	 *
+	 * @return Boolean is sync via cron allowed?
+	 */
+	public static function sync_via_cron_allowed() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::sync_via_cron_allowed();
 	}
 
-	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
+	/**
+	 * Filters a boolean value that determines whether blacklisted posts should be prevented
+	 * from being publicized.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::prevent_publicize_blacklisted_posts
+	 *
+	 * @param Boolean $should_publicize initial setting value.
+	 * @param WP_Post $post the post object.
+	 * @return Boolean whether to prevent publicizing.
+	 */
+	public static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::prevent_publicize_blacklisted_posts( $should_publicize, $post );
 	}
 
-	static function set_is_importing_true() {
+	/**
+	 * Set the importing flag to true.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::set_is_importing_true
+	 */
+	public static function set_is_importing_true() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::set_is_importing_true();
 	}
 
-	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
+	/**
+	 * Send the sync data.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::send_data
+	 *
+	 * @param Mixed   $data the sync data.
+	 * @param String  $codec_name the codec slug.
+	 * @param Integer $sent_timestamp the current server timestamp.
+	 * @param Integer $queue_id the queue identifier.
+	 * @param Integer $checkout_duration time spent retrieving items.
+	 * @param Integer $preprocess_duration Time spent converting items into data.
+	 * @return WP_Response the response object.
+	 */
+	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration );
 	}
 
-	static function do_initial_sync() {
+	/**
+	 * Commence initial sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::do_initial_sync
+	 */
+	public static function do_initial_sync() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::do_initial_sync();
 	}
 
-	static function do_full_sync( $modules = null ) {
+	/**
+	 * Commence full sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::do_full_sync
+	 *
+	 * @param Array $modules the modules list.
+	 * @return Boolean whether the sync was initialized.
+	 */
+	public static function do_full_sync( $modules = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::do_full_sync( $modules );
 	}
 
-	static function jetpack_cron_schedule( $schedules ) {
+	/**
+	 * Schedule cron sessions.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::jetpack_cron_schedule
+	 *
+	 * @param Array $schedules the schedules to add.
+	 */
+	public static function jetpack_cron_schedule( $schedules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::jetpack_cron_schedule( $schedules );
 	}
 
-	static function do_cron_sync() {
+	/**
+	 * Commence cron sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::do_cron_sync
+	 */
+	public static function do_cron_sync() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::do_cron_sync();
 	}
 
-	static function do_cron_full_sync() {
+	/**
+	 * Commence cron full sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::do_cron_full_sync
+	 */
+	public static function do_cron_full_sync() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::do_cron_full_sync();
 	}
 
-	static function do_cron_sync_by_type( $type ) {
+	/**
+	 * Commence cron sync of a specific type of object.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::do_cron_sync_by_type
+	 *
+	 * @param Array $type the type of object to sync.
+	 */
+	public static function do_cron_sync_by_type( $type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::do_cron_sync_by_type();
 	}
 
-	static function initialize_listener() {
+	/**
+	 * Initalize the listener of the object.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::initialize_listener
+	 */
+	public static function initialize_listener() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::initialize_listener();
 	}
 
-	static function initialize_sender() {
+	/**
+	 * Initalize the sender of the object.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::initialize_sender
+	 */
+	public static function initialize_sender() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::initialize_sender();
 	}
 
-	static function initialize_woocommerce() {
+	/**
+	 * Initalize the woocommerce listeners.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::initialize_woocommerce
+	 */
+	public static function initialize_woocommerce() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::initialize_woocommerce();
 	}
 
-	static function add_woocommerce_sync_module( $sync_modules ) {
+	/**
+	 * Add the woocommerce sync module.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::add_woocommerce_sync_module
+	 *
+	 * @param Array $sync_modules an array of modules.
+	 */
+	public static function add_woocommerce_sync_module( $sync_modules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::add_woocommerce_sync_module( $sync_modules );
 	}
 
-	static function initialize_wp_super_cache() {
+	/**
+	 * Initalize the WP Super Cache listener.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::initialize_wp_super_cache
+	 */
+	public static function initialize_wp_super_cache() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::initialize_wp_super_cache();
 	}
 
-	static function add_wp_super_cache_sync_module( $sync_modules ) {
+	/**
+	 * Add the WP Super Cache sync module.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::add_wp_super_cache_sync_module
+	 *
+	 * @param Array $sync_modules the list to be amended.
+	 */
+	public static function add_wp_super_cache_sync_module( $sync_modules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::add_wp_super_cache_sync_module( $sync_modules );
 	}
 
-	static function sanitize_filtered_sync_cron_schedule( $schedule ) {
+	/**
+	 * Sanitizes the filtered sync cron schedule.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::sanitize_filtered_sync_cron_schedule
+	 *
+	 * @param String $schedule the cron schedule to sanitize.
+	 * @return String sanitized cron schedule.
+	 */
+	public static function sanitize_filtered_sync_cron_schedule( $schedule ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::sanitize_filtered_sync_cron_schedule( $schedule );
 	}
 
-	static function get_start_time_offset( $schedule = '', $hook = '' ) {
+	/**
+	 * Returns the time offset for a the start schedule.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::get_start_time_offset
+	 *
+	 * @param String $schedule the schedule string.
+	 * @param String $hook hook slug.
+	 * @return Integer start time offset.
+	 */
+	public static function get_start_time_offset( $schedule = '', $hook = '' ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::get_start_time_offset( $schedule, $hook );
 	}
 
-	static function maybe_schedule_sync_cron( $schedule, $hook ) {
+	/**
+	 * If needed, schedule a cron sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::maybe_schedule_sync_cron
+	 *
+	 * @param String $schedule the schedule string.
+	 * @param String $hook hook slug.
+	 */
+	public static function maybe_schedule_sync_cron( $schedule, $hook ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::maybe_schedule_sync_cron( $schedule, $hook );
 	}
 
-	static function clear_sync_cron_jobs() {
+	/**
+	 * Clears cron jobs scheduled for sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::clear_sync_cron_jobs
+	 */
+	public static function clear_sync_cron_jobs() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::clear_sync_cron_jobs();
 	}
 
-	static function init_sync_cron_jobs() {
+	/**
+	 * Initialize cron jobs for sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::init_sync_cron_jobs
+	 */
+	public static function init_sync_cron_jobs() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::init_sync_cron_jobs();
 	}
 
-	static function cleanup_on_upgrade( $new_version = null, $old_version = null ) {
+	/**
+	 * Cleans up schedules on plugin upgrade.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::cleanup_on_upgrade
+	 *
+	 * @param String $new_version the new version.
+	 * @param String $old_version the old version.
+	 */
+	public static function cleanup_on_upgrade( $new_version = null, $old_version = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::cleanup_on_upgrade( $new_version, $old_version );
 	}
 
-	static function get_sync_status( $fields = null ) {
+	/**
+	 * Clears cron jobs scheduled for sync.
+	 *
+	 * @deprecated \Automattic\Jetpack\Sync\Actions::get_sync_status
+	 *
+	 * @param Array $fields sync fields to get status of.
+	 */
+	public static function get_sync_status( $fields = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
 		return Actions::get_sync_status( $fields );
 	}
-
 }

--- a/packages/compat/legacy/class.jetpack-sync-modules.php
+++ b/packages/compat/legacy/class.jetpack-sync-modules.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * A compatibility shim for the sync modules class.
+ *
+ * @package jetpack-compat
+ */
+
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Class Jetpack_Sync_Modules
@@ -6,7 +13,14 @@
  * @deprecated Use Automattic\Jetpack\Sync\Modules
  */
 class Jetpack_Sync_Modules {
-	static function get_module( $module_name ) {
+
+	/**
+	 * Returns the sync module object.
+	 *
+	 * @param String $module_name the module name.
+	 * @return Automattic\Jetpack\Sync\Modules\Module the module object.
+	 */
+	public static function get_module( $module_name ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Modules' );
 
 		return Modules::get_module( $module_name );


### PR DESCRIPTION
Without this declaration any plugin that would attempt to use Jetpack_Sync_Actions static methods will result
in a fatal error because of the missing Actions class.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes a fatal on a certain Action call.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added the use statement that was missing.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Try to call `Jetpack_Sync_Actions::sync_via_cron_allowed()` on `plugins_loaded`.
* Observe the fatal error.
* Use this PR, observe no more fatal.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed a fatal error when using pre-7.5 Jetpack Sync API.
