### PR TITLE
Build: Use `fancy-log` directly instead of `gulp-util`

### DIFF
--- a/tools/builder/admin-css.js
+++ b/tools/builder/admin-css.js
@@ -9,7 +9,7 @@ import cleanCSS from 'gulp-clean-css';
 import gulp from 'gulp';
 import rename from 'gulp-rename';
 import rtlcss from 'gulp-rtlcss';
-import util from 'gulp-util';
+import log from 'fancy-log';
 
 const admincss = [
 	// Non-concatenated, non-admin styles to be processed
@@ -50,7 +50,7 @@ gulp.task( 'admincss', function() {
 		)
 		.pipe( gulp.dest( '.' ) )
 		.on( 'end', function() {
-			util.log( 'Admin modules CSS finished.' );
+			log( 'Admin modules CSS finished.' );
 		} );
 } );
 
@@ -71,7 +71,7 @@ gulp.task( 'admincss:rtl', function() {
 		.pipe( rename( { suffix: '.min' } ) )
 		.pipe( gulp.dest( '.' ) )
 		.on( 'end', function() {
-			util.log( 'Admin modules RTL CSS finished.' );
+			log( 'Admin modules RTL CSS finished.' );
 		} );
 } );
 

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -10,7 +10,7 @@ import modify from 'gulp-modify';
 import path from 'path';
 import rename from 'gulp-rename';
 import rtlcss from 'gulp-rtlcss';
-import util from 'gulp-util';
+import log from 'fancy-log';
 
 /**
  * Internal dependencies
@@ -94,7 +94,7 @@ gulp.task( 'frontendcss', function() {
 		.pipe( rename( { suffix: '-rtl' } ) )
 		.pipe( gulp.dest( 'css/' ) )
 		.on( 'end', function() {
-			util.log( 'Front end modules CSS finished.' );
+			log( 'Front end modules CSS finished.' );
 		} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
`gulp-util` is [deprecated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).

We also never explicitly declare it as a dependency.

Instead, directly use `fancy-log`, which we do declare.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
N/A

#### Testing instructions:
1. `./node_modules/.bin gulp old-styles`
2. Make sure everything builds.

#### Proposed changelog entry for your changes:
N/A