### PR TITLE
Add Open Graph meta tags to archive pages

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -10,11 +10,12 @@ import NoticeAction from 'components/notice/notice-action.jsx';
 /**
  * Internal dependencies
  */
+import { isDevVersion as _isDevVersion } from 'state/initial-state';
 import {
 	isNoticeDismissed as _isNoticeDismissed,
 	dismissJetpackNotice,
 } from 'state/jetpack-notices';
-import { JETPACK_CONTACT_SUPPORT } from 'constants/urls';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 
 class FeedbackDashRequest extends React.Component {
 	static displayName = 'FeedbackDashRequest';
@@ -24,6 +25,10 @@ class FeedbackDashRequest extends React.Component {
 			return;
 		}
 
+		const supportURl = this.props.isDevVersion
+			? JETPACK_CONTACT_BETA_SUPPORT
+			: JETPACK_CONTACT_SUPPORT;
+
 		return (
 			<div>
 				<SimpleNotice
@@ -32,7 +37,7 @@ class FeedbackDashRequest extends React.Component {
 					onDismissClick={ this.props.dismissNotice }
 					text={ __( 'What would you like to see on your Jetpack Dashboard?' ) }
 				>
-					<NoticeAction href={ JETPACK_CONTACT_SUPPORT }>{ __( 'Let us know!' ) }</NoticeAction>
+					<NoticeAction href={ supportURl }>{ __( 'Let us know!' ) }</NoticeAction>
 				</SimpleNotice>
 			</div>
 		);
@@ -46,6 +51,7 @@ class FeedbackDashRequest extends React.Component {
 export default connect(
 	state => {
 		return {
+			isDevVersion: _isDevVersion( state ),
 			isDismissed: notice => _isNoticeDismissed( state, notice ),
 		};
 	},

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -14,11 +14,11 @@ import analytics from 'lib/analytics';
  * Internal dependencies
  */
 import { PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
-import { isAtomicSite, getUpgradeUrl } from 'state/initial-state';
+import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getSiteConnectionStatus } from 'state/connection';
 import JetpackBanner from 'components/jetpack-banner';
-import { JETPACK_CONTACT_SUPPORT } from 'constants/urls';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 
 class SupportCard extends React.Component {
 	static displayName = 'SupportCard';
@@ -69,6 +69,10 @@ class SupportCard extends React.Component {
 				'undefined' === typeof this.props.sitePlan.product_slug ||
 				'jetpack_free' === this.props.sitePlan.product_slug;
 
+		const jetpackSupportURl = this.props.isDevVersion
+			? JETPACK_CONTACT_BETA_SUPPORT
+			: JETPACK_CONTACT_SUPPORT;
+
 		return (
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
@@ -85,7 +89,7 @@ class SupportCard extends React.Component {
 								href={
 									this.props.isAtomicSite
 										? 'https://wordpress.com/help/contact/'
-										: JETPACK_CONTACT_SUPPORT
+										: jetpackSupportURl
 								}
 							>
 								{ __( 'Ask a question' ) }
@@ -128,6 +132,7 @@ export default connect( state => {
 		siteConnectionStatus: getSiteConnectionStatus( state ),
 		isFetchingSiteData: isFetchingSiteData( state ),
 		isAtomicSite: isAtomicSite( state ),
+		isDevVersion: _isDevVersion( state ),
 		supportUpgradeUrl: getUpgradeUrl( state, 'support' ),
 	};
 } )( SupportCard );

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -94,6 +94,10 @@ class Jetpack_Debug_Data {
 	 * @return array $args Debug information in the same format as the initial argument.
 	 */
 	public static function core_debug_data( $debug ) {
+		$support_url = Jetpack::is_development_version()
+			? 'https://jetpack.com/contact-support/beta-group/'
+			: 'https://jetpack.com/contact-support/';
+
 		$jetpack = array(
 			'jetpack' => array(
 				'label'       => __( 'Jetpack', 'jetpack' ),
@@ -103,7 +107,7 @@ class Jetpack_Debug_Data {
 						'Diagnostic information helpful to <a href="%1$s" target="_blank" rel="noopener noreferrer">your Jetpack Happiness team<span class="screen-reader-text">%2$s</span></a>',
 						'jetpack'
 					),
-					esc_html( 'https://jetpack.com/contact-support/' ),
+					esc_url( $support_url ),
 					__( '(opens in a new tab)', 'jetpack' )
 				),
 				'fields'      => self::debug_data(),

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -79,6 +79,10 @@ class Jetpack_Debugger {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'jetpack' ) );
 		}
 
+		$support_url = Jetpack::is_development_version()
+			? 'https://jetpack.com/contact-support/beta-group/'
+			: 'https://jetpack.com/contact-support/';
+
 		$data       = Jetpack_Debug_Data::debug_data();
 		$debug_info = '';
 		foreach ( $data as $datum ) {
@@ -225,7 +229,7 @@ class Jetpack_Debugger {
 							__( '<a href="%1$s">Contact our Happiness team</a>. When you do, please include the <a href="%2$s">full debug information from your site</a>.', 'jetpack' ),
 							array( 'a' => array( 'href' => array() ) )
 						),
-						'https://jetpack.com/contact-support/',
+						esc_url( $support_url ),
 						esc_url( admin_url() . 'site-health.php?tab=debug' )
 					);
 					$hide_debug = true;
@@ -236,7 +240,7 @@ class Jetpack_Debugger {
 							__( '<a href="%s">Contact our Happiness team</a>. When you do, please include the full debug information below.', 'jetpack' ),
 							array( 'a' => array( 'href' => array() ) )
 						),
-						'https://jetpack.com/contact-support/'
+						esc_url( $support_url )
 					);
 					$hide_debug = false;
 				}

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -295,7 +295,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 	}
 	$image = array();
 
-	if ( is_singular() && ! is_home() ) {
+	if ( ( is_singular() || is_archive() ) && ! is_home() ) {
 		// Grab obvious image if post is an attachment page for an image.
 		if ( is_attachment( get_the_ID() ) && 'image' === substr( get_post_mime_type(), 0, 5 ) ) {
 			$image['src'] = wp_get_attachment_url( get_the_ID() );

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -94,6 +94,24 @@ function jetpack_og_tags() {
 			$tags['profile:first_name'] = get_the_author_meta( 'first_name', $author->ID );
 			$tags['profile:last_name']  = get_the_author_meta( 'last_name', $author->ID );
 		}
+	} elseif ( is_archive() ) {
+		$tags['og:type'] 		= 'website';
+		$tags['og:title']		= wp_get_document_title();
+		$tags['og:site_name']	= get_bloginfo( 'name' );
+
+		$archive = get_queried_object();
+		if ( ! empty( $archive ) ) {
+			if ( is_category() || is_tag() || is_tax() ) {
+				$tags['og:url'] 		= get_term_link( $archive->term_id, $archive->$taxonomy );
+				$tags['og:description']	= $archive->description;
+			} elseif ( is_post_type_archive() ) {
+				$tags['og:url'] 		= get_post_type_archive_link( $archive->name );
+				$tags['og:description']	= $archive->description;
+			} else {
+				$tags['og:url'] 		= home_url( '/' );
+				$tags['og:description']	= get_bloginfo( 'description' );
+			}
+		}
 	} elseif ( is_singular() ) {
 		global $post;
 		$data = $post; // so that we don't accidentally explode the global.

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -265,7 +265,19 @@ class Jetpack_WPCOM_Block_Editor {
 		wp_enqueue_script(
 			'wpcom-block-editor-common',
 			$src_common,
-			array( 'lodash', 'wp-compose', 'wp-data', 'wp-editor', 'wp-rich-text' ),
+			array(
+				'jquery',
+				'lodash',
+				'wp-blocks',
+				'wp-compose',
+				'wp-data',
+				'wp-dom-ready',
+				'wp-editor',
+				'wp-nux',
+				'wp-plugins',
+				'wp-polyfill',
+				'wp-rich-text',
+			),
 			$version,
 			true
 		);
@@ -303,7 +315,18 @@ class Jetpack_WPCOM_Block_Editor {
 			wp_enqueue_script(
 				'wpcom-block-editor-calypso-iframe-bridge',
 				$src_calypso_iframe_bridge,
-				array( 'calypsoify_wpadminmods_js', 'jquery', 'lodash', 'react', 'wp-blocks', 'wp-data', 'wp-hooks', 'wp-tinymce', 'wp-url' ),
+				array(
+					'calypsoify_wpadminmods_js',
+					'jquery',
+					'lodash',
+					'react',
+					'wp-blocks',
+					'wp-data',
+					'wp-hooks',
+					'wp-polyfill',
+					'wp-tinymce',
+					'wp-url',
+				),
 				$version,
 				true
 			);

--- a/packages/analyzer/src/Differences/Class_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Moved.php
@@ -29,7 +29,7 @@ class Class_Moved extends PersistentListItem implements Invocation_Warner {
 	}
 
 	public function find_invocation_warnings( $invocation, $warnings ) {
-		if ( $invocation->depends_on( $this->declaration ) ) {
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(
 				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration )
 			);

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -160,6 +160,10 @@ class Actions {
 			return true;
 		}
 
+		if ( Constants::get_constant( 'WP_CLI' ) ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -534,6 +534,12 @@ class Defaults {
 		'count',
 	);
 
+	static $default_term_relationships_checksum_columns = array(
+		'object_id',
+		'term_taxonomy_id',
+		'term_order',
+	);
+
 	static $default_multisite_callable_whitelist = array(
 		'network_name'                        => array( 'Jetpack', 'network_name' ),
 		'network_allow_new_registrations'     => array( 'Jetpack', 'network_allow_new_registrations' ),

--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -86,6 +86,18 @@ class Replicastore implements Replicastore_Interface {
 	}
 
 	/**
+	 * Retrieve the number of term relationships.
+	 *
+	 * @access public
+	 *
+	 * @return int Number of rows in the term relationships table.
+	 */
+	public function term_relationship_count() {
+		global $wpdb;
+		return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships" );
+	}
+
+	/**
 	 * Retrieve the number of posts with a particular post status within a certain range.
 	 *
 	 * @access public
@@ -1183,6 +1195,8 @@ class Replicastore implements Replicastore_Interface {
 				return Defaults::$default_term_checksum_columns;
 			case 'term_taxonomy':
 				return Defaults::$default_term_taxonomy_checksum_columns;
+			case 'term_relationships':
+				return Defaults::$default_term_relationships_checksum_columns;
 			default:
 				return false;
 		}
@@ -1248,6 +1262,12 @@ class Replicastore implements Replicastore_Interface {
 				$object_table = $wpdb->term_taxonomy;
 				$object_count = $this->term_taxonomy_count();
 				$id_field     = 'term_taxonomy_id';
+				$where_sql    = '1=1';
+				break;
+			case 'term_relationships':
+				$object_table = $wpdb->term_relationships;
+				$object_count = $this->term_relationship_count();
+				$id_field     = 'object_id';
 				$where_sql    = '1=1';
 				break;
 			default:

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -64,7 +64,8 @@ class Callables extends Module {
 	 */
 	const OPTION_NAMES_TO_CALLABLE_NAMES = array(
 		// @TODO: Audit the other option names for differences between the option names and callable names.
-		'home' => 'home_url',
+		'home'    => 'home_url',
+		'siteurl' => 'site_url',
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**This is working code and documentation still in progress.** 
Previously, Open Graph tags were added only for pages that were singular, home, or author archives. These changes add OG tags to all archive pages. 

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #1987

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*