### PR TITLE
Sync: Fix remaining PHPCS errors in sync modules

### DIFF
--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -405,7 +405,7 @@ class Callables extends Module {
 				return;
 			}
 		}
-		
+
 		if ( empty( $callables ) ) {
 			return;
 		}

--- a/packages/sync/src/modules/Users.php
+++ b/packages/sync/src/modules/Users.php
@@ -814,25 +814,25 @@ class Users extends Module {
 	 *
 	 * @access protected
 	 *
-	 * @param $names Mixed string name of function or array of string names of functions.
+	 * @param array|string $names Mixed string name of function or array of string names of functions.
 	 * @return bool
 	 */
 	protected function is_function_in_backtrace( $names ) {
-		$backtrace = debug_backtrace( false ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.debug_backtrace_optionsFound
+		$backtrace = debug_backtrace( false ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 		if ( ! is_array( $names ) ) {
 			$names = array( $names );
 		}
 		$names_as_keys = array_flip( $names );
 
-		//Do check in constant O(1) time for PHP5.5+
+		// Do check in constant O(1) time for PHP5.5+.
 		if ( function_exists( 'array_column' ) ) {
-			$backtrace_functions = array_column( $backtrace, 'function' ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_columnFound
+			$backtrace_functions         = array_column( $backtrace, 'function' ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_columnFound
 			$backtrace_functions_as_keys = array_flip( $backtrace_functions );
-			$intersection = array_intersect_key( $backtrace_functions_as_keys, $names_as_keys );
-			return ! empty ( $intersection );
+			$intersection                = array_intersect_key( $backtrace_functions_as_keys, $names_as_keys );
+			return ! empty( $intersection );
 		}
 
-		//Do check in linear O(n) time for < PHP5.5 ( using isset at least prevents O(n^2) )
+		// Do check in linear O(n) time for < PHP5.5 ( using isset at least prevents O(n^2) ).
 		foreach ( $backtrace as $call ) {
 			if ( isset( $names_as_keys[ $call['function'] ] ) ) {
 				return true;


### PR DESCRIPTION
Committing changes on sync these days has been a pain with all the lint errors. We often had to commit with `--no-verify` and that's not great. And after #12945, even that's no longer a good option. 

So, we've decided to fix all the phpcs errors and warnings in the sync package.

This PR does it for the the remaining files with errors in the modules directory.

#### Changes proposed in this Pull Request:
* Sync: Fix PHPCS errors in the modules directory.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is just a cleanup PR.

#### Testing instructions:
* Shouldn't be necessary, but if you are into it, perform some smoke testing of full sync and incremental sync.

#### Proposed changelog entry for your changes:
* Sync: Fix PHPCS errors in the modules directory.
