### PR TITLE
wpcom block editor: add missing wp deps

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -265,7 +265,19 @@ class Jetpack_WPCOM_Block_Editor {
 		wp_enqueue_script(
 			'wpcom-block-editor-common',
 			$src_common,
-			array( 'lodash', 'wp-compose', 'wp-data', 'wp-editor', 'wp-rich-text' ),
+			array(
+				'jquery',
+				'lodash',
+				'wp-blocks',
+				'wp-compose',
+				'wp-data',
+				'wp-dom-ready',
+				'wp-editor',
+				'wp-nux',
+				'wp-plugins',
+				'wp-polyfill',
+				'wp-rich-text',
+			),
 			$version,
 			true
 		);
@@ -303,7 +315,18 @@ class Jetpack_WPCOM_Block_Editor {
 			wp_enqueue_script(
 				'wpcom-block-editor-calypso-iframe-bridge',
 				$src_calypso_iframe_bridge,
-				array( 'calypsoify_wpadminmods_js', 'jquery', 'lodash', 'react', 'wp-blocks', 'wp-data', 'wp-hooks', 'wp-tinymce', 'wp-url' ),
+				array(
+					'calypsoify_wpadminmods_js',
+					'jquery',
+					'lodash',
+					'react',
+					'wp-blocks',
+					'wp-data',
+					'wp-hooks',
+					'wp-polyfill',
+					'wp-tinymce',
+					'wp-url',
+				),
 				$version,
 				true
 			);


### PR DESCRIPTION
Adds missing core dependencies in `wpcom-block-editor` module.

I noticed files in Calypso's [`/apps/wpcom-block-editor/src/common`](https://github.com/Automattic/wp-calypso/tree/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common) and [`/apps/wpcom-block-editor/src/calypso`](https://github.com/Automattic/wp-calypso/tree/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/calypso) are importing from some core deps that weren't listed as dependencies in PHP side.

In practise these get enqueued in the editor currently anyway so nothing should change per-se. :-) It's just good practice and safer.

**Common script was missing these**
- `jquery` ([#](https://github.com/Automattic/wp-calypso/blob/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common/switch-to-classic.js#L6))
- `wp-blocks` ([#](https://github.com/Automattic/wp-calypso/blob/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common/unregister-experimental-blocks.js#L4))
- `wp-dom-ready` ([#](https://github.com/Automattic/wp-calypso/blob/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common/unregister-experimental-blocks.js#L5))
- `wp-nux` ([#](https://github.com/Automattic/wp-calypso/blob/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common/disable-nux-tour.js#L5))
- `wp-plugins` ([#](https://github.com/Automattic/wp-calypso/blob/871c8f07d0f07d63175488400d8bb75ea9172f2b/apps/wpcom-block-editor/src/common/tracking.js#L5))

**Added to both common- and calypso-scripts**
- `wp-polyfill` — build process doesn't include Babel/polyfill for these files so to make sure things work in IE11, you'll need to ensure it's enqueued.


### Changes proposed in this Pull Request:
* Adds wp core deps

### Testing instructions:
Open the block editor both in Jetpack self hosted's wp-admin as well via Calypso and confirm that everything still works as expected.

### Proposed changelog entry for your changes:
-
