### PR TITLE
Roles: Use roles package everywhere, deprecate legacy methods

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -1,6 +1,7 @@
 <?php //phpcs:ignore
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Actions;
 
 class Jetpack_Provision { //phpcs:ignore
@@ -103,7 +104,8 @@ class Jetpack_Provision { //phpcs:ignore
 			$user = wp_get_current_user();
 
 			// Role.
-			$role        = Jetpack::translate_current_user_to_role();
+			$roles       = new Roles();
+			$role        = $roles->translate_current_user_to_role();
 			$signed_role = Jetpack::sign_role( $role );
 
 			$secrets = Jetpack::init()->generate_secrets( 'authorize' );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -88,7 +88,7 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
 		}
 
-		$cap = Jetpack::translate_role_to_cap( $role );
+		$cap = $roles->translate_role_to_cap( $role );
 		if ( ! $cap ) {
 			return new Jetpack_Error( 'no_cap', 'Invalid request.', 400 );
 		}
@@ -272,7 +272,8 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'scope', 'Invalid Scope', $code );
 		}
 
-		if ( ! $cap = Jetpack::translate_role_to_cap( $role ) ) {
+		$cap = $roles->translate_role_to_cap( $role );
+		if ( ! $cap ) {
 			return new Jetpack_Error( 'scope', 'No Cap', $code );
 		}
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -15,7 +16,8 @@ class Jetpack_Client_Server {
 	function client_authorize() {
 		$data              = stripslashes_deep( $_GET );
 		$data['auth_type'] = 'client';
-		$role              = Jetpack::translate_current_user_to_role();
+		$roles             = new Roles();
+		$role              = $roles->translate_current_user_to_role();
 		$redirect          = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
 
 		check_admin_referer( "jetpack-authorize_{$role}_{$redirect}" );
@@ -79,7 +81,8 @@ class Jetpack_Client_Server {
 		$jetpack_unique_connection['connected'] += 1;
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 
-		$role = Jetpack::translate_current_user_to_role();
+		$roles = new Roles();
+		$role  = $roles->translate_current_user_to_role();
 
 		if ( ! $role ) {
 			return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
@@ -181,7 +184,8 @@ class Jetpack_Client_Server {
 	 * @return object|WP_Error
 	 */
 	function get_token( $data ) {
-		$role = Jetpack::translate_current_user_to_role();
+		$roles = new Roles();
+		$role  = $roles->translate_current_user_to_role();
 
 		if ( ! $role ) {
 			return new Jetpack_Error( 'role', __( 'An administrator for this blog must set up the Jetpack connection.', 'jetpack' ) );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -334,7 +334,8 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		// Generate secrets.
-		$role    = Jetpack::translate_user_to_role( $user );
+		$roles   = new Roles();
+		$role    = $roles->translate_user_to_role( $user );
 		$secrets = Jetpack::init()->generate_secrets( 'authorize', $user->ID );
 
 		$response = array(

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -1,7 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
-
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Sender;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4395,6 +4395,8 @@ p {
 	}
 
 	/**
+	 * Get the role of the current user.
+	 *
 	 * @deprecated 7.6 Use Automattic\Jetpack\Roles::translate_current_user_to_role() instead.
 	 *
 	 * @access public

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4394,14 +4394,19 @@ p {
 		return $url;
 	}
 
-	static function translate_current_user_to_role() {
-		foreach ( self::$capability_translations as $role => $cap ) {
-			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
-				return $role;
-			}
-		}
+	/**
+	 * @deprecated 7.6 Use Automattic\Jetpack\Roles::translate_current_user_to_role() instead.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return string|boolean Current user's role, false if not enough capabilities for any of the roles.
+	 */
+	public static function translate_current_user_to_role() {
+		_deprecated_function( __METHOD__, 'jetpack-7.6.0' );
 
-		return false;
+		$roles = new Roles();
+		return $roles->translate_current_user_to_role();
 	}
 
 	static function translate_user_to_role( $user ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -106,7 +106,17 @@ class Jetpack {
 		'latex'               => array( 'wp-latex/wp-latex.php', 'WP LaTeX' )
 	);
 
-	static $capability_translations = array(
+	/**
+	 * Map of roles we care about, and their corresponding minimum capabilities.
+	 *
+	 * @deprecated 7.6 Use Automattic\Jetpack\Roles::$capability_translations instead.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @var array
+	 */
+	public static $capability_translations = array(
 		'administrator' => 'manage_options',
 		'editor'        => 'edit_others_posts',
 		'author'        => 'publish_posts',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4411,15 +4411,23 @@ p {
 		return $roles->translate_current_user_to_role();
 	}
 
-	static function translate_user_to_role( $user ) {
-		foreach ( self::$capability_translations as $role => $cap ) {
-			if ( user_can( $user, $role ) || user_can( $user, $cap ) ) {
-				return $role;
-			}
-		}
+	/**
+	 * Get the role of a particular user.
+	 *
+	 * @deprecated 7.6 Use Automattic\Jetpack\Roles::translate_user_to_role() instead.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param \WP_User $user User object.
+	 * @return string|boolean User's role, false if not enough capabilities for any of the roles.
+	 */
+	public static function translate_user_to_role( $user ) {
+		_deprecated_function( __METHOD__, 'jetpack-7.6.0' );
 
-		return false;
-    }
+		$roles = new Roles();
+		return $roles->translate_user_to_role( $user );
+	}
 
 	static function translate_role_to_cap( $role ) {
 		if ( ! isset( self::$capability_translations[$role] ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4429,12 +4429,22 @@ p {
 		return $roles->translate_user_to_role( $user );
 	}
 
-	static function translate_role_to_cap( $role ) {
-		if ( ! isset( self::$capability_translations[$role] ) ) {
-			return false;
-		}
+	/**
+	 * Get the minimum capability for a role.
+	 *
+	 * @deprecated 7.6 Use Automattic\Jetpack\Roles::translate_role_to_cap() instead.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $role Role name.
+	 * @return string|boolean Capability, false if role isn't mapped to any capabilities.
+	 */
+	public static function translate_role_to_cap( $role ) {
+		_deprecated_function( __METHOD__, 'jetpack-7.6.0' );
 
-		return self::$capability_translations[$role];
+		$roles = new Roles();
+		return $roles->translate_role_to_cap( $role );
 	}
 
 	static function sign_role( $role, $user_id = null ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector as REST_Connector;
 use Automattic\Jetpack\Connection\XMLRPC_Connector as XMLRPC_Connector;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
@@ -4494,7 +4495,8 @@ p {
 				$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
 			}
 
-			$role = self::translate_current_user_to_role();
+			$roles       = new Roles();
+			$role        = $roles->translate_current_user_to_role();
 			$signed_role = self::sign_role( $role );
 
 			$user = wp_get_current_user();

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-assets": "@dev",
+		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-tracking": "@dev",
 		"automattic/jetpack-autoloader": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c09d9b77fbe174fad981ff2c454e926b",
+    "content-hash": "56dc3d84ef0f2644bbee524c63ee1a4d",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -335,10 +335,11 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "1d7998577b452db00de2a4aabd693379bae0a065",
+                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a",
                 "shasum": null
             },
             "require": {
+                "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-roles": "@dev",
@@ -771,6 +772,7 @@
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-assets": 20,
+        "automattic/jetpack-roles": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-tracking": 20,
         "automattic/jetpack-autoloader": 20,

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
 
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' );
@@ -787,12 +788,13 @@ class Jetpack_SSO {
 
 			$json_api_auth_environment = Jetpack_SSO_Helpers::get_json_api_auth_environment();
 
-			$is_json_api_auth = ! empty( $json_api_auth_environment );
+			$is_json_api_auth  = ! empty( $json_api_auth_environment );
 			$is_user_connected = Jetpack::is_user_connected( $user->ID );
+			$roles             = new Roles();
 			$tracking->record_user_event( 'sso_user_logged_in', array(
 				'user_found_with'  => $user_found_with,
 				'user_connected'   => (bool) $is_user_connected,
-				'user_role'        => Jetpack::translate_current_user_to_role(),
+				'user_role'        => $roles->translate_current_user_to_role(),
 				'is_json_api_auth' => (bool) $is_json_api_auth,
 			) );
 


### PR DESCRIPTION
In previous PRs, we introduced the Roles package, with ports for 3 methods from the Jetpack class:

* `translate_current_user_to_role()`
* `translate_user_to_role()`
* `translate_role_to_cap()`

This PR updates the entire Jetpack to use the methods from the package, and deprecates the original methods.

#### Changes proposed in this Pull Request:
* Make the `Roles` package a dependency of Jetpack.
* Update Jetpack to use `Roles::translate_current_user_to_role()`
* Update Jetpack to use `Roles::translate_user_to_role()`
* Update Jetpack to use `Roles::translate_role_to_cap()`
* Deprecate `Jetpack::translate_current_user_to_role()`
* Deprecate `Jetpack::translate_user_to_role()`
* Deprecate `Jetpack::translate_role_to_cap()`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA.

#### Testing instructions:
* Smoke test connection, incremental sync and full sync.

#### Proposed changelog entry for your changes:
* Make the `Roles` package a dependency of Jetpack.
* Update Jetpack to use `Roles::translate_current_user_to_role()`
* Update Jetpack to use `Roles::translate_user_to_role()`
* Update Jetpack to use `Roles::translate_role_to_cap()`
* Deprecate `Jetpack::translate_current_user_to_role()`
* Deprecate `Jetpack::translate_user_to_role()`
* Deprecate `Jetpack::translate_role_to_cap()`
