### PR TITLE
Sync: Fix PHPCS errors in Actions

### DIFF
--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -46,6 +46,14 @@ class Actions {
 	 * @var string
 	 */
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME  = 'jetpack_sync_interval';
+
+	/**
+	 * Interval between the last and the next sync cron action.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
 	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * MINUTE_IN_SECONDS;
 
 	/**

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -336,7 +336,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @return bool False if sync is not allowed.
+	 * @return bool|null False if sync is not allowed.
 	 */
 	public static function do_initial_sync() {
 		// Lets not sync if we are not suppose to.

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -503,7 +503,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @param array $sync_modules The list of sync modules declared prior to this filer.
+	 * @param array $sync_modules The list of sync modules declared prior to this filter.
 	 * @return array A list of sync modules that now includes Woo's modules.
 	 */
 	public static function add_woocommerce_sync_module( $sync_modules ) {

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -218,7 +218,7 @@ class Actions {
 	 * @static
 	 *
 	 * @param bool     $should_publicize Publicize status prior to this filter running.
-	 * @param \WP_Post $post The post to test for Publicizability.
+	 * @param \WP_Post $post                     The post to test for Publicizability.
 	 * @return bool
 	 */
 	public static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -37,6 +37,14 @@ class Actions {
 	 * @var Automattic\Jetpack\Sync\Listener
 	 */
 	public static $listener                = null;
+
+	/**
+	 * Name of the sync cron schedule.
+	 *
+	 * @access public
+	 *
+	 * @var string
+	 */
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME  = 'jetpack_sync_interval';
 	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * MINUTE_IN_SECONDS;
 

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -568,7 +568,7 @@ class Actions {
 	 * @static
 	 *
 	 * @param string $schedule The name of a cron schedule.
-	 * @param string $hook The hook that this method is responding to.
+	 * @param string $hook     The hook that this method is responding to.
 	 * @return int The offset for the sync cron schedule.
 	 */
 	public static function get_start_time_offset( $schedule = '', $hook = '' ) {

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -24,7 +24,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @var \Automattic\Jetpack\Sync\Sender
+	 * @var Automattic\Jetpack\Sync\Sender
 	 */
 	public static $sender = null;
 	/**

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -400,7 +400,7 @@ class Actions {
 			$display = ( 1 === $minutes ) ?
 				__( 'Every minute', 'jetpack' ) :
 				/* translators: %d is an integer indicating the number of minutes. */
-				sprintf( _n( 'Every %d minute', 'Every %d minutes', $minutes, 'jetpack' ), $minutes );
+				sprintf( __( 'Every %d minutes', 'jetpack' ), $minutes );
 			$schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] = array(
 				'interval' => self::DEFAULT_SYNC_CRON_INTERVAL_VALUE,
 				'display'  => $display,

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -36,7 +36,7 @@ class Actions {
 	 *
 	 * @var Automattic\Jetpack\Sync\Listener
 	 */
-	public static $listener                = null;
+	public static $listener = null;
 
 	/**
 	 * Name of the sync cron schedule.
@@ -45,7 +45,7 @@ class Actions {
 	 *
 	 * @var string
 	 */
-	const DEFAULT_SYNC_CRON_INTERVAL_NAME  = 'jetpack_sync_interval';
+	const DEFAULT_SYNC_CRON_INTERVAL_NAME = 'jetpack_sync_interval';
 
 	/**
 	 * Interval between the last and the next sync cron action.
@@ -205,7 +205,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @return bool
+	 * @return bool|int
 	 */
 	public static function sync_via_cron_allowed() {
 		return ( Settings::get_setting( 'sync_via_cron' ) );
@@ -217,8 +217,8 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @param bool     $should_publicize Publicize status prior to this filter running.
-	 * @param \WP_Post $post                     The post to test for Publicizability.
+	 * @param bool     $should_publicize  Publicize status prior to this filter running.
+	 * @param \WP_Post $post              The post to test for Publicizability.
 	 * @return bool
 	 */
 	public static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
@@ -240,18 +240,18 @@ class Actions {
 	}
 
 	/**
-	 * Sends data to WordPress.com via ann XMLRPC request.
+	 * Sends data to WordPress.com via an XMLRPC request.
 	 *
 	 * @access public
 	 * @static
 	 *
-	 * @param object $data Data relating to a sync action.
-	 * @param string $codec_name The name of the codec that encodes the data.
-	 * @param float  $sent_timestamp Current server time so we can compensate for clock differences.
-	 * @param string $queue_id The queue the action belongs to, sync or full_sync.
-	 * @param float  $checkout_duration Time spent retrieving queue items from the DB.
-	 * @param float  $preprocess_duration Time spent converting queue items into data to send.
-	 * @return \Jetpack_Error|mixed|\WP_Error The result of the sending request.
+	 * @param object $data                   Data relating to a sync action.
+	 * @param string $codec_name             The name of the codec that encodes the data.
+	 * @param float  $sent_timestamp         Current server time so we can compensate for clock differences.
+	 * @param string $queue_id               The queue the action belongs to, sync or full_sync.
+	 * @param float  $checkout_duration      Time spent retrieving queue items from the DB.
+	 * @param float  $preprocess_duration    Time spent converting queue items into data to send.
+	 * @return Jetpack_Error|mixed|WP_Error  The result of the sending request.
 	 */
 	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
 		\Jetpack::load_xml_rpc_client();
@@ -335,6 +335,8 @@ class Actions {
 	 *
 	 * @access public
 	 * @static
+	 *
+	 * @return bool False if sync is not allowed.
 	 */
 	public static function do_initial_sync() {
 		// Lets not sync if we are not suppose to.
@@ -362,8 +364,8 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @param array $modules The sync modules should be included in this full sync. All will be included if null.
-	 * @return bool True if full sync was successfully started.
+	 * @param array $modules  The sync modules should be included in this full sync. All will be included if null.
+	 * @return bool           True if full sync was successfully started.
 	 */
 	public static function do_full_sync( $modules = null ) {
 		if ( ! self::sync_allowed() ) {
@@ -389,15 +391,15 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @param array $schedules A list of WordPress cron schedules.
-	 * @return array
+	 * @param array $schedules  The list of WordPress cron schedules prior to this filter.
+	 * @return array            A list of WordPress cron schedules with the Jetpack sync interval added.
 	 */
 	public static function jetpack_cron_schedule( $schedules ) {
 		if ( ! isset( $schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] ) ) {
 			$minutes = intval( self::DEFAULT_SYNC_CRON_INTERVAL_VALUE / 60 );
 			$display = ( 1 === $minutes ) ?
 				__( 'Every minute', 'jetpack' ) :
-				/* translators: %d is an intereger indicating the number of minutes. */
+				/* translators: %d is an integer indicating the number of minutes. */
 				sprintf( _n( 'Every %d minute', 'Every %d minutes', $minutes, 'jetpack' ), $minutes );
 			$schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] = array(
 				'interval' => self::DEFAULT_SYNC_CRON_INTERVAL_VALUE,

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -27,6 +27,7 @@ class Actions {
 	 * @var Automattic\Jetpack\Sync\Sender
 	 */
 	public static $sender = null;
+
 	/**
 	 * A variable to hold a sync listener object.
 	 *

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -603,7 +603,7 @@ class Actions {
 	 * @static
 	 *
 	 * @param string $schedule The name of a cron schedule.
-	 * @param string $hook The hook that this method is responding to.
+	 * @param string $hook     The hook that this method is responding to.
 	 */
 	public static function maybe_schedule_sync_cron( $schedule, $hook ) {
 		if ( ! $hook ) {


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, we've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Actions class.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Actions class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Jetpack DNA

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Actions class.
