### PR TITLE
Upgrade nudge: Update copy

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -32,12 +32,16 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
 			<div>
 				<span className="jetpack-upgrade-nudge__title">
-					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {
-						planName,
-					} ) }
+					{ __( 'This block is not available with your current plan.', 'jetpack' ) }
 				</span>
 				<span className="jetpack-upgrade-nudge__message">
-					{ __( 'It will be hidden from site visitors until you upgrade.', 'jetpack' ) }
+					{ sprintf(
+						__(
+							'Your site visitors will not see this block until you upgrade to %(planName)s.',
+							'jetpack'
+						),
+						{ planName }
+					) }
 				</span>
 			</div>
 		</div>

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -74,7 +74,7 @@ export default compose( [
 		);
 
 		return {
-			planName: get( plan, [ 'product_name_short' ] ),
+			planName: get( plan, [ 'product_name' ] ),
 			upgradeUrl,
 		};
 	} ),

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -32,15 +32,14 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
 			<div>
 				<span className="jetpack-upgrade-nudge__title">
-					{ __( 'This block is not available with your current plan.', 'jetpack' ) }
+					{ sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
+						planName,
+					} ) }
 				</span>
 				<span className="jetpack-upgrade-nudge__message">
-					{ sprintf(
-						__(
-							'Your site visitors will not see this block until you upgrade to %(planName)s.',
-							'jetpack'
-						),
-						{ planName }
+					{ __(
+						'You can try it out before upgrading, but only you will see it. It will be hidden from visitors until you upgrade.',
+						'jetpack'
 					) }
 				</span>
 			</div>


### PR DESCRIPTION
- Use the long plan name (`WordPress.com Premium`/`Jetpack Premium`) instead of short (`Premium`/`Premium`) in the upgrade nudge. Requested by @dereksmart: p1563283534127100-slack-jetpack-crew
- Lower case "plan" in `WordPress.com Premium plan` and `Jetpack Premium plan`. I recall this guideline but can't find the reference right now.

## Screens

### Before

![Screen Shot 2019-07-16 at 16 17 53](https://user-images.githubusercontent.com/841763/61302267-c53d7780-a7e5-11e9-81d5-ead8f1ce89e7.png)

### After

![Screen Shot 2019-07-16 at 16 17 39](https://user-images.githubusercontent.com/841763/61302274-c8d0fe80-a7e5-11e9-9a16-57dbcb07fde8.png)

## Testing
- You'll need to set the constant `define( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- With a site on a free plan, add the Simple Payments block.
- Make sure the nudge displays as expected (see screenshots).