### PR TITLE
Extensions: Fix upgrade nudge when loading data

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -19,13 +19,18 @@ import './store';
 
 import './style.scss';
 
-const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
+const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName, upgradeUrl } ) => (
 	<Warning
-		actions={ [
-			<Button onClick={ autosaveAndRedirectToUpgrade } target="_top" isDefault>
-				{ __( 'Upgrade', 'jetpack' ) }
-			</Button>,
-		] }
+		actions={
+			// Use upgradeUrl to determine whether or not to display the Upgrade button.
+			// We tried setting autosaveAndRedirectToUpgrade to falsey in `withDispatch`,
+			// but it doesn't seem to be reliably updated after a `withSelect` update.
+			upgradeUrl && [
+				<Button onClick={ autosaveAndRedirectToUpgrade } target="_top" isDefault>
+					{ __( 'Upgrade', 'jetpack' ) }
+				</Button>,
+			]
+		}
 		className="jetpack-upgrade-nudge"
 	>
 		<span className="jetpack-upgrade-nudge__info">
@@ -38,9 +43,11 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 			/>
 			<span className="jetpack-upgrade-nudge__text-container">
 				<span className="jetpack-upgrade-nudge__title">
-					{ sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
-						planName,
-					} ) }
+					{ planName
+						? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
+								planName,
+						  } )
+						: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' ) }
 				</span>
 				<span className="jetpack-upgrade-nudge__message">
 					{ __(
@@ -69,15 +76,13 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
-		const upgradeUrl = addQueryArgs(
-			`https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`,
-			{
+		const upgradeUrl =
+			planPathSlug &&
+			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
 				redirect_to:
 					'/' +
 					compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
-			}
-		);
-
+			} );
 		return {
 			planName: get( plan, [ 'product_name' ] ),
 			upgradeUrl,


### PR DESCRIPTION
Data for the upgrade nudge is loaded dynamically. We may not know:
- The plan name
- The upgrade url

Handle these cases appropriately.

If the plan name is unknown, display a generic plan name.
If the upgrade URL is unknown, do not display the upgrade button.

## Screens

These screens are with request blocking enabled. In normal use, you might see these screens momentarily before seeing the loaded view with the button and the plan details.

### Before

![Screen Shot 2019-07-16 at 16 01 37](https://user-images.githubusercontent.com/841763/61300974-4fd0a780-a7e3-11e9-95ab-ac25265a8e86.png)

### After

![Screen Shot 2019-07-16 at 16 00 56](https://user-images.githubusercontent.com/841763/61300984-52cb9800-a7e3-11e9-88e0-4a047b5f5cd1.png)

## Testing

Does the nudge continue to work well?

You can mimic conditions where the data hasn't loaded by using dev tools request blocking on `public-api.wordpress.com/rest/v1.5/plans`

The Jetpack upgrade URL is determined without an API call, so you'd have to test D30429-code on simple site with request blocking to hide the button.