### PR TITLE
Sync: Fix PHPCS errors in Simple Codec

### DIFF
--- a/packages/sync/src/Simple_Codec.php
+++ b/packages/sync/src/Simple_Codec.php
@@ -1,23 +1,62 @@
 <?php
+/**
+ * Simple codec for encoding and decoding sync objects.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
 /**
- * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
- * algorithm to compress objects serialized using json_encode
+ * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses base64
+ * algorithm to compress objects serialized using json_encode.
  */
 class Simple_Codec extends JSON_Deflate_Array_Codec {
+	/**
+	 * Name of the codec.
+	 *
+	 * @access public
+	 *
+	 * @var string
+	 */
 	const CODEC_NAME = 'simple';
 
+	/**
+	 * Retrieve the name of the codec.
+	 *
+	 * @access public
+	 *
+	 * @return string Name of the codec.
+	 */
 	public function name() {
 		return self::CODEC_NAME;
 	}
 
+	/**
+	 * Encode a sync object.
+	 *
+	 * @access public
+	 *
+	 * @param mixed $object Sync object to encode.
+	 * @return string Encoded sync object.
+	 */
 	public function encode( $object ) {
+		// This is intentionally using base64_encode().
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return base64_encode( $this->json_serialize( $object ) );
 	}
 
+	/**
+	 * Encode a sync object.
+	 *
+	 * @access public
+	 *
+	 * @param string $input Encoded sync object to decode.
+	 * @return mixed Decoded sync object.
+	 */
 	public function decode( $input ) {
+		// This is intentionally using base64_decode().
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		return $this->json_unserialize( base64_decode( $input ) );
 	}
 


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, I've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Simple Codec class.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Simple Codec class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Simple Codec class.
