### PR TITLE
Add Open Graph meta tags for archive pages.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -97,7 +97,6 @@ function jetpack_og_tags() {
 	} elseif ( is_archive() ) {
 		$tags['og:type']      = 'website';
 		$tags['og:title']     = wp_get_document_title();
-		$tags['og:site_name'] = get_bloginfo( 'name' );
 
 		$archive = get_queried_object();
 		if ( ! empty( $archive ) ) {

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -107,10 +107,10 @@ function jetpack_og_tags() {
 			} elseif ( is_post_type_archive() ) {
 				$tags['og:url'] 		= get_post_type_archive_link( $archive->name );
 				$tags['og:description']	= $archive->description;
-			} else {
-				$tags['og:url'] 		= home_url( '/' );
-				$tags['og:description']	= get_bloginfo( 'description' );
 			}
+		} else { // for date archives and future-proofing
+			$tags['og:url'] 		= home_url( '/' );
+			$tags['og:description']	= get_bloginfo( 'description' );
 		}
 	} elseif ( is_singular() ) {
 		global $post;

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -108,9 +108,6 @@ function jetpack_og_tags() {
 				$tags['og:url']         = get_post_type_archive_link( $archive->name );
 				$tags['og:description'] = $archive->description;
 			}
-		} else { // for date archives and future-proofing
-			$tags['og:url']         = '';
-			$tags['og:description'] = get_bloginfo( 'description' );
 		}
 	} elseif ( is_singular() ) {
 		global $post;

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -94,6 +94,24 @@ function jetpack_og_tags() {
 			$tags['profile:first_name'] = get_the_author_meta( 'first_name', $author->ID );
 			$tags['profile:last_name']  = get_the_author_meta( 'last_name', $author->ID );
 		}
+	} elseif ( is_archive() ) {
+		$tags['og:type'] 		= 'website';
+		$tags['og:title']		= wp_get_document_title();
+		$tags['og:site_name']	= get_bloginfo( 'name' );
+
+		$archive = get_queried_object();
+		if ( ! empty( $archive ) ) {
+			if ( is_category() || is_tag() || is_tax() ) {
+				$tags['og:url'] 		= get_term_link( $archive->term_id, $archive->$taxonomy );
+				$tags['og:description']	= $archive->description;
+			} elseif ( is_post_type_archive() ) {
+				$tags['og:url'] 		= get_post_type_archive_link( $archive->name );
+				$tags['og:description']	= $archive->description;
+			} else {
+				$tags['og:url'] 		= home_url( '/' );
+				$tags['og:description']	= get_bloginfo( 'description' );
+			}
+		}
 	} elseif ( is_singular() ) {
 		global $post;
 		$data = $post; // so that we don't accidentally explode the global.

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -95,22 +95,22 @@ function jetpack_og_tags() {
 			$tags['profile:last_name']  = get_the_author_meta( 'last_name', $author->ID );
 		}
 	} elseif ( is_archive() ) {
-		$tags['og:type'] 		= 'website';
-		$tags['og:title']		= wp_get_document_title();
-		$tags['og:site_name']	= get_bloginfo( 'name' );
+		$tags['og:type']      = 'website';
+		$tags['og:title']     = wp_get_document_title();
+		$tags['og:site_name'] = get_bloginfo( 'name' );
 
 		$archive = get_queried_object();
 		if ( ! empty( $archive ) ) {
 			if ( is_category() || is_tag() || is_tax() ) {
-				$tags['og:url'] 		= get_term_link( $archive->term_id, $archive->$taxonomy );
-				$tags['og:description']	= $archive->description;
+				$tags['og:url']         = get_term_link( $archive->term_id, $archive->taxonomy );
+				$tags['og:description'] = $archive->description;
 			} elseif ( is_post_type_archive() ) {
-				$tags['og:url'] 		= get_post_type_archive_link( $archive->name );
-				$tags['og:description']	= $archive->description;
+				$tags['og:url']         = get_post_type_archive_link( $archive->name );
+				$tags['og:description'] = $archive->description;
 			}
 		} else { // for date archives and future-proofing
-			$tags['og:url'] 		= home_url( '/' );
-			$tags['og:description']	= get_bloginfo( 'description' );
+			$tags['og:url']         = '';
+			$tags['og:description'] = get_bloginfo( 'description' );
 		}
 	} elseif ( is_singular() ) {
 		global $post;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, Open Graph tags were added only for pages that were singular, home, or author archives. These changes add Open Graph meta tags to all archive pages.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #1987

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The og:type is set to 'website', which is the default recommended by Facebook and the Open Graph protocol. 
* The title of the archive page is added as the og:title. 
* The site name is added as the og:site_name. 
* For category, tag, taxonomy, and post type archives, the og:url is set to the appropriate archive link and the og:description is set to the relevant description. For date archives, the URL defaults to the site URL and the description defaults to the site description. 
* The og:image and og:locale tags are handled as they are for the home page.
* Tags for author archives are not addressed in this change since they're already included.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

This updates the existing Open Graph meta tag functionality to apply appropriate tags to archive pages.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test Category pages:
* Log in to the WordPress dashboard.
* Go to Posts > Categories.
* Go to a category in the list and hover over the category name to see the menu links appear below.
* Click "View" to view the category archive page.
* Right-click the page and select "Inspect" or "Inspect Element" to open the Web Inspector.
* See the HTML in the Elements panel.
* Within the HTML, click on "<head>" to expand that section.
* See the Open Graph tags in the <head> added by Jetpack as shown below. 
* See that tags are present for og:type, og:title, og:url, og:site_name, og:locale, and og:image.
* If an archive description is present, see that the og:description is present and set to that description.

<img width="659" alt="Screen Shot 2019-07-26 at 2 27 10 PM" src="https://user-images.githubusercontent.com/24902269/61973665-8dd38580-afb2-11e9-805a-56746debf91f.png">

To test Tag pages:
* Repeat the same steps above but for Tags by going to to Posts > Tags, viewing the tag archive page, and continuing from there.

To test custom post type archives: 
* Install and activate the Custom Post Type UI plugin.
* Go to CPT UI > Add/Edit Post Types.
* Fill in the following fields:  
   * Post Type Slug: things
   * Plural Label: Things
   * Singular Label: Thing
* Scroll down to "Has Archive" and select "True".
* Click "Add Post Type".
* Go to Things > Add New.
* Enter a title and click "Publish". 
* Go to <your-site-url>/things to view the Thing archive page.
* Continue with the steps above to inspect the page and see the Open Graph tags in the HTML.

To test custom taxonomy archive pages:
* Complete the steps above to install the Custom Post Type UI plugin and create a CPT called Things.
* Go to CPT UI > Add/Edit Taxonomies.
* Fill in the following fields:  
   * Taxonomy Slug: types
   * Plural Label: Types
   * Singular Label: Type
* Check the box to "Attach to Post Type" for "Things".
* Click "Add Taxonomy".
* Go to Things > Add New.
* Enter a title.
* Under Types, enter "Blue" in the "Add new Type" field and press Enter. 
* Click Publish.
* Go to Things > Types.
* In the list of Types, hover over the name "Blue" to see the menu links appear below.
* Click "View" to view the custom taxonomy archive page. 
* Continue with the steps above to inspect the page and see the Open Graph tags in the HTML.

To test date archive pages:
* Go to <your-site-url>/2019.
* Continue with the steps above to inspect the page and see the Open Graph tags in the HTML.
* Additionally, if a site description is present, see that the og:description is present and set to that description.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add Open Graph meta tags to archive pages.