### PR TITLE
Support links: use the Beta support form when on a dev version

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -10,11 +10,12 @@ import NoticeAction from 'components/notice/notice-action.jsx';
 /**
  * Internal dependencies
  */
+import { isDevVersion as _isDevVersion } from 'state/initial-state';
 import {
 	isNoticeDismissed as _isNoticeDismissed,
 	dismissJetpackNotice,
 } from 'state/jetpack-notices';
-import { JETPACK_CONTACT_SUPPORT } from 'constants/urls';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 
 class FeedbackDashRequest extends React.Component {
 	static displayName = 'FeedbackDashRequest';
@@ -24,6 +25,10 @@ class FeedbackDashRequest extends React.Component {
 			return;
 		}
 
+		const supportURl = this.props.isDevVersion
+			? JETPACK_CONTACT_BETA_SUPPORT
+			: JETPACK_CONTACT_SUPPORT;
+
 		return (
 			<div>
 				<SimpleNotice
@@ -32,7 +37,7 @@ class FeedbackDashRequest extends React.Component {
 					onDismissClick={ this.props.dismissNotice }
 					text={ __( 'What would you like to see on your Jetpack Dashboard?' ) }
 				>
-					<NoticeAction href={ JETPACK_CONTACT_SUPPORT }>{ __( 'Let us know!' ) }</NoticeAction>
+					<NoticeAction href={ supportURl }>{ __( 'Let us know!' ) }</NoticeAction>
 				</SimpleNotice>
 			</div>
 		);
@@ -46,6 +51,7 @@ class FeedbackDashRequest extends React.Component {
 export default connect(
 	state => {
 		return {
+			isDevVersion: _isDevVersion( state ),
 			isDismissed: notice => _isNoticeDismissed( state, notice ),
 		};
 	},

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -14,11 +14,11 @@ import analytics from 'lib/analytics';
  * Internal dependencies
  */
 import { PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
-import { isAtomicSite, getUpgradeUrl } from 'state/initial-state';
+import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getSiteConnectionStatus } from 'state/connection';
 import JetpackBanner from 'components/jetpack-banner';
-import { JETPACK_CONTACT_SUPPORT } from 'constants/urls';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 
 class SupportCard extends React.Component {
 	static displayName = 'SupportCard';
@@ -69,6 +69,10 @@ class SupportCard extends React.Component {
 				'undefined' === typeof this.props.sitePlan.product_slug ||
 				'jetpack_free' === this.props.sitePlan.product_slug;
 
+		const jetpackSupportURl = this.props.isDevVersion
+			? JETPACK_CONTACT_BETA_SUPPORT
+			: JETPACK_CONTACT_SUPPORT;
+
 		return (
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
@@ -85,7 +89,7 @@ class SupportCard extends React.Component {
 								href={
 									this.props.isAtomicSite
 										? 'https://wordpress.com/help/contact/'
-										: JETPACK_CONTACT_SUPPORT
+										: jetpackSupportURl
 								}
 							>
 								{ __( 'Ask a question' ) }
@@ -128,6 +132,7 @@ export default connect( state => {
 		siteConnectionStatus: getSiteConnectionStatus( state ),
 		isFetchingSiteData: isFetchingSiteData( state ),
 		isAtomicSite: isAtomicSite( state ),
+		isDevVersion: _isDevVersion( state ),
 		supportUpgradeUrl: getUpgradeUrl( state, 'support' ),
 	};
 } )( SupportCard );

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -94,6 +94,10 @@ class Jetpack_Debug_Data {
 	 * @return array $args Debug information in the same format as the initial argument.
 	 */
 	public static function core_debug_data( $debug ) {
+		$support_url = Jetpack::is_development_version()
+			? 'https://jetpack.com/contact-support/beta-group/'
+			: 'https://jetpack.com/contact-support/';
+
 		$jetpack = array(
 			'jetpack' => array(
 				'label'       => __( 'Jetpack', 'jetpack' ),
@@ -103,7 +107,7 @@ class Jetpack_Debug_Data {
 						'Diagnostic information helpful to <a href="%1$s" target="_blank" rel="noopener noreferrer">your Jetpack Happiness team<span class="screen-reader-text">%2$s</span></a>',
 						'jetpack'
 					),
-					esc_html( 'https://jetpack.com/contact-support/' ),
+					esc_url( $support_url ),
 					__( '(opens in a new tab)', 'jetpack' )
 				),
 				'fields'      => self::debug_data(),

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -79,6 +79,10 @@ class Jetpack_Debugger {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'jetpack' ) );
 		}
 
+		$support_url = Jetpack::is_development_version()
+			? 'https://jetpack.com/contact-support/beta-group/'
+			: 'https://jetpack.com/contact-support/';
+
 		$data       = Jetpack_Debug_Data::debug_data();
 		$debug_info = '';
 		foreach ( $data as $datum ) {
@@ -225,7 +229,7 @@ class Jetpack_Debugger {
 							__( '<a href="%1$s">Contact our Happiness team</a>. When you do, please include the <a href="%2$s">full debug information from your site</a>.', 'jetpack' ),
 							array( 'a' => array( 'href' => array() ) )
 						),
-						'https://jetpack.com/contact-support/',
+						esc_url( $support_url ),
 						esc_url( admin_url() . 'site-health.php?tab=debug' )
 					);
 					$hide_debug = true;
@@ -236,7 +240,7 @@ class Jetpack_Debugger {
 							__( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ),
 							array( 'a' => array( 'href' => array() ) )
 						),
-						'https://jetpack.com/contact-support/'
+						esc_url( $support_url )
 					);
 					$hide_debug = false;
 				}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-beta/issues/75

#### Changes proposed in this Pull Request:

If you use a development version of Jetpack, all contact support links (in the Debugger as well as in the Jetpack dashboard) now link to the beta support form.

#### Testing instructions:

* Go to Jetpack > Dashboard, or to Jetpack > Debug
* Scroll down and find the button / link to contact support
* That link should now point to https://jetpack.com/contact-support/beta-group/

#### Proposed changelog entry for your changes:

* Support links: use the Beta support form when on a development version
