### PR TITLE
Flickr Widget: Adds option to open Flickr images in a new tab

### DIFF
--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			return array(
 				'title'             => esc_html__( 'Flickr Photos', 'jetpack' ),
 				'items'             => 4,
+                'target'            => false,
 				'flickr_image_size' => 'thumbnail',
 				'flickr_rss_url'    => '',
 			);
@@ -129,8 +130,11 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 							break;
 					}
 
-					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '">';
-					$photos .= '<img src="' . esc_url( $src, array( 'http', 'https' ) ) . '" ';
+					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '" ';
+                    if ( $instance['target'] ) {
+                        $photos .= 'target="_blank" rel="noopener noreferrer" ';
+                    }
+					$photos .= '><img src="' . esc_url( $src, array( 'http', 'https' ) ) . '" ';
 					$photos .= 'alt="' . esc_attr( $photo->get_title() ) . '" ';
 					$photos .= 'title="' . esc_attr( $photo->get_title() ) . '" ';
 					$photos .= ' /></a>';
@@ -187,6 +191,10 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 
 			if ( isset( $new_instance['items'] ) ) {
 				$instance['items'] = intval( $new_instance['items'] );
+			}
+
+			if ( isset( $new_instance['target'] ) ) {
+				$instance['target'] = (bool) $new_instance['target'];
 			}
 
 			if (

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			return array(
 				'title'             => esc_html__( 'Flickr Photos', 'jetpack' ),
 				'items'             => 4,
-                'target'            => false,
+				'target'            => false,
 				'flickr_image_size' => 'thumbnail',
 				'flickr_rss_url'    => '',
 			);
@@ -131,9 +131,9 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 					}
 
 					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '" ';
-                    if ( $instance['target'] ) {
-                        $photos .= 'target="_blank" rel="noopener noreferrer" ';
-                    }
+					if ( $instance['target'] ) {
+						$photos .= 'target="_blank" rel="noopener noreferrer" ';
+					}
 					$photos .= '><img src="' . esc_url( $src, array( 'http', 'https' ) ) . '" ';
 					$photos .= 'alt="' . esc_attr( $photo->get_title() ) . '" ';
 					$photos .= 'title="' . esc_attr( $photo->get_title() ) . '" ';

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -52,6 +52,15 @@
 </p>
 
 <p>
+	<label>
+		<?php esc_html_e( 'Open images in new tab?', 'jetpack' ); ?>
+	</label>
+    <input type="checkbox"
+           name="<?php echo esc_attr( $this->get_field_name( 'target' ) ); ?>"
+           <?php checked( $instance['target'] ); ?>
+    />
+</p>
+<p>
 	<div>
 		<?php esc_html_e( 'What size photos would you like to display?', 'jetpack' ); ?>
 	</div>

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -53,13 +53,13 @@
 
 <p>
 	<label>
+		<input
+			type="checkbox"
+			name="<?php echo esc_attr( $this->get_field_name( 'target' ) ); ?>"
+			<?php checked( $instance['target'] ); ?>
+		/>
 		<?php esc_html_e( 'Open images in new tab?', 'jetpack' ); ?>
 	</label>
-	<input
-		type="checkbox"
-		name="<?php echo esc_attr( $this->get_field_name( 'target' ) ); ?>"
-		<?php checked( $instance['target'] ); ?>
-	/>
 </p>
 <p>
 	<div>

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -55,10 +55,11 @@
 	<label>
 		<?php esc_html_e( 'Open images in new tab?', 'jetpack' ); ?>
 	</label>
-    <input type="checkbox"
-           name="<?php echo esc_attr( $this->get_field_name( 'target' ) ); ?>"
-           <?php checked( $instance['target'] ); ?>
-    />
+	<input
+		type="checkbox"
+		name="<?php echo esc_attr( $this->get_field_name( 'target' ) ); ?>"
+		<?php checked( $instance['target'] ); ?>
+	/>
 </p>
 <p>
 	<div>


### PR DESCRIPTION
Fixes #11405

#### Changes proposed in this Pull Request:
* Previously, Flickr widget images could only be opened in the same window which directs users away from the site owners' site. This PR adds an "Open images in new tab?" option to Flickr widget settings, allowing site owners to choose whether their users are directed away from their site or not.

#### Testing instructions:

1. Activate Jetpack Widgets
2. Add the Flickr (Jetpack) widget to a widget area of your choosing
3. Along with the other settings, check the "Open images in new tab?" checkbox
4. View the Flickr gallery in the front-end and open one of the images.
5. Uncheck the setting to verify images can open in the same window as well

#### Proposed changelog entry for your changes:
* Add option to open Flickr gallery images in new tabs
