### PR TITLE
Upgrade Nudge: Add generic lib, style properly

### DIFF
--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -14,17 +14,17 @@ class Jetpack_Upgrade_Nudge {
 	 *
 	 * @return string The message telling the user to upgrade
 	 */
-    public static function get_upgrade_message() {
-        $support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-        ? 'https://support.wordpress.com/simple-payments/'
-        : 'https://jetpack.com/support/simple-payment-button/';
+	public static function get_upgrade_message() {
+		$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+		? 'https://support.wordpress.com/simple-payments/'
+		: 'https://jetpack.com/support/simple-payment-button/';
 
-        return sprintf(
-            wp_kses(
-                __( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-                array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
-            ),
-            esc_url( $support_url )
-        );
-    }
+		return sprintf(
+			wp_kses(
+				__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+				array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
+			),
+			esc_url( $support_url )
+		);
+	}
 }

--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Upgrade Nudge Library
+ *
+ * Display a plan upgrade nudge on the frontend
+ */
+
+class Jetpack_Upgrade_Nudge {
+
+	/**
+	 * Return a message telling the user to upgrade to enable the block.
+	 *
+	 * @since 7.6.0
+	 *
+	 * @return string The message telling the user to upgrade
+	 */
+    public static function get_upgrade_message() {
+        $support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+        ? 'https://support.wordpress.com/simple-payments/'
+        : 'https://jetpack.com/support/simple-payment-button/';
+
+        return sprintf(
+            wp_kses(
+                __( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+                array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
+            ),
+            esc_url( $support_url )
+        );
+    }
+}

--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -45,7 +45,7 @@ class Jetpack_Upgrade_Nudge {
 		// TODO: Make button work
 
 		return <<<EOF
-<div class="editor-warning block-editor-warning">
+<div class="editor-warning block-editor-warning jetpack-upgrade-nudge">
 	<div class="editor-warning__contents block-editor-warning__contents">
 		<p class="editor-warning__message block-editor-warning__message">
 			<div class="jetpack-upgrade-nudge__info">

--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -27,4 +27,48 @@ class Jetpack_Upgrade_Nudge {
 			esc_url( $support_url )
 		);
 	}
+
+	/**
+	 * Return a message telling the user to upgrade to enable the block.
+	 *
+	 * @since 7.6.0
+	 *
+	 * @return string The message telling the user to upgrade
+	 */
+	public static function get_upgrade_nudge( $plan_name = 'Premium' ) {
+		$title = sprintf( __( 'This block is available under the %1$s Plan.', 'jetpack' ),
+			$plan_name
+		);
+		$message = __( 'It will be hidden from site visitors until you upgrade.', 'jetpack' );
+		$button_label = __( 'Upgrade', 'jetpack' );
+
+		// TODO: Make button work
+
+		return <<<EOF
+<div class="editor-warning block-editor-warning">
+	<div class="editor-warning__contents block-editor-warning__contents">
+		<p class="editor-warning__message block-editor-warning__message">
+			<div class="jetpack-upgrade-nudge__info">
+			<!--<Gridicon class="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />-->
+			<div>
+				<span class="jetpack-upgrade-nudge__title">
+					$title
+				</span>
+				<span class="jetpack-upgrade-nudge__message">
+					$message
+				</span>
+			</div>
+		</p>
+
+		<div class="editor-warning__actions block-editor-warning__actions">
+			<span class="editor-warning__action block-editor-warning__action">
+				<button class="is-primary" onClick="" target="_top">
+					$button_label
+				</button>
+			</span>
+		</div>
+	</div>
+</div>
+EOF;
+	}
 }

--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -45,27 +45,29 @@ class Jetpack_Upgrade_Nudge {
 		// TODO: Make button work
 
 		return <<<EOF
-<div class="editor-warning block-editor-warning jetpack-upgrade-nudge">
-	<div class="editor-warning__contents block-editor-warning__contents">
-		<p class="editor-warning__message block-editor-warning__message">
-			<div class="jetpack-upgrade-nudge__info">
-			<!--<Gridicon class="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />-->
-			<div>
-				<span class="jetpack-upgrade-nudge__title">
-					$title
-				</span>
-				<span class="jetpack-upgrade-nudge__message">
-					$message
+<div class="wp-block editor-block-list__block block-editor-block-list__block is-selected has-warning is-interactive">
+	<div class="editor-warning block-editor-warning jetpack-upgrade-nudge">
+		<div class="editor-warning__contents block-editor-warning__contents">
+			<p class="editor-warning__message block-editor-warning__message">
+				<div class="jetpack-upgrade-nudge__info">
+				<!--<Gridicon class="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />-->
+				<div>
+					<span class="jetpack-upgrade-nudge__title">
+						$title
+					</span>
+					<span class="jetpack-upgrade-nudge__message">
+						$message
+					</span>
+				</div>
+			</p>
+
+			<div class="editor-warning__actions block-editor-warning__actions">
+				<span class="editor-warning__action block-editor-warning__action">
+					<button class="is-primary" onClick="" target="_top">
+						$button_label
+					</button>
 				</span>
 			</div>
-		</p>
-
-		<div class="editor-warning__actions block-editor-warning__actions">
-			<span class="editor-warning__action block-editor-warning__action">
-				<button class="is-primary" onClick="" target="_top">
-					$button_label
-				</button>
-			</span>
 		</div>
 	</div>
 </div>

--- a/_inc/lib/upgrade-nudge.php
+++ b/_inc/lib/upgrade-nudge.php
@@ -51,7 +51,7 @@ class Jetpack_Upgrade_Nudge {
 			<p class="editor-warning__message block-editor-warning__message">
 				<div class="jetpack-upgrade-nudge__info">
 				<!--<Gridicon class="jetpack-upgrade-nudge__icon" icon="star" size={ 18 } />-->
-				<div>
+				<div className="jetpack-upgrade-nudge__text-container">
 					<span class="jetpack-upgrade-nudge__title">
 						$title
 					</span>

--- a/extensions/blocks/simple-payments/view.js
+++ b/extensions/blocks/simple-payments/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import '../../shared/upgrade-nudge/style.scss';

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -13,6 +13,8 @@ class Jetpack_Simple_Payments {
 
 	static $css_classname_prefix = 'jetpack-simple-payments';
 
+	static $required_plan;
+
 	// Increase this number each time there's a change in CSS or JS to bust cache.
 	static $version = '0.25';
 
@@ -23,6 +25,7 @@ class Jetpack_Simple_Payments {
 		if ( ! self::$instance ) {
 			self::$instance = new self();
 			self::$instance->register_init_hooks();
+			self::$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'value_bundle' : 'jetpack_premium';
 		}
 		return self::$instance;
 	}
@@ -64,13 +67,12 @@ class Jetpack_Simple_Payments {
 		if ( $this->is_enabled_jetpack_simple_payments() ) {
 			jetpack_register_block( 'jetpack/simple-payments' );
 		} else {
-			$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'value_bundle' : 'jetpack_premium';
 			Jetpack_Gutenberg::set_extension_unavailable(
 				'jetpack/simple-payments',
 				'missing_plan',
 				array(
 					'required_feature' => 'simple-payments',
-					'required_plan' => ( defined( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE' ) && JETPACK_SHOW_BLOCK_UPGRADE_NUDGE ) ? $required_plan : false
+					'required_plan' => ( defined( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE' ) && JETPACK_SHOW_BLOCK_UPGRADE_NUDGE ) ? self::$required_plan : false
 				)
 			);
 		}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -150,6 +150,7 @@ class Jetpack_Simple_Payments {
 		$data['id'] = $attrs['id'];
 
 		if( ! wp_style_is( 'jetpack-simple-payments', 'enqueued' ) ) {
+			wp_enqueue_style( 'wp-block-editor' );
 			wp_enqueue_style( 'jetpack-simple-payments' );
 		}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -176,30 +176,9 @@ class Jetpack_Simple_Payments {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		$css_prefix = self::$css_classname_prefix;
 
 		jetpack_require_lib( 'upgrade-nudge' );
-
-		return sprintf( '
-<div class="%1$s">
-	<div class="%2$s">
-		<div class="%3$s">
-			<div class="%4$s" id="%5$s">
-				<p>%6$s</p>
-				<p>%7$s</p>
-			</div>
-		</div>
-	</div>
-</div>
-',
-			esc_attr( "{$data['class']} ${css_prefix}-wrapper" ),
-			esc_attr( "${css_prefix}-product" ),
-			esc_attr( "${css_prefix}-details" ),
-			esc_attr( "${css_prefix}-purchase-message show error" ),
-			esc_attr( "{$data['dom_id']}-message-container" ),
-			Jetpack_Upgrade_Nudge::get_upgrade_message(),
-			esc_html__( '(Only administrators will see this message.)', 'jetpack' )
-		);
+		return Jetpack_Upgrade_Nudge::get_upgrade_nudge();
 	}
 
 	function output_shortcode( $data ) {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -154,6 +154,7 @@ class Jetpack_Simple_Payments {
 		}
 
 		if ( ! $this->is_enabled_jetpack_simple_payments() ) {
+			Jetpack_Gutenberg::load_assets_as_required( 'simple-payments' );
 			return $this->output_admin_warning( $data );
 		}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -178,9 +178,7 @@ class Jetpack_Simple_Payments {
 		}
 		$css_prefix = self::$css_classname_prefix;
 
-		$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-			? 'https://support.wordpress.com/simple-payments/'
-			: 'https://jetpack.com/support/simple-payment-button/';
+		jetpack_require_lib( 'upgrade-nudge' );
 
 		return sprintf( '
 <div class="%1$s">
@@ -199,13 +197,7 @@ class Jetpack_Simple_Payments {
 			esc_attr( "${css_prefix}-details" ),
 			esc_attr( "${css_prefix}-purchase-message show error" ),
 			esc_attr( "{$data['dom_id']}-message-container" ),
-			sprintf(
-				wp_kses(
-					__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-					array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
-				),
-				esc_url( $support_url )
-			),
+			Jetpack_Upgrade_Nudge::get_upgrade_message(),
 			esc_html__( '(Only administrators will see this message.)', 'jetpack' )
 		);
 	}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -182,7 +182,8 @@ class Jetpack_Simple_Payments {
 		}
 
 		jetpack_require_lib( 'upgrade-nudge' );
-		return Jetpack_Upgrade_Nudge::get_upgrade_nudge();
+
+		return Jetpack_Upgrade_Nudge::get_upgrade_nudge( self::$required_plan );
 	}
 
 	function output_shortcode( $data ) {

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -1,16 +1,8 @@
 <div class='jetpack-simple-payments-disabled-error'>
 	<p>
 		<?php
-			$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-				? 'https://support.wordpress.com/simple-payments/'
-				: 'https://jetpack.com/support/simple-payment-button/';
-			printf(
-				wp_kses(
-					__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
-					array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
-				),
-				esc_url( $support_url )
-			);
+			jetpack_require_lib( 'upgrade-nudge' );
+			echo Jetpack_Upgrade_Nudge::get_upgrade_message();
 		?>
 	</p>
 </div>


### PR DESCRIPTION
Fixes #13040

#### Changes proposed in this Pull Request:

Move the existing frontend upgrade nudge from the Simple Payments module into a shared library, parametrize it for use with other blocks, and style it akin to its editor (JS) counterpart .

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Modifies an existing part

#### Testing instructions:
TBD

#### Proposed changelog entry for your changes:

TBD
(Test both the block and the widget!)

#### TODO

- Need `Warning` component styling from `@wordpress/block-editor`.
- The way I'm adding styling is currently a bit ugly. We should really build an `UpgradeNudge` specific CSS file (rather than piggy-backing on the view-side mechanism for `SimplePayments`), and enqueue it from `_lib/inc/upgrade-nudge.php`)