### PR TITLE
Tiled gallery block: add stacked layout

### DIFF
--- a/extensions/blocks/tiled-gallery/constants.js
+++ b/extensions/blocks/tiled-gallery/constants.js
@@ -12,6 +12,7 @@ export const LAYOUT_CIRCLE = 'circle';
 export const LAYOUT_COLUMN = 'columns';
 export const LAYOUT_DEFAULT = 'rectangular';
 export const LAYOUT_SQUARE = 'square';
+export const LAYOUT_STACKED = 'stacked';
 export const LAYOUT_STYLES = [
 	{
 		isDefault: true,
@@ -25,5 +26,8 @@ export const LAYOUT_STYLES = [
 	},
 	{
 		name: LAYOUT_COLUMN,
+	},
+	{
+		name: LAYOUT_STACKED,
 	},
 ];

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -16,6 +16,7 @@ import {
 	LAYOUT_COLUMN,
 	LAYOUT_DEFAULT,
 	LAYOUT_SQUARE,
+	LAYOUT_STACKED,
 	LAYOUT_STYLES,
 } from './constants';
 import { isSimpleSite } from '../../shared/site-type-utils';
@@ -48,6 +49,7 @@ const styleNames = {
 	[ LAYOUT_CIRCLE ]: _x( 'Circles', 'Tiled gallery layout', 'jetpack' ),
 	[ LAYOUT_COLUMN ]: _x( 'Tiled columns', 'Tiled gallery layout', 'jetpack' ),
 	[ LAYOUT_SQUARE ]: _x( 'Square tiles', 'Tiled gallery layout', 'jetpack' ),
+	[ LAYOUT_STACKED ]: _x( 'Stacked', 'Tiled gallery layout', 'jetpack' ),
 };
 const layoutStylesWithLabels = LAYOUT_STYLES.map( style => ( {
 	...style,

--- a/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -86,11 +86,11 @@ export default class Mosaic extends Component {
 	render() {
 		const { align, columns, images, layoutStyle, renderedImages, columnWidths } = this.props;
 
+		const columnsToRender = 'stacked' === layoutStyle ? 1 : columns;
 		const ratios = imagesToRatios( images );
-		const rows =
-			'columns' === layoutStyle
-				? ratiosToColumns( ratios, columns )
-				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
+		const rows = [ 'columns', 'stacked' ].includes( layoutStyle )
+			? ratiosToColumns( ratios, columnsToRender )
+			: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
 
 		let cursor = 0;
 		return (

--- a/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -12,6 +12,7 @@ import Gallery from '../gallery';
 import Row from '../row';
 import { getGalleryRows, handleRowResize } from './resize';
 import { imagesToRatios, ratiosToColumns, ratiosToMosaicRows } from './ratios';
+import { LAYOUT_COLUMN, LAYOUT_STACKED } from '../../constants';
 
 export default class Mosaic extends Component {
 	gallery = createRef();
@@ -29,7 +30,10 @@ export default class Mosaic extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.images !== this.props.images || prevProps.align !== this.props.align ) {
 			this.triggerResize();
-		} else if ( 'columns' === this.props.layoutStyle && prevProps.columns !== this.props.columns ) {
+		} else if (
+			LAYOUT_COLUMN === this.props.layoutStyle &&
+			prevProps.columns !== this.props.columns
+		) {
 			this.triggerResize();
 		}
 	}
@@ -86,9 +90,9 @@ export default class Mosaic extends Component {
 	render() {
 		const { align, columns, images, layoutStyle, renderedImages, columnWidths } = this.props;
 
-		const columnsToRender = 'stacked' === layoutStyle ? 1 : columns;
+		const columnsToRender = LAYOUT_STACKED === layoutStyle ? 1 : columns;
 		const ratios = imagesToRatios( images );
-		const rows = [ 'columns', 'stacked' ].includes( layoutStyle )
+		const rows = [ LAYOUT_COLUMN, LAYOUT_STACKED ].includes( layoutStyle )
 			? ratiosToColumns( ratios, columnsToRender )
 			: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
 

--- a/extensions/blocks/tiled-gallery/view.js
+++ b/extensions/blocks/tiled-gallery/view.js
@@ -39,7 +39,8 @@ function getGalleries() {
 	return Array.from(
 		document.querySelectorAll(
 			'.wp-block-jetpack-tiled-gallery.is-style-rectangular > .tiled-gallery__gallery,' +
-				'.wp-block-jetpack-tiled-gallery.is-style-columns > .tiled-gallery__gallery'
+				'.wp-block-jetpack-tiled-gallery.is-style-columns > .tiled-gallery__gallery,' +
+				'.wp-block-jetpack-tiled-gallery.is-style-stacked > .tiled-gallery__gallery'
 		)
 	);
 }

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -29,7 +29,8 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	}
 
 	&.is-style-columns,
-	&.is-style-rectangular {
+	&.is-style-rectangular,
+	&.is-style-stacked {
 		.tiled-gallery__item {
 			display: flex;
 		}


### PR DESCRIPTION
Add stacked layout to tiled gallery block:

<img width="500" alt="Screenshot 2019-07-25 at 14 32 10" src="https://user-images.githubusercontent.com/87168/61871248-0110c500-aee9-11e9-967d-90e0765229f2.png">



#### Changes proposed in this Pull Request:
- Add new stacked layout to the Tiled gallery block.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* enhancement

#### Testing instructions:
- Add Tiled gallery with some images
- From styles, change to "stacked" layout
- Confirm it works in frontend of the site
- Confirm no columns setting available
- Confirm that full alignment works

#### Proposed changelog entry for your changes:
* Adds stacked layout to Tiled gallery block
