### PR TITLE
Upgrade nudge: Remove feature gate

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -72,7 +72,7 @@ class Jetpack_Simple_Payments {
 				'missing_plan',
 				array(
 					'required_feature' => 'simple-payments',
-					'required_plan' => ( defined( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE' ) && JETPACK_SHOW_BLOCK_UPGRADE_NUDGE ) ? self::$required_plan : false
+					'required_plan'    => self::$required_plan,
 				)
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The feature is live on WordPress.com and can be shipped also to Jetpack customers.

Remove the feature gating.

![image](https://user-images.githubusercontent.com/87168/62030947-e2634480-b1ee-11e9-95b8-5b021cb825b2.png)

(Just "WordPress.com Premium" would be "Jetpack Premium" instead)


#### Testing instructions:

- This change removes the need for this to test changes related to the nudge. ~You'll need to set the constant `define( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`~
- With a site on a free plan, add the Simple Payments block.
- Make sure the block is available with the nudge.

#### Proposed changelog entry for your changes:

None.