### PR TITLE
Sync: Fix PHPCS errors in Users

### DIFF
--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Sync for users.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
@@ -6,35 +11,72 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Roles;
 
 /**
- * Class Users
+ * Class Users.
  *
  * Responsible for syncing user data changes.
  */
 class Users {
-	static $user_roles = array();
-	static $connection = null;
+	/**
+	 * Roles of all users, indexed by user ID.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @var array
+	 */
+	public static $user_roles = array();
 
-	static function init() {
-		// TODO: Eventually, this needs to be instantiated at the top level in the sync package.
+	/**
+	 * Jetpack connection manager instance.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @var null|Automattic\Jetpack\Connection\Manager
+	 */
+	public static $connection = null;
+
+	/**
+	 * Initialize sync for user data changes.
+	 *
+	 * @access public
+	 * @static
+	 * @todo Eventually, connection needs to be instantiated at the top level in the sync package.
+	 */
+	public static function init() {
 		self::$connection = new Jetpack_Connection();
 		if ( self::$connection->is_active() ) {
-			// Kick off synchronization of user role when it changes
+			// Kick off synchronization of user role when it changes.
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
 	}
 
 	/**
-	 * Synchronize connected user role changes
+	 * Synchronize connected user role changes.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param int $user_id ID of the user.
 	 */
-	static function user_role_change( $user_id ) {
+	public static function user_role_change( $user_id ) {
 		if ( self::$connection->is_user_connected( $user_id ) ) {
 			self::update_role_on_com( $user_id );
-			// try to choose a new master if we're demoting the current one
+			// Try to choose a new master if we're demoting the current one.
 			self::maybe_demote_master_user( $user_id );
 		}
 	}
 
-	static function get_role( $user_id ) {
+	/**
+	 * Retrieve the role of a user by their ID.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param int $user_id ID of the user.
+	 * @return string Role of the user.
+	 */
+	public static function get_role( $user_id ) {
 		if ( isset( self::$user_roles[ $user_id ] ) ) {
 			return self::$user_roles[ $user_id ];
 		}
@@ -44,24 +86,51 @@ class Users {
 		$roles = new Roles();
 		$role  = $roles->translate_current_user_to_role();
 		wp_set_current_user( $current_user_id );
-		$user_roles[ $user_id ] = $role;
+		self::$user_roles[ $user_id ] = $role;
 
 		return $role;
 	}
 
-	static function get_signed_role( $user_id ) {
+	/**
+	 * Retrieve the signed role of a user by their ID.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param int $user_id ID of the user.
+	 * @return string Signed role of the user.
+	 */
+	public static function get_signed_role( $user_id ) {
 		return \Jetpack::sign_role( self::get_role( $user_id ), $user_id );
 	}
 
-	static function update_role_on_com( $user_id ) {
+	/**
+	 * Retrieve the signed role and update it in WP.com for that user.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param int $user_id ID of the user.
+	 */
+	public static function update_role_on_com( $user_id ) {
 		$signed_role = self::get_signed_role( $user_id );
 		\Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
 	}
 
-	static function maybe_demote_master_user( $user_id ) {
-		$master_user_id = \Jetpack_Options::get_option( 'master_user' );
+	/**
+	 * Choose a new master user if we're demoting the current one.
+	 *
+	 * @access public
+	 * @static
+	 * @todo Disconnect if there is no user with enough capabilities to be the master user.
+	 * @uses \WP_User_Query
+	 *
+	 * @param int $user_id ID of the user.
+	 */
+	public static function maybe_demote_master_user( $user_id ) {
+		$master_user_id = (int) \Jetpack_Options::get_option( 'master_user' );
 		$role           = self::get_role( $user_id );
-		if ( $user_id == $master_user_id && 'administrator' != $role ) {
+		if ( $user_id === $master_user_id && 'administrator' !== $role ) {
 			$query      = new \WP_User_Query(
 				array(
 					'fields'  => array( 'id' ),
@@ -82,7 +151,7 @@ class Users {
 			if ( $new_master ) {
 				\Jetpack_Options::update_option( 'master_user', $new_master );
 			}
-			// else disconnect..?
+			// TODO: else disconnect..?
 		}
 	}
 }


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Users class.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Users class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Users class.
