### PR TITLE
add CSS to calypsoify dashboard notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 	},
 	"require": {
 		"ext-openssl": "*",
+		"automattic/gridicons": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-logo": "@dev",
@@ -37,6 +38,18 @@
 		{
 			"type": "path",
 			"url": "./packages/*"
+		},
+		{
+			"type": "package",
+			"package": {
+				"name": "automattic/gridicons",
+				"version": "3.1.1",
+				"source": {
+					"url": "https://github.com/Automattic/gridicons",
+					"type": "git",
+					"reference": "master"
+				}
+			}
 		}
 	],
 	"autoload": {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -255,6 +255,10 @@ class Jetpack_Calypsoify {
 		wp_style_add_data( 'calypsoify_wpadminmods_css', 'rtl', 'replace' );
 		wp_style_add_data( 'calypsoify_wpadminmods_css', 'suffix', '.min' );
 
+		if ( ! function_exists( 'get_gridicon' ) ) {
+			require_once( JETPACK__PLUGIN_DIR . 'vendor/automattic/gridicons/php/gridicons.php' );
+		}
+
 		$icons = array(
 			'checkmark'   => get_gridicon( 'gridicons-checkmark' ),
 			'chevronDown' => get_gridicon( 'gridicons-chevron-down' ),

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -253,14 +253,23 @@ class Jetpack_Calypsoify {
 	public function enqueue() {
 		wp_enqueue_style( 'calypsoify_wpadminmods_css', plugin_dir_url( __FILE__ ) . 'style.min.css', false, JETPACK__VERSION );
 		wp_style_add_data( 'calypsoify_wpadminmods_css', 'rtl', 'replace' );
-        wp_style_add_data( 'calypsoify_wpadminmods_css', 'suffix', '.min' );
+		wp_style_add_data( 'calypsoify_wpadminmods_css', 'suffix', '.min' );
 
+		$icons = array(
+			'checkmark'   => get_gridicon( 'gridicons-checkmark' ),
+			'chevronDown' => get_gridicon( 'gridicons-chevron-down' ),
+			'cross'       => get_gridicon( 'gridicons-cross' ),
+			'info'        => get_gridicon( 'gridicons-info' ),
+			'notice'      => get_gridicon( 'gridicons-notice' ),
+			'search'      => get_gridicon( 'gridicons-search' ),
+		);
 		wp_enqueue_script( 'calypsoify_wpadminmods_js', plugin_dir_url( __FILE__ ) . 'mods.js', false, JETPACK__VERSION );
 		wp_localize_script( 'calypsoify_wpadminmods_js', 'CalypsoifyOpts', array(
 			'nonces' => array(
-				'autoupdate_plugins' => wp_create_nonce( 'jetpack_toggle_autoupdate-plugins' ),
+				'autoupdate_plugins'              => wp_create_nonce( 'jetpack_toggle_autoupdate-plugins' ),
 				'autoupdate_plugins_translations' => wp_create_nonce( 'jetpack_toggle_autoupdate-plugins_translations' ),
-			)
+			),
+			'icons' => $icons,
 		) );
 	}
 

--- a/modules/calypsoify/mods.js
+++ b/modules/calypsoify/mods.js
@@ -91,11 +91,11 @@
 	 * Prepend icons to notices.
 	 */
 	$( document ).ready( function() {
-		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
-			return;
-		}
-
 		$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+			if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+				return;
+			}
+
 			var icon = CalypsoifyOpts.icons.info;
 			if ( $( this ).hasClass( 'notice-success' ) ) {
 				icon = CalypsoifyOpts.icons.checkmark;
@@ -121,11 +121,11 @@
 	 * Used to prevent side by side content in flexbox when multiple paragraphs exist.
 	 */
 	$( document ).ready( function() {
-		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
-			return;
-		}
-
 		$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+			if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+				return;
+			}
+
 			var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
 			$( this )
 				.find( '.wc-calypso-bridge-notice-icon-wrapper' )

--- a/modules/calypsoify/mods.js
+++ b/modules/calypsoify/mods.js
@@ -86,4 +86,90 @@
 			} );
 		}
 	} );
+
+	/**
+	 * Prepend icons to notices.
+	 */
+	$( document ).ready( function() {
+		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+			return;
+		}
+
+		$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+			var icon = CalypsoifyOpts.icons.info;
+			if ( $( this ).hasClass( 'notice-success' ) ) {
+				icon = CalypsoifyOpts.icons.checkmark;
+			} else if ( $( this ).hasClass( 'error' ) || $( this ).hasClass( 'notice-warning' ) ) {
+				icon = CalypsoifyOpts.icons.notice;
+			}
+			$( this ).prepend(
+				'<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>'
+			);
+		} );
+	} );
+
+	/**
+	 * Replace dismissal buttons in notices.
+	 */
+	$( document ).ready( function() {
+		$( '.notice-dismiss' ).html( CalypsoifyOpts.icons.cross );
+	} );
+
+	/**
+	 * Place notice content inside it's own tag.
+	 *
+	 * Used to prevent side by side content in flexbox when multiple paragraphs exist.
+	 */
+	$( document ).ready( function() {
+		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+			return;
+		}
+
+		$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+			var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
+			$( this )
+				.find( '.wc-calypso-bridge-notice-icon-wrapper' )
+				.after( $noticeContent );
+			$( this )
+				.find( 'p:not(.submit)' )
+				.appendTo( $noticeContent );
+		} );
+	} );
+
+	/**
+	 * Move notices on pages with sub navigation
+	 *
+	 * WP Core moves notices with jQuery so this is needed to move them again since
+	 * we can't control their position.
+	 */
+	$( document ).ready( function() {
+		var $subNavigation = $( '.wrap .subsubsub' );
+		if ( $subNavigation.length ) {
+			$( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation.first() );
+			$( '.jetpack-jitm-message, .jitm-card' ).insertAfter( $subNavigation.first() );
+		}
+	} );
+
+	/**
+	 * Append notice.
+	 */
+	function appendNotice( content, type ) {
+		var html = '';
+		var icon = CalypsoifyOpts.icons.info;
+		var classes = [ 'notice' ];
+		if ( 'success' === type ) {
+			icon = CalypsoifyOpts.icons.checkmark;
+			classes.push( 'notice-success' );
+		} else if ( 'error' === type ) {
+			icon = CalypsoifyOpts.icons.notice;
+			classes.push( 'error' );
+		}
+		html += '<div class="' + classes.join( ' ' ) + '">';
+		html += '<span class="wc-calypso-bridge-notice-icon-wrapper">';
+		html += icon;
+		html += '</span>';
+		html += '<div class="wc-calypso-bridge-notice-content"><p>' + content + '</p></div>';
+		html += '</div>';
+		$( html ).insertAfter( 'h1.wp-heading-inline:first' );
+	}
 } )( jQuery );

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -143,6 +143,161 @@ body,
 	margin-left: 272px;
 }
 
+/*
+ * Notices
+ */
+.wp-admin .wrap div.hidden {
+	display: none;
+}
+
+.wp-admin div.notice > p,
+.wp-admin div.updated > p,
+.wp-admin div.error > p,
+.wc-calypso-bridge-notice-content {
+	padding: 6px 13px;
+	margin: 0;
+	flex-direction: column;
+}
+
+.wp-admin .wc-calypso-bridge-notice-content p {
+	margin: 5px 0;
+	font-size: 14px;
+}
+
+.wp-admin div.notice a,
+.wp-admin div.updated a,
+.wp-admin div.error a {
+	color: #fff;
+}
+
+.wp-admin div.notice p.submit,
+.wp-admin div.updated p.submit,
+.wp-admin div.error p.submit {
+	display: flex;
+	-ms-flex-negative: 1;
+	flex-shrink: 1;
+	-webkit-box-flex: 0;
+	-ms-flex-positive: 0;
+	flex-grow: 0;
+	margin: 0 0 0 auto !important;
+	padding: 13px 16px;
+	justify-content: center;
+}
+
+.wp-admin div.notice .button,
+.wp-admin div.notice .button-primary,
+.wp-admin div.updated .button,
+.wp-admin div.updated .button-primary:not( .debug-report ),
+.wp-admin div.error .button,
+.wp-admin div.error .button-primary {
+	color: #a8bece;
+	background: transparent !important;
+	border-width: 0 !important;
+	font-size: 14px !important;
+	font-weight: 400 !important;
+	padding: 0 !important;
+}
+
+.wp-admin div.notice .button:hover,
+.wp-admin div.notice .button-primary:hover,
+.wp-admin div.updated .button:hover,
+.wp-admin div.updated .button-primary:hover:not( .debug-report ),
+.wp-admin div.error .button:hover,
+.wp-admin div.error .button-primary:hover {
+	color: #fff;
+	background: transparent !important;
+}
+
+.wp-admin div.notice .button:active,
+.wp-admin div.notice .button-primary:active,
+.wp-admin div.updated .button:active,
+.wp-admin div.updated .button-primary:active,
+.wp-admin div.error .button:active,
+.wp-admin div.error .button-primary:active {
+	vertical-align: baseline;
+}
+
+.wc-calypso-bridge-notice-icon-wrapper, .jitm-banner__icon-plan {
+	position: relative;
+	background: #537994;
+	color: #fff;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: baseline;
+	-ms-flex-align: baseline;
+	align-items: baseline;
+	width: 47px;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	border-radius: 3px 0 0 3px;
+	-ms-flex-negative: 0;
+	flex-shrink: 0;
+	-ms-flex-item-align: stretch;
+	align-self: stretch;
+	align-items: center;
+}
+
+.wc-calypso-bridge-notice-icon-wrapper svg path {
+	fill: #fff;
+}
+
+.error .wc-calypso-bridge-notice-icon-wrapper {
+	background: #ea4149;
+}
+
+.notice-success .wc-calypso-bridge-notice-icon-wrapper {
+	background: #4ab866;
+}
+
+.notice-warning .wc-calypso-bridge-notice-icon-wrapper {
+	background: #f0b849;
+}
+
+.notice-dismiss {
+	height: 100%;
+	margin: 0 0 0 auto !important;
+	position: static;
+	padding: 12px 12px 0 12px !important;
+}
+
+.notice-dismiss:before {
+	display: none;
+}
+
+.notice-dismiss:focus {
+	box-shadow: none;
+}
+
+.notice-dismiss svg path {
+	fill: #a8bece;
+}
+
+.notice-dismiss:hover svg path {
+	fill: #fff;
+}
+
+@media screen and (max-width: 480px) {
+	.wp-admin div.notice p,
+	.wp-admin div.notice a.button,
+	.wp-admin div.notice a.button-primary,
+	.wp-admin div.error p,
+	.wp-admin div.error a.button,
+	.wp-admin div.error a.button-primary,
+	.wp-admin div.updated p,
+	.wp-admin div.updated a.button,
+	.wp-admin div.updated a.button-primary {
+		font-size: 12px !important;
+	}
+}
+
+.wp-admin div.notice + br.clear,
+.wp-admin div.updated + br.clear,
+.wp-admin div.error + br.clear {
+	display: none;
+}
+
 #toplevel_page_plugins div.wp-menu-image.svg,
 #toplevel_page_plugin-install div.wp-menu-image.svg {
 	background-size: 24px auto;

--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -146,6 +146,79 @@ body,
 /*
  * Notices
  */
+div.notice,
+div.updated,
+div.error {
+	display: none;
+}
+
+.wp-admin .wrap div.notice,
+.wp-admin .wrap div.updated,
+.wp-admin .wrap div.error,
+div.jitm-card,
+.jitm-banner.jitm-card {
+	display: flex;
+	position: relative;
+	width: 100%;
+	margin: 0 0 24px 0;
+	padding: 0;
+	box-sizing: border-box;
+	animation: appear .3s ease-in-out;
+	background: #2e4453;
+	color: #fff;
+	border-radius: 3px;
+	font-size: 14px;
+	line-height: 1.5;
+	border: 0;
+	overflow: hidden;
+}
+
+div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-banner__info .jitm-banner__description {
+	color: #fff;
+}
+
+.jitm-card {
+	margin: 0 0 24px 0;
+	border-left: 0;
+	padding: 0;
+}
+
+.jitm-banner__content {
+	padding: 13px 13px 13px 0px;
+}
+
+.jp-emblem svg {
+	display: none;
+}
+
+.jp-emblem {
+	height: 24px;
+	width: 24px;
+	background-image:
+	url("data:image/svg+xml;utf8,<svg class='gridicon gridicons-notice' height='24' width='24' fill='#fff' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><g><path d='M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z'></path></g></svg>");
+}
+
+@media screen and (max-width: 480px) {
+	.jitm-banner.jitm-card {
+		display: flex;
+	}
+}
+
+.jitm-banner__dismiss {
+	position: static;
+	float: right;
+	padding: 0px 12px 0 12px !important;
+	font-size: 13px;
+	line-height: 1.23076923;
+	text-decoration: none;
+}
+
+.jitm-banner__dismiss:before {
+	color: #a3bdd0;
+	font: normal 24px/1 dashicons;
+	content: '\f335';
+}
+
 .wp-admin .wrap div.hidden {
 	display: none;
 }


### PR DESCRIPTION
This is a followup PR to #10507 which adds consistent styling for admin notice in Calypsoified admin screens. 

Related issue: https://github.com/Automattic/wc-calypso-bridge/issues/306 (private link)

#### Changes proposed in this Pull Request:
* Add CSS and script to provide consistent styling of dashboard admin notices among Calypso dashboards.

### Screenshots

Before:
<img width="925" alt="Screen Shot 2019-07-25 at 9 56 45 AM" src="https://user-images.githubusercontent.com/343847/61900376-e1cb6500-aef3-11e9-8dad-ce66ec8eaf94.png">

After:
<img width="1204" alt="Screen Shot 2019-07-25 at 3 48 40 PM" src="https://user-images.githubusercontent.com/343847/61900390-e859dc80-aef3-11e9-8a15-cefe8027e7cb.png">



#### Testing instructions:

* Add a notice to the dashboard
* Activate Calypsoify
* Check notice for consistent styling with Calypso

#### Proposed changelog entry for your changes:
* Add consistent styling of dashboard admin notices among Calypso dashboards.
