### PR TITLE
Sync: Fix PHPCS errors in the Queue_Buffer

### DIFF
--- a/packages/sync/src/Queue_Buffer.php
+++ b/packages/sync/src/Queue_Buffer.php
@@ -1,27 +1,77 @@
 <?php
+/**
+ * Sync queue buffer.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
 /**
- * A buffer of items from the queue that can be checked out
+ * A buffer of items from the queue that can be checked out.
  */
 class Queue_Buffer {
+	/**
+	 * Sync queue buffer ID.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
 	public $id;
+
+	/**
+	 * Sync items.
+	 *
+	 * @access public
+	 *
+	 * @var array
+	 */
 	public $items_with_ids;
 
+	/**
+	 * Constructor.
+	 * Initializes the queue buffer.
+	 *
+	 * @access public
+	 *
+	 * @param int   $id             Sync queue buffer ID.
+	 * @param array $items_with_ids Items for the buffer to work with.
+	 */
 	public function __construct( $id, $items_with_ids ) {
 		$this->id             = $id;
 		$this->items_with_ids = $items_with_ids;
 	}
 
+	/**
+	 * Retrieve the sync items in the buffer, in an ID => value form.
+	 *
+	 * @access public
+	 *
+	 * @return array Sync items in the buffer.
+	 */
 	public function get_items() {
 		return array_combine( $this->get_item_ids(), $this->get_item_values() );
 	}
 
+	/**
+	 * Retrieve the values of the sync items in the buffer.
+	 *
+	 * @access public
+	 *
+	 * @return array Sync items values.
+	 */
 	public function get_item_values() {
 		return Utils::get_item_values( $this->items_with_ids );
 	}
 
+	/**
+	 * Retrieve the IDs of the sync items in the buffer.
+	 *
+	 * @access public
+	 *
+	 * @return array Sync items IDs.
+	 */
 	public function get_item_ids() {
 		return Utils::get_item_ids( $this->items_with_ids );
 	}


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, we've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the the Queue Buffer.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in the Queue Buffer.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is just a cleanup PR.

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in the Queue Buffer.
