### PR TITLE
Upgrade nudge: Improve theme style leaking in

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -30,7 +30,7 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 	>
 		<div className="jetpack-upgrade-nudge__info">
 			<GridiconStar className="jetpack-upgrade-nudge__icon" size={ 18 } />
-			<div>
+			<div className="jetpack-upgrade-nudge__text-container">
 				<span className="jetpack-upgrade-nudge__title">
 					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {
 						planName,

--- a/extensions/shared/upgrade-nudge/style.scss
+++ b/extensions/shared/upgrade-nudge/style.scss
@@ -1,15 +1,25 @@
+// Some styling here could inherit from Warning component, but is needed to
+// override some overzealous theme editor styling.
+
 .jetpack-upgrade-nudge {
-	&.block-editor-warning {
+	// Necessary extra specificity
+	&.editor-warning {
 		margin-bottom: 0;
 	}
 
-	// Override `.editor-styles-wrapper p` style overrides on WordPress.com
 	.editor-warning__message {
-		margin: 1em 0;
+		margin: 13px 0;
 	}
 
 	.editor-warning__actions {
 		line-height: 1;
+	}
+
+	.jetpack-upgrade-nudge__info {
+		font-size: 13px;
+		display: flex;
+		flex-direction: row;
+		line-height: 1.4;
 	}
 
 	.jetpack-upgrade-nudge__icon {
@@ -24,9 +34,9 @@
 		padding: 6px;
 	}
 
-	.jetpack-upgrade-nudge__info {
+	.jetpack-upgrade-nudge__text-container {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 	}
 
 	.jetpack-upgrade-nudge__title {
@@ -35,6 +45,5 @@
 
 	.jetpack-upgrade-nudge__message {
 		color: var( --color-text-subtle );
-		display: block;
 	}
 }


### PR DESCRIPTION
Improve styling isolation to protect theme styling leaking in. Fixes https://github.com/Automattic/jetpack/issues/13011

## Screens

### Before

#### Expected (control)

![Screen Shot 2019-07-17 at 15 08 10](https://user-images.githubusercontent.com/841763/61378154-06e12780-a8a5-11e9-9f53-22f5b30fa7c5.png)

#### Problematic theme (Independent Publisher 2)

![Screen Shot 2019-07-17 at 15 07 57](https://user-images.githubusercontent.com/841763/61378169-11032600-a8a5-11e9-9b01-3b09d1165da3.png)

### After

#### Expected (control)

![Screen Shot 2019-07-17 at 18 18 30](https://user-images.githubusercontent.com/841763/61392589-706e2f80-a8bf-11e9-972b-00fc25f8abc4.png)


#### Problematic theme (Independent Publisher 2)

![Screen Shot 2019-07-17 at 18 18 36](https://user-images.githubusercontent.com/841763/61392596-73692000-a8bf-11e9-9365-40bead965719.png)

## Testing
- You'll need to set the constant `define( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- With a site on a free plan, add the Simple Payments block.
- Make sure the nudge displays as expected (see screenshots).
- Apply D30524-code and sandbox a Simple site on a free plan.
- Use "Independent Publisher 2" and verify that the nudge display is improved.