### PR TITLE
Sync: get checksum for term_relationships table

### DIFF
--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -533,6 +533,12 @@ class Defaults {
 		'count',
 	);
 
+	static $default_term_relationships_checksum_columns = array(
+		'object_id',
+		'term_taxonomy_id',
+		'term_order',
+	);
+
 	static $default_multisite_callable_whitelist = array(
 		'network_name'                        => array( 'Jetpack', 'network_name' ),
 		'network_allow_new_registrations'     => array( 'Jetpack', 'network_allow_new_registrations' ),

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -86,6 +86,18 @@ class Replicastore implements Replicastore_Interface {
 	}
 
 	/**
+	 * Retrieve the number of term relationships.
+	 *
+	 * @access public
+	 *
+	 * @return int Number of rows in the term relationships table.
+	 */
+	public function term_relationship_count() {
+		global $wpdb;
+		return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships" );
+	}
+
+	/**
 	 * Retrieve the number of posts with a particular post status within a certain range.
 	 *
 	 * @access public
@@ -1183,6 +1195,8 @@ class Replicastore implements Replicastore_Interface {
 				return Defaults::$default_term_checksum_columns;
 			case 'term_taxonomy':
 				return Defaults::$default_term_taxonomy_checksum_columns;
+			case 'term_relationships':
+				return Defaults::$default_term_relationships_checksum_columns;
 			default:
 				return false;
 		}
@@ -1248,6 +1262,12 @@ class Replicastore implements Replicastore_Interface {
 				$object_table = $wpdb->term_taxonomy;
 				$object_count = $this->term_taxonomy_count();
 				$id_field     = 'term_taxonomy_id';
+				$where_sql    = '1=1';
+				break;
+			case 'term_relationships':
+				$object_table = $wpdb->term_relationships;
+				$object_count = $this->term_relationship_count();
+				$id_field     = 'object_id';
 				$where_sql    = '1=1';
 				break;
 			default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue where we cannot validate a site whose term relationships are out of sync.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensure sync histogram endpoint can calculate a checksum for term relationships

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Ip7rcWF-12N-p2

#### Testing instructions:
* requires an upstream patch D30444-code to test

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
