### PR TITLE
Sync: Fix PHPCS errors in Codec interface

### DIFF
--- a/packages/sync/src/Codec_Interface.php
+++ b/packages/sync/src/Codec_Interface.php
@@ -1,16 +1,44 @@
 <?php
+/**
+ * Interface for encoding and decoding sync objects.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
 /**
- * Very simple interface for encoding and decoding input
- * This is used to provide compression and serialization to messages
+ * Very simple interface for encoding and decoding input.
+ * This is used to provide compression and serialization to messages.
  **/
 interface Codec_Interface {
-	// we send this with the payload so we can select the appropriate decoder at the other end
+	/**
+	 * Retrieve the name of the codec.
+	 * We send this with the payload so we can select the appropriate decoder at the other end.
+	 *
+	 * @access public
+	 *
+	 * @return string Name of the codec.
+	 */
 	public function name();
 
+	/**
+	 * Encode a sync object.
+	 *
+	 * @access public
+	 *
+	 * @param mixed $object Sync object to encode.
+	 * @return string Encoded sync object.
+	 */
 	public function encode( $object );
 
+	/**
+	 * Encode a sync object.
+	 *
+	 * @access public
+	 *
+	 * @param string $input Encoded sync object to decode.
+	 * @return mixed Decoded sync object.
+	 */
 	public function decode( $input );
 }


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, we've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the Codec interface.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in Codec interface.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is just a cleanup PR.

#### Testing instructions:
* Not necessary, we're only adding docs.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in Codec interface.
