### PR TITLE
Prevent disabled connect button from looking green

### DIFF
--- a/_inc/client/components/connect-button/style.scss
+++ b/_inc/client/components/connect-button/style.scss
@@ -9,7 +9,7 @@
 	border-color: $green-secondary;
 	color: $white;
 
-	&:hover, &:focus {
+	&:hover:not([disabled]), &:focus:not([disabled]) {
 		background: $green-secondary;
 		border-color: $green-dark;
 		color: $white;


### PR DESCRIPTION
Extracted from #13112

Very minor, prevents disabled connect button from going green on hover when rendering as a button.

Difficult to repro in current Jetpack version (use inspector to change `.jp-jetpack-connect__button` elements from `a` to `button` and set `disabled` attribute), laying groundwork for smaller future diffs by shipping cosmetic fixes separately.