### PR TITLE
Send disconnecting userid

### DIFF
--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -32,6 +32,9 @@ class Jetpack_IXR_Client extends IXR_Client {
 	function query() {
 		$args = func_get_args();
 		$method = array_shift( $args );
+		if ( 'jetpack.deregister' === $method ) {
+			$args['requesting_user_id'] = get_current_user_id();
+		}
 		$request = new IXR_Request( $method, $args );
 		$xml = trim( $request->getXml() );
 

--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -16,11 +16,6 @@ require_once( ABSPATH . WPINC . '/class-IXR.php' );
 class Jetpack_IXR_Client extends IXR_Client {
 	public $jetpack_args = null;
 
-	/**
-	 * @var array Array of additional parameters
-	 */
-	protected $additional_parameters;
-
 	function __construct( $args = array(), $path = false, $port = 80, $timeout = 15 ) {
 		$defaults = array(
 			'url' => Jetpack::xmlrpc_api_url(),
@@ -37,10 +32,6 @@ class Jetpack_IXR_Client extends IXR_Client {
 	function query() {
 		$args = func_get_args();
 		$method = array_shift( $args );
-		if ( is_array( $this->additional_parameters ) ) {
-			$args = array_merge( $args, $this->additional_parameters );
-		}
-
 		$request = new IXR_Request( $method, $args );
 		$xml = trim( $request->getXml() );
 
@@ -48,7 +39,7 @@ class Jetpack_IXR_Client extends IXR_Client {
 
 		if ( is_wp_error( $response ) ) {
 			$this->error = new IXR_Error( -10520, sprintf( 'Jetpack: [%s] %s', $response->get_error_code(), $response->get_error_message() ) );
-					return false;
+			return false;
 		}
 
 		if ( !$response ) {
@@ -98,10 +89,6 @@ class Jetpack_IXR_Client extends IXR_Client {
 		}
 
 		return new Jetpack_Error( "IXR_{$fault_code}", $fault_string );
-	}
-
-	function add_additional_parameters( $additional_parameters ) {
-		$this->additional_parameters = $additional_parameters;
 	}
 }
 

--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -16,6 +16,11 @@ require_once( ABSPATH . WPINC . '/class-IXR.php' );
 class Jetpack_IXR_Client extends IXR_Client {
 	public $jetpack_args = null;
 
+	/**
+	 * @var array Array of additional parameters
+	 */
+	protected $additional_parameters;
+
 	function __construct( $args = array(), $path = false, $port = 80, $timeout = 15 ) {
 		$defaults = array(
 			'url' => Jetpack::xmlrpc_api_url(),
@@ -32,9 +37,10 @@ class Jetpack_IXR_Client extends IXR_Client {
 	function query() {
 		$args = func_get_args();
 		$method = array_shift( $args );
-		if ( 'jetpack.deregister' === $method ) {
-			$args['requesting_user_id'] = get_current_user_id();
+		if ( is_array( $this->additional_parameters ) ) {
+			$args = array_merge( $args, $this->additional_parameters );
 		}
+
 		$request = new IXR_Request( $method, $args );
 		$xml = trim( $request->getXml() );
 
@@ -42,7 +48,7 @@ class Jetpack_IXR_Client extends IXR_Client {
 
 		if ( is_wp_error( $response ) ) {
 			$this->error = new IXR_Error( -10520, sprintf( 'Jetpack: [%s] %s', $response->get_error_code(), $response->get_error_message() ) );
-			return false;
+					return false;
 		}
 
 		if ( !$response ) {
@@ -92,6 +98,10 @@ class Jetpack_IXR_Client extends IXR_Client {
 		}
 
 		return new Jetpack_Error( "IXR_{$fault_code}", $fault_string );
+	}
+
+	function add_additional_parameters( $additional_parameters ) {
+		$this->additional_parameters = $additional_parameters;
 	}
 }
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3262,8 +3262,7 @@ p {
 			$tracking->record_user_event( 'disconnect_site', array() );
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
-			$xml->add_additional_parameters( array( 'registering_user_id' => get_current_user_id() ) );
-			$xml->query( 'jetpack.deregister' );
+			$xml->query( 'jetpack.deregister', array( 'registering_user_id' => get_current_user_id() ) );
 		}
 
 		Jetpack_Options::delete_option(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3262,7 +3262,7 @@ p {
 			$tracking->record_user_event( 'disconnect_site', array() );
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
-			$xml->query( 'jetpack.deregister', array( 'registering_user_id' => get_current_user_id() ) );
+			$xml->query( 'jetpack.deregister', array( 'requesting_user_id' => get_current_user_id() ) );
 		}
 
 		Jetpack_Options::delete_option(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3262,7 +3262,7 @@ p {
 			$tracking->record_user_event( 'disconnect_site', array() );
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
-			$xml->query( 'jetpack.deregister', array( 'requesting_user_id' => get_current_user_id() ) );
+			$xml->query( 'jetpack.deregister', get_current_user_id() );
 		}
 
 		Jetpack_Options::delete_option(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3262,6 +3262,7 @@ p {
 			$tracking->record_user_event( 'disconnect_site', array() );
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
+			$xml->add_additional_parameters( array( 'registering_user_id' => get_current_user_id() ) );
 			$xml->query( 'jetpack.deregister' );
 		}
 


### PR DESCRIPTION
This PR sends the disconnecting userid so that the user can be logged if it is a connected user.

#### Testing instructions:
Pair with D31005-code
Disconnect Jetpack with a connected user, ensure the Activity Log lists that user as the actor for the Disconnect activity

#### Proposed changelog entry for your changes:
Sends user_id of user disconnecting Jetpack
