### PR TITLE
Sync: Update Close Buffer Endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -288,7 +288,8 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		}
 
 		return array(
-			'success' => Actions::get_sync_status(),
+			'success' => $response,
+			'status' => Actions::get_sync_status(),
 		);
 	}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -280,14 +280,15 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 		$full_sync_module->update_sent_progress_action( $items );
 
-		$response = $queue->close( null, $request_body['item_ids'] );
+		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
+		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
 		return array(
-			'success' => $response
+			'success' => Actions::get_sync_status(),
 		);
 	}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -275,7 +275,8 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		$queue = new Queue( $queue_name );
 
 		/** This action is documented in Full_Sync.php */
-		do_action( 'jetpack_sync_processed_actions', $request_body['item_ids'] );
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		$full_sync_module->update_sent_progress_action( $request_body['item_ids'] );
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
 		if ( is_wp_error( $response ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -271,13 +271,16 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		$request_body ['buffer_id'] = preg_replace( '/[^A-Za-z0-9]/', '', $request_body['buffer_id'] );
 		$request_body['item_ids'] = array_filter( array_map( array( 'Jetpack_JSON_API_Sync_Close_Endpoint', 'sanitize_item_ids' ), $request_body['item_ids'] ) );
 
-		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
 		$queue = new Queue( $queue_name );
+
+		$items = $queue->peek_by_id( $request_body['item_ids'] );
 
 		/** This action is documented in Full_Sync.php */
 		$full_sync_module = Modules::get_module( 'full-sync' );
-		$full_sync_module->update_sent_progress_action( $request_body['item_ids'] );
-		$response = $queue->close( $buffer, $request_body['item_ids'] );
+
+		$full_sync_module->update_sent_progress_action( $items );
+
+		$response = $queue->close( null, $request_body['item_ids'] );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -275,7 +275,7 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 		$items = $queue->peek_by_id( $request_body['item_ids'] );
 
-		/** This action is documented in Full_Sync.php */
+		/** This action is documented in packages/sync/src/modules/Full_Sync.php */
 		$full_sync_module = Modules::get_module( 'full-sync' );
 
 		$full_sync_module->update_sent_progress_action( $items );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -274,6 +274,8 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
 		$queue = new Queue( $queue_name );
 
+		/** This action is documented in Full_Sync.php */
+		do_action( 'jetpack_sync_processed_actions', $request_body['item_ids'] );
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
 		if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fire `jetpack_sync_processed_actions` before closing the buffer in `POST /sites/%s/sync/close` endpoint 

This will allow us to have an updated sync status when pulling sync data from wpcom. See: code-D30760

#### Testing instructions:
😅 
* pull this PR on a big test site
* start a full sync using the debugger
* use the script in code-D30760 to process the queue
* confirm that sync status on the debugger gets updated