### PR TITLE
Extensions: Add a11y props to Gridicons

### DIFF
--- a/extensions/shared/help-message.js
+++ b/extensions/shared/help-message.js
@@ -17,7 +17,9 @@ export default ( { children = null, isError = false, ...props } ) => {
 	return (
 		children && (
 			<div className={ classes } { ...props }>
-				{ isError && <GridiconNoticeOutline size="24" /> }
+				{ isError && (
+					<GridiconNoticeOutline size="24" aria-hidden="true" role="img" focusable="false" />
+				) }
 				<span>{ children }</span>
 			</div>
 		)

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -29,7 +29,13 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 		className="jetpack-upgrade-nudge"
 	>
 		<div className="jetpack-upgrade-nudge__info">
-			<GridiconStar className="jetpack-upgrade-nudge__icon" size={ 18 } />
+			<GridiconStar
+				className="jetpack-upgrade-nudge__icon"
+				size={ 18 }
+				aria-hidden="true"
+				role="img"
+				focusable="false"
+			/>
 			<div className="jetpack-upgrade-nudge__text-container">
 				<span className="jetpack-upgrade-nudge__title">
 					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Adds props to Gridicons:
  - aria-hidden="true"
  - role="img"
  - focusable="false"

These are the same props Gutenberg adds for a11y reasons:

https://github.com/WordPress/gutenberg/blob/e82b7c6a6bb50f4ecb8a9ad51432cc4f5464d214/packages/components/src/primitives/svg/index.js#L15-L17

#### Testing instructions:

## Testing

- Add a Simple Payment block and trigger validation errors, for example by omitting the "Item name"
- Confirm that the rendered `svg` contains the additional properties:

![Screen Shot 2019-07-17 at 13 16 22](https://user-images.githubusercontent.com/841763/61371556-46a01300-a895-11e9-8f2e-6e2187a2ad94.png)


#### Proposed changelog entry for your changes:

None.
