### PR TITLE
Sync: Remove DEFAULT_SYNC_MODULES legacy map

### DIFF
--- a/packages/sync/src/class-modules.php
+++ b/packages/sync/src/class-modules.php
@@ -154,15 +154,4 @@ class Modules {
 		}
 		return $module;
 	}
-
-	/**
-	 * Reset the initialized modules.
-	 * Will force a new fresh loading of all known modules.
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function reset_modules() {
-		self::$initialized_modules = null;
-	}
 }

--- a/packages/sync/src/class-modules.php
+++ b/packages/sync/src/class-modules.php
@@ -155,4 +155,14 @@ class Modules {
 		return $module;
 	}
 
+	/**
+	 * Reset the initialized modules.
+	 * Will force a new fresh loading of all known modules.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public static function reset_modules() {
+		self::$initialized_modules = null;
+	}
 }

--- a/packages/sync/src/class-modules.php
+++ b/packages/sync/src/class-modules.php
@@ -21,53 +21,25 @@ class Modules {
 	 * @var array
 	 */
 	const DEFAULT_SYNC_MODULES = array(
-		'Jetpack_Sync_Modules_Constants',
-		'Jetpack_Sync_Modules_Callables',
-		'Jetpack_Sync_Modules_Network_Options',
-		'Jetpack_Sync_Modules_Options',
-		'Jetpack_Sync_Modules_Terms',
-		'Jetpack_Sync_Modules_Menus',
-		'Jetpack_Sync_Modules_Themes',
-		'Jetpack_Sync_Modules_Users',
-		'Jetpack_Sync_Modules_Import',
-		'Jetpack_Sync_Modules_Posts',
-		'Jetpack_Sync_Modules_Protect',
-		'Jetpack_Sync_Modules_Comments',
-		'Jetpack_Sync_Modules_Updates',
-		'Jetpack_Sync_Modules_Attachments',
-		'Jetpack_Sync_Modules_Meta',
-		'Jetpack_Sync_Modules_Plugins',
-		'Jetpack_Sync_Modules_Stats',
-		'Jetpack_Sync_Modules_Full_Sync',
+		'Automattic\\Jetpack\\Sync\\Modules\\Constants',
+		'Automattic\\Jetpack\\Sync\\Modules\\Callables',
+		'Automattic\\Jetpack\\Sync\\Modules\\Network_Options',
+		'Automattic\\Jetpack\\Sync\\Modules\\Options',
+		'Automattic\\Jetpack\\Sync\\Modules\\Terms',
+		'Automattic\\Jetpack\\Sync\\Modules\\Menus',
+		'Automattic\\Jetpack\\Sync\\Modules\\Themes',
+		'Automattic\\Jetpack\\Sync\\Modules\\Users',
+		'Automattic\\Jetpack\\Sync\\Modules\\Import',
+		'Automattic\\Jetpack\\Sync\\Modules\\Posts',
+		'Automattic\\Jetpack\\Sync\\Modules\\Protect',
+		'Automattic\\Jetpack\\Sync\\Modules\\Comments',
+		'Automattic\\Jetpack\\Sync\\Modules\\Updates',
+		'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
+		'Automattic\\Jetpack\\Sync\\Modules\\Meta',
+		'Automattic\\Jetpack\\Sync\\Modules\\Plugins',
+		'Automattic\\Jetpack\\Sync\\Modules\\Stats',
+		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
 		'Automattic\\Jetpack\\Sync\\Modules\\Term_Relationships',
-	);
-
-	/**
-	 * Maps classnames of sync modules before to v7.5 to classnames of sync modules after v7.5.
-	 *
-	 * @access public
-	 *
-	 * @var array
-	 */
-	const LEGACY_SYNC_MODULES_MAP = array(
-		'Jetpack_Sync_Modules_Constants'       => 'Automattic\\Jetpack\\Sync\\Modules\\Constants',
-		'Jetpack_Sync_Modules_Callables'       => 'Automattic\\Jetpack\\Sync\\Modules\\Callables',
-		'Jetpack_Sync_Modules_Network_Options' => 'Automattic\\Jetpack\\Sync\\Modules\\Network_Options',
-		'Jetpack_Sync_Modules_Options'         => 'Automattic\\Jetpack\\Sync\\Modules\\Options',
-		'Jetpack_Sync_Modules_Terms'           => 'Automattic\\Jetpack\\Sync\\Modules\\Terms',
-		'Jetpack_Sync_Modules_Menus'           => 'Automattic\\Jetpack\\Sync\\Modules\\Menus',
-		'Jetpack_Sync_Modules_Themes'          => 'Automattic\\Jetpack\\Sync\\Modules\\Themes',
-		'Jetpack_Sync_Modules_Users'           => 'Automattic\\Jetpack\\Sync\\Modules\\Users',
-		'Jetpack_Sync_Modules_Import'          => 'Automattic\\Jetpack\\Sync\\Modules\\Import',
-		'Jetpack_Sync_Modules_Posts'           => 'Automattic\\Jetpack\\Sync\\Modules\\Posts',
-		'Jetpack_Sync_Modules_Protect'         => 'Automattic\\Jetpack\\Sync\\Modules\\Protect',
-		'Jetpack_Sync_Modules_Comments'        => 'Automattic\\Jetpack\\Sync\\Modules\\Comments',
-		'Jetpack_Sync_Modules_Updates'         => 'Automattic\\Jetpack\\Sync\\Modules\\Updates',
-		'Jetpack_Sync_Modules_Attachments'     => 'Automattic\\Jetpack\\Sync\\Modules\\Attachments',
-		'Jetpack_Sync_Modules_Meta'            => 'Automattic\\Jetpack\\Sync\\Modules\\Meta',
-		'Jetpack_Sync_Modules_Plugins'         => 'Automattic\\Jetpack\\Sync\\Modules\\Plugins',
-		'Jetpack_Sync_Modules_Stats'           => 'Automattic\\Jetpack\\Sync\\Modules\\Stats',
-		'Jetpack_Sync_Modules_Full_Sync'       => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
 	);
 
 	/**
@@ -146,11 +118,9 @@ class Modules {
 		 */
 		$modules = apply_filters( 'jetpack_sync_modules', self::DEFAULT_SYNC_MODULES );
 
-		$modules = array_map( array( 'Automattic\\Jetpack\\Sync\\Modules', 'map_legacy_modules' ), $modules );
+		$modules = array_map( array( __CLASS__, 'load_module' ), $modules );
 
-		$modules = array_map( array( 'Automattic\\Jetpack\\Sync\\Modules', 'load_module' ), $modules );
-
-		return array_map( array( 'Automattic\\Jetpack\\Sync\\Modules', 'set_module_defaults' ), $modules );
+		return array_map( array( __CLASS__, 'set_module_defaults' ), $modules );
 	}
 
 	/**
@@ -165,25 +135,6 @@ class Modules {
 	 */
 	public static function load_module( $module_class ) {
 		return new $module_class();
-	}
-
-	/**
-	 * For backwards compat, takes the classname of a given module pre Jetpack 7.5,
-	 * and returns the new namespaced classname.
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @param string $module_class The classname of a Jetpack sync module.
-	 *
-	 * @return string
-	 */
-	public static function map_legacy_modules( $module_class ) {
-		$legacy_map = self::LEGACY_SYNC_MODULES_MAP;
-		if ( isset( $legacy_map[ $module_class ] ) ) {
-			return $legacy_map[ $module_class ];
-		}
-		return $module_class;
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -188,7 +188,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create_many( 2 );
 		$this->sender->do_sync();
 
-		$this->assertFalse( empty( $this->server_event_storage->get_all_events() ) );
+		$this->assertFalse( empty(  $this->server_event_storage->get_all_events() ) );
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -188,7 +188,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create_many( 2 );
 		$this->sender->do_sync();
 
-		$this->assertFalse( empty(  $this->server_event_storage->get_all_events() ) );
+		$this->assertFalse( empty( $this->server_event_storage->get_all_events() ) );
 	}
 
 	/**


### PR DESCRIPTION
Remove LEGACY_SYNC_MODULES_MAP,  it has passed more than half a year since we moved to the new Class names. 

It would be good to merge this one early in the cycle and maybe inform VIP and make sure they aren't using `apply_filters( 'jetpack_sync_modules', self::DEFAULT_SYNC_MODULES );`

### How to test

* Play with Sync, does it still work? no Errors/Warnings?