### PR TITLE
Sync: Migrate to use is_user_connected() from the conn package

### DIFF
--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -12,10 +12,12 @@ use Automattic\Jetpack\Roles;
  */
 class Users {
 	static $user_roles = array();
+	static $connection = null;
 
 	static function init() {
-		$connection = new Jetpack_Connection();
-		if ( $connection->is_active() ) {
+		// TODO: Eventually, this needs to be instantiated at the top level in the sync package.
+		self::$connection = new Jetpack_Connection();
+		if ( self::$connection->is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
@@ -25,7 +27,7 @@ class Users {
 	 * Synchronize connected user role changes
 	 */
 	static function user_role_change( $user_id ) {
-		if ( \Jetpack::is_user_connected( $user_id ) ) {
+		if ( self::$connection->is_user_connected( $user_id ) ) {
 			self::update_role_on_com( $user_id );
 			// try to choose a new master if we're demoting the current one
 			self::maybe_demote_master_user( $user_id );
@@ -71,7 +73,7 @@ class Users {
 			$new_master = false;
 			foreach ( $query->results as $result ) {
 				$found_user_id = absint( $result->id );
-				if ( $found_user_id && \Jetpack::is_user_connected( $found_user_id ) ) {
+				if ( $found_user_id && self::$connection->is_user_connected( $found_user_id ) ) {
 					$new_master = $found_user_id;
 					break;
 				}


### PR DESCRIPTION
This PR updates the sync package to use the `is_user_connected()` method from the connection package instead of `Jetpack::is_user_connected()`, in an effort to decouple sync from the Jetpack core.

#### Changes proposed in this Pull Request:
Sync: Migrate to use `is_user_connected()` from the connection package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:

* Checkout the branch.
* Enable WP_DEBUG_LOG.
* Smoke test the site in wp-admin and the frontend.
* Trigger an incremental sync.
* Trigger a full sync.
* Verify sync works well and you have no errors logged.
* Verify tests pass and CI is green.

#### Proposed changelog entry for your changes:
Sync: Migrate to use is_user_connected() from the connection package.
