### PR TITLE
Update calypsoify menu colors to match calypso

### DIFF
--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -48,6 +48,10 @@ body,
 #adminmenu {
 	margin-top: 71px;
 
+	.wp-submenu {
+		padding: 0;
+	}
+
 	.wp-has-current-submenu .wp-submenu,
 	.opensub .wp-submenu,
 	.opensub .wp-submenu:after,
@@ -58,9 +62,12 @@ body,
 	li.menu-top:hover,
 	li.opensub>a.menu-top,
 	li>a.menu-top:focus,
-	li.wp-menu-open,
+	li.wp-menu-open {
+		background: transparent;
+	}
+
 	a:hover {
-		background: $gray-light;
+		background-color: $muriel-gray-50 !important;
 	}
 
 	.wp-submenu-head,
@@ -69,16 +76,9 @@ body,
 	}
 
 	.wp-has-current-submenu ul>li>a {
-		padding: 11px 16px 11px 20px;
-		font-size: 14px;
-	}
-
-	.wp-submenu a:hover {
-		background-color: $muriel-gray-50;
-	}
-
-	> li.wp-first-item {
-		border-bottom: 1px solid $rgba-grey;
+		padding: 7px 12px 7px 46px;
+		font-size: 15px;
+		font-weight: 400 !important;
 	}
 
 	a.wp-has-current-submenu:after,
@@ -94,27 +94,42 @@ body,
 		font-size: 24px;
 	}
 
-	a,
-	div.wp-menu-image:before{
-		color: $gray-dark !important;
+	a {
+		color: $gray-text !important;
 	}
 
+	li.current > a {
+		background: $muriel-blue-50 !important;
+	}
 
-	li.current a.menu-top,
+	div.wp-menu-image:before {
+		color: $gray-darken-20 !important;
+	}
+
+	li a:hover div.wp-menu-image:before {
+		color: $gray-text !important;
+	}
+
+	li.current a div.wp-menu-image:before {
+		color: $color-primary !important;
+	}
+
 	li.wp-has-current-submenu a.wp-has-current-submenu {
-		background: $muriel-blue-50;
+		background: transparent;
 	}
 
 	div.wp-menu-image.svg {
+		filter: brightness(0.6);
+	}
+
+	li a:hover div.wp-menu-image.svg,
+	li.current div.wp-menu-image.svg {
 		filter: brightness(0.25);
 	}
 
-	li.wp-menu-open div.wp-menu-image.svg {
-		filter: brightness(100);
-	}
-
-	li.wp-menu-open div.wp-menu-image:before,
-	li.wp-menu-open div.wp-menu-name {
+	li.current div.wp-menu-image:before,
+	li.current a,
+	li.current .wp-menu-name {
 		color: $color-primary !important;
 	}
 
@@ -122,6 +137,7 @@ body,
 		color: $gray-text;
 		font-size: 15px;
 		padding: 9px 0 8px 41px;
+		font-weight: 600;
 	}
 
 	li.menu-top {
@@ -229,7 +245,7 @@ body,
 		.opensub .wp-submenu,
 		.opensub .wp-submenu:after,
 		a.wp-has-current-submenu:focus+.wp-submenu {
-			background: $gray-lighten-30 !important;
+			background: transparent !important;
 		}
 
 		li.menu-top .wp-submenu>li>a {
@@ -316,13 +332,6 @@ body,
 
 	.auto-fold #adminmenu {
 		top: -14px;
-	}
-
-	.auto-fold #adminmenu .selected,
-	#adminmenu li.opensub>a.menu-top,
-	#adminmenu li>a.menu-top:focus,
-	#adminmenu li.wp-menu-open {
-		background: $muriel-blue-50 !important;
 	}
 
 	#adminmenu .wp-submenu,


### PR DESCRIPTION
Fixes #13128 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Style updates to the admin menu to match calypso

Note: The background svg icons colors don't match perfectly and a better long-term solution is needed here, probably using actual SVGs for easier color manipulation.

### Screenshots
#### Before
<img width="292" alt="Screen Shot 2019-07-25 at 3 35 37 PM" src="https://user-images.githubusercontent.com/10561050/61855596-f2c7a680-aef2-11e9-9cd9-074fa0d9be09.png">

#### After
<img width="275" alt="Screen Shot 2019-07-25 at 3 34 37 PM" src="https://user-images.githubusercontent.com/10561050/61855553-d62b6e80-aef2-11e9-82a0-d0fe7a5080d3.png">

#### Testing instructions:
1. Enable calypsoify by appending `&calypsoify=1` to an admin dashboard page.
2. Note the updated menu styles match those used in Calypso.

#### Proposed changelog entry for your changes:
* Calypsoify: Update menu styles to fix styling in the latest WordPress version.
