### PR TITLE
Upgrade nudge: Use single Gridicon

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import GridiconStar from 'gridicons/dist/star';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
@@ -8,7 +9,6 @@ import { compact, get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 		className="jetpack-upgrade-nudge"
 	>
 		<div className="jetpack-upgrade-nudge__info">
-			<Gridicon className="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />
+			<GridiconStar className="jetpack-upgrade-nudge__icon" size={ 18 } />
 			<div>
 				<span className="jetpack-upgrade-nudge__title">
 					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Use a single `Gridicon` import instead of complete `Gridicon`.

This is an optimization for build-size. No functional changes.



#### Testing instructions:

* You'll need to set the constant `define( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
* With a site on a free plan, add the Simple Payments block.
* Make sure the nudge and icon display as expected:
  ![Screen Shot 2019-07-16 at 16 17 53](https://user-images.githubusercontent.com/841763/61302267-c53d7780-a7e5-11e9-81d5-ead8f1ce89e7.png)



#### Proposed changelog entry for your changes:
None.