### PR TITLE
Sync: allow WordPress.com to fetch out-of-sync term relationships.

### DIFF
--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -1288,10 +1288,15 @@ class Replicastore implements Replicastore_Interface {
 			$where .= " AND $id_field <= " . intval( $end_id );
 		}
 
+		$distinct = '';
+		if ( 'term_relationships' === $object_type ) {
+			$distinct = 'DISTINCT';
+		}
+
 		do {
 			list( $first_id, $last_id ) = $wpdb->get_row(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT MIN($id_field) as min_id, MAX($id_field) as max_id FROM ( SELECT $id_field FROM $object_table WHERE $where AND $id_field > $previous_max_id ORDER BY $id_field ASC LIMIT $bucket_size ) as ids",
+				"SELECT MIN($id_field) as min_id, MAX($id_field) as max_id FROM ( SELECT $distinct $id_field FROM $object_table WHERE $where AND $id_field > $previous_max_id ORDER BY $id_field ASC LIMIT $bucket_size ) as ids",
 				ARRAY_N
 			);
 

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -288,7 +288,7 @@ class Terms extends Module {
 
 	/**
 	 * Appends a term object to a row object from the term_relationships table.
-	 * This aids WordPress.com in re-syncing term_relationship tables that are out of sync.
+	 * This aids WordPress.com in re-syncing term_relationships tables that are out of sync.
 	 *
 	 * @access public
 	 *

--- a/packages/sync/src/modules/Terms.php
+++ b/packages/sync/src/modules/Terms.php
@@ -68,7 +68,7 @@ class Terms extends Module {
 			$objects = $wpdb->get_results( $wpdb->prepare( "SELECT $columns FROM $wpdb->term_relationships WHERE object_id = %d", $id ) );
 			$object  = (object) array(
 				'object_id'     => $id,
-				'relationships' => array_map( array( $this, 'add_term_to_relationship' ), $objects ),
+				'relationships' => array_map( array( $this, 'expand_terms_for_relationship' ), $objects ),
 			);
 		}
 
@@ -287,20 +287,14 @@ class Terms extends Module {
 	}
 
 	/**
-	 * Appends a term object to a row object from the term_relationships table.
-	 * This aids WordPress.com in re-syncing term_relationships tables that are out of sync.
+	 * Gets a term object based on a given row from the term_relationships database table.
 	 *
 	 * @access public
 	 *
 	 * @param object $relationship A row object from the term_relationships table.
-	 * @return object A row object from the term_relationships table with corresponding term object appended.
+	 * @return object|bool A term object, or false if term taxonomy doesn't exist.
 	 */
-	public function add_term_to_relationship( $relationship ) {
-		return (object) array(
-			'object_id'        => $relationship->object_id,
-			'term_taxonomy_id' => $relationship->term_taxonomy_id,
-			'term_order'       => $relationship->term_order,
-			'term'             => get_term_by( 'term_taxonomy_id', $relationship->term_taxonomy_id ),
-		);
+	public function expand_terms_for_relationship( $relationship ) {
+		return get_term_by( 'term_taxonomy_id', $relationship->term_taxonomy_id );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes no known issues. Part of an effort to fix out-of-sync terms relationships.

#### Changes proposed in this Pull Request:
* The terms sync module will now return a term_relationships object given an id

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* see: Ip7rcWF-12N-p2

#### Testing instructions:
- see D30866-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
