### PR TITLE
Fixes de/activation hooks that didn't work.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -187,5 +187,8 @@ if ( is_readable( $jetpack_autoloader ) ) {
 	return;
 }
 
+register_activation_hook( __FILE__, array( 'Jetpack', 'plugin_activation' ) );
+register_deactivation_hook( __FILE__, array( 'Jetpack', 'plugin_deactivation' ) );
+
 // Require everything else, that is not loaded via the autoloader.
 require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -79,8 +79,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
-register_activation_hook( __FILE__, array( 'Jetpack', 'plugin_activation' ) );
-register_deactivation_hook( __FILE__, array( 'Jetpack', 'plugin_deactivation' ) );
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'init', array( 'Jetpack', 'init' ) );
 add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );


### PR DESCRIPTION
Because statements were moved to a different file, the hook was called incorrectly, causing problems, like activation banner never showing.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13013

#### Changes proposed in this Pull Request:
* Adds activation/deactivation hooks back to Jetpack.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Disconnect jetpack, reset options using the footer link.
* Deactivate Jetpack from the plugins view.
* Activate Jetpack using the plugins view link.
* Make sure you see the full-screen banner covering the entire plugins list.

#### Proposed changelog entry for your changes:
* Fixed broken activation/deactivation scripts.
