### PR TITLE
VideoPress: Add video settings to the VideoPress-enhanced video block

### DIFF
--- a/extensions/blocks/videopress/deprecated/v1/index.js
+++ b/extensions/blocks/videopress/deprecated/v1/index.js
@@ -44,4 +44,5 @@ export default {
 		reusable: false,
 	},
 	save,
+	isDeprecation: true,
 };

--- a/extensions/blocks/videopress/deprecated/v1/index.js
+++ b/extensions/blocks/videopress/deprecated/v1/index.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import save from './save';
+
+export default {
+	attributes: {
+		autoplay: {
+			type: 'boolean',
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+		},
+		controls: {
+			type: 'boolean',
+			default: true,
+		},
+		guid: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
+		loop: {
+			type: 'boolean',
+		},
+		muted: {
+			type: 'boolean',
+		},
+		poster: {
+			type: 'string',
+		},
+		preload: {
+			type: 'string',
+			default: 'metadata',
+		},
+		src: {
+			type: 'string',
+		},
+	},
+	support: {
+		reusable: false,
+	},
+	save,
+};

--- a/extensions/blocks/videopress/deprecated/v1/save.js
+++ b/extensions/blocks/videopress/deprecated/v1/save.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/editor';
+
+export default function VideoPressSave( { attributes } ) {
+	const { caption, guid } = attributes;
+
+	if ( ! guid ) {
+		return null;
+	}
+
+	const url = `https://videopress.com/v/${ guid }`;
+
+	return (
+		<figure className="wp-block-embed is-type-video is-provider-videopress">
+			<div className="wp-block-embed__wrapper">
+				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+			</div>
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText.Content tagName="figcaption" value={ caption } />
+			) }
+		</figure>
+	);
+}

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -2,17 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import classnames from 'classnames';
-import { __, sprintf } from '@wordpress/i18n';
-import {
-	BlockControls,
-	InspectorControls,
-	MediaUpload,
-	MediaUploadCheck,
-	RichText,
-} from '@wordpress/editor';
-import { Component, createRef, Fragment } from '@wordpress/element';
-import { compose, createHigherOrderComponent, withInstanceId } from '@wordpress/compose';
+import { isBlobURL } from '@wordpress/blob';
 import {
 	BaseControl,
 	Button,
@@ -24,9 +14,19 @@ import {
 	ToggleControl,
 	Toolbar,
 } from '@wordpress/components';
-import { get } from 'lodash';
-import { isBlobURL } from '@wordpress/blob';
+import { compose, createHigherOrderComponent, withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import {
+	BlockControls,
+	InspectorControls,
+	MediaUpload,
+	MediaUploadCheck,
+	RichText,
+} from '@wordpress/editor';
+import { Component, createRef, Fragment } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -190,9 +190,12 @@ const VideoPressEdit = CoreVideoEdit =>
 								value={ preload }
 								onChange={ value => setAttributes( { preload: value } ) }
 								options={ [
-									{ value: 'auto', label: __( 'Auto', 'jetpack' ) },
-									{ value: 'metadata', label: __( 'Metadata', 'jetpack' ) },
-									{ value: 'none', label: __( 'None', 'jetpack' ) },
+									{ value: 'auto', label: _x( 'Auto', 'VideoPress preload setting', 'jetpack' ) },
+									{
+										value: 'metadata',
+										label: _x( 'Metadata', 'VideoPress preload setting', 'jetpack' ),
+									},
+									{ value: 'none', label: _x( 'None', 'VideoPress preload setting', 'jetpack' ) },
 								] }
 							/>
 							<MediaUploadCheck>

--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -16,9 +16,12 @@ import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-
 import deprecatedV1 from './deprecated/v1';
 
 const addVideoPressSupport = ( settings, name ) => {
-	if ( 'core/video' !== name ) {
+	// Bail if this is not the video block or if the hook has been triggered by a deprecation.
+	if ( 'core/video' !== name || settings.isDeprecation ) {
 		return settings;
 	}
+
+	const { attributes, deprecated, edit, save, supports, transforms } = settings;
 
 	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
@@ -69,7 +72,7 @@ const addVideoPressSupport = ( settings, name ) => {
 			},
 
 			transforms: {
-				...settings.transforms,
+				...transforms,
 				from: [
 					{
 						type: 'files',
@@ -99,19 +102,22 @@ const addVideoPressSupport = ( settings, name ) => {
 			},
 
 			supports: {
-				...settings.supports,
+				...supports,
 				reusable: false,
 			},
 
-			edit: withVideoPressEdit( settings.edit ),
+			edit: withVideoPressEdit( edit ),
 
-			save: withVideoPressSave( settings.save ),
+			save: withVideoPressSave( save ),
 
 			deprecated: [
+				...( deprecated || [] ),
 				{
-					attributes: settings.attributes,
-					save: settings.save,
+					attributes,
 					isEligible: attrs => ! attrs.guid,
+					save,
+					supports,
+					isDeprecation: true,
 				},
 				deprecatedV1,
 			],

--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -13,6 +13,7 @@ import { every } from 'lodash';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
+import deprecatedV1 from './deprecated/v1';
 
 const addVideoPressSupport = ( settings, name ) => {
 	if ( 'core/video' !== name ) {
@@ -50,6 +51,9 @@ const addVideoPressSupport = ( settings, name ) => {
 					type: 'boolean',
 				},
 				muted: {
+					type: 'boolean',
+				},
+				playsInline: {
 					type: 'boolean',
 				},
 				poster: {
@@ -109,7 +113,7 @@ const addVideoPressSupport = ( settings, name ) => {
 					save: settings.save,
 					isEligible: attrs => ! attrs.guid,
 				},
-				...( Array.isArray( settings.deprecated ) ? settings.deprecated : [] ),
+				deprecatedV1,
 			],
 		};
 	}

--- a/extensions/blocks/videopress/save.js
+++ b/extensions/blocks/videopress/save.js
@@ -4,8 +4,15 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { RichText } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl } from './url';
+
 const VideoPressSave = CoreVideoSave => props => {
-	const { attributes: { caption, guid } = {} } = props;
+	const {
+		attributes: { autoplay, caption, controls, guid, loop, muted, poster, preload } = {},
+	} = props;
 
 	if ( ! guid ) {
 		/**
@@ -20,7 +27,14 @@ const VideoPressSave = CoreVideoSave => props => {
 		return CoreVideoSave( props );
 	}
 
-	const url = `https://videopress.com/v/${ guid }`;
+	const url = getVideoPressUrl( guid, {
+		autoplay,
+		controls,
+		loop,
+		muted,
+		poster,
+		preload,
+	} );
 
 	return (
 		<figure className="wp-block-embed is-type-video is-provider-videopress">

--- a/extensions/blocks/videopress/url.js
+++ b/extensions/blocks/videopress/url.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+export const getVideoPressUrl = ( guid, { autoplay, controls, loop, muted, poster, preload } ) => {
+	if ( ! guid ) {
+		return null;
+	}
+
+	const options = {
+		autoPlay: autoplay,
+		controls,
+		loop,
+		muted,
+		...( muted && { persistVolume: false } ),
+		posterUrl: poster,
+		preload,
+	};
+	return addQueryArgs( `https://videopress.com/v/${ guid }`, options );
+};

--- a/extensions/blocks/videopress/url.js
+++ b/extensions/blocks/videopress/url.js
@@ -8,14 +8,20 @@ export const getVideoPressUrl = ( guid, { autoplay, controls, loop, muted, poste
 		return null;
 	}
 
+	// In order to have a cleaner URL, we only set the options differing from the default VideoPress player settings:
+	// - Autoplay: Turned off by default.
+	// - Controls: Turned on by default.
+	// - Loop: Turned off by default.
+	// - Muted: Turned off by default.
+	// - Poster: No image by default.
+	// - Preload: None by default.
 	const options = {
-		autoPlay: autoplay,
-		controls,
-		loop,
-		muted,
-		...( muted && { persistVolume: false } ),
-		posterUrl: poster,
-		preload,
+		...( autoplay && { autoPlay: true } ),
+		...( ! controls && { controls: false } ),
+		...( loop && { loop: true } ),
+		...( muted && { muted: true, persistVolume: false } ),
+		...( poster && { posterUrl: poster } ),
+		...( preload !== 'none' && { preloadContent: preload } ),
 	};
 	return addQueryArgs( `https://videopress.com/v/${ guid }`, options );
 };


### PR DESCRIPTION
Fixes #11837.

#### Changes proposed in this Pull Request:

This PR adds the video settings allowing to customize several options for the VideoPress player rendered by the video block (extended by our VideoPress extension for Gutenberg).

<img width="278" alt="screen shot 2019-02-14 at 10 05 29 am" src="https://user-images.githubusercontent.com/1270189/52807434-4e3a6200-3040-11e9-845e-377366b69f5c.png">

Now, after inserting a VideoPress-enhanced video block, a user can set the following settings:
- Autoplay: whether to start playing as soon as the player renders (note that some browsers can prevent a video from being autoplayed).
- Loop: whether to loop the video.
- Muted: whether the video should start in a muted state.
- Playback controls: whether show the controls to allow the user to control video playback.
- Preload: what content is loaded before the video is played:
  - None: Indicates that the video should not be preloaded.
  - Metadata: Indicates that only video metadata (e.g. length) is fetched.
  - Auto: Indicates that the whole video file can be downloaded, even if the user is not expected to use it.
- Poster image: image to be shown while the video is downloading.

Given that these settings modifies the URL saved in the block content, any existing post containing a VideoPress-enhanced video block would result in a "invalid content" error. In order to support those posts, a deprecated version of the block has been added.

This PR also introduces a new `playsInline` attribute (added in core in https://github.com/WordPress/gutenberg/pull/14500), but it's currently unmodifiable, since VideoPress doesn't support it yet.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
See pafL3P-cU-p2 (Phase 3).

#### Testing instructions:
* [Create a new JN site using this branch](https://jurassic.ninja/create?branch=update/11837-videopress-block-settings&jetpack-beta).
* Connect to WP.com using a premium subscription.
* Go to Jetpack → Settings → Performance and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
* Go to Posts → New.
* Insert a video block.
* Upload or select an existing video.
  * Note that VideoPress only converts videos uploaded via the Media Library, so don't use the "Upload" button (bug already reported: #11194).
* Make sure the VideoPress player is previewed on the editor.
* Make sure the video settings appear in the sidebar.
* Set any video setting you like.
* Make sure the previewed player reflects the video settings you have set.
* Publish the post.
* Check the published view and verify the player reflects the video settings you have set in the editor.

#### Proposed changelog entry for your changes:
* VideoPress: Add video settings to the VideoPress-enhanced video block.
