### PR TITLE
Sync certain options updated via WPCLI instantly

### DIFF
--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -160,6 +160,10 @@ class Actions {
 			return true;
 		}
 
+		if ( Constants::get_constant( 'WP_CLI' ) ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/packages/sync/src/modules/Callables.php
+++ b/packages/sync/src/modules/Callables.php
@@ -64,7 +64,8 @@ class Callables extends Module {
 	 */
 	const OPTION_NAMES_TO_CALLABLE_NAMES = array(
 		// @TODO: Audit the other option names for differences between the option names and callable names.
-		'home' => 'home_url',
+		'home'    => 'home_url',
+		'siteurl' => 'site_url',
 	);
 
 	/**


### PR DESCRIPTION
This PR ensures that certain options updated via WP CLI sync instantly.

Testing instructions:
From a non-docker site (since it will only sync `localhost` as home option):

Try 
`wp option update siteurl https://my-new-domain3.com` and 
`wp option update home https://my-new-domain3.com`,
make sure both come through on your wpcom sandbox right away.

Change the domain values so they're eligible to sync and try again. They should sync right away.