### PR TITLE
Custom CSS: Media Width label misaligned in Firefox

### DIFF
--- a/modules/custom-css/custom-css/css/customizer-control.css
+++ b/modules/custom-css/custom-css/css/customizer-control.css
@@ -44,11 +44,7 @@
 	padding-top: 3px;
 	opacity: .8;
 }
-@-moz-document url-prefix() {
-	#customize-control-wpcom_custom_css_content_width_control input[type="text"] + span {
-		top: 47px;
-	}
-}
+
 #customize-control-wpcom_custom_css_content_width_control input[type="text"]:focus + span {
 	opacity: 1;
 }
@@ -147,4 +143,3 @@ body.editing-css .wp-full-overlay.expanded {
 input[type=jetpackCss] {
 	display: none;
 }
-


### PR DESCRIPTION
Looks like there was some old code that targeted Mozilla browsers (AKA Firefox) to fix some positioning specific on those browsers. It seems Firefox no longer needs that CSS and, in fact, the CSS actually makes it worse in Firefox so I removed it.

It's not clear why the code was added as it was ported into Jetpack three years ago and the original code is no longer easily available.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed CSS targeting Firefox to position a form label

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Not a new feature. Nothing added.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* In Firefox, go to Jetpack's Writing settings and make sure Enhanced CSS is enabled.
* Go to Customizer.
* Select the Custom CSS menu item.
* Scroll down and look at the Media Width section to make sure the form label is aligned correctly.

#### Before
![image](https://user-images.githubusercontent.com/1123119/61248476-60fcb400-a710-11e9-8a6a-4c662554a233.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/61248322-11b68380-a710-11e9-909e-0bda33859830.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed, but if you want to add one: "Fixed label position in for Enhanced CSS option in the Customizer for Firefox users."
