### PR TITLE
Style related posts on AMP Reader Mode

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1703,7 +1703,12 @@ EOT;
 		if ( $style ){
 			wp_enqueue_style( 'jetpack_related-posts', plugins_url( 'related-posts.css', __FILE__ ), array(), self::VERSION );
 			wp_style_add_data( 'jetpack_related-posts', 'rtl', 'replace' );
+			add_action( 'amp_post_template_css', array( $this, 'render_amp_reader_mode_css' ) );
 		}
+	}
+
+	public function render_amp_reader_mode_css() {
+		echo file_get_contents( plugin_dir_path( __FILE__ ) . 'related-posts.css' );
 	}
 
 	/**

--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -53,7 +53,6 @@
 
 .jp-related-posts-i2__post-img-link {
 	order: -1;
-	line-height: 1em;
 }
 .jp-related-posts-i2__post-img-link img {
 	width: 100%;


### PR DESCRIPTION
Fixes #13149 where AMP related-posts content was unstyled in Reader mode.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Render RelatedPosts CSS into Reader mode page

#### Testing instructions:
* Install and activate the AMP plugin and enable "Reader" mode
* Activate Jetpack's "Related Posts" feature
* Add ?amp to any post URL with relatedposts visible
* Related posts block should be styled horizontally (not appear as a bulleted list)

Before:

<img width="214" alt="amp-related-css-before" src="https://user-images.githubusercontent.com/51896/62150301-7e09b900-b2b2-11e9-9b97-84344fafecf2.png">

<img width="364" alt="amp-related-css-before-gen" src="https://user-images.githubusercontent.com/51896/62159123-da2a0880-b2c5-11e9-8cd1-acd40b42be06.png">

After:

<img width="651" alt="amp-related-css-after" src="https://user-images.githubusercontent.com/51896/62150307-83670380-b2b2-11e9-933d-c52e61f0f9fa.png">

<img width="765" alt="amp-related-css-after-gen" src="https://user-images.githubusercontent.com/51896/62159139-e1511680-b2c5-11e9-8dcd-fb062edd4747.png">


cc @westonruter

