### PR TITLE
Upgrade nudge: Use spans for layout - divs are invalid p descendent

### DIFF
--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -28,7 +28,7 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 		] }
 		className="jetpack-upgrade-nudge"
 	>
-		<div className="jetpack-upgrade-nudge__info">
+		<span className="jetpack-upgrade-nudge__info">
 			<GridiconStar
 				className="jetpack-upgrade-nudge__icon"
 				size={ 18 }
@@ -36,7 +36,7 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 				role="img"
 				focusable="false"
 			/>
-			<div className="jetpack-upgrade-nudge__text-container">
+			<span className="jetpack-upgrade-nudge__text-container">
 				<span className="jetpack-upgrade-nudge__title">
 					{ sprintf( __( 'This block is available under the %(planName)s Plan.', 'jetpack' ), {
 						planName,
@@ -45,8 +45,8 @@ const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName } ) => (
 				<span className="jetpack-upgrade-nudge__message">
 					{ __( 'It will be hidden from site visitors until you upgrade.', 'jetpack' ) }
 				</span>
-			</div>
-		</div>
+			</span>
+		</span>
 	</Warning>
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Gutenberg `Warning` wraps content in `p`, which should not have `div` descendants. Use `spans` for layout.

No visual changes.

#### Screens

##### Before

![Screen Shot 2019-07-17 at 14 10 40](https://user-images.githubusercontent.com/841763/61374493-c382bb00-a89c-11e9-940c-9704717b9253.png)


![Screen Shot 2019-07-17 at 14 11 17](https://user-images.githubusercontent.com/841763/61374491-c382bb00-a89c-11e9-80ab-9b87f89de2b3.png)

##### After

![Screen Shot 2019-07-17 at 14 09 42](https://user-images.githubusercontent.com/841763/61374430-9f26de80-a89c-11e9-972e-632381f33b3f.png)

![Screen Shot 2019-07-17 at 14 10 05](https://user-images.githubusercontent.com/841763/61374428-9e8e4800-a89c-11e9-820e-0525a35b622d.png)

#### Testing instructions:

- You'll need to set the constant `define( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- With a site on a free plan, add the Simple Payments block.
- Make sure the nudge displays as expected (see screenshots).

#### Proposed changelog entry for your changes:

None.