### PR TITLE
Save a post revision when overwriting an old autosave with a significantly different new one

### DIFF
--- a/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
@@ -44,6 +44,9 @@ class WPCOM_JSON_API_Autosave_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_
 
 	// /sites/%s/posts/%d/autosave -> $blog_id, $post_id
 	function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
+		if ( ! defined( 'DOING_AUTOSAVE' ) ) {
+			define( 'DOING_AUTOSAVE', true );
+		}
 
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {


### PR DESCRIPTION
Summary:
When a post is autosaved, we don't create a post revision for that save. On multiple
consecutive autosaves, we overwrite the old autosave (i.e., the post itself in case of drafts or
an autosave revision in case of published posts) and its content is lost forever.

This patch adds a plugin that hooks into the "post_updated" action, intercepts the updates
that overwrite an old autosave with a new one, compares the old and new autosaves, determines
if they are significantly different from each other and if they are, saves the old autosave as a separate post revision.

This prevents losing valuable unsaved content in case an autosave goes awry, e.g., it empties
the post content due to an editor bug or unwanted edit.

The patch has three parts:
- fix the autosave REST endpoint by defining `DOING_AUTOSAVE` there. That define tells the `post_update` filters that autosave is done and alters the revision-saving behavior. Already done in the equivalent Core autosave endpoints introduced as part of Gutenberg.
- modify Core code to extract the `wp_post_has_changed_since_last_revision` function out of `wp_save_post_revision` (should be submitted to Core after reviewed). We use it to prevent saving a revision if the last saved revision is identical.
- finally implement the plugin to save the old autosave as permanent revision.

Test Plan:
- edit a draft or published post in various editors (Classic or Block in Calypso or wp-admin)
- add one character and wait for autosave. Check that permanent revision was not created
- add 5+ characters and wait for autosave. Check that permanent revision was created from the previous autosave (+1 char edit)
- start editing again from a fully saved state. Add 5+ characters and wait for autosave. Check that permanent revision was not created: the content before the autosave already has a revision!

Reviewers: donpark, azaozz

Reviewed By: donpark

Subscribers: mbiais, jaysonbasanes

Tags: #touches_jetpack_files

Differential Revision: D30389-code

This commit syncs r194378-wpcom.