### PR TITLE
Site Settings: Allow language change even if WPLANG is defined as constant

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -426,7 +426,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						break;
 					}
 
-					$value = get_option( 'WPLANG' );
+					$value = get_option( 'WPLANG', '' );
 					if ( empty( $value ) && defined( 'WPLANG' ) ) {
 						$value = WPLANG;
 					}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -420,12 +420,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		foreach ( $settings as $setting => $properties ) {
 			switch ( $setting ) {
 				case 'lang_id':
-					if ( defined( 'WPLANG' ) ) {
-						// We can't affect this setting, so warn the client
-						$response[ $setting ] = 'error_const';
-						break;
-					}
-
 					if ( ! current_user_can( 'install_languages' ) ) {
 						// The user doesn't have caps to install language packs, so warn the client
 						$response[ $setting ] = 'error_cap';
@@ -645,7 +639,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 			switch ( $option ) {
 				case 'lang_id':
-					if ( defined( 'WPLANG' ) || ! current_user_can( 'install_languages' ) ) {
+					if ( ! current_user_can( 'install_languages' ) ) {
 						// We can't affect this setting
 						$updated = false;
 						break;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -427,6 +427,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					}
 
 					$value = get_option( 'WPLANG' );
+					if ( empty( $value ) && defined( 'WPLANG' ) ) {
+						$value = WPLANG;
+					}
 					$response[ $setting ] = empty( $value ) ? 'en_US' : $value;
 					break;
 


### PR DESCRIPTION
`wp-admin` users can change site language even if `WPLANG` constant is defined in `wp-config.php`. This PR allows Calypso user to do the same in the general settings page (`/settings/general/`).

Fixes https://github.com/Automattic/wp-calypso/issues/33440

#### Changes proposed in this Pull Request:

Removes `defined( 'WPLANG' )` checks from Jetpack's Core Data API endpoints used by Calypso to change site settings.

#### Testing instructions:

1. Test with a Jetpack site whose `wp-config.php` contains the line `define('WPLANG', '');`
2. Navigate to URL: https://wordpress.com/settings/general/{site_slug}.
3. Check that error message no longer appears.

*Before:*
<img width="855" alt="58593747-97de3f80-8220-11e9-8211-e2b65f0a0d8c" src="https://user-images.githubusercontent.com/127594/62153603-ca0c2c00-b2b9-11e9-8c95-7d53380f247d.png">

*After:*
<img width="772" alt="screenshot_815" src="https://user-images.githubusercontent.com/127594/62153695-02ac0580-b2ba-11e9-8471-fbc8a6af0390.png">

4. Also check that site language can now be changed.
 
#### Proposed changelog entry for your changes:

* allow language to be changed even if `WPLANG` constant is defined.
