### PR TITLE
Fixed variable name to the defined one.

### DIFF
--- a/packages/analyzer/src/Differences/Class_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Moved.php
@@ -29,7 +29,7 @@ class Class_Moved extends PersistentListItem implements Invocation_Warner {
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation->depends_on( $this->declaration ) ) {
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(
 				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
 			);


### PR DESCRIPTION
As `Class_Moved::$declaraion` is not defined, it generates a lot of notices and does not work correctly. I'm guessing the invociation should check for `$old_declaration`.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Running the Analyzer tool, I was getting a lot of
`Notice: Undefined property: Automattic\Jetpack\Analyzer\Differences\Class_Moved::$declaration in .../jetpack/packages/analyzer/src/Differences/Class_Moved.php on line 32`. My guess is that the check should happen against `old_declaration`.


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
When running the compat test for WC core, I noticed this problem. Details of setup along with scripts to run are available in this p2 post: pb22l9-1D-p2


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed variable name in Analyzer module `Class_Moved`.