### PR TITLE
Add check for local files before processing post images in Photon

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -287,7 +287,6 @@ class Jetpack_Photon {
 			$content_width = Jetpack::get_content_width();
 
 			$image_sizes = self::image_sizes();
-			$upload_dir = wp_get_upload_dir();
 
 			foreach ( $images[0] as $index => $tag ) {
 				// Default to resize, though fit may be used in certain cases where a dimension cannot be ascertained

--- a/class.photon.php
+++ b/class.photon.php
@@ -1295,7 +1295,7 @@ class Jetpack_Photon {
 	}
 
 	/**
-	 * Checks if image is a locally upload file via it's URL
+	 * Checks if image is a locally uploaded file via its URL
 	 *
 	 * @param string $url
 	 *

--- a/class.photon.php
+++ b/class.photon.php
@@ -1086,7 +1086,9 @@ class Jetpack_Photon {
 		$stripped_src = $src;
 
 		// Build URL, first removing WP's resized string so we pass the original image to Photon
-		if ( preg_match( '#(-\d+x\d+)\.(' . implode('|', self::$extensions ) . '){1}$#i', $src, $src_parts ) ) {
+		if ( self::is_local_upload( $src ) &&
+			preg_match( '#(-\d+x\d+)\.(' . implode('|', self::$extensions ) . '){1}$#i', $src, $src_parts ) )
+		{
 			$stripped_src = str_replace( $src_parts[1], '', $src );
 			$upload_dir = wp_get_upload_dir();
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -358,7 +358,7 @@ class Jetpack_Photon {
 					// WP Attachment ID, if uploaded to this site
 					if (
 						preg_match( '#class=["|\']?[^"\']*wp-image-([\d]+)[^"\']*["|\']?#i', $images['img_tag'][ $index ], $attachment_id ) &&
-						0 === strpos( $src, $upload_dir['baseurl'] ) &&
+						self::is_local_upload( $src ) &&
 						/**
 						 * Filter whether an image using an attachment ID in its class has to be uploaded to the local site to go through Photon.
 						 *
@@ -1290,5 +1290,18 @@ class Jetpack_Photon {
 	 */
 	private static function is_amp_endpoint() {
 		return class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+	}
+
+	/**
+	 * Checks if image is a locally upload file via it's URL
+	 *
+	 * @param string $url
+	 *
+	 * @return bool
+	 */
+	public static function is_local_upload( $url ) {
+		$upload_dir = wp_get_upload_dir();
+
+		return 0 === strpos( $url, $upload_dir['baseurl'] );
 	}
 }

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1054,4 +1054,37 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
 		$this->assertContains( '?', $data['media_details']['sizes']['medium_large']['source_url'] );
 		}
+	}
+
+	/**
+	 * @covers Jetpack_Photon::strip_image_dimensions_maybe
+	 */
+	public function test_photon_strip_image_dimensions_maybe_ignores_external_files() {
+		$ext_domain = 'https://some.domain/wp-content/uploads/2019/1/test-image-300x300.jpg';
+
+		$this->assertEquals( $ext_domain, Jetpack_Photon::strip_image_dimensions_maybe( $ext_domain ) );
+	}
+
+	/**
+	 * @covers Jetpack_Photon::strip_image_dimensions_maybe
+	 */
+	public function test_photon_strip_image_dimensions_maybe_strips_resized_string() {
+		$orig_filename = '2004-07-22-DSC_0007.jpg';
+		$filename = '2004-07-22-DSC_0007-150x150.jpg';
+		$filepath = DIR_TESTDATA . '/images/' . $orig_filename;
+		$contents = file_get_contents( $filepath );
+
+		$upload = wp_upload_bits( basename( $filepath ), null, $contents );
+
+		$upload_dir = wp_get_upload_dir();
+
+		$id  = $this->_make_attachment( $upload );
+		$url = $upload_dir['url'] . '/' . $filename;
+
+		$expected = wp_get_attachment_url( $id );
+
+		$this->assertEquals( $expected, Jetpack_Photon::strip_image_dimensions_maybe( $url ) );
+
+		wp_delete_attachment( $id );
+	}
 }

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1053,7 +1053,6 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 
 		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
 		$this->assertContains( '?', $data['media_details']['sizes']['medium_large']['source_url'] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
#### Summary

In `Jetpack_Photon::filter_the_content`, the call to `strip_image_dimensions_maybe` is outside the `if` clause that checks for local uploads. This is problematic because `strip_image_dimensions_maybe` only checks if the filename has the image dimensions string, e.g.: `300x300`, and then calls `file_exists` on this file after removing the image dimensions and prepending the `basedir`. If a file is hosted externally, like on a CDN, the call to `file_exists` will only return false. Additionally, if the site is using a custom Stream wrapper implementation to upload files to the CDN, these `file_exists` calls results in a lot of requests to the CDN that returns `404` status. This means those requests are uncached and would slow down the site load times.

#### Changes proposed in this Pull Request:
* Create a dedicated function to check if a file is locally uploaded or not.
* Add the local file check into `strip_image_dimensions_maybe`.

#### Testing instructions:
_Note: Tested on a site hosted on VIP Go._

* Enable Jetpack Photon for site.
* Create a new post with an image that's hosted externally and with a filename that has ends in something like `-300x300.jpg`.
* Visit post and make sure there's no external calls to CDN that results in a `404` response.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add check for local file upload before processing post images with Photon
