### PR TITLE
Remove parentheses from list table view counts when Calypsofying.

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -68,6 +68,8 @@ class Jetpack_Calypsoify {
 		add_action( 'manage_plugins_custom_column', array( $this, 'manage_plugins_custom_column' ), 10, 2 );
 		add_filter( 'bulk_actions-plugins', array( $this, 'bulk_actions_plugins' ) );
 
+		add_action( 'current_screen', array( $this, 'attach_views_filter' ) );
+
 		if ( 'plugins.php' === basename( $_SERVER['PHP_SELF'] ) ) {
 			add_action( 'admin_notices', array( $this, 'plugins_admin_notices' ) );
 		}
@@ -478,6 +480,27 @@ class Jetpack_Calypsoify {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Attach a WP_List_Table views filter to all screens.
+	 */
+	public function attach_views_filter( $current_screen ) {
+		add_filter( "views_{$current_screen->id}", array( $this, 'filter_views' ) );
+	}
+
+	/**
+	 * Remove the parentheses from list table view counts when Calypsofied.
+	 * 
+	 * @param array $views Array of views. See: WP_List_Table::get_views().
+	 * @return array Filtered views.
+	 */
+	public function filter_views( $views ) {
+		foreach ( $views as $id => $view ) {
+			$views[ $id ] = preg_replace( '/<span class="count">\((\d+)\)<\/span>/', '<span class="count">$1</span>', $view );
+		}
+
+		return $views;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wc-calypso-bridge/issues/458.

Original issue:

> When viewing a post listing page, like orders, the type totals shown at the top have styling in place to emulate the `<Count />` component of calypso. But inside the count "bubble" the numbers are displayed inside parenthesis, which looks quite odd. Seems like we should just do one or the other.
> 
> ![order-counts-parens](https://user-images.githubusercontent.com/22080/61161064-f8ff6100-a4b6-11e9-8587-72f77e86b11a.png)


#### Changes proposed in this Pull Request:

* String replaces the list table counts from `(10)` to `10`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Posts listing
* Enable "calypsoify" by appending `?calypsoify=1` to the URL
* Verify there are no parentheses in the Post table view filters (All, Published, etc)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Changelog change probably isn't necessary
