### PR TITLE
Unit Tests: Fix WooCommerce tests bootstrap

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -29,18 +29,17 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 
 		// This is taken from WooCommerce's bootstrap.php file
 
-		// factories
-		require_once( $woo_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook.php' );
-		require_once( $woo_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook-delivery.php' );
-
 		// framework
 		require_once( $woo_tests_dir . '/framework/class-wc-unit-test-factory.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-mock-session-handler.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-mock-wc-data.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-mock-wc-object-query.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-mock-payment-gateway.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-payment-token-stub.php' );
 		// require_once( $woo_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
 
 		// test cases
+		require_once( $woo_tests_dir . '/includes/wp-http-testcase.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-unit-test-case.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-api-unit-test-case.php' );
 		require_once( $woo_tests_dir . '/framework/class-wc-rest-unit-test-case.php' );


### PR DESCRIPTION
Currently, WooCommerce tests are broken. We tried to add some test cases in #13079, but we were unable to run the tests.

The reason seems to be simple: our WooCommerce tests have a hardcoded bit where they load files from the WooCommerce test framework (borrowed from their unit test bootstrap), and some of the file names were obsolete.

This PR fixes those by using the includes from the latest WooCommerce master.

#### Changes proposed in this Pull Request:
* Unit Tests: Fix WooCommerce tests bootstrap

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Needed for #13079.

#### Testing instructions:
* Checkout this branch.
* Make sure you have the latest WooCommerce git repo checked out in `/docker/wp-content/plugins/woocommerce`, and WooCommerce is built (`composer install`, `npm install`, `npm run build` in the woo dir does the job).
* Navigate to the Jetpack repo root.
* Run `yarn docker:sh` 
* While in the shell, run `cd wp-content/plugins/jetpack`
* Run `JETPACK_TEST_WOOCOMMERCE=1 phpunit --filter WP_Test_Jetpack_Sync_WooCommerce`
* Verify tests work and pass ✅ 

#### Proposed changelog entry for your changes:
* Unit Tests: Fix WooCommerce tests bootstrap
