### PR TITLE
Stats: Use Transient API to Improve Cache Performance

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -463,6 +463,9 @@ class Jetpack {
 			do_action( 'jetpack_sitemaps_purge_data' );
 		}
 
+		// Delete old stats cache
+		delete_option( 'jetpack_restapi_stats_cache' );
+
 		delete_transient( self::$plugin_upgrade_lock_key );
 	}
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1644,48 +1644,40 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 	$args        = wp_parse_args( $args, array() );
 	$cache_key   = md5( implode( '|', array( $endpoint, $api_version, serialize( $args ) ) ) );
 
-	// Get cache.
-	$stats_cache = Jetpack_Options::get_option( 'restapi_stats_cache', array() );
-	if ( ! is_array( $stats_cache ) ) {
-		$stats_cache = array();
-	}
+	$transient_name = "jetpack_restapi_stats_cache_{$cache_key}";
+
+	$stats_cache = get_transient( $transient_name );
 
 	// Return or expire this key.
-	if ( isset( $stats_cache[ $cache_key ] ) ) {
-		$time = key( $stats_cache[ $cache_key ] );
-		if ( time() - $time < ( 5 * MINUTE_IN_SECONDS ) ) {
-			$cached_stats = $stats_cache[ $cache_key ][ $time ];
-			if ( is_wp_error( $cached_stats ) ) {
-				return $cached_stats;
-			}
-			$cached_stats = (object) array_merge( array( 'cached_at' => $time ), (array) $cached_stats );
-			return $cached_stats;
+	if ( $stats_cache ) {
+		$time = key( $stats_cache );
+		$data = $stats_cache[ $time ]; // WP_Error or string (JSON encoded object)
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
-		unset( $stats_cache[ $cache_key ] );
+
+		return (object) array_merge( array( 'cached_at' => $time ), (array) json_decode( $data ) );
 	}
 
 	// Do the dirty work.
 	$response = Client::wpcom_json_api_request_as_blog( $endpoint, $api_version, $args );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		// WP_Error
 		$data = is_wp_error( $response ) ? $response : new WP_Error( 'stats_error' );
+		// WP_Error
+		$return = $data;
 	} else {
-		$data = json_decode( wp_remote_retrieve_body( $response ) );
+		// string (JSON encoded object)
+		$data = wp_remote_retrieve_body( $response );
+		// object (rare: null on JSON failure)
+		$return = json_decode( $data );
 	}
 
-	// Expire old keys.
-	foreach ( $stats_cache as $k => $cache ) {
-		if ( ! is_array( $cache ) || ( 5 * MINUTE_IN_SECONDS ) < time() - key( $cache ) ) {
-			unset( $stats_cache[ $k ] );
-		}
-	}
+	// To reduce size in storage: store with time as key, store JSON encoded data (unless error).
+	set_transient( $transient_name, array( time() => $data ), 5 * MINUTE_IN_SECONDS );
 
-	// Set cache.
-	$stats_cache[ $cache_key ] = array(
-		time() => $data,
-	);
-	Jetpack_Options::update_option( 'restapi_stats_cache', $stats_cache, false );
-
-	return $data;
+	return $return;
 }
 
 /**

--- a/packages/options/legacy/class.jetpack-options.php
+++ b/packages/options/legacy/class.jetpack-options.php
@@ -49,7 +49,6 @@ class Jetpack_Options {
 					'site_icon_url',               // (string) url to the full site icon
 					'site_icon_id',                // (int)    Attachment id of the site icon file
 					'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
-					'restapi_stats_cache',         // (array) Stats Cache data.
 					'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 					'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 					'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error


### PR DESCRIPTION
Fixes #13121

#### Changes proposed in this Pull Request:
Rather than storing every cached stats item in one big option, store each separately in their own transient.

Moving to transients also means we don't need to worry about expiring the cache ourselves: Core will take care of it.

Bonus: Storing JSON serialized data is significantly more space efficient for our use case than storing data serialized by `serialize()`. (We're actually doing a bit of both in this PR, but still getting most of the savings.)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bug fix.

#### Testing instructions:
0. `git checkout master`
1. Load the Jetpack dashboard.
2. `wp option get jetpack_restapi_stats_cache` - see a bunch of stuff.
3. `git checkout fix/13121-use-transients-for-stats-cache`
4. *HACK*: bump `JETPACK__VERSION`.
5. Load the Jetpack dashboard.
6. `wp option get jetpack_restapi_stats_cache` - see that the option doesn't exist.
7. `wp transient list --search='jetpack_restapi_stats_cache_*'` - see the data in the transient(s). Note the expiration.
8. Load the Jetpack dashboard.
9. `wp transient list --search='jetpack_restapi_stats_cache_*'` - see the data still in the transient(s). See that the expiration has not changed.
10. *UNHACK your `JETPACK__VERSION`*.

#### Proposed changelog entry for your changes:
Improve Stats Cache performance by switching from the WordPress Options API to the WordPress Transient API.