### PR TITLE
Sync Callables that should be always sent on WP_CLI

### DIFF
--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -394,8 +394,10 @@ class Callables extends Module {
 		$callables = $this->get_all_callables();
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
 			if ( ! is_admin() ) {
-				// If we're not an admin and we're not doing cron, don't sync anything.
-				if ( ! Settings::is_doing_cron() ) {
+				// If we're not an admin and we're not doing cron and this isn't WP_CLI, don't sync anything.
+				if ( ! Settings::is_doing_cron() &&
+					 ! ( defined( 'WP_CLI' ) && WP_CLI )
+				) {
 					return;
 				}
 				// If we're not an admin and we are doing cron, sync the Callables that are always supposed to sync ( See https://github.com/Automattic/jetpack/issues/12924 ).

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -395,9 +395,7 @@ class Callables extends Module {
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
 			if ( ! is_admin() ) {
 				// If we're not an admin and we're not doing cron and this isn't WP_CLI, don't sync anything.
-				if ( ! Settings::is_doing_cron() &&
-					 ! ( defined( 'WP_CLI' ) && WP_CLI )
-				) {
+				if ( ! Settings::is_doing_cron() && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 					return;
 				}
 				// If we're not an admin and we are doing cron, sync the Callables that are always supposed to sync ( See https://github.com/Automattic/jetpack/issues/12924 ).

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Settings;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 
 /**
  * Class to handle sync for callables.
@@ -395,7 +396,7 @@ class Callables extends Module {
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
 			if ( ! is_admin() ) {
 				// If we're not an admin and we're not doing cron and this isn't WP_CLI, don't sync anything.
-				if ( ! Settings::is_doing_cron() && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+				if ( ! Settings::is_doing_cron() && ! Jetpack_Constants::get_constant( 'WP_CLI' ) ) {
 					return;
 				}
 				// If we're not an admin and we are doing cron, sync the Callables that are always supposed to sync ( See https://github.com/Automattic/jetpack/issues/12924 ).


### PR DESCRIPTION
Companion to https://github.com/Automattic/jetpack/pull/13015, this PR will invoke sync for certain whitelisted Callables when options change via WP_CLI

#### Changes proposed in this Pull Request:
This PR will invoke sync for certain whitelisted Callables when options change via WP_CLI

#### Testing instructions:
See testing instructions here, https://github.com/Automattic/jetpack/pull/13015

#### Proposed changelog entry for your changes:
Sync whitelisted callables via WP_CLI