### PR TITLE
Top Posts: allow one to customize avatar image options w/ filter

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -363,7 +363,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 					$image         = Jetpack_PostImages::get_image(
 						$post['post_id'],
 						array(
-							'fallback_to_avatars' => true,
+							'fallback_to_avatars' => (bool) $get_image_options['fallback_to_avatars'],
 							'width'               => (int) $width,
 							'height'              => (int) $height,
 							'avatar_size'         => (int) $get_image_options['avatar_size'],


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The `jetpack_top_posts_widget_image_options` filter allows third-parties to specify custom image options, including the fallback_to_avatars parameter. However we currently do not use the value that comes from the filter when we actually fetch the image. That fixes it.

#### Testing instructions:

* Create a new post without any image, and make sure it appears as one of the most visited posts in the Top Posts widget you add to your sidebar.
* By default, the post should show the author's Gravatar.
* Now add the following code snippet to your site:
```php
function jeherve_custom_top_posts_images( $get_image_options ) {
        $get_image_options['fallback_to_avatars'] = false;
  
        return $get_image_options;
}
add_filter( 'jetpack_top_posts_widget_image_options', 'jeherve_custom_top_posts_images' );
```
* The Gravatar should disappear.

#### Proposed changelog entry for your changes:

* Top Posts: allow one to customize avatar image options with a filter.
